### PR TITLE
Returner registeropplysninger på fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakController.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ba.sak.behandling.restDomene.RestPågåendeSakResponse
 import no.nav.familie.ba.sak.behandling.restDomene.RestSøkParam
 import no.nav.familie.ba.sak.behandling.steg.BehandlerRolle
 import no.nav.familie.ba.sak.behandling.steg.StegService
-import no.nav.familie.ba.sak.behandling.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.RessursUtils
@@ -21,7 +20,6 @@ import no.nav.familie.ba.sak.personopplysninger.domene.PersonIdent
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.ba.sak.tilbakekreving.TilbakekrevingKlient
-import no.nav.familie.ba.sak.validering.FagsaktilgangConstraint
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
@@ -64,7 +62,7 @@ class FagsakController(
     }
 
     @GetMapping(path = ["/{fagsakId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun hentFagsak(@PathVariable @FagsaktilgangConstraint fagsakId: Long): ResponseEntity<Ressurs<RestFagsak>> {
+    fun hentFagsak(@PathVariable fagsakId: Long): ResponseEntity<Ressurs<RestFagsak>> {
         logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} henter fagsak med id $fagsakId")
 
         val fagsak = fagsakService.hentRestFagsak(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersonController.kt
@@ -59,4 +59,3 @@ class PersonController(private val personopplysningerService: Personopplysninger
                 )
     }
 }
-// TODO: Må expande til frontend

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -109,7 +109,7 @@ class PersongrunnlagService(
         personopplysningGrunnlag.personer.addAll(hentBarn(barnasFødselsnummer, personopplysningGrunnlag))
 
         val brukRegisteropplysningerIManuellBehandling =
-                featureToggleService.isEnabled(FeatureToggleConfig.BRUK_REGISTEROPPLYSNINGER)
+                featureToggleService.isEnabled(FeatureToggleConfig.SKJØNNSMESSIGVURDERING)
 
         if (behandling.skalBehandlesAutomatisk && !behandling.erMigrering()) {
             søker.also {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
@@ -32,6 +32,8 @@ abstract class GrBostedsadresse(
 
     abstract fun toSecureString(): String
 
+    abstract fun tilFrontendString(): String
+
     companion object {
 
         fun fraBostedsadresse(bostedsadresse: Bostedsadresse, person: Person): GrBostedsadresse {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
@@ -37,8 +37,7 @@ abstract class GrBostedsadresse(
 
     fun tilRestRegisteropplysning() = RestRegisteropplysning(fom = this.periode?.fom,
                                                              tom = this.periode?.tom,
-                                                             verdi = this.tilFrontendString(),
-                                                             hentetTidspunkt = this.opprettetTidspunkt)
+                                                             verdi = this.tilFrontendString())
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.bostedsadre
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.behandling.restDomene.RestRegisterOpplysning
+import no.nav.familie.ba.sak.behandling.restDomene.RestRegisteropplysning
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.Feil
@@ -35,7 +35,7 @@ abstract class GrBostedsadresse(
 
     abstract fun tilFrontendString(): String
 
-    fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.periode?.fom,
+    fun tilRestRegisteropplysning() = RestRegisteropplysning(fom = this.periode?.fom,
                                                              tom = this.periode?.tom,
                                                              verdi = this.tilFrontendString(),
                                                              hentetTidspunkt = this.opprettetTidspunkt)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
@@ -37,7 +37,8 @@ abstract class GrBostedsadresse(
 
     fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.periode?.fom,
                                                              tom = this.periode?.tom,
-                                                             verdi = this.tilFrontendString())
+                                                             verdi = this.tilFrontendString(),
+                                                             hentetTidspunkt = this.opprettetTidspunkt)
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.bostedsadre
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.behandling.restDomene.RestBostedsadresse
+import no.nav.familie.ba.sak.behandling.restDomene.RestRegisterOpplysning
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.Feil
@@ -35,9 +35,9 @@ abstract class GrBostedsadresse(
 
     abstract fun tilFrontendString(): String
 
-    fun tilRestBostedsadresse() = RestBostedsadresse(fom = this.periode?.fom,
-                                                     tom = this.periode?.tom,
-                                                     bostedsadresse = this.tilFrontendString())
+    fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.periode?.fom,
+                                                             tom = this.periode?.tom,
+                                                             verdi = this.tilFrontendString())
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.bostedsadre
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.behandling.restDomene.RestBostedsadresse
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.Feil
@@ -33,6 +34,10 @@ abstract class GrBostedsadresse(
     abstract fun toSecureString(): String
 
     abstract fun tilFrontendString(): String
+
+    fun tilRestBostedsadresse() = RestBostedsadresse(fom = this.periode?.fom,
+                                                     tom = this.periode?.tom,
+                                                     bostedsadresse = this.tilFrontendString())
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrMatrikkeladresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrMatrikkeladresse.kt
@@ -38,6 +38,8 @@ data class GrMatrikkeladresse(
         return "Matrikkeladresse(detaljer skjult)"
     }
 
+    override fun tilFrontendString() = """Matrikkel $matrikkelId, bruksenhet $bruksenhetsnummer, postnummer $postnummer""".trimMargin()
+
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {
             return false

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrUkjentBosted.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrUkjentBosted.kt
@@ -20,11 +20,14 @@ data class GrUkjentBosted(
         return """UkjentadresseDao(bostedskommune=$bostedskommune""".trimMargin()
     }
 
+    override fun tilFrontendString() = """Ukjent adresse, kommune $bostedskommune""".trimMargin()
+
     override fun toString(): String {
         return "UkjentBostedAdresse(detaljer skjult)"
     }
 
     companion object {
+
         fun fraUkjentBosted(ukjentBosted: UkjentBosted): GrUkjentBosted =
                 GrUkjentBosted(bostedskommune = ukjentBosted.bostedskommune)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrVegadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrVegadresse.kt
@@ -47,6 +47,8 @@ data class GrVegadresse(
         return "Vegadresse(detaljer skjult)"
     }
 
+    override fun tilFrontendString() = """$adressenavn $husnummer$husbokstav, postnummer $postnummer""".trimMargin()
+
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {
             return false

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.opphold
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.behandling.restDomene.RestRegisterOpplysning
+import no.nav.familie.ba.sak.behandling.restDomene.RestRegisteropplysning
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.Utils.storForbokstav
@@ -58,7 +58,7 @@ data class GrOpphold(
         return result
     }
 
-    fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.gyldigPeriode?.fom,
+    fun tilRestRegisteropplysning() = RestRegisteropplysning(fom = this.gyldigPeriode?.fom,
                                                              tom = this.gyldigPeriode?.tom,
                                                              verdi = this.type.name.storForbokstav(),
                                                              hentetTidspunkt = this.opprettetTidspunkt)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
@@ -60,5 +60,6 @@ data class GrOpphold(
 
     fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.gyldigPeriode?.fom,
                                                              tom = this.gyldigPeriode?.tom,
-                                                             verdi = this.type.name.storForbokstav())
+                                                             verdi = this.type.name.storForbokstav(),
+                                                             hentetTidspunkt = this.opprettetTidspunkt)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
@@ -2,8 +2,10 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.opphold
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.behandling.restDomene.RestOpphold
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
+import no.nav.familie.ba.sak.common.Utils.storForbokstav
 import no.nav.familie.ba.sak.common.erInnenfor
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.familie.kontrakter.felles.personopplysning.OPPHOLDSTILLATELSE
@@ -55,4 +57,8 @@ data class GrOpphold(
         result = 31 * result + type.hashCode()
         return result
     }
+
+    fun tilRestOpphold() = RestOpphold(fom = this.gyldigPeriode?.fom,
+                                       tom = this.gyldigPeriode?.tom,
+                                       oppholdstillatelse = this.type.name.storForbokstav())
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.opphold
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.behandling.restDomene.RestOpphold
+import no.nav.familie.ba.sak.behandling.restDomene.RestRegisterOpplysning
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.Utils.storForbokstav
@@ -58,7 +58,7 @@ data class GrOpphold(
         return result
     }
 
-    fun tilRestOpphold() = RestOpphold(fom = this.gyldigPeriode?.fom,
-                                       tom = this.gyldigPeriode?.tom,
-                                       oppholdstillatelse = this.type.name.storForbokstav())
+    fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.gyldigPeriode?.fom,
+                                                             tom = this.gyldigPeriode?.tom,
+                                                             verdi = this.type.name.storForbokstav())
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/opphold/GrOpphold.kt
@@ -60,6 +60,5 @@ data class GrOpphold(
 
     fun tilRestRegisteropplysning() = RestRegisteropplysning(fom = this.gyldigPeriode?.fom,
                                                              tom = this.gyldigPeriode?.tom,
-                                                             verdi = this.type.name.storForbokstav(),
-                                                             hentetTidspunkt = this.opprettetTidspunkt)
+                                                             verdi = this.type.name.storForbokstav())
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
@@ -55,6 +55,5 @@ data class GrStatsborgerskap(
 
     fun tilRestRegisteropplysning() = RestRegisteropplysning(fom = this.gyldigPeriode?.fom,
                                                              tom = this.gyldigPeriode?.tom,
-                                                             verdi = this.landkode,
-                                                             hentetTidspunkt = this.opprettetTidspunkt)
+                                                             verdi = this.landkode)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.statsborger
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.behandling.restDomene.RestRegisterOpplysning
+import no.nav.familie.ba.sak.behandling.restDomene.RestRegisteropplysning
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
@@ -53,7 +53,7 @@ data class GrStatsborgerskap(
         return result
     }
 
-    fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.gyldigPeriode?.fom,
+    fun tilRestRegisteropplysning() = RestRegisteropplysning(fom = this.gyldigPeriode?.fom,
                                                              tom = this.gyldigPeriode?.tom,
                                                              verdi = this.landkode,
                                                              hentetTidspunkt = this.opprettetTidspunkt)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
@@ -55,5 +55,6 @@ data class GrStatsborgerskap(
 
     fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.gyldigPeriode?.fom,
                                                              tom = this.gyldigPeriode?.tom,
-                                                             verdi = this.landkode)
+                                                             verdi = this.landkode,
+                                                             hentetTidspunkt = this.opprettetTidspunkt)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
@@ -3,11 +3,9 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.statsborger
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.behandling.restDomene.RestOpphold
-import no.nav.familie.ba.sak.behandling.restDomene.RestStatsborgerskap
+import no.nav.familie.ba.sak.behandling.restDomene.RestRegisterOpplysning
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
-import no.nav.familie.ba.sak.common.Utils.storForbokstav
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import javax.persistence.*
 
@@ -55,7 +53,7 @@ data class GrStatsborgerskap(
         return result
     }
 
-    fun tilRestStatsborgerskap() = RestStatsborgerskap(fom = this.gyldigPeriode?.fom,
-                                                       tom = this.gyldigPeriode?.tom,
-                                                       landkode = this.landkode)
+    fun tilRestRegisterOpplysning() = RestRegisterOpplysning(fom = this.gyldigPeriode?.fom,
+                                                             tom = this.gyldigPeriode?.tom,
+                                                             verdi = this.landkode)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
@@ -3,8 +3,11 @@ package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.statsborger
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.behandling.restDomene.RestOpphold
+import no.nav.familie.ba.sak.behandling.restDomene.RestStatsborgerskap
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
+import no.nav.familie.ba.sak.common.Utils.storForbokstav
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import javax.persistence.*
 
@@ -33,6 +36,7 @@ data class GrStatsborgerskap(
         @JoinColumn(name = "fk_po_person_id", nullable = false, updatable = false)
         val person: Person
 ) : BaseEntitet() {
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -50,4 +54,8 @@ data class GrStatsborgerskap(
         result = 31 * result + landkode.hashCode()
         return result
     }
+
+    fun tilRestStatsborgerskap() = RestStatsborgerskap(fom = this.gyldigPeriode?.fom,
+                                                       tom = this.gyldigPeriode?.tom,
+                                                       landkode = this.landkode)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
@@ -14,7 +14,7 @@ data class RestPerson(
         val personIdent: String,
         val navn: String,
         val kjønn: Kjønn,
-        val registerHistorikk: RestRegisterHistorikk? = null,
+        val registerhistorikk: RestRegisterhistorikk? = null,
         val målform: Målform
 )
 
@@ -24,29 +24,29 @@ fun Person.tilRestPerson() = RestPerson(
         personIdent = this.personIdent.ident,
         navn = this.navn,
         kjønn = this.kjønn,
-        registerHistorikk = this.tilRestRegisterHistorikk(),
+        registerhistorikk = this.tilRestRegisterhistorikk(),
         målform = this.målform
 )
 
-fun Person.tilRestRegisterHistorikk() = RestRegisterHistorikk(
-        sivilstand = listOf(RestRegisterOpplysning(fom = null,
+fun Person.tilRestRegisterhistorikk() = RestRegisterhistorikk(
+        sivilstand = listOf(RestRegisteropplysning(fom = null,
                                                    tom = null,
                                                    verdi = this.sivilstand.name.storForbokstav(),
                                                    hentetTidspunkt = this.opprettetTidspunkt)), // TODO: Kommer historisk data
-        oppholdstillatelse = opphold.map { it.tilRestRegisterOpplysning() },
-        statsborgerskap = statsborgerskap.map { it.tilRestRegisterOpplysning() },
-        bostedsadresse = this.bostedsadresse?.let { listOf(it.tilRestRegisterOpplysning()) }, // TODO: Kommer historisk data)
+        oppholdstillatelse = opphold.map { it.tilRestRegisteropplysning() },
+        statsborgerskap = statsborgerskap.map { it.tilRestRegisteropplysning() },
+        bostedsadresse = this.bostedsadresse?.let { listOf(it.tilRestRegisteropplysning()) }, // TODO: Kommer historisk data)
 )
 
-data class RestRegisterHistorikk(
+data class RestRegisterhistorikk(
 
-        val sivilstand: List<RestRegisterOpplysning>? = emptyList(),
-        val oppholdstillatelse: List<RestRegisterOpplysning>? = emptyList(),
-        val statsborgerskap: List<RestRegisterOpplysning>? = emptyList(),
-        val bostedsadresse: List<RestRegisterOpplysning>? = emptyList(),
+        val sivilstand: List<RestRegisteropplysning>? = emptyList(),
+        val oppholdstillatelse: List<RestRegisteropplysning>? = emptyList(),
+        val statsborgerskap: List<RestRegisteropplysning>? = emptyList(),
+        val bostedsadresse: List<RestRegisteropplysning>? = emptyList(),
 )
 
-data class RestRegisterOpplysning(
+data class RestRegisteropplysning(
         val fom: LocalDate?,
         val tom: LocalDate?,
         val verdi: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.common.Utils.storForbokstav
-import no.nav.familie.kontrakter.felles.personopplysning.OPPHOLDSTILLATELSE
 import java.time.LocalDate
 
 data class RestPerson(
@@ -14,10 +13,7 @@ data class RestPerson(
         val personIdent: String,
         val navn: String,
         val kjønn: Kjønn,
-        val sivilstand: List<RestSivilstand>? = emptyList(),
-        val oppholdstillatelse: List<RestOpphold>? = emptyList(),
-        val statsborgerskap: List<RestStatsborgerskap>? = emptyList(),
-        val bostedsadresse: List<RestBostedsadresse>? = emptyList(),
+        val registerHistorikk: RestRegisterHistorikk?,
         val målform: Målform
 )
 
@@ -27,38 +23,29 @@ fun Person.tilRestPerson() = RestPerson(
         personIdent = this.personIdent.ident,
         navn = this.navn,
         kjønn = this.kjønn,
-        sivilstand = listOf(RestSivilstand(fom = null, tom = null, sivilstand = this.sivilstand.name.storForbokstav())), // TODO: Kommer historisk data
-        oppholdstillatelse = opphold.map { it.tilRestOpphold() },
-        statsborgerskap = statsborgerskap.map { it.tilRestStatsborgerskap() },
-        bostedsadresse = this.bostedsadresse?.let { listOf(it.tilRestBostedsadresse()) }, // TODO: Kommer historisk data
+        registerHistorikk = this.tilRestRegisterHistorikk(),
         målform = this.målform
 )
 
-interface RestHistoriskOpplysning {
+fun Person.tilRestRegisterHistorikk() = RestRegisterHistorikk(
+        sivilstand = listOf(RestRegisterOpplysning(fom = null,
+                                                   tom = null,
+                                                   verdi = this.sivilstand.name.storForbokstav())), // TODO: Kommer historisk data
+        oppholdstillatelse = opphold.map { it.tilRestRegisterOpplysning() },
+        statsborgerskap = statsborgerskap.map { it.tilRestRegisterOpplysning() },
+        bostedsadresse = this.bostedsadresse?.let { listOf(it.tilRestRegisterOpplysning()) }, // TODO: Kommer historisk data)
+)
 
-    val fom: LocalDate?
-    val tom: LocalDate?
-}
+data class RestRegisterHistorikk(
 
-data class RestOpphold(
-        override val fom: LocalDate?,
-        override val tom: LocalDate?,
-        val oppholdstillatelse: String) : RestHistoriskOpplysning
+        val sivilstand: List<RestRegisterOpplysning>? = emptyList(),
+        val oppholdstillatelse: List<RestRegisterOpplysning>? = emptyList(),
+        val statsborgerskap: List<RestRegisterOpplysning>? = emptyList(),
+        val bostedsadresse: List<RestRegisterOpplysning>? = emptyList(),
+)
 
-data class RestStatsborgerskap(
-        override val fom: LocalDate?,
-        override val tom: LocalDate?,
-        val landkode: String
-) : RestHistoriskOpplysning
-
-data class RestBostedsadresse(
-        override val fom: LocalDate?,
-        override val tom: LocalDate?,
-        val bostedsadresse: String
-) : RestHistoriskOpplysning
-
-data class RestSivilstand(
-        override val fom: LocalDate?,
-        override val tom: LocalDate?,
-        val sivilstand: String
-) : RestHistoriskOpplysning
+data class RestRegisterOpplysning(
+        val fom: LocalDate?,
+        val tom: LocalDate?,
+        val verdi: String,
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
@@ -13,7 +13,7 @@ data class RestPerson(
         val personIdent: String,
         val navn: String,
         val kjønn: Kjønn,
-        val registerHistorikk: RestRegisterHistorikk?,
+        val registerHistorikk: RestRegisterHistorikk? = null,
         val målform: Målform
 )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
@@ -4,6 +4,8 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.common.Utils.storForbokstav
+import no.nav.familie.kontrakter.felles.personopplysning.OPPHOLDSTILLATELSE
 import java.time.LocalDate
 
 data class RestPerson(
@@ -12,6 +14,10 @@ data class RestPerson(
         val personIdent: String,
         val navn: String,
         val kjønn: Kjønn,
+        val sivilstand: List<RestSivilstand>? = emptyList(),
+        val oppholdstillatelse: List<RestOpphold>? = emptyList(),
+        val statsborgerskap: List<RestStatsborgerskap>? = emptyList(),
+        val bostedsadresse: List<RestBostedsadresse>? = emptyList(),
         val målform: Målform
 )
 
@@ -21,5 +27,38 @@ fun Person.tilRestPerson() = RestPerson(
         personIdent = this.personIdent.ident,
         navn = this.navn,
         kjønn = this.kjønn,
+        sivilstand = listOf(RestSivilstand(fom = null, tom = null, sivilstand = this.sivilstand.name.storForbokstav())), // TODO: Kommer historisk data
+        oppholdstillatelse = opphold.map { it.tilRestOpphold() },
+        statsborgerskap = statsborgerskap.map { it.tilRestStatsborgerskap() },
+        bostedsadresse = this.bostedsadresse?.let { listOf(it.tilRestBostedsadresse()) }, // TODO: Kommer historisk data
         målform = this.målform
 )
+
+interface RestHistoriskOpplysning {
+
+    val fom: LocalDate?
+    val tom: LocalDate?
+}
+
+data class RestOpphold(
+        override val fom: LocalDate?,
+        override val tom: LocalDate?,
+        val oppholdstillatelse: String) : RestHistoriskOpplysning
+
+data class RestStatsborgerskap(
+        override val fom: LocalDate?,
+        override val tom: LocalDate?,
+        val landkode: String
+) : RestHistoriskOpplysning
+
+data class RestBostedsadresse(
+        override val fom: LocalDate?,
+        override val tom: LocalDate?,
+        val bostedsadresse: String
+) : RestHistoriskOpplysning
+
+data class RestSivilstand(
+        override val fom: LocalDate?,
+        override val tom: LocalDate?,
+        val sivilstand: String
+) : RestHistoriskOpplysning

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
@@ -29,17 +29,17 @@ fun Person.tilRestPerson() = RestPerson(
 )
 
 fun Person.tilRestRegisterhistorikk() = RestRegisterhistorikk(
+        hentetTidspunkt = this.personopplysningGrunnlag.opprettetTidspunkt,
         sivilstand = listOf(RestRegisteropplysning(fom = null,
                                                    tom = null,
-                                                   verdi = this.sivilstand.name.storForbokstav(),
-                                                   hentetTidspunkt = this.opprettetTidspunkt)), // TODO: Kommer historisk data
+                                                   verdi = this.sivilstand.name.storForbokstav())), // TODO: Kommer historisk data
         oppholdstillatelse = opphold.map { it.tilRestRegisteropplysning() },
         statsborgerskap = statsborgerskap.map { it.tilRestRegisteropplysning() },
         bostedsadresse = this.bostedsadresse?.let { listOf(it.tilRestRegisteropplysning()) }, // TODO: Kommer historisk data)
 )
 
 data class RestRegisterhistorikk(
-
+        val hentetTidspunkt: LocalDateTime,
         val sivilstand: List<RestRegisteropplysning>? = emptyList(),
         val oppholdstillatelse: List<RestRegisteropplysning>? = emptyList(),
         val statsborgerskap: List<RestRegisteropplysning>? = emptyList(),
@@ -50,5 +50,4 @@ data class RestRegisteropplysning(
         val fom: LocalDate?,
         val tom: LocalDate?,
         val verdi: String,
-        val hentetTidspunkt: LocalDateTime
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.common.Utils.storForbokstav
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class RestPerson(
         val type: PersonType,
@@ -30,7 +31,8 @@ fun Person.tilRestPerson() = RestPerson(
 fun Person.tilRestRegisterHistorikk() = RestRegisterHistorikk(
         sivilstand = listOf(RestRegisterOpplysning(fom = null,
                                                    tom = null,
-                                                   verdi = this.sivilstand.name.storForbokstav())), // TODO: Kommer historisk data
+                                                   verdi = this.sivilstand.name.storForbokstav(),
+                                                   hentetTidspunkt = this.opprettetTidspunkt)), // TODO: Kommer historisk data
         oppholdstillatelse = opphold.map { it.tilRestRegisterOpplysning() },
         statsborgerskap = statsborgerskap.map { it.tilRestRegisterOpplysning() },
         bostedsadresse = this.bostedsadresse?.let { listOf(it.tilRestRegisterOpplysning()) }, // TODO: Kommer historisk data)
@@ -48,4 +50,5 @@ data class RestRegisterOpplysning(
         val fom: LocalDate?,
         val tom: LocalDate?,
         val verdi: String,
+        val hentetTidspunkt: LocalDateTime
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Utils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Utils.kt
@@ -12,6 +12,7 @@ import java.util.*
 val nbLocale = Locale("nb", "Norway")
 
 object Utils {
+
     fun slåSammen(values: List<String>): String = Regex("(.*),").replace(values.joinToString(", "), "$1 og")
 
     fun formaterBeløp(beløp: Int): String = NumberFormat.getNumberInstance(nbLocale).format(beløp)
@@ -28,4 +29,6 @@ object Utils {
 
         return model.properties[key]?.toString()
     }
+
+    fun String.storForbokstav() = this.lowercase().replaceFirstChar { it.uppercase() }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -28,7 +28,7 @@ class FeatureToggleConfig(private val enabled: Boolean,
                 lagUnleashFeatureToggleService()
             else {
                 logger.warn("Funksjonsbryter-funksjonalitet er skrudd AV. " +
-                         "Gir standardoppførsel for alle funksjonsbrytere, dvs 'false'")
+                            "Gir standardoppførsel for alle funksjonsbrytere, dvs 'false'")
                 lagDummyFeatureToggleService()
             }
 
@@ -94,7 +94,7 @@ class FeatureToggleConfig(private val enabled: Boolean,
 
         const val BRUK_NAV_CONSUMER_TOKEN_PDL = "familie-ba-sak.sikkerhet.nav-consumer-token-pdl"
         const val TILBAKEKREVING = "familie-ba-sak.behandling.tilbakekreving"
-        const val BRUK_REGISTEROPPLYSNINGER = "familie-ba-sak.behandling.bruk-registeropplysninger"
+        const val SKJØNNSMESSIGVURDERING = "familie-ba-sak.behandling.skjonnsvurdering"
 
         private val logger = LoggerFactory.getLogger(FeatureToggleConfig::class.java)
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Første ledd i visning av registeropplysninger frontend ([favrokort her](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4791)).

Kommer mapping av historisk data for bostedsadresse og sivilstand når dette er på plass. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ønsker spesielt feedback på om denne constraint-endringen gir mening:
commit: [Legg til constraint på nivå nærmere datauthenting. Funksjonene blir kalt mange steder, blant annet hvor det ikke sjekkes fagsaktilgang. Legger det derfor her for å unngå risiko for datalekkasje.](https://github.com/navikt/familie-ba-sak/commit/68de4fc03ac158378c624e0c821c033c25e72b77)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Validert ny mapping. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit skal være ganske oversiktlig, men ["Legg til mapping av opplysninger i restperson"](https://github.com/navikt/familie-ba-sak/commit/fca1bb651f83188d88d65d13016ab425ec0c9889) kan overses med mindre man er interessert i alternativ implementasjon. Synes det ble smør på flesk for de enkle dataene som skal returneres nå. Kan heller gjøre om dersom man skal returnere mer på hver enkeltopplysning. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
