### PR TITLE
Fiks feil ved mutering av eksisterende vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPersonResultat.kt
@@ -28,7 +28,7 @@ data class RestVilkårResultat(
 ) {
 
     fun erAvslagUtenPeriode() = this.erEksplisittAvslagPåSøknad == true && this.periodeFom == null && this.periodeTom == null
-    fun harFremtidigTom() = this.periodeTom == null || this.periodeTom!!.isAfter(LocalDate.now().sisteDagIMåned())
+    fun harFremtidigTom() = this.periodeTom == null || this.periodeTom.isAfter(LocalDate.now().sisteDagIMåned())
 }
 
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtils.kt
@@ -41,7 +41,8 @@ object VilkårsvurderingUtils {
      * Funksjon som tar inn endret vilkår og muterer person resultatet til å få plass til den endrede perioden.
      */
     fun muterPersonResultatPut(personResultat: PersonResultat, restVilkårResultat: RestVilkårResultat) {
-        validerAvslagUtenPeriodeMedLøpende(personResultat, restVilkårResultat)
+        validerAvslagUtenPeriodeMedLøpende(personSomEndres = personResultat,
+                                           vilkårSomEndres = restVilkårResultat)
         val kopiAvVilkårResultater = personResultat.vilkårResultater.toList()
 
         kopiAvVilkårResultater
@@ -56,7 +57,8 @@ object VilkårsvurderingUtils {
     }
 
     fun validerAvslagUtenPeriodeMedLøpende(personSomEndres: PersonResultat, vilkårSomEndres: RestVilkårResultat) {
-        val resultaterPåVilkår = personSomEndres.vilkårResultater.filter { it.vilkårType == vilkårSomEndres.vilkårType }
+        val resultaterPåVilkår =
+                personSomEndres.vilkårResultater.filter { it.vilkårType == vilkårSomEndres.vilkårType && it.id != vilkårSomEndres.id }
         when {
             vilkårSomEndres.erAvslagUtenPeriode() && resultaterPåVilkår.any { it.resultat == Resultat.OPPFYLT && it.harFremtidigTom() } ->
                 throw FunksjonellFeil(

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtilsTest.kt
@@ -27,7 +27,7 @@ class VilkårsvurderingUtilsTest {
                                             regelOutput = null)
         personResultat.vilkårResultater.add(løpendeOppfylt)
 
-        val avslagUtenPeriode = RestVilkårResultat(id = 0,
+        val avslagUtenPeriode = RestVilkårResultat(id = 123,
                                                    vilkårType = Vilkår.BOR_MED_SØKER,
                                                    resultat = Resultat.IKKE_OPPFYLT,
                                                    periodeFom = null,
@@ -59,7 +59,7 @@ class VilkårsvurderingUtilsTest {
                                                erEksplisittAvslagPåSøknad = true)
         personResultat.vilkårResultater.add(avslagUtenPeriode)
 
-        val løpendeOppfylt = RestVilkårResultat(id = 0,
+        val løpendeOppfylt = RestVilkårResultat(id = 123,
                                                 vilkårType = Vilkår.BOR_MED_SØKER,
                                                 resultat = Resultat.OPPFYLT,
                                                 periodeFom = LocalDate.of(2020, 1, 1),
@@ -90,7 +90,7 @@ class VilkårsvurderingUtilsTest {
                                                erEksplisittAvslagPåSøknad = true)
         personResultat.vilkårResultater.add(avslagUtenPeriode)
 
-        val løpendeOppfylt = RestVilkårResultat(id = 0,
+        val løpendeOppfylt = RestVilkårResultat(id = 123,
                                                 vilkårType = Vilkår.BOR_MED_SØKER,
                                                 resultat = Resultat.OPPFYLT,
                                                 periodeFom = LocalDate.of(2020, 1, 1),


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bug som oppstår når _samme_ periode skal muteres fra avslag til løpende JA eller omvendt.

Beskrivelse:
1. Lage avslag på perioden
2. Endre samme periode til en JA -løpende periode 
3. Når den validerer kommer den til å sammenligne med alt som eksisterer på vilkåret, inkludert seg selv og kaster feil
4. I databasen blir derfor ingenting endret (som jo er rett hvis det finnes feil), men i frontenden holder man fortsatt på å redigere vilkår som man nå egentlig skal rette opp i henhold til feilmelding (som er feil at blir kasta). Hvis man reloader siden ser man hvordan dataene som ligger backend er.

Tror det løser seg ved å fikse sammenlignenden på 3.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Et par linjer er bare for 💄 ✨  , selve bugfixen skjer [på denne linja](https://github.com/navikt/familie-ba-sak/compare/fix/avslag-validering?expand=1#diff-ca5652f7cbb608114b356e148a4839f43a8454138c05f83bc16b35e47d83a504R60-R61).

### 🤷‍♀ ️Hvor er det lurt å starte?
https://github.com/navikt/familie-ba-sak/compare/fix/avslag-validering?expand=1#diff-ca5652f7cbb608114b356e148a4839f43a8454138c05f83bc16b35e47d83a504R60-R61

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
