### PR TITLE
Kast funksjonell feil ved manglende dato fra vilkårsvurdering 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/VilkårsvurderingSteg.kt
@@ -26,7 +26,6 @@ class VilkårsvurderingSteg(
         private val vedtakService: VedtakService,
         private val beregningService: BeregningService,
         private val persongrunnlagService: PersongrunnlagService,
-        private val vilkårsvurderingService: VilkårsvurderingService,
         private val behandlingsresultatService: BehandlingsresultatService,
         private val behandlingService: BehandlingService
 ) : BehandlingSteg<String> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/beregning/domene/PeriodeResultat.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.behandling.vilkår.Vilkårsvurdering
 import no.nav.familie.ba.sak.behandling.vilkår.PersonResultat
 import no.nav.familie.ba.sak.behandling.vilkår.Vilkår
 import no.nav.familie.ba.sak.behandling.vilkår.VilkårResultat
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.nare.Resultat
 import no.nav.fpsak.tidsserie.LocalDateInterval.TIDENES_BEGYNNELSE
@@ -35,10 +36,12 @@ data class PeriodeResultat(
 
     fun overlapper(annetPeriodeResultat: PeriodeResultat): Boolean {
         if (periodeFom == null && annetPeriodeResultat.periodeFom == null) {
-            error("Enten søker eller barn må ha fom-dato på vilkårsresultatet")
+            throw FunksjonellFeil(melding = "Enten søker eller barn må ha fom-dato på vilkårsresultatet",
+                                  frontendFeilmelding = "Du må sette en fom-dato på minst et vilkår i vilkårsvurderingen")
         }
         if (periodeTom == null && annetPeriodeResultat.periodeTom == null) {
-            error("Enten søker eller barn må ha tom-dato på vilkårsresultatet")
+            throw FunksjonellFeil(melding = "Enten søker eller barn må ha tom-dato på vilkårsresultatet",
+                                  frontendFeilmelding = "Du må sette en tom-dato på minst et vilkår i vilkårsvurderingen")
         }
 
         return (periodeFom == null || annetPeriodeResultat.periodeTom == null || periodeFom <= annetPeriodeResultat.periodeTom)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Ref nylige feil i # team-familie-alerts på slack: https://nav-it.slack.com/archives/CK59Y6EHE/p1613650956160400

Frontend gjør validering på enkeltvilkår, men validering som ser på helhet gjøres ved validerVilkårsvurderingOgSendInn. Da håndteres VILKÅRSVURDERING-steget backend, som også beregner tilkjent ytelse fra vilkårsvurdering, som gjør ytterligere sjekker på vilkårene. Manglende datoer i vilkårsvurderinga har nå trigga error i `PeriodeResultat.overlapper`, men er egentlig en funksjonell feil. Funksjonen brukes kun til dette. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
