### PR TITLE
Forbedringer på malerservice - gjør det mulig å sende liste begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VedtakBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VedtakBegrunnelse.kt
@@ -239,9 +239,9 @@ enum class VedtakBegrunnelse(val tittel: String) : IVedtakBegrunnelse {
                                      målform: Målform): String =
                 when (målform) {
                     Målform.NB -> "Du og den andre forelderen er uenige om avtalen om delt bosted. Vi har kommet fram til at avtalen om delt bosted for barn født $barnasFødselsdatoer ikke lenger praktiseres fra $vilkårsdato." +
-                                  "\n\u2022 Ved uenighet mellom foreldrene om avtalen om delt bosted, kan barnetrygden opphøres fra måneden etter at vi fikk søknad om full barnetrygd."
+                                  "\nVed uenighet mellom foreldrene om avtalen om delt bosted, kan barnetrygden opphøres fra måneden etter at vi fikk søknad om full barnetrygd."
                     Målform.NN -> "Du og den andre forelderen er usamde om avtalen om delt bustad. Vi har kome fram til at avtalen om delt bustad for barn fødd $barnasFødselsdatoer ikkje lenger blir praktisert frå $vilkårsdato." +
-                                  "\n\u2022 Når de er usamde om avtalen om delt bustad, kan vi opphøyre barnetrygda til deg frå og med månaden etter at vi fekk søknad om full barnetrygd. "
+                                  "\nNår de er usamde om avtalen om delt bustad, kan vi opphøyre barnetrygda til deg frå og med månaden etter at vi fekk søknad om full barnetrygd. "
                 }
     },
     INNVILGET_SATSENDRING("Satsendring") {

--- a/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
@@ -120,30 +120,30 @@ class MalerService(
 
         innvilget.duFaar = beregningOversikt
                 .filter { it.endring.trengerBegrunnelse }
-                .map {
+                .map { utbetalingsperiode ->
                     val barnasFødselsdatoer =
-                            Utils.slåSammen(it.beregningDetaljer
+                            Utils.slåSammen(utbetalingsperiode.beregningDetaljer
                                                     .filter { restBeregningDetalj -> restBeregningDetalj.person.type == PersonType.BARN }
                                                     .sortedBy { restBeregningDetalj -> restBeregningDetalj.person.fødselsdato }
                                                     .map { restBeregningDetalj ->
                                                         restBeregningDetalj.person.fødselsdato?.tilKortString() ?: ""
                                                     })
 
-                    val begrunnelse =
-                            vedtak.utbetalingBegrunnelser.filter { stønadBrevBegrunnelse ->
-                                stønadBrevBegrunnelse.fom == it.periodeFom && stønadBrevBegrunnelse.tom == it.periodeTom
-                            }.toMutableSet().map { utbetalingBegrunnelse ->
-                                utbetalingBegrunnelse.brevBegrunnelse
-                                ?: "Ikke satt"
-                            }.toList()
+                    val begrunnelser =
+                            vedtak.utbetalingBegrunnelser
+                                    .filter { it.fom == utbetalingsperiode.periodeFom && it.tom == utbetalingsperiode.periodeTom }
+                                    .map {
+                                        it.brevBegrunnelse?.lines() ?: listOf("Ikke satt")
+                                    }
+                                    .flatten()
 
                     DuFårSeksjon(
-                            fom = it.periodeFom.tilMånedÅr(),
-                            tom = if (!it.periodeTom.erSenereEnnNesteMåned()) it.periodeTom.tilMånedÅr() else "",
-                            belop = Utils.formaterBeløp(it.utbetaltPerMnd),
-                            antallBarn = it.antallBarn,
+                            fom = utbetalingsperiode.periodeFom.tilMånedÅr(),
+                            tom = if (!utbetalingsperiode.periodeTom.erSenereEnnNesteMåned()) utbetalingsperiode.periodeTom.tilMånedÅr() else "",
+                            belop = Utils.formaterBeløp(utbetalingsperiode.utbetaltPerMnd),
+                            antallBarn = utbetalingsperiode.antallBarn,
                             barnasFodselsdatoer = barnasFødselsdatoer,
-                            begrunnelser = begrunnelse
+                            begrunnelser = begrunnelser
                     )
                 }
 


### PR DESCRIPTION
I enkelte tilfeller er det ønskelig å vise flere punkter begrunnelser for en begrunnelse. Splitter begrunnelser på linjeskift, slik at disse sendes som liste til dokgen. Vurderte muligheten for å lagre som separate databaseinnslag, men tror det blir veldig rotete mtp id'er og oppdatering. 

Forrige forsøk på å legge inn unicode bulletpoints så veldig rart ut. 
Resultat nå: 
![Skjermbilde 2020-10-20 kl  17 16 27](https://user-images.githubusercontent.com/5719550/96607280-80fa2a80-12f8-11eb-9389-84ffc5828453.png)
