### PR TITLE
Oppdater nøkler på templates

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BehandlingResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BehandlingResultat.kt
@@ -65,10 +65,10 @@ data class BehandlingResultat(
 }
 
 enum class BehandlingResultatType(val brevMal: String, val displayName: String) {
-    INNVILGET(brevMal = "Innvilget", displayName = "Innvilget"),
-    DELVIS_INNVILGET(brevMal = "Ukjent", displayName = "Delvis innvilget"),
-    AVSLÅTT(brevMal = "Avslag", displayName = "Avslått"),
-    OPPHØRT(brevMal = "Opphor", displayName = "Opphørt"),
-    HENLAGT(brevMal = "Ukjent", displayName = "Henlagt"),
-    IKKE_VURDERT(brevMal = "Ukjent", displayName = "Ikke vurdert")
+    INNVILGET(brevMal = "innvilget", displayName = "Innvilget"),
+    DELVIS_INNVILGET(brevMal = "ukjent", displayName = "Delvis innvilget"),
+    AVSLÅTT(brevMal = "avslag", displayName = "Avslått"),
+    OPPHØRT(brevMal = "opphor", displayName = "Opphørt"),
+    HENLAGT(brevMal = "ukjent", displayName = "Henlagt"),
+    IKKE_VURDERT(brevMal = "ukjent", displayName = "Ikke vurdert")
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
@@ -113,7 +113,7 @@ class MalerService(
         fun malNavnForMedlemskapOgResultatType(medlemskap: Medlemskap?,
                                                resultatType: BehandlingResultatType): String {
             return when (medlemskap) {
-                Medlemskap.TREDJELANDSBORGER -> "${resultatType.brevMal}-Tredjelandsborger"
+                Medlemskap.TREDJELANDSBORGER -> "${resultatType.brevMal}-tredjelandsborger"
                 else -> resultatType.brevMal
             }
         }

--- a/src/test/kotlin/no/nav/familie/ba/sak/dokument/MalerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/dokument/MalerServiceTest.kt
@@ -9,28 +9,28 @@ import org.junit.jupiter.api.Test
 class MalerServiceTest {
 
     @Test
-    fun `Skal returnere malnavn Innvilget-Tredjelandsborger for medlemskap TREDJELANDSBORGER og resultat INNVILGET`() {
+    fun `Skal returnere malnavn innvilget-tredjelandsborger for medlemskap TREDJELANDSBORGER og resultat INNVILGET`() {
 
         val malNavn = MalerService.malNavnForMedlemskapOgResultatType(Medlemskap.TREDJELANDSBORGER,
                                                                      BehandlingResultatType.INNVILGET)
 
-        assertEquals(malNavn, "Innvilget-Tredjelandsborger")
+        assertEquals(malNavn, "innvilget-tredjelandsborger")
     }
 
     @Test
-    fun `Skal returnere malnavn Innvilget for medlemskap NORDEN og resultat INNVILGET`() {
+    fun `Skal returnere malnavn innvilget for medlemskap NORDEN og resultat INNVILGET`() {
 
         val malNavn = MalerService.malNavnForMedlemskapOgResultatType(Medlemskap.NORDEN,
                                                                      BehandlingResultatType.INNVILGET)
 
-        assertEquals(malNavn, "Innvilget")
+        assertEquals(malNavn, "innvilget")
     }
 
     @Test
-    fun `Skal returnere malnavn Innvilget for resultat INNVILGET når medlemskap er null`() {
+    fun `Skal returnere malnavn innvilget for resultat INNVILGET når medlemskap er null`() {
         val malNavn = MalerService.malNavnForMedlemskapOgResultatType(null,
                                                                      BehandlingResultatType.INNVILGET)
 
-        assertEquals(malNavn, "Innvilget")
+        assertEquals(malNavn, "innvilget")
     }
 }


### PR DESCRIPTION
Når man kaller dokgen sender man template-navn i url. Endrer navnene til å være bedre tilpasset dette ved å fjerne spaces. Endret i samme slengen til å konsekvent bruke lowercase, som er det som påvirkes her. 

Endring i dokgen: https://github.com/navikt/familie-ba-dokgen/pull/40