### PR TITLE
Støtte for opphørsgrunn 0 saksoversikt fra infotrygd ved migrering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/MigreringService.kt
@@ -104,7 +104,7 @@ class MigreringService(private val infotrygdBarnetrygdClient: InfotrygdBarnetryg
 
         val ikkeOpphørteSaker = ferdigBehandledeSaker.sortedByDescending { it.iverksattdato }
                 .filter {
-                    it.stønad != null && it.stønad!!.opphørsgrunn.isNullOrBlank()
+                    it.stønad != null && (it.stønad!!.opphørsgrunn == "0" || it.stønad!!.opphørsgrunn.isNullOrEmpty())
                 }
 
         if (ikkeOpphørteSaker.size > 1) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/MigreringServiceTest.kt
@@ -250,7 +250,8 @@ class MigreringServiceTest {
                                                                                                                  tom = null,
                                                                                                                  beløp = it,
                                                                                                                  typeDelytelse = "MS",
-                                                                                                                 typeUtbetaling = "J") }),
+                                                                                                                 typeUtbetaling = "J",) },
+    opphørsgrunn = "0"),
                                                                status = "FB",
                                                                valg = "OR",
                                                                undervalg = "OS")


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser en bug i migrering hvor opphørsgrunn i saksstaistikk er satt til "0", mens vi filterer på nullOrEmpty

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Nei
