### PR TITLE
Vis navn på land i registeropplysninger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/fagsak/FagsakService.kt
@@ -220,7 +220,7 @@ class FagsakService(
                 underkategori = behandling.underkategori,
                 endretAv = behandling.endretAv,
                 årsak = behandling.opprettetÅrsak,
-                personer = personer?.map { it.tilRestPerson() } ?: emptyList(),
+                personer = personer?.map { persongrunnlagService.mapTilRestPersonMedStatsborgerskapLand(it) } ?: emptyList(),
                 arbeidsfordelingPåBehandling = arbeidsfordeling.tilRestArbeidsfordelingPåBehandling(),
                 skalBehandlesAutomatisk = behandling.skalBehandlesAutomatisk,
                 vedtakForBehandling = vedtak.map {

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.behandling.restDomene.tilRestPerson
 import no.nav.familie.ba.sak.behandling.vilkår.finnNåværendeMedlemskap
 import no.nav.familie.ba.sak.behandling.vilkår.finnSterkesteMedlemskap
 import no.nav.familie.ba.sak.behandling.vilkår.personHarLøpendeArbeidsforhold
+import no.nav.familie.ba.sak.common.Utils.storForbokstav
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.pdl.PersonopplysningerService
@@ -45,7 +46,7 @@ class PersongrunnlagService(
         restPerson.registerhistorikk?.statsborgerskap
                 ?.forEach {
                     val landkode = it.verdi
-                    it.verdi = statsborgerskapService.hentLand(landkode)
+                    it.verdi = statsborgerskapService.hentLand(landkode).storForbokstav()
                 }
         return restPerson
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -44,9 +44,10 @@ class PersongrunnlagService(
     fun mapTilRestPersonMedStatsborgerskapLand(person: Person): RestPerson {
         val restPerson = person.tilRestPerson()
         restPerson.registerhistorikk?.statsborgerskap
-                ?.forEach {
-                    val landkode = it.verdi
-                    it.verdi = statsborgerskapService.hentLand(landkode).storForbokstav()
+                ?.forEach { lagret ->
+                    val landkode = lagret.verdi
+                    val land = statsborgerskapService.hentLand(landkode)
+                    lagret.verdi = if (land.lowercase().contains("uoppgitt")) "$land ($landkode)" else land.storForbokstav()
                 }
         return restPerson
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -10,7 +10,9 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.opphold.Opph
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.sivilstand.GrSivilstand
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.statsborgerskap.GrStatsborgerskap
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.statsborgerskap.StatsborgerskapService
+import no.nav.familie.ba.sak.behandling.restDomene.RestPerson
 import no.nav.familie.ba.sak.behandling.restDomene.SøknadDTO
+import no.nav.familie.ba.sak.behandling.restDomene.tilRestPerson
 import no.nav.familie.ba.sak.behandling.vilkår.finnNåværendeMedlemskap
 import no.nav.familie.ba.sak.behandling.vilkår.finnSterkesteMedlemskap
 import no.nav.familie.ba.sak.behandling.vilkår.personHarLøpendeArbeidsforhold
@@ -37,6 +39,16 @@ class PersongrunnlagService(
         private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
         private val featureToggleService: FeatureToggleService,
 ) {
+
+    fun mapTilRestPersonMedStatsborgerskapLand(person: Person): RestPerson {
+        val restPerson = person.tilRestPerson()
+        restPerson.registerhistorikk?.statsborgerskap
+                ?.forEach {
+                    val landkode = it.verdi
+                    it.verdi = statsborgerskapService.hentLand(landkode)
+                }
+        return restPerson
+    }
 
     fun hentSøker(behandlingId: Long): Person? {
         return personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)!!.personer

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/StatsborgerskapService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/grunnlag/personopplysninger/statsborgerskap/StatsborgerskapService.kt
@@ -17,6 +17,8 @@ class StatsborgerskapService(
         private val personopplysningerService: PersonopplysningerService
 ) {
 
+    fun hentLand(landkode: String): String = integrasjonClient.hentLand(landkode)
+
     val fomComparator =
             Comparator { stb1: GrStatsborgerskap, stb2: GrStatsborgerskap
                 ->
@@ -77,7 +79,7 @@ class StatsborgerskapService(
     private fun hentMedlemskapsIntervaller(eøsLand: List<BetydningDto>?, fra: LocalDate?, til: LocalDate?): List<LocalDate> =
             eøsLand?.flatMap {
                 listOf(it.gyldigFra, it.gyldigTil.plusDays(1))
-            }?.filter {datoForEndringIMedlemskap ->
+            }?.filter { datoForEndringIMedlemskap ->
                 erInnenforDatoerSomBetegnerUendelighetIKodeverk(datoForEndringIMedlemskap)
             }?.filter { datoForEndringIMedlemskap ->
                 (fra == null || datoForEndringIMedlemskap.isAfter(fra)) &&
@@ -107,6 +109,7 @@ class StatsborgerskapService(
             dato.isAfter(TIDLIGSTE_DATO_I_KODEVERK) && dato.isBefore(SENESTE_DATO_I_KODEVERK)
 
     companion object {
+
         const val LANDKODE_UKJENT = "XUK"
         const val LANDKODE_STATSLØS = "XXX"
         val TIDLIGSTE_DATO_I_KODEVERK: LocalDate = LocalDate.parse("1900-01-02")

--- a/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/behandling/restDomene/RestPerson.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.behandling.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.common.Utils.storForbokstav
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -48,5 +47,5 @@ data class RestRegisterhistorikk(
 data class RestRegisteropplysning(
         val fom: LocalDate?,
         val tom: LocalDate?,
-        val verdi: String,
+        var verdi: String,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
@@ -92,6 +92,16 @@ class IntegrasjonClient(@Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val 
         }
     }
 
+    fun hentLand(landkode: String): String {
+        val uri = URI.create("$integrasjonUri/landkoder/{$landkode}")
+
+        return try {
+            getForEntity<Ressurs<String>>(uri).getDataOrThrow()
+        } catch (e: RestClientException) {
+            throw IntegrasjonException("Kall mot integrasjon feilet ved uthenting av land", e, uri)
+        }
+    }
+
     @Retryable(value = [IntegrasjonException::class],
                maxAttempts = 3,
                backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
@@ -386,7 +396,9 @@ class IntegrasjonClient(@Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val 
                                    filtype = Filtype.PDFA,
                                    dokumenttype = vedtak.behandling.resultat.tilDokumenttype(),
                                    tittel = hentOverstyrtDokumenttittel(vedtak.behandling)))
-        logger.info("Journalfører vedtaksbrev for behandling ${vedtak.behandling.id} med tittel ${hentOverstyrtDokumenttittel(vedtak.behandling)}")
+        logger.info("Journalfører vedtaksbrev for behandling ${vedtak.behandling.id} med tittel ${
+            hentOverstyrtDokumenttittel(vedtak.behandling)
+        }")
         val vedlegg = listOf(Dokument(vedleggPdf, filtype = Filtype.PDFA,
                                       dokumenttype = Dokumenttype.BARNETRYGD_VEDLEGG,
                                       tittel = VEDTAK_VEDLEGG_TITTEL))

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
@@ -93,7 +93,7 @@ class IntegrasjonClient(@Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val 
     }
 
     fun hentLand(landkode: String): String {
-        val uri = URI.create("$integrasjonUri/landkoder/{$landkode}")
+        val uri = URI.create("$integrasjonUri/kodeverk/landkoder/$landkode")
 
         return try {
             getForEntity<Ressurs<String>>(uri).getDataOrThrow()

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonClient.kt
@@ -93,6 +93,9 @@ class IntegrasjonClient(@Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val 
     }
 
     fun hentLand(landkode: String): String {
+        if (environment.activeProfiles.contains("e2e")) {
+            return "Testland"
+        }
         val uri = URI.create("$integrasjonUri/kodeverk/landkoder/$landkode")
 
         return try {

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -299,6 +299,8 @@ class ClientMocks {
 
         every { mockIntegrasjonClient.opprettSkyggesak(any(), any()) } returns Unit
 
+        every { mockIntegrasjonClient.hentLand(any()) } returns "Testland"
+
         initEuKodeverk(mockIntegrasjonClient)
 
         return mockIntegrasjonClient
@@ -530,12 +532,14 @@ class ClientMocks {
                                          kjønn = Kjønn.KVINNE,
                                          navn = "Jenta Barnesen",
                                          adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.FORTROLIG),
-                INTEGRASJONER_FNR to PersonInfo(fødselsdato = LocalDate.of(1965, 2, 19),
-                                                bostedsadresse = bostedsadresse,
-                                                sivilstand = SIVILSTAND.GIFT,
-                                                kjønn = Kjønn.KVINNE,
-                                                navn = "Mor Integrasjon person",
-                                                sivilstandHistorikk = sivilstandHistorisk,),
+                INTEGRASJONER_FNR to PersonInfo(
+                        fødselsdato = LocalDate.of(1965, 2, 19),
+                        bostedsadresse = bostedsadresse,
+                        sivilstand = SIVILSTAND.GIFT,
+                        kjønn = Kjønn.KVINNE,
+                        navn = "Mor Integrasjon person",
+                        sivilstandHistorikk = sivilstandHistorisk,
+                ),
                 BARN_DET_IKKE_GIS_TILGANG_TIL_FNR to PersonInfo(fødselsdato = LocalDate.of(2019, 6, 22),
                                                                 bostedsadresse = bostedsadresse,
                                                                 sivilstand = SIVILSTAND.UGIFT,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vis norsk navn på land i stedet for ISO-landkode. Så TUR -> Tyrkia. Fikser formatering så det ikke blir uppercase.
![Skjermbilde 2021-06-03 kl  12 48 17](https://user-images.githubusercontent.com/5719550/120636790-5b2c2b00-c46e-11eb-9dc0-52a1cb22e0e5.png)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Når vi skal få på plass postnummer bør vi cache, men tenker det går fint for enkelte landkoder nå.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Lagt til mock, men bør kanskje skrive for mapfunksjonen? 

### 🤷‍♀ ️Hvor er det lurt å starte?
Kan se ut som det er noen filer det er lenge siden er formatert, så kan være enklere å lese prn med whitespace changes skjult

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
