### PR TITLE
Bug - måned og år compare på begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -30,6 +30,7 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.tilKortString
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.dokument.DokumentService
 import no.nav.familie.ba.sak.logg.LoggService
 import no.nav.familie.ba.sak.nare.Resultat
@@ -246,17 +247,18 @@ class VedtakService(private val behandlingService: BehandlingService,
                         false
                     }
                     oppdatertBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE -> {
-                        vilkårResultat.periodeFom!!.monthValue == utbetalingsperiode.fom.minusMonths(1).monthValue && vilkårResultat.resultat == Resultat.OPPFYLT
+                        vilkårResultat.periodeFom!!.toYearMonth() == utbetalingsperiode.fom.minusMonths(1)
+                                .toYearMonth() && vilkårResultat.resultat == Resultat.OPPFYLT
                     }
 
                     oppdatertBegrunnelseType == VedtakBegrunnelseType.REDUKSJON -> {
                         val oppfyltTomMånedEtter = if (vilkårResultat.vilkårType == Vilkår.UNDER_18_ÅR) 0L else 1L
-                        vilkårResultat.periodeTom != null && vilkårResultat.periodeTom!!.monthValue == utbetalingsperiode.fom.minusMonths(
-                                oppfyltTomMånedEtter).monthValue && vilkårResultat.resultat == Resultat.OPPFYLT
+                        vilkårResultat.periodeTom != null && vilkårResultat.periodeTom!!.toYearMonth() == utbetalingsperiode.fom.minusMonths(
+                                oppfyltTomMånedEtter).toYearMonth() && vilkårResultat.resultat == Resultat.OPPFYLT
                     }
 
                     oppdatertBegrunnelseType == VedtakBegrunnelseType.OPPHØR -> {
-                        vilkårResultat.periodeTom != null && vilkårResultat.periodeTom!!.monthValue == utbetalingsperiode.tom.monthValue
+                        vilkårResultat.periodeTom != null && vilkårResultat.periodeTom!!.toYearMonth() == utbetalingsperiode.tom.toYearMonth()
                         && vilkårResultat.resultat == Resultat.OPPFYLT
                     }
                     else -> throw Feil("Henting av personer med utgjørende vilkår when: Ikke implementert")

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -447,7 +447,7 @@ class ClientMocks {
         }
 
         val søkerFnr = arrayOf("12345678910", "11223344556", "12345678911")
-        val barnFødselsdatoer = arrayOf(LocalDate.now().minusYears(6), LocalDate.now().førsteDagIInneværendeMåned())
+        val barnFødselsdatoer = arrayOf(LocalDate.now().minusYears(6), LocalDate.now().minusYears(1))
         val barnFnr = arrayOf(barnFødselsdatoer[0].tilddMMyy() + "00033", barnFødselsdatoer[1].tilddMMyy() + "00033")
         val barnDetIkkeGisTilgangTilFnr = "12345678912"
         val integrasjonerFnr = "10000111111"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sjekken på dato ble bare gjort på måned. Sjekker nå også på år.

Annet ikke aktuelt.

Endrer på clientmocks da det ikke gir så mye verdi å ha mockdata på barn født inneværende måned. Dette er mest nyttig for fødselshendelser.