### PR TITLE
BUG: innvilget og opphørt brevgenerering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/dokument/MalerService.kt
@@ -46,6 +46,7 @@ class MalerService(
                                                          vedtak.behandling.type),
                 fletteFelter = when (behandlingResultat) {
                     BehandlingResultat.INNVILGET -> mapTilInnvilgetBrevFelter(vedtak, personopplysningGrunnlag)
+                    BehandlingResultat.INNVILGET_OG_OPPHØRT -> mapTilInnvilgetBrevFelter(vedtak, personopplysningGrunnlag)
                     BehandlingResultat.OPPHØRT -> mapTilOpphørtBrevFelter(vedtak, personopplysningGrunnlag)
                     else -> throw FunksjonellFeil(melding = "Brev ikke støttet for behandlingsresultat=$behandlingResultat",
                                                   frontendFeilmelding = "Brev ikke støttet for behandlingsresultat=$behandlingResultat")


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bruker samme logikk for å generere innvilget og opphørt brev som for innvilget. Resultatet er støttet, men det var ikke mappet opp ved brevgenerering. Har bedt Eivind om å bekrefte at det er riktig å bruke samme logikk for de 2 resultatene.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bug

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
