### PR TITLE
Fiks for å iverksette migrering på nytt etter opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/Utbetalingsoppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/Utbetalingsoppdrag.kt
@@ -20,6 +20,7 @@ import java.math.BigDecimal
 fun lagUtbetalingsoppdrag(saksbehandlerId: String,
                           vedtak: Vedtak,
                           behandlingResultatType: BehandlingResultatType,
+                          erFørsteBehandlingPåFagsak: Boolean,
                           andelerTilkjentYtelse: List<AndelTilkjentYtelse>): Utbetalingsoppdrag {
 
     val erOpphør = behandlingResultatType == BehandlingResultatType.OPPHØRT
@@ -56,7 +57,7 @@ fun lagUtbetalingsoppdrag(saksbehandlerId: String,
 
     return Utbetalingsoppdrag(
             saksbehandlerId = saksbehandlerId,
-            kodeEndring = if (!erOpphør) NY else UEND,
+            kodeEndring = if (!erOpphør && erFørsteBehandlingPåFagsak) NY else UEND,
             fagSystem = FAGSYSTEM,
             saksnummer = vedtak.behandling.fagsak.id.toString(),
             aktoer = vedtak.behandling.fagsak.hentAktivIdent().ident,

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiService.kt
@@ -35,7 +35,15 @@ class ØkonomiService(
             beregningService.hentAndelerTilkjentYtelseForBehandling(forrigeVedtak.behandling.id)
         } else beregningService.hentAndelerTilkjentYtelseForBehandling(behandlingsId)
 
-        val utbetalingsoppdrag = lagUtbetalingsoppdrag(saksbehandlerId, vedtak, behandlingResultatType, andelerTilkjentYtelse)
+        val erFørsteBehandlingPåFagsak = behandlingService.hentBehandlinger(vedtak.behandling.fagsak.id).size == 1
+
+        val utbetalingsoppdrag = lagUtbetalingsoppdrag(
+                saksbehandlerId,
+                vedtak,
+                behandlingResultatType,
+                erFørsteBehandlingPåFagsak,
+                andelerTilkjentYtelse
+        )
 
         beregningService.oppdaterTilkjentYtelseMedUtbetalingsoppdrag(vedtak.behandling, utbetalingsoppdrag)
         iverksettOppdrag(vedtak.behandling.id, utbetalingsoppdrag)

--- a/src/test/kotlin/no/nav/familie/ba/sak/toTrinnKontroll/ToTrinnKontrollTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/toTrinnKontroll/ToTrinnKontrollTestConfig.kt
@@ -53,7 +53,7 @@ class ToTrinnKontrollTestConfig {
             totrinnskontrollRepository.save(totrinnskontroll)
         }
 
-        every { totrinnskontrollService.opprettTotrinnskontroll(any()) } answers {
+        every { totrinnskontrollService.opprettTotrinnskontroll(any(), any()) } answers {
             val behandling = firstArg<Behandling>()
             totrinnskontrollRepository.save(Totrinnskontroll(
                     behandling = behandling,

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/UtbetalingsoppdragTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/UtbetalingsoppdragTest.kt
@@ -34,7 +34,8 @@ internal class UtbetalingsoppdragPeriodiseringTest {
                 lagAndelTilkjentYtelse("2019-03-01", "2037-02-28", ORDINÆR_BARNETRYGD, 1054, behandling))
 
         val behandlingResultatType = BehandlingResultatType.INNVILGET
-        val utbetalingsoppdrag = lagUtbetalingsoppdrag("saksbehandler", vedtak, behandlingResultatType, andelerTilkjentYtelse)
+        val utbetalingsoppdrag =
+                lagUtbetalingsoppdrag("saksbehandler", vedtak, behandlingResultatType, true, andelerTilkjentYtelse)
 
         assertEquals(Utbetalingsoppdrag.KodeEndring.NY, utbetalingsoppdrag.kodeEndring)
         assertEquals(3, utbetalingsoppdrag.utbetalingsperiode.size)
@@ -70,7 +71,7 @@ internal class UtbetalingsoppdragPeriodiseringTest {
         val opphørVedtak = lagVedtak(forrigeVedtak = vedtak, opphørsdato = opphørFom)
         val behandlingResultatType = BehandlingResultatType.OPPHØRT
         val utbetalingsoppdrag =
-                lagUtbetalingsoppdrag("saksbehandler", opphørVedtak, behandlingResultatType, andelerTilkjentYtelse)
+                lagUtbetalingsoppdrag("saksbehandler", opphørVedtak, behandlingResultatType, false, andelerTilkjentYtelse)
 
         assertEquals(Utbetalingsoppdrag.KodeEndring.UEND, utbetalingsoppdrag.kodeEndring)
         assertEquals(2, utbetalingsoppdrag.utbetalingsperiode.size)
@@ -120,7 +121,7 @@ internal class UtbetalingsoppdragPeriodiseringTest {
                                        person = personMedFlerePerioder))
 
         val behandlingResultatType = BehandlingResultatType.INNVILGET
-        val utbetalingsoppdrag = lagUtbetalingsoppdrag("saksbehandler", vedtak, behandlingResultatType, andelerTilkjentYtelse)
+        val utbetalingsoppdrag = lagUtbetalingsoppdrag("saksbehandler", vedtak, behandlingResultatType, true, andelerTilkjentYtelse)
 
         assertEquals(Utbetalingsoppdrag.KodeEndring.NY, utbetalingsoppdrag.kodeEndring)
         assertEquals(3, utbetalingsoppdrag.utbetalingsperiode.size)
@@ -142,7 +143,7 @@ internal class UtbetalingsoppdragPeriodiseringTest {
 
         val behandlingResultatType = BehandlingResultatType.INNVILGET
         assertThrows<java.lang.IllegalArgumentException> {
-            lagUtbetalingsoppdrag("saksbehandler", vedtak, behandlingResultatType, andelerTilkjentYtelse)
+            lagUtbetalingsoppdrag("saksbehandler", vedtak, behandlingResultatType, true, andelerTilkjentYtelse)
         }
     }
 


### PR DESCRIPTION
Når Utbetalingsoppdraget lages, sender vi med et flagg som sier om det er første behandling på fagsaken slik at vi vet hvilken kode vi skal bruke for oppdraget (NY eller UENDR)