### PR TITLE
Friteks fom dato optional

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestVedtak.kt
@@ -34,7 +34,7 @@ data class RestPostVedtakBegrunnelse(
 )
 
 data class RestPostFritekstVedtakBegrunnelser(
-        val fom: LocalDate,
+        val fom: LocalDate?,
         val tom: LocalDate?,
         val fritekster: List<String>,
         val vedtaksperiodetype: Vedtaksperiodetype


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Begrunnelse fom dato e optional for avslag, derfor må den også være optional for fritekst.
