### PR TITLE
Oppdater mock til å returnere datoer frontend godtar

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrVegadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrVegadresse.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.bostedsadresse
 
+import no.nav.familie.ba.sak.common.Utils.nullableTilString
+import no.nav.familie.ba.sak.common.Utils.storForbokstav
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
 import java.util.*
@@ -47,7 +49,10 @@ data class GrVegadresse(
         return "Vegadresse(detaljer skjult)"
     }
 
-    override fun tilFrontendString() = """$adressenavn $husnummer$husbokstav, postnummer $postnummer""".trimMargin()
+    override fun tilFrontendString() = """${
+        adressenavn.nullableTilString()
+                .storForbokstav()
+    } ${husnummer.nullableTilString()}${husbokstav.nullableTilString()}${postnummer.let { ", postnummer $it" }}""".trimMargin()
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Utils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Utils.kt
@@ -31,4 +31,5 @@ object Utils {
     }
 
     fun String.storForbokstav() = this.lowercase().replaceFirstChar { it.uppercase() }
+    fun Any?.nullableTilString() = this?.toString() ?: ""
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.common
 
+import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.bostedsadresse.GrVegadresse
 import no.nav.familie.ba.sak.behandling.vilkår.VedtakBegrunnelseSpesifikasjon.Companion.tilBrevTekst
 import no.nav.familie.ba.sak.common.Utils.hentPropertyFraMaven
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -8,6 +9,20 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 internal class UtilsTest {
+
+    @Test
+    fun `Nullable verdier blir tom string`() {
+        val adresse = GrVegadresse(matrikkelId = null,
+                                   bruksenhetsnummer = null,
+                                   husnummer = "1",
+                                   kommunenummer = null,
+                                   tilleggsnavn = null,
+                                   adressenavn = "TEST",
+                                   husbokstav = null,
+                                   postnummer = "1234")
+
+        assertEquals("Test 1, postnummer 1234", adresse.tilFrontendString())
+    }
 
     @Test
     fun `hent property fra maven skal ikke være blank`() {

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -94,7 +94,7 @@ class ClientMocks {
         } answers {
             listOf(Opphold(type = OPPHOLDSTILLATELSE.PERMANENT,
                            oppholdFra = LocalDate.of(1990, 1, 25),
-                           oppholdTil = LocalDate.of(2999, 1, 1)))
+                           oppholdTil = LocalDate.of(2499, 1, 1)))
         }
 
         every {
@@ -349,7 +349,7 @@ class ClientMocks {
         } answers {
             listOf(Opphold(type = OPPHOLDSTILLATELSE.PERMANENT,
                            oppholdFra = LocalDate.of(1990, 1, 25),
-                           oppholdTil = LocalDate.of(2999, 1, 1)))
+                           oppholdTil = LocalDate.of(2499, 1, 1)))
         }
 
         every {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I det nye kalenderapiet sjekkes det at vi ikke jobber med urealistiske datoer, i dette tilfellet etter år 2500. 

Fiks mockdatoer på oppholdstillatelse sånn at frontend ikke brekker. 

Siden det er satt et så høyt årstall antar jeg målet med mocken er en dato man er garantert "aldri" slutter og ikek en realistisk dato. Setter derfor til 2499 som er det høyeste frontend godtar. 