### PR TITLE
Ikke vis "postnummer" som tekst i vegadresse-string

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrVegadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/bostedsadresse/GrVegadresse.kt
@@ -52,7 +52,7 @@ data class GrVegadresse(
     override fun tilFrontendString() = """${
         adressenavn.nullableTilString()
                 .storForbokstav()
-    } ${husnummer.nullableTilString()}${husbokstav.nullableTilString()}${postnummer.let { ", postnummer $it" }}""".trimMargin()
+    } ${husnummer.nullableTilString()}${husbokstav.nullableTilString()}${postnummer.let { ", $it" }}""".trimMargin()
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
@@ -21,7 +21,7 @@ internal class UtilsTest {
                                    husbokstav = null,
                                    postnummer = "1234")
 
-        assertEquals("Test 1, postnummer 1234", adresse.tilFrontendString())
+        assertEquals("Test 1, 1234", adresse.tilFrontendString())
     }
 
     @Test


### PR DESCRIPTION
Liten fiks: oppdaterer adressemapping til å ikke vise "postnummer" som string, men kun selve nummeret.
**Før**
![Skjermbilde 2021-05-31 kl  10 23 09](https://user-images.githubusercontent.com/5719550/120163984-5e1ee580-c1fa-11eb-9b5a-36529fc0f0ba.png)
**Etter**
![Skjermbilde 2021-05-31 kl  10 23 20](https://user-images.githubusercontent.com/5719550/120164002-637c3000-c1fa-11eb-84e7-3c6cd5308c71.png)

På matrikkeladresse hvor det er masse tall/nr vil man fortsatt vise hva de forskjellige tallene er (Matrikkel $matrikkelId, bruksenhet $bruksenhetsnummer, postnummer $postnummer).