### PR TITLE
Justering brev: Oppdater sortering av avslagsperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/brev/BrevPeriodeService.kt
@@ -3,9 +3,7 @@ package no.nav.familie.ba.sak.brev
 import no.nav.familie.ba.sak.behandling.vedtak.Vedtak
 import no.nav.familie.ba.sak.behandling.vedtak.vedtaksperiode.Vedtaksperiode
 import no.nav.familie.ba.sak.behandling.vedtak.vedtaksperiode.VedtaksperiodeService
-import no.nav.familie.ba.sak.behandling.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.brev.domene.maler.BrevPeriode
-import no.nav.familie.ba.sak.common.erSenereEnnInneværendeMåned
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import org.springframework.stereotype.Service
@@ -19,29 +17,16 @@ class BrevPeriodeService(
     fun hentBrevPerioder(vedtak: Vedtak): List<BrevPeriode> {
         val visOpphørsperioder = featureToggleService.isEnabled(FeatureToggleConfig.VIS_OPPHØRSPERIODER_TOGGLE)
         val sorterteVedtaksperioder =
-                sorterVedtaksperioderForBrev(alleVedtaksperioder = vedtaksperiodeService.hentVedtaksperioder(vedtak.behandling),
-                                             visAvslag = featureToggleService.isEnabled(FeatureToggleConfig.VIS_AVSLAG_TOGGLE))
+                sorterVedtaksperioderForBrev(alleVedtaksperioder = vedtaksperiodeService.hentVedtaksperioder(vedtak.behandling))
 
         return vedtaksperioderTilBrevPerioder(sorterteVedtaksperioder, visOpphørsperioder, vedtak).reversed()
     }
 
     companion object {
 
-        fun sorterVedtaksperioderForBrev(alleVedtaksperioder: List<Vedtaksperiode>,
-                                         visAvslag: Boolean = false): List<Vedtaksperiode> {
-
-            return if (visAvslag) {
-                val (avslagsPerioderSistIBrevet, øvrigeVedtaksperioder) = alleVedtaksperioder
-                        .partition { it.vedtaksperiodetype == Vedtaksperiodetype.AVSLAG && (it.periodeTom == null || it.periodeTom!!.erSenereEnnInneværendeMåned()) }
-                val (avslagPerioderHeltUtenDatoer, avslagsPerioderUtenBegrensetPeriode) = avslagsPerioderSistIBrevet
-                        .partition { it.periodeFom == null && it.periodeTom == null }
-
-                øvrigeVedtaksperioder.sortedBy { it.periodeFom } +
-                avslagsPerioderUtenBegrensetPeriode.sortedBy { it.periodeFom } +
-                avslagPerioderHeltUtenDatoer
-            } else alleVedtaksperioder.filter { it.vedtaksperiodetype != Vedtaksperiodetype.AVSLAG }
-                    .sortedBy { it.periodeFom }
-
+        fun sorterVedtaksperioderForBrev(alleVedtaksperioder: List<Vedtaksperiode>): List<Vedtaksperiode> {
+            val (perioderMedFom, perioderUtenFom) = alleVedtaksperioder.partition { it.periodeFom != null }
+            return perioderMedFom.sortedBy { it.periodeFom } + perioderUtenFom
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakUtilsTest.kt
@@ -50,8 +50,7 @@ class VedtakUtilsTest {
     /**
      * Korrekt rekkefølge:
      * 1. Utbetalings-, opphørs- og avslagsperioder sortert på fom-dato
-     * 2. Avslagsperioder som ikke har tom-dato før inneværende måned
-     * 3. Avslagsperioder uten datoer
+     * 2. Avslagsperioder uten datoer
      */
     @Test
     fun `vedtaksperioder sorteres korrekt til brev`() {
@@ -62,6 +61,10 @@ class VedtakUtilsTest {
         val avslagMedTomDatoInneværendeMåned = Avslagsperiode(periodeFom = TIDLIGSTE_FOM_DATO,
                                                               periodeTom = LocalDate.now(),
                                                               vedtaksperiodetype = Vedtaksperiodetype.AVSLAG)
+        val avslagUtenTomDato =
+                Avslagsperiode(periodeFom = TIDLIGSTE_FOM_DATO,
+                               periodeTom = null,
+                               vedtaksperiodetype = Vedtaksperiodetype.AVSLAG)
         val opphørsperiode = Opphørsperiode(periodeFom = LocalDate.now().minusMonths(4),
                                             periodeTom = LocalDate.now().minusMonths(1),
                                             vedtaksperiodetype = Vedtaksperiodetype.OPPHØR)
@@ -84,14 +87,6 @@ class VedtakUtilsTest {
                                                             ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
                                                             utbetaltPerMnd = 1054,
                                                     )))
-        val avslagMedTomDatoEtterInneværendeMåned = Avslagsperiode(periodeFom = TIDLIGSTE_FOM_DATO,
-                                                                   periodeTom = LocalDate.now().plusMonths(5),
-                                                                   vedtaksperiodetype = Vedtaksperiodetype.AVSLAG)
-
-        val avslagUtenTomDato =
-                Avslagsperiode(periodeFom = SENESTE_FOM_DATO,
-                               periodeTom = null,
-                               vedtaksperiodetype = Vedtaksperiodetype.AVSLAG)
 
         val avslagUtenDatoer =
                 Avslagsperiode(periodeFom = null, periodeTom = null, vedtaksperiodetype = Vedtaksperiodetype.AVSLAG)
@@ -99,22 +94,17 @@ class VedtakUtilsTest {
         val sorterteVedtaksperioder = BrevPeriodeService.sorterVedtaksperioderForBrev(listOf(utbetalingsperiode,
                                                                                              opphørsperiode,
                                                                                              avslagMedTomDatoInneværendeMåned,
-                                                                                             avslagMedTomDatoEtterInneværendeMåned,
                                                                                              avslagUtenDatoer,
-                                                                                             avslagUtenTomDato).shuffled(),
-                                                                                      visAvslag = true)
+                                                                                             avslagUtenTomDato).shuffled())
 
-        // Utbetalingsperiode, opphørspersiode og avslagsperiode med foregående tom-dato sorteres etter fom-dato
+        // Utbetalingsperiode, opphørspersiode og avslagsperiode med fom-dato sorteres kronologisk
         Assertions.assertEquals(avslagMedTomDatoInneværendeMåned, sorterteVedtaksperioder[0])
-        Assertions.assertEquals(opphørsperiode, sorterteVedtaksperioder[1])
-        Assertions.assertEquals(utbetalingsperiode, sorterteVedtaksperioder[2])
-
-        // Avslag uten uten foregående tom-dato sorteres etter fom-dato
-        Assertions.assertEquals(avslagMedTomDatoEtterInneværendeMåned, sorterteVedtaksperioder[3])
-        Assertions.assertEquals(avslagUtenTomDato, sorterteVedtaksperioder[4])
+        Assertions.assertEquals(avslagUtenTomDato, sorterteVedtaksperioder[1])
+        Assertions.assertEquals(opphørsperiode, sorterteVedtaksperioder[2])
+        Assertions.assertEquals(utbetalingsperiode, sorterteVedtaksperioder[3])
 
         // Avslag uten datoer legger seg til slutt
-        Assertions.assertEquals(avslagUtenDatoer, sorterteVedtaksperioder[5])
+        Assertions.assertEquals(avslagUtenDatoer, sorterteVedtaksperioder[4])
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter å ha sett sortering i kontekst med mange perioder har man kommet fram til at alle perioder med fom-dato skal inn i vanlig sortering. De rødmerkede periodene uten slutt skal altså ikke lenger spesialhåndteres.
![image (9)](https://user-images.githubusercontent.com/5719550/113851896-4009ab80-979c-11eb-822d-5b1e13c98f62.png)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
