### PR TITLE
Fiks bug pga bruk av week based year

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
@@ -12,10 +12,10 @@ val TIDENES_MORGEN = LocalDate.MIN
 val TIDENES_ENDE = LocalDate.MAX
 
 
-fun LocalDate.tilddMMYY() = this.format(DateTimeFormatter.ofPattern("ddMMYY", nbLocale))
-fun LocalDate.tilKortString() = this.format(DateTimeFormatter.ofPattern("dd.MM.YY", nbLocale))
-fun LocalDate.tilDagMånedÅr() = this.format(DateTimeFormatter.ofPattern("d. MMMM YYYY", nbLocale))
-fun LocalDate.tilMånedÅr() = this.format(DateTimeFormatter.ofPattern("MMMM YYYY", nbLocale))
+fun LocalDate.tilddMMyy() = this.format(DateTimeFormatter.ofPattern("ddMMyy", nbLocale))
+fun LocalDate.tilKortString() = this.format(DateTimeFormatter.ofPattern("dd.MM.yy", nbLocale))
+fun LocalDate.tilDagMånedÅr() = this.format(DateTimeFormatter.ofPattern("d. MMMM yyyy", nbLocale))
+fun LocalDate.tilMånedÅr() = this.format(DateTimeFormatter.ofPattern("MMMM yyyy", nbLocale))
 
 fun LocalDate.sisteDagIForrigeMåned(): LocalDate {
     val sammeDagForrigeMåned = this.minusMonths(1)

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
@@ -224,6 +224,14 @@ internal class TidTest {
         Assertions.assertThat(result.filter { it.tom != null}).hasSize(1)
     }
 
+    @Test
+    fun `formatering gir forventet resultat`() {
+        assertEquals("31. desember 2020", dato("2020-12-31").tilDagMånedÅr())
+        assertEquals("311220", dato("2020-12-31").tilddMMyy())
+        assertEquals("31.12.20", dato("2020-12-31").tilKortString())
+        assertEquals("desember 2020", dato("2020-12-31").tilMånedÅr())
+    }
+
     private fun dato(s: String): LocalDate {
         return LocalDate.parse(s)
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -402,7 +402,7 @@ class ClientMocks {
 
         val søkerFnr = arrayOf("12345678910", "11223344556", "12345678911")
         val barnFødselsdatoer = arrayOf(LocalDate.now().minusYears(4), LocalDate.now().førsteDagIInneværendeMåned())
-        val barnFnr = arrayOf(barnFødselsdatoer[0].tilddMMYY() + "00033", barnFødselsdatoer[1].tilddMMYY() + "00033")
+        val barnFnr = arrayOf(barnFødselsdatoer[0].tilddMMyy() + "00033", barnFødselsdatoer[1].tilddMMyy() + "00033")
         val barnDetIkkeGisTilgangTilFnr = "12345678912"
         val integrasjonerFnr = "10000111111"
         val bostedsadresse = Bostedsadresse(


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-2746

I dag oppdaga en av superbrukerne at t.o.m ble forskjøvet et år i brevet : 31.12.19 -> 31.12.20 🐛 
Fikk gjenskapt samme greia for desember 2020 og 2018, men skjer ikke desember 2017. What?😭 
Vi bruker visst week years **Y** når vi formaterer datoer, og for de årene som blir forskjøvet lander 31. desember i uke 1 påfølgende år 🗓️ 

Endrer nå til year-of-era (**y**) på alle og legger til en liten test.