### PR TITLE
Søknad uten endring skal gi "ikke støttet"-feil i stedet for AVSLAG

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingsresultatService.kt
@@ -29,7 +29,7 @@ class BehandlingsresultatService(
         val forrigeTilkjentYtelse: TilkjentYtelse? =
                 forrigeBehandling?.let { beregningService.hentOptionalTilkjentYtelseForBehandling(behandlingId = it.id) }
 
-        val personerMedEksplisitteAvslag = vilkårsvurderingService.finnPersonerMedEksplisittAvslagPåBehandling(behandlingId)
+        val barnMedEksplisitteAvslag = vilkårsvurderingService.finnBarnMedEksplisittAvslagPåBehandling(behandlingId)
 
         val ytelsePersoner: List<YtelsePerson> =
                 if (behandling.opprettetÅrsak == BehandlingÅrsak.FØDSELSHENDELSE) {
@@ -39,14 +39,14 @@ class BehandlingsresultatService(
                     YtelsePersonUtils.utledKrav(
                             søknadDTO = søknadGrunnlagService.hentAktiv(behandlingId = behandlingId)?.hentSøknadDto(),
                             forrigeAndelerTilkjentYtelse = forrigeTilkjentYtelse?.andelerTilkjentYtelse?.toList() ?: emptyList(),
-                            personerMedEksplisitteAvslag = personerMedEksplisitteAvslag)
+                            barnMedEksplisitteAvslag = barnMedEksplisitteAvslag)
                 }
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.populerYtelsePersonerMedResultat(
                 ytelsePersoner = ytelsePersoner,
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.toList(),
                 forrigeAndelerTilkjentYtelse = forrigeTilkjentYtelse?.andelerTilkjentYtelse?.toList() ?: emptyList(),
-                personerMedEksplisitteAvslag = personerMedEksplisitteAvslag)
+                barnMedEksplisitteAvslag = barnMedEksplisitteAvslag)
 
         val behandlingsresultat =
                 BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(ytelsePersonerMedResultat)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingsresultatUtils.kt
@@ -56,7 +56,7 @@ object BehandlingsresultatUtils {
                 !personSøktFor.resultater.contains(YtelsePersonResultat.AVSLÅTT)
             }
             val resultaterPåSøknad = framstiltNå.flatMap { it.resultater }
-            val erAvslått = resultaterPåSøknad.all { it == YtelsePersonResultat.AVSLÅTT }
+            val erAvslått = resultaterPåSøknad.isNotEmpty() && resultaterPåSøknad.all { it == YtelsePersonResultat.AVSLÅTT }
             val erDelvisInnvilget =
                     (resultaterPåSøknad.any { it == YtelsePersonResultat.AVSLÅTT }) && resultaterPåSøknad.any { it == YtelsePersonResultat.INNVILGET }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePerson.kt
@@ -4,6 +4,14 @@ import no.nav.familie.ba.sak.beregning.domene.YtelseType
 import java.time.YearMonth
 import java.util.*
 
+/**
+ * Representer en person det er framstilt krav for nå eller tidligere
+ * @property personIdent Personens ident
+ * @property ytelseType Typen ytelse
+ * @property kravOpprinnelse Om krav for person er framstilt nå i søknad, ligger på behandling fra tidligere, eller begge deler
+ * @property resultater Hvilke konsekvenser _denne_ behandlingen har for personen
+ * @property ytelseSlutt Tom-dato på personens siste andel etter denne behandlingen (utbetalingsslutt)
+ */
 data class YtelsePerson(
         val personIdent: String,
         val ytelseType: YtelseType,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
@@ -41,7 +41,6 @@ object YtelsePersonUtils {
                             )
                         } ?: emptyList()
 
-
         val framstiltKravForNåEksplisitt =
                 tidligereAndelerMedEksplisittAvslag.map {
                     YtelsePerson(
@@ -50,6 +49,11 @@ object YtelsePersonUtils {
                             kravOpprinnelse = KravOpprinnelse.SØKNAD_OG_TIDLIGERE,
                     )
                 }
+
+        if (personerMedEksplisitteAvslag.any { person ->
+                    !framstiltKravForNåEksplisitt.map { it.personIdent }.contains(person)
+                    && !framstiltKravForNåViaSøknad.map { it.personIdent }.contains(person)
+                }) throw Feil("Person med eksplisitt avslag finnes ikke behandling fra tidligere eller søknad")
 
         val framstiltKravForNå: List<YtelsePerson> = framstiltKravForNåViaSøknad + framstiltKravForNåEksplisitt
 
@@ -112,9 +116,7 @@ object YtelsePersonUtils {
             val segmenterFjernet = forrigeAndelerTidslinje.disjoint(andelerTidslinje)
 
             val resultater = ytelsePerson.resultater.toMutableSet()
-            if (personerMedEksplisitteAvslag.contains(ytelsePerson.personIdent)
-                || finnesAvslag(personSomSjekkes = ytelsePerson,
-                                segmenterLagtTil = segmenterLagtTil)) {
+            if (personerMedEksplisitteAvslag.contains(ytelsePerson.personIdent)) {
                 resultater.add(YtelsePersonResultat.AVSLÅTT)
             }
             if (erYtelsenOpphørt(andeler = andeler) && (segmenterFjernet + segmenterLagtTil).isNotEmpty()) {
@@ -146,9 +148,6 @@ object YtelsePersonUtils {
             )
         }
     }
-
-    private fun finnesAvslag(personSomSjekkes: YtelsePerson, segmenterLagtTil: LocalDateTimeline<AndelTilkjentYtelse>) =
-            personSomSjekkes.erFramstiltKravForINåværendeBehandling() && segmenterLagtTil.isEmpty
 
     private fun finnesInnvilget(personSomSjekkes: YtelsePerson, segmenterLagtTil: LocalDateTimeline<AndelTilkjentYtelse>) =
             personSomSjekkes.erFramstiltKravForINåværendeBehandling() && !segmenterLagtTil.isEmpty

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
@@ -96,9 +96,7 @@ object YtelsePersonUtils {
             }
 
     /**
-     * Utleder krav for personer framstilt nå eller tidligere.
-     * Disse populeres med behandlingens utfall for enkeltpersonene (YtelsePerson),
-     * som igjen brukes for å utlede det totale BehandlingResultat.
+     * Utleder hvilke konsekvenser _denne_ behandlingen har for personen og populerer "resultater" med utfallet.
      *
      * @param [ytelsePersoner] Personer framstilt krav for nå og/eller tidligere
      * @param [forrigeAndelerTilkjentYtelse] Eventuelle tilstand etter forrige behandling

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
@@ -18,12 +18,12 @@ object YtelsePersonUtils {
      */
     fun utledKrav(søknadDTO: SøknadDTO?,
                   forrigeAndelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-                  personerMedEksplisitteAvslag: List<String> = emptyList()): List<YtelsePerson> {
+                  barnMedEksplisitteAvslag: List<String> = emptyList()): List<YtelsePerson> {
 
         val (tidligereAndelerMedEksplisittAvslag, tidligereAndeler)
                 = forrigeAndelerTilkjentYtelse
                 .distinctBy { Pair(it.personIdent, it.type) }
-                .partition { personerMedEksplisitteAvslag.contains(it.personIdent) }
+                .partition { barnMedEksplisitteAvslag.contains(it.personIdent) }
 
         val framstiltKravForNåViaSøknad =
                 søknadDTO?.barnaMedOpplysninger
@@ -51,7 +51,7 @@ object YtelsePersonUtils {
                     )
                 }
 
-        if (personerMedEksplisitteAvslag.any { person ->
+        if (barnMedEksplisitteAvslag.any { person ->
                     !framstiltKravForNåEksplisitt.map { it.personIdent }.contains(person)
                     && !framstiltKravForNåViaSøknad.map { it.personIdent }.contains(person)
                 }) throw Feil("Person med eksplisitt avslag finnes ikke behandling fra tidligere eller søknad")
@@ -92,7 +92,7 @@ object YtelsePersonUtils {
     fun populerYtelsePersonerMedResultat(ytelsePersoner: List<YtelsePerson>,
                                          forrigeAndelerTilkjentYtelse: List<AndelTilkjentYtelse>,
                                          andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-                                         personerMedEksplisitteAvslag: List<String> = emptyList()): List<YtelsePerson> {
+                                         barnMedEksplisitteAvslag: List<String> = emptyList()): List<YtelsePerson> {
         return ytelsePersoner.map { ytelsePerson: YtelsePerson ->
             val andeler = andelerTilkjentYtelse.filter { andel -> andel.personIdent == ytelsePerson.personIdent }
             val forrigeAndeler =
@@ -117,7 +117,7 @@ object YtelsePersonUtils {
             val segmenterFjernet = forrigeAndelerTidslinje.disjoint(andelerTidslinje)
 
             val resultater = ytelsePerson.resultater.toMutableSet()
-            if (personerMedEksplisitteAvslag.contains(ytelsePerson.personIdent)
+            if (barnMedEksplisitteAvslag.contains(ytelsePerson.personIdent)
                 || avslagPåNyPerson(personSomSjekkes = ytelsePerson,
                                     segmenterLagtTil = segmenterLagtTil)) {
                 resultater.add(YtelsePersonResultat.AVSLÅTT)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
@@ -41,6 +41,7 @@ object YtelsePersonUtils {
                             )
                         } ?: emptyList()
 
+
         val framstiltKravForNåEksplisitt =
                 tidligereAndelerMedEksplisittAvslag.map {
                     YtelsePerson(
@@ -116,7 +117,9 @@ object YtelsePersonUtils {
             val segmenterFjernet = forrigeAndelerTidslinje.disjoint(andelerTidslinje)
 
             val resultater = ytelsePerson.resultater.toMutableSet()
-            if (personerMedEksplisitteAvslag.contains(ytelsePerson.personIdent)) {
+            if (personerMedEksplisitteAvslag.contains(ytelsePerson.personIdent)
+                || avslagPåNyPerson(personSomSjekkes = ytelsePerson,
+                                    segmenterLagtTil = segmenterLagtTil)) {
                 resultater.add(YtelsePersonResultat.AVSLÅTT)
             }
             if (erYtelsenOpphørt(andeler = andeler) && (segmenterFjernet + segmenterLagtTil).isNotEmpty()) {
@@ -148,6 +151,9 @@ object YtelsePersonUtils {
             )
         }
     }
+
+    private fun avslagPåNyPerson(personSomSjekkes: YtelsePerson, segmenterLagtTil: LocalDateTimeline<AndelTilkjentYtelse>) =
+            personSomSjekkes.kravOpprinnelse == KravOpprinnelse.SØKNAD && segmenterLagtTil.isEmpty
 
     private fun finnesInnvilget(personSomSjekkes: YtelsePerson, segmenterLagtTil: LocalDateTimeline<AndelTilkjentYtelse>) =
             personSomSjekkes.erFramstiltKravForINåværendeBehandling() && !segmenterLagtTil.isEmpty

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtils.kt
@@ -12,9 +12,15 @@ import java.time.YearMonth
 object YtelsePersonUtils {
 
     /**
-     * Metode for å utlede kravene for å utlede behandlingsresultat per krav.
-     * Metoden finner kravene som ble stilt i søknaden,
-     * samt ytelsestypene per person fra forrige behandling.
+     * Utleder krav for personer framstilt nå og/eller tidligere.
+     * Disse populeres med behandlingens utfall for enkeltpersonene (YtelsePerson),
+     * som igjen brukes for å utlede det totale BehandlingResultat.
+     *
+     * @param [søknadDTO] Eventuell søknad som trigget denne behandlingen
+     * @param [forrigeAndelerTilkjentYtelse] Eventuelle andeler fra forrige behandling
+     * @param [forrigeAndelerTilkjentYtelse] Eventuelle andeler fra forrige behandling
+     * @param [barnMedEksplisitteAvslag] Avslåtte barn søker har bedt om noe for, men ikke søkt for
+     * @return Liste med informasjon om hvordan hver enkelt person påvirkes i behandlingen (se YtelsePerson-doc)
      */
     fun utledKrav(søknadDTO: SøknadDTO?,
                   forrigeAndelerTilkjentYtelse: List<AndelTilkjentYtelse>,
@@ -54,7 +60,7 @@ object YtelsePersonUtils {
         if (barnMedEksplisitteAvslag.any { person ->
                     !framstiltKravForNåEksplisitt.map { it.personIdent }.contains(person)
                     && !framstiltKravForNåViaSøknad.map { it.personIdent }.contains(person)
-                }) throw Feil("Person med eksplisitt avslag finnes ikke behandling fra tidligere eller søknad")
+                }) throw Feil("Barn med eksplisitt avslag finnes ikke behandling fra tidligere eller søknad")
 
         val framstiltKravForNå: List<YtelsePerson> = framstiltKravForNåViaSøknad + framstiltKravForNåEksplisitt
 
@@ -89,6 +95,17 @@ object YtelsePersonUtils {
                 )
             }
 
+    /**
+     * Utleder krav for personer framstilt nå eller tidligere.
+     * Disse populeres med behandlingens utfall for enkeltpersonene (YtelsePerson),
+     * som igjen brukes for å utlede det totale BehandlingResultat.
+     *
+     * @param [ytelsePersoner] Personer framstilt krav for nå og/eller tidligere
+     * @param [forrigeAndelerTilkjentYtelse] Eventuelle tilstand etter forrige behandling
+     * @param [andelerTilkjentYtelse] Tilstand etter nåværende behandling
+     * @param [barnMedEksplisitteAvslag] Avslåtte barn søker har bedt om noe for, men ikke søkt for
+     * @return Personer populert med utfall (resultater) etter denne behandlingen
+     */
     fun populerYtelsePersonerMedResultat(ytelsePersoner: List<YtelsePerson>,
                                          forrigeAndelerTilkjentYtelse: List<AndelTilkjentYtelse>,
                                          andelerTilkjentYtelse: List<AndelTilkjentYtelse>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/PersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/PersonResultat.kt
@@ -93,7 +93,7 @@ class PersonResultat(
                 vilkårResultater.map { it.kopierMedParent(nyttPersonResultat) }.toSortedSet(VilkårResultatComparator)
         nyttPersonResultat.setSortedVilkårResultater(kopierteVilkårResultater)
 
-        if(inkluderAndreVurderinger) {
+        if (inkluderAndreVurderinger) {
             val kopierteAndreVurderinger: MutableSet<AnnenVurdering> =
                     andreVurderinger.map { it.kopierMedParent(nyttPersonResultat) }.toMutableSet()
 
@@ -101,4 +101,6 @@ class PersonResultat(
         }
         return nyttPersonResultat
     }
+
+    fun erSøkersResultater() = vilkårResultater.none { it.vilkårType == Vilkår.UNDER_18_ÅR }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vilkår/VilkårsvurderingService.kt
@@ -20,9 +20,14 @@ class VilkårsvurderingService(private val vilkårsvurderingRepository: Vilkårs
         return vilkårsvurderingRepository.finnBehandlingResultater(behandlingId = behandlingId)
     }
 
-    fun finnPersonerMedEksplisittAvslagPåBehandling(behandlingId: Long): List<String> {
+    fun finnBarnMedEksplisittAvslagPåBehandling(behandlingId: Long): List<String> {
         val eksplisistteAvslagPåBehandling = hentEksplisitteAvslagPåBehandling(behandlingId)
-        return eksplisistteAvslagPåBehandling.map { it.personResultat!!.personIdent }.distinct()
+        return eksplisistteAvslagPåBehandling
+                .filterNot {
+                    it.personResultat?.erSøkersResultater() ?: error("VilkårResultat mangler kobling til PersonResultat")
+                }
+                .map { it.personResultat!!.personIdent }
+                .distinct()
     }
 
     private fun hentEksplisitteAvslagPåBehandling(behandlingId: Long): List<VilkårResultat> {

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingResultatMedSøknadTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/BehandlingResultatMedSøknadTest.kt
@@ -5,8 +5,10 @@ import no.nav.familie.ba.sak.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.common.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class BehandlingResultatMedSøknadTest {
+
     val søker = tilfeldigPerson()
 
     val barn1Ident = randomFnr()
@@ -361,29 +363,6 @@ class BehandlingResultatMedSøknadTest {
     }
 
     @Test
-    fun `AVSLÅTT - søknad uten endringer på løpende behandling gir avslått (fortsatt innvilget)`() {
-        val behandlingsresultat = BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(
-                listOf(
-                        YtelsePerson(
-                                personIdent = barn1Ident,
-                                ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                                kravOpprinnelse = KravOpprinnelse.TIDLIGERE,
-                                resultater = setOf(),
-                                ytelseSlutt = defaultYtelseSluttForLøpende
-                        ),
-                        YtelsePerson(
-                                personIdent = barn2Ident,
-                                ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                                kravOpprinnelse = KravOpprinnelse.SØKNAD,
-                                resultater = setOf(),
-                                ytelseSlutt = defaultYtelseSluttForLøpende
-                        ),
-                )
-        )
-        assertEquals(BehandlingResultat.AVSLÅTT, behandlingsresultat)
-    }
-
-    @Test
     fun `AVSLÅTT_OG_OPPHØRT - revurdering vurderes til avslått og opphørt`() {
         val behandlingsresultat = BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(
                 listOf(
@@ -450,5 +429,22 @@ class BehandlingResultatMedSøknadTest {
                 )
         )
         assertEquals(BehandlingResultat.AVSLÅTT_ENDRET_OG_OPPHØRT, behandlingsresultat)
+    }
+
+    @Test
+    fun `SØKNAD UTEN ENDRING - søknad uten endringer på løpende behandling gir kaster feil (fortsatt innvilget)`() {
+        assertThrows<Feil> {
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(
+                    listOf(
+                            YtelsePerson(
+                                    personIdent = barn1Ident,
+                                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                                    kravOpprinnelse = KravOpprinnelse.SØKNAD_OG_TIDLIGERE,
+                                    resultater = setOf(),
+                                    ytelseSlutt = inneværendeMåned()
+                            ),
+                    )
+            )
+        }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonResultatTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonResultatTest.kt
@@ -260,6 +260,7 @@ class YtelsePersonResultatTest {
                         personIdent = barn1.personIdent.ident,
                         ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
                         kravOpprinnelse = KravOpprinnelse.SØKNAD,
+                        resultater = setOf(YtelsePersonResultat.AVSLÅTT)
                 ),
         )
 
@@ -290,6 +291,7 @@ class YtelsePersonResultatTest {
                         personIdent = barn2.personIdent.ident,
                         ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
                         kravOpprinnelse = KravOpprinnelse.SØKNAD,
+                        resultater = setOf(YtelsePersonResultat.AVSLÅTT)
                 )
         )
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtilsTest.kt
@@ -142,7 +142,7 @@ class YtelsePersonUtilsTest {
             YtelsePersonUtils.utledKrav(
                     søknadDTO = søknadDTO,
                     forrigeAndelerTilkjentYtelse = emptyList(),
-                    personerMedEksplisitteAvslag = listOf(barn1.personIdent.ident)
+                    barnMedEksplisitteAvslag = listOf(barn1.personIdent.ident)
             )
         }
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/resultat/YtelsePersonUtilsTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.behandling.resultat
 
 import no.nav.familie.ba.sak.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.inneværendeMåned
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagSøknadDTO
@@ -9,11 +10,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class YtelsePersonUtilsTest {
 
     val søker = tilfeldigPerson()
     val barn1 = tilfeldigPerson()
+    val barn2 = tilfeldigPerson()
 
     @Test
     fun `Skal kun finne søknadsytelsePersoner`() {
@@ -103,5 +106,44 @@ class YtelsePersonUtilsTest {
         assertEquals(2, ytelsePersoner.size)
         assertTrue(ytelsePersoner.any { it.personIdent == barn1.personIdent.ident && it.ytelseType == YtelseType.ORDINÆR_BARNETRYGD && it.erFramstiltKravForINåværendeBehandling() })
         assertTrue(ytelsePersoner.any { it.personIdent == barn1.personIdent.ident && it.ytelseType == YtelseType.UTVIDET_BARNETRYGD && !it.erFramstiltKravForINåværendeBehandling() })
+    }
+
+    @Test
+    fun `Skal utlede krav for person som ikke finnes i søknad, men har andeler fra tidligere`() {
+        val søknadDTO = lagSøknadDTO(
+                søkerIdent = søker.personIdent.ident,
+                barnasIdenter = listOf(barn2.personIdent.ident)
+        )
+
+        val forrigeAndelBarn1 = lagAndelTilkjentYtelse(inneværendeMåned().minusYears(3).toString(),
+                                                       "2020-01",
+                                                       YtelseType.ORDINÆR_BARNETRYGD,
+                                                       1054,
+                                                       person = barn1)
+
+        val ytelsePersoner = YtelsePersonUtils.utledKrav(
+                søknadDTO = søknadDTO,
+                forrigeAndelerTilkjentYtelse = listOf(forrigeAndelBarn1),
+        )
+
+        assertEquals(2, ytelsePersoner.size)
+        assertTrue(ytelsePersoner.any { it.personIdent == barn1.personIdent.ident && it.kravOpprinnelse == KravOpprinnelse.TIDLIGERE && !it.erFramstiltKravForINåværendeBehandling() })
+        assertTrue(ytelsePersoner.any { it.personIdent == barn2.personIdent.ident && it.kravOpprinnelse == KravOpprinnelse.SØKNAD && it.erFramstiltKravForINåværendeBehandling() })
+    }
+
+    @Test
+    fun `Skal kaste feil dersom det finnes eksplisitt avslåtte personer som hverken finnes i søknad eller har andeler fra tidligere`() {
+        val søknadDTO = lagSøknadDTO(
+                søkerIdent = søker.personIdent.ident,
+                barnasIdenter = listOf(barn2.personIdent.ident)
+        )
+
+        assertThrows<Feil> {
+            YtelsePersonUtils.utledKrav(
+                    søknadDTO = søknadDTO,
+                    forrigeAndelerTilkjentYtelse = emptyList(),
+                    personerMedEksplisitteAvslag = listOf(barn1.personIdent.ident)
+            )
+        }
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4674
Søknad uten endring skal kunne gi et eget resultat som ikke er støttet enda, da det kan hende bruker søker om akkurat det man har fått tidligere. I disse tilfellene blir det feil å gi avslag.

Gir nå:
![Skjermbilde 2021-05-11 kl  18 09 02](https://user-images.githubusercontent.com/5719550/117848898-0d177380-b284-11eb-883d-c2d3fdd0b6a4.png)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
- Endringen i [disse to testene ](https://github.com/navikt/familie-ba-sak/compare/feature/h%C3%A5ndtering-fortsatt-innvilget?expand=1#diff-259a01501a7f7a63e82f7f8c6ac965969e923cccdfdc45fd03e4ac8ef1e9d5edL363-L454)gjenspeiler den funksjonelle endringen
- Fikk en feil i e2e og gjorde en oppdatering [her](https://github.com/navikt/familie-ba-sak/pull/1039/commits/09f4d61d1b533d68f3b6b7e3180586367a106086) som kan være greit å se på isolert 
 
### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
