### PR TITLE
Opprett en task send til infotrygd per fødselsmelding

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedClient.kt
@@ -24,10 +24,10 @@ class InfotrygdFeedClient(@Value("\${FAMILIE_BA_INFOTRYGD_FEED_API_URL}") privat
     : AbstractRestClient(restOperations, "infotrygd_feed") {
 
     fun sendFødselhendelsesFeedTilInfotrygd(infotrygdFødselhendelsesFeedDto: InfotrygdFødselhendelsesFeedDto) =
-        sendFeedTilInfotrygd(URI.create("$clientUri/barnetrygd/v1/feed/foedselsmelding"), infotrygdFødselhendelsesFeedDto)
+            sendFeedTilInfotrygd(URI.create("$clientUri/barnetrygd/v1/feed/foedselsmelding"), infotrygdFødselhendelsesFeedDto)
 
     fun sendVedtakFeedTilInfotrygd(infotrygdVedtakFeedDto: InfotrygdVedtakFeedDto) =
-         sendFeedTilInfotrygd(URI.create("$clientUri/barnetrygd/v1/feed/vedtaksmelding"), infotrygdVedtakFeedDto)
+            sendFeedTilInfotrygd(URI.create("$clientUri/barnetrygd/v1/feed/vedtaksmelding"), infotrygdVedtakFeedDto)
 
     @Retryable(value = [IOException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
     private fun sendFeedTilInfotrygd(endpoint: URI, feed: Any) {
@@ -41,7 +41,7 @@ class InfotrygdFeedClient(@Value("\${FAMILIE_BA_INFOTRYGD_FEED_API_URL}") privat
                 onSuccess = {
                 },
                 onFailure = {
-                    if(it is HttpClientErrorException) {
+                    if (it is HttpClientErrorException) {
                         logger.error("Http feil mot infotrygd feed: httpkode: ${it.statusCode}, feilmelding ${it.message}", it)
                     } else {
                         logger.error("Feil mot infotrygd feed; melding ${it.message}", it)
@@ -53,6 +53,7 @@ class InfotrygdFeedClient(@Value("\${FAMILIE_BA_INFOTRYGD_FEED_API_URL}") privat
     }
 
     companion object {
+
         val logger: Logger = LoggerFactory.getLogger(this::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedService.kt
@@ -12,10 +12,7 @@ class InfotrygdFeedService(val taskRepository: TaskRepository) {
     @Transactional
     fun sendTilInfotrygdFeed(barnsIdenter: List<String>) {
         LOG.info("Send ${barnsIdenter.size} av fødselsmeldinger til Infotrygd.")
-
-        barnsIdenter.forEach {
-            taskRepository.save(SendFeedTilInfotrygdTask.opprettTask(it))
-        }
+        taskRepository.save(SendFeedTilInfotrygdTask.opprettTask(barnsIdenter))
     }
 
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/domene/FeedDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/domene/FeedDto.kt
@@ -2,5 +2,7 @@ package no.nav.familie.ba.sak.infotrygd.domene
 
 import java.time.LocalDate
 
+data class InfotrygdFødselhendelsesFeedTaskDto(val fnrBarn: List<String>)
+
 data class InfotrygdFødselhendelsesFeedDto(val fnrBarn: String)
 data class InfotrygdVedtakFeedDto(val fnrStoenadsmottaker: String, val datoStartNyBa: LocalDate)

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedClientTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.infotrygd
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import no.nav.familie.ba.sak.config.ApplicationConfig
 import no.nav.familie.ba.sak.infotrygd.domene.InfotrygdFødselhendelsesFeedDto
+import no.nav.familie.ba.sak.infotrygd.domene.InfotrygdFødselhendelsesFeedTaskDto
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.NavHttpHeaders
@@ -49,9 +50,11 @@ class InfotrygdFeedClientTest {
     fun `skal legge til fødselsnummer i infotrygd feed`() {
         stubFor(post("/api/barnetrygd/v1/feed/foedselsmelding").willReturn(
                 okJson(objectMapper.writeValueAsString(success("Create")))))
-        val request = InfotrygdFødselhendelsesFeedDto("fnr")
+        val request = InfotrygdFødselhendelsesFeedTaskDto(listOf("fnr"))
 
-        client.sendFødselhendelsesFeedTilInfotrygd(request)
+        request.fnrBarn.forEach {
+            client.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto(fnrBarn = it))
+        }
 
         verify(anyRequestedFor(anyUrl())
                        .withHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString(), equalTo("familie-ba-sak"))
@@ -64,8 +67,7 @@ class InfotrygdFeedClientTest {
         stubFor(post("/api/barnetrygd/v1/feed/foedselsmelding").willReturn(aResponse().withStatus(401)))
 
         assertThrows<HttpClientErrorException> {
-            client.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto(
-                    "fnr"))
+            client.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto("fnr"))
         }
     }
 
@@ -75,8 +77,7 @@ class InfotrygdFeedClientTest {
         stubFor(post("/api/barnetrygd/v1/feed/foedselsmelding").willReturn(aResponse().withBody("Create")))
 
         assertThrows<RuntimeException> {
-            client.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto(
-                    "fnr"))
+            client.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto("fnr"))
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdFeedClientTest.kt
@@ -58,7 +58,8 @@ class InfotrygdFeedClientTest {
 
         verify(anyRequestedFor(anyUrl())
                        .withHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString(), equalTo("familie-ba-sak"))
-                       .withRequestBody(equalToJson(objectMapper.writeValueAsString(request))))
+                       .withRequestBody(equalToJson(
+                               objectMapper.writeValueAsString(InfotrygdFødselhendelsesFeedDto(fnrBarn = request.fnrBarn.first())))))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/SendFeedTilInfotrygdTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/SendFeedTilInfotrygdTaskTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.infotrygd
 
-import no.nav.familie.ba.sak.infotrygd.domene.InfotrygdFødselhendelsesFeedDto
+import no.nav.familie.ba.sak.infotrygd.domene.InfotrygdFødselhendelsesFeedTaskDto
 import no.nav.familie.ba.sak.task.SendFeedTilInfotrygdTask
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.junit.jupiter.api.Assertions
@@ -18,9 +18,9 @@ class SendFeedTilInfotrygdTaskTest {
     @Test
     fun `Legg til fødselsmelding til task`() {
         val fnrBarn = "12345678910"
-        val testTask = SendFeedTilInfotrygdTask.opprettTask(fnrBarn)
+        val testTask = SendFeedTilInfotrygdTask.opprettTask(listOf(fnrBarn))
 
-        val infotrygdFeedDto = objectMapper.readValue(testTask.payload, InfotrygdFødselhendelsesFeedDto::class.java)
+        val infotrygdFeedDto = objectMapper.readValue(testTask.payload, InfotrygdFødselhendelsesFeedTaskDto::class.java)
 
         Assertions.assertEquals(fnrBarn, infotrygdFeedDto.fnrBarn)
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/SendFeedTilInfotrygdTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/SendFeedTilInfotrygdTaskTest.kt
@@ -22,7 +22,7 @@ class SendFeedTilInfotrygdTaskTest {
 
         val infotrygdFeedDto = objectMapper.readValue(testTask.payload, InfotrygdFødselhendelsesFeedTaskDto::class.java)
 
-        Assertions.assertEquals(fnrBarn, infotrygdFeedDto.fnrBarn)
+        Assertions.assertEquals(listOf(fnrBarn), infotrygdFeedDto.fnrBarn)
     }
 
 }


### PR DESCRIPTION
En task 'send feed til Infotrygd' per barn ble opprette.
Det er redusert til at en task per fødselsmleding blir opprettet. 