### PR TITLE
Opprett eller oppdater behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -33,15 +33,13 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
 
         val aktivBehandling = hentBehandlingHvisEksisterer(fagsak.id)
 
-        if (aktivBehandling != null) {
-            if (aktivBehandling.status == BehandlingStatus.OPPRETTET || aktivBehandling.status == BehandlingStatus.UNDER_BEHANDLING) {
-                leggTilBarnIPersonopplysningsgrunnlaget(nyBehandling.barnasFødselsnummer, aktivBehandling)
-            } else if (aktivBehandling.status == BehandlingStatus.LAGT_PA_KO_FOR_SENDING_MOT_OPPDRAG || aktivBehandling.status == BehandlingStatus.SENDT_TIL_IVERKSETTING) {
-                throw Exception("Kan ikke lagre ny behandling. Fagsaken har en aktiv behandling som ikke er iverksatt.")
-            }
-        } else {
+        if (aktivBehandling == null || aktivBehandling.status == BehandlingStatus.IVERKSATT) {
             val behandling = opprettNyBehandlingPåFagsak(fagsak, nyBehandling.journalpostID, nyBehandling.behandlingType, randomSaksnummer())
             leggTilSøkerIPersonopplysningsgrunnlaget(nyBehandling, behandling)
+        } else  if (aktivBehandling.status == BehandlingStatus.OPPRETTET || aktivBehandling.status == BehandlingStatus.UNDER_BEHANDLING) {
+            leggTilBarnIPersonopplysningsgrunnlaget(nyBehandling.barnasFødselsnummer, aktivBehandling)
+        } else {
+            throw Exception("Kan ikke lagre ny behandling. Fagsaken har en aktiv behandling som ikke er iverksatt.")
         }
 
         return fagsak

--- a/src/main/kotlin/no/nav/familie/ba/sak/mottak/MottakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/mottak/MottakController.kt
@@ -28,7 +28,7 @@ class MottakController(private val oidcUtil: OIDCUtil,
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PostMapping(path = ["/behandling/opprett"])
-    fun opprettBehandling(@RequestBody nyBehandling: NyBehandling): ResponseEntity<Ressurs<RestFagsak>> {
+    fun opprettEllerOppdaterBehandling(@RequestBody nyBehandling: NyBehandling): ResponseEntity<Ressurs<RestFagsak>> {
         val saksbehandlerId = try {
             oidcUtil.getClaim("preferred_username") ?: "VL"
         } catch (e: JwtTokenValidatorException) {
@@ -37,7 +37,7 @@ class MottakController(private val oidcUtil: OIDCUtil,
 
         FagsakController.logger.info("{} oppretter ny behandling", saksbehandlerId)
 
-        return Result.runCatching { behandlingService.opprettBehandling(nyBehandling) }
+        return Result.runCatching { behandlingService.opprettEllerOppdaterBehandling(nyBehandling) }
                 .fold(
                         onFailure = {
                             logger.info("Opprettelse av behandling feilet", it)

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdrag.kt
@@ -33,7 +33,7 @@ class IverksettMotOppdrag(
         val iverksettingTask = objectMapper.readValue(task.payload, IverksettingTaskDTO::class.java)
         val behandling = behandlingService.hentBehandling(iverksettingTask.behandlingsId)
         Assert.notNull(behandling, "Skal iverksette mot økonomi, men finner ikke behandling med id ${iverksettingTask.behandlingsId}.")
-        Assert.isTrue(behandling?.status == BehandlingStatus.OPPRETTET, "Skal iverksette mot økonomi, men behandlingen har ${behandling?.status}.")
+        Assert.isTrue(behandling?.status == BehandlingStatus.SENDT_TIL_IVERKSETTING, "Skal iverksette mot økonomi, men behandlingen har status ${behandling?.status}.")
 
         LOG.debug("Iverksetting av vedtak med ID ${iverksettingTask.vedtaksId} mot oppdrag gikk OK")
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/BehandlingIntegrationTest.kt
@@ -273,6 +273,4 @@ class BehandlingIntegrationTest {
         Assertions.assertNotNull(grunnlag.personer.find { it.personIdent.ident == barn1Id })
         Assertions.assertNotNull(grunnlag.personer.find { it.personIdent.ident == barn2Id })
     }
-
-    // strøket test som sjekker at vi kaster feil dersom behandlingen har kommet forbi UNDER_BEHANDLING (men som ikke er IVERKSATT enda)
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/BehandlingIntegrationTest.kt
@@ -248,15 +248,15 @@ class BehandlingIntegrationTest {
         val barn2Id = "10000010002"
 
         every {
-            integrasjonTjeneste.hentPersoninfoFor("morId")
+            integrasjonTjeneste.hentPersoninfoFor(morId)
         } returns Personinfo(LocalDate.now())
 
         every {
-            integrasjonTjeneste.hentPersoninfoFor("barn1Id")
+            integrasjonTjeneste.hentPersoninfoFor(barn1Id)
         } returns Personinfo(LocalDate.now())
 
         every {
-            integrasjonTjeneste.hentPersoninfoFor("barn2Id")
+            integrasjonTjeneste.hentPersoninfoFor(barn2Id)
         } returns Personinfo(LocalDate.now())
 
         val fagsak1 = behandlingService.opprettEllerOppdaterBehandling(NyBehandling(morId, arrayOf(barn1Id), BehandlingType.FØRSTEGANGSBEHANDLING, null))

--- a/src/test/kotlin/no/nav/familie/ba/sak/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/BehandlingIntegrationTest.kt
@@ -102,7 +102,7 @@ class BehandlingIntegrationTest {
 
     @Test
     @Tag("integration")
-    fun `Test hele smæla`() {
+    fun `Test at opprettEllerOppdaterBehandling kjører uten feil`() {
         every {
             integrasjonTjeneste.hentPersoninfoFor("1234567")
         } returns Personinfo(LocalDate.now())

--- a/src/test/kotlin/no/nav/familie/ba/sak/BehandlingNegativeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/BehandlingNegativeIntegrationTest.kt
@@ -32,7 +32,8 @@ class BehandlingNegativeIntegrationTest(@Autowired
         val failRess = behandlingService.hentHtmlVedtakForBehandling(100)
         Assertions.assertEquals(Ressurs.Status.FEILET, failRess.status)
 
-        val behandling = behandlingService.nyBehandling("6", BehandlingType.FØRSTEGANGSBEHANDLING, "sdf", "sak1")
+        val fagsak = behandlingService.hentEllerOpprettFagsakForPersonIdent("6")
+        val behandling = behandlingService.opprettNyBehandlingPåFagsak(fagsak, "sdf", BehandlingType.FØRSTEGANGSBEHANDLING, "sak1")
         Assertions.assertNotNull(behandling.fagsak.id)
         Assertions.assertNotNull(behandling.id)
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/BeregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/BeregningTest.kt
@@ -47,7 +47,7 @@ class BeregningTest(
      */
     @Test
     fun `Skal sjekke at tidslinjen for 3 barn blir riktig`() {
-        val behandling = behandlingService.nyBehandling("0", BehandlingType.FØRSTEGANGSBEHANDLING, "sdf", "lagRandomSaksnummer")
+        val behandling = behandlingService.nyBehandling("12345", BehandlingType.FØRSTEGANGSBEHANDLING, "sdf", "lagRandomSaksnummer")
         val vedtak = Vedtak(behandling = behandling,
                             ansvarligSaksbehandler = "ansvarligSaksbehandler",
                             vedtaksdato = LocalDate.now(),

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/BeregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/BeregningTest.kt
@@ -47,7 +47,8 @@ class BeregningTest(
      */
     @Test
     fun `Skal sjekke at tidslinjen for 3 barn blir riktig`() {
-        val behandling = behandlingService.nyBehandling("12345", BehandlingType.FØRSTEGANGSBEHANDLING, "sdf", "lagRandomSaksnummer")
+        val fagsak = behandlingService.hentEllerOpprettFagsakForPersonIdent("12345")
+        val behandling = behandlingService.opprettNyBehandlingPåFagsak(fagsak, "sdf", BehandlingType.FØRSTEGANGSBEHANDLING, "lagRandomSaksnummer")
         val vedtak = Vedtak(behandling = behandling,
                             ansvarligSaksbehandler = "ansvarligSaksbehandler",
                             vedtaksdato = LocalDate.now(),

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.økonomi
 import no.nav.familie.ba.sak.HttpTestBase
 import no.nav.familie.ba.sak.behandling.BehandlingService
 import no.nav.familie.ba.sak.behandling.FagsakController
+import no.nav.familie.ba.sak.behandling.domene.Behandling
 import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.behandling.domene.personopplysninger.Person
@@ -47,12 +48,6 @@ class ØkonomiIntegrasjonTest : HttpTestBase(
     @Autowired
     lateinit var økonomiService: ØkonomiService
 
-    @Autowired
-    lateinit var fagsakController: FagsakController
-
-    @Autowired
-    lateinit var taskRepository: TaskRepository
-
     @Test
     @Tag("integration")
     fun `Iverksett vedtak på aktiv behandling`() {
@@ -64,7 +59,8 @@ class ØkonomiIntegrasjonTest : HttpTestBase(
         mockServer.enqueue(response)
         mockServer.enqueue(response)
 
-        val behandling = behandlingService.nyBehandling("0", BehandlingType.FØRSTEGANGSBEHANDLING, "sdf", "randomSaksnummer")
+        val fagsak = behandlingService.hentEllerOpprettFagsakForPersonIdent("0")
+        val behandling = behandlingService.opprettNyBehandlingPåFagsak(fagsak, "sdf", BehandlingType.FØRSTEGANGSBEHANDLING, "randomSaksnummer")
         Assertions.assertNotNull(behandling.fagsak.id)
 
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandling.id)
@@ -73,12 +69,14 @@ class ØkonomiIntegrasjonTest : HttpTestBase(
                            type = PersonType.SØKER,
                            personopplysningGrunnlag = personopplysningGrunnlag,
                            fødselsdato = LocalDate.now())
+
         personopplysningGrunnlag.leggTilPerson(søker)
 
         personopplysningGrunnlag.leggTilPerson(Person(personIdent = PersonIdent("123456789011"),
                                                       type = PersonType.BARN,
                                                       personopplysningGrunnlag = personopplysningGrunnlag,
                                                       fødselsdato = LocalDate.now()))
+
         personopplysningGrunnlag.aktiv = true
         personopplysningGrunnlagRepository.save(personopplysningGrunnlag)
 


### PR DESCRIPTION
Restrukturering av BehandlingService for å støtte at vi kan oppdatere en behandling dersom det kommer flere hendelser på samme søker innenfor et gitt tidsrom (foreløpig må behandlingen være OPPRETTET eller UNDER_BEHANDLING)

Tester er endret pga endret flyt.

Test for å oppdatere behandling er lagt til.

EDIT: Vi har nå to endepunkter, ett for frontend og ett for hendelser, som håndterer nye behandlinger på litt ulik måte.