### PR TITLE
Fix master build errors: use task-scheduling profile

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/SchedulingConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/SchedulingConfig.kt
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.EnableScheduling
 
-@Profile("!mock-scheduling")
+@Profile("prod", "preprod", "e2e", "task-scheduling")
 @Configuration
 @EnableScheduling
 class SchedulingConfig

--- a/src/test/kotlin/DevLauncher.kt
+++ b/src/test/kotlin/DevLauncher.kt
@@ -13,7 +13,8 @@ object DevLauncher {
                         "mock-infotrygd-feed",
                         "mock-infotrygd-barnetrygd",
                         "mock-pdl",
-                        "mock-tilbakekreving-klient"
+                        "mock-tilbakekreving-klient",
+                        "task-scheduling"
                 )
         app.run(*args)
     }

--- a/src/test/kotlin/DevLauncherPostgres.kt
+++ b/src/test/kotlin/DevLauncherPostgres.kt
@@ -11,6 +11,7 @@ fun main(args: Array<String>) {
             "mock-infotrygd-feed",
             "mock-infotrygd-barnetrygd",
             "mock-pdl",
-            "mock-tilbakekreving-klient"
+            "mock-tilbakekreving-klient",
+            "task-scheduling"
     ).run(*args)
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/AbstractSpringIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/AbstractSpringIntegrationTest.kt
@@ -21,8 +21,7 @@ import javax.sql.DataSource
         "mock-brev-klient",
         "mock-infotrygd-feed",
         "mock-oauth",
-        "mock-rest-template-config",
-        "mock-scheduling"
+        "mock-rest-template-config"
 )
 @ContextConfiguration(initializers = [DbContainerInitializer::class])
 @AutoConfigureWireMock(port = 28085)

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
@@ -67,8 +67,7 @@ import java.time.format.DateTimeFormatter
     "mock-brev-klient",
     "mock-infotrygd-feed",
     "mock-oauth",
-    "mock-rest-template-config",
-    "mock-scheduling"
+    "mock-rest-template-config"
 )
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Tag("integration")

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.ClientMocks
+import no.nav.familie.ba.sak.config.e2e.DatabaseCleanupService
 import no.nav.familie.ba.sak.ekstern.restDomene.FagsakDeltagerRolle
 import no.nav.familie.ba.sak.ekstern.restDomene.RestSøkParam
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
@@ -20,6 +21,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.personopplysning.Ident
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -47,7 +49,16 @@ class FagsakControllerTest(
 
         @Autowired
         private val persongrunnlagService: PersongrunnlagService,
+
+        @Autowired
+        private val databaseCleanupService: DatabaseCleanupService,
+
 ) : AbstractSpringIntegrationTest() {
+
+    @BeforeEach
+    fun init() {
+        databaseCleanupService.truncate()
+    }
 
     @Test
     @Tag("integration")

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
@@ -22,8 +22,7 @@ val MOCK_SERVER_IMAGE = "ghcr.io/navikt/familie-mock-server/familie-mock-server:
         "mock-infotrygd-barnetrygd",
         "mock-rest-template-config",
         "mock-task-repository",
-        "mock-task-service",
-        "mock-scheduling"
+        "mock-task-service"
 )
 abstract class AbstractVerdikjedetest : WebSpringAuthTestRunner() {
     fun familieBaSakKlient(): FamilieBaSakKlient = FamilieBaSakKlient(


### PR DESCRIPTION
Task scheduling routine can run in background when tests are running, which will break the tests.
To disable Task Scheduling either we use "mock-scheduling" profile for all the tests, or on the contrary we use "scheduling-task" profile when we are not testing. The latter is easier because remembering to add "mock-scheduling" to any new test is error prone, and the error message is also difficult to connect to the reason