### PR TITLE
Sett forrige målform som default på revurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/RegistrerPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/RegistrerPersongrunnlag.kt
@@ -25,12 +25,13 @@ class RegistrerPersongrunnlag(
         if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomErIverksatt != null) {
             val forrigePersongrunnlag = persongrunnlagService.hentAktiv(behandlingId = forrigeBehandlingSomErIverksatt.id)
             val forrigePersongrunnlagBarna = forrigePersongrunnlag?.barna?.map { it.personIdent.ident }!!
+            val forrigeMålform = persongrunnlagService.hentSøkersMålform(behandlingId = forrigeBehandlingSomErIverksatt.id)
 
             persongrunnlagService.lagreSøkerOgBarnIPersonopplysningsgrunnlaget(data.ident,
                                                                                data.barnasIdenter.union(forrigePersongrunnlagBarna)
                                                                                        .toList(),
                                                                                behandling,
-                                                                               Målform.NB)
+                                                                               forrigeMålform)
         } else {
             persongrunnlagService.lagreSøkerOgBarnIPersonopplysningsgrunnlaget(data.ident,
                                                                                data.barnasIdenter,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sett målform til forrige behandlings målform som default for at varsel om revurdering skal kunne sendes på nynorsk 

Bakgrunn: 
Siden registrering av persongrunnlag og sending av brev skal kunne skje før registrering av søknad defaultes det til bokmål inntil vi får integrert mot tjenesten som tilbyr målform (KRR?). I revurderinger uten søknad (f.eks. nye opplysninger) får man aldri mulighet til å sette målform igjen og denne defaulter til målform. I disse tilfellene setter jeg derfor til den gamle. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Validerer i miljø 
