### PR TITLE
BUG: Legger til eksplisitt httpHeaders funksjon for stsOnly klienten mot pdl.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/pdl/PdlRestClient.kt
@@ -250,22 +250,21 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
                    httpStatus = HttpStatus.NOT_FOUND)
     }
 
-    protected fun httpHeaders(): HttpHeaders {
+    private fun httpHeaders(): HttpHeaders {
         return HttpHeaders().apply {
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
             if (SikkerhetContext.erSystemKontekst() || featureToggleService.isEnabled(BRUK_NAV_CONSUMER_TOKEN_PDL, false)) {
                 add("Nav-Consumer-Token", "Bearer ${stsRestClient.systemOIDCToken}")
             }
-            add("Tema", TEMA)
-            secureLogger.info("Headere ved kall mot pdl: $this, ${this["Nav-Consumer-Token"]}, ${this["Authorization"]}")
+            add("Tema", PDL_TEMA)
         }
     }
 
     companion object {
 
         private const val PATH_GRAPHQL = "graphql"
-        private const val TEMA = "BAR"
+        const val PDL_TEMA = "BAR"
         private val logger = LoggerFactory.getLogger(PdlRestClient::class.java)
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I forbindelse med bugfix mot pdl for azure tokens ble det laget logikk for å fjerne nav-consumer-token. Dette var uheldig for stsOnly klienten.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke aktuelt

### 🤷‍♀ ️Hvor er det lurt å starte?
alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
