### PR TITLE
Save the simulation task after creating it

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.RessursUtils.illegalState
 import no.nav.familie.ba.sak.task.SimuleringTask
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -26,7 +27,8 @@ import org.springframework.web.bind.annotation.*
 @ProtectedWithClaims(issuer = "azuread")
 @Validated
 class BehandlingController(private val fagsakService: FagsakService,
-                           private val stegService: StegService) {
+                           private val stegService: StegService,
+                           private val taskRepository: TaskRepository) {
 
     private val antallManuelleBehandlingerOpprettet: Map<BehandlingType, Counter> = initBehandlingMetrikker("manuell")
 
@@ -38,7 +40,7 @@ class BehandlingController(private val fagsakService: FagsakService,
     fun opprettBehandling(@RequestBody nyBehandling: NyBehandling): ResponseEntity<Ressurs<RestFagsak>> {
         if (nyBehandling.søkersIdent.isBlank()) {
             throw Feil(message = "Søkers ident kan ikke være blank",
-                    frontendFeilmelding = "Klarte ikke å opprette behandling. Mangler ident på bruker.")
+                       frontendFeilmelding = "Klarte ikke å opprette behandling. Mangler ident på bruker.")
         }
 
         return Result.runCatching {
@@ -58,7 +60,10 @@ class BehandlingController(private val fagsakService: FagsakService,
     @PutMapping(path = ["behandlinger"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun opprettEllerOppdaterBehandlingFraHendelse(@RequestBody
                                                   nyBehandling: NyBehandlingHendelse): ResponseEntity<Ressurs<String>> {
-        return Result.runCatching { SimuleringTask.opprettTask(nyBehandling) }
+        return Result.runCatching {
+            val task = SimuleringTask.opprettTask(nyBehandling)
+            taskRepository.save(task)
+        }
                 .fold(
                         onFailure = {
                             illegalState("Opprettelse av behandling fra hendelse feilet: ${it.message}", it)
@@ -73,9 +78,9 @@ class BehandlingController(private val fagsakService: FagsakService,
     private fun initBehandlingMetrikker(type: String): Map<BehandlingType, Counter> {
         return BehandlingType.values().map {
             it to Metrics.counter("behandling.opprettet.$type", "type",
-                    it.name,
-                    "beskrivelse",
-                    it.visningsnavn)
+                                  it.name,
+                                  "beskrivelse",
+                                  it.visningsnavn)
         }.toMap()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SimuleringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SimuleringTask.kt
@@ -20,6 +20,7 @@ class SimuleringTask(
     override fun doTask(task: Task) {
         val nyBehandling = objectMapper.readValue(task.payload, NyBehandlingHendelse::class.java)
         try {
+            LOG.info("Kjører simulering task")
             stegService.regelkjørBehandling(nyBehandling)
         } catch (e: SimulationException) {
             LOG.info("Simulering av behandling. Data ikke persistert.")


### PR DESCRIPTION
In the previous PR we created a task for simulating "behandling" for "fødselshendelse", but we did not save it to task repository, which caused the task never being executed. The PR fixes the bug by saving the task, and also added log to make the execution of task easier to trace.