### PR TITLE
Barn 18 år i inneværende og påfølgende måned skal tas med i 18års

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjon.kt
@@ -477,7 +477,10 @@ enum class VedtakBegrunnelseSpesifikasjon(val tittel: String, val erTilgjengelig
                 målform: Målform
         ): String {
             val fødselsMånedOgÅrForAlder18 = YearMonth.from(LocalDate.now()).minusYears(18)
-            val fødselsdatoerForBarn18År = barnasFødselsdatoer.filter { it.toYearMonth().equals(fødselsMånedOgÅrForAlder18) }
+            val fødselsdatoerForBarn18År = barnasFødselsdatoer.filter {
+                it.toYearMonth().equals(fødselsMånedOgÅrForAlder18) ||
+                        it.toYearMonth().equals(fødselsMånedOgÅrForAlder18.plusMonths(1))
+            }
             return when (målform) {
                 Målform.NB -> "Barnetrygden reduseres fordi barn født ${fødselsdatoerForBarn18År.tilBrevTekst()} er 18 år."
                 Målform.NN -> "Barnetrygda er redusert fordi barn fødd ${fødselsdatoerForBarn18År.tilBrevTekst()} er 18 år."


### PR DESCRIPTION

Prodfeil: I vedtaksbegrunnelsen 'reduksjon barn under 18år' blir ikke barn som fyller 18 år påfølgende måned inkludert.