### PR TITLE
Fiks bug som gjør at man ikke får satt reduksjon med 18års-begrunnelse på dette vilkåret.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -367,15 +367,18 @@ class VedtakService(private val arbeidsfordelingService: ArbeidsfordelingService
             val utgjørendeVilkår = personResultat.vilkårResultater.firstOrNull { vilkårResultat ->
                 when {
                     vilkårResultat.vilkårType != oppdatertVilkår -> false
-                    vilkårResultat.periodeFom == null -> {
-                        false
-                    }
+                    vilkårResultat.periodeFom == null -> false
                     oppdatertBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE -> {
-                        vilkårResultat.periodeFom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.minusMonths(1).monthValue && vilkårResultat.resultat == Resultat.JA
+                        vilkårResultat.periodeFom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.forrigeMåned() &&
+                        vilkårResultat.resultat == Resultat.JA
+                    }
+                    oppdatertVilkår == Vilkår.UNDER_18_ÅR -> {
+                        vilkårResultat.periodeTom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.monthValue &&
+                        vilkårResultat.resultat == Resultat.NEI
                     }
                     else -> {
-                        vilkårResultat.periodeTom != null && vilkårResultat.periodeTom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.minusMonths(
-                                1).monthValue && vilkårResultat.resultat == Resultat.NEI
+                        vilkårResultat.periodeTom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.forrigeMåned() &&
+                        vilkårResultat.resultat == Resultat.NEI
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -372,13 +372,10 @@ class VedtakService(private val arbeidsfordelingService: ArbeidsfordelingService
                         vilkårResultat.periodeFom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.forrigeMåned() &&
                         vilkårResultat.resultat == Resultat.JA
                     }
-                    oppdatertVilkår == Vilkår.UNDER_18_ÅR -> {
-                        vilkårResultat.periodeTom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.monthValue &&
-                        vilkårResultat.resultat == Resultat.NEI
-                    }
                     else -> {
+                        vilkårResultat.periodeTom != null &&
                         vilkårResultat.periodeTom!!.monthValue == opprinneligUtbetalingBegrunnelse.fom.forrigeMåned() &&
-                        vilkårResultat.resultat == Resultat.NEI
+                        vilkårResultat.resultat == Resultat.JA
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
@@ -35,6 +35,8 @@ fun LocalDate.sisteDagIMåned(): LocalDate {
     return YearMonth.from(this).atEndOfMonth()
 }
 
+fun LocalDate.forrigeMåned() : Int = this.minusMonths(1).monthValue
+
 fun LocalDate.førsteDagINesteMåned() = this.plusMonths(1).withDayOfMonth(1)
 fun LocalDate.førsteDagIInneværendeMåned() = this.withDayOfMonth(1)
 


### PR DESCRIPTION
 Sammenligner med måned før, men 18årsvilkåret er kun oppfylt til og med måneden før og reduseres samme måned 18år er slutt. Har ikke blitt catcha før siden vi ikke har hatt reduksjon. 