### PR TITLE
Fix/mocking

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
@@ -12,6 +12,7 @@ val TIDENES_MORGEN = LocalDate.MIN
 val TIDENES_ENDE = LocalDate.MAX
 
 
+fun LocalDate.tilddMMYY() = this.format(DateTimeFormatter.ofPattern("ddMMYY", nbLocale))
 fun LocalDate.tilKortString() = this.format(DateTimeFormatter.ofPattern("dd.MM.YY", nbLocale))
 fun LocalDate.tilDagMånedÅr() = this.format(DateTimeFormatter.ofPattern("d. MMMM YYYY", nbLocale))
 fun LocalDate.tilMånedÅr() = this.format(DateTimeFormatter.ofPattern("MMMM YYYY", nbLocale))

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -4,10 +4,7 @@ import io.mockk.*
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.GrBostedsadresseperiode
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.common.DatoIntervallEntitet
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.randomAktørId
-import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.common.*
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonException
 import no.nav.familie.ba.sak.integrasjoner.domene.Arbeidsfordelingsenhet
@@ -379,7 +376,8 @@ class ClientMocks {
         }
 
         val søkerFnr = arrayOf("12345678910", "11223344556")
-        val barnFnr = arrayOf("01101800033", "01101900033")
+        val barnFødselsdatoer = arrayOf(LocalDate.now().minusYears(2), LocalDate.now().førsteDagIInneværendeMåned())
+        val barnFnr = arrayOf(barnFødselsdatoer[0].tilddMMYY()+"00033", barnFødselsdatoer[1].tilddMMYY()+"00033")
         val integrasjonerFnr = "10000111111"
         val bostedsadresse = Bostedsadresse(
                 matrikkeladresse = Matrikkeladresse(matrikkelId = 123L, bruksenhetsnummer = "H301", tilleggsnavn = "navn",

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -377,7 +377,7 @@ class ClientMocks {
 
         val søkerFnr = arrayOf("12345678910", "11223344556")
         val barnFødselsdatoer = arrayOf(LocalDate.now().minusYears(2), LocalDate.now().førsteDagIInneværendeMåned())
-        val barnFnr = arrayOf(barnFødselsdatoer[0].tilddMMYY()+"00033", barnFødselsdatoer[1].tilddMMYY()+"00033")
+        val barnFnr = arrayOf(barnFødselsdatoer[0].tilddMMYY() + "00033", barnFødselsdatoer[1].tilddMMYY() + "00033")
         val integrasjonerFnr = "10000111111"
         val bostedsadresse = Bostedsadresse(
                 matrikkeladresse = Matrikkeladresse(matrikkelId = 123L, bruksenhetsnummer = "H301", tilleggsnavn = "navn",
@@ -395,12 +395,12 @@ class ClientMocks {
                                           sivilstand = SIVILSTAND.GIFT,
                                           kjønn = Kjønn.MANN,
                                           navn = "Far Faresen"),
-                barnFnr[0] to PersonInfo(fødselsdato = LocalDate.now().minusYears(2),
+                barnFnr[0] to PersonInfo(fødselsdato = barnFødselsdatoer[0],
                                          bostedsadresse = bostedsadresse,
                                          sivilstand = SIVILSTAND.UOPPGITT,
                                          kjønn = Kjønn.MANN,
                                          navn = "Gutten Barnesen"),
-                barnFnr[1] to PersonInfo(fødselsdato = LocalDate.now().førsteDagIInneværendeMåned(),
+                barnFnr[1] to PersonInfo(fødselsdato = barnFødselsdatoer[1],
                                          bostedsadresse = bostedsadresse,
                                          sivilstand = SIVILSTAND.UGIFT,
                                          kjønn = Kjønn.KVINNE,

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.e2e.DatabaseCleanupService
 import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
@@ -29,6 +30,9 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
                                       @Autowired private val behandlingRepository: BehandlingRepository,
                                       @Autowired private val databaseCleanupService: DatabaseCleanupService) {
 
+    val barnIdent = ClientMocks.barnFnr[0]
+    val morsIdent = ClientMocks.søkerFnr[0]
+
     @BeforeEach
     fun init() {
         databaseCleanupService.truncate()
@@ -40,8 +44,8 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns true
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
-        Assertions.assertNull(fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910")))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
+        Assertions.assertNull(fagsakRepository.finnFagsakForPersonIdent(PersonIdent(morsIdent)))
     }
 
     @Test
@@ -50,8 +54,8 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns false
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
-        Assertions.assertNotNull(fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910")))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
+        Assertions.assertNotNull(fagsakRepository.finnFagsakForPersonIdent(PersonIdent(morsIdent)))
     }
 
     @Test
@@ -60,9 +64,9 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns false
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter =listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
 
-        val fagsak = fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910"))!!
+        val fagsak = fagsakRepository.finnFagsakForPersonIdent(PersonIdent(morsIdent))!!
         val behandling = behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!
         behandling.status = BehandlingStatus.AVSLUTTET
         behandlingRepository.save(behandling)
@@ -71,7 +75,7 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns true
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent ="12345678910", barnasIdenter = listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
         Assertions.assertEquals(behandling.id, behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!.id)
     }
 
@@ -81,15 +85,15 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns false
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
 
-        val fagsak = fagsakRepository.finnFagsakForPersonIdent(PersonIdent("12345678910"))!!
+        val fagsak = fagsakRepository.finnFagsakForPersonIdent(PersonIdent(morsIdent))!!
         val behandling = behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!
         behandling.status = BehandlingStatus.AVSLUTTET
         behandlingRepository.save(behandling)
 
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
-                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = "12345678910", barnasIdenter = listOf("01101900033")))))
+                BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
         Assertions.assertNotEquals(behandling.id, behandlingRepository.findByFagsakAndAktiv(fagsakId = fagsak.id)!!.id)
     }
 }


### PR DESCRIPTION
Koble dato og fødselsnummer for barn i pdl-mock. Fikser også tester som var avhengig av hardkoda fnr for barn.