### PR TITLE
Fiks bug som gjør at avslagbegrunnelser blir hengende igjen når periode blir "slukt" av innvilget periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/Vedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/Vedtak.kt
@@ -133,6 +133,9 @@ class Vedtak(
         }.toSet())
     }
 
+    fun slettAlleAvslagBegrunnelserForVilkår(vilkårResultatId: Long) = settBegrunnelser(vedtakBegrunnelser.filterNot { it.vilkårResultat?.id == vilkårResultatId }
+                                                                                                .toSet())
+
     fun hentHjemler(): SortedSet<Int> {
         val hjemler = mutableSetOf<Int>()
         this.vedtakBegrunnelser.forEach {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -258,9 +258,18 @@ class VedtakService(
             }
 
     @Transactional
-    fun oppdaterAvslagBegrunnelser(vilkårResultat: VilkårResultat,
-                                   begrunnelser: List<VedtakBegrunnelseSpesifikasjon>,
-                                   behandlingId: Long): List<VedtakBegrunnelseSpesifikasjon> {
+    fun slettAvslagBegrunnelserForVilkår(vilkårResultatId: Long,
+                                         behandlingId: Long) {
+        val vedtak = hentAktivForBehandling(behandlingId)
+                     ?: throw Feil(message = "Finner ikke aktivt vedtak på behandling ved oppdatering av avslagbegrunnelser")
+        vedtak.slettAlleAvslagBegrunnelserForVilkår(vilkårResultatId = vilkårResultatId)
+        oppdater(vedtak)
+    }
+
+    @Transactional
+    fun oppdaterAvslagBegrunnelserForVilkår(vilkårResultat: VilkårResultat,
+                                            begrunnelser: List<VedtakBegrunnelseSpesifikasjon>,
+                                            behandlingId: Long): List<VedtakBegrunnelseSpesifikasjon> {
 
         if (begrunnelser.any { it.finnVilkårFor() != vilkårResultat.vilkårType }) error("Avslagbegrunnelser som oppdateres må tilhøre samme vilkår")
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingUtils.kt
@@ -45,9 +45,13 @@ object VilkårsvurderingUtils {
     }
 
     /**
-     * Funksjon som tar inn endret vilkår og muterer person resultatet til å få plass til den endrede perioden.
+     * Funksjon som tar inn endret vilkår og muterer personens vilkårresultater til å få plass til den endrede perioden.
+     * @param[personResultat] Person med vilkår som eventuelt justeres
+     * @param[restVilkårResultat] Det endrede vilkårresultatet
+     * @return VilkårResultater før og etter mutering
      */
-    fun muterPersonResultatPut(personResultat: PersonResultat, restVilkårResultat: RestVilkårResultat) {
+    fun muterPersonVilkårResultaterPut(personResultat: PersonResultat,
+                                       restVilkårResultat: RestVilkårResultat): Pair<List<VilkårResultat>, List<VilkårResultat>> {
         validerAvslagUtenPeriodeMedLøpende(personSomEndres = personResultat,
                                            vilkårSomEndres = restVilkårResultat)
         val kopiAvVilkårResultater = personResultat.vilkårResultater.toList()
@@ -61,6 +65,8 @@ object VilkårsvurderingUtils {
                             restVilkårResultat = restVilkårResultat
                     )
                 }
+
+        return Pair(kopiAvVilkårResultater, personResultat.vilkårResultater.toList())
     }
 
     fun validerAvslagUtenPeriodeMedLøpende(personSomEndres: PersonResultat, vilkårSomEndres: RestVilkårResultat) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/AvslagBegrunnelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/AvslagBegrunnelseTest.kt
@@ -231,9 +231,9 @@ class AvslagBegrunnelseTest(
                 tom = LocalDate.of(2010, 2, 28),
                 vedtakBegrunnelse = VedtakBegrunnelseSpesifikasjon.INNVILGET_BOSATT_I_RIKTET
         ), fagsakId = fagsak.id)
-        vedtakService.oppdaterAvslagBegrunnelser(behandlingId = behandling.id,
-                                                 vilkårResultat = vilkårResultatAvslag,
-                                                 begrunnelser = listOf(VedtakBegrunnelseSpesifikasjon.AVSLAG_BOSATT_I_RIKET))
+        vedtakService.oppdaterAvslagBegrunnelserForVilkår(behandlingId = behandling.id,
+                                                          vilkårResultat = vilkårResultatAvslag,
+                                                          begrunnelser = listOf(VedtakBegrunnelseSpesifikasjon.AVSLAG_BOSATT_I_RIKET))
         val vedtak = vedtakService.hentAktivForBehandling(behandlingId = behandling.id)
 
         assertEquals(2, vedtak?.vedtakBegrunnelser?.size)
@@ -250,17 +250,17 @@ class AvslagBegrunnelseTest(
     @Test
     fun `Oppdatering av avslagbegrunnelse som ikke samsvarer med vilkår kaster feil`() {
         assertThrows<IllegalStateException> {
-            vedtakService.oppdaterAvslagBegrunnelser(behandlingId = behandling.id,
-                                                     vilkårResultat = vilkårResultatAvslag,
-                                                     begrunnelser = listOf(VedtakBegrunnelseSpesifikasjon.AVSLAG_LOVLIG_OPPHOLD_EØS_BORGER))
+            vedtakService.oppdaterAvslagBegrunnelserForVilkår(behandlingId = behandling.id,
+                                                              vilkårResultat = vilkårResultatAvslag,
+                                                              begrunnelser = listOf(VedtakBegrunnelseSpesifikasjon.AVSLAG_LOVLIG_OPPHOLD_EØS_BORGER))
         }
     }
 
     @Test
     fun `Avslagbegrunnelser mappes til korrekt RestVilkårResultat`() {
-        vedtakService.oppdaterAvslagBegrunnelser(behandlingId = behandling.id,
-                                                 vilkårResultat = vilkårResultatAvslag,
-                                                 begrunnelser = listOf(VedtakBegrunnelseSpesifikasjon.AVSLAG_MEDLEM_I_FOLKETRYGDEN))
+        vedtakService.oppdaterAvslagBegrunnelserForVilkår(behandlingId = behandling.id,
+                                                          vilkårResultat = vilkårResultatAvslag,
+                                                          begrunnelser = listOf(VedtakBegrunnelseSpesifikasjon.AVSLAG_MEDLEM_I_FOLKETRYGDEN))
 
         val restBehandling = fagsakService.hentRestFagsak(fagsakId = fagsak.id).data!!.behandlinger.first()
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårServiceTest.kt
@@ -350,8 +350,8 @@ class VilkårServiceTest(
         val borMedSøkerVilkår = personResultat.vilkårResultater.find { it.vilkårType == Vilkår.BOR_MED_SØKER }!!
         Assertions.assertEquals(behandling.id, borMedSøkerVilkår.behandlingId)
 
-        VilkårsvurderingUtils.muterPersonResultatPut(personResultat,
-                                                     RestVilkårResultat(borMedSøkerVilkår.id,
+        VilkårsvurderingUtils.muterPersonVilkårResultaterPut(personResultat,
+                                                             RestVilkårResultat(borMedSøkerVilkår.id,
                                                                         Vilkår.BOR_MED_SØKER,
                                                                         Resultat.OPPFYLT,
                                                                         LocalDate.of(2010, 6, 2),

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingStegUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingStegUtilsTest.kt
@@ -65,8 +65,8 @@ class VilkårsvurderingStegUtilsTest {
                                                     "",
                                                     LocalDateTime.now(),
                                                     behandling.id)
-        VilkårsvurderingUtils.muterPersonResultatPut(personResultat,
-                                                     restVilkårResultat)
+        VilkårsvurderingUtils.muterPersonVilkårResultaterPut(personResultat,
+                                                             restVilkårResultat)
 
         assertEquals(2, personResultat.vilkårResultater.size)
         assertPeriode(Periode(LocalDate.of(2010, 1, 1),
@@ -87,8 +87,8 @@ class VilkårsvurderingStegUtilsTest {
                                                     LocalDateTime.now(),
                                                     behandling.id)
 
-        VilkårsvurderingUtils.muterPersonResultatPut(personResultat,
-                                                     restVilkårResultat)
+        VilkårsvurderingUtils.muterPersonVilkårResultaterPut(personResultat,
+                                                             restVilkårResultat)
 
         assertEquals(4, personResultat.vilkårResultater.size)
         assertPeriode(Periode(LocalDate.of(2010, 1, 1),
@@ -114,8 +114,8 @@ class VilkårsvurderingStegUtilsTest {
                                                     LocalDateTime.now(),
                                                     behandling.id)
 
-        VilkårsvurderingUtils.muterPersonResultatPut(personResultat,
-                                                     restVilkårResultat)
+        VilkårsvurderingUtils.muterPersonVilkårResultaterPut(personResultat,
+                                                             restVilkårResultat)
 
         assertEquals(3, personResultat.vilkårResultater.size)
         assertPeriode(Periode(LocalDate.of(2010, 1, 1),
@@ -138,8 +138,8 @@ class VilkårsvurderingStegUtilsTest {
                                                     LocalDateTime.now(),
                                                     behandling.id)
 
-        VilkårsvurderingUtils.muterPersonResultatPut(personResultat,
-                                                     restVilkårResultat)
+        VilkårsvurderingUtils.muterPersonVilkårResultaterPut(personResultat,
+                                                             restVilkårResultat)
 
         assertEquals(3, personResultat.vilkårResultater.size)
         assertPeriode(Periode(LocalDate.of(2010, 1, 1),


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Dersom man har ikke-oppfylte perioder og legger til en oppfylt periode som overlapper med disse muteres/fjernes periodene som treffes. I tilfellene hvor de eksisterende periodene blir slukt helt (og dermed fjernes) ble avslagbegrunnelsene nå hengende igjen i databasen. (Orphanremoval kan ikke brukes her pga begrunnelsens tilknytning til vedtak.)

### 🔎️ Er det noe spesielt du ønsker å fremheve?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
- [Test av funksjonalitet](https://github.com/navikt/familie-ba-sak/compare/bugfix/avslagbegrunnelser?expand=1#diff-4ae7b132675b3120a2ea60776cf82646335ce44f3097272cae2821e3d1ccdf8cR250-R268)
- [Oppdatert endreVilkår-funksjon](https://github.com/navikt/familie-ba-sak/compare/bugfix/avslagbegrunnelser?expand=1#diff-50759c261f5c1a9857e2172b9a91e1ea7087a460d28e5e39eae649fba76dde06R44-R69)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
