### PR TITLE
Fjerner opprettelse av avslagsbegrunnelse ved uregistrerte barn.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
@@ -44,16 +44,6 @@ class RegistrereSøknad(
 
         val vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId = behandling.id)
 
-        if (data.søknad.barnaMedOpplysninger.any { !it.erFolkeregistrert }
-            && vedtak.vedtakBegrunnelser.none { it.begrunnelse == VedtakBegrunnelseSpesifikasjon.AVSLAG_UREGISTRERT_BARN }) {
-            vedtak.leggTilBegrunnelse(VedtakBegrunnelse(
-                    fom = null,
-                    tom = null,
-                    vedtak = vedtak,
-                    begrunnelse = VedtakBegrunnelseSpesifikasjon.AVSLAG_UREGISTRERT_BARN
-            ))
-        }
-
         vedtakService.oppdater(vedtak)
 
         return hentNesteStegForNormalFlyt(behandling)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ettersom vi viser både ny og gammel modell frontend så blir denne begrunnelsen synlig frontend, men den kommer ikke med i brevet.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei, men på sikt bør vi nok gjøre noe med uthenting av barn slik at uregistrerte barn kommer med i denne spesifikasjonen. Fritekst må foreløpig brukes. Avklarer fortløpende med Eivind.
