### PR TITLE
Mapping og publisering av melding til datavarehus-topic ved fagsakoppdateringer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <felles.version>1.20201012050219_e63b118</felles.version>
         <felles-kontrakter.version>2.0_20200923130242_766e389</felles-kontrakter.version>
         <felles.prosessering.version>1.20200624154125_0d8ff39</felles.prosessering.version>
-        <familie.kontrakter.saksstatistikk>2.0_20200930143114_268ea08</familie.kontrakter.saksstatistikk>
+        <familie.kontrakter.saksstatistikk>2.0_20201012132018_dc05978</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20200922092220_f20484b</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.9.3</mockk.version>
         <token-validation-spring.version>1.3.0</token-validation-spring.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.pdl.internal.FAMILIERELASJONSROLLE
 import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
+import no.nav.familie.ba.sak.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.totrinnskontroll.TotrinnskontrollRepository
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -44,7 +45,8 @@ class FagsakService(
         private val vedtakRepository: VedtakRepository,
         private val totrinnskontrollRepository: TotrinnskontrollRepository,
         private val tilkjentYtelseRepository: TilkjentYtelseRepository,
-        private val personopplysningerService: PersonopplysningerService) {
+        private val personopplysningerService: PersonopplysningerService,
+        private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher) {
 
 
     private val antallFagsakerOpprettet = Metrics.counter("familie.ba.sak.fagsak.opprettet")
@@ -75,6 +77,7 @@ class FagsakService(
                 it.søkerIdenter = setOf(FagsakPerson(personIdent = personIdent, fagsak = it))
                 lagre(it)
             }
+            saksstatistikkEventPublisher.publish(fagsak.id)
             antallFagsakerOpprettet.increment()
         } else if (fagsak.søkerIdenter.none { fagsakPerson -> fagsakPerson.personIdent == personIdent }) {
             fagsak.also {
@@ -105,6 +108,7 @@ class FagsakService(
         fagsak.status = nyStatus
 
         lagre(fagsak)
+        saksstatistikkEventPublisher.publish(fagsak.id)
     }
 
     fun hentRestFagsak(fagsakId: Long): Ressurs<RestFagsak> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
@@ -84,6 +84,7 @@ class FagsakService(
                 it.søkerIdenter += FagsakPerson(personIdent = personIdent, fagsak = it)
                 lagre(it)
             }
+            saksstatistikkEventPublisher.publish(fagsak.id)
         }
         return fagsak
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
@@ -9,7 +9,7 @@ class SaksstatistikkEventListener(private val saksstatistikkService: Saksstatist
                                   private val kafkaProducer: KafkaProducer) : ApplicationListener<SaksstatistikkEvent> {
 
     override fun onApplicationEvent(event: SaksstatistikkEvent) {
-        saksstatistikkService.loggBehandlingStatus(event.behandlingId, event.forrigeBehandlingId).also {
+        saksstatistikkService.mapTilBehandlingDVH(event.behandlingId, event.forrigeBehandlingId).also {
             kafkaProducer.sendMessage(it)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
@@ -9,8 +9,14 @@ class SaksstatistikkEventListener(private val saksstatistikkService: Saksstatist
                                   private val kafkaProducer: KafkaProducer) : ApplicationListener<SaksstatistikkEvent> {
 
     override fun onApplicationEvent(event: SaksstatistikkEvent) {
-        saksstatistikkService.mapTilBehandlingDVH(event.behandlingId, event.forrigeBehandlingId).also {
-            kafkaProducer.sendMessage(it)
+        if (event.behandlingId != null) {
+            saksstatistikkService.mapTilBehandlingDVH(event.behandlingId, event.forrigeBehandlingId).also {
+                kafkaProducer.sendMessage(it)
+            }
+        } else if (event.fagsakId != null){
+            saksstatistikkService.mapTilSakDvh(event.fagsakId).also {
+                kafkaProducer.sendMessage(it)
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
@@ -11,11 +11,11 @@ class SaksstatistikkEventListener(private val saksstatistikkService: Saksstatist
     override fun onApplicationEvent(event: SaksstatistikkEvent) {
         if (event.behandlingId != null) {
             saksstatistikkService.mapTilBehandlingDVH(event.behandlingId, event.forrigeBehandlingId).also {
-                kafkaProducer.sendMessage(it)
+                kafkaProducer.sendMessageForTopicBehandling(it)
             }
         } else if (event.fagsakId != null){
             saksstatistikkService.mapTilSakDvh(event.fagsakId).also {
-                kafkaProducer.sendMessage(it)
+                kafkaProducer.sendMessageForTopicSak(it)
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventPublisher.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventPublisher.kt
@@ -13,8 +13,15 @@ class SaksstatistikkEventPublisher {
     lateinit var applicationEventPublisher: ApplicationEventPublisher
 
     fun publish(behandlingId: Long, forrigeBehandlingId: Long?) {
-        applicationEventPublisher.publishEvent(SaksstatistikkEvent(this, behandlingId, forrigeBehandlingId))
+        applicationEventPublisher.publishEvent(SaksstatistikkEvent(this, null, behandlingId, forrigeBehandlingId))
+    }
+
+    fun publish(fagsakId: Long) {
+        applicationEventPublisher.publishEvent(SaksstatistikkEvent(this, fagsakId, null, null))
     }
 }
 
-class SaksstatistikkEvent(source: Any, val behandlingId: Long, val forrigeBehandlingId: Long?) : ApplicationEvent(source)
+class SaksstatistikkEvent(source: Any,
+                          val fagsakId: Long?,
+                          val behandlingId: Long?,
+                          val forrigeBehandlingId: Long?) : ApplicationEvent(source)

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
@@ -3,16 +3,24 @@ package no.nav.familie.ba.sak.saksstatistikk
 import no.nav.familie.ba.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.behandling.BehandlingService
 import no.nav.familie.ba.sak.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.behandling.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.common.Utils.hentPropertyFraMaven
 import no.nav.familie.ba.sak.journalføring.JournalføringService
 import no.nav.familie.ba.sak.journalføring.domene.JournalføringRepository
+import no.nav.familie.ba.sak.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.SYSTEM_NAVN
 import no.nav.familie.ba.sak.totrinnskontroll.TotrinnskontrollService
+import no.nav.familie.eksterne.kontrakter.saksstatistikk.AktørDVH
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.BehandlingDVH
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.ResultatBegrunnelseDVH
+import no.nav.familie.eksterne.kontrakter.saksstatistikk.SakDVH
+import no.nav.familie.kontrakter.felles.getDataOrThrow
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
+import no.nav.familie.kontrakter.felles.personopplysning.Ident
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -22,9 +30,11 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
                             private val journalføringService: JournalføringService,
                             private val arbeidsfordelingService: ArbeidsfordelingService,
                             private val totrinnskontrollService: TotrinnskontrollService,
-                            private val vedtakService: VedtakService) {
+                            private val vedtakService: VedtakService,
+                            private val fagsakService: FagsakService,
+                            private val personopplysningerService: PersonopplysningerService) {
 
-    fun loggBehandlingStatus(behandlingId: Long, forrigeBehandlingId: Long? = null): BehandlingDVH {
+    fun mapTilBehandlingDVH(behandlingId: Long, forrigeBehandlingId: Long? = null): BehandlingDVH {
         val behandling = behandlingService.hent(behandlingId)
 
         val datoMottatt = when (behandling.opprettetÅrsak) {
@@ -89,6 +99,27 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
         }
 
         return behandlingDVH
+    }
+
+    fun mapTilSakDvh(sakId: Long): SakDVH {
+        val fagsak = fagsakService.hentRestFagsak(sakId).getDataOrThrow()
+
+        val søkersAktørId = personopplysningerService.hentAktivAktørId(Ident(fagsak.søkerFødselsnummer))
+
+        val deltagere = fagsakService.hentFagsakDeltager(fagsak.søkerFødselsnummer).filter { it.fagsakId == sakId }
+                .map { AktørDVH(personopplysningerService.hentAktivAktørId(Ident(it.ident)).id.toLong(), it.rolle.name) }
+
+        return SakDVH(
+                funksjonellTid = ZonedDateTime.now(),
+                tekniskTid = ZonedDateTime.now(),
+                opprettetDato = LocalDate.now(),
+                sakId = sakId.toString(),
+                aktorId = søkersAktørId.id.toLong(),
+                aktorer = deltagere,
+                sakStatus = fagsak.status.name,
+                avsender = "familie-ba-sak",
+                versjon = hentPropertyFraMaven("familie.kontrakter.saksstatistikk") ?: "2",
+        )
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkTestController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkTestController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.saksstatistikk
 
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.BehandlingDVH
+import no.nav.familie.eksterne.kontrakter.saksstatistikk.SakDVH
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.Unprotected
 import org.slf4j.LoggerFactory
@@ -27,7 +28,18 @@ class SaksstatistikkTestController(
         try {
             return saksstatistikkService.mapTilBehandlingDVH(behandlingId, null)
         } catch (e: Exception) {
-            LOG.error("Feil ved henting av sakstatistikk", e)
+            LOG.warn("Feil ved henting av sakstatistikk", e)
+            throw e
+        }
+    }
+
+    @GetMapping(path = ["/sak/{fagsakId}"])
+    @Unprotected
+    fun hentSakDvh(@PathVariable(name = "fagsakId", required = true) fagsakId: Long): SakDVH {
+        try {
+            return saksstatistikkService.mapTilSakDvh(fagsakId)
+        } catch (e: Exception) {
+            LOG.warn("Feil ved henting av sakstatistikk sak", e)
             throw e
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkTestController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkTestController.kt
@@ -1,15 +1,10 @@
 package no.nav.familie.ba.sak.saksstatistikk
 
-import no.nav.familie.ba.sak.pdl.PdlRestClient
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.BehandlingDVH
-import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.prosessering.domene.Task
-import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.Unprotected
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -30,7 +25,7 @@ class SaksstatistikkTestController(
     @Unprotected
     fun hentBehandlingDvh(@PathVariable(name = "behandlingId", required = true) behandlingId: Long): BehandlingDVH {
         try {
-            return saksstatistikkService.loggBehandlingStatus(behandlingId, null)
+            return saksstatistikkService.mapTilBehandlingDVH(behandlingId, null)
         } catch (e: Exception) {
             LOG.error("Feil ved henting av sakstatistikk", e)
             throw e

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PubliserVedtakTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PubliserVedtakTask.kt
@@ -21,7 +21,7 @@ class PubliserVedtakTask(val kafkaProducer: KafkaProducer,
 
     override fun doTask(task: Task) {
         val vedtakDVH = stønadsstatistikkService.hentVedtak(task.payload.toLong())
-        task.metadata["offset"] = kafkaProducer.sendMessage(vedtakDVH).toString()
+        task.metadata["offset"] = kafkaProducer.sendMessageForTopicVedtak(vedtakDVH).toString()
 
         taskRepository.save(task)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/vedtak/producer/KafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/vedtak/producer/KafkaProducer.kt
@@ -14,9 +14,9 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 
 interface KafkaProducer {
-    fun sendMessage(vedtak: VedtakDVH): Long
-    fun sendMessage(behandling: BehandlingDVH): Long
-    fun sendMessage(sak: SakDVH): Long
+    fun sendMessageForTopicVedtak(vedtak: VedtakDVH): Long
+    fun sendMessageForTopicBehandling(behandling: BehandlingDVH): Long
+    fun sendMessageForTopicSak(sak: SakDVH): Long
 }
 
 @Service
@@ -30,19 +30,19 @@ class DefaultKafkaProducer : KafkaProducer {
     @Autowired
     lateinit var kafkaTemplate: KafkaTemplate<String, Any>
 
-    override fun sendMessage(vedtak: VedtakDVH): Long {
+    override fun sendMessageForTopicVedtak(vedtak: VedtakDVH): Long {
         val response = kafkaTemplate.send(VEDTAK_TOPIC, vedtak.behandlingsId, vedtak).get()
         logger.info("$VEDTAK_TOPIC -> message sent -> ${response.recordMetadata.offset()}")
         return response.recordMetadata.offset()
     }
 
-    override fun sendMessage(behandling: BehandlingDVH): Long {
+    override fun sendMessageForTopicBehandling(behandling: BehandlingDVH): Long {
         val response = kafkaTemplate.send(SAKSSTATISTIKK_BEHANDLING_TOPIC, behandling.behandlingId, behandling).get()
         logger.info("$SAKSSTATISTIKK_BEHANDLING_TOPIC -> message sent -> ${response.recordMetadata.offset()}")
         return response.recordMetadata.offset()
     }
 
-    override fun sendMessage(sak: SakDVH): Long {
+    override fun sendMessageForTopicSak(sak: SakDVH): Long {
         val response = kafkaTemplate.send(SAKSSTATISTIKK_SAK_TOPIC, sak.sakId, sak).get()
         logger.info("$SAKSSTATISTIKK_SAK_TOPIC -> message sent -> ${response.recordMetadata.offset()}")
         return response.recordMetadata.offset()
@@ -61,20 +61,20 @@ class MockKafkaProducer : KafkaProducer {
 
     val logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun sendMessage(vedtak: VedtakDVH): Long {
+    override fun sendMessageForTopicVedtak(vedtak: VedtakDVH): Long {
         logger.info("Skipper sending av vedtak for ${vedtak.behandlingsId} fordi kafka ikke er enablet")
 
         sendteMeldinger["vedtak-${vedtak.behandlingsId}"] = vedtak
         return 0
     }
 
-    override fun sendMessage(behandling: BehandlingDVH): Long {
+    override fun sendMessageForTopicBehandling(behandling: BehandlingDVH): Long {
         logger.info("Skipper sending av saksstatistikk behandling for ${behandling.behandlingId} fordi kafka ikke er enablet")
         sendteMeldinger["behandling-${behandling.behandlingId}"] = behandling
         return 0
     }
 
-    override fun sendMessage(sak: SakDVH): Long {
+    override fun sendMessageForTopicSak(sak: SakDVH): Long {
         logger.info("Skipper sending av saksstatistikk sak for ${sak.sakId} fordi kafka ikke er enablet")
         sendteMeldinger["sak-${sak.sakId}"] = sak
         return 0

--- a/src/main/kotlin/no/nav/familie/ba/sak/vedtak/verktøy/KafkaController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/vedtak/verktøy/KafkaController.kt
@@ -22,6 +22,6 @@ class KafkaController @Autowired internal constructor(private val producer: Kafk
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
     @Deprecated("For midlertidig testbruk")
     fun sendMessageToKafkaTopic(@RequestBody vedtak: VedtakDVH) {
-        producer.sendMessage(vedtak)
+        producer.sendMessageForTopicVedtak(vedtak)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakServiceTest.kt
@@ -22,6 +22,8 @@ import no.nav.familie.ba.sak.pdl.internal.Familierelasjon
 import no.nav.familie.ba.sak.pdl.internal.PersonInfo
 import no.nav.familie.ba.sak.pdl.internal.Personident
 import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
+import no.nav.familie.ba.sak.vedtak.producer.MockKafkaProducer
+import no.nav.familie.eksterne.kontrakter.saksstatistikk.SakDVH
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.TestInstance.Lifecycle
@@ -43,9 +45,6 @@ class FagsakServiceTest(
 
         @Autowired
         private val stegService: StegService,
-
-        @Autowired
-        private val integrasjonClient: IntegrasjonClient,
 
         @Autowired
         private val personopplysningerService: PersonopplysningerService,
@@ -186,6 +185,11 @@ class FagsakServiceTest(
         assertEquals(1, søkeresultat3.filter { it.ident == søker3Fnr }.size)
         assertEquals("søker3", søkeresultat3.filter { it.ident == søker3Fnr }[0].navn)
         assertNull(søkeresultat3.find { it.ident == søker3Fnr }!!.fagsakId)
+
+        val fagsak = fagsakService.hent(PersonIdent(søker1Fnr))!!
+        Assertions.assertEquals(FagsakStatus.OPPRETTET.name,
+                                (MockKafkaProducer.meldingSendtFor(fagsak) as SakDVH).sakStatus)
+
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -27,8 +27,8 @@ import java.util.*
 import kotlin.math.abs
 import kotlin.random.Random
 
-fun randomFnr(): String = UUID.randomUUID().toString()
-fun randomAktørId(): AktørId = AktørId(UUID.randomUUID().toString())
+fun randomFnr(): String = Random.nextLong(10_000_000_000, 31_121_299_999).toString()
+fun randomAktørId(): AktørId = AktørId(Random.nextLong(1000_000_000_000, 31_121_299_99999).toString())
 
 private var gjeldendeVedtakId: Long = abs(Random.nextLong(10000000))
 private var gjeldendeUtbetalingBegrunnelseId: Long = abs(Random.nextLong(10000000))

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -191,6 +191,21 @@ class ClientMocks {
                         Familierelasjon(personIdent = Personident(id = søkerFnr[1]),
                                         relasjonsrolle = FAMILIERELASJONSROLLE.MEDMOR)))
 
+        every{
+            mockPersonopplysningerService.hentPersoninfoMedRelasjoner(any())
+        } returns personInfo.getValue(integrasjonerFnr).copy(
+                familierelasjoner = setOf(
+                        Familierelasjon(personIdent = Personident(id = barnFnr[0]),
+                                        relasjonsrolle = FAMILIERELASJONSROLLE.BARN,
+                                        navn = personInfo.getValue(barnFnr[0]).navn,
+                                        fødselsdato = personInfo.getValue(barnFnr[0]).fødselsdato),
+                        Familierelasjon(personIdent = Personident(id = barnFnr[1]),
+                                        relasjonsrolle = FAMILIERELASJONSROLLE.BARN,
+                                        navn = personInfo.getValue(barnFnr[1]).navn,
+                                        fødselsdato = personInfo.getValue(barnFnr[1]).fødselsdato),
+                        Familierelasjon(personIdent = Personident(id = søkerFnr[1]),
+                                        relasjonsrolle = FAMILIERELASJONSROLLE.MEDMOR)))
+
         every {
             mockPersonopplysningerService.hentAdressebeskyttelseSomSystembruker(any())
         } returns ADRESSEBESKYTTELSEGRADERING.UGRADERT

--- a/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventPublisherFailSafe.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventPublisherFailSafe.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.ba.sak.saksstatistikk
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+@TestConfiguration
+class SaksstatistikkEventPublisherFailSafe: SaksstatistikkEventPublisher() {
+
+    @Bean
+    @Primary
+    fun safeSaksstatistikkEventPublisher(): SaksstatistikkEventPublisher {
+        return this
+    }
+
+    override fun publish(behandlingId: Long, forrigeBehandlingId: Long?) {
+        runCatching {
+            super.publish(behandlingId, forrigeBehandlingId)
+        }
+    }
+
+    override fun publish(fagsakId: Long) {
+        runCatching {
+            super.publish(fagsakId)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ba.sak.behandling.BehandlingService
 import no.nav.familie.ba.sak.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.vedtak.UtbetalingBegrunnelse
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.behandling.vilkår.VedtakBegrunnelse
@@ -16,6 +17,7 @@ import no.nav.familie.ba.sak.integrasjoner.lagTestJournalpost
 import no.nav.familie.ba.sak.journalføring.JournalføringService
 import no.nav.familie.ba.sak.journalføring.domene.DbJournalpost
 import no.nav.familie.ba.sak.journalføring.domene.JournalføringRepository
+import no.nav.familie.ba.sak.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.SYSTEM_NAVN
 import no.nav.familie.ba.sak.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.totrinnskontroll.domene.Totrinnskontroll
@@ -41,6 +43,8 @@ internal class SaksstatistikkServiceTest {
     private val journalføringService: JournalføringService = mockk()
     private val arbeidsfordelingService: ArbeidsfordelingService = mockk()
     private val totrinnskontrollService: TotrinnskontrollService = mockk()
+    private val fagsakService: FagsakService = mockk()
+    private val personopplysningerService: PersonopplysningerService = mockk()
 
     private val vedtakService: VedtakService = mockk()
 
@@ -50,7 +54,9 @@ internal class SaksstatistikkServiceTest {
             journalføringService,
             arbeidsfordelingService,
             totrinnskontrollService,
-            vedtakService)
+            vedtakService,
+            fagsakService,
+            personopplysningerService)
 
 
     @BeforeAll
@@ -75,7 +81,7 @@ internal class SaksstatistikkServiceTest {
                 behandling = behandling
         )
 
-        val behandlingDvh = sakstatistikkService.loggBehandlingStatus(2, 1)
+        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2, 1)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(behandlingDvh))
 
         assertThat(behandlingDvh.funksjonellTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
@@ -133,7 +139,7 @@ internal class SaksstatistikkServiceTest {
         val jp = lagTestJournalpost("123", "123").copy(relevanteDatoer = listOf(RelevantDato(mottattDato, "DATO_REGISTRERT")))
         every { journalføringService.hentJournalpost(any()) } returns Ressurs.Companion.success(jp)
 
-        val behandlingDvh = sakstatistikkService.loggBehandlingStatus(2, 1)
+        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2, 1)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(behandlingDvh))
 
         assertThat(behandlingDvh.funksjonellTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
@@ -156,6 +162,12 @@ internal class SaksstatistikkServiceTest {
         assertThat(behandlingDvh.avsender).isEqualTo("familie-ba-sak")
         assertThat(behandlingDvh.versjon).isNotEmpty
 
+    }
+
+
+    @Test
+    fun `Skal mappe til sakDVH for manuell rute`() {
+        
     }
 
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.task.dto.FerdigstillBehandlingDTO
 import no.nav.familie.ba.sak.vedtak.producer.MockKafkaProducer.Companion.meldingSendtFor
 import no.nav.familie.ba.sak.økonomi.ØkonomiService
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.BehandlingDVH
+import no.nav.familie.eksterne.kontrakter.saksstatistikk.SakDVH
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.domene.Task
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -108,6 +109,7 @@ class FerdigstillBehandlingTaskTest {
 
         val ferdigstiltFagsak = ferdigstiltBehandling.fagsak
         assertEquals(FagsakStatus.LØPENDE, ferdigstiltFagsak.status)
+        assertEquals(FagsakStatus.LØPENDE.name, (meldingSendtFor(ferdigstiltFagsak) as SakDVH).sakStatus)
     }
 
     @Test
@@ -124,6 +126,7 @@ class FerdigstillBehandlingTaskTest {
 
         val ferdigstiltFagsak = ferdigstiltBehandling.fagsak
         assertEquals(FagsakStatus.AVSLUTTET, ferdigstiltFagsak.status)
+        assertEquals(FagsakStatus.AVSLUTTET.name, (meldingSendtFor(ferdigstiltFagsak) as SakDVH).sakStatus)
     }
 
     fun iverksettMotOppdrag(vedtakId: Long) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/PubliserVedtakTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/PubliserVedtakTaskTest.kt
@@ -44,7 +44,7 @@ class PubliserVedtakTaskTest {
 
     @Test
     fun `skal kjøre task`() {
-        every { kafkaProducerMock.sendMessage(ofType(VedtakDVH::class)) }.returns(100)
+        every { kafkaProducerMock.sendMessageForTopicVedtak(ofType(VedtakDVH::class)) }.returns(100)
 
         publiserVedtakTask.doTask(PubliserVedtakTask.opprettTask("ident", 42))
 


### PR DESCRIPTION
Ny metode for mapping til SakDVH-kontrakten i SaksstatistikkService.
Publiserer sakshendelse ved opprettelse og oppdatering av fagsakstatus.

Lagt til assertions på at meldinger blir publisert til kafka-topic i enkelte integrasjonstester som treffer den nye koden.
Lagt til Test config med fail-safe SaksstatistikkEventPublisher bean, for at saksstatistikk ikke skal være en show stopper i test context. 
Lagt til getSakDVH i i testcontroller for enkelhets skyld i preprod.
