### PR TITLE
Fjerner blokkering av migrering på Infotrygd kjøredato i preprod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -175,8 +175,8 @@ class MigreringService(private val infotrygdBarnetrygdClient: InfotrygdBarnetryg
             return when {
                 this.isBefore(kjøredato) -> this.førsteDagIInneværendeMåned()
                 this.isAfter(kjøredato.plusDays(1)) -> this.førsteDagINesteMåned()
-                env.erDev() || env.erE2E() -> this.førsteDagINesteMåned()
-                else -> throw FunksjonellFeil("Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)}",
+                !env.erProd() -> this.førsteDagINesteMåned()
+                else -> throw FunksjonellFeil("Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)} da det kolliderer med Infotrygds kjøredato",
                                               "Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)}")
             }.minusMonths(1)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -175,7 +175,7 @@ class MigreringService(private val infotrygdBarnetrygdClient: InfotrygdBarnetryg
             return when {
                 this.isBefore(kjøredato) -> this.førsteDagIInneværendeMåned()
                 this.isAfter(kjøredato.plusDays(1)) -> this.førsteDagINesteMåned()
-                !env.erProd() -> this.førsteDagINesteMåned()
+                env.erDev() || env.erE2E() || env.erPreprod() -> this.førsteDagINesteMåned()
                 else -> throw FunksjonellFeil("Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)} da det kolliderer med Infotrygds kjøredato",
                                               "Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)}")
             }.minusMonths(1)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -177,7 +177,7 @@ class MigreringService(private val infotrygdBarnetrygdClient: InfotrygdBarnetryg
                 this.isAfter(kjøredato.plusDays(1)) -> this.førsteDagINesteMåned()
                 env.erDev() || env.erE2E() || env.erPreprod() -> this.førsteDagINesteMåned()
                 else -> throw FunksjonellFeil("Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)} da det kolliderer med Infotrygds kjøredato",
-                                              "Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)}")
+                                              "Migrering er midlertidig deaktivert frem til ${kjøredato.plusDays(2)} da det kolliderer med Infotrygds kjøredato")
             }.minusMonths(1)
         }
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Tillate migrering på infotrygds kjøredato i alle miljøer, bortsett fra prod

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Prøvde også å endre betingelsen til `!env.erProd()`, men da var det en mengde tester som brakk

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Dekket av eksisterende