### PR TITLE
Erstatt gyldigFraOgMed med angitt flyttedato på bostedsadresse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring.cloud.version>3.0.3</spring.cloud.version>
         <spring.vault.version>2.3.2</spring.vault.version>
         <felles.version>1.20210607085527_b0c86f4</felles.version>
-        <felles-kontrakter.version>2.0_20210614094453_8e3e8c4</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20210617084158_5b8c07d</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20210427132344_d9066f5</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20210429143557_6cff407</familie.kontrakter.stønadsstatistikk>
         <mockk.version>1.11.0</mockk.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -235,8 +235,8 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
                            frontendFeilmelding = "Feilet ved henting av bostedsadresseperioder for person $ident",
                            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
             }
-            if (response.data.person.bostedsadresse.any { it.gyldigFraOgMed == null }) {
-                logger.warn("Uventet response (gyldigFraOgMed == null) fra PDL ved henting av bostedadresseperioder.")
+            if (response.data.person.bostedsadresse.any { it.angittFlyttedato == null }) {
+                logger.warn("Uventet response (angittFlyttedato == null) fra PDL ved henting av bostedadresseperioder.")
             }
             return response.data.person.bostedsadresse
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerService.kt
@@ -138,7 +138,7 @@ class PersonopplysningerService(
             pdlRestClient.hentBostedsadresseperioder(ident).map {
                 GrBostedsadresseperiode(
                         periode = DatoIntervallEntitet(
-                                fom = it.gyldigFraOgMed?.toLocalDate(),
+                                fom = it.angittFlyttedato?.toLocalDate(),
                                 tom = it.gyldigTilOgMed?.toLocalDate()
                         ))
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/internal/PdlBostedsadresseperioderResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/internal/PdlBostedsadresseperioderResponse.kt
@@ -11,6 +11,6 @@ data class PdlBostedsadresseperioderResponse (val data: Data,
 }
 
 class Bostedsadresseperiode(
-        val gyldigFraOgMed : LocalDateTime?,
+        val angittFlyttedato : LocalDateTime?,
         val gyldigTilOgMed : LocalDateTime?
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -29,6 +29,7 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.Ident
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -170,8 +171,9 @@ class PersongrunnlagService(
             }
         } else if (!behandling.erMigrering() && brukRegisteropplysningerIManuellBehandling) {
             personopplysningGrunnlag.personer.forEach { person ->
-
                 val personinfoManuell = personopplysningerService.hentHistoriskPersoninfoManuell(person.personIdent.ident)
+
+                secureLogger.info("Hentet registeropplyninger for person ${person.personIdent.ident}: $personinfoManuell")
 
                 person.opphold = personinfoManuell.opphold?.map { GrOpphold.fraOpphold(it, person) } ?: emptyList()
                 person.statsborgerskap =
@@ -224,13 +226,14 @@ class PersongrunnlagService(
         return if (farEllerMedmorRelasjon != null) {
             val farEllerMedmorPersonIdent = farEllerMedmorRelasjon.personIdent.id
             val personinfo = personopplysningerService.hentPersoninfoMedRelasjoner(farEllerMedmorPersonIdent)
-            val farEllerMedmor = Person(personIdent = PersonIdent(farEllerMedmorPersonIdent),
-                                        type = PersonType.ANNENPART,
-                                        personopplysningGrunnlag = personopplysningGrunnlag,
-                                        fødselsdato = personinfo.fødselsdato,
-                                        aktørId = personopplysningerService.hentAktivAktørId(Ident(farEllerMedmorPersonIdent)),
-                                        navn = personinfo.navn ?: "",
-                                        kjønn = personinfo.kjønn ?: Kjønn.UKJENT,
+            val farEllerMedmor = Person(
+                    personIdent = PersonIdent(farEllerMedmorPersonIdent),
+                    type = PersonType.ANNENPART,
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    fødselsdato = personinfo.fødselsdato,
+                    aktørId = personopplysningerService.hentAktivAktørId(Ident(farEllerMedmorPersonIdent)),
+                    navn = personinfo.navn ?: "",
+                    kjønn = personinfo.kjønn ?: Kjønn.UKJENT,
             ).also { person ->
                 person.statsborgerskap =
                         statsborgerskapService.hentStatsborgerskapMedMedlemskapOgHistorikk(Ident(farEllerMedmorPersonIdent),
@@ -274,6 +277,7 @@ class PersongrunnlagService(
 
     companion object {
 
+        private val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
         private val logger = LoggerFactory.getLogger(PersongrunnlagService::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/bostedsadresse/GrBostedsadresse.kt
@@ -61,7 +61,7 @@ abstract class GrBostedsadresse(
             }
             return mappetAdresse.also {
                 it.person = person
-                it.periode = DatoIntervallEntitet(bostedsadresse.gyldigFraOgMed, bostedsadresse.gyldigTilOgMed)
+                it.periode = DatoIntervallEntitet(bostedsadresse.angittFlyttedato, bostedsadresse.gyldigTilOgMed)
             }
         }
 

--- a/src/main/resources/pdl/hentBostedsadresseperioder.graphql
+++ b/src/main/resources/pdl/hentBostedsadresseperioder.graphql
@@ -1,6 +1,6 @@
 query($ident: ID!) {person: hentPerson(ident: $ident) {
     bostedsadresse(historikk: true) {
-        gyldigFraOgMed
+        angittFlyttedato
         gyldigTilOgMed
     }
 }}

--- a/src/main/resources/pdl/hentperson-enkel-manuell-behandling.graphql
+++ b/src/main/resources/pdl/hentperson-enkel-manuell-behandling.graphql
@@ -3,7 +3,7 @@ query($ident: ID!) {person: hentPerson(ident: $ident) {
         foedselsdato
     }
     bostedsadresse(historikk: true) {
-        gyldigFraOgMed
+        angittFlyttedato
         gyldigTilOgMed
         vegadresse {
             matrikkelId

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -494,14 +494,14 @@ class ClientMocks {
                                                     postnummer = "0202", kommunenummer = "2231")
         )
         val bostedsadresseHistorikk = mutableListOf(
-                Bostedsadresse(gyldigFraOgMed = LocalDate.now().minusDays(15),
+                Bostedsadresse(angittFlyttedato = LocalDate.now().minusDays(15),
                                gyldigTilOgMed = null,
                                matrikkeladresse = Matrikkeladresse(matrikkelId = 123L,
                                                                    bruksenhetsnummer = "H301",
                                                                    tilleggsnavn = "navn",
                                                                    postnummer = "0202",
                                                                    kommunenummer = "2231")),
-                Bostedsadresse(gyldigFraOgMed = LocalDate.now().minusYears(1),
+                Bostedsadresse(angittFlyttedato = LocalDate.now().minusYears(1),
                                gyldigTilOgMed = LocalDate.now().minusDays(16),
                                matrikkeladresse = Matrikkeladresse(matrikkelId = 123L,
                                                                    bruksenhetsnummer = "H301",

--- a/src/test/resources/pdl/PdlIntegrasjon/bostedsadresseperioderResponse.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/bostedsadresseperioderResponse.json
@@ -3,7 +3,7 @@
     "person": {
       "bostedsadresse": [
         {
-          "gyldigFraOgMed": "2002-01-03T00:00:00",
+          "angittFlyttedato": "2002-01-03T00:00:00",
           "gyldigTilOgMed": "2002-01-04T00:00:00"
         }
       ]


### PR DESCRIPTION
Under saksbehandling vurderer saksbehandler ut i fra datoen personen selv har oppgitt for flyttingen og ikke fregs vedtaksdato, slik vi henter nå (se doc).

Dette vil ikke løse alt, men en av tingene i: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5139

Venter på svar angående resterende. Lager en ny pr på fjerning av toggles og logging når vi har kommet til bunns i resten. 