### PR TITLE
Fyll ut tom-datoer til frontend når bostedsadresser er back-to-back

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestRegisterhistorikk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestRegisterhistorikk.kt
@@ -16,7 +16,7 @@ fun Person.tilRestRegisterhistorikk() = RestRegisterhistorikk(
         hentetTidspunkt = this.personopplysningGrunnlag.opprettetTidspunkt,
         oppholdstillatelse = opphold.map { it.tilRestRegisteropplysning() },
         statsborgerskap = statsborgerskap.map { it.tilRestRegisteropplysning() },
-        bostedsadresse = this.bostedsadresser.map { it.tilRestRegisteropplysning() },
+        bostedsadresse = this.bostedsadresser.map { it.tilRestRegisteropplysning() }.fyllInnTomDatoer(),
         sivilstand = this.sivilstander.map { it.tilRestRegisteropplysning() },
 )
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5139

Jeg snek inn [logikk og tester her](https://github.com/navikt/familie-ba-sak/pull/1171/commits/989f3a5cd712fa9113575c98184607fde8e83edf), men bruker først funksjonaliteten i denne pr'en.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Velger å ikke fylle inn back-to-back når fom-dato mangler, da man ikke kan være 100% på at den er back-to-back med første periode.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
https://github.com/navikt/familie-ba-sak/pull/1171/commits/989f3a5cd712fa9113575c98184607fde8e83edf

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
