### PR TITLE
Opprettt tilbakebehandling bare om åpenbehandling ikke finnes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/VurderTilbakekrevingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/steg/VurderTilbakekrevingSteg.kt
@@ -14,8 +14,10 @@ class VurderTilbakekrevingSteg(val featureToggleService: FeatureToggleService, v
 
     @Transactional
     override fun utførStegOgAngiNeste(behandling: Behandling, restTilbakekreving: RestTilbakekreving?): StegType {
+        
+        if (featureToggleService.isEnabled(FeatureToggleConfig.TILBAKEKREVING) &&
+            !tilbakekrevingService.søkerHarÅpenTilbakekreving(behandling.fagsak.id)) {
 
-        if (featureToggleService.isEnabled(FeatureToggleConfig.TILBAKEKREVING)) {
             tilbakekrevingService.validerRestTilbakekreving(restTilbakekreving, behandling.id)
             if (restTilbakekreving != null) {
                 tilbakekrevingService.lagreTilbakekreving(restTilbakekreving, behandling.id)

--- a/src/test/kotlin/no/nav/familie/ba/sak/dokument/DokumentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/dokument/DokumentServiceTest.kt
@@ -51,6 +51,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
                 "mock-oauth",
                 "mock-pdl",
                 "mock-task-repository",
+                "mock-tilbakekreving-klient",
                 "mock-infotrygd-barnetrygd",
 )
 @Tag("integration")


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
En tilbakebetalingsbehandling skal opprettes i familie-tilbake om det finnes om tilbakebetaling og om det ikke allerede finnes en åpen tilbakebetalingsbehandling.
Siste sjekken ble ikke gjort men er lagt inn nå.


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [/] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Eksisterende tester er ikke konstruert å teste på det nivået og inforing gir mer jobb enn det gir av verdi.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
