### PR TITLE
Fiks: Sende riktig resultatstruktur til datavarehus

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventListener.kt
@@ -10,11 +10,11 @@ class SaksstatistikkEventListener(private val saksstatistikkService: Saksstatist
 
     override fun onApplicationEvent(event: SaksstatistikkEvent) {
         if (event.behandlingId != null) {
-            saksstatistikkService.mapTilBehandlingDVH(event.behandlingId, event.forrigeBehandlingId).also {
+            saksstatistikkService.mapTilBehandlingDVH(event.behandlingId, event.forrigeBehandlingId)?.also {
                 kafkaProducer.sendMessageForTopicBehandling(it)
             }
         } else if (event.fagsakId != null){
-            saksstatistikkService.mapTilSakDvh(event.fagsakId).also {
+            saksstatistikkService.mapTilSakDvh(event.fagsakId)?.also {
                 kafkaProducer.sendMessageForTopicSak(it)
             }
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
@@ -3,13 +3,20 @@ package no.nav.familie.ba.sak.saksstatistikk
 import no.nav.familie.ba.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.behandling.BehandlingService
 import no.nav.familie.ba.sak.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.behandling.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
+import no.nav.familie.ba.sak.behandling.vilkår.BehandlingResultat
+import no.nav.familie.ba.sak.behandling.vilkår.BehandlingResultatService
+import no.nav.familie.ba.sak.behandling.vilkår.BehandlingResultatType.*
+import no.nav.familie.ba.sak.behandling.vilkår.Vilkår
+import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.Utils.hentPropertyFraMaven
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.journalføring.JournalføringService
 import no.nav.familie.ba.sak.journalføring.domene.JournalføringRepository
+import no.nav.familie.ba.sak.nare.Resultat.*
 import no.nav.familie.ba.sak.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.SYSTEM_NAVN
 import no.nav.familie.ba.sak.totrinnskontroll.TotrinnskontrollService
@@ -25,8 +32,10 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
+
 @Service
 class SaksstatistikkService(private val behandlingService: BehandlingService,
+                            private val behandlingResultatService: BehandlingResultatService,
                             private val journalføringRepository: JournalføringRepository,
                             private val journalføringService: JournalføringService,
                             private val arbeidsfordelingService: ArbeidsfordelingService,
@@ -34,12 +43,15 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
                             private val vedtakService: VedtakService,
                             private val fagsakService: FagsakService,
                             private val personopplysningerService: PersonopplysningerService,
+                            private val persongrunnlagService: PersongrunnlagService,
                             private val featureToggleService: FeatureToggleService) {
 
     fun mapTilBehandlingDVH(behandlingId: Long, forrigeBehandlingId: Long? = null): BehandlingDVH? {
         val behandling = behandlingService.hent(behandlingId)
 
         if (behandling.skalBehandlesAutomatisk && fødselshendelseSkalRullesTilbake()) return null
+
+        val behandlingResultat =  behandlingResultatService.hentAktivForBehandling(behandlingId)
 
         val datoMottatt = when (behandling.opprettetÅrsak) {
             BehandlingÅrsak.SØKNAD -> {
@@ -88,11 +100,9 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
                                           vedtaksDato = aktivtVedtak?.vedtaksdato,
                                           relatertBehandlingId = forrigeBehandlingId?.toString(),
                                           vedtakId = aktivtVedtak?.id?.toString(),
-                                          resultat = aktivtVedtak?.hentUtbetalingBegrunnelse(behandlingId)?.begrunnelseType?.name,
+                                          resultat = behandlingResultat?.samletResultat?.name,
                                           behandlingTypeBeskrivelse = behandling.type.visningsnavn,
-                                          resultatBegrunnelser = aktivtVedtak?.utbetalingBegrunnelser?.mapNotNull { it.vedtakBegrunnelse }
-                                                  ?.map { ResultatBegrunnelseDVH(it.name, it.tittel) }
-                                                  .orEmpty(),
+                                          resultatBegrunnelser = behandlingResultat?.samletResultatBegrunnelser() ?: emptyList(),
                                           behandlingOpprettetAv = behandling.opprettetAv,
                                           behandlingOpprettetType = "saksbehandlerId",
                                           behandlingOpprettetTypeBeskrivelse = "saksbehandlerId. VL ved automatisk behandling"
@@ -130,6 +140,49 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
         )
     }
 
+    private fun BehandlingResultat.samletResultatBegrunnelser(): List<ResultatBegrunnelseDVH> {
+        return when (samletResultat) {
+            IKKE_VURDERT -> emptyList()
+            AVSLÅTT -> finnÅrsakerTilAvslag()
+            DELVIS_INNVILGET -> TODO()
+            HENLAGT -> TODO()
+            OPPHØRT -> TODO()
+            INNVILGET -> listOf(ResultatBegrunnelseDVH("Alle vilkår er oppfylt",
+                                                       "Vilkår vurdert for søker: ${Vilkår.hentVilkårFor(PersonType.SØKER)}\n" +
+                                                       "Vilkår vurdert for barn: ${
+                                                           Vilkår.hentVilkårFor(PersonType.BARN).toMutableList().apply {
+                                                               if (behandling.skalBehandlesAutomatisk) this.remove(Vilkår.LOVLIG_OPPHOLD)
+                                                           }
+                                                       }"))
+        }
+    }
+
+    private fun BehandlingResultat.finnÅrsakerTilAvslag(): List<ResultatBegrunnelseDVH> {
+        val søker = persongrunnlagService.hentSøker(behandling)?.personIdent?.ident
+        val barna = persongrunnlagService.hentBarna(behandling).map { it.personIdent.ident }
+
+        val søkerResultatNei = personResultater.find { it.personIdent == søker }
+                ?.vilkårResultater?.filter { it.resultat == NEI }
+
+        if (!søkerResultatNei.isNullOrEmpty()) {
+            return søkerResultatNei.map { ResultatBegrunnelseDVH("${it.vilkårType.name} ikke oppfylt for søker") }
+        } else {
+
+            val negativeVilkårResultater = Vilkår.values().map { it to mutableListOf<String>() }.toMap()
+
+            personResultater.filter { barna.contains(it.personIdent) }
+                    .forEach { personResultat ->
+                        personResultat.vilkårResultater.filter { it.resultat == NEI }
+                                .forEach { vilkårResultatNei ->
+                                    negativeVilkårResultater[vilkårResultatNei.vilkårType]!!.add(personResultat.personIdent)
+                                }
+                    }
+
+            return negativeVilkårResultater.filterValues { it.isNotEmpty() }.map { (negativtVilkår, personer) ->
+                ResultatBegrunnelseDVH("${negativtVilkår.name} ikke oppfylt for barn ${Utils.slåSammen(personer)}")
+            }
+        }
+    }
 
     private fun fødselshendelseSkalRullesTilbake() : Boolean =
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkTestController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkTestController.kt
@@ -26,9 +26,9 @@ class SaksstatistikkTestController(
     @Unprotected
     fun hentBehandlingDvh(@PathVariable(name = "behandlingId", required = true) behandlingId: Long): BehandlingDVH {
         try {
-            return saksstatistikkService.mapTilBehandlingDVH(behandlingId, null)
+            return saksstatistikkService.mapTilBehandlingDVH(behandlingId, null)!!
         } catch (e: Exception) {
-            LOG.warn("Feil ved henting av sakstatistikk", e)
+            LOG.warn("Feil ved henting av sakstatistikk behandling", e)
             throw e
         }
     }
@@ -37,7 +37,7 @@ class SaksstatistikkTestController(
     @Unprotected
     fun hentSakDvh(@PathVariable(name = "fagsakId", required = true) fagsakId: Long): SakDVH {
         try {
-            return saksstatistikkService.mapTilSakDvh(fagsakId)
+            return saksstatistikkService.mapTilSakDvh(fagsakId)!!
         } catch (e: Exception) {
             LOG.warn("Feil ved henting av sakstatistikk sak", e)
             throw e

--- a/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.ba.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ba.sak.behandling.BehandlingService
+import no.nav.familie.ba.sak.behandling.domene.Behandling
 import no.nav.familie.ba.sak.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakStatus
@@ -16,6 +17,7 @@ import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.behandling.vilkår.VedtakBegrunnelse
 import no.nav.familie.ba.sak.behandling.vilkår.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.common.*
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ba.sak.integrasjoner.lagTestJournalpost
 import no.nav.familie.ba.sak.journalføring.JournalføringService
@@ -51,6 +53,7 @@ internal class SaksstatistikkServiceTest {
     private val totrinnskontrollService: TotrinnskontrollService = mockk()
     private val fagsakService: FagsakService = mockk()
     private val personopplysningerService: PersonopplysningerService = mockk()
+    private val featureToggleService: FeatureToggleService = mockk()
 
     private val vedtakService: VedtakService = mockk()
 
@@ -62,7 +65,8 @@ internal class SaksstatistikkServiceTest {
             totrinnskontrollService,
             vedtakService,
             fagsakService,
-            personopplysningerService)
+            personopplysningerService,
+            featureToggleService)
 
 
     @BeforeAll
@@ -72,6 +76,7 @@ internal class SaksstatistikkServiceTest {
                 behandlendeEnhetNavn = "Nav",
                 behandlingId = 1)
         every { arbeidsfordelingService.hentArbeidsfordelingsenhet(any()) } returns Arbeidsfordelingsenhet("4821", "NAV")
+        every { featureToggleService.isEnabled(any()) } returns false
     }
 
     @Test
@@ -90,26 +95,26 @@ internal class SaksstatistikkServiceTest {
         val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2, 1)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(behandlingDvh))
 
-        assertThat(behandlingDvh.funksjonellTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
-        assertThat(behandlingDvh.tekniskTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
-        assertThat(behandlingDvh.mottattDato).isEqualTo(ZonedDateTime.of(behandling.opprettetTidspunkt,
-                                                                         SaksstatistikkService.TIMEZONE))
-        assertThat(behandlingDvh.registrertDato).isEqualTo(ZonedDateTime.of(behandling.opprettetTidspunkt,
-                                                                            SaksstatistikkService.TIMEZONE))
-        assertThat(behandlingDvh.vedtaksDato).isEqualTo(vedtak.vedtaksdato)
-        assertThat(behandlingDvh.behandlingId).isEqualTo(behandling.id.toString())
-        assertThat(behandlingDvh.relatertBehandlingId).isEqualTo("1")
-        assertThat(behandlingDvh.sakId).isEqualTo(behandling.fagsak.id.toString())
-        assertThat(behandlingDvh.vedtakId).isEqualTo(vedtak.id.toString())
-        assertThat(behandlingDvh.behandlingType).isEqualTo(behandling.type.name)
-        assertThat(behandlingDvh.behandlingKategori).isEqualTo(behandling.kategori.name)
-        assertThat(behandlingDvh.behandlingUnderkategori).isEqualTo(behandling.underkategori.name)
-        assertThat(behandlingDvh.behandlingStatus).isEqualTo(behandling.status.name)
-        assertThat(behandlingDvh.totrinnsbehandling).isFalse
-        assertThat(behandlingDvh.saksbehandler).isNull()
-        assertThat(behandlingDvh.beslutter).isNull()
-        assertThat(behandlingDvh.avsender).isEqualTo("familie-ba-sak")
-        assertThat(behandlingDvh.versjon).isNotEmpty
+        assertThat(behandlingDvh?.funksjonellTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
+        assertThat(behandlingDvh?.tekniskTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
+        assertThat(behandlingDvh?.mottattDato).isEqualTo(ZonedDateTime.of(behandling.opprettetTidspunkt,
+                                                                          SaksstatistikkService.TIMEZONE))
+        assertThat(behandlingDvh?.registrertDato).isEqualTo(ZonedDateTime.of(behandling.opprettetTidspunkt,
+                                                                             SaksstatistikkService.TIMEZONE))
+        assertThat(behandlingDvh?.vedtaksDato).isEqualTo(vedtak.vedtaksdato)
+        assertThat(behandlingDvh?.behandlingId).isEqualTo(behandling.id.toString())
+        assertThat(behandlingDvh?.relatertBehandlingId).isEqualTo("1")
+        assertThat(behandlingDvh?.sakId).isEqualTo(behandling.fagsak.id.toString())
+        assertThat(behandlingDvh?.vedtakId).isEqualTo(vedtak.id.toString())
+        assertThat(behandlingDvh?.behandlingType).isEqualTo(behandling.type.name)
+        assertThat(behandlingDvh?.behandlingKategori).isEqualTo(behandling.kategori.name)
+        assertThat(behandlingDvh?.behandlingUnderkategori).isEqualTo(behandling.underkategori.name)
+        assertThat(behandlingDvh?.behandlingStatus).isEqualTo(behandling.status.name)
+        assertThat(behandlingDvh?.totrinnsbehandling).isFalse
+        assertThat(behandlingDvh?.saksbehandler).isNull()
+        assertThat(behandlingDvh?.beslutter).isNull()
+        assertThat(behandlingDvh?.avsender).isEqualTo("familie-ba-sak")
+        assertThat(behandlingDvh?.versjon).isNotEmpty
 
     }
 
@@ -148,25 +153,25 @@ internal class SaksstatistikkServiceTest {
         val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2, 1)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(behandlingDvh))
 
-        assertThat(behandlingDvh.funksjonellTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
-        assertThat(behandlingDvh.tekniskTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
-        assertThat(behandlingDvh.mottattDato).isEqualTo(mottattDato.atZone(SaksstatistikkService.TIMEZONE))
-        assertThat(behandlingDvh.registrertDato).isEqualTo(mottattDato.atZone(SaksstatistikkService.TIMEZONE))
-        assertThat(behandlingDvh.vedtaksDato).isEqualTo(vedtak.vedtaksdato)
-        assertThat(behandlingDvh.behandlingId).isEqualTo(behandling.id.toString())
-        assertThat(behandlingDvh.relatertBehandlingId).isEqualTo("1")
-        assertThat(behandlingDvh.sakId).isEqualTo(behandling.fagsak.id.toString())
-        assertThat(behandlingDvh.vedtakId).isEqualTo(vedtak.id.toString())
-        assertThat(behandlingDvh.behandlingType).isEqualTo(behandling.type.name)
-        assertThat(behandlingDvh.behandlingStatus).isEqualTo(behandling.status.name)
-        assertThat(behandlingDvh.totrinnsbehandling).isTrue
-        assertThat(behandlingDvh.saksbehandler).isNull()
-        assertThat(behandlingDvh.beslutter).isNull()
-        assertThat(behandlingDvh.resultatBegrunnelser).hasSize(1)
+        assertThat(behandlingDvh?.funksjonellTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
+        assertThat(behandlingDvh?.tekniskTid).isCloseTo(ZonedDateTime.now(), within(1, ChronoUnit.MINUTES))
+        assertThat(behandlingDvh?.mottattDato).isEqualTo(mottattDato.atZone(SaksstatistikkService.TIMEZONE))
+        assertThat(behandlingDvh?.registrertDato).isEqualTo(mottattDato.atZone(SaksstatistikkService.TIMEZONE))
+        assertThat(behandlingDvh?.vedtaksDato).isEqualTo(vedtak.vedtaksdato)
+        assertThat(behandlingDvh?.behandlingId).isEqualTo(behandling.id.toString())
+        assertThat(behandlingDvh?.relatertBehandlingId).isEqualTo("1")
+        assertThat(behandlingDvh?.sakId).isEqualTo(behandling.fagsak.id.toString())
+        assertThat(behandlingDvh?.vedtakId).isEqualTo(vedtak.id.toString())
+        assertThat(behandlingDvh?.behandlingType).isEqualTo(behandling.type.name)
+        assertThat(behandlingDvh?.behandlingStatus).isEqualTo(behandling.status.name)
+        assertThat(behandlingDvh?.totrinnsbehandling).isTrue
+        assertThat(behandlingDvh?.saksbehandler).isNull()
+        assertThat(behandlingDvh?.beslutter).isNull()
+        assertThat(behandlingDvh?.resultatBegrunnelser).hasSize(1)
                 .extracting("resultatBegrunnelse")
                 .containsOnly("INNVILGET_BOR_HOS_SØKER")
-        assertThat(behandlingDvh.avsender).isEqualTo("familie-ba-sak")
-        assertThat(behandlingDvh.versjon).isNotEmpty
+        assertThat(behandlingDvh?.avsender).isEqualTo("familie-ba-sak")
+        assertThat(behandlingDvh?.versjon).isNotEmpty
 
     }
 
@@ -188,14 +193,15 @@ internal class SaksstatistikkServiceTest {
                                                                          RestFagsakDeltager(ident = "12345678911",
                                                                                             rolle = FagsakDeltagerRolle.BARN,
                                                                                             fagsakId = 2))
+        every { behandlingService.hentAktivForFagsak(any()) } returns null
 
         val sakDvh = sakstatistikkService.mapTilSakDvh(1)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(sakDvh))
 
-        assertThat(sakDvh.aktorId).isEqualTo(1234567891011)
-        assertThat(sakDvh.aktorer).hasSize(1).extracting("rolle").containsOnly("FORELDER")
-        assertThat(sakDvh.sakStatus).isEqualTo(FagsakStatus.OPPRETTET.name)
-        assertThat(sakDvh.avsender).isEqualTo("familie-ba-sak")
+        assertThat(sakDvh?.aktorId).isEqualTo(1234567891011)
+        assertThat(sakDvh?.aktorer).hasSize(1).extracting("rolle").containsOnly("FORELDER")
+        assertThat(sakDvh?.sakStatus).isEqualTo(FagsakStatus.OPPRETTET.name)
+        assertThat(sakDvh?.avsender).isEqualTo("familie-ba-sak")
 
     }
 


### PR DESCRIPTION
Går vekk fra å bruke UtbetalingBegrunnelser og henter resultat og resultatBegrunnelser fra BehandlingResultat istedenfor.

I tillegg har vi en fiks for ikke å sende saksstatistikk ved autovedtak som rulles tilbake.

Har lagt inn Todo's på uthenting av resultatBegrunnelse ved OPPHØRT, HENLAGT OG DELVIS_INNVILGET resultat. Men sistnevnte kan nok langt på vei bruke en kombinasjon av resultatBegrunnelsene for AVSLÅTT OG INNVILGET når disse er godkjent