### PR TITLE
Grensesnittavstemming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# familie-ba-sak
+Saksbehandling for barnetrygd
+
+## Kjøring lokalt
+For å kjøre opp appen lokalt kan en kjøre `DevLauncher` med Spring-profilen `dev` satt.
+Appen tilgjengeliggjøres da på `localhost:8089`. 
+
+### Database
+Dersom man vil kjøre med postgres, kan man bytte til Spring-profilen `postgres`. Da må man sette opp postgres-databasen, dette gjøres slik:
+```
+docker run --name familie-ba-sak -e POSTGRES_PASSWORD=test -d -p 5432:5432 postgres
+docker ps (finn container id)
+docker exec -it <container_id> bash
+psql -U postgres
+CREATE DATABASE "familie-ba-sak";
+```
+
+### Autentisering
+Dersom man vil gjøre autentiserte kall mot andre tjenester, må man sette opp følgende miljø-variabler:
+* Client secret
+* Client id
+* Scope for den aktuelle tjenesten
+
+Alle disse variablene finnes i applikasjonens mappe for preprod-fss på vault.
+Variablene legges inn under DevLauncher -> Edit Configurations -> Environment Variables. 
+
+## Kontaktinformasjon
+For NAV-interne kan henvendelser om applikasjonen rettes til #team-familie på slack. Ellers kan man opprette et issue her på github.

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <spring.cloud.version>2.2.0.RELEASE</spring.cloud.version>
         <felles.version>1.0_20200110142205_7c24f15</felles.version>
         <felles-kontrakter.version>2.0_20200113101906_b1bcc2f</felles-kontrakter.version>
+        <mockk.version>1.9.3</mockk.version>
         <token-validation-spring.version>1.1.3</token-validation-spring.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
@@ -191,6 +192,12 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
+            <version>${mockk.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/FagsakController.kt
@@ -7,14 +7,12 @@ import no.nav.familie.ba.sak.task.AvstemMotOppdrag
 import no.nav.familie.ba.sak.task.IverksettMotOppdrag
 import no.nav.familie.ba.sak.økonomi.AvstemmingTaskDTO
 import no.nav.familie.ba.sak.økonomi.IverksettingTaskDTO
-import no.nav.familie.ba.sak.økonomi.ØkonomiService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.sikkerhet.OIDCUtil
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import no.nav.security.token.support.core.api.Unprotected
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
@@ -94,7 +92,6 @@ class FagsakController(
 
 
     @GetMapping("/avstemming")
-    @Unprotected
     fun settIGangAvstemming(): ResponseEntity<Ressurs<String>> {
 
         val iDag = LocalDateTime.now().toLocalDate().atStartOfDay()

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FlywayConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FlywayConfiguration.kt
@@ -6,8 +6,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
 @Configuration
+@Profile("!dev")
 @ConditionalOnProperty("spring.flyway.enabled")
 class FlywayConfiguration {
     @Bean

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdrag.kt
@@ -25,7 +25,6 @@ class AvstemMotOppdrag(val avstemmingService: AvstemmingService, val taskReposit
     }
 
     override fun onCompletion(task: Task) {
-        LOG.debug("Avstemming mot oppdrag utført.")
         val nesteAvstemmingTaskDTO = nesteAvstemmingDTO(task.triggerTid!!.toLocalDate().plusDays(1), 1)
 
         val nesteAvstemmingTask = Task.nyTaskMedTriggerTid(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdrag.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.økonomi.AvstemmingService
+import no.nav.familie.ba.sak.økonomi.AvstemmingTaskDTO
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.MonthDay
+
+@Service
+@TaskStepBeskrivelse(taskStepType = AvstemMotOppdrag.TASK_STEP_TYPE, beskrivelse = "Grensesnittavstemming mot oppdrag", maxAntallFeil = 3)
+class AvstemMotOppdrag(val avstemmingService: AvstemmingService, val taskRepository: TaskRepository) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val avstemmingTask = objectMapper.readValue(task.payload, AvstemmingTaskDTO::class.java)
+        LOG.info("Gjør avstemming mot oppdrag fra og med ${avstemmingTask.fomDato} til og med ${avstemmingTask.tomDato}")
+
+        avstemmingService.avstemOppdrag(avstemmingTask.fomDato, avstemmingTask.tomDato)
+    }
+
+    override fun onCompletion(task: Task) {
+        LOG.info("Avstemming mot oppdrag utført.")
+        val nesteAvstemmingTaskDTO = nesteAvstemmingDTO(LocalDate.now().plusDays(1), 1)
+
+        val nesteAvstemmingTask = Task.nyTaskMedTriggerTid(
+                TASK_STEP_TYPE,
+                objectMapper.writeValueAsString(nesteAvstemmingTaskDTO),
+                nesteAvstemmingTaskDTO.tomDato.toLocalDate().atTime(8, 0)
+        )
+
+        taskRepository.save(nesteAvstemmingTask)
+    }
+
+    fun nesteAvstemmingDTO(nesteDag: LocalDate, antallDager: Int): AvstemmingTaskDTO {
+        return if (erHelgEllerHelligdag(nesteDag)) nesteAvstemmingDTO(nesteDag.plusDays(1), antallDager + 1)
+        else AvstemmingTaskDTO(nesteDag.minusDays(antallDager.toLong()).atStartOfDay(), nesteDag.atStartOfDay())
+    }
+
+    private fun erHelgEllerHelligdag(dato: LocalDate): Boolean {
+        return dato.dayOfWeek == DayOfWeek.SATURDAY
+                || dato.dayOfWeek == DayOfWeek.SUNDAY
+                || FASTE_HELLIGDAGER.contains(MonthDay.from(dato))
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "avstemMotOppdrag"
+        val FASTE_HELLIGDAGER = setOf(
+                MonthDay.of(1, 1),
+                MonthDay.of(5, 1),
+                MonthDay.of(5, 17),
+                MonthDay.of(12, 25),
+                MonthDay.of(12, 26)
+        )
+        val LOG = LoggerFactory.getLogger(AvstemMotOppdrag::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdrag.kt
@@ -25,8 +25,8 @@ class AvstemMotOppdrag(val avstemmingService: AvstemmingService, val taskReposit
     }
 
     override fun onCompletion(task: Task) {
-        LOG.info("Avstemming mot oppdrag utført.")
-        val nesteAvstemmingTaskDTO = nesteAvstemmingDTO(LocalDate.now().plusDays(1), 1)
+        LOG.debug("Avstemming mot oppdrag utført.")
+        val nesteAvstemmingTaskDTO = nesteAvstemmingDTO(task.triggerTid!!.toLocalDate().plusDays(1), 1)
 
         val nesteAvstemmingTask = Task.nyTaskMedTriggerTid(
                 TASK_STEP_TYPE,

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/DefaultRestTaskMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/DefaultRestTaskMapper.kt
@@ -9,7 +9,11 @@ import org.springframework.stereotype.Service
 @Service
 class DefaultRestTaskMapper : RestTaskMapper {
     override fun toDto(task: Task): RestTask {
-        val taskDTO = objectMapper.convertValue(task, DefaultTaskDTO::class.java)
-        return RestTask(task, null, null, taskDTO.personIdent)
+        return try {
+            val taskDTO = objectMapper.convertValue(task, DefaultTaskDTO::class.java)
+            RestTask(task, null, null, taskDTO.personIdent)
+        } catch (e: IllegalArgumentException) {
+            RestTask(task, null, null, "")
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -13,11 +13,10 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient) {
         Result.runCatching { økonomiKlient.avstemOppdrag(fraDato, tilDato) }
                 .fold(
                         onSuccess = {
-                            LOG.info("Avstemming sendt ok")
                             return Ressurs.success("Avstemming OK")
                         },
                         onFailure = {
-                            LOG.info("Feil i sending til avstemming")
+                            LOG.warn("Avstemming oppdrag feilet")
                             throw it
                         }
                 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -18,7 +18,7 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient) {
                         },
                         onFailure = {
                             LOG.info("Feil i sending til avstemming")
-                            return Ressurs.failure("Iverksetting mot oppdrag feilet", it)
+                            throw it
                         }
                 )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.økonomi
 
-import no.nav.familie.kontrakter.felles.Ressurs
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -8,15 +7,15 @@ import java.time.LocalDateTime
 @Service
 class AvstemmingService(val økonomiKlient: ØkonomiKlient) {
 
-    fun avstemOppdrag(fraDato: LocalDateTime, tilDato: LocalDateTime): Ressurs<String> {
+    fun avstemOppdrag(fraDato: LocalDateTime, tilDato: LocalDateTime) {
 
         Result.runCatching { økonomiKlient.avstemOppdrag(fraDato, tilDato) }
                 .fold(
                         onSuccess = {
-                            return Ressurs.success("Avstemming OK")
+                            LOG.debug("Avstemming mot oppdrag utført.")
                         },
                         onFailure = {
-                            LOG.error("Avstemming av oppdrag feilet", it)
+                            LOG.error("Avstemming mot oppdrag feilet", it)
                             throw it
                         }
                 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.ba.sak.økonomi
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class AvstemmingService(val økonomiKlient: ØkonomiKlient) {
+
+    fun avstemOppdrag(fraDato: LocalDateTime, tilDato: LocalDateTime): Ressurs<String> {
+
+        Result.runCatching { økonomiKlient.avstemOppdrag(fraDato, tilDato) }
+                .fold(
+                        onSuccess = {
+                            LOG.info("Avstemming sendt ok")
+                            return Ressurs.success("Avstemming OK")
+                        },
+                        onFailure = {
+                            LOG.info("Feil i sending til avstemming")
+                            return Ressurs.failure("Iverksetting mot oppdrag feilet", it)
+                        }
+                )
+    }
+
+    companion object {
+        val LOG = LoggerFactory.getLogger(AvstemmingService::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -16,7 +16,7 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient) {
                             return Ressurs.success("Avstemming OK")
                         },
                         onFailure = {
-                            LOG.warn("Avstemming oppdrag feilet")
+                            LOG.error("Avstemming av oppdrag feilet", it)
                             throw it
                         }
                 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingTaskDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingTaskDTO.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.ba.sak.økonomi
+
+import java.time.LocalDateTime
+
+data class AvstemmingTaskDTO(val fomDato: LocalDateTime, val tomDato: LocalDateTime)

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
@@ -53,7 +53,7 @@ class ØkonomiKlient(
         headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), MDC.get(MDCConstants.MDC_CALL_ID))
 
         return restTemplate.exchange(
-                URI.create("$familieOppdragUri/avstemming?fom=$fraDato&tom=$tilDato"),
+                URI.create("$familieOppdragUri/avstemming/BA/?fom=$fraDato&tom=$tilDato"),
                 HttpMethod.POST,
                 HttpEntity<String>(headers),
                 Ressurs::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
@@ -17,6 +17,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import java.net.URI
+import java.time.LocalDateTime
 
 private const val OAUTH2_CLIENT_CONFIG_KEY = "familie-oppdrag-clientcredentials"
 
@@ -43,6 +44,18 @@ class ØkonomiKlient(
                 URI.create("$familieOppdragUri/oppdrag"),
                 HttpMethod.POST,
                 HttpEntity(objectMapper.writeValueAsString(utbetalingsoppdrag), headers),
+                Ressurs::class.java)
+    }
+
+    fun avstemOppdrag(fraDato: LocalDateTime, tilDato: LocalDateTime): ResponseEntity<Ressurs<*>> {
+        val headers = HttpHeaders()
+        headers.acceptCharset = listOf(Charsets.UTF_8)
+        headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), MDC.get(MDCConstants.MDC_CALL_ID))
+
+        return restTemplate.exchange(
+                URI.create("$familieOppdragUri/avstemming?fom=$fraDato&tom=$tilDato"),
+                HttpMethod.POST,
+                HttpEntity<String>(headers),
                 Ressurs::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
@@ -53,7 +53,7 @@ class ØkonomiKlient(
         headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), MDC.get(MDCConstants.MDC_CALL_ID))
 
         return restTemplate.exchange(
-                URI.create("$familieOppdragUri/avstemming/BA/?fom=$fraDato&tom=$tilDato"),
+                URI.create("$familieOppdragUri/grensesnittavstemming/BA/?fom=$fraDato&tom=$tilDato"),
                 HttpMethod.POST,
                 HttpEntity<String>(headers),
                 Ressurs::class.java)

--- a/src/test/kotlin/DevLauncher.kt
+++ b/src/test/kotlin/DevLauncher.kt
@@ -5,7 +5,7 @@ object DevLauncher {
     @JvmStatic
     fun main(args: Array<String>) {
         val app = SpringApplicationBuilder(ApplicationConfig::class.java)
-                .profiles("postgres", "mock-dokgen-java")
+                .profiles("dev", "mock-dokgen-java")
         app.run(*args)
     }
 }

--- a/src/test/kotlin/DevLauncher.kt
+++ b/src/test/kotlin/DevLauncher.kt
@@ -5,7 +5,7 @@ object DevLauncher {
     @JvmStatic
     fun main(args: Array<String>) {
         val app = SpringApplicationBuilder(ApplicationConfig::class.java)
-                .profiles("dev", "mock-dokgen-java")
+                .profiles("postgres", "mock-dokgen-java")
         app.run(*args)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdragTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdragTest.kt
@@ -1,8 +1,14 @@
 package no.nav.familie.ba.sak.task
 
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import junit.framework.Assert.assertEquals
 import no.nav.familie.ba.sak.økonomi.AvstemmingService
+import no.nav.familie.ba.sak.økonomi.AvstemmingTaskDTO
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -52,9 +58,9 @@ class AvstemMotOppdragTest {
 
     @Test
     fun skalBeregneNesteAvstemmingForLanghelg() {
-        val førsteMai = LocalDate.of(2020, 5, 1)
+        val fredagFørsteMai = LocalDate.of(2020, 5, 1)
 
-        val testDto = avstemMotOppdrag.nesteAvstemmingDTO(førsteMai, 1)
+        val testDto = avstemMotOppdrag.nesteAvstemmingDTO(fredagFørsteMai, 1)
 
         assertEquals(LocalDate.of(2020, 5, 4).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2020, 4, 30).atStartOfDay(), testDto.fomDato)
@@ -68,5 +74,22 @@ class AvstemMotOppdragTest {
 
         assertEquals(LocalDate.of(2020, 1, 15).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2020, 1, 14).atStartOfDay(), testDto.fomDato)
+    }
+
+    @Test
+    fun skalLageNyAvstemmingstaskEtterJobb() {
+        val iDag = LocalDate.of(2020, 1, 15).atStartOfDay()
+        val testTask = Task.nyTaskMedTriggerTid(AvstemMotOppdrag.TASK_STEP_TYPE, objectMapper.writeValueAsString(AvstemmingTaskDTO(iDag.minusDays(1), iDag)), iDag.toLocalDate().atTime(8,0))
+        val slot = slot<Task>()
+        every { taskRepositoryMock.save(any()) } returns testTask
+
+        avstemMotOppdrag.onCompletion(testTask)
+
+        verify(exactly = 1) { taskRepositoryMock.save(capture(slot)) }
+        assertEquals(AvstemMotOppdrag.TASK_STEP_TYPE, slot.captured.taskStepType)
+        assertEquals(iDag.plusDays(1).toLocalDate().atTime(8, 0 ), slot.captured.triggerTid)
+        val taskDTO = objectMapper.readValue(slot.captured.payload, AvstemmingTaskDTO::class.java)
+        assertEquals(taskDTO.fomDato, iDag)
+        assertEquals(taskDTO.tomDato, iDag.plusDays(1))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdragTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/AvstemMotOppdragTest.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.mockk
+import junit.framework.Assert.assertEquals
+import no.nav.familie.ba.sak.økonomi.AvstemmingService
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class AvstemMotOppdragTest {
+
+    lateinit var avstemMotOppdrag: AvstemMotOppdrag
+    lateinit var taskRepositoryMock: TaskRepository
+
+    @BeforeEach
+    fun setUp() {
+        val avstemmingServiceMock = mockk<AvstemmingService>()
+        taskRepositoryMock = mockk()
+        avstemMotOppdrag = AvstemMotOppdrag(avstemmingServiceMock, taskRepositoryMock)
+    }
+
+    @Test
+    fun skalBeregneNesteAvstemmingForHelg() {
+        val enLørdag = LocalDate.of(2020, 1, 11)
+
+        val testDto = avstemMotOppdrag.nesteAvstemmingDTO(enLørdag, 1)
+
+        assertEquals(LocalDate.of(2020, 1, 13).atStartOfDay(), testDto.tomDato)
+        assertEquals(LocalDate.of(2020, 1, 10).atStartOfDay(), testDto.fomDato)
+    }
+
+    @Test
+    fun skalBeregneNesteAvstemmingForSammenhengendeHelligdag() {
+        val førsteJuledag = LocalDate.of(2019, 12,25)
+
+        val testDto = avstemMotOppdrag.nesteAvstemmingDTO(førsteJuledag, 1)
+
+        assertEquals(LocalDate.of(2019, 12, 27).atStartOfDay(), testDto.tomDato)
+        assertEquals(LocalDate.of(2019, 12, 24).atStartOfDay(), testDto.fomDato)
+    }
+
+    @Test
+    fun skalBeregneNesteAvstemmingForEnkeltHelligdag() {
+        val førsteNyttårsdag = LocalDate.of(2020, 1, 1)
+
+        val testDto = avstemMotOppdrag.nesteAvstemmingDTO(førsteNyttårsdag, 1)
+
+        assertEquals(LocalDate.of(2020, 1, 2).atStartOfDay(), testDto.tomDato)
+        assertEquals(LocalDate.of(2019, 12, 31).atStartOfDay(), testDto.fomDato)
+    }
+
+    @Test
+    fun skalBeregneNesteAvstemmingForLanghelg() {
+        val førsteMai = LocalDate.of(2020, 5, 1)
+
+        val testDto = avstemMotOppdrag.nesteAvstemmingDTO(førsteMai, 1)
+
+        assertEquals(LocalDate.of(2020, 5, 4).atStartOfDay(), testDto.tomDato)
+        assertEquals(LocalDate.of(2020, 4, 30).atStartOfDay(), testDto.fomDato)
+    }
+
+    @Test
+    fun skalBeregneNesteAvstemmingForUkedag() {
+        val enOnsdag = LocalDate.of(2020, 1, 15)
+
+        val testDto = avstemMotOppdrag.nesteAvstemmingDTO(enOnsdag, 1)
+
+        assertEquals(LocalDate.of(2020, 1, 15).atStartOfDay(), testDto.tomDato)
+        assertEquals(LocalDate.of(2020, 1, 14).atStartOfDay(), testDto.fomDato)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/sak/util/DbContainerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/util/DbContainerInitializer.kt
@@ -25,8 +25,8 @@ class DbContainerInitializer : ApplicationContextInitializer<ConfigurableApplica
         private val postgres: KPostgreSQLContainer by lazy {
             KPostgreSQLContainer("postgres:11.1")
                     .withDatabaseName("databasename")
-                    .withUsername("sak")
-                    .withPassword("sak")
+                    .withUsername("postgres")
+                    .withPassword("test")
         }
     }
 }

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -42,10 +42,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
-    hikari:
-      password: sak
-      username: sak
+    url: jdbc:postgresql://localhost:5432/familie-ba-sak
+    password: test
+    username: postgres
   flyway:
     enabled: true
   jpa:
@@ -59,7 +58,7 @@ spring:
   cloud:
     vault:
       database:
-        role: sak
+        role: postgres
 
 
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087/api


### PR DESCRIPTION
Task som kjører løpende grensesnittavstemming. Når tasken er fullført, beregner den når neste avstemming skal kjøre og oppretter en task på det. Er litt usikker på om vi skal sende med fagområde som parameter etc på requesten til familie-oppdrag eller om familie-oppdrag kan klare å trekke det ut av tokenet. 

Er litt usikker på hvordan vi skal sette i gang den aller første avstemmingen. Lagde et endepunkt for det som jeg har brukt for å teste, men det er jo litt malplassert i FagsakControlleren. Endepunktet slettes så klart når vi har trigget første avstemming. Vi kan evt gjøre en manuell insert til task-basen, men litt hassle å få all inputdataen riktig (call-id, payload osv). Tar gjerne i mot meninger/innspill her. 

Ellers litt flikking på det lokale postgres-oppsettet slik at man kan kjøre opp postgres på samme postgres-server som de andre appene. Da slipper man en ny docker-container for hver app. Også lagde jeg en README :)