### PR TITLE
Funksjon eksplisitt for oppdatering og egen for brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/dokument/DokumentController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/dokument/DokumentController.kt
@@ -42,7 +42,7 @@ class DokumentController(
 
         return dokumentService.genererBrevForVedtak(vedtak).let {
             vedtak.stønadBrevPdF = it
-            vedtakService.lagreEllerOppdater(vedtak)
+            vedtakService.oppdater(vedtak)
             Ressurs.success(it)
         }
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakBegrunnelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakBegrunnelseTest.kt
@@ -403,13 +403,13 @@ class VedtakBegrunnelseTest(
                 tom = andrePeriode.tom,
                 begrunnelse = VedtakBegrunnelseSpesifikasjon.INNVILGET_LOVLIG_OPPHOLD_EØS_BORGER
         ))
-        val oppdatertVedtakMed2BegrunnelserForAndrePeriode = vedtakService.lagreEllerOppdater(vedtak)
+        val oppdatertVedtakMed2BegrunnelserForAndrePeriode = vedtakService.oppdater(vedtak)
         assertEquals(2,
                      oppdatertVedtakMed2BegrunnelserForAndrePeriode.vedtakBegrunnelser.filter { it.fom == andrePeriode.fom && it.tom == andrePeriode.tom }.size)
 
         oppdatertVedtakMed2BegrunnelserForAndrePeriode.slettBegrunnelserForPeriode(andrePeriode)
         val oppdatertVedtakUtenBegrunnelserForAndrePeriode =
-                vedtakService.lagreEllerOppdater(oppdatertVedtakMed2BegrunnelserForAndrePeriode)
+                vedtakService.oppdater(oppdatertVedtakMed2BegrunnelserForAndrePeriode)
         assertEquals(0,
                      oppdatertVedtakUtenBegrunnelserForAndrePeriode.vedtakBegrunnelser.filter { it.fom == andrePeriode.fom && it.tom == andrePeriode.tom }.size)
     }
@@ -459,7 +459,7 @@ class VedtakBegrunnelseTest(
                 tom = andrePeriode.tom,
                 begrunnelse = VedtakBegrunnelseSpesifikasjon.OPPHØR_BARN_DØD
         ))
-        val oppdatertVedtakMed2BegrunnelserForAndrePeriode = vedtakService.lagreEllerOppdater(vedtak)
+        val oppdatertVedtakMed2BegrunnelserForAndrePeriode = vedtakService.oppdater(vedtak)
         assertEquals(3,
                      oppdatertVedtakMed2BegrunnelserForAndrePeriode.vedtakBegrunnelser.filter { it.fom == andrePeriode.fom && it.tom == andrePeriode.tom }.size)
 
@@ -470,7 +470,7 @@ class VedtakBegrunnelseTest(
                         vedtakbegrunnelseTyper = listOf(VedtakBegrunnelseType.INNVILGELSE, VedtakBegrunnelseType.REDUKSJON)
                 ))
         val oppdatertVedtakUtenBegrunnelserForAndrePeriode =
-                vedtakService.lagreEllerOppdater(oppdatertVedtakMed2BegrunnelserForAndrePeriode)
+                vedtakService.oppdater(oppdatertVedtakMed2BegrunnelserForAndrePeriode)
         assertEquals(1,
                      oppdatertVedtakUtenBegrunnelserForAndrePeriode.vedtakBegrunnelser.filter { it.fom == andrePeriode.fom && it.tom == andrePeriode.tom }.size)
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiIntegrasjonTest.kt
@@ -107,7 +107,7 @@ class ØkonomiIntegrasjonTest {
         val vedtak = vedtakService.hentAktivForBehandling(behandlingId = behandling.id)
         Assertions.assertNotNull(vedtak)
         vedtak!!.vedtaksdato = LocalDateTime.now()
-        vedtakService.lagreEllerOppdater(vedtak)
+        vedtakService.oppdater(vedtak)
 
         val oppdatertFagsak = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

**Bakgrunn:**
I forbindelse med lagring av vedtaksbegrunnelser for avslag er det behov for å lagre vedtak tidligere. 
Nå lagrer vi nye vedtak hver gang en saksbehandler trykker seg videre fra vilkårsvurderinga og ender med mange vedtak.  
Ønsker å initiere tomt vedtak til tidligere i løpet og kun lagre nye rader i databasen på nye behandlinger og etter underkjenning. 

**Denne pr'en:** 
- rename `lagreEllerOppdater` -> `oppdater` (stedene det kalles gjør bare oppdater og skal kaste feil hvis vedtak ikke finnes, så endring av navn er for å tydeliggjøre at det er det den brukes til, også ved senere bruk. Lagring/initiering skal kun skje via en egen metode med mer businesslogikk)
- Fjern vedtaksbrevlogikk fra `oppdater` og la `oppdaterVedtakMedStønadsbrev` lagre selv

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke ny logikk, det kommer i egen pr

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
