### PR TITLE
Revurder behandlinger uten utbetalingsoppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autorevurdering/SatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autorevurdering/SatsendringScheduler.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.autorevurdering
 
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.leader.LeaderClient
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
@@ -12,7 +11,6 @@ import java.net.InetAddress
 @Service
 class SatsendringScheduler(
         private val satsendringService: SatsendringService,
-        private val behandlingRepository: BehandlingRepository,
         private val featureToggleService: FeatureToggleService) {
 
     /**
@@ -26,7 +24,7 @@ class SatsendringScheduler(
             when (LeaderClient.isLeader()) {
                 true -> {
                     val hostname: String = InetAddress.getLocalHost().hostName
-                    val behandlinger = behandlingRepository.finnBehandlingerSomSkalSatsendresSeptember21()
+                    val behandlinger = listOf<Long>(1071507, 1080851)
                     logger.info("Leaderpod $hostname Starter automatisk revurdering av ${behandlinger.size} behandlinger")
 
                     var vellykkedeRevurderinger = 0

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -56,9 +56,9 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                             FROM behandling b
                                    INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
                                    INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
-                            WHERE b.aktiv = true
+                            WHERE b.aktiv = TRUE
                               AND f.status = 'LØPENDE'
-                              AND ty.utbetalingsoppdrag IS NOT NULL
+                              AND ty.utbetalingsoppdrag IS NULL
                             GROUP BY fagsakid)
                         
                         SELECT DISTINCT aty.fk_behandling_id

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -48,29 +48,6 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Query("SELECT count(*) FROM Behandling b WHERE NOT b.status = 'AVSLUTTET'")
     fun finnAntallBehandlingerIkkeAvsluttet(): Long
 
-    /**
-     * Gjenbruker finnSisteIverksatteBehandlingFraLøpendeFagsaker og filtrerer på beløp og datoer
-     */
-    @Query(value = """WITH sisteiverksattebehandlingfraløpendefagsak AS (
-                            SELECT f.id AS fagsakid, MAX(b.id) AS behandlingid
-                            FROM behandling b
-                                   INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
-                                   INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
-                            WHERE b.aktiv = TRUE
-                              AND f.status = 'LØPENDE'
-                              AND ty.utbetalingsoppdrag IS NULL
-                            GROUP BY fagsakid)
-                        
-                        SELECT DISTINCT aty.fk_behandling_id
-                        FROM andel_tilkjent_ytelse aty
-                        WHERE aty.fk_behandling_id IN (SELECT behandlingid FROM sisteiverksattebehandlingfraløpendefagsak)
-                            AND aty.belop = 1354
-                            AND aty.stonad_fom <= TO_TIMESTAMP('01-09-2021', 'DD-MM-YYYY')
-                            AND aty.stonad_tom >= TO_TIMESTAMP('30-09-2021', 'DD-MM-YYYY')""",
-           nativeQuery = true)
-    fun finnBehandlingerSomSkalSatsendresSeptember21(): List<Long>
-
-
     @Query("SELECT b FROM Behandling b WHERE b.opprettetÅrsak = 'FØDSELSHENDELSE' AND b.opprettetTidspunkt >= current_date")
     fun finnFødselshendelserOpprettetIdag(): List<Behandling>
 }


### PR DESCRIPTION
<img width="1072" alt="Skjermbilde 2021-08-25 kl  09 01 53" src="https://user-images.githubusercontent.com/5719550/130749670-d2d6ee48-eabd-4f78-b887-4c7427cf2ffa.png">

Plukker eksplisitt ut de casene som ble missa siden oppdraget lå på inaktive behandlinger. 

Sletter SatsendringScheduler, men bevarer SatsendringService i neste pr når dette er kjørt. 