### PR TITLE
Ta hensyn til korrigert vedtaksbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
@@ -35,6 +35,7 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 
 fun hentBrevtype(behandling: Behandling): Brevmal =
         if (behandling.opprettetÅrsak == BehandlingÅrsak.DØDSFALL_BRUKER) Brevmal.DØDSFALL
+        else if (behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV) Brevmal.VEDTAK_KORREKSJON_VEDTAKSBREV
         else hentVedtaksbrevmal(behandling)
 
 fun hentVedtaksbrevmal(behandling: Behandling): Brevmal {


### PR DESCRIPTION
Gjedler korreksjonssaken under behandling i prod.

Det er ikke så elegant å spesialhåndtere disse, men alternativet var å ha mildere typesikring på ordinære vedtaksbrev. Ordinære vedtaksbrev har en del ting disse ikke skal ha, så om de skulle vært med der måtte man enten hatt rausere typesikring i signaturen til funksjonen eller i selve vedtaksbrevet, og da faller jo litt av vitsen bort. 