### PR TITLE
Bugfix: Beregning med Tredjelandsborger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/TilkjentYtelseService.kt
@@ -15,6 +15,7 @@ import java.time.YearMonth
 object TilkjentYtelseService {
 
     fun beregnTilkjentYtelse(behandlingResultat: BehandlingResultat,
+                             sakType: SakType,
                              personopplysningGrunnlag: PersonopplysningGrunnlag): TilkjentYtelse {
 
         val identBarnMap = personopplysningGrunnlag.barna
@@ -26,13 +27,13 @@ object TilkjentYtelseService {
         val innvilgetPeriodeResultatSøker = behandlingResultat.periodeResultater(brukMåned = true).filter {
             søkerMap.containsKey(it.personIdent) && it.allePåkrevdeVilkårErOppfylt(
                     PersonType.SØKER,
-                    SakType.valueOfType(behandlingResultat.behandling.kategori)
+                    sakType
             )
         }
         val innvilgedePeriodeResultatBarna = behandlingResultat.periodeResultater(brukMåned = true).filter {
             identBarnMap.containsKey(it.personIdent) && it.allePåkrevdeVilkårErOppfylt(
                     PersonType.BARN,
-                    SakType.valueOfType(behandlingResultat.behandling.kategori)
+                    sakType
             )
         }
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/beregning/BeregningServiceTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.behandling.domene.BehandlingResultatRepository
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.behandling.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.behandling.restDomene.toRestFagsak
 import no.nav.familie.ba.sak.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.beregning.domene.*
@@ -20,6 +21,7 @@ class BeregningServiceTest {
 
     val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
     val behandlingResultatRepository = mockk<BehandlingResultatRepository>()
+    val søknadGrunnlagService = mockk<SøknadGrunnlagService>()
 
     lateinit var beregningService: BeregningService
 
@@ -30,7 +32,8 @@ class BeregningServiceTest {
 
          beregningService = BeregningService(andelTilkjentYtelseRepository,
                 fagsakService,
-                tilkjentYtelseRepository,
+                 søknadGrunnlagService,
+                 tilkjentYtelseRepository,
                 behandlingResultatRepository)
 
         every { andelTilkjentYtelseRepository.slettAlleAndelerTilkjentYtelseForBehandling(any()) } just Runs
@@ -73,6 +76,7 @@ class BeregningServiceTest {
 
         every { behandlingResultatRepository.findByBehandlingAndAktiv(any()) } answers { behandlingResultat }
         every { tilkjentYtelseRepository.save(any<TilkjentYtelse>()) } returns lagInitiellTilkjentYtelse(behandling)
+        every { søknadGrunnlagService.hentAktiv(any())?.hentSøknadDto() } returns lagSøknadDTO(søkerFnr, randomFnr(), listOf(barn1Fnr))
 
         beregningService.oppdaterBehandlingMedBeregning(behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag)
@@ -120,6 +124,7 @@ class BeregningServiceTest {
 
         every { behandlingResultatRepository.findByBehandlingAndAktiv(any()) } answers { behandlingResultat }
         every { tilkjentYtelseRepository.save(any<TilkjentYtelse>()) } returns lagInitiellTilkjentYtelse(behandling)
+        every { søknadGrunnlagService.hentAktiv(any())?.hentSøknadDto() } returns lagSøknadDTO(søkerFnr, randomFnr(), listOf(barn1Fnr))
 
         beregningService.oppdaterBehandlingMedBeregning(behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag)
@@ -172,6 +177,7 @@ class BeregningServiceTest {
 
         every { behandlingResultatRepository.findByBehandlingAndAktiv(any()) } answers { behandlingResultat }
         every { tilkjentYtelseRepository.save(any<TilkjentYtelse>()) } returns lagInitiellTilkjentYtelse(behandling)
+        every { søknadGrunnlagService.hentAktiv(any())?.hentSøknadDto() } returns lagSøknadDTO(søkerFnr, randomFnr(), listOf(barn1Fnr))
 
         beregningService.oppdaterBehandlingMedBeregning(behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag)
@@ -256,6 +262,7 @@ class BeregningServiceTest {
 
         every { behandlingResultatRepository.findByBehandlingAndAktiv(any()) } answers { behandlingResultat }
         every { tilkjentYtelseRepository.save(any<TilkjentYtelse>()) } returns lagInitiellTilkjentYtelse(behandling)
+        every { søknadGrunnlagService.hentAktiv(any())?.hentSøknadDto() } returns lagSøknadDTO(søkerFnr, randomFnr(), listOf(barn1Fnr, barn2Fnr))
 
         beregningService.oppdaterBehandlingMedBeregning(behandling = behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag)

--- a/src/test/kotlin/no/nav/familie/ba/sak/beregning/VilkårTilTilkjentYtelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/beregning/VilkårTilTilkjentYtelseTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.behandling.vilkår.PersonResultat
+import no.nav.familie.ba.sak.behandling.vilkår.SakType
 import no.nav.familie.ba.sak.behandling.vilkår.Vilkår
 import no.nav.familie.ba.sak.behandling.vilkår.VilkårResultat
 import no.nav.familie.ba.sak.beregning.domene.*
@@ -14,7 +15,6 @@ import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.nare.core.evaluations.Resultat
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
 import java.time.LocalDate
@@ -63,6 +63,7 @@ class VilkårTilTilkjentYtelseTest {
 
         val faktiskTilkjentYtelse = TilkjentYtelseService.beregnTilkjentYtelse(
                 behandlingResultat = behandlingResultat,
+                sakType = SakType.valueOf(sakType),
                 personopplysningGrunnlag = personopplysningGrunnlag
         )
 
@@ -125,6 +126,7 @@ class VilkårTilTilkjentYtelseTest {
 
         val faktiskTilkjentYtelse = TilkjentYtelseService.beregnTilkjentYtelse(
                 behandlingResultat = behandlingResultat,
+                sakType = SakType.NASJONAL,
                 personopplysningGrunnlag = personopplysningGrunnlag
         )
 


### PR DESCRIPTION
Logikk for å hente riktig sakstype i beregning. For tredjelandsborgere er det avhengig av søknadsgrunnlaget, ikke bare behandlingskategorien