### PR TITLE
WIP: Begrunnelsetekster

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestVedtak.kt
@@ -2,8 +2,10 @@ package no.nav.familie.ba.sak.behandling.restDomene
 
 import no.nav.familie.ba.sak.behandling.vedtak.UtbetalingBegrunnelse
 import no.nav.familie.ba.sak.behandling.vedtak.Vedtak
+import no.nav.familie.ba.sak.behandling.vilkår.BegrunnelseService
 import no.nav.familie.ba.sak.behandling.vilkår.BehandlingResultatType
 import no.nav.familie.ba.sak.behandling.vilkår.BehandlingresultatOgVilkårBegrunnelse
+import no.nav.familie.ba.sak.behandling.vilkår.Vilkår
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -29,8 +31,13 @@ data class RestPutUtbetalingBegrunnelse(
         val behandlingresultatOgVilkårBegrunnelse: BehandlingresultatOgVilkårBegrunnelse?
 )
 
+data class RestPutUtbetalingBegrunnelseForslag(
+        val kategori: BegrunnelseService.BegrunnelseKategori?,
+        val vilkår: Vilkår?
+)
+
 data class RestVedtakBegrunnelse(
-        val id: BehandlingresultatOgVilkårBegrunnelse,
+        val id: BegrunnelseService.Begrunnelse,
         val navn: String
 )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BegrunnelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BegrunnelseService.kt
@@ -42,7 +42,8 @@ object BegrunnelseService {
             },
     )
 
-    fun hentBegrunnelserFor(vilkår: Vilkår): List<Begrunnelse> = begrunnelser.filter { it.relevantFor == vilkår }
+    fun hentBegrunnelserFor(vilkår: Vilkår, begrunnelsekategori: BegrunnelseKategori): List<Begrunnelse> = begrunnelser.filter { it.relevantFor == vilkår && it.begrunnelsekategori == begrunnelsekategori }
+    fun hentBegrunnelserFor(vilkår: Vilkår): List<Begrunnelse> = begrunnelser.filter { it.relevantFor == vilkår}
 
 
     data class Begrunnelse(val begrunnelsekategori: BegrunnelseKategori,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BegrunnelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BegrunnelseService.kt
@@ -1,0 +1,63 @@
+package no.nav.familie.ba.sak.behandling.vilkår
+
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Målform
+
+object BegrunnelseService {
+
+    private val begrunnelser = listOf(
+            Begrunnelse(BegrunnelseKategori.INNVILGET,
+                        Vilkår.BOSATT_I_RIKET,
+                        "Norsk, nordisk, tredjelandsborger med lovlig opphold samtidig som bosatt i Norge"
+            ) { gjelderSøker, barnasFødselsdatoer, vilkårsdato, målform ->
+                when (målform) {
+                    Målform.NB -> "Du får barnetrygd fordi${if (gjelderSøker && barnasFødselsdatoer.isNotBlank()) " du og " else if (gjelderSøker) " du " else " "}${if (barnasFødselsdatoer.isNotBlank()) "barn født $barnasFødselsdatoer " else ""}er bosatt i Norge fra $vilkårsdato."
+                    Målform.NN -> ""
+                }
+            },
+
+            Begrunnelse(BegrunnelseKategori.INNVILGET,
+                        Vilkår.LOVLIG_OPPHOLD,
+                        "Tredjelandsborger bosatt før lovlig opphold i Norge"
+            ) { gjelderSøker, barnasFødselsdatoer, vilkårsdato, målform ->
+                when (målform) {
+                    Målform.NB -> "Du får barnetrygd fordi${if (gjelderSøker && barnasFødselsdatoer.isNotBlank()) " du og " else if (gjelderSøker) " du " else " "}${if (barnasFødselsdatoer.isNotBlank()) "barn født $barnasFødselsdatoer " else ""}har oppholdstillatelse fra $vilkårsdato."
+                    Målform.NN -> ""
+                }
+            },
+            Begrunnelse(BegrunnelseKategori.INNVILGET, Vilkår.LOVLIG_OPPHOLD, "EØS-borger: Søker har oppholdsrett"
+            ) { _, _, vilkårsdato, målform ->
+                when (målform) {
+                    Målform.NB -> "Du får barnetrygd fordi du har oppholdsrett som EØS-borger fra $vilkårsdato."
+                    Målform.NN -> ""
+                }
+            },
+            Begrunnelse(BegrunnelseKategori.REDUKSJON,
+                        Vilkår.BOSATT_I_RIKET,
+                        ""
+            ) { gjelderSøker, barnasFødselsdatoer, vilkårsdato, målform ->
+                when (målform) {
+                    Målform.NB -> "Barnetrygden reduseres fordi barn født $barnasFødselsdatoer har flyttet fra deg $vilkårsdato" // TODO: Husk å håndtere reduksjoner med tom-datoer i stedet for fom
+                    Målform.NN -> ""
+                }
+            },
+    )
+
+    fun hentBegrunnelserFor(vilkår: Vilkår): List<Begrunnelse> = begrunnelser.filter { it.relevantFor == vilkår }
+
+
+    data class Begrunnelse(val begrunnelsekategori: BegrunnelseKategori,
+                           val relevantFor: Vilkår, // TODO: Relevant for flere? Gjøre om til liste?
+                           val tittel: String,
+                           val beskrivelseGenerator:
+                           (gjelderSøker: Boolean,
+                            barnasFødselsdatoer: String,
+                            vilkårsdato: String,
+                            målform: Målform)
+                           -> String
+    )
+
+    enum class BegrunnelseKategori {
+        INNVILGET,
+        REDUKSJON
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BehandlingresultatOgVilkårBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/BehandlingresultatOgVilkårBegrunnelse.kt
@@ -4,6 +4,7 @@ interface IVedtakBegrunnelse {
     fun hentBeskrivelse(gjelderSøker: Boolean = false, barnasFødselsdatoer: String = "", vilkårsdato: String): String
 }
 
+// GÅR ALTSÅ BORT I FRA :
 enum class BehandlingresultatOgVilkårBegrunnelse(val tittel: String) : IVedtakBegrunnelse {
     INNVILGET_BOSATT_I_RIKTET("Norsk, nordisk, tredjelandsborger med lovlig opphold samtidig som bosatt i Norge") {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/Vilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/Vilkår.kt
@@ -3,13 +3,16 @@ package no.nav.familie.ba.sak.behandling.vilkår
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType.BARN
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType.SØKER
+import no.nav.familie.ba.sak.behandling.vilkår.BegrunnelseService.hentBegrunnelserFor
+import no.nav.familie.ba.sak.behandling.vilkår.BegrunnelseService.BegrunnelseKategori
+import no.nav.familie.ba.sak.behandling.vilkår.BegrunnelseService.Begrunnelse
 import no.nav.familie.ba.sak.nare.Spesifikasjon
 import java.time.LocalDate
 
 
 enum class Vilkår(val parterDetteGjelderFor: List<PersonType>,
                   val spesifikasjon: Spesifikasjon<FaktaTilVilkårsvurdering>,
-                  val begrunnelser: Map<BehandlingResultatType, List<BehandlingresultatOgVilkårBegrunnelse>> = emptyMap(),
+                  val begrunnelser: List<Begrunnelse> = emptyMap(),
                   val gyldigVilkårsperiode: GyldigVilkårsperiode) {
 
     UNDER_18_ÅR(
@@ -28,15 +31,7 @@ enum class Vilkår(val parterDetteGjelderFor: List<PersonType>,
                         søkerErMor(this) og barnBorMedSøker(this)
                     }
             ),
-            begrunnelser = mapOf(
-                    BehandlingResultatType.INNVILGET
-                            to
-                            listOf(
-                                    BehandlingresultatOgVilkårBegrunnelse.INNVILGET_OMSORG_FOR_BARN,
-                                    BehandlingresultatOgVilkårBegrunnelse.INNVILGET_BOR_HOS_SØKER,
-                                    BehandlingresultatOgVilkårBegrunnelse.INNVILGET_FAST_OMSORG_FOR_BARN
-                            )
-            ),
+            begrunnelser = hentBegrunnelserFor(BOR_MED_SØKER),
             gyldigVilkårsperiode = GyldigVilkårsperiode()),
     GIFT_PARTNERSKAP(
             parterDetteGjelderFor = listOf<PersonType>(BARN),
@@ -51,13 +46,7 @@ enum class Vilkår(val parterDetteGjelderFor: List<PersonType>,
                     beskrivelse = "Bosatt i riket",
                     identifikator = "BOSATT_I_RIKET",
                     implementasjon = { bosattINorge(this) }),
-            begrunnelser = mapOf(
-                    BehandlingResultatType.INNVILGET
-                            to
-                            listOf(
-                                    BehandlingresultatOgVilkårBegrunnelse.INNVILGET_BOSATT_I_RIKTET
-                            )
-            ),
+            begrunnelser = hentBegrunnelserFor(BOSATT_I_RIKET),
             gyldigVilkårsperiode = GyldigVilkårsperiode()),
     LOVLIG_OPPHOLD(
             parterDetteGjelderFor = listOf<PersonType>(SØKER, BARN),
@@ -66,15 +55,7 @@ enum class Vilkår(val parterDetteGjelderFor: List<PersonType>,
                     identifikator = "LOVLIG_OPPHOLD",
                     implementasjon =
                     { lovligOpphold(this) }),
-            begrunnelser = mapOf(
-                    BehandlingResultatType.INNVILGET
-                            to
-                            listOf(
-                                    BehandlingresultatOgVilkårBegrunnelse.INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE,
-                                    BehandlingresultatOgVilkårBegrunnelse.INNVILGET_LOVLIG_OPPHOLD_EØS_BORGER,
-                                    BehandlingresultatOgVilkårBegrunnelse.INNVILGET_LOVLIG_OPPHOLD_AAREG
-                            )
-            ),
+            begrunnelser = hentBegrunnelserFor(LOVLIG_OPPHOLD),
             gyldigVilkårsperiode = GyldigVilkårsperiode());
 
     override fun toString(): String {


### PR DESCRIPTION
Begynte på et lite utkast for å få begrunnelser på et mer strukturert format:
Legge kategori (INNVILGET) og vilkår (BOSATT_I_RIKET) i en begrunnelse-dataklasse i stedet for å bevare denne informasjonen i navn (INNVILGET_BOSATT_I_RIKTET). 

Det aller enkleste er å bare copy paste, slik som her: https://github.com/navikt/familie-ba-sak/compare/feature/reduksjontekster?expand=1 . Siden vi antakeligvis skal begynne på en omskriving til sanity i november er det mulig det er like greit å bare gjøre dette.

Det er bare et raskt utkast med eksempler, så koden kjører ikke nå og alle begrunnelsene er ikke implementert. 