### PR TITLE
Bugfix: Saksbehandler får ikke opp søker for å sende brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerJournalføringBehandlingerMedManglendeData.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerJournalføringBehandlingerMedManglendeData.kt
@@ -14,7 +14,7 @@ import java.net.http.HttpResponse
 
 // TODO: Fjern etter migrering
 @Component
-class MigrerNyeBehandlinger(
+class MigrerJournalføringBehandlingerMedManglendeData(
         private val stegService: StegService,
         private val behandlingRepository: BehandlingRepository,
 ) {
@@ -68,7 +68,7 @@ class MigrerNyeBehandlinger(
 
     companion object {
 
-        val logger = LoggerFactory.getLogger(MigrerNyeBehandlinger::class.java)
+        val logger = LoggerFactory.getLogger(MigrerJournalføringBehandlingerMedManglendeData::class.java)
         val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerJournalføringBehandlingerMedManglendeData.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerJournalføringBehandlingerMedManglendeData.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.behandling.steg.StegService
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.net.InetAddress
 import java.net.URI
 import java.net.http.HttpClient
@@ -20,7 +19,6 @@ class MigrerJournalføringBehandlingerMedManglendeData(
 ) {
 
     @Scheduled(initialDelay = 60000, fixedDelay = Long.MAX_VALUE)
-    @Transactional
     fun migrer() {
 
         val client = HttpClient.newHttpClient()

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerNyeBehandlinger.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/MigrerNyeBehandlinger.kt
@@ -1,0 +1,74 @@
+package no.nav.familie.ba.sak.behandling
+
+import no.nav.familie.ba.sak.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.behandling.steg.StegService
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.net.InetAddress
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+// TODO: Fjern etter migrering
+@Component
+class MigrerNyeBehandlinger(
+        private val stegService: StegService,
+        private val behandlingRepository: BehandlingRepository,
+) {
+
+    @Scheduled(initialDelay = 60000, fixedDelay = Long.MAX_VALUE)
+    @Transactional
+    fun migrer() {
+
+        val client = HttpClient.newHttpClient()
+        val request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:4040"))
+                .GET()
+                .build()
+
+        val response: HttpResponse<String> = client.send(request, HttpResponse.BodyHandlers.ofString())
+        val hostname: String = InetAddress.getLocalHost().hostName
+        val erLeader = response.body().contains(hostname)
+
+        logger.info("Respons=${response.body()}, hostname=$hostname")
+        logger.info("Er leader : $erLeader")
+
+        if (erLeader) {
+            logger.info("Migrerer nye behandlinger med manglende persongrunnlag ferdig")
+            val behandlinger = behandlingRepository.finnBehandlingerForMigrering()
+
+            var vellykkedeMigreringer = 0
+            var mislykkedeMigreringer = 0
+            behandlinger.forEach { behandling ->
+                val søker = behandling.fagsak.søkerIdenter.singleOrNull() ?: error("Søker har flere identer")
+                kotlin.runCatching {
+                    stegService.håndterNyBehandlingMigrering(behandling = behandling, søkersIdent = søker.personIdent.ident)
+                }.fold(
+                        onSuccess = {
+                            logger.info("Vellykket migrering for behandling ${behandling.id}")
+                            vellykkedeMigreringer++
+                        },
+                        onFailure = {
+                            logger.warn("Mislykket migrering for behandling ${behandling.id}")
+                            secureLogger.warn("Mislykket migrering for behandling ${behandling.id}", it)
+                            mislykkedeMigreringer++
+                        }
+                )
+            }
+
+            logger.info("Migrering av nye behandlinger med manglende persongrunnlag ferdig.\n" +
+                        "Antall behandlinger=${behandlinger.size}\n" +
+                        "Vellykede migreringer=$vellykkedeMigreringer\n" +
+                        "Mislykkede migreringer=$mislykkedeMigreringer\n")
+        }
+    }
+
+    companion object {
+
+        val logger = LoggerFactory.getLogger(MigrerNyeBehandlinger::class.java)
+        val secureLogger = LoggerFactory.getLogger("secureLogger")
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/domene/BehandlingRepository.kt
@@ -49,6 +49,16 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                         )""")
     fun finnBehandlingerMedPersonerMedFødselsdatoInnenfor(fom: LocalDate, tom: LocalDate): List<Behandling>
 
+    // TODO: Fjern etter migrering
+    @Query(value = """select * from behandling
+                        left join gr_personopplysninger gp on behandling.id = gp.fk_behandling_id
+                        where gp.fk_behandling_id is null
+                          and behandling.aktiv = TRUE
+                          and behandling.status != 'AVSLUTTET'
+                          and behandling_type not in ('TEKNISK_OPPHØR','MIGRERING_FRA_INFOTRYGD_OPPHØRT');""",
+           nativeQuery = true)
+    fun finnBehandlingerForMigrering(): List<Behandling>
+
     @Lock(LockModeType.NONE)
     @Query("SELECT count(*) FROM Behandling b WHERE NOT b.status = 'AVSLUTTET'")
     fun finnAntallBehandlingerIkkeAvsluttet(): Long

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
@@ -40,7 +40,6 @@ class StegService(
         private val fagsakService: FagsakService,
         private val behandlingService: BehandlingService,
         private val søknadGrunnlagService: SøknadGrunnlagService,
-        private val vedtakService: VedtakService,
         private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
         private val envService: EnvService,
         private val skyggesakService: SkyggesakService,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/StegService.kt
@@ -75,6 +75,13 @@ class StegService(
         }
     }
 
+    // TODO: Fjern etter migrering
+    @Transactional
+    fun håndterNyBehandlingMigrering(behandling: Behandling, søkersIdent: String): Behandling =
+            håndterPersongrunnlag(behandling,
+                                  RegistrerPersongrunnlagDTO(ident = søkersIdent,
+                                                             barnasIdenter = emptyList()))
+
     @Transactional
     fun opprettNyBehandlingOgRegistrerPersongrunnlagForHendelse(nyBehandlingHendelse: NyBehandlingHendelse): Behandling {
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(nyBehandlingHendelse.morsIdent, true)

--- a/src/main/kotlin/no/nav/familie/ba/sak/dokument/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/dokument/DokumentService.kt
@@ -19,6 +19,8 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.dokument.DokumentController.ManueltBrevRequest
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.journalføring.JournalføringService
+import no.nav.familie.ba.sak.journalføring.domene.DbJournalpost
+import no.nav.familie.ba.sak.journalføring.domene.JournalføringRepository
 import no.nav.familie.ba.sak.logg.LoggService
 import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -33,7 +35,7 @@ class DokumentService(
         private val integrasjonClient: IntegrasjonClient,
         private val arbeidsfordelingService: ArbeidsfordelingService,
         private val loggService: LoggService,
-        private val journalføringService: JournalføringService,
+        private val journalføringRepository: JournalføringRepository,
         private val brevKlient: BrevKlient,
         private val brevService: BrevService,
         private val vilkårsvurderingService: VilkårsvurderingService,
@@ -126,7 +128,12 @@ class DokumentService(
                                                                     førsteside = førsteside,
                                                                     brevType = manueltBrevRequest.brevmal.arkivType)
 
-        journalføringService.lagreJournalPost(behandling, journalpostId)
+        journalføringRepository.save(
+                DbJournalpost(
+                        behandling = behandling,
+                        journalpostId = journalpostId
+                )
+        )
 
         if (manueltBrevRequest.brevmal == no.nav.familie.ba.sak.dokument.domene.BrevType.INNHENTE_OPPLYSNINGER ||
             manueltBrevRequest.brevmal == no.nav.familie.ba.sak.dokument.domene.BrevType.VARSEL_OM_REVURDERING) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/journalføring/JournalføringService.kt
@@ -150,16 +150,6 @@ class JournalføringService(
         return sak.fagsakId ?: ""
     }
 
-    fun lagreJournalPost(
-        behandling: Behandling,
-        journalpostId: String
-    ) = journalføringRepository.save(
-        DbJournalpost(
-            behandling = behandling,
-            journalpostId = journalpostId
-        )
-    )
-
     fun lagreJournalpostOgKnyttFagsakTilJournalpost(
         tilknyttedeBehandlingIder: List<String>,
         journalpostId: String

--- a/src/main/kotlin/no/nav/familie/ba/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/journalføring/JournalføringService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.behandling.domene.*
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
 import no.nav.familie.ba.sak.behandling.restDomene.RestJournalføring
 import no.nav.familie.ba.sak.behandling.restDomene.RestOppdaterJournalpost
+import no.nav.familie.ba.sak.behandling.steg.StegService
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.assertGenerelleSuksessKriterier
 import no.nav.familie.ba.sak.integrasjoner.IntegrasjonClient
@@ -33,6 +34,7 @@ class JournalføringService(
     private val oppgaveService: OppgaveService,
     private val journalføringRepository: JournalføringRepository,
     private val loggService: LoggService,
+    private val stegService: StegService,
     private val journalføringMetrikk: JournalføringMetrikk
 ) {
 
@@ -95,7 +97,7 @@ class JournalføringService(
         årsak: BehandlingÅrsak
     ): Behandling {
         fagsakService.hentEllerOpprettFagsak(PersonIdent(personIdent))
-        return behandlingService.opprettBehandling(
+        return stegService.håndterNyBehandling(
             NyBehandling(
                 kategori = BehandlingKategori.NASJONAL,
                 underkategori = BehandlingUnderkategori.ORDINÆR,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
- [Bugfix: Saksbehandler får ikke opp søker for å sende brev](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4045)
- Årsak: PersonopplysningsGrunnlag fantes ikke
- Løsning: `NyBehandling` må gjennom funksjonen `håndterNyBehandling` (blir da likt som ved opprettelse via fødselshendelse og manuelt fra behandlingsmeny) 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Se kommentarer.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Migrering testes på tilsvarende caser i dev.
Når det gjelder utplukking av behandlinger for migrering i prod har Eivind fått fagsakider og skal dobbeltsjekke at det er korrekt før migrering.

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
