### PR TITLE
Feature/sammenlign adresser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/GrVegadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/GrVegadresse.kt
@@ -49,10 +49,17 @@ data class GrVegadresse(
             return false
         }
         val otherVegadresse = other as GrVegadresse
+
         return this === other
-               || matrikkelId != null
-               && matrikkelId == otherVegadresse.matrikkelId
-               && bruksenhetsnummer == otherVegadresse.bruksenhetsnummer
+               || ((matrikkelId != null && matrikkelId == otherVegadresse.matrikkelId)
+               || ((matrikkelId == null && otherVegadresse.matrikkelId == null)
+                   && !(adressenavn == null && husnummer == null && husbokstav == null && postnummer == null)
+                   && (adressenavn == otherVegadresse.adressenavn)
+                   && (husnummer == otherVegadresse.husnummer)
+                   && (husbokstav == otherVegadresse.husbokstav)
+                   && (postnummer == otherVegadresse.postnummer)
+                  )
+              )
     }
 
     override fun hashCode(): Int {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/GrVegadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/GrVegadresse.kt
@@ -53,7 +53,8 @@ data class GrVegadresse(
         return this === other
                || ((matrikkelId != null && matrikkelId == otherVegadresse.matrikkelId)
                || ((matrikkelId == null && otherVegadresse.matrikkelId == null)
-                   && !(adressenavn == null && husnummer == null && husbokstav == null && postnummer == null)
+                   && postnummer != null
+                   && !(adressenavn == null && husnummer == null && husbokstav == null)
                    && (adressenavn == otherVegadresse.adressenavn)
                    && (husnummer == otherVegadresse.husnummer)
                    && (husbokstav == otherVegadresse.husbokstav)

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BarnBorMedSøkerVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BarnBorMedSøkerVilkårTest.kt
@@ -26,8 +26,8 @@ class BarnBorMedSøkerVilkårTest {
     }
 
     @Test
-    fun `Address som mangler attributter`() {
-        val fakta = opprettFaktaObject(adresseTomBarn, adresseTomSøker)
+    fun `Address som mangler postnummer`() {
+        val fakta = opprettFaktaObject(adresseIkkePostnummerBarn, adresseIkkePostnummerSøker)
 
         val evaluering = vilkår.spesifikasjon.evaluer(fakta)
         Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.NEI)
@@ -67,11 +67,11 @@ class BarnBorMedSøkerVilkårTest {
         val adresseMatrikkelId1barn = opprettAdresse(1234L)
         val adresseMatrikkelId2Søker = opprettAdresse(4321L)
         val adresseMatrikkelId1SøkerBruksenhetsnummer = opprettAdresse(matrikkelId = 1234L, bruksenhetsnummer = "123")
-        val adresseTomBarn = opprettAdresse()
-        val adresseTomSøker = opprettAdresse()
-        val adresseAttrBarn = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123")
-        val adresseAttrSøker = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123")
-        val adresseAttr2Søker = opprettAdresse(adressenavn = "Fågelveien", husnummer = "11")
+        val adresseIkkePostnummerBarn = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123")
+        val adresseIkkePostnummerSøker = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123")
+        val adresseAttrBarn = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123", postnummer = "0245")
+        val adresseAttrSøker = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123", postnummer = "0245")
+        val adresseAttr2Søker = opprettAdresse(adressenavn = "Fågelveien", husnummer = "11", postnummer = "0245")
 
         private fun opprettAdresse(matrikkelId: Long? = null,
                                    bruksenhetsnummer: String? = null,

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BarnBorMedSøkerVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BarnBorMedSøkerVilkårTest.kt
@@ -1,0 +1,91 @@
+package no.nav.familie.ba.sak.behandling.vilkår
+
+import no.nav.familie.ba.sak.behandling.domene.BehandlingOpprinnelse
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.*
+import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.nare.core.evaluations.Resultat
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class BarnBorMedSøkerVilkårTest {
+
+    @Test
+    fun `Samme matrikkelId men ellers forskjellige adresser`() {
+        val fakta = opprettFaktaObject(adresseMatrikkelId1barn, adresseMatrikkelId1SøkerBruksenhetsnummer)
+
+        val evaluering = vilkår.spesifikasjon.evaluer(fakta)
+        Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.JA)
+    }
+
+    @Test
+    fun `Forskjellige matrikkelId`() {
+        val fakta = opprettFaktaObject(adresseMatrikkelId1barn, adresseMatrikkelId2Søker)
+
+        val evaluering = vilkår.spesifikasjon.evaluer(fakta)
+        Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.NEI)
+    }
+
+    @Test
+    fun `Address som mangler attributter`() {
+        val fakta = opprettFaktaObject(adresseTomBarn, adresseTomSøker)
+
+        val evaluering = vilkår.spesifikasjon.evaluer(fakta)
+        Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.NEI)
+    }
+
+    @Test
+    fun `Address som mangler matrikkelid`() {
+        val fakta = opprettFaktaObject(adresseAttrBarn, adresseAttrSøker)
+
+        val evaluering = vilkår.spesifikasjon.evaluer(fakta)
+        Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.JA)
+    }
+
+    @Test
+    fun `To forskjellige address som begge mangler matrikkelid`() {
+        val fakta = opprettFaktaObject(adresseAttrBarn, adresseAttr2Søker)
+
+        val evaluering = vilkår.spesifikasjon.evaluer(fakta)
+        Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.NEI)
+    }
+
+    private fun opprettFaktaObject(bostedsadresseSøker: GrBostedsadresse, bostedsadresseBarn: GrBostedsadresse): Fakta {
+        val barnMedAdresse = barn.copy(bostedsadresse = bostedsadresseBarn)
+        barnMedAdresse.personopplysningGrunnlag.personer.clear()
+        barnMedAdresse.personopplysningGrunnlag.personer.add(søker.copy(bostedsadresse = bostedsadresseSøker))
+
+        return Fakta(personForVurdering = barnMedAdresse,
+                          behandlingOpprinnelse = BehandlingOpprinnelse.AUTOMATISK_VED_FØDSELSHENDELSE)
+    }
+
+    companion object {
+        val vilkår = Vilkår.BOR_MED_SØKER
+        val barn = tilfeldigPerson(personType = PersonType.BARN)
+
+        val søker = tilfeldigPerson(personType = PersonType.SØKER, kjønn = Kjønn.KVINNE)
+
+        val adresseMatrikkelId1barn = opprettAdresse(1234L)
+        val adresseMatrikkelId2Søker = opprettAdresse(4321L)
+        val adresseMatrikkelId1SøkerBruksenhetsnummer = opprettAdresse(matrikkelId = 1234L, bruksenhetsnummer = "123")
+        val adresseTomBarn = opprettAdresse()
+        val adresseTomSøker = opprettAdresse()
+        val adresseAttrBarn = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123")
+        val adresseAttrSøker = opprettAdresse(adressenavn = "Fågelveien", husnummer = "123")
+        val adresseAttr2Søker = opprettAdresse(adressenavn = "Fågelveien", husnummer = "11")
+
+        private fun opprettAdresse(matrikkelId: Long? = null,
+                                   bruksenhetsnummer: String? = null,
+                                   adressenavn: String? = null,
+                                   husnummer: String? = null,
+                                   husbokstav: String? = null,
+                                   postnummer: String? = null) =
+                GrVegadresse(matrikkelId = matrikkelId,
+                             husnummer = husnummer,
+                             husbokstav = husbokstav,
+                             bruksenhetsnummer = bruksenhetsnummer,
+                             adressenavn = adressenavn,
+                             kommunenummer = null,
+                             tilleggsnavn = null,
+                             postnummer = postnummer)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårVurderingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårVurderingTest.kt
@@ -204,7 +204,7 @@ class VilkårVurderingTest(
     fun `Sjekk barn bor med søker`() {
         val søkerAddress = GrVegadresse(1234, "11", "B", "H022",
                                         "St. Olavsvegen", "1232", "whatever", "4322")
-        val barnAddress = GrVegadresse(1234, "11", "B", "H024",
+        val barnAddress = GrVegadresse(1235, "11", "B", "H024",
                                        "St. Olavsvegen", "1232", "whatever", "4322")
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 1)
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -65,7 +65,7 @@ fun lagBehandling(fagsak: Fagsak = defaultFagsak,
                underkategori = BehandlingUnderkategori.ORDINÆR,
                opprinnelse = BehandlingOpprinnelse.MANUELL)
 
-fun tilfeldigPerson(fødselsdato: LocalDate = LocalDate.now(), personType: PersonType = PersonType.BARN) = Person(
+fun tilfeldigPerson(fødselsdato: LocalDate = LocalDate.now(), personType: PersonType = PersonType.BARN, kjønn: Kjønn = Kjønn.MANN) = Person(
         id = nestePersonId(),
         aktørId = randomAktørId(),
         personIdent = PersonIdent(randomFnr()),
@@ -73,7 +73,7 @@ fun tilfeldigPerson(fødselsdato: LocalDate = LocalDate.now(), personType: Perso
         type = personType,
         personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 0),
         navn = "",
-        kjønn = Kjønn.MANN,
+        kjønn = kjønn,
         sivilstand = SIVILSTAND.UGIFT
 )
 


### PR DESCRIPTION
Vilkåret søker bra med barn sammenligner barnets adresse med søkers adresse.

Sammenlignins logikken er endret fra; at to adresser anses som samme bare om man er sikker på at de er samme, til; at to adresser anses som samme om sannsynligheten for det er stor.  