### PR TITLE
Lagt på tilgangskontroll ved henting av personinfo.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger
 
 import no.nav.familie.ba.sak.common.RessursResponse.illegalState
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonOnBehalfClient
+import no.nav.familie.ba.sak.validering.PersontilgangConstraint
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
@@ -22,6 +23,7 @@ class PersonController(private val integrasjonOnBehalfClient: IntegrasjonOnBehal
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @GetMapping
+    @PersontilgangConstraint
     fun hentPerson(@RequestHeader personIdent: String): ResponseEntity<Ressurs<RestPersonInfo>> {
         return Result.runCatching {
                     integrasjonOnBehalfClient.hentPersoninfo(personIdent)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonOnBehalfClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonOnBehalfClient.kt
@@ -29,8 +29,13 @@ class IntegrasjonOnBehalfClient(@Value("\${FAMILIE_INTEGRASJONER_API_URL}") priv
     val personinfoEnkelUri = URI.create("$integrasjonUri/personopplysning/v1/infoEnkel/BAR")
 
     fun sjekkTilgangTilPersoner(personer: Set<Person>): List<Tilgang> {
-        val identer = personer.map { it.personIdent.ident }
-        return postForEntity(tilgangUri, identer)!!
+        return sjekkTilgangTilPersoner(
+                personer.map { it.personIdent.ident }
+        )
+    }
+
+    fun sjekkTilgangTilPersoner(personIdenter: List<String>): List<Tilgang> {
+        return postForEntity(tilgangUri, personIdenter)!!
     }
 
     fun hentPersoninfo(personident: String): Personinfo {

--- a/src/main/kotlin/no/nav/familie/ba/sak/validering/Persontilgang.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/validering/Persontilgang.kt
@@ -1,0 +1,32 @@
+package no.nav.familie.ba.sak.validering
+
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.RestPersonInfo
+import no.nav.familie.ba.sak.integrasjoner.IntegrasjonOnBehalfClient
+import no.nav.familie.kontrakter.felles.Ressurs
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+@Component
+class Persontilgang(private val integrasjonOnBehalfClient: IntegrasjonOnBehalfClient)
+    : ConstraintValidator<PersontilgangConstraint, ResponseEntity<Ressurs<RestPersonInfo>>> {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    override fun isValid(response: ResponseEntity<Ressurs<RestPersonInfo>>, ctx: ConstraintValidatorContext): Boolean {
+        val personInfo = response.body?.data!!
+        val personIdenter = personInfo.familierelasjoner.map { it.personIdent }.toMutableList()
+        personIdenter.add(personInfo.personIdent)
+        integrasjonOnBehalfClient.sjekkTilgangTilPersoner(personIdenter)
+                .filterNot { it.harTilgang }
+                .forEach {
+                    logger.error("Bruker har ikke tilgang: ${it.begrunnelse}")
+                    return false
+                }
+
+        return true
+    }
+
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/validering/PersontilgangConstraint.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/validering/PersontilgangConstraint.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.ba.sak.validering
+
+import javax.validation.Constraint
+import javax.validation.Payload
+import kotlin.reflect.KClass
+
+@Suppress("unused")
+@MustBeDocumented
+@Constraint(validatedBy = [Persontilgang::class])
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PersontilgangConstraint(val message: String = "Ikke tilgang til personer",
+                                         val groups: Array<KClass<*>> = [],
+                                         val payload: Array<KClass<out Payload>> = [])

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.config
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonOnBehalfClient
@@ -22,7 +23,11 @@ class ClientMocks {
         val mockIntegrasjonOnBehalfClient = mockk<IntegrasjonOnBehalfClient>(relaxed = false)
 
         every {
-            mockIntegrasjonOnBehalfClient.sjekkTilgangTilPersoner(any())
+            mockIntegrasjonOnBehalfClient.sjekkTilgangTilPersoner(any<Set<Person>>())
+        } returns listOf(Tilgang(true, null))
+
+        every {
+            mockIntegrasjonOnBehalfClient.sjekkTilgangTilPersoner(any<List<String>>())
         } returns listOf(Tilgang(true, null))
 
         every {

--- a/src/test/kotlin/no/nav/familie/ba/sak/validering/PersontilgangTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/validering/PersontilgangTest.kt
@@ -1,0 +1,55 @@
+package no.nav.familie.ba.sak.validering
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.RestFamilierelasjon
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.RestPersonInfo
+import no.nav.familie.ba.sak.integrasjoner.IntegrasjonOnBehalfClient
+import no.nav.familie.ba.sak.integrasjoner.domene.FAMILIERELASJONSROLLE
+import no.nav.familie.ba.sak.integrasjoner.domene.Tilgang
+import no.nav.familie.kontrakter.felles.Ressurs
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+import java.time.LocalDate
+
+class PersontilgangTest {
+    private lateinit var onBehalfClient: IntegrasjonOnBehalfClient
+    private lateinit var persontilgang: Persontilgang
+
+    @BeforeEach
+    fun setUp() {
+        onBehalfClient = mockk()
+        persontilgang = Persontilgang(onBehalfClient)
+    }
+
+    @Test
+    fun `isValid returnerer true hvis sjekkTilgangTilPersoner returnerer true for alle personer`() {
+        every { onBehalfClient.sjekkTilgangTilPersoner(any<List<String>>()) }
+                .returns(listOf(Tilgang(true),
+                                Tilgang(true),
+                                Tilgang(true)))
+        val harTilgang = persontilgang.isValid(ResponseEntity.ok(Ressurs.success(restPersonInfo())), mockk())
+        assertTrue(harTilgang)
+    }
+
+    @Test
+    fun `isValid returnerer false hvis sjekkTilgangTilPersoner returnerer false for minst en person`() {
+        every { onBehalfClient.sjekkTilgangTilPersoner(any<List<String>>()) }
+                .returns(listOf(Tilgang(true),
+                                Tilgang(false),
+                                Tilgang(true)))
+        val harTilgang = persontilgang.isValid(ResponseEntity.ok(Ressurs.success(restPersonInfo())), mockk())
+        assertFalse(harTilgang)
+    }
+
+    private fun restPersonInfo(): RestPersonInfo {
+        val familierelasjoner = listOf(
+                RestFamilierelasjon(personIdent = "123", navn = "", relasjonRolle = FAMILIERELASJONSROLLE.BARN, fødselsdato = null),
+                RestFamilierelasjon(personIdent = "456", navn = "", relasjonRolle = FAMILIERELASJONSROLLE.BARN, fødselsdato = null)
+        )
+        return RestPersonInfo(personIdent = "789", navn = "", kjønn = null, fødselsdato = LocalDate.now(), familierelasjoner = familierelasjoner)
+    }
+}


### PR DESCRIPTION
Tilgangskontroll gjøres her mot returverdien til kontrolleren, ikke på parametere på vei inn. Dette fordi vi på det tidspunktet ikke har alle data vi trenger å gjøre kontroll mot (vi har kun personident på søker, ikke på familierelasjonene). Sjekken gjøres derfor mot returverdien slik at vi ikke må gjøre et ekstra oppslag mot PDL.