### PR TITLE
Samle brevmaler til én enum class uten interface

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevKlient.kt
@@ -15,7 +15,7 @@ class BrevKlient(
 ) {
 
     fun genererBrev(målform: String, brev: Brev): ByteArray {
-        val url = URI.create("$familieBrevUri/api/ba-brev/dokument/${målform}/${brev.type.apiNavn}/pdf")
+        val url = URI.create("$familieBrevUri/api/ba-brev/dokument/${målform}/${brev.mal.apiNavn}/pdf")
         secureLogger.info("Kaller familie brev($url) med data ${brev.data.toBrevString()}")
         logger.info("Kaller familie brev med url: $url}")
         val response = restTemplate.postForEntity<ByteArray>(url, brev.data)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.AutovedtakNyfødtBarnF
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.AutovedtakNyfødtFørsteBarn
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Avslag
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brev
+import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Dødsfall
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.DødsfallData
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Etterbetaling
@@ -27,7 +28,6 @@ import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.SignaturVedtak
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.VedtakEndring
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.VedtakFellesfelter
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Vedtaksbrev
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Vedtaksbrevtype
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
@@ -50,7 +50,7 @@ class BrevService(
 ) {
 
     fun hentVedtaksbrevData(vedtak: Vedtak): Vedtaksbrev {
-        val vedtakstype = hentVedtaksbrevtype(vedtak.behandling)
+        val brevmal = hentVedtaksbrevmal(vedtak.behandling)
         val vedtakFellesfelter =
                 if (vedtak.behandling.resultat == BehandlingResultat.FORTSATT_INNVILGET ||
                     (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_VEDTAKSTYPE_MED_BEGRUNNELSER)
@@ -59,51 +59,52 @@ class BrevService(
                     lagVedtaksbrevFellesfelter(vedtak)
                 else
                     lagVedtaksbrevFellesfelterDeprecated(vedtak)
-        validerBrevdata(vedtakstype, vedtakFellesfelter)
+        validerBrevdata(brevmal, vedtakFellesfelter)
 
-        return when (vedtakstype) {
-            Vedtaksbrevtype.FØRSTEGANGSVEDTAK -> Førstegangsvedtak(vedtakFellesfelter = vedtakFellesfelter,
-                                                                   etterbetaling = hentEtterbetaling(vedtak))
+        return when (brevmal) {
+            Brevmal.FØRSTEGANGSVEDTAK -> Førstegangsvedtak(vedtakFellesfelter = vedtakFellesfelter,
+                                                           etterbetaling = hentEtterbetaling(vedtak))
 
-            Vedtaksbrevtype.VEDTAK_ENDRING -> VedtakEndring(
+            Brevmal.VEDTAK_ENDRING -> VedtakEndring(
                     vedtakFellesfelter = vedtakFellesfelter,
                     etterbetaling = hentEtterbetaling(vedtak),
                     erKlage = vedtak.behandling.erKlage(),
                     erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.behandling.id),
             )
 
-            Vedtaksbrevtype.OPPHØRT -> Opphørt(vedtakFellesfelter = vedtakFellesfelter,
-                                               erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.id))
+            Brevmal.OPPHØRT -> Opphørt(vedtakFellesfelter = vedtakFellesfelter,
+                                       erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.id))
 
-            Vedtaksbrevtype.OPPHØR_MED_ENDRING -> OpphørMedEndring(
+            Brevmal.OPPHØR_MED_ENDRING -> OpphørMedEndring(
                     vedtakFellesfelter = vedtakFellesfelter,
                     etterbetaling = hentEtterbetaling(vedtak),
                     erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.id),
             )
 
-            Vedtaksbrevtype.AVSLAG -> Avslag(vedtakFellesfelter = vedtakFellesfelter)
+            Brevmal.AVSLAG -> Avslag(vedtakFellesfelter = vedtakFellesfelter)
 
-            Vedtaksbrevtype.FORTSATT_INNVILGET -> ForsattInnvilget(vedtakFellesfelter = vedtakFellesfelter)
+            Brevmal.FORTSATT_INNVILGET -> ForsattInnvilget(vedtakFellesfelter = vedtakFellesfelter)
 
-            Vedtaksbrevtype.AUTOVEDTAK_BARN6_ÅR,
-            Vedtaksbrevtype.AUTOVEDTAK_BARN18_ÅR -> VedtakEndring(vedtakFellesfelter = vedtakFellesfelter,
-                                                                  etterbetaling = null,
-                                                                  erKlage = false,
-                                                                  erFeilutbetalingPåBehandling = false)
-            Vedtaksbrevtype.AUTOVEDTAK_NYFØDT_FØRSTE_BARN -> AutovedtakNyfødtFørsteBarn(
+            Brevmal.AUTOVEDTAK_BARN6_ÅR,
+            Brevmal.AUTOVEDTAK_BARN18_ÅR -> VedtakEndring(vedtakFellesfelter = vedtakFellesfelter,
+                                                          etterbetaling = null,
+                                                          erKlage = false,
+                                                          erFeilutbetalingPåBehandling = false)
+            Brevmal.AUTOVEDTAK_NYFØDT_FØRSTE_BARN -> AutovedtakNyfødtFørsteBarn(
                     vedtakFellesfelter = vedtakFellesfelter,
                     etterbetaling = hentEtterbetaling(vedtak),
             )
-            Vedtaksbrevtype.AUTOVEDTAK_NYFØDT_BARN_FRA_FØR -> AutovedtakNyfødtBarnFraFør(
+            Brevmal.AUTOVEDTAK_NYFØDT_BARN_FRA_FØR -> AutovedtakNyfødtBarnFraFør(
                     vedtakFellesfelter = vedtakFellesfelter,
                     etterbetaling = hentEtterbetaling(vedtak),
             )
+            else -> throw Feil("Forsøker å hente vedtaksbrevdata for brevmal ${brevmal.visningsTekst}")
         }
     }
 
-    private fun validerBrevdata(vedtakstype: Vedtaksbrevtype,
+    private fun validerBrevdata(brevmal: Brevmal,
                                 vedtakFellesfelter: VedtakFellesfelter) {
-        if (vedtakstype == Vedtaksbrevtype.OPPHØRT && vedtakFellesfelter.perioder.size > 1) {
+        if (brevmal == Brevmal.OPPHØRT && vedtakFellesfelter.perioder.size > 1) {
             throw Feil("Brevtypen er \"opphørt\", men mer enn én periode ble sendt med. Brev av typen opphørt skal kun ha én " +
                        "periode.")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
@@ -62,8 +62,8 @@ class BrevService(
         validerBrevdata(brevmal, vedtakFellesfelter)
 
         return when (brevmal) {
-            Brevmal.FØRSTEGANGSVEDTAK -> Førstegangsvedtak(vedtakFellesfelter = vedtakFellesfelter,
-                                                           etterbetaling = hentEtterbetaling(vedtak))
+            Brevmal.VEDTAK_FØRSTEGANGSVEDTAK -> Førstegangsvedtak(vedtakFellesfelter = vedtakFellesfelter,
+                                                                  etterbetaling = hentEtterbetaling(vedtak))
 
             Brevmal.VEDTAK_ENDRING -> VedtakEndring(
                     vedtakFellesfelter = vedtakFellesfelter,
@@ -72,18 +72,18 @@ class BrevService(
                     erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.behandling.id),
             )
 
-            Brevmal.OPPHØRT -> Opphørt(vedtakFellesfelter = vedtakFellesfelter,
-                                       erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.id))
+            Brevmal.VEDTAK_OPPHØRT -> Opphørt(vedtakFellesfelter = vedtakFellesfelter,
+                                              erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.id))
 
-            Brevmal.OPPHØR_MED_ENDRING -> OpphørMedEndring(
+            Brevmal.VEDTAK_OPPHØR_MED_ENDRING -> OpphørMedEndring(
                     vedtakFellesfelter = vedtakFellesfelter,
                     etterbetaling = hentEtterbetaling(vedtak),
                     erFeilutbetalingPåBehandling = erFeilutbetalingPåBehandling(vedtak.id),
             )
 
-            Brevmal.AVSLAG -> Avslag(vedtakFellesfelter = vedtakFellesfelter)
+            Brevmal.VEDTAK_AVSLAG -> Avslag(vedtakFellesfelter = vedtakFellesfelter)
 
-            Brevmal.FORTSATT_INNVILGET -> ForsattInnvilget(vedtakFellesfelter = vedtakFellesfelter)
+            Brevmal.VEDTAK_FORTSATT_INNVILGET -> ForsattInnvilget(vedtakFellesfelter = vedtakFellesfelter)
 
             Brevmal.AUTOVEDTAK_BARN6_ÅR,
             Brevmal.AUTOVEDTAK_BARN18_ÅR -> VedtakEndring(vedtakFellesfelter = vedtakFellesfelter,
@@ -104,7 +104,7 @@ class BrevService(
 
     private fun validerBrevdata(brevmal: Brevmal,
                                 vedtakFellesfelter: VedtakFellesfelter) {
-        if (brevmal == Brevmal.OPPHØRT && vedtakFellesfelter.perioder.size > 1) {
+        if (brevmal == Brevmal.VEDTAK_OPPHØRT && vedtakFellesfelter.perioder.size > 1) {
             throw Feil("Brevtypen er \"opphørt\", men mer enn én periode ble sendt med. Brev av typen opphørt skal kun ha én " +
                        "periode.")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
@@ -24,7 +24,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat.INNVILG
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat.OPPHØRT
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.BrevType
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.steg.StegType
@@ -50,7 +49,7 @@ fun hentVedtaksbrevmal(behandling: Behandling): Brevmal {
         hentManuellVedtaksbrevtype(behandling.type, behandling.resultat)
     }
 
-    return if (brevmal.brevType == BrevType.VEDAK) brevmal else throw Feil("Brevmal ${brevmal.visningsTekst} er ikke brev av typen ${BrevType.VEDAK}")
+    return if (brevmal.erVedtaksbrev) brevmal else throw Feil("Brevmal ${brevmal.visningsTekst} er ikke vedtaksbrev")
 }
 
 private fun hentAutomatiskVedtaksbrevtype(behandlingÅrsak: BehandlingÅrsak, fagsakStatus: FagsakStatus): Brevmal =
@@ -81,9 +80,9 @@ fun hentManuellVedtaksbrevtype(behandlingType: BehandlingType,
                 INNVILGET,
                 INNVILGET_OG_OPPHØRT,
                 DELVIS_INNVILGET,
-                DELVIS_INNVILGET_OG_OPPHØRT -> Brevmal.FØRSTEGANGSVEDTAK
+                DELVIS_INNVILGET_OG_OPPHØRT -> Brevmal.VEDTAK_FØRSTEGANGSVEDTAK
 
-                AVSLÅTT -> Brevmal.AVSLAG
+                AVSLÅTT -> Brevmal.VEDTAK_AVSLAG
 
                 else -> throw FunksjonellFeil(melding = feilmeldingBehandlingTypeOgResultat,
                                               frontendFeilmelding = frontendFeilmelding)
@@ -98,7 +97,7 @@ fun hentManuellVedtaksbrevtype(behandlingType: BehandlingType,
                 AVSLÅTT_OG_ENDRET,
                 ENDRET -> Brevmal.VEDTAK_ENDRING
 
-                OPPHØRT -> Brevmal.OPPHØRT
+                OPPHØRT -> Brevmal.VEDTAK_OPPHØRT
 
                 INNVILGET_OG_OPPHØRT,
                 INNVILGET_ENDRET_OG_OPPHØRT,
@@ -106,11 +105,11 @@ fun hentManuellVedtaksbrevtype(behandlingType: BehandlingType,
                 DELVIS_INNVILGET_ENDRET_OG_OPPHØRT,
                 AVSLÅTT_OG_OPPHØRT,
                 AVSLÅTT_ENDRET_OG_OPPHØRT,
-                ENDRET_OG_OPPHØRT -> Brevmal.OPPHØR_MED_ENDRING
+                ENDRET_OG_OPPHØRT -> Brevmal.VEDTAK_OPPHØR_MED_ENDRING
 
-                FORTSATT_INNVILGET -> Brevmal.FORTSATT_INNVILGET
+                FORTSATT_INNVILGET -> Brevmal.VEDTAK_FORTSATT_INNVILGET
 
-                AVSLÅTT -> Brevmal.AVSLAG
+                AVSLÅTT -> Brevmal.VEDTAK_AVSLAG
 
                 else -> throw FunksjonellFeil(melding = feilmeldingBehandlingTypeOgResultat,
                                               frontendFeilmelding = frontendFeilmelding)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/DokumentService.kt
@@ -16,9 +16,7 @@ import no.nav.familie.ba.sak.kjerne.dokument.DokumentController.ManueltBrevReque
 import no.nav.familie.ba.sak.kjerne.dokument.domene.BrevType.INNHENTE_OPPLYSNINGER
 import no.nav.familie.ba.sak.kjerne.dokument.domene.BrevType.VARSEL_OM_REVURDERING
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brev
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.BrevType
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.EnkelBrevtype
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Vedtaksbrevtype
+import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.tilBrevmal
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -50,8 +48,7 @@ class DokumentService(
         private val rolleConfig: RolleConfig
 ) {
 
-    private val antallBrevSendt: Map<BrevType, Counter> = mutableListOf<BrevType>().plus(EnkelBrevtype.values()).plus(
-            Vedtaksbrevtype.values()).map {
+    private val antallBrevSendt: Map<Brevmal, Counter> = mutableListOf<Brevmal>().plus(Brevmal.values()).map {
         it to Metrics.counter("brev.sendt",
                               "brevtype", it.visningsTekst)
     }.toMap()
@@ -159,21 +156,21 @@ class DokumentService(
                                             behandlingId = behandling.id,
                                             loggTekst = manueltBrevRequest.brevmal.visningsTekst.replaceFirstChar { it.uppercase() },
                                             loggBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
-                                            brevType = manueltBrevRequest.brevmal.tilSanityBrevtype())
+                                            brevMal = manueltBrevRequest.brevmal.tilSanityBrevtype())
     }
 
     fun distribuerBrevOgLoggHendelse(journalpostId: String,
                                      behandlingId: Long,
                                      loggTekst: String,
                                      loggBehandlerRolle: BehandlerRolle,
-                                     brevType: BrevType
+                                     brevMal: Brevmal
 
     ): Ressurs<String> {
         val distribuerBrevBestillingId = integrasjonClient.distribuerBrev(journalpostId)
         loggService.opprettDistribuertBrevLogg(behandlingId = behandlingId,
                                                tekst = loggTekst,
                                                rolle = loggBehandlerRolle)
-        antallBrevSendt[brevType]?.increment()
+        antallBrevSendt[brevMal]?.increment()
 
         return distribuerBrevBestillingId
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/MalMedData.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/MalMedData.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.EnkelBrevtype
+import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brevmal
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 
 enum class BrevType(val malId: String, val dokumenttype: Dokumenttype, val visningsTekst: String, val genererForside: Boolean) {
@@ -23,9 +23,9 @@ enum class BrevType(val malId: String, val dokumenttype: Dokumenttype, val visni
 
     fun tilSanityBrevtype() =
             when (this) {
-                INNHENTE_OPPLYSNINGER -> EnkelBrevtype.INNHENTE_OPPLYSNINGER
-                VARSEL_OM_REVURDERING -> EnkelBrevtype.VARSEL_OM_REVURDERING
-                HENLEGGE_TRUKKET_SØKNAD -> EnkelBrevtype.HENLEGGE_TRUKKET_SØKNAD
+                INNHENTE_OPPLYSNINGER -> Brevmal.INNHENTE_OPPLYSNINGER
+                VARSEL_OM_REVURDERING -> Brevmal.VARSEL_OM_REVURDERING
+                HENLEGGE_TRUKKET_SØKNAD -> Brevmal.HENLEGGE_TRUKKET_SØKNAD
                 VEDTAK -> throw Feil("Kan ikke oversette gammel brevtype til vedtak")
             }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/AutovedtakNyfødtBarnFraFør.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/AutovedtakNyfødtBarnFraFør.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class AutovedtakNyfødtBarnFraFør(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
+        override val mal: Brevmal = Brevmal.AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
         override val data: AutovedtakNyfødtBarnFraFørData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/AutovedtakNyfødtFørsteBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/AutovedtakNyfødtFørsteBarn.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class AutovedtakNyfødtFørsteBarn(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.AUTOVEDTAK_NYFØDT_FØRSTE_BARN,
+        override val mal: Brevmal = Brevmal.AUTOVEDTAK_NYFØDT_FØRSTE_BARN,
         override val data: AutovedtakNyfødtFørsteBarnData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Avslag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Avslag.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class Avslag(
-        override val mal: Brevmal = Brevmal.AVSLAG,
+        override val mal: Brevmal = Brevmal.VEDTAK_AVSLAG,
         override val data: AvslagData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Avslag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Avslag.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class Avslag(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.AVSLAG,
+        override val mal: Brevmal = Brevmal.AVSLAG,
         override val data: AvslagData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Brev.kt
@@ -12,27 +12,22 @@ interface Brev {
     val data: BrevData
 }
 
-enum class BrevType {
-    ENKEL,
-    VEDAK,
-}
+enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visningsTekst: String) {
+    INNHENTE_OPPLYSNINGER(false, "innhenteOpplysninger", "innhente opplysninger"),
+    HENLEGGE_TRUKKET_SØKNAD(false, "henleggeTrukketSoknad", "henlegge trukket søknad"),
+    VARSEL_OM_REVURDERING(false, "varselOmRevurdering", "varsel om revurdering"),
+    DØDSFALL(false, "dodsfall", "Dødsfall"),
 
-enum class Brevmal(val brevType: BrevType, val apiNavn: String, val visningsTekst: String) {
-    INNHENTE_OPPLYSNINGER(BrevType.ENKEL, "innhenteOpplysninger", "innhente opplysninger"),
-    HENLEGGE_TRUKKET_SØKNAD(BrevType.ENKEL, "henleggeTrukketSoknad", "henlegge trukket søknad"),
-    VARSEL_OM_REVURDERING(BrevType.ENKEL, "varselOmRevurdering", "varsel om revurdering"),
-    DØDSFALL(BrevType.ENKEL, "dodsfall", "Dødsfall"),
-
-    FØRSTEGANGSVEDTAK(BrevType.VEDAK, "forstegangsvedtak", "Førstegangsvedtak"),
-    VEDTAK_ENDRING(BrevType.VEDAK, "vedtakEndring", "Vedtak endring"),
-    OPPHØRT(BrevType.VEDAK, "opphort", "Opphørt"),
-    OPPHØR_MED_ENDRING(BrevType.VEDAK, "opphorMedEndring", "Opphør med endring"),
-    AVSLAG(BrevType.VEDAK, "vedtakAvslag", "Avslag"),
-    FORTSATT_INNVILGET(BrevType.VEDAK, "vedtakFortsattInnvilget", "Vedtak fortstatt innvilget"),
-    AUTOVEDTAK_BARN6_ÅR(BrevType.VEDAK, "autovedtakBarn6År", "Autovedtak - Barn 6 år"),
-    AUTOVEDTAK_BARN18_ÅR(BrevType.VEDAK, "autovedtakBarn18År", "Autovedtak - Barn 18 år"),
-    AUTOVEDTAK_NYFØDT_FØRSTE_BARN(BrevType.VEDAK, "autovedtakNyfodtForsteBarn", "Autovedtak nyfødt - første barn"),
-    AUTOVEDTAK_NYFØDT_BARN_FRA_FØR(BrevType.VEDAK, "autovedtakNyfodtBarnFraFor", "Autovedtak nyfødt - barn fra før"),
+    VEDTAK_FØRSTEGANGSVEDTAK(true, "forstegangsvedtak", "Førstegangsvedtak"),
+    VEDTAK_ENDRING(true, "vedtakEndring", "Vedtak endring"),
+    VEDTAK_OPPHØRT(true, "opphort", "Opphørt"),
+    VEDTAK_OPPHØR_MED_ENDRING(true, "opphorMedEndring", "Opphør med endring"),
+    VEDTAK_AVSLAG(true, "vedtakAvslag", "Avslag"),
+    VEDTAK_FORTSATT_INNVILGET(true, "vedtakFortsattInnvilget", "Vedtak fortstatt innvilget"),
+    AUTOVEDTAK_BARN6_ÅR(true, "autovedtakBarn6År", "Autovedtak - Barn 6 år"),
+    AUTOVEDTAK_BARN18_ÅR(true, "autovedtakBarn18År", "Autovedtak - Barn 18 år"),
+    AUTOVEDTAK_NYFØDT_FØRSTE_BARN(true, "autovedtakNyfodtForsteBarn", "Autovedtak nyfødt - første barn"),
+    AUTOVEDTAK_NYFØDT_BARN_FRA_FØR(true, "autovedtakNyfodtBarnFraFor", "Autovedtak nyfødt - barn fra før"),
 }
 
 interface BrevData {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Brev.kt
@@ -8,34 +8,31 @@ import java.time.LocalDate
 
 interface Brev {
 
-    val type: BrevType
+    val mal: Brevmal
     val data: BrevData
 }
 
-interface BrevType {
-
-    val apiNavn: String
-    val visningsTekst: String
+enum class BrevType {
+    ENKEL,
+    VEDAK,
 }
 
-enum class EnkelBrevtype(override val apiNavn: String, override val visningsTekst: String) : BrevType {
-    INNHENTE_OPPLYSNINGER("innhenteOpplysninger", "innhente opplysninger"),
-    HENLEGGE_TRUKKET_SØKNAD("henleggeTrukketSoknad", "henlegge trukket søknad"),
-    VARSEL_OM_REVURDERING("varselOmRevurdering", "varsel om revurdering"),
-    DØDSFALL("dodsfall", "Dødsfall"),
-}
+enum class Brevmal(val brevType: BrevType, val apiNavn: String, val visningsTekst: String) {
+    INNHENTE_OPPLYSNINGER(BrevType.ENKEL, "innhenteOpplysninger", "innhente opplysninger"),
+    HENLEGGE_TRUKKET_SØKNAD(BrevType.ENKEL, "henleggeTrukketSoknad", "henlegge trukket søknad"),
+    VARSEL_OM_REVURDERING(BrevType.ENKEL, "varselOmRevurdering", "varsel om revurdering"),
+    DØDSFALL(BrevType.ENKEL, "dodsfall", "Dødsfall"),
 
-enum class Vedtaksbrevtype(override val apiNavn: String, override val visningsTekst: String) : BrevType {
-    FØRSTEGANGSVEDTAK("forstegangsvedtak", "Førstegangsvedtak"),
-    VEDTAK_ENDRING("vedtakEndring", "Vedtak endring"),
-    OPPHØRT("opphort", "Opphørt"),
-    OPPHØR_MED_ENDRING("opphorMedEndring", "Opphør med endring"),
-    AVSLAG("vedtakAvslag", "Avslag"),
-    FORTSATT_INNVILGET("vedtakFortsattInnvilget", "Vedtak fortstatt innvilget"),
-    AUTOVEDTAK_BARN6_ÅR("autovedtakBarn6År", "Autovedtak - Barn 6 år"),
-    AUTOVEDTAK_BARN18_ÅR("autovedtakBarn18År", "Autovedtak - Barn 18 år"),
-    AUTOVEDTAK_NYFØDT_FØRSTE_BARN("autovedtakNyfodtForsteBarn", "Autovedtak nyfødt - første barn"),
-    AUTOVEDTAK_NYFØDT_BARN_FRA_FØR("autovedtakNyfodtBarnFraFor", "Autovedtak nyfødt - barn fra før"),
+    FØRSTEGANGSVEDTAK(BrevType.VEDAK, "forstegangsvedtak", "Førstegangsvedtak"),
+    VEDTAK_ENDRING(BrevType.VEDAK, "vedtakEndring", "Vedtak endring"),
+    OPPHØRT(BrevType.VEDAK, "opphort", "Opphørt"),
+    OPPHØR_MED_ENDRING(BrevType.VEDAK, "opphorMedEndring", "Opphør med endring"),
+    AVSLAG(BrevType.VEDAK, "vedtakAvslag", "Avslag"),
+    FORTSATT_INNVILGET(BrevType.VEDAK, "vedtakFortsattInnvilget", "Vedtak fortstatt innvilget"),
+    AUTOVEDTAK_BARN6_ÅR(BrevType.VEDAK, "autovedtakBarn6År", "Autovedtak - Barn 6 år"),
+    AUTOVEDTAK_BARN18_ÅR(BrevType.VEDAK, "autovedtakBarn18År", "Autovedtak - Barn 18 år"),
+    AUTOVEDTAK_NYFØDT_FØRSTE_BARN(BrevType.VEDAK, "autovedtakNyfodtForsteBarn", "Autovedtak nyfødt - første barn"),
+    AUTOVEDTAK_NYFØDT_BARN_FRA_FØR(BrevType.VEDAK, "autovedtakNyfodtBarnFraFor", "Autovedtak nyfødt - barn fra før"),
 }
 
 interface BrevData {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Dødsfall.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Dødsfall.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import java.time.LocalDate
 
 data class Dødsfall(
-        override val type: BrevType = EnkelBrevtype.DØDSFALL,
+        override val mal: Brevmal = Brevmal.DØDSFALL,
         override val data: DødsfallData
 ) : Brev
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/ForsattInnvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/ForsattInnvilget.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class ForsattInnvilget(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.FORTSATT_INNVILGET,
+        override val mal: Brevmal = Brevmal.FORTSATT_INNVILGET,
         override val data: ForsattInnvilgetData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/ForsattInnvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/ForsattInnvilget.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class ForsattInnvilget(
-        override val mal: Brevmal = Brevmal.FORTSATT_INNVILGET,
+        override val mal: Brevmal = Brevmal.VEDTAK_FORTSATT_INNVILGET,
         override val data: ForsattInnvilgetData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Førstegangsvedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Førstegangsvedtak.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class Førstegangsvedtak(
-        override val mal: Brevmal = Brevmal.FØRSTEGANGSVEDTAK,
+        override val mal: Brevmal = Brevmal.VEDTAK_FØRSTEGANGSVEDTAK,
         override val data: FørstegangsvedtakData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Førstegangsvedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Førstegangsvedtak.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class Førstegangsvedtak(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.FØRSTEGANGSVEDTAK,
+        override val mal: Brevmal = Brevmal.FØRSTEGANGSVEDTAK,
         override val data: FørstegangsvedtakData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/HenleggeTrukketSøknadBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/HenleggeTrukketSøknadBrev.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class HenleggeTrukketSøknadBrev(
-        override val type: BrevType = EnkelBrevtype.HENLEGGE_TRUKKET_SØKNAD,
+        override val mal: Brevmal = Brevmal.HENLEGGE_TRUKKET_SØKNAD,
         override val data: HenleggeTrukketSøknadData
 ) : Brev
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/InnhenteOpplysningerBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/InnhenteOpplysningerBrev.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import java.time.LocalDate
 
 data class InnhenteOpplysningerBrev(
-        override val type: BrevType = EnkelBrevtype.INNHENTE_OPPLYSNINGER,
+        override val mal: Brevmal = Brevmal.INNHENTE_OPPLYSNINGER,
         override val data: InnhenteOpplysningerData
 ) : Brev
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/OpphørMedEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/OpphørMedEndring.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class OpphørMedEndring(
-        override val mal: Brevmal = Brevmal.OPPHØR_MED_ENDRING,
+        override val mal: Brevmal = Brevmal.VEDTAK_OPPHØR_MED_ENDRING,
         override val data: OpphørMedEndringData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/OpphørMedEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/OpphørMedEndring.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class OpphørMedEndring(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.OPPHØR_MED_ENDRING,
+        override val mal: Brevmal = Brevmal.OPPHØR_MED_ENDRING,
         override val data: OpphørMedEndringData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Opphørt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Opphørt.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class Opphørt(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.OPPHØRT,
+        override val mal: Brevmal = Brevmal.OPPHØRT,
         override val data: OpphørtData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Opphørt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Opphørt.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class Opphørt(
-        override val mal: Brevmal = Brevmal.OPPHØRT,
+        override val mal: Brevmal = Brevmal.VEDTAK_OPPHØRT,
         override val data: OpphørtData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/VarselOmRevurderingBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/VarselOmRevurderingBrev.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import java.time.LocalDate
 
 data class VarselOmRevurderingBrev(
-        override val type: BrevType = EnkelBrevtype.VARSEL_OM_REVURDERING,
+        override val mal: Brevmal = Brevmal.VARSEL_OM_REVURDERING,
         override val data: VarselOmRevurderingData
 ) : Brev
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/VedtakEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/VedtakEndring.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 data class VedtakEndring(
-        override val type: Vedtaksbrevtype = Vedtaksbrevtype.VEDTAK_ENDRING,
+        override val mal: Brevmal = Brevmal.VEDTAK_ENDRING,
         override val data: EndringVedtakData
 ) : Vedtaksbrev {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Vedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/Vedtaksbrev.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.dokument.domene.maler
 
 interface Vedtaksbrev : Brev {
 
-    override val type: Vedtaksbrevtype
+    override val mal: Brevmal
     override val data: VedtaksbrevData
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/DistribuerVedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/DistribuerVedtaksbrev.kt
@@ -25,7 +25,7 @@ class DistribuerVedtaksbrev(
                                                      behandlingId = data.behandlingId,
                                                      loggTekst = vedtakstype.visningsTekst,
                                                      loggBehandlerRolle = BehandlerRolle.SYSTEM,
-                                                     brevType = vedtakstype)
+                                                     brevMal = vedtakstype)
 
         val ferdigstillBehandlingTask = FerdigstillBehandlingTask.opprettTask(
                 personIdent = data.personIdent,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -22,8 +22,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Vedtaksbrevtype
-import no.nav.familie.ba.sak.kjerne.dokument.hentVedtaksbrevtype
+import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brevmal
+import no.nav.familie.ba.sak.kjerne.dokument.hentVedtaksbrevmal
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -258,9 +258,9 @@ class VedtaksperiodeService(
         slettVedtaksperioderFor(vedtak)
         if (vedtak.behandling.resultat == BehandlingResultat.FORTSATT_INNVILGET) {
 
-            val vedtakstype = hentVedtaksbrevtype(vedtak.behandling)
-            val erAutobrevFor6Og18År = vedtakstype == Vedtaksbrevtype.AUTOVEDTAK_BARN6_ÅR
-                                       || vedtakstype == Vedtaksbrevtype.AUTOVEDTAK_BARN18_ÅR
+            val vedtaksbrevmal = hentVedtaksbrevmal(vedtak.behandling)
+            val erAutobrevFor6Og18År = vedtaksbrevmal == Brevmal.AUTOVEDTAK_BARN6_ÅR
+                                       || vedtaksbrevmal == Brevmal.AUTOVEDTAK_BARN18_ÅR
 
             val fom = if (erAutobrevFor6Og18År) {
                 YearMonth.now().førsteDagIInneværendeMåned()

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
@@ -102,7 +102,7 @@ internal class BrevUtilsTest {
 
         støttedeBehandlingsersultaterFørstegangsbehandling.filterNot { it == BehandlingResultat.AVSLÅTT }.forEach {
             Assertions.assertEquals(
-                    Brevmal.FØRSTEGANGSVEDTAK,
+                    Brevmal.VEDTAK_FØRSTEGANGSVEDTAK,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.FØRSTEGANGSBEHANDLING,
                             it),
@@ -113,7 +113,7 @@ internal class BrevUtilsTest {
     @Test
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for avslått førstegangsbehandling`() {
         Assertions.assertEquals(
-                Brevmal.AVSLAG,
+                Brevmal.VEDTAK_AVSLAG,
                 hentManuellVedtaksbrevtype(
                         BehandlingType.FØRSTEGANGSBEHANDLING,
                         BehandlingResultat.AVSLÅTT),
@@ -160,7 +160,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Opphørt'`() {
         behandlingsersultaterForOpphørt.forEach {
             Assertions.assertEquals(
-                    Brevmal.OPPHØRT,
+                    Brevmal.VEDTAK_OPPHØRT,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -182,7 +182,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Opphør med endring'`() {
         behandlingsersultaterForOpphørMedEndring.forEach {
             Assertions.assertEquals(
-                    Brevmal.OPPHØR_MED_ENDRING,
+                    Brevmal.VEDTAK_OPPHØR_MED_ENDRING,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -197,7 +197,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Fortsatt innvilget'`() {
         behandlingsersultaterForFortsattInnvilget.forEach {
             Assertions.assertEquals(
-                    Brevmal.FORTSATT_INNVILGET,
+                    Brevmal.VEDTAK_FORTSATT_INNVILGET,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -211,7 +211,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Avslag'`() {
         behandlingsersultaterForAvslag.forEach {
             Assertions.assertEquals(
-                    Brevmal.AVSLAG,
+                    Brevmal.VEDTAK_AVSLAG,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
@@ -5,14 +5,13 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Vedtaksbrevtype
+import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -103,7 +102,7 @@ internal class BrevUtilsTest {
 
         støttedeBehandlingsersultaterFørstegangsbehandling.filterNot { it == BehandlingResultat.AVSLÅTT }.forEach {
             Assertions.assertEquals(
-                    Vedtaksbrevtype.FØRSTEGANGSVEDTAK,
+                    Brevmal.FØRSTEGANGSVEDTAK,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.FØRSTEGANGSBEHANDLING,
                             it),
@@ -114,7 +113,7 @@ internal class BrevUtilsTest {
     @Test
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for avslått førstegangsbehandling`() {
         Assertions.assertEquals(
-                Vedtaksbrevtype.AVSLAG,
+                Brevmal.AVSLAG,
                 hentManuellVedtaksbrevtype(
                         BehandlingType.FØRSTEGANGSBEHANDLING,
                         BehandlingResultat.AVSLÅTT),
@@ -147,7 +146,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Vedtak endring'`() {
         behandlingsersultaterForVedtakEndring.forEach {
             Assertions.assertEquals(
-                    Vedtaksbrevtype.VEDTAK_ENDRING,
+                    Brevmal.VEDTAK_ENDRING,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -161,7 +160,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Opphørt'`() {
         behandlingsersultaterForOpphørt.forEach {
             Assertions.assertEquals(
-                    Vedtaksbrevtype.OPPHØRT,
+                    Brevmal.OPPHØRT,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -183,7 +182,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Opphør med endring'`() {
         behandlingsersultaterForOpphørMedEndring.forEach {
             Assertions.assertEquals(
-                    Vedtaksbrevtype.OPPHØR_MED_ENDRING,
+                    Brevmal.OPPHØR_MED_ENDRING,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -198,7 +197,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Fortsatt innvilget'`() {
         behandlingsersultaterForFortsattInnvilget.forEach {
             Assertions.assertEquals(
-                    Vedtaksbrevtype.FORTSATT_INNVILGET,
+                    Brevmal.FORTSATT_INNVILGET,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -212,7 +211,7 @@ internal class BrevUtilsTest {
     fun `test hentManuellVedtaksbrevtype gir riktig vedtaksbrevtype for 'Avslag'`() {
         behandlingsersultaterForAvslag.forEach {
             Assertions.assertEquals(
-                    Vedtaksbrevtype.AVSLAG,
+                    Brevmal.AVSLAG,
                     hentManuellVedtaksbrevtype(
                             BehandlingType.REVURDERING,
                             it),
@@ -247,7 +246,7 @@ internal class BrevUtilsTest {
                 lagBehandling(fagsak = fagsak, automatiskOpprettelse = true, årsak = BehandlingÅrsak.FØDSELSHENDELSE).copy(
                         resultat = BehandlingResultat.INNVILGET)
         Assertions.assertEquals(
-                Vedtaksbrevtype.AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
+                Brevmal.AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
                 hentBrevtype(behandling))
     }
 
@@ -258,7 +257,7 @@ internal class BrevUtilsTest {
                 lagBehandling(fagsak = fagsak, automatiskOpprettelse = true, årsak = BehandlingÅrsak.FØDSELSHENDELSE).copy(
                         resultat = BehandlingResultat.INNVILGET)
         Assertions.assertEquals(
-                Vedtaksbrevtype.AUTOVEDTAK_NYFØDT_FØRSTE_BARN,
+                Brevmal.AUTOVEDTAK_NYFØDT_FØRSTE_BARN,
                 hentBrevtype(behandling))
     }
 


### PR DESCRIPTION
**Hva?** 
Gjøre det mulig å lese lagret BrevType-stringer fra database til enums (feks _VEDTAK_ENDRING_)

**Hvorfor?**
I forbindelse med at vi ønsker å kunne gjøre distribusjon av manuelle brev async har vi behov for å lagre og hente opp igjen hvordan brev som skal sendes. 

**Hvordan?**

I nåværende løsning er dette `interface BrevType` som implementeres av enumklassene `Vedtaksbrevtype` og `EnkelBrevType`. 

Siden interface ikke har constructors feiler deserialisering fra databasen. `
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `no.nav.familie.ba.sak.kjerne.dokument.domene.maler.BrevType` (no Creators, like default constructor, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information`)

Enums kan ikke extende abstrakte klasser, så vi må hjelpe deserialiseringa fra db. Fikk ikke det til å fungere med jpa-converter og ser ut til at man må definere typer for å hjelpe jackson https://stackoverflow.com/questions/25387978/how-to-add-custom-deserializer-to-interface-using-jackson. Synes da det virker ryddigere med én klasse med type-parameter. 
Foreslått løsning: 
**Erstatt `Vedtaksbrevtype: BrevType` og `EnkelBrevType: BrevType` med én `Brevmal` som har type** 
