### PR TITLE
Feilhåndtering: Fritekster kan kun settes i kombinasjon med vanlige begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/vedtak/VedtakService.kt
@@ -248,6 +248,7 @@ class VedtakService(
         vedtak.slettBegrunnelse(begrunnelseId)
 
         oppdater(vedtak)
+        vedtak.validerVedtakBegrunnelserForFritekstOpphørOgReduksjon()
 
         return vedtak.vedtakBegrunnelser.toList()
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Løser: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4888 
- Legger til validering ved sletting av begrunnelse og kaster feil dersom fritekst blir liggende igjen alene
- Legger til test for dette caset

Tidligere kom ikke denne feilmeldingen og man fikk lov til å legge til fritekster uten at vanlige begrunnelser er satt. Dette førte til en state hvor man kunne forsøke å lagre nye fritekster når det ikke fantes vanlige og dette trigga dårlig feilvisning (vil ikke være mulig nå).
![Skjermbilde 2021-06-02 kl  14 23 23](https://user-images.githubusercontent.com/5719550/120479724-9109da80-c3ae-11eb-93ac-5996a476441d.png)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
@MarcusGustafson74 Som du nevnte vil man ikke kunne legge til fritekstbegrunnelser når ingen vanlige begrunnelser er satt (boksen skjules)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
