### PR TITLE
Bump spring boot til 2.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ docker exec -it <container_id> bash
 psql -U postgres
 CREATE DATABASE "familie-ba-sak";
 ```
+Obs! Husk å sette VM Options til `-Dspring.profiles.active=postgres`.
 
 ### Autentisering
 Dersom man vil gjøre autentiserte kall mot andre tjenester, må man sette opp følgende miljø-variabler:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.5.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -32,7 +32,7 @@
 
         <!-- Må settes for å kunne kjøre opp mock-oauth2-server i unit-tester -->
         <okhttp3.version>4.9.0</okhttp3.version>
-        <mock-oauth2-server.version>0.3.1</mock-oauth2-server.version>
+        <mock-oauth2-server.version>0.3.3</mock-oauth2-server.version>
         <!-- Må settes for å kunne kjøre opp mock-oauth2-server i unit-tester -->
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
@@ -42,8 +42,6 @@
         <!--suppress UnresolvedMavenProperty Ligger som secret i github-->
         <sonar.login>${SONAR_LOGIN}</sonar.login>
 
-        <!-- Setter disse til token-support sine versjoner, versjoner(9.x) i spring er ikke kompatibel med oauth2-oidc-sdk -->
-        <nimbus-jose-jwt.version>8.20.2</nimbus-jose-jwt.version>
     </properties>
 
     <dependencies>

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -123,6 +123,15 @@ funksjonsbrytere:
       enabled: false
 
 spring:
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql=false
+    hibernate:
+      ddl-auto: create
+  flyway:
+    enabled: false
   kafka:
     bootstrap-servers: http://localhost:9092
     properties:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -123,6 +123,13 @@ funksjonsbrytere:
       enabled: false
 
 spring:
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql=false
+  flyway:
+    enabled: false
   kafka:
     bootstrap-servers: http://localhost:9092
     properties:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -123,13 +123,6 @@ funksjonsbrytere:
       enabled: false
 
 spring:
-  jpa:
-    show-sql: false
-    properties:
-      hibernate:
-        format_sql=false
-  flyway:
-    enabled: false
   kafka:
     bootstrap-servers: http://localhost:9092
     properties:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -123,15 +123,6 @@ funksjonsbrytere:
       enabled: false
 
 spring:
-  jpa:
-    show-sql: false
-    properties:
-      hibernate:
-        format_sql=false
-    hibernate:
-      ddl-auto: create
-  flyway:
-    enabled: false
   kafka:
     bootstrap-servers: http://localhost:9092
     properties:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi [reverta bump tidligere i sommer](https://github.com/navikt/familie-ba-sak/commit/349869429c700e8246656824b423d989d824db3c) fordi bumpen førte til nye constraint-navn og tap av all data lokalt. Årsaken til dette er trolig at de fleste har kjørt med `-Dspring.profiles.active=dev` i henhold til readme, også under postgres-kjøring, siden vi er vant til å eksplisitt sette profiler på klasser og launchere. Dessverre er ikke det tilstrekkelig for bootstrap og vi må sette på et høyere nivå, sånn jeg forstår det.

Antakeligvis har postgres-configen tidligere overskrevet dev-configen, mens nå skjer det motsatte. Oppdaterer readme for å tydeliggjøre dette. 