### PR TITLE
Default verdi for behandlingsårsak og test for å catche nye

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
@@ -51,7 +51,7 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
 
         if (behandling.skalBehandlesAutomatisk && fødselshendelseSkalRullesTilbake()) return null
 
-        val behandlingResultat =  behandlingResultatService.hentAktivForBehandling(behandlingId)
+        val behandlingResultat = behandlingResultatService.hentAktivForBehandling(behandlingId)
 
         val datoMottatt = when (behandling.opprettetÅrsak) {
             BehandlingÅrsak.SØKNAD -> {
@@ -62,13 +62,7 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
                         .mapNotNull { it.datoMottatt }
                         .minOrNull() ?: behandling.opprettetTidspunkt
             }
-            BehandlingÅrsak.FØDSELSHENDELSE -> {
-                behandling.opprettetTidspunkt
-            }
-            BehandlingÅrsak.TEKNISK_OPPHØR -> {
-                behandling.opprettetTidspunkt
-            }
-            else -> error("Statistikkhåndtering for behandling med opprinnelse ${behandling.opprettetÅrsak.name} ikke implementert.")
+            else -> behandling.opprettetTidspunkt
         }
 
         val behandlendeEnhetsKode = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId).behandlendeEnhetId
@@ -184,7 +178,7 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
         }
     }
 
-    private fun fødselshendelseSkalRullesTilbake() : Boolean =
+    private fun fødselshendelseSkalRullesTilbake(): Boolean =
             featureToggleService.isEnabled("familie-ba-sak.rollback-automatisk-regelkjoring")
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -218,4 +218,15 @@ internal class SaksstatistikkServiceTest {
 
     }
 
+
+    @Test
+    fun `Skal gi feil hvis det kommer en ny BehandlingÅrsak som det ikke er tatt høyde for mot statistikk - Ved feil diskuterer ønsket resultat med statistikk`() {
+        assertThat(enumValues<BehandlingÅrsak>()).containsOnly(BehandlingÅrsak.SØKNAD,
+                                                               BehandlingÅrsak.FØDSELSHENDELSE,
+                                                               BehandlingÅrsak.TEKNISK_OPPHØR,
+                                                               BehandlingÅrsak.DØDSFALL,
+                                                               BehandlingÅrsak.ÅRLIG_KONTROLL,
+                                                               BehandlingÅrsak.NYE_OPPLYSNINGER)
+    }
+
 }


### PR DESCRIPTION
Tea-2677

Lagt til default value. Burde vi ha andre dataoer på de nye årsakene?

Lag til test som detekterer nye. 