### PR TITLE
Utvider kontrakt til å ta imot morsIdent

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
@@ -69,8 +69,12 @@ class BehandlingController(private val fagsakService: FagsakService,
     fun opprettEllerOppdaterBehandlingFraHendelse(@RequestBody
                                                   nyBehandling: NyBehandlingHendelse): ResponseEntity<Ressurs<String>> {
         return Result.runCatching {
+
+
+            val ident = nyBehandling.morsIdent
+                        ?: (nyBehandling.søkersIdent ?: error("Fant ingen gyldig ident på mor/søker"))
             val skalBehandlesHosInfotrygd =
-                    fødselshendelseService.fødselshendelseSkalBehandlesHosInfotrygd(nyBehandling.søkersIdent,
+                    fødselshendelseService.fødselshendelseSkalBehandlesHosInfotrygd(ident,
                                                                                     nyBehandling.barnasIdenter)
             fødselshendelseService.sendTilInfotrygdFeed(nyBehandling.barnasIdenter)
             val task = BehandleFødselshendelseTask.opprettTask(BehandleFødselshendelseTaskDTO(nyBehandling))
@@ -107,6 +111,7 @@ data class NyBehandling(
         val barnasIdenter: List<String> = emptyList())
 
 class NyBehandlingHendelse(
-        val søkersIdent: String,
+        val søkersIdent: String? = null,
+        val morsIdent: String? = null,
         val barnasIdenter: List<String>
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
@@ -55,10 +55,12 @@ class StegService(
 
     @Transactional
     fun håndterNyBehandlingFraHendelse(nyBehandling: NyBehandlingHendelse): Behandling {
-        fagsakService.hentEllerOpprettFagsakForPersonIdent(nyBehandling.søkersIdent)
+        val ident = nyBehandling.morsIdent
+                    ?: (nyBehandling.søkersIdent ?: error("Fant ingen gyldig ident på mor/søker"))
+        fagsakService.hentEllerOpprettFagsakForPersonIdent(ident)
 
         val behandling = behandlingService.opprettBehandling(NyBehandling(
-                søkersIdent = nyBehandling.søkersIdent,
+                søkersIdent = ident,
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 kategori = BehandlingKategori.NASJONAL,
                 underkategori = BehandlingUnderkategori.ORDINÆR,
@@ -68,7 +70,7 @@ class StegService(
         loggService.opprettFødselshendelseLogg(behandling)
 
         return håndterPersongrunnlag(behandling,
-                                     RegistrerPersongrunnlagDTO(ident = nyBehandling.søkersIdent,
+                                     RegistrerPersongrunnlagDTO(ident = ident,
                                                                 barnasIdenter = nyBehandling.barnasIdenter,
                                                                 bekreftEndringerViaFrontend = true))
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
@@ -40,7 +40,7 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns true
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse("12345678910", listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
         Assertions.assertNull(fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910")))
     }
 
@@ -50,7 +50,7 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns false
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse("12345678910", listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
         Assertions.assertNotNull(fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910")))
     }
 
@@ -60,7 +60,7 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns false
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse("12345678910", listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter =listOf("01101900033")))))
 
         val fagsak = fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910"))!!
         val behandling = behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!
@@ -71,7 +71,7 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns true
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse("12345678910", listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent ="12345678910", barnasIdenter = listOf("01101900033")))))
         Assertions.assertEquals(behandling.id, behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!.id)
     }
 
@@ -81,7 +81,7 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns false
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse("12345678910", listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
 
         val fagsak = fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910"))!!
         val behandling = behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!
@@ -89,7 +89,7 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
         behandlingRepository.save(behandling)
 
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse("12345678910", listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
         Assertions.assertNotEquals(behandling.id, behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!.id)
     }
 }


### PR DESCRIPTION
Utvider hendelse DTO med morsIdent. Etter at ba-mottak har tatt i bruk morsIdent, så skal søkersIdent slettes.