### PR TITLE
Slett tomme vedtakbegrunnelser

### DIFF
--- a/src/main/resources/db/migration/V110__slett_tomme_vedtakbegrunnelser.sql
+++ b/src/main/resources/db/migration/V110__slett_tomme_vedtakbegrunnelser.sql
@@ -1,0 +1,1 @@
+DELETE FROM vedtak_begrunnelse WHERE begrunnelse is null;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3643 
Bug meldt inn via sentry hvor saksbehandler får feil ved forsøk på å gå inn på vedtaksside. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Tidligere la man til "tomme entries" som man så la til begrunnelse i. Nå gjøres en antakelse om at begrunnelser bare legges til og slettes. Bugen er at noen behandlinger (som den Berit har trøbbel med) er under behandling og har påbegynt begrunnelsedelen med tom begrunnelse. 

### ✅ Checklist
_Jeg har ikke skrevet tester fordi:_
Har validert i prod at man kun sletter på behandlinger hvor vedtak ikke er gjort 
`select * from vedtak_begrunnelse inner join vedtak v on v.id = vedtak_begrunnelse.fk_vedtak_id where begrunnelse is null and vedtaksdato is not null;
`