### PR TITLE
Lagre flere registeropplysninger ved manuell behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -108,7 +108,6 @@ class PersongrunnlagService(
                 søker.opphold = oppholdService.hentOpphold(søker)
             }
         } else if (!behandling.erMigrering() && brukRegisteropplysningerIManuellBehandling) {
-            logger.info("Bruker registeropplysninger i manuell behandling")
             personopplysningGrunnlag.personer.forEach {
                 it.statsborgerskap = statsborgerskapService.hentStatsborgerskapMedMedlemskapOgHistorikk(Ident(fødselsnummer), it)
                 it.bostedsadresseperiode = personopplysningerService.hentBostedsadresseperioder(it.personIdent.ident)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -68,8 +68,11 @@ class PersongrunnlagService(
                                                      målform: Målform) {
         val brukRegisterOpplysninger = true //TODO: Legg til toggle
         if (brukRegisterOpplysninger) {
+            logger.info("Bruker v2 lagreSøkerOgBarnIPersonopplysningsgrunnlaget")
             lagreSøkerOgBarnIPersonopplysningsgrunnlagetV2(fødselsnummer, barnasFødselsnummer, behandling, målform)
         } else {
+
+            logger.info("Bruker v1 lagreSøkerOgBarnIPersonopplysningsgrunnlaget")
             lagreSøkerOgBarnIPersonopplysningsgrunnlagetV1(fødselsnummer, barnasFødselsnummer, behandling, målform)
         }
     }
@@ -168,6 +171,7 @@ class PersongrunnlagService(
                 søker.opphold = oppholdService.hentOpphold(søker)
             }
         } else if (!behandling.erMigrering()) {
+            logger.info("Lagrer ekstra data for personer")
             personopplysningGrunnlag.personer.forEach {
                 it.statsborgerskap = statsborgerskapService.hentStatsborgerskapMedMedlemskapOgHistorikk(Ident(fødselsnummer), it)
                 it.bostedsadresseperiode =

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -95,6 +95,7 @@ class FeatureToggleConfig(private val enabled: Boolean,
         const val BRUK_NAV_CONSUMER_TOKEN_PDL = "familie-ba-sak.sikkerhet.nav-consumer-token-pdl"
         const val TILBAKEKREVING = "familie-ba-sak.behandling.tilbakekreving"
         const val BRUK_SIMULERING = "familie-ba-sak.simulering.bruk-simulering"
+        const val BRUK_REGISTEROPPLYSNINGER = "familie-ba-sak.behandling.bruk-registeropplysninger"
 
         private val logger = LoggerFactory.getLogger(FeatureToggleConfig::class.java)
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
@@ -9,9 +9,11 @@ import no.nav.familie.ba.sak.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakService
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.GrBostedsadresseperiode
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.restDomene.RestRegistrerSøknad
 import no.nav.familie.ba.sak.behandling.steg.StegService
+import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.lagSøknadDTO
@@ -26,7 +28,10 @@ import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Ident
+import no.nav.familie.kontrakter.felles.personopplysning.OPPHOLDSTILLATELSE
+import no.nav.familie.kontrakter.felles.personopplysning.Opphold
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
+import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -340,6 +345,19 @@ class ArbeidsfordelingMockConfiguration {
         } answers {
             AktørId(id = "0${hentAktørIdIdentSlot.captured.ident}")
         }
+
+        every { personopplysningerServiceMock.hentStatsborgerskap(any()) } returns listOf(Statsborgerskap(land = "NOR",
+                                                                                                          LocalDate.now(),
+                                                                                                          LocalDate.now()))
+
+        every { personopplysningerServiceMock.hentBostedsadresseperioder(any()) } returns listOf(GrBostedsadresseperiode(0,
+                                                                                                                         DatoIntervallEntitet(
+                                                                                                                                 LocalDate.now(),
+                                                                                                                                 LocalDate.now())))
+
+        every { personopplysningerServiceMock.hentOpphold(any()) } returns listOf(Opphold(OPPHOLDSTILLATELSE.PERMANENT,
+                                                                                          LocalDate.now(),
+                                                                                          LocalDate.now()))
 
         return personopplysningerServiceMock
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseIntegrasjonTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.behandling.fødselshendelse.MockConfiguration.Companion.barnefnr
 import no.nav.familie.ba.sak.behandling.fødselshendelse.MockConfiguration.Companion.morsfnr
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.GrBostedsadresseperiode
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.behandling.steg.StegService
@@ -20,6 +21,7 @@ import no.nav.familie.ba.sak.behandling.vilkår.VilkårsvurderingRepository
 import no.nav.familie.ba.sak.beregning.SatsService
 import no.nav.familie.ba.sak.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.beregning.domene.SatsType
+import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.Feil
@@ -68,7 +70,12 @@ import java.time.YearMonth
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(initializers = [DbContainerInitializer::class])
-@ActiveProfiles("postgres", "mock-brev-klient", "mock-oauth", "mock-pdl-flere-barn", "mock-task-repository", "mock-infotrygd-barnetrygd")
+@ActiveProfiles("postgres",
+                "mock-brev-klient",
+                "mock-oauth",
+                "mock-pdl-flere-barn",
+                "mock-task-repository",
+                "mock-infotrygd-barnetrygd")
 @Tag("integration")
 class FødselshendelseIntegrasjonTest(
         @Autowired
@@ -359,6 +366,19 @@ class MockConfiguration {
         every {
             personopplysningerServiceMock.hentVergeData(any())
         } returns VergeData(false)
+
+        every { personopplysningerServiceMock.hentStatsborgerskap(any()) } returns listOf(Statsborgerskap(land = "NOR",
+                                                                                                          LocalDate.now(),
+                                                                                                          LocalDate.now()))
+
+        every { personopplysningerServiceMock.hentBostedsadresseperioder(any()) } returns listOf(GrBostedsadresseperiode(0,
+                                                                                                                         DatoIntervallEntitet(
+                                                                                                                                 LocalDate.now(),
+                                                                                                                                 LocalDate.now())))
+
+        every { personopplysningerServiceMock.hentOpphold(any()) } returns listOf(Opphold(OPPHOLDSTILLATELSE.PERMANENT,
+                                                                                          LocalDate.now(),
+                                                                                          LocalDate.now()))
 
         return personopplysningerServiceMock
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseIntegrasjonTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.behandling.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.behandling.fødselshendelse.MockConfiguration.Companion.barnefnr
 import no.nav.familie.ba.sak.behandling.fødselshendelse.MockConfiguration.Companion.morsfnr
-import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.GrBostedsadresseperiode
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.behandling.steg.StegService
@@ -21,7 +20,6 @@ import no.nav.familie.ba.sak.behandling.vilkår.VilkårsvurderingRepository
 import no.nav.familie.ba.sak.beregning.SatsService
 import no.nav.familie.ba.sak.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.beregning.domene.SatsType
-import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.Feil
@@ -367,18 +365,13 @@ class MockConfiguration {
             personopplysningerServiceMock.hentVergeData(any())
         } returns VergeData(false)
 
-        every { personopplysningerServiceMock.hentStatsborgerskap(any()) } returns listOf(Statsborgerskap(land = "NOR",
-                                                                                                          LocalDate.now(),
-                                                                                                          LocalDate.now()))
+        every {
+            personopplysningerServiceMock.hentStatsborgerskap(match { barnefnr.contains(it.ident) })
+        } returns listOf(Statsborgerskap(land = "NOR", gyldigFraOgMed = null, gyldigTilOgMed = null))
 
-        every { personopplysningerServiceMock.hentBostedsadresseperioder(any()) } returns listOf(GrBostedsadresseperiode(0,
-                                                                                                                         DatoIntervallEntitet(
-                                                                                                                                 LocalDate.now(),
-                                                                                                                                 LocalDate.now())))
-
-        every { personopplysningerServiceMock.hentOpphold(any()) } returns listOf(Opphold(OPPHOLDSTILLATELSE.PERMANENT,
-                                                                                          LocalDate.now(),
-                                                                                          LocalDate.now()))
+        every {
+            personopplysningerServiceMock.hentOpphold(match { barnefnr.contains(it) })
+        } returns listOf(Opphold(OPPHOLDSTILLATELSE.PERMANENT, null, null))
 
         return personopplysningerServiceMock
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/GDPRInnhentingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/vilkår/GDPRInnhentingTest.kt
@@ -152,7 +152,8 @@ class GDPRInnhentingTest(
     }
 
     /**
-     * Manuell saksbehandling, skal ikke hente noe ekstra informasjon
+     * Manuell saksbehandling, henter bosted, opphold og statsborgerskap for søker
+     * Data for barn hentes først ved valgt barn i registrer søknad
      */
     @Test
     fun `Manuell saksbehandling`() {
@@ -167,28 +168,23 @@ class GDPRInnhentingTest(
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING
         ))
 
-        verify(exactly = 0) {
+
+        verify(exactly = 1) {
             personopplysningerService.hentBostedsadresseperioder(GDPRMockConfiguration.morsfnr[4])
             personopplysningerService.hentOpphold(GDPRMockConfiguration.morsfnr[4])
             personopplysningerService.hentStatsborgerskap(Ident(GDPRMockConfiguration.morsfnr[4]))
+        }
+
+        verify(exactly = 0) {
             integrasjonClient.hentArbeidsforhold(GDPRMockConfiguration.morsfnr[4], any())
+
+            personopplysningerService.hentBostedsadresseperioder(GDPRMockConfiguration.barnefnr[4])
+            personopplysningerService.hentOpphold(GDPRMockConfiguration.barnefnr[4])
+            personopplysningerService.hentStatsborgerskap(Ident(GDPRMockConfiguration.barnefnr[4]))
+            integrasjonClient.hentArbeidsforhold(GDPRMockConfiguration.barnefnr[4], any())
         }
     }
-
-    fun mapTilFaktaTilFiltrering(faktaTilFiltrering: String): SubsetFaktaTilFiltreringForTest = objectMapper.readValue(
-            faktaTilFiltrering)
-
-    fun mapTilFaktaTilVilkårsvurdering(faktaTilVilkårsvurdering: String): SubsetFaktaTilVilkårsvurderingForTest = objectMapper.readValue(
-            faktaTilVilkårsvurdering)
 }
-
-data class SubsetFaktaTilFiltreringForTest(val mor: SubsetAvPersonForTest)
-
-data class SubsetFaktaTilVilkårsvurderingForTest(val personForVurdering: SubsetAvPersonForTest)
-
-data class SubsetAvPersonForTest(
-        val personIdent: PersonIdent,
-)
 
 @Configuration
 class GDPRMockConfiguration {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Første del av støtte for skjønnsmessig vurdering, hvor fakta som fravikes skal lagres.
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4790

Denne oppgaven utvider lagring av registeropplysninger ved manuell behandling. I neste ledd vil mer data bli inkludert her.

### 🔎️ Er det noe spesielt du ønsker å fremheve?

 **Tilpassede PDL-requests vs flere kall:** Vi vurderer å lage tilpassede pdl-requests for de ulike databehovene, framfor å gjøre flere kall og "fylle på" med f.eks historikk og statsborgerksap i etterkant. Samtidig husker vi at man ved automatiske behandlinger ønska å hente litt etter litt ved behov underveis i behandlingen, så mulig nåværende løsning er mest hensiktsmessig? 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
