### PR TITLE
Ikke marker perioder som framtidig dersom de har en feilutbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/simulering/SimuleringUtil.kt
@@ -30,7 +30,7 @@ fun vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere: List
                 (it.tom > tidSimuleringHentet && it.forfallsdato > tidSimuleringHentet)
             }
 
-    val nestePeriode = framtidigePerioder.minByOrNull { it.fom }
+    val nestePeriode = framtidigePerioder.filter { it.feilutbetaling == BigDecimal.ZERO }.minByOrNull { it.fom }
 
     return RestSimulering(
             perioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere),


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ikke marker perioder som framtidig dersom de har en feilutbetaling



Den originale pren hadde en unsigned commit, så jeg prøver på nytt
https://github.com/navikt/familie-ba-sak/pull/1025