### PR TITLE
Send saksstatistikk ved manuelt enhetsbytte

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfo
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -22,7 +23,8 @@ class ArbeidsfordelingService(private val arbeidsfordelingPåBehandlingRepositor
                               private val loggService: LoggService,
                               private val norg2RestClient: Norg2RestClient,
                               private val integrasjonClient: IntegrasjonClient,
-                              private val personopplysningerService: PersonopplysningerService) {
+                              private val personopplysningerService: PersonopplysningerService,
+private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher) {
 
     fun manueltOppdaterBehandlendeEnhet(behandling: Behandling, endreBehandlendeEnhet: RestEndreBehandlendeEnhet) {
         val aktivArbeidsfordelingPåBehandling =
@@ -47,6 +49,7 @@ class ArbeidsfordelingService(private val arbeidsfordelingPåBehandlingRepositor
                 manuellOppdatering = true,
                 begrunnelse = endreBehandlendeEnhet.begrunnelse
         )
+        saksstatistikkEventPublisher.publiserBehandlingsstatistikk(behandling.id)
     }
 
     fun fastsettBehandlendeEnhet(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.AVSLUTTET
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.FATTER_VEDTAK
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.initStatus
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatUtils
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakPersonRepository
@@ -130,9 +129,7 @@ class BehandlingService(
     }
 
     private fun sendTilDvh(behandling: Behandling) {
-        saksstatistikkEventPublisher.publiserBehandlingsstatistikk(behandling.id,
-                                                                   hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
-                                                                           .takeIf { erRevurderingEllerTekniskOpphør(behandling) }?.id)
+        saksstatistikkEventPublisher.publiserBehandlingsstatistikk(behandling.id)
     }
 
     fun hentAktivForFagsak(fagsakId: Long): Behandling? {
@@ -235,9 +232,6 @@ class BehandlingService(
 
         return lagreEllerOppdater(behandling)
     }
-
-    private fun erRevurderingEllerTekniskOpphør(behandling: Behandling) =
-            behandling.type == BehandlingType.REVURDERING || behandling.type == BehandlingType.TEKNISK_OPPHØR
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkEventListener.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkEventListener.kt
@@ -17,7 +17,7 @@ class SaksstatistikkEventListener(private val saksstatistikkService: Saksstatist
 
     override fun onApplicationEvent(event: SaksstatistikkEvent) {
         if (event.behandlingId != null) {
-            saksstatistikkService.mapTilBehandlingDVH(event.behandlingId, event.forrigeBehandlingId)?.also {
+            saksstatistikkService.mapTilBehandlingDVH(event.behandlingId)?.also {
                 saksstatistikkMellomlagringRepository.save(
                     SaksstatistikkMellomlagring(
                         funksjonellId = it.funksjonellId,

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkEventPublisher.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkEventPublisher.kt
@@ -12,16 +12,15 @@ class SaksstatistikkEventPublisher {
     @Autowired
     lateinit var applicationEventPublisher: ApplicationEventPublisher
 
-    fun publiserBehandlingsstatistikk(behandlingId: Long, forrigeBehandlingId: Long?) {
-        applicationEventPublisher.publishEvent(SaksstatistikkEvent(this, null, behandlingId, forrigeBehandlingId))
+    fun publiserBehandlingsstatistikk(behandlingId: Long) {
+        applicationEventPublisher.publishEvent(SaksstatistikkEvent(this, null, behandlingId))
     }
 
     fun publiserSaksstatistikk(fagsakId: Long) {
-        applicationEventPublisher.publishEvent(SaksstatistikkEvent(this, fagsakId, null, null))
+        applicationEventPublisher.publishEvent(SaksstatistikkEvent(this, fagsakId, null))
     }
 }
 
 class SaksstatistikkEvent(source: Any,
                           val fagsakId: Long?,
-                          val behandlingId: Long?,
-                          val forrigeBehandlingId: Long?) : ApplicationEvent(source)
+                          val behandlingId: Long?) : ApplicationEvent(source)

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ba.sak.integrasjoner.journalføring.JournalføringService
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpostType
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.JournalføringRepository
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.AktørDVH
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.BehandlingDVH
@@ -49,8 +50,9 @@ class SaksstatistikkService(
         private val vedtaksperiodeService: VedtaksperiodeService,
 ) {
 
-    fun mapTilBehandlingDVH(behandlingId: Long, forrigeBehandlingId: Long? = null): BehandlingDVH? {
+    fun mapTilBehandlingDVH(behandlingId: Long): BehandlingDVH? {
         val behandling = behandlingService.hent(behandlingId)
+        val forrigeBehandlingId = behandlingService.hentForrigeBehandlingSomErIverksatt(behandling).takeIf { erRevurderingEllerTekniskOpphør(behandling) }?.id
 
         if (behandling.opprettetÅrsak == FØDSELSHENDELSE && !envService.skalIverksetteBehandling()) return null
 
@@ -166,6 +168,9 @@ class SaksstatistikkService(
             personopplysningerService.hentLandkodeUtenlandskBostedsadresse(ident)
         }
     }
+
+    private fun erRevurderingEllerTekniskOpphør(behandling: Behandling) =
+        behandling.type == BehandlingType.REVURDERING || behandling.type == BehandlingType.TEKNISK_OPPHØR
 
     private fun Behandling.resultatBegrunnelser(): List<ResultatBegrunnelseDVH> {
         return when (resultat) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTestController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTestController.kt
@@ -26,7 +26,7 @@ class SaksstatistikkTestController(
     @Unprotected
     fun hentBehandlingDvh(@PathVariable(name = "behandlingId", required = true) behandlingId: Long): BehandlingDVH {
         try {
-            return saksstatistikkService.mapTilBehandlingDVH(behandlingId, null)!!
+            return saksstatistikkService.mapTilBehandlingDVH(behandlingId)!!
         } catch (e: Exception) {
             logger.warn("Feil ved henting av sakstatistikk behandling", e)
             throw e

--- a/src/test/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkEventPublisherFailSafe.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkEventPublisherFailSafe.kt
@@ -13,9 +13,9 @@ class SaksstatistikkEventPublisherFailSafe: SaksstatistikkEventPublisher() {
         return this
     }
 
-    override fun publiserBehandlingsstatistikk(behandlingId: Long, forrigeBehandlingId: Long?) {
+    override fun publiserBehandlingsstatistikk(behandlingId: Long) {
         runCatching {
-            super.publiserBehandlingsstatistikk(behandlingId, forrigeBehandlingId)
+            super.publiserBehandlingsstatistikk(behandlingId)
         }.onFailure { it.printStackTrace() }
     }
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -106,7 +106,7 @@ internal class SaksstatistikkServiceTest {
         every { totrinnskontrollService.hentAktivForBehandling(any()) } returns null
         every { vedtakService.hentAktivForBehandling(any()) } returns null
 
-        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2, 1)
+        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(behandlingDvh))
 
         assertThat(behandlingDvh?.resultat).isEqualTo("HENLAGT_FEILAKTIG_OPPRETTET")
@@ -132,6 +132,7 @@ internal class SaksstatistikkServiceTest {
         val vedtaksperiodeMedBegrunnelser = lagVedtaksperiodeMedBegrunnelser(vedtak = vedtak)
 
         every { behandlingService.hent(any()) } returns behandling
+        every { behandlingService.hentForrigeBehandlingSomErIverksatt(any()) } returns null
         every { vedtakService.hentAktivForBehandling(any()) } returns vedtak
         every { vedtaksperiodeService.hentPersisterteVedtaksperioder(any()) } returns listOf(vedtaksperiodeMedBegrunnelser)
         every { totrinnskontrollService.hentAktivForBehandling(any()) } returns Totrinnskontroll(
@@ -143,7 +144,7 @@ internal class SaksstatistikkServiceTest {
                 behandling = behandling
         )
 
-        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2, 1)
+        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(behandlingDvh))
 
 
@@ -155,7 +156,7 @@ internal class SaksstatistikkServiceTest {
                                                                              SaksstatistikkService.TIMEZONE))
         assertThat(behandlingDvh?.vedtaksDato).isEqualTo(vedtak.vedtaksdato?.toLocalDate())
         assertThat(behandlingDvh?.behandlingId).isEqualTo(behandling.id.toString())
-        assertThat(behandlingDvh?.relatertBehandlingId).isEqualTo("1")
+        assertThat(behandlingDvh?.relatertBehandlingId).isNull()
         assertThat(behandlingDvh?.sakId).isEqualTo(behandling.fagsak.id.toString())
         assertThat(behandlingDvh?.vedtakId).isEqualTo(vedtak.id.toString())
         assertThat(behandlingDvh?.behandlingType).isEqualTo(behandling.type.name)
@@ -209,6 +210,7 @@ internal class SaksstatistikkServiceTest {
                 lagVedtaksperiodeMedBegrunnelser(vedtak = vedtak, fom = vedtaksperiodeFom, tom = vedtaksperiodeTom)
 
         every { behandlingService.hent(any()) } returns behandling
+        every { behandlingService.hentForrigeBehandlingSomErIverksatt(any()) } returns null
         every { persongrunnlagService.hentSøker(any()) } returns tilfeldigSøker()
         every { persongrunnlagService.hentBarna(any()) } returns listOf(tilfeldigPerson()
                                                                                 .copy(personIdent = PersonIdent("01010000001")))
@@ -225,7 +227,7 @@ internal class SaksstatistikkServiceTest {
         val jp = lagTestJournalpost("123", "123").copy(relevanteDatoer = listOf(RelevantDato(mottattDato, "DATO_REGISTRERT")))
         every { journalføringService.hentJournalpost(any()) } returns Ressurs.Companion.success(jp)
 
-        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2, 1)
+        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2)
         println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(behandlingDvh))
 
 
@@ -235,7 +237,7 @@ internal class SaksstatistikkServiceTest {
         assertThat(behandlingDvh?.registrertDato).isEqualTo(mottattDato.atZone(SaksstatistikkService.TIMEZONE))
         assertThat(behandlingDvh?.vedtaksDato).isEqualTo(vedtak.vedtaksdato?.toLocalDate())
         assertThat(behandlingDvh?.behandlingId).isEqualTo(behandling.id.toString())
-        assertThat(behandlingDvh?.relatertBehandlingId).isEqualTo("1")
+        assertThat(behandlingDvh?.relatertBehandlingId).isNull()
         assertThat(behandlingDvh?.sakId).isEqualTo(behandling.fagsak.id.toString())
         assertThat(behandlingDvh?.vedtakId).isEqualTo(vedtak.id.toString())
         assertThat(behandlingDvh?.behandlingType).isEqualTo(behandling.type.name)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sender saksstatistikk ved manuelt enhetsbytte. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Måtte flytte logikken for forrigeBehandligid ned til sakstatistikkService for å  unngå cyclic dependency problemer med å ha behandlingService i ArbeidsfordelingService. Tenker at det var like greit når vi likevel alltid gjør en query.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
