### PR TITLE
Teste ut for å unngå så mye trafikk ved draft-pr

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -2,7 +2,6 @@ name: Build-Deploy-Preprod
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ba-sak:${{ github.sha }}

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -7,8 +7,8 @@ on:
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ba-sak:${{ github.sha }}
 jobs:
-  if: github.event.pull_request.draft == false
   deploy-to-dev:
+    if: github.event.pull_request.draft == false
     name: Bygg app/image, push til github, deploy til dev-fss
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -1,11 +1,13 @@
 name: Build-Deploy-Preprod
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ba-sak:${{ github.sha }}
 jobs:
+  if: github.event.pull_request.draft == false
   deploy-to-dev:
     name: Bygg app/image, push til github, deploy til dev-fss
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ser at det er hensiktsmessig å ha åpne drafts en stund for diskusjon mens arbeidet fortsatt er WIP. Da er det fort gjort å glemme at det deployer mens man utveksler kode. Vet ikke om dette funker, men vi kan jo prøve? 

https://github.community/t/dont-run-actions-on-draft-pull-requests/16817/16 