### PR TITLE
Bugfix/skal ikke logge ved uendret behandlingsresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/logg/LoggService.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.behandling.domene.Behandling
 import no.nav.familie.ba.sak.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.behandling.steg.BehandlerRolle
 import no.nav.familie.ba.sak.behandling.vedtak.Beslutning
-import no.nav.familie.ba.sak.behandling.vilkår.Vilkårsvurdering
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.config.RolleConfig
 import no.nav.familie.ba.sak.integrasjoner.domene.Arbeidsfordelingsenhet
@@ -84,15 +83,13 @@ class LoggService(
 
     fun opprettVilkårsvurderingLogg(behandling: Behandling,
                                     forrigeBehandlingResultat: BehandlingResultat,
-                                    nyttBehandlingResultat: BehandlingResultat): Logg {
+                                    nyttBehandlingResultat: BehandlingResultat): Logg? {
 
-        val tekst = if (forrigeBehandlingResultat != BehandlingResultat.IKKE_VURDERT) {
-            if (forrigeBehandlingResultat != nyttBehandlingResultat) {
-                "Resultat gikk fra ${forrigeBehandlingResultat.displayName.toLowerCase()} til ${nyttBehandlingResultat.displayName.toLowerCase()}"
-            } else {
-                "Resultat fortsatt ${nyttBehandlingResultat.displayName.toLowerCase()}"
-            }
-        } else "Resultat ble ${nyttBehandlingResultat.displayName.toLowerCase()}"
+        val tekst = if (forrigeBehandlingResultat == BehandlingResultat.IKKE_VURDERT) {
+            "Resultat ble ${nyttBehandlingResultat.displayName.toLowerCase()}"
+        } else if (forrigeBehandlingResultat != nyttBehandlingResultat) {
+            "Resultat gikk fra ${forrigeBehandlingResultat.displayName.toLowerCase()} til ${nyttBehandlingResultat.displayName.toLowerCase()}"
+        } else return null
 
         return lagre(Logg(
                 behandlingId = behandling.id,

--- a/src/test/kotlin/no/nav/familie/ba/sak/logg/LoggServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/logg/LoggServiceTest.kt
@@ -107,7 +107,7 @@ class LoggServiceTest(
                                                                            nyttBehandlingResultat = BehandlingResultat.INNVILGET)
 
         Assertions.assertNotNull(vilkårsvurderingLogg)
-        Assertions.assertEquals("Vilkårsvurdering gjennomført", vilkårsvurderingLogg.tittel)
+        Assertions.assertEquals("Vilkårsvurdering gjennomført", vilkårsvurderingLogg!!.tittel)
 
 
         behandling.resultat = BehandlingResultat.INNVILGET
@@ -117,9 +117,18 @@ class LoggServiceTest(
                                                         nyttBehandlingResultat = BehandlingResultat.AVSLÅTT)
 
         Assertions.assertNotNull(nyVilkårsvurderingLogg)
-        Assertions.assertEquals("Vilkårsvurdering endret", nyVilkårsvurderingLogg.tittel)
+        Assertions.assertEquals("Vilkårsvurdering endret", nyVilkårsvurderingLogg!!.tittel)
 
         val logger = loggService.hentLoggForBehandling(behandlingId = behandling.id)
         Assertions.assertEquals(2, logger.size)
+    }
+
+    @Test
+    fun `Skal ikke logge ved uforandret behandlingsresultat`() {
+        val vilkårsvurderingLogg = loggService.opprettVilkårsvurderingLogg(behandling = lagBehandling(),
+                                                                           forrigeBehandlingResultat = BehandlingResultat.FORTSATT_INNVILGET,
+                                                                           nyttBehandlingResultat = BehandlingResultat.FORTSATT_INNVILGET)
+
+        Assertions.assertNull(vilkårsvurderingLogg)
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Skal ikke lages historikk-innslag i loggen dersom behandlingsresultat ikke endrer seg når en navigerer videre fra vilkårsvurdering.
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3229

### 🔎️ Er det noe spesielt du ønsker å fremheve?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x ] Nei
