### PR TITLE
Satt opphørs poster først i requesten

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
@@ -92,7 +92,7 @@ class UtbetalingsoppdragGenerator(
                 fagSystem = FAGSYSTEM,
                 saksnummer = vedtak.behandling.fagsak.id.toString(),
                 aktoer = vedtak.behandling.fagsak.hentAktivIdent().ident,
-                utbetalingsperiode = listOf(opprettes, opphøres).flatten()
+                utbetalingsperiode = listOf(opphøres, opprettes).flatten()
         )
     }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I Simulerings oppdrag til Økonomin ble poster som skulle opphøres satt sist i requesten, dette medførte i mange tilfeller at simuleringen feilet. I denne PR blir disse poster alltid satt først. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [/] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️ 
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [/] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
PR må deployes for vi kan verifisere om fiksen løser problemet.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
