### PR TITLE
Oppdatere simulering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/VilkårsvurderingSteg.kt
@@ -58,7 +58,7 @@ class VilkårsvurderingSteg(
         if (behandling.skalBehandlesAutomatisk) {
             behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.IVERKSETTER_VEDTAK)
         } else {
-            if (toggleService.isEnabled("familie-ba-sak.simulering.bruk-simulering", false)) {
+            if (toggleService.isEnabled("familie-ba-sak.simulering.bruk-simulering")) {
                 val vedtak = vedtakService.hentAktivForBehandling(behandling.id)
                              ?: throw Feil("Fant ikke vedtak på behandling ${behandling.id}")
                 // TODO: SimuleringServiceTest må fikses.

--- a/src/main/kotlin/no/nav/familie/ba/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/simulering/SimuleringService.kt
@@ -46,7 +46,7 @@ class SimuleringService(
 
             return simuleringKlient.hentSimulering(utbetalingsoppdrag).body?.data
         } catch (feil: Throwable) {
-            throw Feil("Henting av simuleringsresultat feilet: ${feil.message}" )
+            throw Feil("Henting av simuleringsresultat feilet: ${feil.message}")
         }
     }
 
@@ -85,10 +85,10 @@ class SimuleringService(
     }
 
     private fun simuleringErUtdatert(simulering: RestVedtakSimulering) =
-            simulering.tidSimuleringHentet != null &&
-            simulering.forfallsdatoNestePeriode != null &&
-            simulering.tidSimuleringHentet < simulering.forfallsdatoNestePeriode &&
-            LocalDate.now() > simulering.forfallsdatoNestePeriode
+            simulering.tidSimuleringHentet == null
+            || (simulering.forfallsdatoNestePeriode != null
+                && simulering.tidSimuleringHentet < simulering.forfallsdatoNestePeriode
+                && LocalDate.now() > simulering.forfallsdatoNestePeriode)
 
     @Transactional
     fun oppdaterSimuleringPåVedtak(vedtak: Vedtak): List<VedtakSimuleringMottaker> {


### PR DESCRIPTION
Det skal egentlig ikke være mulig at `restSimulering.tidSimuleringHentet == null`, men side toggler var skrudd av backend og på frontend har man endt i denne situasjonen