### PR TITLE
Fiks for MigreringServiceTest-tester

### DIFF
--- a/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/behandling/fødselshendelse/FødselshendelseServiceTest.kt
@@ -137,6 +137,8 @@ class FødselshendelseServiceTest {
 
         verify(exactly = 1) { IverksettMotOppdragTask.opprettTask(any(), any(), any()) }
         verify { OpprettOppgaveTask.opprettTask(any(), any(), any()) wasNot called }
+
+        uninitMockk()
     }
 
 
@@ -150,6 +152,8 @@ class FødselshendelseServiceTest {
 
         verify(exactly = 1) { OpprettOppgaveTask.opprettTask(any(), any(), any()) }
         verify { IverksettMotOppdragTask.opprettTask(any(), any(), any()) wasNot called }
+
+        uninitMockk()
     }
 
     @Test
@@ -163,6 +167,8 @@ class FødselshendelseServiceTest {
         }
         verify { IverksettMotOppdragTask.opprettTask(any(), any(), any()) wasNot called }
         verify { OpprettOppgaveTask.opprettTask(any(), any(), any()) wasNot called }
+
+        uninitMockk()
     }
 
     @Test
@@ -176,6 +182,8 @@ class FødselshendelseServiceTest {
         verify(exactly = 0) { stegServiceMock.evaluerVilkårForFødselshendelse(any(), any()) }
         verify(exactly = 1) { OpprettOppgaveTask.opprettTask(any(), any(), any()) }
         verify { IverksettMotOppdragTask.opprettTask(any(), any(), any()) wasNot called }
+
+        uninitMockk()
     }
 
     @Test
@@ -189,6 +197,8 @@ class FødselshendelseServiceTest {
 
         verify(exactly = 1) { IverksettMotOppdragTask.opprettTask(any(), any(), any()) }
         verify { OpprettOppgaveTask.opprettTask(any(), any(), any()) wasNot called }
+
+        uninitMockk()
     }
 
     private fun initMockk(behandlingResultat: BehandlingResultat,
@@ -258,6 +268,11 @@ class FødselshendelseServiceTest {
 
         mockkObject(OpprettOppgaveTask.Companion)
         every { OpprettOppgaveTask.opprettTask(any(), any(), any()) } returns opprettOppgaveTask
+    }
+
+    fun uninitMockk() {
+        unmockkObject(IverksettMotOppdragTask.Companion)
+        unmockkObject(OpprettOppgaveTask.Companion)
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/infotrygd/MigreringServiceTest.kt
@@ -87,7 +87,6 @@ class MigreringServiceTest {
         every { infotrygdBarnetrygdClient.harÅpenSakIInfotrygd(any(), any()) } returns false
     }
 
-    @Disabled
     @Test
     fun `migrering happy case`() {
         every {
@@ -127,7 +126,6 @@ class MigreringServiceTest {
         }
     }
 
-    @Disabled
     @Test
     fun`skal sette periodeFom til barnas fødselsdatoer på vilkårene som skal gjelde fra fødselsdato`() {
         every {
@@ -143,7 +141,6 @@ class MigreringServiceTest {
                 .hasSameElementsAs(barnasFødselsdatoer)
     }
 
-    @Disabled
     @Test
     fun `migrering skal feile dersom migrering av person allerede er påbegynt`() {
         every {
@@ -157,7 +154,6 @@ class MigreringServiceTest {
         }.hasMessageContaining("allerede påbegynt")
     }
 
-    @Disabled
     @Test
     fun `migrering skal feile dersom personen allerede er migrert`() {
         run { `migrering happy case`() }
@@ -248,7 +244,6 @@ class MigreringServiceTest {
         }
     }
 
-    @Disabled
     @Test
     fun `fagsak og saksstatistikk mellomlagring skal rulles tilbake når migrering feiler`() {
         every { infotrygdBarnetrygdClient.hentSaker(any(), any()) } returns
@@ -273,7 +268,6 @@ class MigreringServiceTest {
                 }
     }
 
-    @Disabled
     @Test
     fun `innhold i meldinger til saksstatistikk ved migrering`() {
         run { `migrering happy case`() }


### PR DESCRIPTION
Fiksen består i å unmocke den statiske IverksettMotOppdragTask.opprettTask, som er mocket i FødselhendelseServiceTest.

Testrekkefølgen ble endret de siste dagene på Github Actions, som førte til at FødselhendelseServiceTest ble kjørt før MigreringServiceTest, som krever en umocket variant av IverksettMotOppdragTask.opprettTask.
