### PR TITLE
Endret feilende tester som følge av endret oppførsel når den 21. i må…

### DIFF
--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/filtreringsregler/FiltreringsreglerForFlereBarnTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/filtreringsregler/FiltreringsreglerForFlereBarnTest.kt
@@ -119,7 +119,7 @@ class FiltreringsreglerForFlereBarnTest {
 
         every { personopplysningerServiceMock.hentVergeData(Ident(gyldigFnr.ident)) } returns VergeData(harVerge = false)
 
-        every { localDateServiceMock.now() } returns LocalDate.now()
+        every { localDateServiceMock.now() } returns LocalDate.now().withDayOfMonth(20)
 
         val (_, evaluering) = evaluerFiltreringsreglerForFødselshendelse.evaluerFiltreringsregler(behandling,
                                                                                                   setOf(barnFnr0.ident,

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/filtreringsregler/FiltreringsreglerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/filtreringsregler/FiltreringsreglerTest.kt
@@ -49,14 +49,15 @@ internal class FiltreringsreglerTest {
         val restenAvBarna: List<PersonInfo> = listOf(PersonInfo(LocalDate.now().minusMonths(8).minusDays(1)),
                                                      PersonInfo(LocalDate.now().minusMonths(8)))
 
-        val evaluering = Filtreringsregler.hentSamletSpesifikasjon()
-                .evaluer(Fakta(mor,
-                               listOf(barnet1, barnet2),
-                               restenAvBarna,
-                               morLever = true,
-                               barnetLever = true,
-                               morHarVerge = false))
 
+        val evaluering = Filtreringsregler.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.spesifikasjon.evaluer(
+                Fakta(mor,
+                      listOf(barnet1, barnet2),
+                      restenAvBarna,
+                      morLever = true,
+                      barnetLever = true,
+                      morHarVerge = false)
+        )
         assertThat(evaluering.resultat).isEqualTo(Resultat.JA)
     }
 
@@ -68,16 +69,15 @@ internal class FiltreringsreglerTest {
         val restenAvBarna: List<PersonInfo> = listOf(PersonInfo(LocalDate.now().minusMonths(5).minusDays(1)),
                                                      PersonInfo(LocalDate.now().minusMonths(8)))
 
-        val evaluering = Filtreringsregler.hentSamletSpesifikasjon()
-                .evaluer(Fakta(mor,
-                               listOf(barnet1, barnet2),
-                               restenAvBarna,
-                               morLever = true,
-                               barnetLever = true,
-                               morHarVerge = false))
+        val evaluering = Filtreringsregler.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.spesifikasjon.evaluer(
+                Fakta(mor,
+                      listOf(barnet1, barnet2),
+                      restenAvBarna,
+                      morLever = true,
+                      barnetLever = true,
+                      morHarVerge = false))
 
         assertThat(evaluering.resultat).isEqualTo(Resultat.NEI)
-        assertEnesteRegelMedResultatNei(evaluering.children, Filtreringsregler.MER_ENN_5_MND_SIDEN_FORRIGE_BARN)
     }
 
     @Test


### PR DESCRIPTION
…neden er nådd.

Det er to ting som er rettet.
1. FiltreringsreglerForFlereBarnTest: Her er oppsettet av testdata endret slik at datoen for now() er satt til å være på den 20. i måneden.
2. FiltreringsreglerTest: Her er to tester endret til kun å teste den regelen de ønsker å teste, og ikke implisitt alle filtreringsreglene. Da blir det enklere å ha kontroll på testdataene.