### PR TITLE
Midlertidig håndtering av behandlinger hos beslutter som som skal gjennom på gammel modell

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseSpesifikasjon
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeRepository
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -83,7 +84,7 @@ class BehandlingMetrikker(
             val vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingId = behandling.id)
                          ?: error("Finner ikke aktivt vedtak på behandling ${behandling.id}")
 
-            if (featureToggleService.isEnabled(BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER)) {
+            if (featureToggleService.isEnabled(BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER) && !VedtaksperiodeService.behandlingerIGammelState.contains(behandling.id)) {
                 val vedtaksperiodeMedBegrunnelser = vedtaksperiodeRepository.finnVedtaksperioderFor(vedtakId = vedtak.id)
 
                 vedtaksperiodeMedBegrunnelser.forEach {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -109,7 +109,7 @@ class BehandlingService(
         )
 
         if (kopierVedtakBegrunnelser && deaktivertVedtak != null) {
-            if (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER)) {
+            if (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER)) { // TODO: Ved nytt vedtak vil man måtte resette begrunnelser
                 vedtaksperiodeService.kopierOverVedtaksperioder(deaktivertVedtak = deaktivertVedtak,
                                                                 aktivtVedtak = nyttVedtak)
             } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
@@ -51,7 +51,9 @@ class BrevService(
         val vedtakstype = hentVedtaksbrevtype(vedtak.behandling)
         val vedtakFellesfelter =
                 if (vedtak.behandling.resultat == BehandlingResultat.FORTSATT_INNVILGET ||
-                    featureToggleService.isEnabled(FeatureToggleConfig.BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER))
+                    (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER)
+                     && !VedtaksperiodeService.behandlingerIGammelState.contains(
+                            vedtak.behandling.id)))
                     lagVedtaksbrevFellesfelter(vedtak)
                 else
                     lagVedtaksbrevFellesfelterDeprecated(vedtak)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -453,6 +453,12 @@ class VedtaksperiodeService(
 
     companion object {
 
-        val behandlingerIGammelState: List<Long> = listOf(1234)
+        val behandlingerIGammelState: List<Long> = listOf(
+                1058408,
+                1075799,
+                1075801,
+                1082701,
+                1082651,
+        )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -245,7 +245,7 @@ class VedtaksperiodeService(
                     vedtak = vedtak,
                     type = Vedtaksperiodetype.FORTSATT_INNVILGET
             ))
-        } else if (featureToggleService.isEnabled(BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER)) {
+        } else if (featureToggleService.isEnabled(BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER) && !behandlingerIGammelState.contains(vedtak.behandling.id)) {
             val utbetalingOgOpphørsperioder =
                     (hentUtbetalingsperioder(vedtak.behandling) + hentOpphørsperioder(vedtak.behandling)).map {
                         VedtaksperiodeMedBegrunnelser(
@@ -449,5 +449,10 @@ class VedtaksperiodeService(
         return begrunnelseOgIdentListe
                 .groupBy { (begrunnelse, _) -> begrunnelse }
                 .mapValues { (_, parGruppe) -> parGruppe.map { it.second } }
+    }
+
+    companion object {
+
+        val behandlingerIGammelState: List<Long> = listOf(1234)
     }
 }


### PR DESCRIPTION
Må slå på toggle for å stoppe nye caser på gammelt format, samtidig som vi har behov for å behandle ferdig de som ligger hos beslutter på gamlemåten. Behandlingene som ligger hos beslutter kan ikke migreres fordi det skal re-genereres når beslutter godkjenner og de gamle vedtaksbegrunnelsene mangler person-informasjonen man trenger for å generere begrunnelser på den nye måten.