### PR TITLE
Ruller tilbake endringen hvor fult vedtak blir sendt inn til Simuleri…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/simulering/SimuleringService.kt
@@ -44,7 +44,6 @@ class SimuleringService(
                     vedtak = vedtak,
                     saksbehandlerId = SikkerhetContext.hentSaksbehandler().take(8),
                     skalOppdatereTilkjentYtelse = false,
-                    erKomplettUtbetalingsoppdrag = true,
             )
 
             if (utbetalingsoppdrag.utbetalingsperiode.isEmpty()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/økonomi/ØkonomiService.kt
@@ -73,7 +73,6 @@ class ØkonomiService(
             vedtak: Vedtak,
             saksbehandlerId: String,
             skalOppdatereTilkjentYtelse: Boolean = true,
-            erKomplettUtbetalingsoppdrag: Boolean = false
     ): Utbetalingsoppdrag {
         val oppdatertBehandling = vedtak.behandling
         val oppdatertTilstand = beregningService.hentAndelerTilkjentYtelseForBehandling(oppdatertBehandling.id)
@@ -83,7 +82,7 @@ class ØkonomiService(
                 beregningService.hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(oppdatertBehandling.fagsak.id).isEmpty()
 
 
-        return if (erFørsteIverksatteBehandlingPåFagsak || erKomplettUtbetalingsoppdrag) {
+        return if (erFørsteIverksatteBehandlingPåFagsak) {
             utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOpptaderTilkjentYtelse(
                     saksbehandlerId = saksbehandlerId,
                     vedtak = vedtak,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Commit 59ea956b rulles tilbake. Denne kom inn grunnet en misforståelse om hav økonomi trenger for å simulere et komplett simulering, derfor rulles denne endringen tilbake.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [-] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tilbakerulling som ikke påvirker eksisterende tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
