### PR TITLE
Feature/trigging av vetaksbegrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -1,10 +1,14 @@
 package no.nav.familie.ba.sak.kjerne.beregning.domene
 
-import no.nav.familie.ba.sak.common.*
+import no.nav.familie.ba.sak.common.BaseEntitet
+import no.nav.familie.ba.sak.common.YearMonthConverter
+import no.nav.familie.ba.sak.common.inneværendeMåned
+import no.nav.familie.ba.sak.common.nesteMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.fpsak.tidsserie.LocalDateSegment
 import java.time.YearMonth
-import java.util.*
+import java.util.Objects
 import javax.persistence.*
 
 @EntityListeners(RollestyringMotDatabase::class)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
@@ -1415,14 +1415,13 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
     fun triggesForPeriode(vedtaksperiodeMedBegrunnelser: VedtaksperiodeMedBegrunnelser,
                           vilkårsvurdering: Vilkårsvurdering,
-                          begrunnelseForVilkår: VedtakBegrunnelseSpesifikasjon,
                           persongrunnlag: PersonopplysningGrunnlag,
                           identerMedUtbetaling: List<String>): Boolean {
         if (!this.triggesAv.valgbar) {
             return false
         }
 
-        if (vedtaksperiodeMedBegrunnelser.type != begrunnelseForVilkår.vedtakBegrunnelseType.tilVedtaksperiodeType()) {
+        if (vedtaksperiodeMedBegrunnelser.type != this.vedtakBegrunnelseType.tilVedtaksperiodeType()) {
             return false
         }
 
@@ -1442,12 +1441,12 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
                             fom = vedtaksperiodeMedBegrunnelser.fom ?: TIDENES_MORGEN,
                             tom = vedtaksperiodeMedBegrunnelser.tom ?: TIDENES_ENDE
                     ),
-                    oppdatertBegrunnelseType = begrunnelseForVilkår.vedtakBegrunnelseType,
+                    oppdatertBegrunnelseType = this.vedtakBegrunnelseType,
                     utgjørendeVilkår = it,
                     aktuellePersonerForVedtaksperiode = persongrunnlag.personer
                             .filter{ person -> this.triggesAv.personTyper.contains(person.type)}
                             .filter { person ->
-                        if (begrunnelseForVilkår.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE) {
+                        if (this.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE) {
                             identerMedUtbetaling.contains(person.personIdent.ident) || person.type == PersonType.SØKER
                         } else true
                     },

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
@@ -319,7 +319,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), medlemskap = true)
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), medlemskap = true)
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
@@ -9,11 +9,16 @@ import no.nav.familie.ba.sak.common.forrigeMåned
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakUtils.hentPersonerMedUtgjørendeVilkår
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.*
@@ -22,6 +27,7 @@ import javax.persistence.Converter
 
 interface IVedtakBegrunnelse {
 
+    val triggesAv: TriggesAv
     val vedtakBegrunnelseType: VedtakBegrunnelseType
     fun hentHjemler(): SortedSet<Int>
     fun hentSanityApiNavn(): String
@@ -33,12 +39,23 @@ interface IVedtakBegrunnelse {
     ): String
 }
 
+data class TriggesAv(val vilkår: Set<Vilkår>? = null,
+                     val personType: Set<PersonType> = setOf(PersonType.BARN, PersonType.SØKER),
+                     val personerManglerOpplysninger: Boolean = false,
+                     val satsendring: Boolean = false,
+                     val barnMedSeksårsdag: Boolean = false,
+                     val vurderingAnnetGrunnlag: Boolean = false,
+                     val medlemskap: Boolean = false,
+                     val deltbosted: Boolean = false,
+                     val valgbar: Boolean = true)
+
 enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengeligFrontend: Boolean = true) : IVedtakBegrunnelse {
     INNVILGET_BOSATT_I_RIKTET("Norsk, nordisk bosatt i Norge") {
 
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11, 2)
         override fun hentSanityApiNavn() = "norskNordiskBosattINorge"
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -57,6 +74,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11, 2)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET, Vilkår.LOVLIG_OPPHOLD))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -75,6 +93,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -93,6 +112,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.SØKER))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -109,6 +129,9 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD),
+                                           personType = setOf(PersonType.SØKER),
+                                           vurderingAnnetGrunnlag = true)
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -125,6 +148,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD),
+                                           vurderingAnnetGrunnlag = true)
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -147,6 +172,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -165,6 +191,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -183,6 +210,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), vurderingAnnetGrunnlag = true)
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -203,6 +231,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), vurderingAnnetGrunnlag = true)
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -221,6 +250,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UNDER_18_ÅR))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -237,6 +267,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UNDER_18_ÅR))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -253,6 +284,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11, 14)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UNDER_18_ÅR))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -269,6 +301,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11, 14)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UNDER_18_ÅR))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -286,6 +319,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), medlemskap = true)
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -302,6 +336,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), vurderingAnnetGrunnlag = true)
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -326,6 +361,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personType = setOf(PersonType.BARN))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -342,6 +379,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.BARN))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -358,6 +397,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -374,6 +415,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -390,6 +433,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), vurderingAnnetGrunnlag = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -406,6 +451,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(17, 18)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(personerManglerOpplysninger = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -422,6 +469,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UNDER_18_ÅR))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -441,6 +490,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(10)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(barnMedSeksårsdag = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -460,6 +511,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), deltbosted = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -476,6 +529,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), deltbosted = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -494,6 +549,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 12)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), vurderingAnnetGrunnlag = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -510,6 +567,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf()
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(valgbar = false)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -523,6 +582,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
 
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 10)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(satsendring = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -539,6 +600,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -561,6 +624,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -581,6 +646,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -601,6 +668,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -621,6 +690,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -647,6 +718,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -675,6 +748,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -703,6 +778,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 12)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -719,6 +796,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -735,6 +814,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -755,6 +836,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -775,6 +858,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(17, 18)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -791,6 +876,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -807,6 +894,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(valgbar = false)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -823,6 +912,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf()
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(valgbar = false)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -835,6 +926,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -851,6 +944,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personType = setOf(PersonType.BARN))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -867,6 +962,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personType = setOf(PersonType.SØKER))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -883,6 +980,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -899,6 +998,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -915,6 +1016,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), vurderingAnnetGrunnlag = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -931,6 +1034,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.BARN))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -947,6 +1052,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.SØKER))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -963,6 +1070,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(17, 18)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(personerManglerOpplysninger = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -979,6 +1088,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), deltbosted = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -995,6 +1106,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), deltbosted = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1013,6 +1126,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UNDER_18_ÅR))
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1029,6 +1144,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf()
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(valgbar = false)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1041,6 +1158,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 12)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), vurderingAnnetGrunnlag = true)
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1057,6 +1176,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1077,6 +1198,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1093,6 +1216,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1113,6 +1238,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1133,6 +1260,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1149,6 +1278,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1169,6 +1300,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1193,6 +1326,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1209,6 +1344,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1225,6 +1362,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1241,6 +1380,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1257,6 +1398,8 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf()
         override fun hentSanityApiNavn() = TODO()
+        override val triggesAv = TriggesAv()
+
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
                 barnasFødselsdatoer: List<LocalDate>,
@@ -1269,6 +1412,53 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
                                          OPPHØR_FRITEKST,
                                          AVSLAG_FRITEKST,
                                          FORTSATT_INNVILGET_FRITEKST).contains(this)
+
+    fun triggesForPeriode(vedtaksperiodeMedBegrunnelser: VedtaksperiodeMedBegrunnelser,
+                          vilkårsvurdering: Vilkårsvurdering,
+                          begrunnelseForVilkår: VedtakBegrunnelseSpesifikasjon,
+                          persongrunnlag: PersonopplysningGrunnlag,
+                          identerMedUtbetaling: List<String>): Boolean {
+        if (!this.triggesAv.valgbar) {
+            return false
+        }
+
+        if (vedtaksperiodeMedBegrunnelser.type != begrunnelseForVilkår.vedtakBegrunnelseType.tilVedtaksperiodeType()) {
+            return false
+        }
+
+        if (this.triggesAv.personerManglerOpplysninger) return vilkårsvurdering.harPersonerManglerOpplysninger()
+
+        if (this.triggesAv.barnMedSeksårsdag) return persongrunnlag.harBarnMedSeksårsdagPåFom(vedtaksperiodeMedBegrunnelser.fom)
+
+        if (this.triggesAv.satsendring)
+            return SatsService.finnSatsendring(vedtaksperiodeMedBegrunnelser.fom ?: TIDENES_MORGEN).isNotEmpty()
+
+        var personerSomOppfyllerTriggerVilkår = persongrunnlag.personer.toMutableSet()
+
+        this.triggesAv.vilkår?.forEach {
+            val personerMedVilkårForPeriode = hentPersonerMedUtgjørendeVilkår(
+                    vilkårsvurdering = vilkårsvurdering,
+                    vedtaksperiode = Periode(
+                            fom = vedtaksperiodeMedBegrunnelser.fom ?: TIDENES_MORGEN,
+                            tom = vedtaksperiodeMedBegrunnelser.tom ?: TIDENES_ENDE
+                    ),
+                    oppdatertBegrunnelseType = begrunnelseForVilkår.vedtakBegrunnelseType,
+                    utgjørendeVilkår = it,
+                    aktuellePersonerForVedtaksperiode = persongrunnlag.personer.filter { person ->
+                        if (begrunnelseForVilkår.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE) {
+                            identerMedUtbetaling.contains(person.personIdent.ident) || person.type == PersonType.SØKER
+                        } else true
+                    },
+                    deltBosted = this.triggesAv.deltbosted,
+                    vurderingAnnetGrunnlag = this.triggesAv.vurderingAnnetGrunnlag
+            )
+
+            personerSomOppfyllerTriggerVilkår =
+                    personerSomOppfyllerTriggerVilkår.intersect(personerMedVilkårForPeriode).toMutableSet()
+        }
+
+        return personerSomOppfyllerTriggerVilkår.isNotEmpty()
+    }
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
@@ -1417,13 +1417,9 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
                           vilkårsvurdering: Vilkårsvurdering,
                           persongrunnlag: PersonopplysningGrunnlag,
                           identerMedUtbetaling: List<String>): Boolean {
-        if (!this.triggesAv.valgbar) {
-            return false
-        }
+        if (!this.triggesAv.valgbar) return false
 
-        if (vedtaksperiodeMedBegrunnelser.type != this.vedtakBegrunnelseType.tilVedtaksperiodeType()) {
-            return false
-        }
+        if (vedtaksperiodeMedBegrunnelser.type != this.vedtakBegrunnelseType.tilVedtaksperiodeType()) return false
 
         if (this.triggesAv.personerManglerOpplysninger) return vilkårsvurdering.harPersonerManglerOpplysninger()
 
@@ -1444,12 +1440,12 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
                     oppdatertBegrunnelseType = this.vedtakBegrunnelseType,
                     utgjørendeVilkår = it,
                     aktuellePersonerForVedtaksperiode = persongrunnlag.personer
-                            .filter{ person -> this.triggesAv.personTyper.contains(person.type)}
+                            .filter { person -> this.triggesAv.personTyper.contains(person.type) }
                             .filter { person ->
-                        if (this.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE) {
-                            identerMedUtbetaling.contains(person.personIdent.ident) || person.type == PersonType.SØKER
-                        } else true
-                    },
+                                if (this.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE) {
+                                    identerMedUtbetaling.contains(person.personIdent.ident) || person.type == PersonType.SØKER
+                                } else true
+                            },
                     deltBosted = this.triggesAv.deltbosted,
                     vurderingAnnetGrunnlag = this.triggesAv.vurderingAnnetGrunnlag
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
@@ -40,7 +40,7 @@ interface IVedtakBegrunnelse {
 }
 
 data class TriggesAv(val vilkår: Set<Vilkår>? = null,
-                     val personType: Set<PersonType> = setOf(PersonType.BARN, PersonType.SØKER),
+                     val personTyper: Set<PersonType> = setOf(PersonType.BARN, PersonType.SØKER),
                      val personerManglerOpplysninger: Boolean = false,
                      val satsendring: Boolean = false,
                      val barnMedSeksårsdag: Boolean = false,
@@ -112,7 +112,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.INNVILGELSE
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.SØKER))
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personTyper = setOf(PersonType.SØKER))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -130,7 +130,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
         override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD),
-                                           personType = setOf(PersonType.SØKER),
+                                           personTyper = setOf(PersonType.SØKER),
                                            vurderingAnnetGrunnlag = true)
 
         override fun hentBeskrivelse(
@@ -361,7 +361,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personType = setOf(PersonType.BARN))
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personTyper = setOf(PersonType.BARN))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -379,7 +379,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.BARN))
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personTyper = setOf(PersonType.BARN))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -944,7 +944,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personType = setOf(PersonType.BARN))
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personTyper = setOf(PersonType.BARN))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -962,7 +962,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(2, 4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personType = setOf(PersonType.SØKER))
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), personTyper = setOf(PersonType.SØKER))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -1034,7 +1034,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.BARN))
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personTyper = setOf(PersonType.BARN))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -1052,7 +1052,7 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override fun hentHjemler(): SortedSet<Int> = sortedSetOf(4, 11)
         override fun hentSanityApiNavn() = TODO()
-        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personType = setOf(PersonType.SØKER))
+        override val triggesAv = TriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD), personTyper = setOf(PersonType.SØKER))
 
         override fun hentBeskrivelse(
                 gjelderSøker: Boolean,
@@ -1444,7 +1444,9 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
                     ),
                     oppdatertBegrunnelseType = begrunnelseForVilkår.vedtakBegrunnelseType,
                     utgjørendeVilkår = it,
-                    aktuellePersonerForVedtaksperiode = persongrunnlag.personer.filter { person ->
+                    aktuellePersonerForVedtaksperiode = persongrunnlag.personer
+                            .filter{ person -> this.triggesAv.personTyper.contains(person.type)}
+                            .filter { person ->
                         if (begrunnelseForVilkår.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE) {
                             identerMedUtbetaling.contains(person.personIdent.ident) || person.type == PersonType.SØKER
                         } else true

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -328,7 +328,6 @@ class VedtaksperiodeService(
         val persongrunnlag = persongrunnlagService.hentAktiv(behandling.id) ?: error("Finner ikke persongrunnlag")
 
         return vedtaksperioderMedBegrunnelser.map { vedtaksperiodeMedBegrunnelser ->
-            val vilkår = Vilkår.values()
             val gyldigeBegrunnelser = mutableSetOf<VedtakBegrunnelseSpesifikasjon>()
 
             when (vedtaksperiodeMedBegrunnelser.type) {
@@ -346,9 +345,10 @@ class VedtaksperiodeService(
                                            ?: error("Finner ikke vilkårsvurdering ved begrunning av vedtak")
 
                     val identerMedUtbetaling =
-                            if (vedtaksperiodeMedBegrunnelser.type == Vedtaksperiodetype.OPPHØR) emptyList() else hentUtbetalingsperiodeForVedtaksperiode(
-                                    utbetalingsperioder = utbetalingsperioder,
-                                    fom = vedtaksperiodeMedBegrunnelser.fom).utbetalingsperiodeDetaljer
+                            if (vedtaksperiodeMedBegrunnelser.type == Vedtaksperiodetype.OPPHØR) emptyList()
+                            else hentUtbetalingsperiodeForVedtaksperiode(utbetalingsperioder = utbetalingsperioder,
+                                                                         fom = vedtaksperiodeMedBegrunnelser.fom)
+                                    .utbetalingsperiodeDetaljer
                                     .map { utbetalingsperiodeDetalj -> utbetalingsperiodeDetalj.person.personIdent }
 
                     (vilkårMedVedtakBegrunnelser.flatMap { it.value } + vedtakBegrunnelserIkkeTilknyttetVilkår)
@@ -367,7 +367,7 @@ class VedtaksperiodeService(
                                                                                        .toList())
         }
     }
-    
+
     fun oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(vedtak: Vedtak,
                                                                vedtakBegrunnelseSpesifikasjon: VedtakBegrunnelseSpesifikasjon) {
         val vedtaksperioder = hentPersisterteVedtaksperioder(vedtak)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -355,7 +355,6 @@ class VedtaksperiodeService(
                             .forEach {
                                 if (it.triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
                                                          vilkårsvurdering = vilkårsvurdering,
-                                                         begrunnelseForVilkår = it,
                                                          persongrunnlag = persongrunnlag,
                                                          identerMedUtbetaling = identerMedUtbetaling)) {
                                     gyldigeBegrunnelser.add(it)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakBegrunnelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakBegrunnelseTest.kt
@@ -655,10 +655,35 @@ class VedtakBegrunnelseTest(
                      restVedtaksperioderMedBegrunnelser.filter { it.type != Vedtaksperiodetype.UTBETALING && it.type != Vedtaksperiodetype.OPPHØR }.size)
 
         val gyldigeOpphørsbegrunnelser = VedtakBegrunnelseSpesifikasjon.values()
-                .filter { it.vedtakBegrunnelseType == VedtakBegrunnelseType.OPPHØR && it != VedtakBegrunnelseSpesifikasjon.OPPHØR_UNDER_18_ÅR && !it.erFritekstBegrunnelse() && it.erTilgjengeligFrontend }
+                .filter {
+                    it.vedtakBegrunnelseType == VedtakBegrunnelseType.OPPHØR &&
+                    it != VedtakBegrunnelseSpesifikasjon.OPPHØR_UNDER_18_ÅR &&
+                    !it.erFritekstBegrunnelse() && it.erTilgjengeligFrontend &&
+                    !it.triggesAv.vurderingAnnetGrunnlag &&
+                    !it.triggesAv.deltbosted &&
+                    !it.triggesAv.personerManglerOpplysninger &&
+                    it.triggesAv.valgbar
+                }
 
         assertEquals(gyldigeOpphørsbegrunnelser.size,
                      restVedtaksperioderMedBegrunnelser.find { it.type == Vedtaksperiodetype.OPPHØR }?.gyldigeBegrunnelser?.size)
+
+        val gyldigeUtbetalingsbegrunnelser = VedtakBegrunnelseSpesifikasjon.values()
+                .filter {
+                    it.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE &&
+                    it != VedtakBegrunnelseSpesifikasjon.OPPHØR_UNDER_18_ÅR &&
+                    !it.erFritekstBegrunnelse() && it.erTilgjengeligFrontend &&
+                    !it.triggesAv.vurderingAnnetGrunnlag &&
+                    !it.triggesAv.deltbosted &&
+                    !it.triggesAv.personerManglerOpplysninger &&
+                    !it.triggesAv.satsendring &&
+                    it.triggesAv.vilkår?.contains(Vilkår.UNDER_18_ÅR) != true &&
+                    it.triggesAv.valgbar
+                }
+
+        assertEquals(gyldigeUtbetalingsbegrunnelser.size,
+                     restVedtaksperioderMedBegrunnelser.find { it.type == Vedtaksperiodetype.UTBETALING }?.gyldigeBegrunnelser?.size)
+
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakBegrunnelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakBegrunnelseTest.kt
@@ -605,7 +605,7 @@ class VedtakBegrunnelseTest(
     }
 
     @Test
-    fun `Skal sjekke at kun opphørsbegrunnelser er valgbare ved opphør`() {
+    fun `Skal sjekke at kun valgbare opphørs- og innvilgelsesbegrunnelser returneres`() {
         val behandlingEtterVilkårsvurderingSteg = kjørStegprosessForFGB(
                 tilSteg = StegType.VILKÅRSVURDERING,
                 søkerFnr = randomFnr(),
@@ -671,7 +671,6 @@ class VedtakBegrunnelseTest(
         val gyldigeUtbetalingsbegrunnelser = VedtakBegrunnelseSpesifikasjon.values()
                 .filter {
                     it.vedtakBegrunnelseType == VedtakBegrunnelseType.INNVILGELSE &&
-                    it != VedtakBegrunnelseSpesifikasjon.OPPHØR_UNDER_18_ÅR &&
                     !it.erFritekstBegrunnelse() && it.erTilgjengeligFrontend &&
                     !it.triggesAv.vurderingAnnetGrunnlag &&
                     !it.triggesAv.deltbosted &&

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjonTest.kt
@@ -1,0 +1,127 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.lagVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class VedtakBegrunnelseSpesifikasjonTest {
+
+    val behandling = lagBehandling()
+    val søker = tilfeldigPerson(personType = PersonType.SØKER)
+    val barn = tilfeldigPerson(personType = PersonType.BARN)
+    val vedtaksperiodeMedBegrunnelser = lagVedtaksperiodeMedBegrunnelser(
+            type = Vedtaksperiodetype.UTBETALING,
+    )
+    val vilkårsvurdering = lagVilkårsvurdering(søker.personIdent.ident, lagBehandling(), Resultat.OPPFYLT)
+    val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søker, barn)
+
+    val identerMedUtbetaling = listOf(søker.personIdent.ident, barn.personIdent.ident)
+
+    @Test
+    fun `Oppfyller vilkår skal gi true`() {
+        assertTrue(VedtakBegrunnelseSpesifikasjon.INNVILGET_BOSATT_I_RIKTET
+                           .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                              vilkårsvurdering = vilkårsvurdering,
+                                              persongrunnlag = personopplysningGrunnlag,
+                                              identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Ikke valgbar skal gi false`() {
+        assertFalse(VedtakBegrunnelseSpesifikasjon.REDUKSJON_FRITEKST
+                            .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                               vilkårsvurdering = vilkårsvurdering,
+                                               persongrunnlag = personopplysningGrunnlag,
+                                               identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Annen periode type skal gi false`() {
+        assertFalse(VedtakBegrunnelseSpesifikasjon.OPPHØR_SØKER_UTVANDRET
+                            .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                               vilkårsvurdering = vilkårsvurdering,
+                                               persongrunnlag = personopplysningGrunnlag,
+                                               identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Har ikke barn med seksårsdag skal gi false`() {
+        //val persongrunnlag = mockk<PersonopplysningGrunnlag>()
+        //every { persongrunnlag.harBarnMedSeksårsdagPåFom(vedtaksperiodeMedBegrunnelser.fom) } returns true
+        assertFalse(VedtakBegrunnelseSpesifikasjon.REDUKSJON_UNDER_6_ÅR
+                            .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                               vilkårsvurdering = vilkårsvurdering,
+                                               persongrunnlag = personopplysningGrunnlag,
+                                               identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Har barn med seksårsdag skal gi true`() {
+        val persongrunnlag = mockk<PersonopplysningGrunnlag>()
+        every { persongrunnlag.harBarnMedSeksårsdagPåFom(vedtaksperiodeMedBegrunnelser.fom) } returns true
+
+        assertTrue(VedtakBegrunnelseSpesifikasjon.REDUKSJON_UNDER_6_ÅR
+                           .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                              vilkårsvurdering = vilkårsvurdering,
+                                              persongrunnlag = persongrunnlag,
+                                              identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Har sats endring skal gi true`() {
+        val vedtaksperiodeMedBegrunnelserSatsEndring = lagVedtaksperiodeMedBegrunnelser(
+                fom = LocalDate.of(2021, 9, 1),
+                type = Vedtaksperiodetype.UTBETALING,
+        )
+
+        assertTrue(VedtakBegrunnelseSpesifikasjon.INNVILGET_SATSENDRING
+                           .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelserSatsEndring,
+                                              vilkårsvurdering = vilkårsvurdering,
+                                              persongrunnlag = personopplysningGrunnlag,
+                                              identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Har ikke sats endring skal gi false`() {
+
+        assertFalse(VedtakBegrunnelseSpesifikasjon.INNVILGET_SATSENDRING
+                            .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                               vilkårsvurdering = vilkårsvurdering,
+                                               persongrunnlag = personopplysningGrunnlag,
+                                               identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Oppfyller ikke vilkår for person skal gi false`() {
+        val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, barn)
+
+        assertFalse(VedtakBegrunnelseSpesifikasjon.INNVILGET_LOVLIG_OPPHOLD_EØS_BORGER
+                            .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                               vilkårsvurdering = vilkårsvurdering,
+                                               persongrunnlag = personopplysningGrunnlag,
+                                               identerMedUtbetaling = identerMedUtbetaling))
+    }
+
+    @Test
+    fun `Oppfyller vilkår for person skal gi true`() {
+        val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søker)
+
+        assertTrue(VedtakBegrunnelseSpesifikasjon.INNVILGET_LOVLIG_OPPHOLD_EØS_BORGER
+                           .triggesForPeriode(vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                                              vilkårsvurdering = vilkårsvurdering,
+                                              persongrunnlag = personopplysningGrunnlag,
+                                              identerMedUtbetaling = identerMedUtbetaling))
+    }
+}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Forbedre filtering av hvilke vedtaksbegrunnelser som er valgbare.
I denne første PR er fokuset til å få det funksjonelt å virke.
Opprydding og tex fjerning av validering kommer i påfølgende PRer

For info om oppgave se: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5787

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Noter at fokus i denne PRen er på det funksjonelle og at opprydding kommer i senere PRer

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tester er oppdatert og omskrevet men detaljnivået av logikken som testes er høy og det er mange brancher som ikke blir testet.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
