### PR TITLE
Migrer behandlinger opprettet før vedtakinitiering ble innført ved opprettelse av behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerBehandlingerUtenInitialisertVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerBehandlingerUtenInitialisertVedtak.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ba.sak.behandling
+
+import no.nav.familie.ba.sak.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
+import no.nav.familie.leader.LeaderClient
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class MigrerBehandlingerUtenInitialisertVedtak(
+        private val behandlingRepository: BehandlingRepository,
+        private val vedtakService: VedtakService,
+) {
+
+    @Scheduled(initialDelay = 1000, fixedDelay = Long.MAX_VALUE)
+    private fun migrer() {
+        if (LeaderClient.isLeader() == true) {
+            logger.info("Migrerer behandlinger opprettet før behandling initierer vedtak")
+            val behandlinger = behandlingRepository.findAll()
+
+            var vellykkedeMigreringer = 0
+            var mislykkedeMigreringer = 0
+            behandlinger.filter { it.aktiv && it.status != BehandlingStatus.AVSLUTTET }.forEach { behandling ->
+                val vedtak = vedtakService.hentAktivForBehandling(behandlingId = behandling.id)
+
+                if (vedtak == null) {
+                    kotlin.runCatching {
+                        vedtakService.initierVedtakForAktivBehandling(behandling)
+                    }.fold(
+                            onSuccess = {
+                                logger.info("Vellykket migrering for behandling ${behandling.id}")
+                                vellykkedeMigreringer++
+                            },
+                            onFailure = {
+                                logger.warn("Mislykket migrering for behandling ${behandling.id}")
+                                secureLogger.warn("Mislykket migrering for behandling ${behandling.id}", it)
+                                mislykkedeMigreringer++
+                            }
+                    )
+                } else if (behandling.opprettetTidspunkt.isBefore(LocalDateTime.of(2021, 3, 8, 0, 0, 0))) {
+                    logger.warn("Aktiv behandling ${behandling.id} ble opprettet før 8.mars og ble ikke migrert")
+                } else {
+                    logger.info("Aktiv behandling ${behandling.id} ble opprettet etter 8.mars og ble ikke migrert")
+                }
+            }
+
+            logger.info("Migrering av enhet fra vedtak til arbeidsfordeling på behandling ferdig.\n" +
+                        "Antall behandlinger=${behandlinger.size}\n" +
+                        "Vellykede migreringer=$vellykkedeMigreringer\n" +
+                        "Mislykkede migreringer=$mislykkedeMigreringer\n")
+        }
+    }
+
+    companion object {
+
+        private val logger = LoggerFactory.getLogger(this::class.java)
+        private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    }
+}


### PR DESCRIPTION
https://github.com/navikt/familie-ba-sak/pull/831
Da dette ble gjort ble ikke initiering gjort på behandlingene som var opprettet tidligere enn migrering og ikke hadde kommet til vedtaksteget enda. 

Fører til følgende bug for behandlingene dette treffer:
https://nav-it.slack.com/archives/C01G9BA8JKZ/p1615207754045000