### PR TITLE
BUG: Automatisk vurdert vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPersonResultat.kt
@@ -21,7 +21,8 @@ data class RestVilkårResultat(
         val endretAv: String,
         val endretTidspunkt: LocalDateTime,
         val behandlingId: Long,
-        val erVurdert: Boolean? = null
+        val erVurdert: Boolean = false,
+        val erAutomatiskVurdert: Boolean = false,
 )
 
 
@@ -30,6 +31,7 @@ fun PersonResultat.tilRestPersonResultat() =
                            vilkårResultater = this.vilkårResultater.map { vilkårResultat ->
                                RestVilkårResultat(
                                        resultat = vilkårResultat.resultat,
+                                       erAutomatiskVurdert = vilkårResultat.erAutomatiskVurdert,
                                        id = vilkårResultat.id,
                                        vilkårType = vilkårResultat.vilkårType,
                                        periodeFom = vilkårResultat.periodeFom,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårResultat.kt
@@ -43,6 +43,9 @@ class VilkårResultat(
         @Column(name = "fk_behandling_id", nullable = false)
         var behandlingId: Long,
 
+        @Column(name = "er_automatisk_vurdert", nullable = false)
+        var erAutomatiskVurdert: Boolean = false,
+
         @Column(name = "evaluering_aarsak")
         @Convert(converter = StringListConverter::class)
         val evalueringÅrsaker: List<String> = emptyList(),
@@ -77,12 +80,14 @@ class VilkårResultat(
         periodeTom = restVilkårResultat.periodeTom
         begrunnelse = restVilkårResultat.begrunnelse
         resultat = restVilkårResultat.resultat
+        erAutomatiskVurdert = false
         oppdaterPekerTilBehandling()
     }
 
     fun kopierMedParent(nyPersonResultat: PersonResultat? = null): VilkårResultat {
         return VilkårResultat(
                 personResultat = nyPersonResultat ?: personResultat,
+                erAutomatiskVurdert = erAutomatiskVurdert,
                 vilkårType = vilkårType,
                 resultat = resultat,
                 periodeFom = if (periodeFom != null) LocalDate.from(periodeFom) else null,
@@ -97,6 +102,7 @@ class VilkårResultat(
     fun kopierMedNyPeriode(fom: LocalDate, tom: LocalDate, behandlingId: Long): VilkårResultat {
         return VilkårResultat(
                 personResultat = personResultat,
+                erAutomatiskVurdert = erAutomatiskVurdert,
                 vilkårType = vilkårType,
                 resultat = resultat,
                 periodeFom = if (fom == TIDENES_MORGEN) null else fom,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårService.kt
@@ -179,8 +179,11 @@ class VilkårService(
                 val tom: LocalDate? =
                         if (vilkår == Vilkår.UNDER_18_ÅR) person.fødselsdato.plusYears(18) else null
 
-
                 VilkårResultat(personResultat = personResultat,
+                               erAutomatiskVurdert = when (vilkår) {
+                                   Vilkår.UNDER_18_ÅR, Vilkår.GIFT_PARTNERSKAP -> true
+                                   else -> false
+                               },
                                resultat = when (vilkår) {
                                    Vilkår.UNDER_18_ÅR -> Resultat.OPPFYLT
                                    Vilkår.GIFT_PARTNERSKAP -> if (person.sivilstand.somForventetHosBarn())
@@ -283,6 +286,7 @@ class VilkårService(
             }
 
             VilkårResultat(personResultat = personResultat,
+                           erAutomatiskVurdert = true,
                            resultat = child.resultat,
                            vilkårType = vilkår,
                            evalueringÅrsaker = child.evalueringÅrsaker.map { it.toString() },

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtils.kt
@@ -95,29 +95,16 @@ object VilkårsvurderingUtils {
                 }
                 periodePåNyttVilkår.kanFlytteFom(periode) -> {
                     vilkårResultat.periodeFom = nyFom
+                    vilkårResultat.erAutomatiskVurdert = false
                     vilkårResultat.oppdaterPekerTilBehandling()
                 }
                 periodePåNyttVilkår.kanFlytteTom(periode) -> {
                     vilkårResultat.periodeTom = nyTom
+                    vilkårResultat.erAutomatiskVurdert = false
                     vilkårResultat.oppdaterPekerTilBehandling()
                 }
             }
         }
-    }
-
-    fun hentNesteVilkårResultat(vilkårResultater: SortedSet<VilkårResultat>, index: Int): VilkårResultat? {
-        var next = false
-        vilkårResultater.forEachIndexed { forEachIndex, vilkårResultat ->
-            if (next) {
-                return vilkårResultat
-            }
-
-            if (forEachIndex == index) {
-                next = true
-            }
-        }
-
-        return null
     }
 
     /**

--- a/src/main/resources/db/migration/V107__vilkår_resultat_er_automatisk_vurdert.sql
+++ b/src/main/resources/db/migration/V107__vilkår_resultat_er_automatisk_vurdert.sql
@@ -1,0 +1,7 @@
+ALTER TABLE VILKAR_RESULTAT
+    ADD COLUMN er_automatisk_vurdert BOOLEAN DEFAULT FALSE NOT NULL;
+
+
+UPDATE VILKAR_RESULTAT
+SET er_automatisk_vurdert = TRUE
+WHERE vilkar = 'UNDER_18_ÅR';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Legger til logikk for å vurdere om et vilkår er automatisk behandlet. Oppdaterer kun under 18 år vilkår på data i produksjon da vi ikke kan garantere for gift vilkåret. Logikken frontend var at "endretAv=VL". Det blir riktig for autovedtak, men ikke for manuell behandling der vi "manuelt" bygger en vilkårsvurdering.

Lager det som draft slik at jeg kan endre på migreringsscriptet.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
VilkårResultat begynner å bli litt stor, så man kan vurdere om man heller skulle innført en status på vilkåret (IKKE_TATT_STILLING_TIL, AUTOMATISK_VURDERT, MANUELT_VURDERT, MANUELT_OVERSTYRT etc)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
