### PR TITLE
Kaller mockserver for e2e infotrygd-barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/infotrygd/InfotrygdBarnetrygdClient.kt
@@ -41,8 +41,6 @@ class InfotrygdBarnetrygdClient(@Value("\${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_U
     }
 
     fun hentSaker(søkersIdenter: List<String>, barnasIdenter: List<String> = emptyList()): InfotrygdSøkResponse<Sak> {
-        if (environment.activeProfiles.contains("e2e")) return InfotrygdSøkResponse(emptyList(), emptyList())
-
         val uri = URI.create("$clientUri/infotrygd/barnetrygd/saker")
 
         return try {

--- a/src/main/resources/application-e2e.yaml
+++ b/src/main/resources/application-e2e.yaml
@@ -75,8 +75,8 @@ FAMILIE_BREV_API_URL: http://familie-brev:8001
 FAMILIE_OPPDRAG_API_URL: http://familie-oppdrag:8087/api
 FAMILIE_INTEGRASJONER_API_URL: http://familie-integrasjoner:8085/api
 NORG2_BASE_URL: http://familie-mock-server:1337/rest/api/norg2
+FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL: http://familie-mock-server:1337/rest/api/infotrygd/ba
 FAMILIE_BA_INFOTRYGD_FEED_API_URL: http://familie-ba-infotrygd-feed:8092/api
-FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL: dummy
 STS_URL: http://nav-auth-mock:8200/nais-sts/token
 PDL_URL: http://familie-mock-server:1337/rest/api/pdl
 CREDENTIAL_USERNAME: srvfamilie-ba-sak


### PR DESCRIPTION
Kun for å hente saker - nødvendig for å kunne lage e2e-test for migrering.