### PR TITLE
V2/konsistensavstemming endepunkt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring.cloud.version>2.2.6.RELEASE</spring.cloud.version>
         <spring.vault.version>2.3.0</spring.vault.version>
         <felles.version>1.20201123131335_671787f</felles.version>
-        <felles-kontrakter.version>2.0_20210104141601_662329d</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20210105115213_05f0728</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20201217113247_876a253</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20201124122241_0f9f95a</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.10.4</mockk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring.cloud.version>2.2.6.RELEASE</spring.cloud.version>
         <spring.vault.version>2.3.0</spring.vault.version>
         <felles.version>1.20201123131335_671787f</felles.version>
-        <felles-kontrakter.version>2.0_20201217132236_b7bcab2</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20210104141601_662329d</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20201217113247_876a253</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20201124122241_0f9f95a</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.10.4</mockk.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
 import no.nav.familie.ba.sak.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.økonomi.OppdragIdForFagsystem
-import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -98,28 +97,7 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
                         behandlingId)
             }
 
-    fun hentDataForKonsistensavstemming(): List<PerioderForBehandling> {
-        val relevanteBehandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
-        return relevanteBehandlinger
-                .map { behandlingId ->
-                    val andelerIRelevantBehandling = beregningService.hentAndelerTilkjentYtelseForBehandling(behandlingId)
-                    andelerIRelevantBehandling
-                            .groupBy { it.kildeBehandlingId }
-                            .map { (kildeBehandlingId, andeler) ->
-                                PerioderForBehandling(behandlingId = kildeBehandlingId.toString(),
-                                                      perioder = andeler
-                                                              .map {
-                                                                  it.periodeOffset
-                                                                  ?: error("Andel ${it.id} på iverksatt behandling på løpende fagsak mangler periodeOffset")
-                                                              }
-                                                              .toSet())
-                            }
-                }
-                .reduce(::samleFagsaker)
-    }
-
-    private fun samleFagsaker(akkumulert: List<PerioderForBehandling>,
-                              nesteFagsak: List<PerioderForBehandling>) = listOf(akkumulert, nesteFagsak).flatten()
+    fun finnSisteIverksatteBehandlingFraLøpendeFagsaker(): List<Long> = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
 
     fun hentBehandlinger(fagsakId: Long): List<Behandling> {
         return behandlingRepository.finnBehandlinger(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -97,7 +97,7 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
                         behandlingId)
             }
 
-    fun finnSisteIverksatteBehandlingFraLøpendeFagsaker(): List<Long> = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+    fun finnSisteIverksatteBehandlingerFraLøpendeFagsaker(): List<Long> = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
 
     fun hentBehandlinger(fagsakId: Long): List<Behandling> {
         return behandlingRepository.finnBehandlinger(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
 import no.nav.familie.ba.sak.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.økonomi.OppdragIdForFagsystem
+import no.nav.familie.kontrakter.felles.oppdrag.PeriodeIdnForFagsak
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -97,6 +98,18 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
                         behandlingId)
             }
 
+    fun hentDataForKonsistensavstemming(): List<PeriodeIdnForFagsak> {
+        val behandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        return behandlinger.map { behandling ->
+            PeriodeIdnForFagsak(fagsakId = behandling.fagsak.id.toString(),
+                                periodeIdn = beregningService.hentAndelerTilkjentYtelseForBehandling(behandling.id)
+                                        .map {
+                                            it.periodeOffset
+                                            ?: error("Andel ${it.id} på iverksatt behandling på løpende fagsak mangler periodeOffset")
+                                        }
+                                        .toSet())
+        }
+    }
 
     fun hentBehandlinger(fagsakId: Long): List<Behandling> {
         return behandlingRepository.finnBehandlinger(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
 import no.nav.familie.ba.sak.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.økonomi.OppdragIdForFagsystem
-import no.nav.familie.kontrakter.felles.oppdrag.PeriodeIdnForFagsak
+import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -98,18 +98,28 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
                         behandlingId)
             }
 
-    fun hentDataForKonsistensavstemming(): List<PeriodeIdnForFagsak> {
-        val behandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
-        return behandlinger.map { behandling ->
-            PeriodeIdnForFagsak(fagsakId = behandling.fagsak.id.toString(),
-                                periodeIdn = beregningService.hentAndelerTilkjentYtelseForBehandling(behandling.id)
-                                        .map {
-                                            it.periodeOffset
-                                            ?: error("Andel ${it.id} på iverksatt behandling på løpende fagsak mangler periodeOffset")
-                                        }
-                                        .toSet())
-        }
+    fun hentDataForKonsistensavstemming(): List<PerioderForBehandling> {
+        val relevanteBehandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        return relevanteBehandlinger
+                .map { behandlingId ->
+                    val andelerIRelevantBehandling = beregningService.hentAndelerTilkjentYtelseForBehandling(behandlingId)
+                    andelerIRelevantBehandling
+                            .groupBy { it.kildeBehandlingId }
+                            .map { (kildeBehandlingId, andeler) ->
+                                PerioderForBehandling(behandlingId = kildeBehandlingId.toString(),
+                                                      perioder = andeler
+                                                              .map {
+                                                                  it.periodeOffset
+                                                                  ?: error("Andel ${it.id} på iverksatt behandling på løpende fagsak mangler periodeOffset")
+                                                              }
+                                                              .toSet())
+                            }
+                }
+                .reduce(::samleFagsaker)
     }
+
+    private fun samleFagsaker(akkumulert: List<PerioderForBehandling>,
+                              nesteFagsak: List<PerioderForBehandling>) = listOf(akkumulert, nesteFagsak).flatten()
 
     fun hentBehandlinger(fagsakId: Long): List<Behandling> {
         return behandlingRepository.finnBehandlinger(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.behandling.domene.*
 import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus.AVSLUTTET
 import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus.FATTER_VEDTAK
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakPersonRepository
-import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.behandling.steg.FØRSTE_STEG
 import no.nav.familie.ba.sak.behandling.steg.StegType
 import no.nav.familie.ba.sak.beregning.BeregningService
@@ -15,7 +14,6 @@ import no.nav.familie.ba.sak.oppgave.OppgaveService
 import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
 import no.nav.familie.ba.sak.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
-import no.nav.familie.ba.sak.økonomi.OppdragIdForFagsystem
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -27,7 +25,6 @@ import java.time.LocalDate
 class BehandlingService(private val behandlingRepository: BehandlingRepository,
                         private val behandlingMetrikker: BehandlingMetrikker,
                         private val fagsakPersonRepository: FagsakPersonRepository,
-                        private val persongrunnlagService: PersongrunnlagService,
                         private val beregningService: BeregningService,
                         private val loggService: LoggService,
                         private val arbeidsfordelingService: ArbeidsfordelingService,
@@ -90,14 +87,7 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
         return behandlingRepository.finnBehandling(behandlingId)
     }
 
-    fun hentOppdragIderTilKonsistensavstemming(): List<OppdragIdForFagsystem> = behandlingRepository.finnBehandlingerMedLøpendeAndel()
-            .map { behandlingId ->
-                OppdragIdForFagsystem(
-                        persongrunnlagService.hentSøker(behandlingId)!!.personIdent.ident,
-                        behandlingId)
-            }
-
-    fun finnSisteIverksatteBehandlingerFraLøpendeFagsaker(): List<Long> = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+    fun hentSisteIverksatteBehandlingerFraLøpendeFagsaker(): List<Long> = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
 
     fun hentBehandlinger(fagsakId: Long): List<Behandling> {
         return behandlingRepository.finnBehandlinger(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
@@ -34,6 +34,19 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
            nativeQuery = true)
     fun finnBehandlingerMedLøpendeAndel(): List<Long>
 
+    @Query(value = """with sisteIverksatteBehandlingFraLøpendeFagsak as (
+                            select f.id as fagsakId, max(b.id) as behandlingId
+                            from behandling b
+                                   inner join fagsak f on f.id = b.fk_fagsak_id
+                                   inner join tilkjent_ytelse ty on b.id = ty.fk_behandling_id
+                            where f.status = 'LØPENDE'
+                              AND ty.utbetalingsoppdrag IS NOT NULL
+                            GROUP BY fagsakId)
+                        
+                        select * from behandling where behandling.id in (select behandlingId from sisteIverksatteBehandlingFraLøpendeFagsak)""",
+           nativeQuery = true)
+    fun finnSisteIverksatteBehandlingFraLøpendeFagsaker(): List<Behandling>
+
     @Query("SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id = :fagsakId AND b.status = 'AVSLUTTET'")
     fun findByFagsakAndAvsluttet(fagsakId: Long): List<Behandling>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
@@ -14,7 +14,6 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Query("SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id = :fagsakId AND b.aktiv = true")
     fun findByFagsakAndAktiv(fagsakId: Long): Behandling?
 
-
     /* Denne henter først siste iverksatte behandling på en løpende fagsak.
      * Finner så alle perioder på siste iverksatte behandling
      * Finner deretter første behandling en periode oppstod i, som er det som skal avstemmes
@@ -43,9 +42,9 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                               AND ty.utbetalingsoppdrag IS NOT NULL
                             GROUP BY fagsakId)
                         
-                        select * from behandling where behandling.id in (select behandlingId from sisteIverksatteBehandlingFraLøpendeFagsak)""",
+                        select behandlingId from sisteIverksatteBehandlingFraLøpendeFagsak""",
            nativeQuery = true)
-    fun finnSisteIverksatteBehandlingFraLøpendeFagsaker(): List<Behandling>
+    fun finnSisteIverksatteBehandlingFraLøpendeFagsaker(): List<Long>
 
     @Query("SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id = :fagsakId AND b.status = 'AVSLUTTET'")
     fun findByFagsakAndAvsluttet(fagsakId: Long): List<Behandling>

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
@@ -14,25 +14,6 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Query("SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id = :fagsakId AND b.aktiv = true")
     fun findByFagsakAndAktiv(fagsakId: Long): Behandling?
 
-    /* Denne henter først siste iverksatte behandling på en løpende fagsak.
-     * Finner så alle perioder på siste iverksatte behandling
-     * Finner deretter første behandling en periode oppstod i, som er det som skal avstemmes
-     */
-    @Query(value = """with sisteIverksatteBehandlingFraLøpendeFagsak as (
-                            select f.id as fagsakId, max(b.id) as behandlingId
-                            from behandling b
-                                   inner join fagsak f on f.id = b.fk_fagsak_id
-                                   inner join tilkjent_ytelse ty on b.id = ty.fk_behandling_id
-                            where f.status = 'LØPENDE'
-                              AND ty.utbetalingsoppdrag IS NOT NULL
-                            GROUP BY fagsakId)
-                        
-                        select distinct andel_tilkjent_ytelse.kilde_behandling_id
-                        from andel_tilkjent_ytelse inner join sisteIverksatteBehandlingFraLøpendeFagsak 
-                            on andel_tilkjent_ytelse.fk_behandling_id = sisteIverksatteBehandlingFraLøpendeFagsak.behandlingId""",
-           nativeQuery = true)
-    fun finnBehandlingerMedLøpendeAndel(): List<Long>
-
     @Query(value = """with sisteIverksatteBehandlingFraLøpendeFagsak as (
                             select f.id as fagsakId, max(b.id) as behandlingId
                             from behandling b

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
@@ -37,6 +37,10 @@ class BeregningService(
         return andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(listOf(behandlingId))
     }
 
+    fun hentSisteAndelerTilkjentYtelseForFagsak(behandlingId: Long): List<AndelTilkjentYtelse> {
+        return andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(listOf(behandlingId))
+    }
+
     fun lagreTilkjentYtelseMedOppdaterteAndeler(tilkjentYtelse: TilkjentYtelse) {
         tilkjentYtelseRepository.save(tilkjentYtelse)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
@@ -33,21 +33,18 @@ class BeregningService(
         private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository
 ) {
 
-    fun hentAndelerTilkjentYtelseForBehandling(behandlingId: Long): List<AndelTilkjentYtelse> {
-        return andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(listOf(behandlingId))
-    }
+    fun hentAndelerTilkjentYtelseForBehandlinger(behandlingIder: List<Long>): List<AndelTilkjentYtelse> =
+            andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(behandlingIder)
 
-    fun lagreTilkjentYtelseMedOppdaterteAndeler(tilkjentYtelse: TilkjentYtelse) {
-        tilkjentYtelseRepository.save(tilkjentYtelse)
-    }
+    fun hentAndelerTilkjentYtelseForBehandling(behandlingId: Long): List<AndelTilkjentYtelse> =
+            andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(listOf(behandlingId))
 
-    fun hentTilkjentYtelseForBehandling(behandlingId: Long): TilkjentYtelse {
-        return tilkjentYtelseRepository.findByBehandling(behandlingId)
-    }
+    fun lagreTilkjentYtelseMedOppdaterteAndeler(tilkjentYtelse: TilkjentYtelse) = tilkjentYtelseRepository.save(tilkjentYtelse)
 
-    fun hentOptionalTilkjentYtelseForBehandling(behandlingId: Long): TilkjentYtelse? {
-        return tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
-    }
+    fun hentTilkjentYtelseForBehandling(behandlingId: Long) = tilkjentYtelseRepository.findByBehandling(behandlingId)
+
+    fun hentOptionalTilkjentYtelseForBehandling(behandlingId: Long) =
+            tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
 
     fun hentSisteTilkjentYtelseFørBehandling(behandling: Behandling): TilkjentYtelse? {
         val iverksatteBehandlinger = behandlingRepository.finnBehandlinger(behandling.fagsak.id).filter {

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/BeregningService.kt
@@ -37,10 +37,6 @@ class BeregningService(
         return andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(listOf(behandlingId))
     }
 
-    fun hentSisteAndelerTilkjentYtelseForFagsak(behandlingId: Long): List<AndelTilkjentYtelse> {
-        return andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(listOf(behandlingId))
-    }
-
     fun lagreTilkjentYtelseMedOppdaterteAndeler(tilkjentYtelse: TilkjentYtelse) {
         tilkjentYtelseRepository.save(tilkjentYtelse)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdrag.kt
@@ -19,7 +19,7 @@ class KonsistensavstemMotOppdrag(val avstemmingService: AvstemmingService) : Asy
     override fun doTask(task: Task) {
         val konsistensavstemmingTask = objectMapper.readValue(task.payload, KonsistensavstemmingTaskDTO::class.java)
 
-        avstemmingService.konsistensavstemOppdrag(konsistensavstemmingTask.avstemmingdato)
+        avstemmingService.konsistensavstemOppdragV2(konsistensavstemmingTask.avstemmingdato)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdrag.kt
@@ -19,7 +19,7 @@ class KonsistensavstemMotOppdrag(val avstemmingService: AvstemmingService) : Asy
     override fun doTask(task: Task) {
         val konsistensavstemmingTask = objectMapper.readValue(task.payload, KonsistensavstemmingTaskDTO::class.java)
 
-        avstemmingService.konsistensavstemOppdragV2(konsistensavstemmingTask.avstemmingdato)
+        avstemmingService.konsistensavstemOppdrag(konsistensavstemmingTask.avstemmingdato)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -33,7 +33,7 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient,
 
         LOG.info("Utfører konsisensavstemming for ${perioderTilAvstemming.size} løpende saker")
 
-        Result.runCatching { økonomiKlient.konsistensavstemOppdragV2(avstemmingsdato, perioderTilAvstemming) }
+        Result.runCatching { økonomiKlient.konsistensavstemOppdrag(avstemmingsdato, perioderTilAvstemming) }
                 .fold(
                         onSuccess = {
                             LOG.debug("Konsistensavstemming mot oppdrag utført.")

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -1,13 +1,17 @@
 package no.nav.familie.ba.sak.økonomi
 
 import no.nav.familie.ba.sak.behandling.BehandlingService
+import no.nav.familie.ba.sak.beregning.BeregningService
+import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
 @Service
-class AvstemmingService(val økonomiKlient: ØkonomiKlient, val behandlingService: BehandlingService) {
+class AvstemmingService(val økonomiKlient: ØkonomiKlient,
+                        val behandlingService: BehandlingService,
+                        val beregningService: BeregningService) {
 
     fun grensesnittavstemOppdrag(fraDato: LocalDateTime, tilDato: LocalDateTime) {
 
@@ -42,7 +46,7 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient, val behandlingServic
 
     fun konsistensavstemOppdragV2(avstemmingsdato: LocalDateTime) {
 
-        val perioderTilAvstemming = behandlingService.hentDataForKonsistensavstemming()
+        val perioderTilAvstemming = hentDataForKonsistensavstemming()
 
         LOG.info("Utfører konsisensavstemming for ${perioderTilAvstemming.size} løpende saker")
 
@@ -58,8 +62,29 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient, val behandlingServic
                 )
     }
 
+    fun hentDataForKonsistensavstemming(): List<PerioderForBehandling> {
+        val relevanteBehandlinger = behandlingService.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        return relevanteBehandlinger
+                .map { behandlingId ->
+                    val andelerIRelevantBehandling = beregningService.hentAndelerTilkjentYtelseForBehandling(behandlingId)
+                    andelerIRelevantBehandling
+                            .groupBy { it.kildeBehandlingId }
+                            .map { (kildeBehandlingId, andeler) ->
+                                PerioderForBehandling(behandlingId = kildeBehandlingId.toString(),
+                                                      perioder = andeler
+                                                              .map {
+                                                                  it.periodeOffset
+                                                                  ?: error("Andel ${it.id} på iverksatt behandling på løpende fagsak mangler periodeOffset")
+                                                              }
+                                                              .toSet())
+                            }
+                }
+                .flatten()
+    }
+
 
     companion object {
+
         val LOG: Logger = LoggerFactory.getLogger(AvstemmingService::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -63,12 +63,12 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient,
     }
 
     fun hentDataForKonsistensavstemming(): List<PerioderForBehandling> {
-        val relevanteBehandlinger = behandlingService.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        val relevanteBehandlinger = behandlingService.finnSisteIverksatteBehandlingerFraLøpendeFagsaker()
         return relevanteBehandlinger
-                .map { behandlingId ->
-                    val andelerIRelevantBehandling = beregningService.hentAndelerTilkjentYtelseForBehandling(behandlingId)
-                    andelerIRelevantBehandling
-                            .groupBy { it.kildeBehandlingId }
+                .chunked(1000)
+                .map { chunk ->
+                    val relevanteAndeler = beregningService.hentAndelerTilkjentYtelseForBehandlinger(chunk)
+                    relevanteAndeler.groupBy { it.kildeBehandlingId }
                             .map { (kildeBehandlingId, andeler) ->
                                 PerioderForBehandling(behandlingId = kildeBehandlingId.toString(),
                                                       perioder = andeler
@@ -78,10 +78,8 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient,
                                                               }
                                                               .toSet())
                             }
-                }
-                .flatten()
+                }.flatten()
     }
-
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -40,6 +40,24 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient, val behandlingServic
                 )
     }
 
+    fun konsistensavstemOppdragV2(avstemmingsdato: LocalDateTime) {
+
+        val perioderTilAvstemming = behandlingService.hentDataForKonsistensavstemming()
+
+        LOG.info("Utfører konsisensavstemming for ${perioderTilAvstemming.size} løpende saker")
+
+        Result.runCatching { økonomiKlient.konsistensavstemOppdragV2(avstemmingsdato, perioderTilAvstemming) }
+                .fold(
+                        onSuccess = {
+                            LOG.debug("Konsistensavstemming mot oppdrag utført.")
+                        },
+                        onFailure = {
+                            LOG.error("Konsistensavstemming mot oppdrag feilet", it)
+                            throw it
+                        }
+                )
+    }
+
 
     companion object {
         val LOG: Logger = LoggerFactory.getLogger(AvstemmingService::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/AvstemmingService.kt
@@ -29,23 +29,6 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient,
 
     fun konsistensavstemOppdrag(avstemmingsdato: LocalDateTime) {
 
-        val oppdragTilAvstemming = behandlingService.hentOppdragIderTilKonsistensavstemming()
-        LOG.info("Utfører konsistensavstemming for ${oppdragTilAvstemming.size} løpende saker")
-
-        Result.runCatching { økonomiKlient.konsistensavstemOppdrag(avstemmingsdato, oppdragTilAvstemming) }
-                .fold(
-                        onSuccess = {
-                            LOG.debug("Konsistensavstemming mot oppdrag utført.")
-                        },
-                        onFailure = {
-                            LOG.error("Konsistensavstemming mot oppdrag feilet", it)
-                            throw it
-                        }
-                )
-    }
-
-    fun konsistensavstemOppdragV2(avstemmingsdato: LocalDateTime) {
-
         val perioderTilAvstemming = hentDataForKonsistensavstemming()
 
         LOG.info("Utfører konsisensavstemming for ${perioderTilAvstemming.size} løpende saker")
@@ -62,8 +45,8 @@ class AvstemmingService(val økonomiKlient: ØkonomiKlient,
                 )
     }
 
-    fun hentDataForKonsistensavstemming(): List<PerioderForBehandling> {
-        val relevanteBehandlinger = behandlingService.finnSisteIverksatteBehandlingerFraLøpendeFagsaker()
+    private fun hentDataForKonsistensavstemming(): List<PerioderForBehandling> {
+        val relevanteBehandlinger = behandlingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
         return relevanteBehandlinger
                 .chunked(1000)
                 .map { chunk ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/KonsistensavstemmingScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/KonsistensavstemmingScheduler.kt
@@ -22,7 +22,7 @@ class KonsistensavstemmingScheduler(val batchService: BatchService,
 
     @Scheduled(cron = "0 0 17 * * *")
     fun utførKonsistensavstemming() {
-        val inneværendeMåned = YearMonth.from(now())
+        val inneværendeMåned = YearMonth.from(now()) // TODO: Manuelt sette inn ny kjøredato?
         val plukketBatch = batchService.plukkLedigeBatchKjøringerFor(dato = now()) ?: return
 
         LOG.info("Kjører konsistensavstemming for $inneværendeMåned")

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
@@ -94,11 +94,11 @@ class ØkonomiKlient(
     }
 
     fun konsistensavstemOppdragV2(avstemmingsdato: LocalDateTime,
-                                  perioderTilAvstemming: List<PeriodeIdnForFagsak>): ResponseEntity<Ressurs<String>> {
+                                  perioderTilAvstemming: List<PerioderForBehandling>): ResponseEntity<Ressurs<String>> {
         
         val body = KonsistensavstemmingRequestV2(fagsystem = FAGSYSTEM,
                                                  avstemmingstidspunkt = avstemmingsdato,
-                                                 periodeIdn = perioderTilAvstemming)
+                                                 perioderForBehandlinger = perioderTilAvstemming)
 
         val headers = HttpHeaders().medContentTypeJsonUTF8()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
@@ -3,9 +3,7 @@ package no.nav.familie.ba.sak.økonomi
 import no.nav.familie.ba.sak.common.BaseService
 import no.nav.familie.ba.sak.task.dto.FAGSYSTEM
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
-import no.nav.familie.kontrakter.felles.oppdrag.RestSimulerResultat
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.*
 import no.nav.familie.log.NavHttpHeaders
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
@@ -93,5 +91,22 @@ class ØkonomiKlient(
                 URI.create("$familieOppdragUri/konsistensavstemming/$FAGSYSTEM/?avstemmingsdato=$avstemmingsdato"),
                 HttpMethod.POST,
                 HttpEntity<List<OppdragIdForFagsystem>>(oppdragTilAvstemming, headers))
+    }
+
+    fun konsistensavstemOppdragV2(avstemmingsdato: LocalDateTime,
+                                  perioderTilAvstemming: List<PeriodeIdnForFagsak>): ResponseEntity<Ressurs<String>> {
+        
+        val body = KonsistensavstemmingRequestV2(fagsystem = FAGSYSTEM,
+                                                 avstemmingstidspunkt = avstemmingsdato,
+                                                 periodeIdn = perioderTilAvstemming)
+
+        val headers = HttpHeaders().medContentTypeJsonUTF8()
+
+        headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), MDC.get(MDCConstants.MDC_CALL_ID))
+
+        return restOperations.exchange(
+                URI.create("$familieOppdragUri/v2/konsistensavstemming"),
+                HttpMethod.POST,
+                HttpEntity<KonsistensavstemmingRequestV2>(body, headers))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiKlient.kt
@@ -82,19 +82,7 @@ class ØkonomiKlient(
     }
 
     fun konsistensavstemOppdrag(avstemmingsdato: LocalDateTime,
-                                oppdragTilAvstemming: List<OppdragIdForFagsystem>): ResponseEntity<Ressurs<String>> {
-        val headers = HttpHeaders().medContentTypeJsonUTF8()
-
-        headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), MDC.get(MDCConstants.MDC_CALL_ID))
-
-        return restOperations.exchange(
-                URI.create("$familieOppdragUri/konsistensavstemming/$FAGSYSTEM/?avstemmingsdato=$avstemmingsdato"),
-                HttpMethod.POST,
-                HttpEntity<List<OppdragIdForFagsystem>>(oppdragTilAvstemming, headers))
-    }
-
-    fun konsistensavstemOppdragV2(avstemmingsdato: LocalDateTime,
-                                  perioderTilAvstemming: List<PerioderForBehandling>): ResponseEntity<Ressurs<String>> {
+                                perioderTilAvstemming: List<PerioderForBehandling>): ResponseEntity<Ressurs<String>> {
         
         val body = KonsistensavstemmingRequestV2(fagsystem = FAGSYSTEM,
                                                  avstemmingstidspunkt = avstemmingsdato,

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakBegrunnelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakBegrunnelseTest.kt
@@ -83,7 +83,6 @@ class VedtakBegrunnelseTest(
                 behandlingRepository,
                 behandlingMetrikker,
                 fagsakPersonRepository,
-                persongrunnlagService,
                 beregningService,
                 loggService,
                 arbeidsfordelingService,

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakServiceTest.kt
@@ -99,7 +99,6 @@ class VedtakServiceTest(
                 behandlingRepository,
                 behandlingMetrikker,
                 fagsakPersonRepository,
-                persongrunnlagService,
                 beregningService,
                 loggService,
                 arbeidsfordelingService,

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/KonsistensavstemmingUtplukkingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/KonsistensavstemmingUtplukkingIntegrationTest.kt
@@ -63,9 +63,13 @@ class KonsistensavstemmingUtplukkingIntegrationTest {
                 opprettOgLagreBehandlingMedAndeler(personIdent = forelderIdent,
                                                    kildeOgOffsetPåAndeler = listOf(KildeOgOffsetPåAndel(null, 1L)))
 
-        val gjeldendeBehandlinger = behandlingRepository.finnBehandlingerMedLøpendeAndel()
+        val iverksattOgLøpendeBehandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        val behandlingerMedRelevanteAndeler =
+                andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(iverksattOgLøpendeBehandlinger)
+                        .map { it.kildeBehandlingId }
+                        .distinct()
 
-        Assertions.assertTrue(gjeldendeBehandlinger.filter { it == førstegangsbehandling.id }.isNotEmpty())
+        Assertions.assertTrue(behandlingerMedRelevanteAndeler.filter { it == førstegangsbehandling.id }.isNotEmpty())
     }
 
     @Test
@@ -86,11 +90,16 @@ class KonsistensavstemmingUtplukkingIntegrationTest {
                                                             KildeOgOffsetPåAndel(førstegangsbehandling.id, 1L),
                                                             KildeOgOffsetPåAndel(null, 2L)))
 
-        val gjeldendeBehandlinger = behandlingRepository.finnBehandlingerMedLøpendeAndel()
+        val iverksattOgLøpendeBehandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        val behandlingerMedRelevanteAndeler =
+                andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(iverksattOgLøpendeBehandlinger)
+                        .map { it.kildeBehandlingId }
+                        .sortedBy { it }
+                        .distinct()
 
-        Assertions.assertEquals(2, gjeldendeBehandlinger.size)
-        Assertions.assertEquals(førstegangsbehandling.id, gjeldendeBehandlinger[0])
-        Assertions.assertEquals(revurdering.id, gjeldendeBehandlinger[1])
+        Assertions.assertEquals(2, behandlingerMedRelevanteAndeler.size)
+        Assertions.assertEquals(førstegangsbehandling.id, behandlingerMedRelevanteAndeler[0])
+        Assertions.assertEquals(revurdering.id, behandlingerMedRelevanteAndeler[1])
     }
 
     @Test
@@ -108,10 +117,14 @@ class KonsistensavstemmingUtplukkingIntegrationTest {
                                                     kildeOgOffsetPåAndeler = listOf(KildeOgOffsetPåAndel(null, 2L)))
 
 
-        val gjeldendeBehandlinger = behandlingRepository.finnBehandlingerMedLøpendeAndel()
+        val iverksattOgLøpendeBehandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        val behandlingerMedRelevanteAndeler =
+                andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(iverksattOgLøpendeBehandlinger)
+                        .map { it.kildeBehandlingId }
+                        .distinct()
 
-        Assertions.assertEquals(1, gjeldendeBehandlinger.size)
-        Assertions.assertEquals(revurdering.id, gjeldendeBehandlinger[0])
+        Assertions.assertEquals(1, behandlingerMedRelevanteAndeler.size)
+        Assertions.assertEquals(revurdering.id, behandlingerMedRelevanteAndeler[0])
     }
 
     @Test
@@ -128,9 +141,13 @@ class KonsistensavstemmingUtplukkingIntegrationTest {
         opprettOgLagreRevurderingMedAndeler(personIdent = forelderIdent,
                                             kildeOgOffsetPåAndeler = emptyList())
 
-        val gjeldendeBehandlinger = behandlingRepository.finnBehandlingerMedLøpendeAndel()
+        val iverksattOgLøpendeBehandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        val behandlingerMedRelevanteAndeler =
+                andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(iverksattOgLøpendeBehandlinger)
+                        .map { it.kildeBehandlingId }
+                        .distinct()
 
-        Assertions.assertTrue(gjeldendeBehandlinger.isEmpty())
+        Assertions.assertTrue(behandlingerMedRelevanteAndeler.isEmpty())
     }
 
     @Test
@@ -149,10 +166,14 @@ class KonsistensavstemmingUtplukkingIntegrationTest {
                                             kildeOgOffsetPåAndeler = listOf(KildeOgOffsetPåAndel(null, 2L)),
                                             erIverksatt = false)
 
-        val gjeldendeBehandlinger = behandlingRepository.finnBehandlingerMedLøpendeAndel()
+        val iverksattOgLøpendeBehandlinger = behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
+        val behandlingerMedRelevanteAndeler =
+                andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(iverksattOgLøpendeBehandlinger)
+                        .map { it.kildeBehandlingId }
+                        .distinct()
 
-        Assertions.assertEquals(1, gjeldendeBehandlinger.size)
-        Assertions.assertEquals(iverksattBehandling.id, gjeldendeBehandlinger[0])
+        Assertions.assertEquals(1, behandlingerMedRelevanteAndeler.size)
+        Assertions.assertEquals(iverksattBehandling.id, behandlingerMedRelevanteAndeler[0])
     }
 
     private fun opprettOgLagreBehandlingMedAndeler(personIdent: String,

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
@@ -155,9 +155,9 @@ class ØkonomiIntegrasjonTest {
         fagsak.status = FagsakStatus.LØPENDE
         fagsakService.lagre(fagsak)
 
-        val søkerOgBehandlingListe = behandlingService.hentOppdragIderTilKonsistensavstemming()
+        val behandlingerMedAndelerTilAvstemming = behandlingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
 
-        Assertions.assertTrue(søkerOgBehandlingListe.contains(OppdragIdForFagsystem(fnr, behandling.id)))
+        Assertions.assertTrue(behandlingerMedAndelerTilAvstemming.contains(behandling.id))
     }
 
     private fun lagBehandlingResultat(behandling: Behandling,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Tar i bruk oppdatert kontrakt og endepunkt for å løse opp i format sendt til konsistensavstemming. Forhåpentligvis løser dette eksisterende avvik.

I korte trekk må vi plukke ut gjeldende perioder og generere et helt nytt oppdrag til avstemming, framfor å avstemme tidligere oppdrag. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?

**Trigging av ny avstemming**
Nå skal i utgangspunktet batchjobben kjøres i morgen 06.01.21. Hvis vi ikke får merget innen da legger jeg til et script som manuelt inserter en kjøredato, så det er dokumentert, framfor å  trigge med midlertidig kode. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det nye oppdragsendepunktet er testet av EF. Ny trigging av konsistensavstemming i prod blir nok beste validering her. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
