### PR TITLE
Spring boot 2.5-bump m/venner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.5.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -32,7 +32,7 @@
 
         <!-- Må settes for å kunne kjøre opp mock-oauth2-server i unit-tester -->
         <okhttp3.version>4.9.0</okhttp3.version>
-        <mock-oauth2-server.version>0.3.1</mock-oauth2-server.version>
+        <mock-oauth2-server.version>0.3.3</mock-oauth2-server.version>
         <!-- Må settes for å kunne kjøre opp mock-oauth2-server i unit-tester -->
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
@@ -42,8 +42,6 @@
         <!--suppress UnresolvedMavenProperty Ligger som secret i github-->
         <sonar.login>${SONAR_LOGIN}</sonar.login>
 
-        <!-- Setter disse til token-support sine versjoner, versjoner(9.x) i spring er ikke kompatibel med oauth2-oidc-sdk -->
-        <nimbus-jose-jwt.version>8.20.2</nimbus-jose-jwt.version>
     </properties>
 
     <dependencies>

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -123,6 +123,13 @@ funksjonsbrytere:
       enabled: false
 
 spring:
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql=false
+  flyway:
+    enabled: false
   kafka:
     bootstrap-servers: http://localhost:9092
     properties:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -123,15 +123,6 @@ funksjonsbrytere:
       enabled: false
 
 spring:
-  jpa:
-    show-sql: false
-    properties:
-      hibernate:
-        format_sql=false
-    hibernate:
-      ddl-auto: create
-  flyway:
-    enabled: false
   kafka:
     bootstrap-servers: http://localhost:9092
     properties:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi [reverta bump tidligere i sommer](https://github.com/navikt/familie-ba-sak/commit/349869429c700e8246656824b423d989d824db3c) fordi bumpen førte til random constraint-navn og tap av all data lokalt. Ser nå at hibernate:ddl-auto:create nok fører til drop og opprettelse ved boot, om jeg forstår det rett. Det forklarer også hvorfor dette ikke har skjedd i miljø som defaulter til none i stedet for create. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Er det en grunn til at vi har satt create lokalt? 