### PR TITLE
override shouldNotFilter for path "/internal"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/BisysConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/BisysConfig.kt
@@ -29,5 +29,7 @@ class BisysConfig(private val oidcUtil: OIDCUtil,
                 filterChain.doFilter(request, response)
             }
         }
+
+        override fun shouldNotFilter(request: HttpServletRequest) = request.requestURI.startsWith("/internal")
     }
 }


### PR DESCRIPTION
Forrige PR  automerget selv om deploy gikk rødt.