### PR TITLE
Utplukking av saker med satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -95,6 +95,7 @@ class FeatureToggleConfig(private val enabled: Boolean,
         const val BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER = "familie-ba-sak.behandling.vedtakstype-med-begrunnelser"
         const val AUTOMATISK_FØDSELSHENDELSE = "familie-ba-sak.behandling.automatisk-fødselshendelse"
         const val BRUK_ER_DELT_BOSTED = "familie-ba-sak.behandling.delt_bosted"
+        const val KJØR_SATSENDRING_SCHEDULER = "familie-ba-sak.satsendring-scheduler"
 
         private val logger = LoggerFactory.getLogger(FeatureToggleConfig::class.java)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/SchedulingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/SchedulingController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.internal
 import no.nav.familie.ba.sak.kjerne.autobrev.Autobrev6og18ÅrScheduler
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.kjerne.autorevurdering.SatsendringService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.http.ResponseEntity
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
 class SchedulingController(
         private val scheduler: Autobrev6og18ÅrScheduler,
         private val satsendringService: SatsendringService,
-        private val behandlingRepository: BehandlingRepository,
         private val envService: EnvService) {
 
     @GetMapping(path = ["/autobrev"])
@@ -31,13 +29,11 @@ class SchedulingController(
         }
     }
 
-    // TODO: Erstattes av schedulertrigging når automatisk utplukking er implementert
     @GetMapping(path = ["/test-satsendring/{behandlingId}"])
     @Unprotected
     fun utførSatsendringPåBehandling(@PathVariable behandlingId: Long): ResponseEntity<Ressurs<String>> {
         return if (envService.erPreprod() || envService.erDev() || envService.erE2E()) {
-            val behandling = behandlingRepository.finnBehandling(behandlingId = behandlingId)
-            satsendringService.utførSatsendring(behandling)
+            satsendringService.utførSatsendring(behandlingId)
             ResponseEntity.ok(Ressurs.success("Trigget satsendring"))
         } else {
             ResponseEntity.ok(Ressurs.success("Endepunktet gjør ingenting i prod."))

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autorevurdering/SatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autorevurdering/SatsendringScheduler.kt
@@ -1,0 +1,61 @@
+package no.nav.familie.ba.sak.kjerne.autorevurdering
+
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.leader.LeaderClient
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.net.InetAddress
+
+@Service
+class SatsendringScheduler(
+        private val satsendringService: SatsendringService,
+        private val behandlingRepository: BehandlingRepository,
+        private val featureToggleService: FeatureToggleService) {
+
+    /**
+     * Jobb som skal kjøres i forbindelse med satsendring som trer i kraft september 2021.
+     * For hver behandling det skal utføres satsendring på kjøres en transaksjon som oppretter satsendringbehandling og iverksettingstask.
+     * Kjøres ved oppstart når togglet på.
+     */
+    @Scheduled(initialDelay = 120000, fixedDelay = Long.MAX_VALUE)
+    fun gjennomførSatsendring() {
+        when (LeaderClient.isLeader() == true && featureToggleService.isEnabled(FeatureToggleConfig.KJØR_SATSENDRING_SCHEDULER)) {
+            true -> {
+                val hostname: String = InetAddress.getLocalHost().hostName
+                val behandlinger = behandlingRepository.finnBehandlingerSomSkalSatsendresSeptember21()
+                logger.info("Leaderpod $hostname Starter automatisk revurdering av ${behandlinger.size} behandlinger")
+
+                var vellykkedeRevurderinger = 0
+                var mislykkedeRevurderinger = 0
+
+                behandlinger.forEach { behandlingId ->
+                    Result.runCatching {
+                        satsendringService.utførSatsendring(behandlingId)
+                    }.onSuccess {
+                        logger.info("Vellykket revurdering for behandling ${behandlingId}")
+                        vellykkedeRevurderinger++
+                    }.onFailure {
+                        logger.info("Revurdering feilet for behandling ${behandlingId}")
+                        secureLogger.info("Revurdering feilet for behandling ${behandlingId}", it)
+                        mislykkedeRevurderinger++
+                    }
+                }
+
+                logger.info("Automatiske revurderinger av satsendringer gjennomført.\n" +
+                            "Vellykede=$vellykkedeRevurderinger\n" +
+                            "Mislykkede=$mislykkedeRevurderinger\n")
+            }
+            false -> logger.info("Poden er ikke satt opp som leader")
+            null -> logger.info("Poden svarer ikke om den er leader eller ikke")
+        }
+    }
+
+    companion object {
+
+        private val logger = LoggerFactory.getLogger(SatsendringScheduler::class.java)
+        private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autorevurdering/SatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autorevurdering/SatsendringService.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.autorevurdering
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -14,23 +14,20 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.FerdigstillBehandlingTask
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
 import no.nav.familie.prosessering.domene.TaskRepository
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SatsendringService(private val stegService: StegService,
                          private val vedtakService: VedtakService,
-                         private val taskRepository: TaskRepository) {
+                         private val taskRepository: TaskRepository,
+                         private val behandlingRepository: BehandlingRepository) {
 
-
-    // TODO: Behandlinger plukkes og kjøres i egen jobb
     @Transactional
-    fun utførSatsendring(behandling: Behandling) {
+    fun utførSatsendring(behandlingId: Long) {
 
+        val behandling = behandlingRepository.finnBehandling(behandlingId = behandlingId)
         val søkerIdent = behandling.fagsak.hentAktivIdent().ident
-
-        logger.info("Utfører satsendring på fagsak ${behandling.fagsak.id}")
 
         if (behandling.fagsak.status != FagsakStatus.LØPENDE) throw Feil("Forsøker å utføre satsendring på ikke løpende fagsak ${behandling.fagsak.id}")
         if (behandling.status != BehandlingStatus.AVSLUTTET) throw Feil("Forsøker å utføre satsendring på behandling ${behandling.id} som ikke er avsluttet")
@@ -58,10 +55,5 @@ class SatsendringService(private val stegService: StegService,
         }
         taskRepository.save(task)
 
-    }
-
-    companion object {
-
-        private val logger = LoggerFactory.getLogger(SatsendringService::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -20,16 +20,16 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
      * Finner så alle perioder på siste iverksatte behandling
      * Finner deretter første behandling en periode oppstod i, som er det som skal avstemmes
      */
-    @Query(value = """with sisteIverksatteBehandlingFraLøpendeFagsak as (
-                            select f.id as fagsakId, max(b.id) as behandlingId
-                            from behandling b
-                                   inner join fagsak f on f.id = b.fk_fagsak_id
-                                   inner join tilkjent_ytelse ty on b.id = ty.fk_behandling_id
-                            where f.status = 'LØPENDE'
+    @Query(value = """WITH sisteiverksattebehandlingfraløpendefagsak AS (
+                            SELECT f.id AS fagsakid, MAX(b.id) AS behandlingid
+                            FROM behandling b
+                                   INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
+                                   INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
+                            WHERE f.status = 'LØPENDE'
                               AND ty.utbetalingsoppdrag IS NOT NULL
-                            GROUP BY fagsakId)
+                            GROUP BY fagsakid)
                         
-                        select behandlingId from sisteIverksatteBehandlingFraLøpendeFagsak""",
+                        SELECT behandlingid FROM sisteiverksattebehandlingfraløpendefagsak""",
            nativeQuery = true)
     fun finnSisteIverksatteBehandlingFraLøpendeFagsaker(): List<Long>
 
@@ -44,4 +44,25 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Lock(LockModeType.NONE)
     @Query("SELECT count(*) FROM Behandling b WHERE NOT b.status = 'AVSLUTTET'")
     fun finnAntallBehandlingerIkkeAvsluttet(): Long
+
+    /**
+     * Gjenbruker finnSisteIverksatteBehandlingFraLøpendeFagsaker og filtrerer på beløp og datoer
+     */
+    @Query(value = """WITH sisteiverksattebehandlingfraløpendefagsak AS (
+                            SELECT f.id AS fagsakid, MAX(b.id) AS behandlingid
+                            FROM behandling b
+                                   INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
+                                   INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
+                            WHERE f.status = 'LØPENDE'
+                              AND ty.utbetalingsoppdrag IS NOT NULL
+                            GROUP BY fagsakid)
+                        
+                        SELECT DISTINCT aty.fk_behandling_id
+                        FROM andel_tilkjent_ytelse aty
+                        WHERE aty.fk_behandling_id IN (SELECT behandlingid FROM sisteiverksattebehandlingfraløpendefagsak)
+                            AND aty.belop = 1354
+                            AND aty.stonad_fom <= TO_TIMESTAMP('01-09-2021', 'DD-MM-YYYY')
+                            AND aty.stonad_tom >= TO_TIMESTAMP('30-09-2021', 'DD-MM-YYYY')""",
+           nativeQuery = true)
+    fun finnBehandlingerSomSkalSatsendresSeptember21(): List<Long>
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Utplukking av behandlinger til satsendringen i september https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5529
- Gjenbruker logikk for uthenting av siste iverksatte behandlinger på løpende saker (samme som vi lagde til konsistensavstemming og brukes der)
- Filtrerer ut de med andel september 2021 og beløp 1354

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Siden satsendring allerede er ute antas det at vi ikke trenger å spesialhåndtere saker som utredes eller ligger mellom sb1 og sb2 på kjøretidspunkt. Disse vil behandles med ny sats dersom de har tillegg september 2021. Vil uansett gjøre en kontroll i etterkant av kjøring for å validere at ingen ligger igjen med 1354 framover. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

Validert ved å teste script mot database. 

**Dev**
I dev har jeg oppretta behandlinger med gammel sats og sørget for at de blir plukket ut: 
- https://barnetrygd.dev.adeo.no/fagsak/1070401/1084001/vedtak plukkes
- https://barnetrygd.dev.adeo.no/fagsak/1070451/1084051/vedtak plukkes
- https://barnetrygd.dev.adeo.no/fagsak/1070452/1084002/vedtak trigga satsendring på, plukkes ikke
Får totalt 212 treff i dev, hvor alle bortsett fra tre er sist endret _før_ satsendring kom på plass, og det gir mening. Resterende tre er de to nevnt over for plukking og én som ble opprettet i overgangen og ser ut til at det er riktig at skal plukkes.

**Prod**
I prod plukkes 509 behandlinger. 
Har også forsøkt å kjøre utplukkingsscriptet i prod med følgende justering: 
`WHERE f.status != 'LØPENDE'
      OR ty.utbetalingsoppdrag IS NULL`
For å sjekke 1354kr-andeler i september 2021 som _ikke_ eventuelt måtte fanges opp av scriptet. Her får jeg 13 treff, hvor: 
- 7 x henlagt
- 2 x omregningsbehandlinger uten utbetalingsoppdrag. Dvs at et av de _andre_ barna på fagsaken fyller år. Jeg har validert at foregående behandling plukkes for disse fagsakene.
- 4 x ikke avsluttet. Her er to under utredning og to hos beslutter. Disse må vi følge opp og sørge for at blir ferdigstilt. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [X] Ja, kan gjerne ta en muntlig gjennomgang :) 
- [ ] Nei
