### PR TITLE
Sett dato i opphørsbrev til tom-dato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -169,15 +169,10 @@ class VedtakService(private val behandlingService: BehandlingService,
                 }
 
                 val vilkårsdato = when (restPutUtbetalingBegrunnelse.vedtakBegrunnelseType) {
-                    VedtakBegrunnelseType.REDUKSJON -> {
-                        opprinneligUtbetalingBegrunnelse.tom.minusMonths(1).tilMånedÅr()
-                    }
-                    VedtakBegrunnelseType.OPPHØR -> {
+                    VedtakBegrunnelseType.REDUKSJON -> opprinneligUtbetalingBegrunnelse.tom.minusMonths(1).tilMånedÅr()
+                    VedtakBegrunnelseType.OPPHØR ->
                         opprinneligUtbetalingBegrunnelse.tom.tilMånedÅr()
-                    }
-                    else -> {
-                        opprinneligUtbetalingBegrunnelse.fom.minusMonths(1).tilMånedÅr()
-                    }
+                    else -> opprinneligUtbetalingBegrunnelse.fom.minusMonths(1).tilMånedÅr()
                 }
 
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -168,9 +168,17 @@ class VedtakService(private val behandlingService: BehandlingService,
                     it.first
                 }
 
-                val vilkårsdato = if (restPutUtbetalingBegrunnelse.vedtakBegrunnelseType == VedtakBegrunnelseType.REDUKSJON)
-                    opprinneligUtbetalingBegrunnelse.tom.minusMonths(1).tilMånedÅr() else
-                    opprinneligUtbetalingBegrunnelse.fom.minusMonths(1).tilMånedÅr()
+                val vilkårsdato = when (restPutUtbetalingBegrunnelse.vedtakBegrunnelseType) {
+                    VedtakBegrunnelseType.REDUKSJON -> {
+                        opprinneligUtbetalingBegrunnelse.tom.minusMonths(1).tilMånedÅr()
+                    }
+                    VedtakBegrunnelseType.OPPHØR -> {
+                        opprinneligUtbetalingBegrunnelse.tom.tilMånedÅr()
+                    }
+                    else -> {
+                        opprinneligUtbetalingBegrunnelse.fom.minusMonths(1).tilMånedÅr()
+                    }
+                }
 
 
                 val barnasFødselsdatoer = slåSammen(barnaMedVilkårSomPåvirkerUtbetaling.sortedBy { it.fødselsdato }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Dato i opphørsbrevene var feil. Den var satt til f.o.m dato, men skal være t.o.m dato

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Siden vi per i dag setter opphørs-begrunnelse på den siste oppfylte perioden, skal datoen i brevet til f.eks. teksten "du flyttet fra Norge november 2020" være t.o.m på den siste perioden. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
