### PR TITLE
Fikser feil ved kopiering av begrunnelser til nytt vedtak.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -299,12 +299,13 @@ class VedtaksperiodeService(
         val gamleVedtaksperioderMedBegrunnelser = vedtaksperiodeRepository.finnVedtaksperioderFor(vedtakId = deaktivertVedtak.id)
 
         gamleVedtaksperioderMedBegrunnelser.forEach { vedtaksperiodeMedBegrunnelser ->
-            val nyVedtaksperiodeMedBegrunnelser = VedtaksperiodeMedBegrunnelser(
+            val nyVedtaksperiodeMedBegrunnelser = lagre(VedtaksperiodeMedBegrunnelser(
                     vedtak = aktivtVedtak,
                     fom = vedtaksperiodeMedBegrunnelser.fom,
                     tom = vedtaksperiodeMedBegrunnelser.tom,
                     type = vedtaksperiodeMedBegrunnelser.type,
-            )
+            ))
+
             lagre(nyVedtaksperiodeMedBegrunnelser.copy(
                     begrunnelser = vedtaksperiodeMedBegrunnelser.begrunnelser.map { it.kopier(nyVedtaksperiodeMedBegrunnelser) }
                             .toMutableSet(),


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser feil der begrunnelsene ble lagret samtidig som "parent" og det likte ikke hibernate.

[org.hibernate.TransientPropertyValueException]  En feil har oppstått: Not-null property references a transient value - transient instance must be saved before current operation : no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse.vedtaksperiodeMedBegrunnelser -> no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser

