### PR TITLE
Send inn datoer i stedet for sammenslått string ved brevtekst-generering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/Person.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/Person.kt
@@ -109,8 +109,6 @@ data class Person(
     fun hentSeksårsdag(): LocalDate = fødselsdato.plusYears(6)
 }
 
-fun List<Person>.tilBrevTekst(): String = Utils.slåSammen(this.sortedBy { it.fødselsdato }.map { it.fødselsdato.tilKortString() })
-
 enum class Kjønn {
     MANN,
     KVINNE,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -149,8 +149,6 @@ class VedtakService(
                     person.type == PersonType.BARN
                 }
 
-        val barnasFødselsdatoer = barnaMedVilkårSomPåvirkerUtbetaling.map { it.fødselsdato }
-
         return if (VedtakBegrunnelseUtils.vedtakBegrunnelserIkkeTilknyttetVilkår.contains(vedtakBegrunnelse)) {
             if (vedtakBegrunnelse == VedtakBegrunnelseSpesifikasjon.INNVILGET_SATSENDRING
                 && SatsService.finnSatsendring(restPostVedtakBegrunnelse.fom).isEmpty()) {
@@ -164,7 +162,7 @@ class VedtakService(
                                       frontendFeilmelding = "Begrunnelsen stemmer ikke med fødselsdag. Vennligst velg en annen periode eller begrunnelse.")
             }
             vedtakBegrunnelse.hentBeskrivelse(målform = personopplysningGrunnlag.søker.målform,
-                                              barnasFødselsdatoer = barnasFødselsdatoer)
+                                              barnasFødselsdatoer = barnaMedVilkårSomPåvirkerUtbetaling.map { it.fødselsdato })
         } else {
             if (personerMedUtgjørendeVilkårForUtbetalingsperiode.isEmpty()) {
                 throw FunksjonellFeil(melding = "Begrunnelsen samsvarte ikke med vilkårsvurderingen",
@@ -176,7 +174,7 @@ class VedtakService(
             }
 
             vedtakBegrunnelse.hentBeskrivelse(gjelderSøker = gjelderSøker,
-                                              barnasFødselsdatoer = barnasFødselsdatoer,
+                                              barnasFødselsdatoer = barnaMedVilkårSomPåvirkerUtbetaling.map { it.fødselsdato },
                                               månedOgÅrBegrunnelsenGjelderFor = vedtakBegrunnelseType.hentMånedOgÅrForBegrunnelse(
                                                       periode = Periode(fom = restPostVedtakBegrunnelse.fom,
                                                                         tom = restPostVedtakBegrunnelse.tom ?: TIDENES_ENDE)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VedtakBegrunnelseSpesifikasjon.kt
@@ -1,11 +1,8 @@
 package no.nav.familie.ba.sak.behandling.vilkår
 
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Målform
-import no.nav.familie.ba.sak.common.Periode
-import no.nav.familie.ba.sak.common.TIDENES_ENDE
-import no.nav.familie.ba.sak.common.TIDENES_MORGEN
-import no.nav.familie.ba.sak.common.forrigeMåned
-import no.nav.familie.ba.sak.common.tilMånedÅr
+import no.nav.familie.ba.sak.common.*
+import java.time.LocalDate
 import java.util.*
 
 interface IVedtakBegrunnelse {
@@ -14,7 +11,7 @@ interface IVedtakBegrunnelse {
     fun hentHjemler(): SortedSet<Int>
     fun hentBeskrivelse(
             gjelderSøker: Boolean = false,
-            barnasFødselsdatoer: String = "",
+            barnasFødselsdatoer: List<LocalDate> = emptyList(),
             månedOgÅrBegrunnelsenGjelderFor: String = "",
             målform: Målform
     ): String
@@ -28,7 +25,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
@@ -51,7 +48,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
@@ -74,7 +71,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
@@ -89,7 +86,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
@@ -104,7 +101,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
@@ -119,12 +116,12 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
-            Målform.NB -> "Du får barnetrygd fordi du har omsorgen for barn født $barnasFødselsdatoer fra $månedOgÅrBegrunnelsenGjelderFor."
-            Målform.NN -> "Du får barnetrygd fordi du har omsorga for barn fødd $barnasFødselsdatoer frå $månedOgÅrBegrunnelsenGjelderFor."
+            Målform.NB -> "Du får barnetrygd fordi du har omsorgen for barn født ${barnasFødselsdatoer.tilBrevTekst()} fra $månedOgÅrBegrunnelsenGjelderFor."
+            Målform.NN -> "Du får barnetrygd fordi du har omsorga for barn fødd ${barnasFødselsdatoer.tilBrevTekst()} frå $månedOgÅrBegrunnelsenGjelderFor."
         }
     },
     INNVILGET_BOR_HOS_SØKER("Barn har flyttet til søker") {
@@ -134,12 +131,12 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
-            Målform.NB -> "Du får barnetrygd fordi barn født $barnasFødselsdatoer bor hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
-            Målform.NN -> "Du får barnetrygd fordi barn fødd $barnasFødselsdatoer bur hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
+            Målform.NB -> "Du får barnetrygd fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} bor hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
+            Målform.NN -> "Du får barnetrygd fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} bur hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
         }
     },
     INNVILGET_FAST_OMSORG_FOR_BARN("Søker har fast omsorg for barn") {
@@ -149,12 +146,12 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
-            Målform.NB -> "Du får barnetrygd fordi vi har kommet fram til at barn født $barnasFødselsdatoer bor fast hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
-            Målform.NN -> "Du får barnetrygd fordi vi har kome fram til at barn fødd $barnasFødselsdatoer bur fast hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
+            Målform.NB -> "Du får barnetrygd fordi vi har kommet fram til at barn født ${barnasFødselsdatoer.tilBrevTekst()} bor fast hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
+            Målform.NN -> "Du får barnetrygd fordi vi har kome fram til at barn fødd ${barnasFødselsdatoer.tilBrevTekst()} bur fast hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
         }
     },
     INNVILGET_NYFØDT_BARN("Nyfødt barn") {
@@ -164,7 +161,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
@@ -180,7 +177,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
@@ -195,12 +192,12 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = when (målform) {
-            Målform.NB -> "Du får barnetrygd fordi barn født $barnasFødselsdatoer bor sammen med deg."
-            Målform.NN -> "Du får barnetrygd fordi barn fødd $barnasFødselsdatoer bur saman med deg."
+            Målform.NB -> "Du får barnetrygd fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} bor sammen med deg."
+            Målform.NN -> "Du får barnetrygd fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} bur saman med deg."
         }
     },
     REDUKSJON_BOSATT_I_RIKTET("Barn har flyttet fra Norge") {
@@ -209,13 +206,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi barn født $barnasFødselsdatoer har flyttet fra Norge i $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd $barnasFødselsdatoer har flytta frå Noreg i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barnetrygden reduseres fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} har flyttet fra Norge i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} har flytta frå Noreg i $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     REDUKSJON_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE_BARN("Barn har ikke oppholdstillatelse") {
@@ -224,13 +221,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi barn født $barnasFødselsdatoer ikke lenger har oppholdstillatelse i Norge fra $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd $barnasFødselsdatoer ikkje lenger har opphaldsløyve i Noreg frå $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barnetrygden reduseres fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} ikke lenger har oppholdstillatelse i Norge fra $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} ikkje lenger har opphaldsløyve i Noreg frå $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     REDUKSJON_FLYTTET_FORELDER("Søker har flyttet fra barn") {
@@ -239,13 +236,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi du i $månedOgÅrBegrunnelsenGjelderFor flyttet fra barn født $barnasFødselsdatoer."
-                    Målform.NN -> "Barnetrygda er redusert fordi du i $månedOgÅrBegrunnelsenGjelderFor flyttå frå barn fødd $barnasFødselsdatoer."
+                    Målform.NB -> "Barnetrygden reduseres fordi du i $månedOgÅrBegrunnelsenGjelderFor flyttet fra barn født ${barnasFødselsdatoer.tilBrevTekst()}."
+                    Målform.NN -> "Barnetrygda er redusert fordi du i $månedOgÅrBegrunnelsenGjelderFor flyttå frå barn fødd ${barnasFødselsdatoer.tilBrevTekst()}."
                 }
     },
     REDUKSJON_FLYTTET_BARN("Barn har flyttet fra søker (flytting mellom foreldre, andre omsorgspersoner)") {
@@ -254,13 +251,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi barn født $barnasFødselsdatoer har flyttet fra deg $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd $barnasFødselsdatoer har flytta frå deg $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barnetrygden reduseres fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} har flyttet fra deg $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} har flytta frå deg $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     REDUKSJON_BARN_DØD(tittel = "Barn død", erTilgjengeligFrontend = false) {
@@ -269,13 +266,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String, // TODO: [BARNS DØDSDATO]
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi barn født $barnasFødselsdatoer døde i $månedOgÅrBegrunnelsenGjelderFor. "
-                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd $barnasFødselsdatoer døydde i $månedOgÅrBegrunnelsenGjelderFor. "
+                    Målform.NB -> "Barnetrygden reduseres fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} døde i $månedOgÅrBegrunnelsenGjelderFor. "
+                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} døydde i $månedOgÅrBegrunnelsenGjelderFor. "
                 }
     },
     REDUKSJON_FAST_OMSORG_FOR_BARN("Søker har ikke lenger fast omsorg for barn: Beredskapshjem, fosterhjem, institusjon, vurdering fast bosted mellom foreldrene") {
@@ -284,13 +281,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi vi har kommet fram til at barn født $barnasFødselsdatoer ikke lenger bor fast hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barnetrygda er redusert fordi vi har kome fram til at barn fødd $barnasFødselsdatoer ikkje lenger bur fast hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barnetrygden reduseres fordi vi har kommet fram til at barn født ${barnasFødselsdatoer.tilBrevTekst()} ikke lenger bor fast hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barnetrygda er redusert fordi vi har kome fram til at barn fødd ${barnasFødselsdatoer.tilBrevTekst()} ikkje lenger bur fast hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     REDUKSJON_MANGLENDE_OPPLYSNINGER(tittel = "Ikke mottatt dokumentasjon", erTilgjengeligFrontend = true) {
@@ -299,7 +296,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(17, 18)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -314,13 +311,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi barn født $barnasFødselsdatoer fylte 18 år."
-                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd $barnasFødselsdatoer fylte 18 år. "
+                    Målform.NB -> "Barnetrygden reduseres fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} fylte 18 år."
+                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} fylte 18 år. "
                 }
     },
     REDUKSJON_UNDER_6_ÅR("Barn har fylt 6 år") {
@@ -329,13 +326,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(10)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi barn født $barnasFødselsdatoer fyller 6 år."
-                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd $barnasFødselsdatoer fyller 6 år."
+                    Målform.NB -> "Barnetrygden reduseres fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} fyller 6 år."
+                    Målform.NN -> "Barnetrygda er redusert fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} fyller 6 år."
                 }
     },
     REDUKSJON_DELT_BOSTED_ENIGHET("Enighet om opphør av avtale om delt bosted") {
@@ -344,13 +341,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygden reduseres fordi avtalen om delt bosted for barn født $barnasFødselsdatoer er opphørt fra $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barnetrygda er redusert fordi avtalen om delt bustad for barn fødd $barnasFødselsdatoer er opphøyrt frå $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barnetrygden reduseres fordi avtalen om delt bosted for barn født ${barnasFødselsdatoer.tilBrevTekst()} er opphørt fra $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barnetrygda er redusert fordi avtalen om delt bustad for barn fødd ${barnasFødselsdatoer.tilBrevTekst()} er opphøyrt frå $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     REDUKSJON_DELT_BOSTED_UENIGHET("Uenighet om opphør av avtale om delt bosted") {
@@ -359,14 +356,14 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Du og den andre forelderen er uenige om avtalen om delt bosted. Vi har kommet fram til at avtalen om delt bosted for barn født $barnasFødselsdatoer ikke lenger praktiseres fra $månedOgÅrBegrunnelsenGjelderFor." +
+                    Målform.NB -> "Du og den andre forelderen er uenige om avtalen om delt bosted. Vi har kommet fram til at avtalen om delt bosted for barn født ${barnasFødselsdatoer.tilBrevTekst()} ikke lenger praktiseres fra $månedOgÅrBegrunnelsenGjelderFor." +
                                   "\nVed uenighet mellom foreldrene om avtalen om delt bosted, kan barnetrygden opphøres fra måneden etter at vi fikk søknad om full barnetrygd."
-                    Målform.NN -> "Du og den andre forelderen er usamde om avtalen om delt bustad. Vi har kome fram til at avtalen om delt bustad for barn fødd $barnasFødselsdatoer ikkje lenger blir praktisert frå $månedOgÅrBegrunnelsenGjelderFor." +
+                    Målform.NN -> "Du og den andre forelderen er usamde om avtalen om delt bustad. Vi har kome fram til at avtalen om delt bustad for barn fødd ${barnasFødselsdatoer.tilBrevTekst()} ikkje lenger blir praktisert frå $månedOgÅrBegrunnelsenGjelderFor." +
                                   "\nNår de er usamde om avtalen om delt bustad, kan vi opphøyre barnetrygda til deg frå og med månaden etter at vi fekk søknad om full barnetrygd. "
                 }
     },
@@ -376,7 +373,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf()
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = ""
@@ -388,7 +385,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(10)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -403,7 +400,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -424,7 +421,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -445,15 +442,15 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygd fordi barn født $barnasFødselsdatoer ikke bor hos deg${
+                    Målform.NB -> "Barnetrygd fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} ikke bor hos deg${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }."
-                    Målform.NN -> "Barnetrygd fordi barn fødd $barnasFødselsdatoer ikkje bur hos deg${
+                    Målform.NN -> "Barnetrygd fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} ikkje bur hos deg${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }."
                 }
@@ -464,15 +461,15 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygd fordi vi har kommet fram til at du ikke har fast omsorg for barn født $barnasFødselsdatoer${
+                    Målform.NB -> "Barnetrygd fordi vi har kommet fram til at du ikke har fast omsorg for barn født ${barnasFødselsdatoer.tilBrevTekst()}${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }."
-                    Målform.NN -> "Barnetrygd fordi vi har kome fram til at du ikkje har fast omsorg for barn fødd $barnasFødselsdatoer${
+                    Målform.NN -> "Barnetrygd fordi vi har kome fram til at du ikkje har fast omsorg for barn fødd ${barnasFødselsdatoer.tilBrevTekst()}${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }."
                 }
@@ -483,7 +480,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -502,7 +499,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -521,7 +518,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -540,13 +537,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(12)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygd fordi den andre forelderen allerede får barnetrygd for barn født $barnasFødselsdatoer."
-                    Målform.NN -> "Barnetrygd fordi den andre forelderen allereie mottek barnetrygd for barn fødd $barnasFødselsdatoer."
+                    Målform.NB -> "Barnetrygd fordi den andre forelderen allerede får barnetrygd for barn født ${barnasFødselsdatoer.tilBrevTekst()}."
+                    Målform.NN -> "Barnetrygd fordi den andre forelderen allereie mottek barnetrygd for barn fødd ${barnasFødselsdatoer.tilBrevTekst()}."
                 }
     },
     AVSLAG_UNDER_18_ÅR("Barn over 18 år") {
@@ -555,13 +552,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygd fordi barn født $barnasFødselsdatoer er over 18 år. "
-                    Målform.NN -> "Barnetrygd fordi barn fødd $barnasFødselsdatoer er over 18 år."
+                    Målform.NB -> "Barnetrygd fordi barn født ${barnasFødselsdatoer.tilBrevTekst()} er over 18 år. "
+                    Målform.NN -> "Barnetrygd fordi barn fødd ${barnasFødselsdatoer.tilBrevTekst()} er over 18 år."
                 }
     },
     AVSLAG_UGYLDIG_AVTALE_OM_DELT_BOSTED("Ugyldig avtale om delt bosted") {
@@ -570,15 +567,15 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygd fordi du ikke har en gyldig avtale om delt bosted for barn født $barnasFødselsdatoer${
+                    Målform.NB -> "Barnetrygd fordi du ikke har en gyldig avtale om delt bosted for barn født ${barnasFødselsdatoer.tilBrevTekst()}${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }. Barnetrygden kan derfor ikke deles. "
-                    Målform.NN -> "Barnetrygd fordi du ikkje har ein gyldig avtale om delt bustad for barn fødd $barnasFødselsdatoer${
+                    Målform.NN -> "Barnetrygd fordi du ikkje har ein gyldig avtale om delt bustad for barn fødd ${barnasFødselsdatoer.tilBrevTekst()}${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }. Barnetrygda kan derfor ikkje delast."
                 }
@@ -589,15 +586,15 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barnetrygd fordi du ikke har en avtale om delt bosted for barn født $barnasFødselsdatoer${
+                    Målform.NB -> "Barnetrygd fordi du ikke har en avtale om delt bosted for barn født ${barnasFødselsdatoer.tilBrevTekst()}${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }. Barnetrygden kan derfor ikke deles. "
-                    Målform.NN -> "Barnetrygd fordi du ikkje har ein avtale om delt bustad for barn fødd $barnasFødselsdatoer${
+                    Målform.NN -> "Barnetrygd fordi du ikkje har ein avtale om delt bustad for barn fødd ${barnasFødselsdatoer.tilBrevTekst()}${
                         fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor, målform)
                     }. Barnetrygda kan derfor ikkje delast."
                 }
@@ -608,7 +605,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(17, 18)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -623,7 +620,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -638,7 +635,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf()
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = ""
@@ -649,13 +646,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barn født $barnasFødselsdatoer har flyttet fra deg i $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barn fødd $barnasFødselsdatoer har flytta frå deg i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barn født ${barnasFødselsdatoer.tilBrevTekst()} har flyttet fra deg i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barn fødd ${barnasFødselsdatoer.tilBrevTekst()} har flytta frå deg i $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     OPPHØR_SØKER_FLYTTET_FRA_BARN("Søker har flyttet fra barn") {
@@ -664,13 +661,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Du i $månedOgÅrBegrunnelsenGjelderFor flyttet fra barn født $barnasFødselsdatoer."
-                    Målform.NN -> "Du i $månedOgÅrBegrunnelsenGjelderFor flytta frå barn fødd $barnasFødselsdatoer."
+                    Målform.NB -> "Du i $månedOgÅrBegrunnelsenGjelderFor flyttet fra barn født ${barnasFødselsdatoer.tilBrevTekst()}."
+                    Målform.NN -> "Du i $månedOgÅrBegrunnelsenGjelderFor flytta frå barn fødd ${barnasFødselsdatoer.tilBrevTekst()}."
                 }
     },
     OPPHØR_BARN_UTVANDRET("Barn har flyttet fra Norge") {
@@ -679,13 +676,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barn født $barnasFødselsdatoer har flyttet fra Norge i $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barn fødd $barnasFødselsdatoer har flytta frå Noreg i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barn født ${barnasFødselsdatoer.tilBrevTekst()} har flyttet fra Norge i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barn fødd ${barnasFødselsdatoer.tilBrevTekst()} har flytta frå Noreg i $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     OPPHØR_SØKER_UTVANDRET("Søker har flyttet fra Norge") {
@@ -694,7 +691,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -709,13 +706,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String, // TODO: [BARNS DØDSDATO]
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barn født $barnasFødselsdatoer døde i $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barn fødd $barnasFødselsdatoer døydde i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barn født ${barnasFødselsdatoer.tilBrevTekst()} døde i $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barn fødd ${barnasFødselsdatoer.tilBrevTekst()} døydde i $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     OPPHØR_SØKER_HAR_IKKE_FAST_OMSORG("Søker har ikke lenger fast omsorg for barn (beredskapshjem, vurdering av fast bosted)") {
@@ -724,13 +721,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Vi har kommet fram til at barn født $barnasFødselsdatoer ikke lenger bor fast hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Vi har kome fram til at barn fødd $barnasFødselsdatoer ikkje lenger bur fast hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Vi har kommet fram til at barn født ${barnasFødselsdatoer.tilBrevTekst()} ikke lenger bor fast hos deg fra $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Vi har kome fram til at barn fødd ${barnasFødselsdatoer.tilBrevTekst()} ikkje lenger bur fast hos deg frå $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     OPPHØR_BARN_HAR_IKKE_OPPHOLDSTILLATELSE("Barn har ikke oppholdstillatelse") {
@@ -739,13 +736,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Barn født $barnasFødselsdatoer ikke lenger har oppholdstillatelse i Norge fra $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Barn fødd $barnasFødselsdatoer ikkje lenger har opphaldsløyve i Noreg frå $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Barn født ${barnasFødselsdatoer.tilBrevTekst()} ikke lenger har oppholdstillatelse i Norge fra $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Barn fødd ${barnasFødselsdatoer.tilBrevTekst()} ikkje lenger har opphaldsløyve i Noreg frå $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     OPPHØR_SØKER_HAR_IKKE_OPPHOLDSTILLATELSE("Søker har ikke oppholdstillatelse") {
@@ -754,7 +751,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -769,7 +766,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(17, 18)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
@@ -784,13 +781,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Avtalen om delt bosted for barn født $barnasFødselsdatoer  er opphørt fra $månedOgÅrBegrunnelsenGjelderFor."
-                    Målform.NN -> "Avtalen om delt bustad for barn fødd $barnasFødselsdatoer  er opphøyrt frå $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NB -> "Avtalen om delt bosted for barn født ${barnasFødselsdatoer.tilBrevTekst()}  er opphørt fra $månedOgÅrBegrunnelsenGjelderFor."
+                    Målform.NN -> "Avtalen om delt bustad for barn fødd ${barnasFødselsdatoer.tilBrevTekst()}  er opphøyrt frå $månedOgÅrBegrunnelsenGjelderFor."
                 }
     },
     OPPHØR_DELT_BOSTED_OPPHØRT_UENIGHET("Uenighet om opphør av avtale om delt bosted") {
@@ -799,14 +796,14 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String =
                 when (målform) {
-                    Målform.NB -> "Du og den andre forelderen er uenige om avtalen om delt bosted. Vi har kommet fram til at avtale om delt bosted for barn født $barnasFødselsdatoer ikke lenger praktiseres fra $månedOgÅrBegrunnelsenGjelderFor.\r" +
+                    Målform.NB -> "Du og den andre forelderen er uenige om avtalen om delt bosted. Vi har kommet fram til at avtale om delt bosted for barn født ${barnasFødselsdatoer.tilBrevTekst()} ikke lenger praktiseres fra $månedOgÅrBegrunnelsenGjelderFor.\r" +
                                   "Ved uenighet mellom foreldrene om avtalen om delt bosted, kan barnetrygden opphøres fra måneden etter at vi fikk søknad om full barnetrygd."
-                    Målform.NN -> "Du og den andre forelderen er usamde om avtalen om delt bustad. Vi har kome fram til at avtalen om delt bustad for barn fødd $barnasFødselsdatoer ikkje lenger blir praktisert frå $månedOgÅrBegrunnelsenGjelderFor.\r" +
+                    Målform.NN -> "Du og den andre forelderen er usamde om avtalen om delt bustad. Vi har kome fram til at avtalen om delt bustad for barn fødd ${barnasFødselsdatoer.tilBrevTekst()} ikkje lenger blir praktisert frå $månedOgÅrBegrunnelsenGjelderFor.\r" +
                                   "Når de er usamde om avtalen om delt bustad, kan vi opphøyre barnetrygda til deg frå og med månaden etter at vi fekk søknad om full barnetrygd."
                 }
     },
@@ -816,7 +813,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf()
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
-                barnasFødselsdatoer: String,
+                barnasFødselsdatoer: List<LocalDate>,
                 månedOgÅrBegrunnelsenGjelderFor: String,
                 målform: Målform
         ): String = ""
@@ -833,10 +830,12 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
             else vilkårForBegrunnelse.singleOrNull()
         }
 
-        fun duOgEllerBarnaFødtFormulering(gjelderSøker: Boolean, barnasFødselsdatoer: String, målform: Målform) =
+        fun List<LocalDate>.tilBrevTekst(): String = Utils.slåSammen(this.sorted().map { it.tilKortString() })
+
+        fun duOgEllerBarnaFødtFormulering(gjelderSøker: Boolean, barnasFødselsdatoer: List<LocalDate>, målform: Målform) =
                 when (målform) {
-                    Målform.NB -> "${if (gjelderSøker && barnasFødselsdatoer.isNotBlank()) " du og " else if (gjelderSøker) " du " else " "}${if (barnasFødselsdatoer.isNotBlank()) "barn født $barnasFødselsdatoer " else ""}"
-                    Målform.NN -> "${if (gjelderSøker && barnasFødselsdatoer.isNotBlank()) " du og " else if (gjelderSøker) " du " else " "}${if (barnasFødselsdatoer.isNotBlank()) "barn fødd $barnasFødselsdatoer " else ""}"
+                    Målform.NB -> "${if (gjelderSøker && barnasFødselsdatoer.isNotEmpty()) " du og " else if (gjelderSøker) " du " else " "}${if (barnasFødselsdatoer.isNotEmpty()) "barn født ${barnasFødselsdatoer.tilBrevTekst()} " else ""}"
+                    Målform.NN -> "${if (gjelderSøker && barnasFødselsdatoer.isNotEmpty()) " du og " else if (gjelderSøker) " du " else " "}${if (barnasFødselsdatoer.isNotEmpty()) "barn fødd ${barnasFødselsdatoer.tilBrevTekst()} " else ""}"
                 }
 
         fun fraOgTilFormulering(månedOgÅrBegrunnelsenGjelderFor: String, målform: Målform) =

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/AvslagBegrunnelseSammenslåingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/AvslagBegrunnelseSammenslåingTest.kt
@@ -163,13 +163,13 @@ class AvslagBegrunnelseSammenslåingTest {
     @Test
     fun `Avslagbegrunnelser i samme periode blir sortert på søker, så barnas fødselsdatoer`() {
         val kunSøker = VedtakService.Companion.BrevtekstParametre(gjelderSøker = true,
-                                                                  barnasFødselsdatoer = "",
+                                                                  barnasFødselsdatoer = emptyList(),
                                                                   målform = Målform.NN)
         val beggeDeler = VedtakService.Companion.BrevtekstParametre(gjelderSøker = true,
-                                                                    barnasFødselsdatoer = "01.01.99",
+                                                                    barnasFødselsdatoer = listOf(barnFødselsdato),
                                                                     målform = Målform.NN)
         val kunBarn = VedtakService.Companion.BrevtekstParametre(gjelderSøker = false,
-                                                                 barnasFødselsdatoer = "01.01.99",
+                                                                 barnasFødselsdatoer = listOf(barnFødselsdato),
                                                                  målform = Målform.NN)
         val sortert =
                 mapOf(VedtakBegrunnelseSpesifikasjon.AVSLAG_UNDER_18_ÅR to kunBarn,

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakUtilsTest.kt
@@ -107,7 +107,7 @@ class VedtakUtilsTest {
     @Test
     fun `Begrunnelse av typen AVSLAG uten periode gir korrekt formatert brevtekst uten datoer`() {
         val begrunnelse = VedtakBegrunnelseSpesifikasjon.AVSLAG_BOSATT_I_RIKET
-        val brevtekst = begrunnelse.hentBeskrivelse(barnasFødselsdatoer = LocalDate.of(1814, 5, 17).tilKortString(),
+        val brevtekst = begrunnelse.hentBeskrivelse(barnasFødselsdatoer = listOf(LocalDate.of(1814, 5, 17)),
                                                     månedOgÅrBegrunnelsenGjelderFor = begrunnelse.vedtakBegrunnelseType.hentMånedOgÅrForBegrunnelse(
                                                             periode = Periode(fom = TIDENES_MORGEN,
                                                                               tom = TIDENES_ENDE)
@@ -119,7 +119,7 @@ class VedtakUtilsTest {
     @Test
     fun `Begrunnelse av typen AVSLAG med kun fom gir korrekt formatert brevtekst med kun fom`() {
         val begrunnelse = VedtakBegrunnelseSpesifikasjon.AVSLAG_BOSATT_I_RIKET
-        val brevtekst = begrunnelse.hentBeskrivelse(barnasFødselsdatoer = LocalDate.of(1814, 5, 17).tilKortString(),
+        val brevtekst = begrunnelse.hentBeskrivelse(barnasFødselsdatoer = listOf(LocalDate.of(1814, 5, 17)),
                                                     månedOgÅrBegrunnelsenGjelderFor = begrunnelse.vedtakBegrunnelseType.hentMånedOgÅrForBegrunnelse(
                                                             periode = Periode(fom = LocalDate.of(1814, 12, 12),
                                                                               tom = TIDENES_ENDE)
@@ -131,7 +131,7 @@ class VedtakUtilsTest {
     @Test
     fun `Begrunnelse av typen AVSLAG med både fom og tom gir korrekt formatert brevtekst med fom og tom`() {
         val begrunnelse = VedtakBegrunnelseSpesifikasjon.AVSLAG_BOSATT_I_RIKET
-        val brevtekst = begrunnelse.hentBeskrivelse(barnasFødselsdatoer = LocalDate.of(1814, 5, 17).tilKortString(),
+        val brevtekst = begrunnelse.hentBeskrivelse(barnasFødselsdatoer = listOf(LocalDate.of(1814, 5, 17)),
                                                     månedOgÅrBegrunnelsenGjelderFor = begrunnelse.vedtakBegrunnelseType.hentMånedOgÅrForBegrunnelse(
                                                             periode = Periode(fom = LocalDate.of(1814, 12, 12),
                                                                               tom = LocalDate.of(1815, 12, 12))

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.common
 
-import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.tilBrevTekst
+import no.nav.familie.ba.sak.behandling.vilkår.VedtakBegrunnelseSpesifikasjon.Companion.tilBrevTekst
 import no.nav.familie.ba.sak.common.Utils.hentPropertyFraMaven
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -26,7 +26,7 @@ internal class UtilsTest {
         val førsteBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
 
         assertEquals(førsteBarn.fødselsdato.tilKortString(),
-                     listOf(førsteBarn).tilBrevTekst())
+                     listOf(førsteBarn.fødselsdato).tilBrevTekst())
     }
 
     @Test
@@ -35,7 +35,7 @@ internal class UtilsTest {
         val andreBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
 
         assertEquals("${førsteBarn.fødselsdato.tilKortString()} og ${andreBarn.fødselsdato.tilKortString()}",
-                     listOf(førsteBarn, andreBarn).tilBrevTekst())
+                     listOf(førsteBarn.fødselsdato, andreBarn.fødselsdato).tilBrevTekst())
     }
 
     @Test
@@ -45,7 +45,7 @@ internal class UtilsTest {
         val tredjeBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
 
         assertEquals("${førsteBarn.fødselsdato.tilKortString()}, ${andreBarn.fødselsdato.tilKortString()} og ${tredjeBarn.fødselsdato.tilKortString()}",
-                     listOf(førsteBarn, andreBarn, tredjeBarn).tilBrevTekst())
+                     listOf(førsteBarn.fødselsdato, andreBarn.fødselsdato, tredjeBarn.fødselsdato).tilBrevTekst())
     }
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi har behov for å vite om det dreier seg om et eller flere barn i begrunnelsene  ("barnet/"barna" - kommer som neste pr). 
Flytter derfor sammenslåing av string "et nivå inn". 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Kunne alternativt lagt til en bool `gjelderFlereBarn` i likehet med `gjelderSøker`, men måtte da gjentatt samme sjekk alle steder det sendes inn, så synes det var ryddigere å ta det inn her. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ingen funksjonell endring, oppdatert tester. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
