### PR TITLE
BUG: beregning returnerer fagsak unødvendig

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -54,10 +54,6 @@ class BeregningService(
     fun hentOptionalTilkjentYtelseForBehandling(behandlingId: Long) =
             tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
 
-    fun hentAndelerTilkjentYtelserInneværendeMåned(behandlingId: Long): List<AndelTilkjentYtelse> =
-            andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(listOf(behandlingId))
-                    .filter { it.stønadFom <= YearMonth.now() && it.stønadTom >= YearMonth.now() }
-
     fun hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId: Long): List<TilkjentYtelse> {
         val iverksatteBehandlinger = behandlingRepository.findByFagsakAndAvsluttet(fagsakId)
         return iverksatteBehandlinger.mapNotNull { tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(it.id) }
@@ -97,7 +93,7 @@ class BeregningService(
 
     @Transactional
     fun oppdaterBehandlingMedBeregning(behandling: Behandling,
-                                       personopplysningGrunnlag: PersonopplysningGrunnlag): Ressurs<RestFagsak> {
+                                       personopplysningGrunnlag: PersonopplysningGrunnlag): TilkjentYtelse {
 
         tilkjentYtelseRepository.slettTilkjentYtelseFor(behandling)
         val vilkårsvurdering = vilkårsvurderingRepository.findByBehandlingAndAktiv(behandling.id)
@@ -106,9 +102,7 @@ class BeregningService(
         val tilkjentYtelse = TilkjentYtelseUtils
                 .beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, featureToggleService)
 
-        tilkjentYtelseRepository.save(tilkjentYtelse)
-
-        return fagsakService.hentRestFagsak(behandling.fagsak.id)
+        return tilkjentYtelseRepository.save(tilkjentYtelse)
     }
 
     fun oppdaterTilkjentYtelseMedUtbetalingsoppdrag(behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -70,7 +70,7 @@ class VilkårsvurderingSteg(
 
         if (behandlingMedResultat.opprettetÅrsak != BehandlingÅrsak.SATSENDRING) {
             vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(vedtak = vedtakService.hentAktivForBehandlingThrows(
-                    behandlingId = behandlingMedResultat.id))
+                    behandlingId = behandling.id))
         }
 
         if (behandlingMedResultat.skalBehandlesAutomatisk && behandlingMedResultat.resultat != BehandlingResultat.AVSLÅTT) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
@@ -102,9 +102,7 @@ class ØkonomiIntegrasjonTest : AbstractSpringIntegrationTest() {
         vedtak!!.vedtaksdato = LocalDateTime.now()
         vedtakService.oppdater(vedtak)
 
-        val oppdatertFagsak = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
-
-        Assertions.assertEquals(Ressurs.Status.SUKSESS, oppdatertFagsak.status)
+        beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
 
         assertDoesNotThrow {
             økonomiService.oppdaterTilkjentYtelseOgIverksettVedtak(vedtak, "ansvarligSaksbehandler")

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
@@ -6,7 +6,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import io.mockk.MockKAnnotations
 import io.mockk.every
-import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPersonResultat
@@ -18,6 +17,7 @@ import no.nav.familie.ba.sak.common.toLocalDate
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.e2e.DatabaseCleanupService
+import no.nav.familie.ba.sak.ekstern.restDomene.tilRestPersonerMedAndeler
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
@@ -73,18 +73,10 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDate
 import java.time.YearMonth
 import javax.transaction.Transactional
@@ -133,7 +125,7 @@ class BehandlingIntegrationTest(
         @Autowired
         private val infotrygdBarnetrygdClient: InfotrygdBarnetrygdClient,
 
-        ): AbstractSpringIntegrationTest() {
+        ) : AbstractSpringIntegrationTest() {
 
 
     @BeforeEach
@@ -344,10 +336,11 @@ class BehandlingIntegrationTest(
         )
         vilkårsvurderingRepository.save(vilkårsvurdering)
 
-        val restVedtakBarnMap = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
-                .data!!.behandlinger
-                .flatMap { it.personerMedAndelerTilkjentYtelse }
-                .associateBy({ it.personIdent }, { it.ytelsePerioder.sortedBy { it.stønadFom } })
+        val tilkjentYtelse = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
+        val restVedtakBarnMap =
+                personopplysningGrunnlag.tilRestPersonerMedAndeler(andelerKnyttetTilPersoner = tilkjentYtelse.andelerTilkjentYtelse.toList())
+                        .associateBy({ it.personIdent },
+                                     { restPersonMedAndeler -> restPersonMedAndeler.ytelsePerioder.sortedBy { it.stønadFom } })
 
         val satsEndringDato2020 = SatsService.hentDatoForSatsendring(SatsType.TILLEGG_ORBA, 1354)!!.toYearMonth()
         val satsEndringDato2121 = SatsService.hentDatoForSatsendring(SatsType.TILLEGG_ORBA, 1654)!!.toYearMonth()
@@ -430,10 +423,11 @@ class BehandlingIntegrationTest(
 
         val satsEndringDato = SatsService.hentDatoForSatsendring(SatsType.TILLEGG_ORBA, 1654)!!.toYearMonth()
 
-        val restVedtakBarnMap = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
-                .data!!.behandlinger
-                .flatMap { it.personerMedAndelerTilkjentYtelse }
-                .associateBy({ it.personIdent }, { it.ytelsePerioder.sortedBy { it.stønadFom } })
+        val tilkjentYtelse = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
+        val restVedtakBarnMap =
+                personopplysningGrunnlag.tilRestPersonerMedAndeler(andelerKnyttetTilPersoner = tilkjentYtelse.andelerTilkjentYtelse.toList())
+                        .associateBy({ it.personIdent },
+                                     { restPersonMedAndeler -> restPersonMedAndeler.ytelsePerioder.sortedBy { it.stønadFom } })
 
         assertEquals(2, restVedtakBarnMap.size)
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Retter opp i bug hvor beregn tilkjent ytelse returnerte fagsak som prøvde å mappe opp gyldige begrunnelser på gamle vedtaksperioder.

