### PR TITLE
Feature/utvider saksstatistikk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <spring.vault.version>2.3.0</spring.vault.version>
         <felles.version>1.20210121113106_ca34836</felles.version>
         <felles-kontrakter.version>2.0_20210122103953_cb55034</felles-kontrakter.version>
-        <familie.kontrakter.saksstatistikk>2.0_20201217113247_876a253</familie.kontrakter.saksstatistikk>
+        <familie.kontrakter.saksstatistikk>2.0_20210127182008_e28939f</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20201124122241_0f9f95a</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.10.5</mockk.version>
         <token-validation-spring.version>1.3.2</token-validation-spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <spring.vault.version>2.3.0</spring.vault.version>
         <felles.version>1.20210121113106_ca34836</felles.version>
         <felles-kontrakter.version>2.0_20210122103953_cb55034</felles-kontrakter.version>
-        <familie.kontrakter.saksstatistikk>2.0_20210127182008_e28939f</familie.kontrakter.saksstatistikk>
+        <familie.kontrakter.saksstatistikk>2.0_20210128104331_9bd0bd2</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20201124122241_0f9f95a</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.10.5</mockk.version>
         <token-validation-spring.version>1.3.2</token-validation-spring.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
@@ -85,7 +85,7 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
                              behandlingStatus = behandling.status.name,
                              behandlingKategori = behandling.underkategori.name, // Gjøres pga. tilpasning til DVH-modell
                              behandlingAarsak = behandling.opprettetÅrsak.name,
-                             automatiskBehandlet = behandling.skalBehandlesAutomatisk, // TODO: er dette riktig?
+                             automatiskBehandlet = behandling.skalBehandlesAutomatisk,
                              utenlandstilsnitt = behandling.kategori.name, // Gjøres pga. tilpasning til DVH-modell
                              ansvarligEnhetKode = ansvarligEnhetKode,
                              behandlendeEnhetKode = behandlendeEnhetsKode,

--- a/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkService.kt
@@ -83,9 +83,10 @@ class SaksstatistikkService(private val behandlingService: BehandlingService,
                              sakId = behandling.fagsak.id.toString(),
                              behandlingType = behandling.type.name,
                              behandlingStatus = behandling.status.name,
-                             behandlingKategori = behandling.kategori.name,
-                             behandlingUnderkategori = behandling.underkategori.name,
-                             utenlandstilsnitt = "NASJONAL",
+                             behandlingKategori = behandling.underkategori.name, // Gjøres pga. tilpasning til DVH-modell
+                             behandlingAarsak = behandling.opprettetÅrsak.name,
+                             automatiskBehandlet = behandling.skalBehandlesAutomatisk, // TODO: er dette riktig?
+                             utenlandstilsnitt = behandling.kategori.name, // Gjøres pga. tilpasning til DVH-modell
                              ansvarligEnhetKode = ansvarligEnhetKode,
                              behandlendeEnhetKode = behandlendeEnhetsKode,
                              ansvarligEnhetType = "NORG",

--- a/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -143,8 +143,9 @@ internal class SaksstatistikkServiceTest {
         assertThat(behandlingDvh?.sakId).isEqualTo(behandling.fagsak.id.toString())
         assertThat(behandlingDvh?.vedtakId).isEqualTo(vedtak.id.toString())
         assertThat(behandlingDvh?.behandlingType).isEqualTo(behandling.type.name)
-        assertThat(behandlingDvh?.behandlingKategori).isEqualTo(behandling.kategori.name)
-        assertThat(behandlingDvh?.behandlingUnderkategori).isEqualTo(behandling.underkategori.name)
+        assertThat(behandlingDvh?.utenlandstilsnitt).isEqualTo(behandling.kategori.name)
+        assertThat(behandlingDvh?.behandlingKategori).isEqualTo(behandling.underkategori.name)
+        assertThat(behandlingDvh?.behandlingUnderkategori).isNull()
         assertThat(behandlingDvh?.behandlingStatus).isEqualTo(behandling.status.name)
         assertThat(behandlingDvh?.totrinnsbehandling).isFalse
         assertThat(behandlingDvh?.saksbehandler).isEqualTo(SYSTEM_NAVN)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Legger til behandlingAarsak og automatiskBehandlet til BehandlingDVH.

feltet automatiskBehandlet mappes fra Behandling.skalBehandlesAutomatisk. Mapperobjektet går utifra at felter som dette er oppdatert idet det mappes om, så skalBehandlesAutomatisk må settes riktig ved f.eks. fødselshendelser, der det avgjøres hvorvidt en hendelse kan behandles automatisk eller ei. (er nå alltid true ved fødselshendelser!)

OBS:
BehandlingKategori peker nå mot utenlandstilsnitt, og BehandlingUnderkategori peker mot behandlingKategori i BehandlingDVH. (etter ønske fra DVH)

behandlingUnderkategori står som tom, er tiltenkt "småbarnstillegg" (i beregninger er småbarnstillegg en av "Kategorier", så det er mulig dette feltet blir overflødig m/ hht DVH.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
