### PR TITLE
La til barns fødselsnummer til 6års begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonRepository.kt
@@ -10,7 +10,4 @@ interface PersonRepository : JpaRepository<Person, Long> {
     @Query("SELECT p FROM Person p" +
             " WHERE p.personIdent = :personIdent")
     fun findByPersonIdent(personIdent: PersonIdent): List<Person>
-
-    @Query("SELECT p FROM Person p WHERE p.fødselsdato BETWEEN :fom AND :tom ")
-    fun finnAllePersonerMedFødselsdatoInnenfor(fom: LocalDate, tom: LocalDate): List<Person>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VedtakBegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VedtakBegrunnelseUtils.kt
@@ -44,6 +44,5 @@ object VedtakBegrunnelseUtils {
                              VedtakBegrunnelseSpesifikasjon.REDUKSJON_BARN_DØD)
 
     val utenVilkår = listOf(VedtakBegrunnelseSpesifikasjon.REDUKSJON_UNDER_6_ÅR,
-                            VedtakBegrunnelseSpesifikasjon.REDUKSJON_UNDER_18_ÅR,
                             VedtakBegrunnelseSpesifikasjon.INNVILGET_SATSENDRING)
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ved generering av begrunnelsestekst for reduksjon, grunnet fylte 6 år, til vedtaksbrev ble ikke barnets fødselsnummer inkludert. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
