### PR TITLE
Legg til preprod-workflow uten e2e-tester

### DIFF
--- a/.github/workflows/build-and-deploy-preprod-skip-e2e.yml
+++ b/.github/workflows/build-and-deploy-preprod-skip-e2e.yml
@@ -1,0 +1,50 @@
+name: Build-Deploy-Preprod-Skip-E2E
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ba-sak:${{ github.sha }}
+jobs:
+  deploy-to-dev:
+    name: Bygg app/image, push til github, deploy til dev-fss
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-cache-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-cache-
+      - name: Bygg med maven + sonar
+        env:
+          SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
+          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B --no-transfer-progress package verify sonar:sonar --settings .m2/maven-settings.xml --file pom.xml
+      - name: Bygg Docker image
+        run: |
+          docker build -t $IMAGE .
+      - name: Login to Github Package Registry
+        env:
+          DOCKER_USERNAME: x-access-token
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_DOCKER_PUSH_PACKAGE_TOKEN }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
+      - name: Push Docker image
+        run: docker push $IMAGE
+      - uses: navikt/github-app-token-generator@master
+        id: get-token
+        with:
+          private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}
+          app-id: ${{ secrets.REPO_CLONER_APP_ID }}
+      - name: Deploy til dev-fss
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+          CLUSTER: dev-fss
+          RESOURCE: app-preprod.yaml

--- a/.github/workflows/build-and-deploy-preprod-skip-e2e.yml
+++ b/.github/workflows/build-and-deploy-preprod-skip-e2e.yml
@@ -37,11 +37,6 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
       - name: Push Docker image
         run: docker push $IMAGE
-      - uses: navikt/github-app-token-generator@master
-        id: get-token
-        with:
-          private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}
-          app-id: ${{ secrets.REPO_CLONER_APP_ID }}
       - name: Deploy til dev-fss
         uses: nais/deploy/actions/deploy@v1
         env:


### PR DESCRIPTION
Til testing av brancher i miljø. Kan kun trigges manuelt (workflow dispatch).

På pull requester kjøres flyt med e2e.