### PR TITLE
Ikke automatisk revurder saker som har fått revurdering uten gammel sats

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -56,7 +56,8 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                             FROM behandling b
                                    INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
                                    INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
-                            WHERE f.status = 'LØPENDE'
+                            WHERE b.aktiv = true
+                              AND f.status = 'LØPENDE'
                               AND ty.utbetalingsoppdrag IS NOT NULL
                             GROUP BY fagsakid)
                         


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Legger til filtrering slik at saker som skulle hatt gammel sats i september, men har blitt revurdert til noe annet, ikke plukkes opp. Ikke krise hvis det hadde blir utført overflødig autokjøring på de, siden vi i utgangspunktet var forberedt på at man kanskje måtte regne med noen slike, men greit å unngå når man kan.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Neste steg blir å kjøre på alle behandlinger i testmiljø. 
