### PR TITLE
Legg til etterbetaling og feilutbetaling på innvilgelsebrev 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
@@ -108,14 +108,16 @@ class MalerService(
                                         enhet: String,
                                         målform: Målform): String {
         val totrinnskontroll = totrinnskontrollService.opprettEllerHentTotrinnskontroll(vedtak.behandling)
-
+        val etterbetalingsbeløp = etterbetalingsbeløpFraSimulering().takeIf { it > 0 }
         val innvilget = Innvilget(
                 enhet = enhet,
                 saksbehandler = totrinnskontroll.saksbehandler,
                 beslutter = totrinnskontroll.beslutter
                             ?: totrinnskontroll.saksbehandler,
                 hjemmel = Utils.slåSammen(listOf("§§ 2", "4", "11")),
-                maalform = målform.toString()
+                maalform = målform.toString(),
+                etterbetalingsbelop = etterbetalingsbeløp?.run { Utils.formaterBeløp(this) } ?: "",
+                erFeilutbetaling = tilbakekrevingsbeløpFraSimulering() > 0,
         )
 
         innvilget.duFaar = beregningOversikt
@@ -170,6 +172,9 @@ class MalerService(
     }
 
     private fun etterbetalingsbeløpFraSimulering() = 0 //TODO Må legges inn senere når simulering er implementert.
+    // Inntil da er det tryggest å utelate denne informasjonen fra brevet.
+
+    private fun tilbakekrevingsbeløpFraSimulering() = 0 //TODO Må legges inn senere når simulering er implementert.
     // Inntil da er det tryggest å utelate denne informasjonen fra brevet.
 
     private fun mapTilAvslagBrevFelter(vedtak: Vedtak): String {

--- a/src/main/kotlin/no/nav/familie/ba/sak/dokument/domene/maler/Innvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/dokument/domene/maler/Innvilget.kt
@@ -9,7 +9,9 @@ data class Innvilget(
         val beslutter: String,
         val hjemmel: String, // "§2, 4 og 11"
         var duFaar: List<DuFårSeksjon> = emptyList(),
-        val maalform: String
+        val maalform: String,
+        val etterbetalingsbelop: String? = "",
+        val erFeilutbetaling: Boolean? = false,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
- Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-2468
- Oppdaterer innvilgelsemaler for førstegangsvedtak (manuell) og revurdering: https://github.com/navikt/familie-ba-dokgen/pulls
- Trenger da etterbetalingsbeløp for begge og feilutbetaling for revurdering. Ikke implementert simulering enda. 