### PR TITLE
Bugfix: Beregning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
@@ -91,8 +91,8 @@ fun PersonResultat.tilPeriodeResultater(brukMåned: Boolean): List<PeriodeResult
                             it.vilkårType,
                             it.resultat,
                             it.begrunnelse,
-                            it.periodeFom?.withDayOfMonth(1),
-                            it.periodeTom?.sisteDagIMåned())
+                            if (brukMåned) it.periodeFom?.withDayOfMonth(1) else it.periodeFom,
+                            if (brukMåned) it.periodeTom?.sisteDagIMåned() else it.periodeTom)
                 }.toSet()
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/e2e/DatabaseCleanupService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/e2e/DatabaseCleanupService.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.full.findAnnotation
  * @author Sebastien Dubois
  */
 @Service
-@Profile("dev", "e2e")
+@Profile("dev", "e2e", "postgres")
 class DatabaseCleanupService(
         private val entityManager: EntityManager,
         private val environment: Environment
@@ -49,7 +49,7 @@ class DatabaseCleanupService(
     fun truncate() {
         logger.info("Truncating tables: $tableNames")
         entityManager.flush()
-        if (environment.activeProfiles.contains("e2e")) {
+        if (environment.activeProfiles.contains("e2e") || environment.activeProfiles.contains("postgres")) {
             tableNames.forEach { tableName ->
                 entityManager.createNativeQuery("TRUNCATE TABLE $tableName CASCADE").executeUpdate()
             }

--- a/src/test/kotlin/DevLauncher.kt
+++ b/src/test/kotlin/DevLauncher.kt
@@ -5,7 +5,7 @@ object DevLauncher {
     @JvmStatic
     fun main(args: Array<String>) {
         val app = SpringApplicationBuilder(ApplicationConfig::class.java)
-                .profiles("postgres",
+                .profiles("dev",
                           "mock-dokgen-java",
                           "mock-iverksett",
                           "mock-infotrygd-feed",

--- a/src/test/kotlin/DevLauncher.kt
+++ b/src/test/kotlin/DevLauncher.kt
@@ -5,7 +5,7 @@ object DevLauncher {
     @JvmStatic
     fun main(args: Array<String>) {
         val app = SpringApplicationBuilder(ApplicationConfig::class.java)
-                .profiles("dev",
+                .profiles("postgres",
                           "mock-dokgen-java",
                           "mock-iverksett",
                           "mock-infotrygd-feed",

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/BehandlingIntegrationTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.beregning.BeregningService
 import no.nav.familie.ba.sak.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.common.*
 import no.nav.familie.ba.sak.config.ClientMocks
+import no.nav.familie.ba.sak.e2e.DatabaseCleanupService
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.domene.Personinfo
 import no.nav.familie.ba.sak.logg.LoggService
@@ -36,10 +37,7 @@ import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.nare.core.evaluations.Resultat
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -96,12 +94,17 @@ class BehandlingIntegrationTest {
     lateinit var integrasjonClient: IntegrasjonClient
 
     @Autowired
+    lateinit var databaseCleanupService: DatabaseCleanupService
+
+    @Autowired
     lateinit var loggService: LoggService
 
     lateinit var behandlingService: BehandlingService
 
     @BeforeEach
     fun setup() {
+        databaseCleanupService.truncate()
+
         MockKAnnotations.init(this)
         behandlingService = BehandlingService(
                 behandlingRepository,


### PR DESCRIPTION
Fant en bug mellom vilkårsvurdering og beregning i preprod. For en vilkårsvurdering som ser feks ut som dette: 
14.07.20 - 10.11.20: Vilkår oppfylt
11.11.20 - 21.07.21: Vilkår ikke oppfylt
22.07.21 - : Vilkår oppfylt 

Fikk vi dette beregningsresultatet: 
01.08.20 - 30.11.20: Utbetaling
01.09.21 - : Utbetaling 

Her skulle den siste utbetalingsperioden startet 01.08.21 siden vilkårene igjen er oppfylt fra 22.07.21. Det viser seg at når man setter flagget `brukMåned` i vilkårsvurderingen, ender den opp med å sette hele juli 2021 til ikke oppfylt slik at vilkårene er oppfylt fom 01.08.21 og utbetalingen beregnes til å starte 01.09.21. Jeg mener det blir mer riktig og bedre "separation of concerns" dersom beregningservicen kan ha ansvar for å konvertere periodene til hele måneder da det kun gjøres for at utbetalingene skal bli riktig. Beholder likevel `brukMåned`-flagget i vilkårsvurderingen da det er i bruk flere andre steder i koden som jeg ikke har så god kjennskap til. 