### PR TITLE
Sorter beskrivelse for lesbarhet i grafana

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
@@ -266,7 +266,7 @@ class StegService(
                                              "steg",
                                              it.stegType().name,
                                              "beskrivelse",
-                                             it.stegType().displayName())
+                                             it.stegType().rekkefølge.toString() + it.stegType().displayName())
         }.toMap()
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
@@ -266,7 +266,7 @@ class StegService(
                                              "steg",
                                              it.stegType().name,
                                              "beskrivelse",
-                                             it.stegType().rekkefølge.toString() + it.stegType().displayName())
+                                             it.stegType().rekkefølge.toString() + " " + it.stegType().displayName())
         }.toMap()
     }
 


### PR DESCRIPTION
Har lagt til et par metrikker og gjort noen utbedringer etter gjennomgang med @EAamli . (https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-1139
).

På steg-oversikt er det ønskelig å sortere stegene i sin "naturlige" rekkefølge. Finner ikke noen måte å sortere legend på Graph, så legger til steg i beskrivelse-taggen i stedet for i en egen tag siden legend (beskrivelse) for graph sorteres alfabetisk by default. Hvis noen vet hvordan man kan sortere på tag tas det gjerne i mot tips. For alle pie charts kan man velge å sortere på antall ved å klikke på header som jeg nå har kalt "Antall".

![Skjermbilde 2020-09-16 kl  14 15 15](https://user-images.githubusercontent.com/5719550/93335932-662f2480-f827-11ea-9328-c97afd4e104a.png)
