### PR TITLE
Flytter sending av saksstatistikk til å få med flere hendelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
@@ -86,7 +86,6 @@ class FagsakService(
         }
         val fagsak = hentEllerOpprettFagsak(personIdent)
         return hentRestFagsak(fagsakId = fagsak.id).also {
-            saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id)
             skyggesakService.opprettSkyggesak(personIdent.ident, fagsak.id)
         }
     }
@@ -128,7 +127,7 @@ class FagsakService(
     @Transactional
     fun lagre(fagsak: Fagsak): Fagsak {
         LOG.info("${SikkerhetContext.hentSaksbehandlerNavn()} oppretter fagsak $fagsak")
-        return fagsakRepository.save(fagsak)
+        return fagsakRepository.save(fagsak).also { saksstatistikkEventPublisher.publiserSaksstatistikk(it.id) }
     }
 
     fun oppdaterStatus(fagsak: Fagsak, nyStatus: FagsakStatus) {
@@ -136,7 +135,6 @@ class FagsakService(
         fagsak.status = nyStatus
 
         lagre(fagsak)
-        saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id)
     }
 
     fun hentRestFagsak(fagsakId: Long): Ressurs<RestFagsak> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
@@ -23,7 +23,6 @@ import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.logg.LoggService
-import no.nav.familie.ba.sak.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.ba.sak.skyggesak.SkyggesakService
@@ -41,7 +40,6 @@ class StegService(
         private val behandlingService: BehandlingService,
         private val søknadGrunnlagService: SøknadGrunnlagService,
         private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
-        private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
         private val envService: EnvService,
         private val skyggesakService: SkyggesakService,
         private val tilgangService: TilgangService
@@ -83,7 +81,6 @@ class StegService(
             //Denne vil sende selv om det allerede eksisterer en fagsak. Vi tenker det er greit. Ellers så blir det vanskelig å
             //filtere bort for fødselshendelser. Når vi slutter å filtere bort fødselshendelser, så kan vi flytte den tilbake til
             //hentEllerOpprettFagsak
-            saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id)
             skyggesakService.opprettSkyggesak(nyBehandlingHendelse.morsIdent, fagsak.id)
         }
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventPublisherFailSafe.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/saksstatistikk/SaksstatistikkEventPublisherFailSafe.kt
@@ -16,7 +16,7 @@ class SaksstatistikkEventPublisherFailSafe: SaksstatistikkEventPublisher() {
     override fun publiserBehandlingsstatistikk(behandlingId: Long, forrigeBehandlingId: Long?) {
         runCatching {
             super.publiserBehandlingsstatistikk(behandlingId, forrigeBehandlingId)
-        }
+        }.onFailure { it.printStackTrace() }
     }
 
     override fun publiserSaksstatistikk(fagsakId: Long) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
@@ -78,9 +78,9 @@ class BehandleFødselshendelseTaskTest(@Autowired private val behandleFødselshe
                 BehandleFødselshendelseTaskDTO(NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barnIdent)))))
         val fagsak = fagsakRepository.finnFagsakForPersonIdent(PersonIdent(morsIdent))
         assertNotNull(fagsak)
-        assertThat(saksstatistikkMellomlagringRepository.finnMeldingerKlarForSending()).hasSize(3)
+        assertThat(saksstatistikkMellomlagringRepository.finnMeldingerKlarForSending()).hasSize(4)
         assertThat(saksstatistikkMellomlagringRepository.finnMeldingerKlarForSending().filter { it.type == SaksstatistikkMellomlagringType.SAK }).hasSize(2)
-        assertThat(saksstatistikkMellomlagringRepository.finnMeldingerKlarForSending().filter { it.type == SaksstatistikkMellomlagringType.BEHANDLING }).hasSize(1)
+        assertThat(saksstatistikkMellomlagringRepository.finnMeldingerKlarForSending().filter { it.type == SaksstatistikkMellomlagringType.BEHANDLING }).hasSize(2)
         verify(exactly = 1) { mockIntegrasjonClient.opprettSkyggesak(any(), fagsak?.id!!) }
     }
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/toTrinnKontroll/ToTrinnKontrollTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/toTrinnKontroll/ToTrinnKontrollTest.kt
@@ -50,11 +50,10 @@ class ToTrinnKontrollTest(
 
         behandlingService.sendBehandlingTilBeslutter(behandling)
         Assertions.assertEquals(BehandlingStatus.FATTER_VEDTAK, behandlingService.hent(behandling.id).status)
-        val dvh = saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SaksstatistikkMellomlagringType.BEHANDLING, behandling.id)
         assertThat(saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SaksstatistikkMellomlagringType.BEHANDLING, behandling.id))
-            .hasSize(1)
+            .hasSize(2)
         assertThat(saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SaksstatistikkMellomlagringType.BEHANDLING, behandling.id)
-                       .first().jsonToBehandlingDVH().behandlingStatus).isEqualTo(BehandlingStatus.FATTER_VEDTAK.name)
+                       .last().jsonToBehandlingDVH().behandlingStatus).isEqualTo(BehandlingStatus.FATTER_VEDTAK.name)
         
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling = behandling)
 
@@ -64,7 +63,7 @@ class ToTrinnKontrollTest(
         Assertions.assertEquals(BehandlingStatus.IVERKSETTER_VEDTAK, behandlingService.hent(behandling.id).status)
 
         assertThat(saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SaksstatistikkMellomlagringType.BEHANDLING, behandling.id))
-            .hasSize(2)
+            .hasSize(3)
         assertThat(saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SaksstatistikkMellomlagringType.BEHANDLING, behandling.id)
                                .last().jsonToBehandlingDVH().behandlingStatus).isEqualTo(BehandlingStatus.IVERKSETTER_VEDTAK.name)
 
@@ -88,7 +87,7 @@ class ToTrinnKontrollTest(
         totrinnskontrollService.besluttTotrinnskontroll(behandling, "Beslutter", "beslutterId", Beslutning.UNDERKJENT)
         Assertions.assertEquals(BehandlingStatus.UTREDES, behandlingService.hent(behandling.id).status)
         assertThat(saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SaksstatistikkMellomlagringType.BEHANDLING, behandling.id))
-            .hasSize(2)
+            .hasSize(3)
         assertThat(saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SaksstatistikkMellomlagringType.BEHANDLING, behandling.id)
                        .last().jsonToBehandlingDVH().behandlingStatus).isEqualTo(BehandlingStatus.UTREDES.name)
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Flyttet logikk for utsending av saksstatistikk ned til metodene som lagrer til databasen. Dette gjør av vi sender ut oftere og ved endringer. Det blir vanskeligere å opprette saker og behandlinger uten at det sendes til DVH som i journalføringsservice, som brukte metode som ikke sendte til dvh.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Det er større sjanse for dupliserte meldinger, men tror dette skal være ok.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇



### 🤷‍♀ ️Hvor er det lurt å starte?
Sikkert lurest å starte med FagsakService og BehandlingService

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Nei
