### PR TITLE
Oppdatert felles-prosessering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <spring.vault.version>2.2.2.RELEASE</spring.vault.version>
         <felles.version>1.20201019090015_53d0e1b</felles.version>
         <felles-kontrakter.version>2.0_20201019114215_23568f6</felles-kontrakter.version>
-        <felles.prosessering.version>1.20200624154125_0d8ff39</felles.prosessering.version>
         <familie.kontrakter.saksstatistikk>2.0_20201012132018_dc05978</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20201021122803_a1ef69e</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.9.3</mockk.version>
@@ -173,7 +172,7 @@
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>prosessering</artifactId>
-            <version>${felles.prosessering.version}</version>
+            <version>${felles.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseService.kt
@@ -28,6 +28,7 @@ import no.nav.familie.kontrakter.felles.personopplysning.Ident
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
@@ -77,7 +78,7 @@ class FødselshendelseService(private val infotrygdFeedService: InfotrygdFeedSer
         infotrygdFeedService.sendTilInfotrygdFeed(barnIdenter)
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun opprettBehandlingOgKjørReglerForFødselshendelse(nyBehandling: NyBehandlingHendelse) {
         val behandling = stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForHendelse(nyBehandling)
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
@@ -19,6 +19,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
@@ -39,16 +41,19 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
     }
 
     @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun `ved behandling av fødselshendelse persisteres ikke behandlingsdata til databasen`() {
         every {
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
         } returns true
+
         behandleFødselshendelseTask.doTask(BehandleFødselshendelseTask.opprettTask(
                 BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
         Assertions.assertNull(fagsakRepository.finnFagsakForPersonIdent(PersonIdent(morsIdent)))
     }
 
     @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun `ved behandling av fødselshendelse persisteres behandlingsdata til databasen`() {
         every {
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/KonsistensavstemmingSchedulerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/KonsistensavstemmingSchedulerTest.kt
@@ -84,7 +84,7 @@ class KonsistensavstemmingSchedulerTest {
 
         konsistensavstemmingScheduler.utførKonsistensavstemming()
 
-        val tasks = taskRepository.finnTasksTilFrontend(listOf(Status.UBEHANDLET), Pageable.unpaged())
+        val tasks = taskRepository.finnTasksMedStatus(listOf(Status.UBEHANDLET), Pageable.unpaged())
 
         Assertions.assertEquals(1, tasks.size)
 


### PR DESCRIPTION
Kjører fødselshendelser i egen transaksjon så rollback fungerer. Rollback testet manuelt.