### PR TITLE
Bug: Forbedrer håndtering av ferdigstillelse av oppgaver.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -129,11 +129,15 @@ class OppgaveService(private val integrasjonClient: IntegrasjonClient,
         val oppgave = oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(oppgavetype,
                                                                                          behandlingRepository.finnBehandling(
                                                                                                  behandlingId))
-                      ?: error("Finner ikke oppgave for behandling $behandlingId")
-        integrasjonClient.ferdigstillOppgave(oppgave.gsakId.toLong())
 
-        oppgave.erFerdigstilt = true
-        oppgaveRepository.save(oppgave)
+        if (oppgave == null) {
+            logger.info("Finner ingen oppgaver av type $oppgavetype på behandling $behandlingId som kan ferdigstilles")
+        } else {
+            integrasjonClient.ferdigstillOppgave(oppgave.gsakId.toLong())
+
+            oppgave.erFerdigstilt = true
+            oppgaveRepository.save(oppgave)
+        }
     }
 
     fun lagOppgaveTekst(fagsakId: Long, beskrivelse: String? = null): String {

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -120,20 +120,6 @@ class OppgaveServiceTest {
     }
 
     @Test
-    fun `Ferdigstill oppgave feiler fordi den ikke finner oppgave på behandlingen`() {
-        every {
-            oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(any<Oppgavetype>(),
-                                                                               any<Behandling>())
-        } returns null
-        every { oppgaveRepository.save(any<DbOppgave>()) } returns lagTestOppgave()
-        every { behandlingRepository.finnBehandling(BEHANDLING_ID) } returns mockk {}
-
-        assertThatThrownBy { oppgaveService.ferdigstillOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak) }
-                .hasMessage("Finner ikke oppgave for behandling $BEHANDLING_ID")
-                .isInstanceOf(java.lang.IllegalStateException::class.java)
-    }
-
-    @Test
     fun `Fordel oppgave skal tildele oppgave til saksbehandler`() {
         val oppgaveSlot = slot<Long>()
         val saksbehandlerSlot = slot<String>()


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ettersom SB kan opprette behandlinger utenom den "vanlige" løypa er det ikke alltid at ba-sak er oppretter av oppgave. Derfor er det helt vanlig at vi ikke nødvendigvis har noe å ferdigstille hos oss. Endrer derfor til logging istedet for error ved slike tilfeller.

Såvidt jeg vet har dette kun vært vanlig i testene hittil.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei
