### PR TITLE
Synk med ny versjon av kontrakter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring.cloud.version>3.0.1</spring.cloud.version>
         <spring.vault.version>2.3.0</spring.vault.version>
         <felles.version>1.20210223111349_05be6ea</felles.version>
-        <felles-kontrakter.version>2.0_20210217152814_ffc3c9e</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20210303133941_2f9439f</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20210211132003_f81111d</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20210201142541_5c3705c</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.10.5</mockk.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClient.kt
@@ -1,6 +1,9 @@
 package no.nav.familie.ba.sak.infotrygd
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkRequest
+import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
+import no.nav.familie.kontrakter.ba.infotrygd.Sak
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.infotrygd
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.pdl.internal.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.kontrakter.ba.infotrygd.Sak
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdService.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.infotrygd
 
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.pdl.PersonopplysningerService
+import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
+import no.nav.familie.kontrakter.ba.infotrygd.Sak
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClientMock.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.infotrygd
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClientTest.kt
@@ -3,6 +3,9 @@ package no.nav.familie.ba.sak.infotrygd
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import no.nav.familie.ba.sak.config.ApplicationConfig
 import no.nav.familie.ba.sak.config.ClientMocks
+import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkRequest
+import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
+import no.nav.familie.kontrakter.ba.infotrygd.Sak
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdControllerTest.kt
@@ -7,6 +7,8 @@ import io.mockk.junit5.MockKExtension
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.pdl.internal.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
+import no.nav.familie.kontrakter.ba.infotrygd.Sak
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll


### PR DESCRIPTION
### Hva forsøker du å løse i denne PR'en
Modulen for barnetrygd i familie-kontrakter har endrede pakkenavn i hht standard pakkenavn for familie-kontrakter.

Denne commiten synker kun ba-sak med familie-kontrakter.