### PR TITLE
Sjekk mot infotrygd og ruting av hendelser: Flytt til task og redegjør flyt.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ba.sak.common.RessursUtils.ok
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
 import no.nav.familie.ba.sak.task.dto.BehandleFødselshendelseTaskDTO
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.*
 @Validated
 class BehandlingController(private val fagsakService: FagsakService,
                            private val stegService: StegService,
-                           private val fødselshendelseService: FødselshendelseService,
                            private val taskRepository: TaskRepository) {
 
     private val antallManuelleBehandlingerOpprettet: Map<BehandlingType, Counter> = initBehandlingMetrikker("manuell")
@@ -70,9 +69,9 @@ class BehandlingController(private val fagsakService: FagsakService,
         return try {
             val task = BehandleFødselshendelseTask.opprettTask(BehandleFødselshendelseTaskDTO(nyBehandling))
             taskRepository.save(task)
-            ok("OK")
+            ok("Task opprettet for behandling av fødselshendelse.")
         } catch (ex: Throwable) {
-            illegalState("Opprettelse av behandling fra hendelse feilet: ${ex.message}", ex)
+            illegalState("Task kunne ikke opprettes for behandling av fødselshendelse: ${ex.message}", ex)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingController.kt
@@ -36,8 +36,6 @@ class BehandlingController(private val fagsakService: FagsakService,
 
     private val antallManuelleBehandlingerOpprettet: Map<BehandlingType, Counter> = initBehandlingMetrikker("manuell")
 
-    private val antallAutomatiskeBehandlingerOpprettet: Map<BehandlingType, Counter> = initBehandlingMetrikker("automatisk")
-
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PostMapping(path = ["behandlinger"], produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -72,7 +70,6 @@ class BehandlingController(private val fagsakService: FagsakService,
         return try {
             val task = BehandleFødselshendelseTask.opprettTask(BehandleFødselshendelseTaskDTO(nyBehandling))
             taskRepository.save(task)
-            antallAutomatiskeBehandlingerOpprettet[BehandlingType.FØRSTEGANGSBEHANDLING]?.increment()
             ok("OK")
         } catch (ex: Throwable) {
             illegalState("Opprettelse av behandling fra hendelse feilet: ${ex.message}", ex)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseService.kt
@@ -45,8 +45,8 @@ class FødselshendelseService(private val infotrygdFeedService: InfotrygdFeedSer
                              private val vilkårsvurderingMetrics: VilkårsvurderingMetrics,
                              private val gdprService: GDPRService) {
 
-    val finnesLøpendeSakIInfotrygd: Counter = Metrics.counter("foedselshendelse.mor.eller.barn.finnes.loepende.i.infotrygd")
-    val finnesIkkeLøpendeSakIInfotrygd: Counter =
+    val harLøpendeSakIInfotrygdCounter: Counter = Metrics.counter("foedselshendelse.mor.eller.barn.finnes.loepende.i.infotrygd")
+    val harIkkeLøpendeSakIInfotrygdCounter: Counter =
             Metrics.counter("foedselshendelse.mor.eller.barn.finnes.ikke.loepende.i.infotrygd")
     val stansetIAutomatiskFiltreringCounter = Metrics.counter("familie.ba.sak.henvendelse.stanset", "steg", "filtrering")
     val stansetIAutomatiskVilkårsvurderingCounter =
@@ -64,13 +64,13 @@ class FødselshendelseService(private val infotrygdFeedService: InfotrygdFeedSer
                     .map { identinfo -> identinfo.ident }
         }
 
-        val finnesHosInfotrygd = !infotrygdBarnetrygdClient.finnesIkkeHosInfotrygd(morsIdenter, alleBarnasIdenter)
-        when (finnesHosInfotrygd) {
-            true -> finnesLøpendeSakIInfotrygd.increment()
-            false -> finnesIkkeLøpendeSakIInfotrygd.increment()
+        return if (infotrygdBarnetrygdClient.harIkkeLøpendeSakIInfotrygd(morsIdenter, alleBarnasIdenter)) {
+            harIkkeLøpendeSakIInfotrygdCounter.increment()
+            false
+        } else {
+            harLøpendeSakIInfotrygdCounter.increment()
+            true
         }
-
-        return finnesHosInfotrygd
     }
 
     fun sendTilInfotrygdFeed(barnIdenter: List<String>) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClient.kt
@@ -18,7 +18,7 @@ class InfotrygdBarnetrygdClient(@Value("\${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_U
                                 private val environment: Environment)
     : AbstractRestClient(restOperations, "infotrygd_barnetrygd") {
 
-    fun finnesIkkeHosInfotrygd(søkersIdenter: List<String>, barnasIdenter: List<String>): Boolean {
+    fun harIkkeLøpendeSakIInfotrygd(søkersIdenter: List<String>, barnasIdenter: List<String>): Boolean {
         if (environment.activeProfiles.contains("e2e")) {
             return true
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.task
 
+import no.nav.familie.ba.sak.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.behandling.fødselshendelse.FødselshendelseService
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.gdpr.domene.FødelshendelsePreLanseringRepository
@@ -26,8 +27,31 @@ class BehandleFødselshendelseTask(
         val behandleFødselshendelseTaskDTO = objectMapper.readValue(task.payload, BehandleFødselshendelseTaskDTO::class.java)
         LOG.info("Kjører BehandleFødselshendelseTask")
 
+        val nyBehandling = behandleFødselshendelseTaskDTO.nyBehandling
+        val fødselshendelseSkalBehandlesHosInfotrygd = fødselshendelseService.fødselshendelseSkalBehandlesHosInfotrygd(nyBehandling.morsIdent, nyBehandling.barnasIdenter)
+
+        // Vi har overtatt ruting.
+        // Pr. nå sender vi alle hendelser til infotrygd.
+        // behandleHendelseIBaSak skal gjøre en "dry run", kun for metrikkers skyld, og skal hverken lage oppgave eller vedtak.
+        // Koden under fjernes når vi går live.
+        fødselshendelseService.sendTilInfotrygdFeed(nyBehandling.barnasIdenter)
+        behandleHendelseIBaSak(nyBehandling)
+
+        // Dette er flyten, slik den skal se ut når vi går "live".
+        //
+        // if (fødselshendelseSkalBehandlesHosInfotrygd) {
+        //     fødselshendelseService.sendTilInfotrygdFeed(nyBehandling.barnasIdenter)
+        // } else {
+        //     behandleHendelseIBaSak(nyBehandling)
+        // }
+        //
+        // Når vi går live skal ba-sak behandle saker som ikke er løpende i infotrygd.
+        // Etterhvert som vi kan behandle flere typer saker, utvider vi fødselshendelseSkalBehandlesHosInfotrygd.
+    }
+
+    private fun behandleHendelseIBaSak(nyBehandling: NyBehandlingHendelse) {
         try {
-            fødselshendelseService.opprettBehandlingOgKjørReglerForFødselshendelse(behandleFødselshendelseTaskDTO.nyBehandling)
+            fødselshendelseService.opprettBehandlingOgKjørReglerForFødselshendelse(nyBehandling)
         } catch (e: KontrollertRollbackException) {
             when (e.fødselshendelsePreLansering) {
                 null -> LOG.error("Rollback har blitt trigget, men data fra fødselshendelse mangler")

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseServiceTest.kt
@@ -73,7 +73,7 @@ class FødselshendelseServiceTest {
         every { personopplysningerServiceMock.hentIdenter(any()) } returns listOf(IdentInformasjon(søkerFnr,
                                                                                                    false,
                                                                                                    "FOLKEREGISTERIDENT"))
-        every { infotrygdBarnetrygdClientMock.finnesIkkeHosInfotrygd(any(), any()) } returns false
+        every { infotrygdBarnetrygdClientMock.harIkkeLøpendeSakIInfotrygd(any(), any()) } returns false
 
         val skalBehandlesHosInfotrygd =
                 fødselshendelseService.fødselshendelseSkalBehandlesHosInfotrygd(søkerFnr, listOf(barn1Fnr))
@@ -94,7 +94,7 @@ class FødselshendelseServiceTest {
                                                                                                              "FOLKEREGISTERIDENT"))
 
         val slot = slot<List<String>>()
-        every { infotrygdBarnetrygdClientMock.finnesIkkeHosInfotrygd(capture(slot), any()) } returns false
+        every { infotrygdBarnetrygdClientMock.harIkkeLøpendeSakIInfotrygd(capture(slot), any()) } returns false
 
         fødselshendelseService.fødselshendelseSkalBehandlesHosInfotrygd(søkerFnr, listOf(barn1Fnr))
 
@@ -121,7 +121,7 @@ class FødselshendelseServiceTest {
                                                                                                              "FOLKEREGISTERIDENT"))
 
         val slot = slot<List<String>>()
-        every { infotrygdBarnetrygdClientMock.finnesIkkeHosInfotrygd(any(), capture(slot)) } returns false
+        every { infotrygdBarnetrygdClientMock.harIkkeLøpendeSakIInfotrygd(any(), capture(slot)) } returns false
 
         fødselshendelseService.fødselshendelseSkalBehandlesHosInfotrygd(søkerFnr, listOf(barn1Fnr, barn2Fnr))
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/GDPRInnhentingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/GDPRInnhentingTest.kt
@@ -43,7 +43,7 @@ import java.time.LocalDate
 
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
-@ActiveProfiles("dev", "mock-pdl-gdpr")
+@ActiveProfiles("dev", "mock-pdl-gdpr", "mock-infotrygd-feed")
 @Tag("integration")
 @TestInstance(Lifecycle.PER_CLASS)
 class GDPRInnhentingTest(

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/GDPRInnhentingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/GDPRInnhentingTest.kt
@@ -43,7 +43,7 @@ import java.time.LocalDate
 
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
-@ActiveProfiles("dev", "mock-pdl-gdpr", "mock-infotrygd-feed")
+@ActiveProfiles("dev", "mock-pdl-gdpr", "mock-infotrygd-feed", "mock-infotrygd-barnetrygd")
 @Tag("integration")
 @TestInstance(Lifecycle.PER_CLASS)
 class GDPRInnhentingTest(

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.config
 
 import io.mockk.*
-import no.nav.familie.ba.sak.behandling.fødselshendelse.FødselshendelseService
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.GrBostedsadresseperiode
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
@@ -9,8 +8,6 @@ import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
-import no.nav.familie.ba.sak.infotrygd.InfotrygdBarnetrygdClient
-import no.nav.familie.ba.sak.infotrygd.InfotrygdFeedClient
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonException
 import no.nav.familie.ba.sak.integrasjoner.domene.Arbeidsfordelingsenhet

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.config
 
 import io.mockk.*
+import no.nav.familie.ba.sak.behandling.fødselshendelse.FødselshendelseService
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.GrBostedsadresseperiode
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
@@ -8,6 +9,8 @@ import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.infotrygd.InfotrygdBarnetrygdClient
+import no.nav.familie.ba.sak.infotrygd.InfotrygdFeedClient
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonException
 import no.nav.familie.ba.sak.integrasjoner.domene.Arbeidsfordelingsenhet
@@ -346,6 +349,30 @@ class ClientMocks {
         } returns false
 
         return mockFeatureToggleService
+    }
+
+    @Bean
+    @Primary
+    fun mockInfotrygdBarnetrygdClient(): InfotrygdBarnetrygdClient {
+        val mockInfotrygdBarnetrygdClient = mockk<InfotrygdBarnetrygdClient>()
+
+        every {
+            mockInfotrygdBarnetrygdClient.harIkkeLøpendeSakIInfotrygd(any(), any())
+        } returns true
+
+        return mockInfotrygdBarnetrygdClient
+    }
+
+    @Bean
+    @Primary
+    fun mockInfotrygdFeedClient(): InfotrygdFeedClient {
+        val mockInfotrygdFeedClient = mockk<InfotrygdFeedClient>()
+
+        every {
+            mockInfotrygdFeedClient.sendFødselhendelsesFeedTilInfotrygd(any())
+        } just runs
+
+        return mockInfotrygdFeedClient
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -363,18 +363,6 @@ class ClientMocks {
         return mockInfotrygdBarnetrygdClient
     }
 
-    @Bean
-    @Primary
-    fun mockInfotrygdFeedClient(): InfotrygdFeedClient {
-        val mockInfotrygdFeedClient = mockk<InfotrygdFeedClient>()
-
-        every {
-            mockInfotrygdFeedClient.sendFødselhendelsesFeedTilInfotrygd(any())
-        } just runs
-
-        return mockInfotrygdFeedClient
-    }
-
     companion object {
 
         val FOM_1900 = LocalDate.of(1900, Month.JANUARY, 1)

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -351,18 +351,6 @@ class ClientMocks {
         return mockFeatureToggleService
     }
 
-    @Bean
-    @Primary
-    fun mockInfotrygdBarnetrygdClient(): InfotrygdBarnetrygdClient {
-        val mockInfotrygdBarnetrygdClient = mockk<InfotrygdBarnetrygdClient>()
-
-        every {
-            mockInfotrygdBarnetrygdClient.harIkkeLøpendeSakIInfotrygd(any(), any())
-        } returns true
-
-        return mockInfotrygdBarnetrygdClient
-    }
-
     companion object {
 
         val FOM_1900 = LocalDate.of(1900, Month.JANUARY, 1)

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClientMock.kt
@@ -16,7 +16,7 @@ class InfotrygdBarnetrygdConfig {
     @Primary
     fun mockInfotrygdBarnetrygd(): InfotrygdBarnetrygdClient {
         val mockk = mockk<InfotrygdBarnetrygdClient>(relaxed = true)
-        every { mockk.finnesIkkeHosInfotrygd(any(), any()) } returns true
+        every { mockk.harIkkeLøpendeSakIInfotrygd(any(), any()) } returns true
         return mockk
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
@@ -21,7 +21,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
-@ActiveProfiles("dev", "mock-pdl", "mock-dokgen")
+@ActiveProfiles("dev", "mock-pdl", "mock-dokgen", "mock-infotrygd-feed")
 @Tag("integration")
 class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshendelseTask: BehandleFødselshendelseTask,
                                       @Autowired private val featureToggleService: FeatureToggleService,

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
@@ -21,7 +21,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
-@ActiveProfiles("dev", "mock-pdl", "mock-dokgen", "mock-infotrygd-feed")
+@ActiveProfiles("dev", "mock-pdl", "mock-dokgen", "mock-infotrygd-feed", "mock-infotrygd-barnetrygd")
 @Tag("integration")
 class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshendelseTask: BehandleFødselshendelseTask,
                                       @Autowired private val featureToggleService: FeatureToggleService,


### PR DESCRIPTION
Siden det feilet mot infotrygd-replikaen i dag, og dette kjøres utenfor task-rammeverket, flytter vi dette til BehandleFødselshendelseTask så det går an å rekjøre tasken dersom det feiler mot infotrygd-replika i fremtiden.

Det er også gjort noen endringer for å gjøre ting tydeligere:
- siden det er lett å glemme hvordan rutingen skal se ut når vi går live, er flyten skrevet inn som kommentarer.
- korrekt navngivning av variabler/funksjonsnavn mot infotrygd-replika
- unngå dobbel negasjon

Metrikk er flyttet til tasken og fortsetter å telle på samme måte som tidligere.