### PR TITLE
Bugfix: Deserialisering av oppdrag til konsistensavstemming

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
@@ -77,11 +77,9 @@ class ØkonomiKlient(
         headers.acceptCharset = listOf(Charsets.UTF_8)
         headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), MDC.get(MDCConstants.MDC_CALL_ID))
 
-        val requestBody = objectMapper.writeValueAsString(oppdragTilAvstemming)
-
         return restOperations.exchange(
                 URI.create("$familieOppdragUri/konsistensavstemming/$FAGSYSTEM/?avstemmingsdato=$avstemmingsdato"),
                 HttpMethod.POST,
-                HttpEntity<String>(requestBody, headers))
+                HttpEntity<List<OppdragId>>(oppdragTilAvstemming, headers))
     }
 }


### PR DESCRIPTION
Send over listen av oppdrag til konsistensavstemming uten å stringifisere den først, da server-siden ikke klarer å deserialisere stringen. 