### PR TITLE
Støtte for vedtaksdato på deaktiverte vedtak i stønadsstatistikk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/stønadsstatistikk/StønadsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/stønadsstatistikk/StønadsstatistikkService.kt
@@ -51,7 +51,6 @@ class StønadsstatistikkService(private val behandlingService: BehandlingService
                 ?: error("Fant ikke vedtaksdato for behandling $behandlingId")
         }
 
-        vedtakRepository.finnVedtakForBehandling(behandlingId).first()
         val tidspunktVedtak = datoVedtak
 
         return VedtakDVH(

--- a/src/test/kotlin/no/nav/familie/ba/sak/stønadsstatistikk/StønadsstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/stønadsstatistikk/StønadsstatistikkServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.behandling.BehandlingService
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.behandling.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.behandling.vedtak.VedtakService
 import no.nav.familie.ba.sak.beregning.BeregningService
 import no.nav.familie.ba.sak.beregning.domene.YtelseType
@@ -26,13 +27,15 @@ internal class StønadsstatistikkServiceTest {
     private val beregningService: BeregningService = mockk()
     private val vedtakService: VedtakService = mockk()
     private val personopplysningerService: PersonopplysningerService = mockk()
+    private val vedtakRepository: VedtakRepository = mockk()
 
     private val stønadsstatistikkService =
             StønadsstatistikkService(behandlingService,
                                      persongrunnlagService,
                                      beregningService,
                                      vedtakService,
-                                     personopplysningerService)
+                                     personopplysningerService,
+                                     vedtakRepository)
 
     @BeforeAll
     fun init() {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ved sending av stønadsstatistikk på gamle meldinger, så får man ikke vedtaksdato for deaktiverte vedtak. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 🤷‍♀ ️Hvor er det lurt å starte?
alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
