### PR TITLE
Teknisk opphør mot økonomi

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/Behandling.kt
@@ -61,7 +61,8 @@ enum class BehandlingType(val visningsnavn: String) {
     REVURDERING("Revurdering"),
     MIGRERING_FRA_INFOTRYGD("Migrering fra infotrygd"),
     KLAGE("Klage"),
-    MIGRERING_FRA_INFOTRYGD_OPPHØRT("Opphør migrering fra infotrygd")
+    MIGRERING_FRA_INFOTRYGD_OPPHØRT("Opphør migrering fra infotrygd"),
+    TEKNISK_OPPHØR("Teknisk opphør")
 }
 
 enum class BehandlingKategori {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -7,7 +7,10 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Personopplys
 import no.nav.familie.ba.sak.behandling.grunnlag.søknad.SøknadDTO
 import no.nav.familie.ba.sak.behandling.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.behandling.restDomene.RestFagsak
+import no.nav.familie.ba.sak.behandling.steg.StegType
 import no.nav.familie.ba.sak.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.dokument.DokumentService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -23,6 +26,7 @@ class VedtakService(private val behandlingService: BehandlingService,
                     private val behandlingResultatService: BehandlingResultatService,
                     private val søknadGrunnlagService: SøknadGrunnlagService,
                     private val vedtakRepository: VedtakRepository,
+                    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
                     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
                     private val dokumentService: DokumentService,
                     private val fagsakService: FagsakService) {
@@ -70,6 +74,14 @@ class VedtakService(private val behandlingService: BehandlingService,
         // Trenger ikke flush her fordi det kreves unikhet på (behandlingid,aktiv) og det er ny behandlingsid
         vedtakRepository.save(gjeldendeVedtak.also { it.aktiv = false })
         vedtakRepository.save(nyttVedtak)
+
+        val nyTilkjentYtelse = TilkjentYtelse(
+                behandling = nyBehandling,
+                opprettetDato = LocalDate.now(),
+                endretDato = LocalDate.now()
+        )
+        tilkjentYtelseRepository.save(nyTilkjentYtelse)
+        behandlingRepository.save(nyBehandling.also { it.steg = StegType.FERDIGSTILLE_BEHANDLING })
 
         postProsessor(nyttVedtak)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/StatusFraOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/StatusFraOppdrag.kt
@@ -54,7 +54,9 @@ class StatusFraOppdrag(
                                 BehandlingStatus.IVERKSATT
                         )
 
-                        if (behandling.type != BehandlingType.MIGRERING_FRA_INFOTRYGD && behandling.type != BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT) {
+                        if (behandling.type !== BehandlingType.MIGRERING_FRA_INFOTRYGD
+                                && behandling.type !== BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT
+                                && behandling.type !== BehandlingType.TEKNISK_OPPHØR) {
                             opprettTaskJournalførVedtaksbrev(statusFraOppdragDTO.vedtaksId, task)
                         } else {
                             opprettFerdigstillBehandling(statusFraOppdragDTO)

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.behandling.BehandlingService
 import no.nav.familie.ba.sak.behandling.domene.BehandlingResultatService
 import no.nav.familie.ba.sak.behandling.domene.BehandlingResultatType
 import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.beregning.BeregningService
 import no.nav.familie.ba.sak.task.dto.StatusFraOppdragDTO
@@ -23,7 +24,10 @@ class ØkonomiService(
     fun oppdaterTilkjentYtelseOgIverksettVedtak(behandlingsId: Long, vedtakId: Long, saksbehandlerId: String) {
         val vedtak = vedtakService.hent(vedtakId)
         val behandlingResultatType =
-                behandlingResultatService.hentBehandlingResultatTypeFraBehandling(behandlingId = vedtak.behandling.id)
+                if (vedtak.behandling.type == BehandlingType.TEKNISK_OPPHØR
+                        || vedtak.behandling.type == BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT)
+                    BehandlingResultatType.OPPHØRT
+                else behandlingResultatService.hentBehandlingResultatTypeFraBehandling(behandlingId = vedtak.behandling.id)
 
         val andelerTilkjentYtelse = if (behandlingResultatType == BehandlingResultatType.OPPHØRT) {
             val forrigeVedtak = vedtakService.hent(vedtak.forrigeVedtakId!!)


### PR DESCRIPTION
Ny behandlingstype for teknisk opphør, for å støtte opphør på mer enn migreringer. Noen justeringer i opphørsfunksjonalitet etter store endringer i vilkårsvurdering og beregning i det siste. 

Har testet dette med postgres lokalt og ser ut til å fungere. 