### PR TITLE
Opprettet ny stegsekvens definisjon for autobrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/BehandlingSteg.kt
@@ -174,6 +174,17 @@ fun hentNesteSteg(behandling: Behandling, utførendeStegType: StegType): StegTyp
                 else -> throw IllegalStateException("Stegtype ${utførendeStegType.displayName()} er ikke implementert for behandling med årsak $behandlingÅrsak og type $behandlingType.")
             }
         }
+        BehandlingÅrsak.OMREGNING_18ÅR, BehandlingÅrsak.OMREGNING_6ÅR -> {
+            when (utførendeStegType) {
+                REGISTRERE_PERSONGRUNNLAG -> VILKÅRSVURDERING
+                VILKÅRSVURDERING -> JOURNALFØR_VEDTAKSBREV
+                JOURNALFØR_VEDTAKSBREV -> DISTRIBUER_VEDTAKSBREV
+                DISTRIBUER_VEDTAKSBREV -> FERDIGSTILLE_BEHANDLING
+                FERDIGSTILLE_BEHANDLING -> BEHANDLING_AVSLUTTET
+                BEHANDLING_AVSLUTTET -> BEHANDLING_AVSLUTTET
+                else -> throw IllegalStateException("Stegtype ${utførendeStegType.displayName()} er ikke implementert for behandling med årsak $behandlingÅrsak og type $behandlingType.")
+            }
+        }
         else -> {
             when (utførendeStegType) {
                 REGISTRERE_PERSONGRUNNLAG -> VILKÅRSVURDERING

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/WebConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/WebConfig.kt
@@ -21,6 +21,7 @@ class WebConfig(
                 .excludePathPatterns("/api/task/**")
                 .excludePathPatterns("/api/v2/task/**")
                 .excludePathPatterns("/internal")
+                .excludePathPatterns("/testverktoy")
                 .excludePathPatterns("/api/feature")
         super.addInterceptors(registry)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/SchedulingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/SchedulingController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/internal")
+@RequestMapping("/testverktoy")
 class SchedulingController(
         private val scheduler: Autobrev6og18ÅrScheduler,
 private val envService: EnvService) {
@@ -18,7 +18,7 @@ private val envService: EnvService) {
     @GetMapping(path = ["/autobrev"])
     @Unprotected
     fun kjørSchedulerForAutobrev(): ResponseEntity<Ressurs<String>> {
-        return if (envService.erPreprod() || envService.erDev()) {
+        return if (envService.erPreprod() || envService.erDev() || envService.erE2E()) {
             scheduler.opprettTask()
             ResponseEntity.ok(Ressurs.success("Laget task."))
         } else {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Autobrev feilet ettersom default steg-sekvens ikke var riktig for automatisk autobrev, det har blitt fikset med en dedikert sekvens for autobrev.
I tillegg har api for å rigge autobrev manuelt fått ny uri.


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
E2E test som sjekkes inn i separat PR tester denne endringen.

### 🤷‍♀ ️Hvor er det lurt å starte?
Kjør E2E tester fra PR https://github.com/navikt/familie-ba-e2e/pull/56/files

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
