### PR TITLE
Endringer ifm. utvidelse av rutingreglene for dokument

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
@@ -1,10 +1,7 @@
 package no.nav.familie.ba.sak.behandling.fagsak
 
 import no.nav.familie.ba.sak.behandling.BehandlingService
-import no.nav.familie.ba.sak.behandling.restDomene.RestFagsak
-import no.nav.familie.ba.sak.behandling.restDomene.RestFagsakDeltager
-import no.nav.familie.ba.sak.behandling.restDomene.RestPågåendeSakSøk
-import no.nav.familie.ba.sak.behandling.restDomene.RestSøkParam
+import no.nav.familie.ba.sak.behandling.restDomene.*
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.RessursUtils.illegalState
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -89,8 +86,8 @@ class FagsakController(
     }
 
     @PostMapping(path = ["fagsaker/sok/ba-sak-og-infotrygd"])
-    fun søkEtterPågåendeSak(@RequestBody restSøkParam: RestSøkParam): ResponseEntity<Ressurs<RestPågåendeSakSøk>> {
-        return Result.runCatching { fagsakService.hentPågåendeSakStatus(restSøkParam.personIdent) }
+    fun søkEtterPågåendeSak(@RequestBody restSøkParam: RestPågåendeSakRequest): ResponseEntity<Ressurs<RestPågåendeSakResponse>> {
+        return Result.runCatching { fagsakService.hentPågåendeSakStatus(restSøkParam.søkersIdent, restSøkParam.barnasIdenter) }
                 .fold(
                         onSuccess = { ResponseEntity.ok(Ressurs.success(it)) },
                         onFailure = {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
@@ -87,7 +87,7 @@ class FagsakController(
 
     @PostMapping(path = ["fagsaker/sok/ba-sak-og-infotrygd"])
     fun søkEtterPågåendeSak(@RequestBody restSøkParam: RestPågåendeSakRequest): ResponseEntity<Ressurs<RestPågåendeSakResponse>> {
-        return Result.runCatching { fagsakService.hentPågåendeSakStatus(restSøkParam.søkersIdent, restSøkParam.barnasIdenter) }
+        return Result.runCatching { fagsakService.hentPågåendeSakStatus(restSøkParam.personIdent, restSøkParam.barnasIdenter) }
                 .fold(
                         onSuccess = { ResponseEntity.ok(Ressurs.success(it)) },
                         onFailure = {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
@@ -87,7 +87,7 @@ class FagsakController(
 
     @PostMapping(path = ["fagsaker/sok/ba-sak-og-infotrygd"])
     fun søkEtterPågåendeSak(@RequestBody restSøkParam: RestPågåendeSakRequest): ResponseEntity<Ressurs<RestPågåendeSakResponse>> {
-        return Result.runCatching { fagsakService.hentPågåendeSakStatus(restSøkParam.personIdent, restSøkParam.barnasIdenter) }
+        return Result.runCatching { fagsakService.hentPågåendeSakStatus(restSøkParam.personIdent, restSøkParam.barnasIdenter ?: emptyList()) }
                 .fold(
                         onSuccess = { ResponseEntity.ok(Ressurs.success(it)) },
                         onFailure = {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
@@ -355,7 +355,11 @@ class FagsakService(
 
     fun hentPågåendeSakStatus(søkersIdent: String, barnasIdenter: List<String>): RestPågåendeSakResponse {
         val fagsakSøker = hent(PersonIdent(søkersIdent))
-        val alleFagsaker = barnasIdenter.flatMap { hentFagsakerPåPerson(PersonIdent(it)) }.toMutableSet().also {
+
+        val alleBarnasIdenter = barnasIdenter.flatMap { barn ->
+            personopplysningerService.hentIdenter(Ident(barn)).filter { it.gruppe == "FOLKEREGISTERIDENT" }.map { it.ident }
+        }
+        val alleFagsaker = alleBarnasIdenter.flatMap { hentFagsakerPåPerson(PersonIdent(it)) }.toMutableSet().also {
             if (fagsakSøker != null) {
                 it.add(fagsakSøker)
             }
@@ -370,7 +374,7 @@ class FagsakService(
 
         return RestPågåendeSakResponse(
                 harPågåendeSakIBaSak = harLøpendeFagsak || harÅpenBehandling,
-                harPågåendeSakIInfotrygd = harLøpendeSakIInfotrygd(søkersIdent, barnasIdenter)
+                harPågåendeSakIInfotrygd = harLøpendeSakIInfotrygd(søkersIdent, alleBarnasIdenter)
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
@@ -24,8 +24,8 @@ data class RestFagsakDeltager(
 )
 
 data class RestPågåendeSakRequest(
-        val søkersIdent: String,
-        val barnasIdenter: List<String> = emptyList()
+        var personIdent: String,
+        val barnasIdenter: List<String> = emptyList(),
 )
 
 data class RestPågåendeSakResponse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
@@ -25,7 +25,7 @@ data class RestFagsakDeltager(
 
 data class RestPågåendeSakRequest(
         var personIdent: String,
-        val barnasIdenter: List<String> = emptyList(),
+        val barnasIdenter: List<String>?,
 )
 
 data class RestPågåendeSakResponse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
@@ -23,7 +23,12 @@ data class RestFagsakDeltager(
         var harTilgang: Boolean = true
 )
 
-data class RestPågåendeSakSøk(
+data class RestPågåendeSakRequest(
+        val søkersIdent: String,
+        val barnasIdenter: List<String>
+)
+
+data class RestPågåendeSakResponse(
     val harPågåendeSakIBaSak: Boolean,
     val harPågåendeSakIInfotrygd: Boolean
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestFagsakSøk.kt
@@ -25,7 +25,7 @@ data class RestFagsakDeltager(
 
 data class RestPågåendeSakRequest(
         val søkersIdent: String,
-        val barnasIdenter: List<String>
+        val barnasIdenter: List<String> = emptyList()
 )
 
 data class RestPågåendeSakResponse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
@@ -72,7 +72,7 @@ class BeregningService(
     fun hentIverksattTilkjentYtelseForBarn(barnIdent: PersonIdent,
                                            behandlendeBehandling: Behandling): List<TilkjentYtelse> {
         val andreFagsaker = fagsakService.hentFagsakerPåPerson(barnIdent)
-                .filter { it.id != behandlendeBehandling.fagsak.id }
+            .filter { it.id != behandlendeBehandling.fagsak.id }
 
         return andreFagsaker.map { fagsak ->
             behandlingRepository.finnBehandlinger(fagsakId = fagsak.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
@@ -72,7 +72,7 @@ class BeregningService(
     fun hentIverksattTilkjentYtelseForBarn(barnIdent: PersonIdent,
                                            behandlendeBehandling: Behandling): List<TilkjentYtelse> {
         val andreFagsaker = fagsakService.hentFagsakerPåPerson(barnIdent)
-            .filter { it.id != behandlendeBehandling.fagsak.id }
+                .filter { it.id != behandlendeBehandling.fagsak.id }
 
         return andreFagsaker.map { fagsak ->
             behandlingRepository.finnBehandlinger(fagsakId = fagsak.id)

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakControllerTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.behandling.fagsak
 import io.mockk.every
 import io.mockk.verify
 import no.nav.familie.ba.sak.behandling.BehandlingService
+import no.nav.familie.ba.sak.behandling.restDomene.RestPågåendeSakRequest
 import no.nav.familie.ba.sak.behandling.restDomene.RestSøkParam
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.randomAktørId
@@ -163,7 +164,7 @@ class FagsakControllerTest(
         fagsakService.hentEllerOpprettFagsak(PersonIdent(personIdent))
                 .also { fagsakService.oppdaterStatus(it, FagsakStatus.LØPENDE) }
 
-        fagsakController.søkEtterPågåendeSak(RestSøkParam(personIdent)).apply {
+        fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, emptyList())).apply {
             assertTrue(body!!.data!!.harPågåendeSakIBaSak)
             assertFalse(body!!.data!!.harPågåendeSakIInfotrygd)
         }
@@ -174,9 +175,9 @@ class FagsakControllerTest(
         val personIdent = randomFnr()
 
         fagsakService.hentEllerOpprettFagsak(PersonIdent(personIdent))
-        behandlingService.opprettBehandling(nyOrdinærBehandling(personIdent))
+        val behandling = behandlingService.opprettBehandling(nyOrdinærBehandling(personIdent))
 
-        fagsakController.søkEtterPågåendeSak(RestSøkParam(personIdent)).apply {
+        fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, emptyList())).apply {
             assertTrue(body!!.data!!.harPågåendeSakIBaSak)
             assertFalse(body!!.data!!.harPågåendeSakIInfotrygd)
         }
@@ -190,11 +191,11 @@ class FagsakControllerTest(
             mockInfotrygdBarnetrygdClient.harLøpendeSakIInfotrygd(any())
         } returns true andThen false
 
-        fagsakController.søkEtterPågåendeSak(RestSøkParam(personIdent)).apply {
+        fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, emptyList())).apply {
             assertFalse(body!!.data!!.harPågåendeSakIBaSak)
             assertTrue(body!!.data!!.harPågåendeSakIInfotrygd)
         }
-        fagsakController.søkEtterPågåendeSak(RestSøkParam(personIdent)).apply {
+        fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, emptyList())).apply {
             assertFalse(body!!.data!!.harPågåendeSakIInfotrygd)
         }
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakControllerTest.kt
@@ -3,11 +3,14 @@ package no.nav.familie.ba.sak.behandling.fagsak
 import io.mockk.every
 import io.mockk.verify
 import no.nav.familie.ba.sak.behandling.BehandlingService
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.behandling.restDomene.RestPågåendeSakRequest
 import no.nav.familie.ba.sak.behandling.restDomene.RestSøkParam
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.pdl.PersonopplysningerService
@@ -47,6 +50,9 @@ class FagsakControllerTest(
 
         @Autowired
         private val mockIntegrasjonClient: IntegrasjonClient,
+
+        @Autowired
+        private val persongrunnlagService: PersongrunnlagService,
 ) {
 
     @Test
@@ -158,7 +164,7 @@ class FagsakControllerTest(
     }
 
     @Test
-    fun `Skal flagge pågående sak ved løpende fagsak på personIdent`() {
+    fun `Skal flagge pågående sak ved løpende fagsak på søker`() {
         val personIdent = randomFnr()
 
         fagsakService.hentEllerOpprettFagsak(PersonIdent(personIdent))
@@ -171,13 +177,62 @@ class FagsakControllerTest(
     }
 
     @Test
+    fun `Skal ikke ha pågående sak i ba-sak når søker mangler fagsak og det ikke er sak på annenpart`() {
+        val personIdent = randomFnr()
+
+        fagsakService.hentEllerOpprettFagsak(PersonIdent(ClientMocks.søkerFnr[0]))
+                .also { fagsakService.oppdaterStatus(it, FagsakStatus.LØPENDE) }
+
+        val behandling = behandlingService.opprettBehandling(nyOrdinærBehandling(ClientMocks.søkerFnr[0]))
+        persongrunnlagService.lagreSøkerOgBarnIPersonopplysningsgrunnlaget(personIdent, ClientMocks.barnFnr.toList(), behandling, Målform.NB )
+
+        fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, emptyList())).apply {
+            assertFalse(body!!.data!!.harPågåendeSakIBaSak)
+        }
+    }
+
+    @Test
+    fun `Skal flagge pågående sak når søker mangler fagsak men det er sak på annenpart`() {
+        val personIdent = randomFnr()
+
+        fagsakService.hentEllerOpprettFagsak(PersonIdent(ClientMocks.søkerFnr[0]))
+                .also { fagsakService.oppdaterStatus(it, FagsakStatus.LØPENDE) }
+
+        val behandling = behandlingService.opprettBehandling(nyOrdinærBehandling(ClientMocks.søkerFnr[0]))
+        persongrunnlagService.lagreSøkerOgBarnIPersonopplysningsgrunnlaget(personIdent, ClientMocks.barnFnr.toList(), behandling, Målform.NB )
+
+        fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, ClientMocks.barnFnr.toList())).apply {
+            assertTrue(body!!.data!!.harPågåendeSakIBaSak)
+            assertFalse(body!!.data!!.harPågåendeSakIInfotrygd)
+        }
+    }
+
+
+    @Test
     fun `Skal flagge pågående sak ved pågående behandling på fagsak`() {
         val personIdent = randomFnr()
 
         fagsakService.hentEllerOpprettFagsak(PersonIdent(personIdent))
+                .also { fagsakService.oppdaterStatus(it, FagsakStatus.AVSLUTTET) }
         val behandling = behandlingService.opprettBehandling(nyOrdinærBehandling(personIdent))
 
         fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, emptyList())).apply {
+            assertTrue(body!!.data!!.harPågåendeSakIBaSak)
+            assertFalse(body!!.data!!.harPågåendeSakIInfotrygd)
+        }
+    }
+
+    @Test
+    fun `Skal flagge pågående sak når søker mangler fagsak men det er en åpen behandling på annenpart`() {
+        val personIdent = randomFnr()
+
+        fagsakService.hentEllerOpprettFagsak(PersonIdent(ClientMocks.søkerFnr[0]))
+                .also { fagsakService.oppdaterStatus(it, FagsakStatus.AVSLUTTET) }
+
+        val behandling = behandlingService.opprettBehandling(nyOrdinærBehandling(ClientMocks.søkerFnr[0]))
+        persongrunnlagService.lagreSøkerOgBarnIPersonopplysningsgrunnlaget(personIdent, ClientMocks.barnFnr.toList(), behandling, Målform.NB )
+
+        fagsakController.søkEtterPågåendeSak(RestPågåendeSakRequest(personIdent, ClientMocks.barnFnr.toList())).apply {
             assertTrue(body!!.data!!.harPågåendeSakIBaSak)
             assertFalse(body!!.data!!.harPågåendeSakIInfotrygd)
         }


### PR DESCRIPTION
Utvider søkEtterPågåendeSak-tjenesten med ekstra input-parameter over søkers barn
og endrer logikken som avgjør om det finnes sak tilknyttet søker i ba-sak/infotrygd
til å inkludere saker tilknyttet barna