### PR TITLE
Ved revurdering filtrer vekk barn uten noen periode med tilkjent ytelse 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -11,6 +11,9 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
     @Query(value = "SELECT aty FROM AndelTilkjentYtelse aty WHERE aty.behandlingId = :behandlingId")
     fun finnAndelerTilkjentYtelseForBehandling(behandlingId: Long): List<AndelTilkjentYtelse>
 
+    @Query(value = "SELECT aty FROM AndelTilkjentYtelse aty WHERE aty.behandlingId = :behandlingId AND aty.personIdent = :barnIdent")
+    fun finnAndelerTilkjentYtelseForBehandlingOgBarn(behandlingId: Long, barnIdent: String): List<AndelTilkjentYtelse>
+
     @Query(value = "SELECT aty FROM AndelTilkjentYtelse aty WHERE aty.behandlingId IN :behandlingIder AND aty.stønadTom >= CURRENT_TIMESTAMP")
     fun finnLøpendeAndelerTilkjentYtelseForBehandlinger(behandlingIder: List<Long>): List<AndelTilkjentYtelse>
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
@@ -28,7 +28,7 @@ class RegistrerPersongrunnlag(
             val forrigeMålform = persongrunnlagService.hentSøkersMålform(behandlingId = forrigeBehandlingSomErIverksatt.id)
 
             persongrunnlagService.hentOgLagreSøkerOgBarnINyttGrunnlag(data.ident,
-                                                                      data.barnasIdenter.union(
+                                                                      data.barnasIdenter.intersect(
                                                                                                forrigePersongrunnlagBarna)
                                                                                                .toList(),
                                                                       behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
@@ -23,12 +23,11 @@ class RegistrerPersongrunnlag(
         val forrigeBehandlingSomErIverksatt =
                 behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
         if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomErIverksatt != null) {
-            val forrigePersongrunnlag = persongrunnlagService.hentAktiv(behandlingId = forrigeBehandlingSomErIverksatt.id)
-            val forrigePersongrunnlagBarna = forrigePersongrunnlag?.barna?.map { it.personIdent.ident }!!
+            val forrigePersongrunnlagBarna = behandlingService.finnBarnFraBehandlingMedTilkjentYtsele(behandlingId = forrigeBehandlingSomErIverksatt.id)
             val forrigeMålform = persongrunnlagService.hentSøkersMålform(behandlingId = forrigeBehandlingSomErIverksatt.id)
 
             persongrunnlagService.hentOgLagreSøkerOgBarnINyttGrunnlag(data.ident,
-                                                                      data.barnasIdenter.intersect(
+                                                                      data.barnasIdenter.union(
                                                                                                forrigePersongrunnlagBarna)
                                                                                                .toList(),
                                                                       behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -63,13 +63,12 @@ class StegService(
             val sisteBehandling = behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
                                   ?: behandlingService.hentSisteBehandlingSomIkkeErHenlagt(behandling.fagsak.id)
                                   ?: throw Feil("Forsøker å opprette en revurdering eller teknisk opphør, men kan ikke finne tidligere behandling på fagsak ${behandling.fagsak.id}")
-            val barnFraSisteBehandling =
-                    personopplysningGrunnlagRepository.findByBehandlingAndAktiv(sisteBehandling.id)?.barna?.map { it.personIdent.ident }
-                    ?: throw Feil("Forsøker å opprette en revurdering eller teknisk opphør, men kan ikke finne personopplysningsgrunnlag på siste behandling ${behandling.id}")
+
+            val barnFraSisteBehandlingMedAndelTilkjentYtelse = behandlingService.finnBarnFraBehandlingMedTilkjentYtsele(sisteBehandling.id)
 
             håndterPersongrunnlag(behandling,
                                   RegistrerPersongrunnlagDTO(ident = nyBehandling.søkersIdent,
-                                                             barnasIdenter = barnFraSisteBehandling))
+                                                             barnasIdenter = barnFraSisteBehandlingMedAndelTilkjentYtelse))
         } else throw Feil("Ukjent oppførsel ved opprettelse av behandling.")
     }
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -2,34 +2,41 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.e2e.DatabaseCleanupService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 
 @Tag("integration")
 class BehandlingServiceTest(
-    @Autowired
-    private val fagsakService: FagsakService,
+        @Autowired
+        private val fagsakService: FagsakService,
 
-    @Autowired
-    private val behandlingService: BehandlingService,
+        @Autowired
+        private val behandlingService: BehandlingService,
 
-    @Autowired
-    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+        @Autowired
+        private val tilkjentYtelseRepository: TilkjentYtelseRepository,
 
-    @Autowired
-    private val databaseCleanupService: DatabaseCleanupService
+        @Autowired
+        private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+
+        @Autowired
+        private val databaseCleanupService: DatabaseCleanupService
 ) : AbstractSpringIntegrationTest() {
 
     @BeforeAll
@@ -56,6 +63,27 @@ class BehandlingServiceTest(
         val forrigeBehandling = behandlingService.hentForrigeBehandlingSomErIverksatt(behandling = revurderingInnvilgetBehandling)
         Assertions.assertNotNull(forrigeBehandling)
         Assertions.assertEquals(behandling.id, forrigeBehandling?.id)
+    }
+
+    @Test
+    fun `Skal bare hente barn med tilkjentytelse for den aktuelle behandlingen`() {
+        val søker = randomFnr()
+        val barn = randomFnr()
+
+        val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søker)
+        val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
+
+        tilkjentYtelseRepository.save(TilkjentYtelse(behandling = behandling,
+                                                     opprettetDato = LocalDate.now(),
+                                                     endretDato = LocalDate.now(),
+                                                     andelerTilkjentYtelse = mutableSetOf()))
+
+        val testPersonopplysningsGrunnlag = lagTestPersonopplysningGrunnlag(behandlingId = behandling.id,
+                                                                            søkerPersonIdent = søker,
+                                                                            barnasIdenter = listOf(barn))
+        personopplysningGrunnlagRepository.save(testPersonopplysningsGrunnlag)
+
+        Assertions.assertEquals(0, behandlingService.finnBarnFraBehandlingMedTilkjentYtsele(behandlingId = behandling.id).size)
     }
 
     private fun ferdigstillBehandling(behandling: Behandling) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakBegrunnelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakBegrunnelseTest.kt
@@ -29,10 +29,12 @@ import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingMetrikker
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakPersonRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
@@ -108,7 +110,10 @@ class VedtakBegrunnelseTest(
         private val stegService: StegService,
 
         @Autowired
-        private val tilbakekrevingService: TilbakekrevingService,
+        private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+
+        @Autowired
+        private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
 
         @Autowired
         private val infotrygdService: InfotrygdService,
@@ -128,6 +133,8 @@ class VedtakBegrunnelseTest(
         MockKAnnotations.init(this)
         behandlingService = BehandlingService(
                 behandlingRepository,
+                personopplysningGrunnlagRepository,
+                andelTilkjentYtelseRepository,
                 behandlingMetrikker,
                 fagsakPersonRepository,
                 vedtakRepository,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
@@ -19,11 +19,13 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingMetrikker
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakPersonRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseSpesifikasjon
@@ -94,6 +96,12 @@ class VedtakServiceTest(
 
         @Autowired
         private val featureToggleService: FeatureToggleService,
+
+        @Autowired
+        private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+
+        @Autowired
+        private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
 ) : AbstractSpringIntegrationTest() {
 
     lateinit var behandlingService: BehandlingService
@@ -111,6 +119,8 @@ class VedtakServiceTest(
         MockKAnnotations.init(this)
         behandlingService = BehandlingService(
                 behandlingRepository,
+                personopplysningGrunnlagRepository,
+                andelTilkjentYtelseRepository,
                 behandlingMetrikker,
                 fagsakPersonRepository,
                 vedtakRepository,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/AvslagBegrunnelseOppdateringTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/AvslagBegrunnelseOppdateringTest.kt
@@ -18,11 +18,13 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingMetrikker
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakPersonRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -89,7 +91,13 @@ class AvslagBegrunnelseOppdateringTest(
         private val infotrygdService: InfotrygdService,
 
         @Autowired
-        private val featureToggleService: FeatureToggleService
+        private val featureToggleService: FeatureToggleService,
+
+        @Autowired
+        private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+
+        @Autowired
+        private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
 ) : AbstractSpringIntegrationTest() {
 
     lateinit var behandlingService: BehandlingService
@@ -105,6 +113,8 @@ class AvslagBegrunnelseOppdateringTest(
         MockKAnnotations.init(this)
         behandlingService = BehandlingService(
                 behandlingRepository,
+                personopplysningGrunnlagRepository,
+                andelTilkjentYtelseRepository,
                 behandlingMetrikker,
                 fagsakPersonRepository,
                 vedtakRepository,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ved revurdering er det ikke ønskelig å videreføre barn uten noen periode med tilkjent ytelse til den nye behandlingen.
En konsekvens er at det blir lov å opprette en revurderings behandling uten barn.
For med info se: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3641 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
