### PR TITLE
Bug: begrunnelse ikke gyldig for å mappe til visningstekst frontend.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
@@ -248,7 +248,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
             Målform.NN -> "Du får meir barnetrygd fordi du har fått nytt barn, og barna bur saman med deg. Du får barnetrygden frå månaden etter at det nye barnet er fødd."
         }
     },
-    INNVILGET_FØDSELSHENDELSE_NYFØDT_BARN_FØRSTE("Nyfødt barn - første barn", erTilgjengeligFrontend = false) {
+    INNVILGET_FØDSELSHENDELSE_NYFØDT_BARN_FØRSTE("Nyfødt barn - første barn") {
 
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11, 14)
@@ -264,7 +264,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
             Målform.NN -> "Du får barnetrygd fordi du har fått barn og barnet bur saman med deg."
         }
     },
-    INNVILGET_FØDSELSHENDELSE_NYFØDT_BARN("Nyfødt barn - har barn fra før", erTilgjengeligFrontend = false) {
+    INNVILGET_FØDSELSHENDELSE_NYFØDT_BARN("Nyfødt barn - har barn fra før") {
 
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11, 14)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Enabler fødselshendelsebegrunnelse for frontend, men lar det ikke være en gyldig begrunnelse å velge for saksbehandler da dette bestemmes av gyldigeBegrunnelser på vedtaksperioden.

Mulig vi bør fjerne "erTilgjengeligFrontend" ettersom det er ikke det feltet som bestemmer om det er valgbart lenger. @MarcusGustafson74 dette er noe du kan ha i bakhodet når man rydder opp i gammel vedtaksperiodeløsning.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
