### PR TITLE
Bugfix: Sjekk riktig status etter at iverksetting har kjørt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdrag.kt
@@ -33,7 +33,7 @@ class IverksettMotOppdrag(
         val iverksettingTask = objectMapper.readValue(task.payload, IverksettingTaskDTO::class.java)
         val behandling = behandlingService.hentBehandling(iverksettingTask.behandlingsId)
         Assert.notNull(behandling, "Skal iverksette mot økonomi, men finner ikke behandling med id ${iverksettingTask.behandlingsId}.")
-        Assert.isTrue(behandling?.status == BehandlingStatus.OPPRETTET, "Skal iverksette mot økonomi, men behandlingen har ${behandling?.status}.")
+        Assert.isTrue(behandling?.status == BehandlingStatus.SENDT_TIL_IVERKSETTING, "Skal iverksette mot økonomi, men behandlingen har status ${behandling?.status}.")
 
         LOG.debug("Iverksetting av vedtak med ID ${iverksettingTask.vedtaksId} mot oppdrag gikk OK")
 


### PR DESCRIPTION
Iverksetting-tasken kjører `økonomiservice.iverksettVedtak(..)` i sin `doTask`. Denne oppdaterer statusen på behandlingen til `SENDT_TIL_IVERKSETTING`. Fikser slik at `onCompletion` sjekker at behandlingen har den oppdaterte statusen og ikke `OPPRETTET`. 