### PR TITLE
Legger til harTilgang til RestPersonInfo

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
@@ -25,7 +25,6 @@ class PersonController(private val personopplysningerService: Personopplysninger
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @GetMapping
-    @PersontilgangConstraint
     fun hentPerson(@RequestHeader personIdent: String): ResponseEntity<Ressurs<RestPersonInfo>> {
         return Result.runCatching {
             personopplysningerService.hentMaskertPersonInfoVedManglendeTilgang(personIdent)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
@@ -28,7 +28,8 @@ class PersonController(private val personopplysningerService: Personopplysninger
     @PersontilgangConstraint
     fun hentPerson(@RequestHeader personIdent: String): ResponseEntity<Ressurs<RestPersonInfo>> {
         return Result.runCatching {
-            personopplysningerService.hentPersoninfoMedRelasjoner(personIdent)
+            personopplysningerService.hentMaskertPersonInfoVedManglendeTilgang(personIdent)
+                    ?: personopplysningerService.hentPersoninfoMedRelasjoner(personIdent).tilRestPersonInfo(personIdent)
         }
                 .fold(
                         onFailure = {
@@ -37,7 +38,7 @@ class PersonController(private val personopplysningerService: Personopplysninger
                                        throwable = it)
                         },
                         onSuccess = {
-                            ResponseEntity.ok(Ressurs.success(it.tilRestPersonInfo(personIdent)))
+                            ResponseEntity.ok(Ressurs.success(it))
                         }
                 )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPersonInfo.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPersonInfo.kt
@@ -6,11 +6,12 @@ import java.time.LocalDate
 
 data class RestPersonInfo(
         val personIdent: String,
-        var fødselsdato: LocalDate,
+        var fødselsdato: LocalDate? = null,
         val navn: String? = null,
         val kjønn: Kjønn? = null,
         val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,
-        val familierelasjoner: List<RestFamilierelasjon>,
+        var harTilgang: Boolean = true,
+        val familierelasjoner: List<RestFamilierelasjon> = emptyList(),
         val familierelasjonerMaskert: List<RestFamilierelasjonMaskert> = emptyList()
 )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/pdl/PersonopplysningerService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.pdl
 
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.GrBostedsadresseperiode
+import no.nav.familie.ba.sak.behandling.restDomene.RestPersonInfo
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.pdl.internal.*
@@ -53,6 +54,18 @@ class PersonopplysningerService(
 
     private fun hentPersoninfoMedQuery(personIdent: String, personInfoQuery: PersonInfoQuery): PersonInfo {
         return pdlRestClient.hentPerson(personIdent, personInfoQuery)
+    }
+
+    fun hentMaskertPersonInfoVedManglendeTilgang(personIdent: String): RestPersonInfo? {
+        val harTilgang = integrasjonClient.sjekkTilgangTilPersoner(listOf(personIdent)).first().harTilgang
+        return if (!harTilgang) {
+            val adressebeskyttelse = hentAdressebeskyttelseSomSystembruker(personIdent)
+            RestPersonInfo(
+                    personIdent = personIdent,
+                    adressebeskyttelseGradering = adressebeskyttelse,
+                    harTilgang = false
+            )
+        } else null
     }
 
     fun hentAktivAktørId(ident: Ident): AktørId {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Utvider RestPersonInfo med harTilgang, og henter adressebeskyttelsegradering dersom saksbehandler ikke har tilgang (på samme måte som hentMaskertFagsakdeltakerVedManglendeTilgang i FagsakService).

Dette trengs for å gi korrekt feilmelding når saksbehandler prøver å endre til en kode 6 / 7 bruker via "endre bruker" i manuell journalføringsvinduet.

Annoteringen PersontilgangConstraint blir fjernet, da den da blir overflødig.

### ✅ Checklist
_Jeg har ikke skrevet tester fordi:_
Hovedfunksjonaliteten er allerede testet, det er kun gjort små modifikasjoner. Ser over at ting ser riktig ut på vei ut til frontend.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x ] Nei
