### PR TITLE
Bugfix: Fritekst forsvinner ved underkjennelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/BehandlingService.kt
@@ -107,6 +107,7 @@ class BehandlingService(private val behandlingRepository: BehandlingRepository,
             nyttVedtak.settBegrunnelser(deaktivertVedtak.vedtakBegrunnelser.map { original ->
                 VedtakBegrunnelse(
                         begrunnelse = original.begrunnelse,
+                        brevBegrunnelse = original.brevBegrunnelse,
                         fom = original.fom,
                         tom = original.tom,
                         vilkårResultat = begrunnelseVilkårPekere.find { it.first == original.vilkårResultat }?.second,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
-Bugfix:[ Fritekst forsvinner ved underkjennelse](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4484)
- Kopier brevtekster ved underkjenning av vedtak, da fritekster ikke kan re-genereres som andre begrunnelsetekster

