### PR TITLE
Bugfix/pdl

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.behandling.fagsak.Fagsak
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
+import no.nav.familie.ba.sak.integrasjoner.domene.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.ba.sak.integrasjoner.domene.Arbeidsfordelingsenhet
 import org.springframework.stereotype.Service
 
@@ -13,19 +14,30 @@ class ArbeidsfordelingService(private val behandlingRepository: BehandlingReposi
                               private val integrasjonClient: IntegrasjonClient) {
 
     fun hentBehandlendeEnhet(fagsak: Fagsak): List<Arbeidsfordelingsenhet> {
-        val søker = integrasjonClient.hentPersoninfoFor(fagsak.personIdent.ident)
+        val søker = identMedAdressebeskyttelse(fagsak.personIdent.ident)
 
         val aktivBehandling = behandlingRepository.findByFagsakAndAktiv(fagsak.id)
                               ?: error("Kunne ikke finne en aktiv behandling på fagsak med ID: ${fagsak.id}")
 
-        val personinfoliste = when (val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(aktivBehandling.id)) {
-              null -> listOf(søker)
-              else -> personopplysningGrunnlag.barna.map { barn ->
-                integrasjonClient.hentPersoninfoFor(barn.personIdent.ident) }.plus(søker)
+        val personinfoliste = when (val personopplysningGrunnlag =
+                personopplysningGrunnlagRepository.findByBehandlingAndAktiv(aktivBehandling.id)) {
+            null -> listOf(søker)
+            else -> personopplysningGrunnlag.barna.map { barn ->
+                identMedAdressebeskyttelse(barn.personIdent.ident)
+            }.plus(søker)
         }
-                val strengesteDiskresjonskode =
-                finnStrengesteDiskresjonskode(personinfoliste)
 
-        return integrasjonClient.hentBehandlendeEnhet(søker.geografiskTilknytning, strengesteDiskresjonskode)
+        val identMedStrengeste = finnPersonMedStrengesteAdressebeskyttelse(personinfoliste)
+
+        return integrasjonClient.hentBehandlendeEnhet(identMedStrengeste ?: søker.ident)
     }
+
+    fun identMedAdressebeskyttelse(ident: String) = IdentMedAdressebeskyttelse(
+            ident = ident,
+            adressebeskyttelsegradering = integrasjonClient.hentPersoninfoFor(ident).adressebeskyttelseGradering)
+
+    data class IdentMedAdressebeskyttelse(
+            val ident: String,
+            val adressebeskyttelsegradering: ADRESSEBESKYTTELSEGRADERING?
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/DiskresjonskodeUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/DiskresjonskodeUtils.kt
@@ -1,22 +1,27 @@
 package no.nav.familie.ba.sak.arbeidsfordeling
 
-import no.nav.familie.ba.sak.integrasjoner.domene.Personinfo
+import no.nav.familie.ba.sak.integrasjoner.domene.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.ba.sak.arbeidsfordeling.ArbeidsfordelingService.IdentMedAdressebeskyttelse
 
-fun finnStrengesteDiskresjonskode(personer: List<Personinfo>): String? {
-    return personer.fold(null, fun(kode: String?, personinfo: Personinfo): String? {
-        return when {
-            kode == Diskresjonskode.KODE6.kode || personinfo.diskresjonskode == Diskresjonskode.KODE6.kode -> {
-                Diskresjonskode.KODE6.kode
-            }
-            kode == Diskresjonskode.KODE7.kode || personinfo.diskresjonskode == Diskresjonskode.KODE7.kode -> {
-                Diskresjonskode.KODE7.kode
-            }
-            else -> null
-        }
-    })
-}
-
-enum class Diskresjonskode(val kode: String) {
-    KODE6("SPSF"),
-    KODE7("SPFO")
+fun finnPersonMedStrengesteAdressebeskyttelse(personer: List<IdentMedAdressebeskyttelse>): String? {
+    return personer.fold(null,
+                         fun(person: IdentMedAdressebeskyttelse?,
+                             neste: IdentMedAdressebeskyttelse): IdentMedAdressebeskyttelse? {
+                             return when {
+                                 person?.adressebeskyttelsegradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG -> {
+                                     person
+                                 }
+                                 neste.adressebeskyttelsegradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG -> {
+                                     neste
+                                 }
+                                 person?.adressebeskyttelsegradering == ADRESSEBESKYTTELSEGRADERING.FORTROLIG -> {
+                                     person
+                                 }
+                                 neste.adressebeskyttelsegradering == ADRESSEBESKYTTELSEGRADERING.FORTROLIG
+                                 -> {
+                                     neste
+                                 }
+                                 else -> null
+                             }
+                         })?.ident
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/ToTrinnKontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/ToTrinnKontrollService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.behandling
 import no.nav.familie.ba.sak.behandling.domene.Behandling
 import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.behandling.vedtak.Beslutning
-import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/ToTrinnKontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/ToTrinnKontrollService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.behandling
 import no.nav.familie.ba.sak.behandling.domene.Behandling
 import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.behandling.vedtak.Beslutning
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
@@ -141,16 +141,13 @@ class IntegrasjonClient(@Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val 
     }
 
     @Retryable(value = [IntegrasjonException::class], maxAttempts = 3, backoff = Backoff(delay = 5000))
-    fun hentBehandlendeEnhet(geografiskTilknytning: String?, diskresjonskode: String?): List<Arbeidsfordelingsenhet> {
+    fun hentBehandlendeEnhet(ident: String): List<Arbeidsfordelingsenhet> {
         val uri = UriComponentsBuilder.fromUri(integrasjonUri)
-                .pathSegment("arbeidsfordeling", "enhet")
-                .queryParam("tema", "BAR")
-                .queryParam("geografi", geografiskTilknytning)
-                .queryParam("diskresjonskode", diskresjonskode)
+                .pathSegment("arbeidsfordeling", "enhet", "BAR")
                 .build().toUri()
 
         return try {
-            val response = getForEntity<Ressurs<List<Arbeidsfordelingsenhet>>>(uri)
+            val response = getForEntity<Ressurs<List<Arbeidsfordelingsenhet>>>(uri, httpHeaders = HttpHeaders().medPersonident(ident))
             response.data ?: throw IntegrasjonException("Objektet fra integrasjonstjenesten mot arbeidsfordeling er tomt",
                                                         null,
                                                         uri)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/domene/Personinfo.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/domene/Personinfo.kt
@@ -12,8 +12,7 @@ import java.time.LocalDate
 @JsonIgnoreProperties
 data class Personinfo(
         var fødselsdato: LocalDate,
-        val geografiskTilknytning: String? = null,
-        val diskresjonskode: String? = null,
+        val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,
         val navn: String? = null,
         @JsonDeserialize(using = KjonnDeserializer::class)
         val kjønn: Kjønn? = null,
@@ -30,6 +29,13 @@ data class Familierelasjoner(
 data class Personident(
         val id: String
 )
+
+enum class ADRESSEBESKYTTELSEGRADERING {
+    STRENGT_FORTROLIG_UTLAND, // Kode 19
+    FORTROLIG, // Kode 7
+    STRENGT_FORTROLIG, // Kode 6
+    UGRADERT
+}
 
 data class IdentInformasjon(val ident: String,
                             val historisk: Boolean,

--- a/src/test/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -33,10 +33,9 @@ class ArbeidsfordelingServiceTest {
 
     @Test
     fun `hentBehandlendeEnhet skal kjøre uten feil`() {
-        val fagsak = Fagsak(personIdent = PersonIdent(""),
-                                                                                       aktørId = AktørId("1"))
+        val fagsak = Fagsak(personIdent = PersonIdent(""), aktørId = AktørId("1"))
 
-        every { integrasjonClient.hentBehandlendeEnhet(any(), any()) } returns listOf()
+        every { integrasjonClient.hentBehandlendeEnhet(any()) } returns listOf()
         every { integrasjonClient.hentPersoninfoFor(any()) } returns Personinfo(LocalDate.now())
         every { behandlingRepository.findByFagsakAndAktiv(any()) } returns Behandling(
                 fagsak = fagsak,

--- a/src/test/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/DiskresjonskodeUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/DiskresjonskodeUtilsTest.kt
@@ -1,54 +1,52 @@
 package no.nav.familie.ba.sak.arbeidsfordeling
 
-import no.nav.familie.ba.sak.integrasjoner.domene.Personinfo
+import no.nav.familie.ba.sak.integrasjoner.domene.ADRESSEBESKYTTELSEGRADERING
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
+import no.nav.familie.ba.sak.arbeidsfordeling.ArbeidsfordelingService.IdentMedAdressebeskyttelse
+
 
 class DiskresjonskodeUtilsTest {
-    val personUtenDiskresjonskode = Personinfo(LocalDate.now(), null, null)
-    val personKode7 = Personinfo(LocalDate.now(), null, Diskresjonskode.KODE7.kode)
-    val personKode6 = Personinfo(LocalDate.now(), null, Diskresjonskode.KODE6.kode)
-    val personMedAnnenDiskresjonskode = Personinfo(LocalDate.now(), null, "FOO")
+    val personUtenDiskresjonskode = IdentMedAdressebeskyttelse(
+                    ident = "IDENT_UTEN",
+                    adressebeskyttelsegradering = null)
+    val personFortrolig = IdentMedAdressebeskyttelse(
+            ident = "IDENT_FORTROLIG",
+            adressebeskyttelsegradering = ADRESSEBESKYTTELSEGRADERING.FORTROLIG) // Kode 7
+    val personStrengtFortrolig = IdentMedAdressebeskyttelse(
+            ident = "IDENT_STRENGT_FORTROLIG",
+            adressebeskyttelsegradering = ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)// Kode 6
 
     @Test
-    fun `ingen er kode 6 eller kode 7 - skal gi null`() {
-        assertEquals(null, finnStrengesteDiskresjonskode(listOf(
+    fun `ingen har adressebeskyttelse - skal gi null`() {
+        assertEquals(null, finnPersonMedStrengesteAdressebeskyttelse(listOf(
                 personUtenDiskresjonskode,
                 personUtenDiskresjonskode)
         ))
     }
 
     @Test
-    fun `en er kode 6, en er kode 7, en har ingen diskresjonskode - skal gi kode 6`() {
-        assertEquals(Diskresjonskode.KODE6.kode,
-                     finnStrengesteDiskresjonskode(listOf(
-                             personKode7,
-                             personKode6,
+    fun `en har adressebeskyttelse STRENGT_FORTROLIG, en har adressebeskyttelse FORTROLIG, en har ingen adressebeskyttelse - skal gi adressebeskyttelse STRENGT_FORTROLIG`() {
+        assertEquals("IDENT_STRENGT_FORTROLIG",
+                     finnPersonMedStrengesteAdressebeskyttelse(listOf(
+                             personFortrolig,
+                             personStrengtFortrolig,
                              personUtenDiskresjonskode)
                      ))
     }
 
     @Test
-    fun `en har en annen diskresjonskode som vi ikke håndterer - skal gi null`() {
-        assertEquals(null,
-                     finnStrengesteDiskresjonskode(listOf(
-                             personMedAnnenDiskresjonskode)))
-    }
-
-    @Test
-    fun `en har kode 7, en har ingen diskresjonskode, en har en ukjent diskresjonskode - skal gi kode 7`() {
-        assertEquals(Diskresjonskode.KODE7.kode,
-                     finnStrengesteDiskresjonskode(listOf(
+    fun `en har adressebeskyttelse FORTROLIG, en har ingen adressebeskyttelse - skal gi adressebeskyttelse FORTROLIG`() {
+        assertEquals("IDENT_FORTROLIG",
+                     finnPersonMedStrengesteAdressebeskyttelse(listOf(
                              personUtenDiskresjonskode,
-                             personKode7,
-                             personMedAnnenDiskresjonskode
+                             personFortrolig
                      )))
     }
 
     @Test
     fun `tom liste - skal gi null`() {
         assertEquals(null,
-                     finnStrengesteDiskresjonskode(listOf<Personinfo>()))
+                     finnPersonMedStrengesteAdressebeskyttelse(listOf<IdentMedAdressebeskyttelse>()))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -55,7 +55,7 @@ class ClientMocks {
 
         every { mockIntegrasjonClient.journalFørVedtaksbrev(any(), any(), TEST_PDF) } returns "journalpostId"
 
-        every { mockIntegrasjonClient.hentBehandlendeEnhet(any(), any()) } returns listOf(Arbeidsfordelingsenhet("9999",
+        every { mockIntegrasjonClient.hentBehandlendeEnhet(any()) } returns listOf(Arbeidsfordelingsenhet("9999",
                                                                                                                  "Ukjent"))
 
         every { mockIntegrasjonClient.distribuerVedtaksbrev(any()) } just runs
@@ -64,7 +64,7 @@ class ClientMocks {
 
         every { mockIntegrasjonClient.ferdigstillOppgave(any()) } just runs
 
-        every { mockIntegrasjonClient.hentBehandlendeEnhet(any(), any()) } returns
+        every { mockIntegrasjonClient.hentBehandlendeEnhet(any()) } returns
                 listOf(Arbeidsfordelingsenhet("2970", "enhetsNavn"))
 
         every { mockIntegrasjonClient.hentDokument(any(), any()) } returns

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
@@ -236,7 +236,7 @@ class IntergrasjonTjenesteTest {
                         .willReturn(okJson(objectMapper.writeValueAsString(success(listOf(
                                 Arbeidsfordelingsenhet("2", "foo")))))))
 
-        val enhet = integrasjonClient.hentBehandlendeEnhet("1", null)
+        val enhet = integrasjonClient.hentBehandlendeEnhet("1")
         assertThat(enhet).isNotEmpty
         assertThat(enhet.first().enhetId).isEqualTo("2")
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
@@ -231,7 +231,7 @@ class IntergrasjonTjenesteTest {
     @Test
     @Tag("integration")
     fun `hentBehandlendeEnhet returnerer OK`() {
-        stubFor(get("/api/arbeidsfordeling/enhet?tema=BAR&geografi=1&diskresjonskode")
+        stubFor(get("/api/arbeidsfordeling/enhet/BAR")
                         .withHeader("Accept", containing("json"))
                         .willReturn(okJson(objectMapper.writeValueAsString(success(listOf(
                                 Arbeidsfordelingsenhet("2", "foo")))))))


### PR DESCRIPTION
Går over til å bruke nytt endepunkt i familie-integrasjoner hvor integrasjoner selv henter diskresjonskode og geografisk tilknytning på bruker. Vi sender inn brukeren med høyest addressebeskyttelse.