### PR TITLE
Bugfix: Beregning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningController.kt
@@ -5,10 +5,8 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Personopplys
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.behandling.restDomene.RestBeregningDetalj
 import no.nav.familie.ba.sak.behandling.restDomene.RestBeregningOversikt
-import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.restDomene.RestPerson
 import no.nav.familie.ba.sak.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.common.RessursUtils.badRequest
 import no.nav.familie.ba.sak.common.RessursUtils.notFound
@@ -31,9 +29,7 @@ import java.time.LocalDate
 @Validated
 class BeregningController(
         private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
-        private val beregningService: BeregningService,
-        private val fagsakService: FagsakService,
-        private val vedtakService: VedtakService
+        private val beregningService: BeregningService
 ) {
 
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -45,6 +41,8 @@ class BeregningController(
         logger.info("{} henter oversikt over beregnet utbetaling for behandlingId={}", saksbehandlerId, behandlingId)
 
         val tilkjentYtelseForBehandling = beregningService.hentTilkjentYtelseForBehandling(behandlingId)
+        if (tilkjentYtelseForBehandling.andelerTilkjentYtelse.isEmpty()) return ResponseEntity.ok(Ressurs.success(data = emptyList()))
+
         val utbetalingsPerioder = beregnUtbetalingsperioderUtenKlassifisering(tilkjentYtelseForBehandling.andelerTilkjentYtelse)
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandling(behandlingId)
                 ?: return notFound("Fant ikke personopplysninggrunnlag for behandling $behandlingId")

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
@@ -87,7 +87,7 @@ object TilkjentYtelseService {
         return if (erBarnetrygdTil18ÅrsDag)
             YearMonth.from(tilOgMed.minusMonths(1))
         else
-            YearMonth.from(tilOgMed.plusMonths(1))
+            YearMonth.from(tilOgMed)
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
@@ -93,7 +93,7 @@ object TilkjentYtelseService {
 
 private fun maksimum(periodeFomSoker: LocalDate?, periodeFomBarn: LocalDate?): LocalDate {
     if (periodeFomSoker == null && periodeFomBarn == null) {
-        throw error("Både søker og barn kan ikke ha null i periodeFom-dato")
+        error("Både søker og barn kan ikke ha null i periodeFom-dato")
     }
 
     return maxOf(periodeFomSoker ?: LocalDate.MIN, periodeFomBarn ?: LocalDate.MIN)
@@ -101,7 +101,7 @@ private fun maksimum(periodeFomSoker: LocalDate?, periodeFomBarn: LocalDate?): L
 
 private fun minimum(periodeTomSoker: LocalDate?, periodeTomBarn: LocalDate?): LocalDate {
     if (periodeTomSoker == null && periodeTomBarn == null) {
-        throw error("Både søker og barn kan ikke ha null i periodeTom-dato")
+        error("Både søker og barn kan ikke ha null i periodeTom-dato")
     }
 
     return minOf(periodeTomBarn ?: LocalDate.MAX, periodeTomSoker ?: LocalDate.MAX)

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
@@ -93,7 +93,7 @@ object TilkjentYtelseService {
 
 private fun maksimum(periodeFomSoker: LocalDate?, periodeFomBarn: LocalDate?): LocalDate {
     if (periodeFomSoker == null && periodeFomBarn == null) {
-        throw IllegalStateException("Både søker og barn kan ikke ha null i periodeFom dato")
+        throw error("Både søker og barn kan ikke ha null i periodeFom-dato")
     }
 
     return maxOf(periodeFomSoker ?: LocalDate.MIN, periodeFomBarn ?: LocalDate.MIN)
@@ -101,7 +101,7 @@ private fun maksimum(periodeFomSoker: LocalDate?, periodeFomBarn: LocalDate?): L
 
 private fun minimum(periodeTomSoker: LocalDate?, periodeTomBarn: LocalDate?): LocalDate {
     if (periodeTomSoker == null && periodeTomBarn == null) {
-        throw IllegalStateException("Både søker og barn kan ikke ha null i periodeTom dato")
+        throw error("Både søker og barn kan ikke ha null i periodeTom-dato")
     }
 
     return minOf(periodeTomBarn ?: LocalDate.MAX, periodeTomSoker ?: LocalDate.MAX)

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
@@ -27,9 +27,14 @@ data class PeriodeResultat(
     }
 
     fun overlapper(annetPeriodeResultat: PeriodeResultat): Boolean {
-         return !(periodeFom == null && annetPeriodeResultat.periodeFom == null)
-                && !(periodeTom == null && annetPeriodeResultat.periodeTom == null)
-                && (periodeFom == null || annetPeriodeResultat.periodeTom == null || periodeFom <= annetPeriodeResultat.periodeTom)
+        if (periodeFom == null && annetPeriodeResultat.periodeFom == null) {
+            throw error("Både søker og barn kan ikke ha null i fom-dato på vilkårsresultatet")
+        }
+        if (periodeTom == null && annetPeriodeResultat.periodeTom == null) {
+            throw error("Både søker og barn kan ikke ha null i tom-dato på vilkårsresultatet")
+        }
+
+        return (periodeFom == null || annetPeriodeResultat.periodeTom == null || periodeFom <= annetPeriodeResultat.periodeTom)
                 && (periodeTom == null || annetPeriodeResultat.periodeFom == null || periodeTom >= annetPeriodeResultat.periodeFom)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
@@ -28,10 +28,10 @@ data class PeriodeResultat(
 
     fun overlapper(annetPeriodeResultat: PeriodeResultat): Boolean {
         if (periodeFom == null && annetPeriodeResultat.periodeFom == null) {
-            throw error("Både søker og barn kan ikke ha null i fom-dato på vilkårsresultatet")
+            error("Enten søker eller barn må ha fom-dato på vilkårsresultatet")
         }
         if (periodeTom == null && annetPeriodeResultat.periodeTom == null) {
-            throw error("Både søker og barn kan ikke ha null i tom-dato på vilkårsresultatet")
+            error("Enten søker eller barn må ha tom-dato på vilkårsresultatet")
         }
 
         return (periodeFom == null || annetPeriodeResultat.periodeTom == null || periodeFom <= annetPeriodeResultat.periodeTom)

--- a/src/test/kotlin/no/nav/familie/ba/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/beregning/BeregningServiceTest.kt
@@ -266,7 +266,7 @@ class BeregningServiceTest {
         val andelerTilkjentYtelse = slot.captured.andelerTilkjentYtelse.sortedBy { it.stønadTom }
 
         Assertions.assertEquals(periode1Fom.plusMonths(1).withDayOfMonth(1), andelerTilkjentYtelse[0].stønadFom)
-        Assertions.assertEquals(periode1Tom.plusMonths(1).sisteDagIMåned(), andelerTilkjentYtelse[0].stønadTom)
+        Assertions.assertEquals(periode1Tom.sisteDagIMåned(), andelerTilkjentYtelse[0].stønadTom)
         Assertions.assertEquals(1054, andelerTilkjentYtelse[0].beløp)
 
         Assertions.assertEquals(periode3Fom.plusMonths(1).withDayOfMonth(1), andelerTilkjentYtelse[1].stønadFom)
@@ -274,7 +274,7 @@ class BeregningServiceTest {
         Assertions.assertEquals(1054, andelerTilkjentYtelse[1].beløp)
 
         Assertions.assertEquals(periode3Fom.plusMonths(1).withDayOfMonth(1), andelerTilkjentYtelse[2].stønadFom)
-        Assertions.assertEquals(periode3Tom.plusMonths(1).sisteDagIMåned(), andelerTilkjentYtelse[2].stønadTom)
+        Assertions.assertEquals(periode3Tom.sisteDagIMåned(), andelerTilkjentYtelse[2].stønadTom)
         Assertions.assertEquals(1054, andelerTilkjentYtelse[2].beløp)
     }
 }

--- a/src/test/resources/beregning/vilkår_til_tilkjent_ytelse/søker_med_ett_barn_inntil_to_perioder.csv
+++ b/src/test/resources/beregning/vilkår_til_tilkjent_ytelse/søker_med_ett_barn_inntil_to_perioder.csv
@@ -2,9 +2,9 @@ sakType;søkerPeriode1;søkerVilkår1;søkerPeriode2;søkerVilkår2;barn1Periode
 NASJONAL;;;;;;;;;;;;;;;
 NASJONAL;;;;;2021-09 – 2034-05;Under 18;;;;;;;;;
 NASJONAL;2020-09 – 2022-05;Gift;;;;;;;;;;;;;
-NASJONAL;2020-09 – 2022-05;Bosatt;;;2021-09 – 2034-05;Gift, bosatt, under 18, bor med søker;;;;1054;2021-10-01 - 2022-06-30;ORDINÆR_BARNETRYGD;;;
-NASJONAL;2020-09 – 2022-05;Bosatt;2022-06 – 2024-11;Bosatt;2018-09 – 2021-07;Gift, bosatt, under 18, bor med søker;2023-02 – 2027-04;Gift, bosatt, under 18, bor med søker;;1054;2020-10-01 – 2021-06-30;ORDINÆR_BARNETRYGD;1054;2023-03-01 – 2024-12-31;ORDINÆR_BARNETRYGD
+NASJONAL;2020-09 – 2022-05;Bosatt;;;2021-09 – 2034-05;Gift, bosatt, under 18, bor med søker;;;;1054;2021-10-01 - 2022-05-31;ORDINÆR_BARNETRYGD;;;
+NASJONAL;2020-09 – 2022-05;Bosatt;2022-06 – 2024-11;Bosatt;2018-09 – 2021-07;Gift, bosatt, under 18, bor med søker;2023-02 – 2027-04;Gift, bosatt, under 18, bor med søker;;1054;2020-10-01 – 2021-06-30;ORDINÆR_BARNETRYGD;1054;2023-03-01 – 2024-11-30;ORDINÆR_BARNETRYGD
 NASJONAL;2020-09 – 2034-05;Bosatt;;;2020-09 – 2034-05;Gift, bosatt, under 18, bor med søker;;;;1054;2020-10-01 – 2034-04-30;ORDINÆR_BARNETRYGD;;;
-NASJONAL;2022-09 – 2034-05;Bosatt;;;2018-09 – 2024-07;Gift, bosatt, under 18, bor med søker;2027-02 – 2037-10;Gift, bosatt, under 18, bor med søker;;1054;2022-10-01 – 2024-06-30;ORDINÆR_BARNETRYGD;1054;2027-03-01 – 2034-06-30;ORDINÆR_BARNETRYGD
+NASJONAL;2022-09 – 2034-05;Bosatt;;;2018-09 – 2024-07;Gift, bosatt, under 18, bor med søker;2027-02 – 2037-10;Gift, bosatt, under 18, bor med søker;;1054;2022-10-01 – 2024-06-30;ORDINÆR_BARNETRYGD;1054;2027-03-01 – 2034-05-31;ORDINÆR_BARNETRYGD
 EØS;2020-09 – 2034-05;Bosatt;;;2020-09 – 2034-05;Gift, bosatt, under 18, bor med søker;;;;;;;;;
 EØS;2020-09 – 2034-05;Bosatt, opphold;;;2020-09 – 2034-05;Gift, bosatt, opphold, under 18, bor med søker;;;;1054;2020-10-01 - 2034-04-30;ORDINÆR_BARNETRYGD;;;


### PR DESCRIPTION
Noen småfikser på beregning 🔨 
- Returner en tom liste opp til beregningsoversikten i frontend hvis søker ikke har fått noen utbetaling. Tidligere feilet endepunktet og skapte støy i logger/alerts
- I tilfeller hvor det ikke er 18-års vilkåret som begrenser tom-dato for stønaden, settes tom-dato til den siste måneden hvor vilkårene er innfridd. Tidligere var tom-datoen satt til måneden etter, klassisk misforståelse rundt begrepsbruk 🤦‍♀️ 
- Kast feil dersom både søker og barn har nullverdi i fom eller tom på vilkårsresultatet. Tidligere feilet denne "stille" og vilkårsvurderingen gikk gjennom, det ble bare ikke opprettet andeler og neste skjermbilde kræsjet. 