### PR TITLE
Fjern ubrukt parameter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/Vilkårsvurdering.kt
@@ -35,10 +35,8 @@ class Vilkårsvurdering(
         } else {
             vilkårService.vurderVilkårOgLagResultat(personopplysningGrunnlag, vilkårsvurdertBehandling.id)
         }
-
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(vilkårsvurdertBehandling,
                                                                  personopplysningGrunnlag,
-                                                                 data.samletVilkårResultat,
                                                                  ansvarligSaksbehandler = SikkerhetContext.hentSaksbehandler())
 
         return vilkårsvurdertBehandling

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -84,7 +84,6 @@ class VedtakService(private val behandlingService: BehandlingService,
     @Transactional
     fun lagreEllerOppdaterVedtakForAktivBehandling(behandling: Behandling,
                                                    personopplysningGrunnlag: PersonopplysningGrunnlag,
-                                                   restSamletVilkårResultat: List<RestVilkårResultat>,
                                                    ansvarligSaksbehandler: String): Vedtak {
         val forrigeVedtak = hentForrigeVedtak(behandling = behandling)
         val vedtak = Vedtak(

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/BehandlingIntegrationTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ba.sak.behandling.steg.StegType
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.behandling.vedtak.Ytelsetype
-import no.nav.familie.ba.sak.behandling.vilkår.vilkårsvurderingKomplettForBarnOgSøker
 import no.nav.familie.ba.sak.beregning.PersonBeregning
 import no.nav.familie.ba.sak.beregning.NyBeregning
 import no.nav.familie.ba.sak.common.*

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/BehandlingIntegrationTest.kt
@@ -204,10 +204,6 @@ class BehandlingIntegrationTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        søkerFnr,
-                        listOf(barn1Fnr,
-                               barn2Fnr)),
                 ansvarligSaksbehandler = "saksbehandler1")
 
         val vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingId = behandling.id)

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakServiceTest.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.behandling.BehandlingService
 import no.nav.familie.ba.sak.behandling.domene.*
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
-import no.nav.familie.ba.sak.behandling.vilkår.vilkårsvurderingKomplettForBarnOgSøker
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakServiceTest.kt
@@ -97,9 +97,6 @@ class VedtakServiceTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        fnr,
-                        listOf(barnFnr)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
 
@@ -128,9 +125,6 @@ class VedtakServiceTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        fnr,
-                        listOf(barnFnr)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
 
@@ -156,9 +150,6 @@ class VedtakServiceTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 behandling = behandling,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        fnr,
-                        listOf(barnFnr)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
 
@@ -174,9 +165,6 @@ class VedtakServiceTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 behandling = revurderingInnvilgetBehandling,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        fnr,
-                        listOf(barnFnr)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårVurderingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårVurderingTest.kt
@@ -57,7 +57,7 @@ class VilkårVurderingTest {
     }
 
     @Test
-    fun `Hent relevante vilkår for saktype`() { //Banal test, legg til saktyper
+    fun`Hent relevante vilkår for saktype`() { //Banal test, legg til saktyper
         val relevanteVilkårSaktypeFinnes = Vilkår.hentVilkårForSakstype(SakType.VILKÅRGJELDERFOR)
         val relevanteVilkårSaktypeFinnesIkke = Vilkår.hentVilkårForSakstype(SakType.VILKÅRGJELDERIKKEFOR)
         val vilkårForSaktypeFinnes = setOf(Vilkår.UNDER_18_ÅR_OG_BOR_MED_SØKER,

--- a/src/test/kotlin/no/nav/familie/ba/sak/beregning/BeregningNegativeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/beregning/BeregningNegativeIntegrationTest.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Personopplys
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.behandling.vedtak.Ytelsetype
-import no.nav.familie.ba.sak.behandling.vilkår.vilkårsvurderingKomplettForBarnOgSøker
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
@@ -65,9 +64,6 @@ class BeregningNegativeIntegrationTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        fnr,
-                        listOf(barnFnr)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
         val vedtak = vedtakService.hentAktivForBehandling(behandling.id)

--- a/src/test/kotlin/no/nav/familie/ba/sak/dokument/DokumentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/dokument/DokumentServiceTest.kt
@@ -98,9 +98,6 @@ class DokumentServiceTest(
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 behandling = behandling,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        fnr,
-                        listOf(barnFnr)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/dokument/DokumentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/dokument/DokumentServiceTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Persongrunnl
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.behandling.vedtak.Ytelsetype
-import no.nav.familie.ba.sak.behandling.vilkår.vilkårsvurderingKomplettForBarnOgSøker
 import no.nav.familie.ba.sak.beregning.PersonBeregning
 import no.nav.familie.ba.sak.beregning.NyBeregning
 import no.nav.familie.ba.sak.common.DbContainerInitializer

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTest.kt
@@ -69,9 +69,6 @@ class FerdigstillBehandlingTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(
-                        fnr,
-                        listOf(fnrBarn)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTest.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Personopplys
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.steg.StegType
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
-import no.nav.familie.ba.sak.behandling.vilkår.vilkårsvurderingKomplettForBarnOgSøker
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.vedtak.Vedtak
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.behandling.vedtak.Ytelsetype
-import no.nav.familie.ba.sak.behandling.vilkår.vilkårsvurderingKomplettForBarnOgSøker
 import no.nav.familie.ba.sak.beregning.PersonBeregning
 import no.nav.familie.ba.sak.beregning.NyBeregning
 import no.nav.familie.ba.sak.common.lagBehandling

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
@@ -85,7 +85,6 @@ class ØkonomiIntegrasjonTest {
         vedtakService.lagreEllerOppdaterVedtakForAktivBehandling(
                 behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                restSamletVilkårResultat = vilkårsvurderingKomplettForBarnOgSøker(fnr, listOf(barnFnr)),
                 ansvarligSaksbehandler = "ansvarligSaksbehandler"
         )
 


### PR DESCRIPTION
Lista av restvilkårresultat som sendes inn til `lagreEllerOppdaterVedtakForAktivBehandling` ser ikke ut til å ha blitt brukt på en stund. Ikke stor endring, men tar det i egen pr siden det treffer en del filer
