### PR TITLE
Skill ut toggle for å unngå forvirring i preprod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -193,8 +193,8 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
 
     fun oppdaterResultatPåBehandling(behandlingId: Long, resultat: BehandlingResultat): Behandling {
         val behandling = hent(behandlingId)
-        val visAvslag = featureToggleService.isEnabled(FeatureToggleConfig.VIS_AVSLAG_TOGGLE, false)
-        BehandlingsresultatUtils.validerBehandlingsresultat(behandling, resultat, visAvslag)
+        val skipStøttetValidering = featureToggleService.isEnabled(FeatureToggleConfig.SKIP_STØTTET_BEHANDLINGRESULTAT_SJEKK, false)
+        BehandlingsresultatUtils.validerBehandlingsresultat(behandling, resultat, skipStøttetValidering)
 
         LOG.info("${SikkerhetContext.hentSaksbehandlerNavn()} endrer resultat på behandling $behandlingId fra ${behandling.resultat} til $resultat")
         loggService.opprettVilkårsvurderingLogg(behandling = behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingsresultatUtils.kt
@@ -101,7 +101,7 @@ object BehandlingsresultatUtils {
         }
     }
 
-    fun validerBehandlingsresultat(behandling: Behandling, resultat: BehandlingResultat, visAvslag: Boolean = false) {
+    fun validerBehandlingsresultat(behandling: Behandling, resultat: BehandlingResultat, skipStøttetValidering: Boolean = false) {
         if ((behandling.type == BehandlingType.FØRSTEGANGSBEHANDLING && setOf(
                         BehandlingResultat.AVSLÅTT_OG_OPPHØRT,
                         BehandlingResultat.ENDRET,
@@ -116,7 +116,7 @@ object BehandlingsresultatUtils {
             throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
         }
 
-        if (!behandling.skalBehandlesAutomatisk && !resultat.erStøttetIManuellBehandling && !visAvslag) {
+        if (!behandling.skalBehandlesAutomatisk && !resultat.erStøttetIManuellBehandling && !skipStøttetValidering) {
             throw FunksjonellFeil(frontendFeilmelding = "Behandlingsresultatet ${resultat.displayName.toLowerCase()} er ikke støttet i løsningen enda. Ta kontakt med Team familie om du er uenig i resultatet.",
                                   melding = "Behandlingsresultatet ${resultat.displayName.toLowerCase()} er ikke støttet i løsningen, se securelogger for resultatene som ble utledet.")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -97,6 +97,7 @@ class FeatureToggleConfig(private val enabled: Boolean,
 
         val VIS_AVSLAG_TOGGLE = "familie-ba-sak.behandling.vis-avslag"
         val VIS_OPPHØRSPERIODER_TOGGLE = "familie-ba-sak.behandling.vis-opphoersperioder"
+        val SKIP_STØTTET_BEHANDLINGRESULTAT_SJEKK = "familie-ba-sak.behandling.skip-stottet-behandlingresultat-sjekk"
 
         val LOG = LoggerFactory.getLogger(this::class.java)
     }


### PR DESCRIPTION
Vært noe forvirring i preprod fordi avslagtoggle også slår av validering av støttet behandlingresultat. Skiller derfor ut i egen toggle. 