### PR TITLE
Sette beslutter til system ved automatisk totrinnskontroll

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/totrinnskontroll/TotrinnskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/totrinnskontroll/TotrinnskontrollService.kt
@@ -57,8 +57,8 @@ class TotrinnskontrollService(private val behandlingService: BehandlingService,
                 godkjent = true,
                 saksbehandler = SikkerhetContext.hentSaksbehandlerNavn(),
                 saksbehandlerId = SikkerhetContext.hentSaksbehandler(),
-                beslutter = SikkerhetContext.hentSaksbehandlerNavn(),
-                beslutterId = SikkerhetContext.hentSaksbehandler(),
+                beslutter = SikkerhetContext.SYSTEM_NAVN,
+                beslutterId = SikkerhetContext.SYSTEM_FORKORTELSE,
         ))
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/totrinnskontroll/TotrinnskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/totrinnskontroll/TotrinnskontrollService.kt
@@ -52,6 +52,10 @@ class TotrinnskontrollService(private val behandlingService: BehandlingService,
     }
 
     fun opprettAutomatiskTotrinnskontroll(behandling: Behandling) {
+        if (!behandling.skalBehandlesAutomatisk) {
+            throw Feil(message = "Kan ikke opprette automatisk totrinnskontroll ved manuell behandling")
+        }
+
         lagreOgDeaktiverGammel(Totrinnskontroll(
                 behandling = behandling,
                 godkjent = true,

--- a/src/main/kotlin/no/nav/familie/ba/sak/totrinnskontroll/TotrinnskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/totrinnskontroll/TotrinnskontrollService.kt
@@ -55,8 +55,8 @@ class TotrinnskontrollService(private val behandlingService: BehandlingService,
         lagreOgDeaktiverGammel(Totrinnskontroll(
                 behandling = behandling,
                 godkjent = true,
-                saksbehandler = SikkerhetContext.hentSaksbehandlerNavn(),
-                saksbehandlerId = SikkerhetContext.hentSaksbehandler(),
+                saksbehandler = SikkerhetContext.SYSTEM_NAVN,
+                saksbehandlerId = SikkerhetContext.SYSTEM_FORKORTELSE,
                 beslutter = SikkerhetContext.SYSTEM_NAVN,
                 beslutterId = SikkerhetContext.SYSTEM_FORKORTELSE,
         ))


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Automatisk totrinnskontroll får saksbehandler og beslutter satt som felt i Totrinnskontroll. Når dette trigges fra frontend, som f. eks ved manuell migrering, så vil IverksettMotOpprdag-steget feile fordi saksbehandler og beslutter er satt til innlogget bruker.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Vil dette skape noen problemer for andre automatisk totrinnskontroll? Tror ikke det

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Det er tester, men hvordan teste med å kjøre i saksbehandler sikkershetscontext? Det har vi ikke funnet noen mekanismer på.