### PR TITLE
Utvid opprettOppgave med beskrivelse som parameter.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/oppgave/OppgaveService.kt
@@ -26,7 +26,8 @@ class OppgaveService(private val integrasjonClient: IntegrasjonClient,
                        oppgavetype: Oppgavetype,
                        fristForFerdigstillelse: LocalDate,
                        enhetId: String? = null,
-                       tilordnetNavIdent: String? = null): String {
+                       tilordnetNavIdent: String? = null,
+                       beskrivelse: String? = null): String {
         val behandling = behandlingRepository.finnBehandling(behandlingId)
         val fagsakId = behandling.fagsak.id
 
@@ -47,7 +48,7 @@ class OppgaveService(private val integrasjonClient: IntegrasjonClient,
                     tema = Tema.BAR,
                     oppgavetype = oppgavetype,
                     fristFerdigstillelse = fristForFerdigstillelse,
-                    beskrivelse = lagOppgaveTekst(fagsakId),
+                    beskrivelse = lagOppgaveTekst(fagsakId, beskrivelse),
                     enhetsnummer = enhetId ?: enhetsnummer?.enhetId,
                     behandlingstema = Behandlingstema.ORDINÆR_BARNETRYGD.kode,
                     tilordnetRessurs = tilordnetNavIdent
@@ -88,8 +89,9 @@ class OppgaveService(private val integrasjonClient: IntegrasjonClient,
         oppgaveRepository.save(oppgave)
     }
 
-    fun lagOppgaveTekst(fagsakId: Long): String {
-        return "----- Opprettet av familie-ba-sak ${LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)} --- \n" +
+    fun lagOppgaveTekst(fagsakId: Long, beskrivelse: String? = null): String {
+        return if (beskrivelse != null) { beskrivelse + "\n" } else { "" } +
+               "----- Opprettet av familie-ba-sak ${LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)} --- \n" +
                "https://barnetrygd.nais.adeo.no/fagsak/${fagsakId}"
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.task
 
 import no.nav.familie.ba.sak.oppgave.OppgaveService
-import no.nav.familie.ba.sak.task.dto.OpprettOppgaveDTO
+import no.nav.familie.ba.sak.task.dto.OpprettOppgaveTaskDTO
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -20,7 +20,7 @@ class OpprettOppgaveTask(
         private val taskRepository: TaskRepository) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
-        val opprettOppgaveDTO = objectMapper.readValue(task.payload, OpprettOppgaveDTO::class.java)
+        val opprettOppgaveDTO = objectMapper.readValue(task.payload, OpprettOppgaveTaskDTO::class.java)
         task.metadata["oppgaveId"] = oppgaveService.opprettOppgave(
                 opprettOppgaveDTO.behandlingId,
                 opprettOppgaveDTO.oppgavetype,
@@ -36,7 +36,7 @@ class OpprettOppgaveTask(
         fun opprettTask(behandlingId: Long, oppgavetype: Oppgavetype, fristForFerdigstillelse: LocalDate, beskrivelse: String? = null): Task {
             return Task.nyTask(
                     type = TASK_STEP_TYPE,
-                    payload = objectMapper.writeValueAsString(OpprettOppgaveDTO(behandlingId, oppgavetype, fristForFerdigstillelse, beskrivelse))
+                    payload = objectMapper.writeValueAsString(OpprettOppgaveTaskDTO(behandlingId, oppgavetype, fristForFerdigstillelse, beskrivelse))
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTask.kt
@@ -24,7 +24,8 @@ class OpprettOppgaveTask(
         task.metadata["oppgaveId"] = oppgaveService.opprettOppgave(
                 opprettOppgaveDTO.behandlingId,
                 opprettOppgaveDTO.oppgavetype,
-                opprettOppgaveDTO.fristForFerdigstillelse
+                opprettOppgaveDTO.fristForFerdigstillelse,
+                beskrivelse = opprettOppgaveDTO.beskrivelse
         )
         taskRepository.saveAndFlush(task)
     }
@@ -32,10 +33,10 @@ class OpprettOppgaveTask(
     companion object {
         const val TASK_STEP_TYPE = "opprettOppgaveTask"
 
-        fun opprettTask(behandlingId: Long, oppgavetype: Oppgavetype, fristForFerdigstillelse: LocalDate): Task {
+        fun opprettTask(behandlingId: Long, oppgavetype: Oppgavetype, fristForFerdigstillelse: LocalDate, beskrivelse: String? = null): Task {
             return Task.nyTask(
                     type = TASK_STEP_TYPE,
-                    payload = objectMapper.writeValueAsString(OpprettOppgaveDTO(behandlingId, oppgavetype, fristForFerdigstillelse))
+                    payload = objectMapper.writeValueAsString(OpprettOppgaveDTO(behandlingId, oppgavetype, fristForFerdigstillelse, beskrivelse))
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettOppgaveDTO.kt
@@ -6,5 +6,6 @@ import java.time.LocalDate
 data class OpprettOppgaveDTO (
         val behandlingId: Long,
         val oppgavetype: Oppgavetype,
-        val fristForFerdigstillelse: LocalDate
+        val fristForFerdigstillelse: LocalDate,
+        val beskrivelse: String?
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettOppgaveTaskDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettOppgaveTaskDTO.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.task.dto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import java.time.LocalDate
 
-data class OpprettOppgaveDTO (
+data class OpprettOppgaveTaskDTO (
         val behandlingId: Long,
         val oppgavetype: Oppgavetype,
         val fristForFerdigstillelse: LocalDate,


### PR DESCRIPTION
Pga TEA-1381 (https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-1381) må vi kunne legge ved en beskrivelse når vi oppretter en oppgave.

Dersom en beskrivelse legges ved, kommer denne i tillegg til den generiske beskrivelsen ("-----laget av familie-ba-sak med fagsak....")

Kode som pr. nå benytter opprettOppgave eller opprettOppgaveTask er uberørt av denne endringen.