### PR TITLE
Fjern gammel funksjonallitet til nedtrekksmeny

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -97,7 +97,6 @@ class FeatureToggleConfig(private val enabled: Boolean,
         const val AUTOMATISK_FØDSELSHENDELSE = "familie-ba-sak.behandling.automatisk-fodselshendelse"
         const val BRUK_ER_DELT_BOSTED = "familie-ba-sak.behandling.delt_bosted"
         const val MIGRER_VEDTAK_BEGRUNNELSES_MODEL_UTREDNING = "familie-ba-sak.behandling.migrering.behandlingsmodel.utredning"
-        const val BRUK_BEGRUNNELSE_FRA_SANITY_NEDTREKKSMENY = "familie-ba-sak.behandling.begrunnelse-fra-sanity-nedtrekksmeny"
         const val BRUK_BEGRUNNELSE_FRA_SANITY_BACKEND = "familie-ba-sak.behandling.begrunnelse-fra-sanity-backend"
         const val BRUK_BEGRUNNELSE_TRIGGES_AV_FRA_SANITY = "familie-ba-sak.behandling.begrunnelse-trigges-av"
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestVedtakBegrunnelseTilknyttetVilkår
 import no.nav.familie.ba.sak.kjerne.dokument.BrevKlient
 import no.nav.familie.ba.sak.kjerne.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseSpesifikasjon
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -89,29 +88,10 @@ class VilkårsvurderingService(
     }
 
     fun hentVilkårsbegrunnelser(): Map<VedtakBegrunnelseType, List<RestVedtakBegrunnelseTilknyttetVilkår>> {
-        if (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_BEGRUNNELSE_FRA_SANITY_NEDTREKKSMENY)) {
             val sanityBegrunnelser = brevKlient.hentSanityBegrunnelse()
             val skalBrukeTriggesAvFraSanity =
                     featureToggleService.isEnabled(FeatureToggleConfig.BRUK_BEGRUNNELSE_TRIGGES_AV_FRA_SANITY)
             return vedtakBegrunnelseSpesifikasjonerTilNedtrekksmenytekster(sanityBegrunnelser, skalBrukeTriggesAvFraSanity)
-        } else {
-            return VedtakBegrunnelseSpesifikasjon.values()
-                    .groupBy { it.vedtakBegrunnelseType }
-                    .mapValues { begrunnelseGruppe ->
-                        begrunnelseGruppe.value
-                                .filter { it.erTilgjengeligFrontend }
-                                .flatMap { vedtakBegrunnelse ->
-                                    vedtakBegrunnelse.triggesAv.vilkår?.map {
-                                        RestVedtakBegrunnelseTilknyttetVilkår(id = vedtakBegrunnelse,
-                                                                              navn = vedtakBegrunnelse.tittel,
-                                                                              vilkår = it
-                                        )
-                                    } ?: listOf(RestVedtakBegrunnelseTilknyttetVilkår(id = vedtakBegrunnelse,
-                                                                                      navn = vedtakBegrunnelse.tittel,
-                                                                                      vilkår = null))
-                                }
-                    }
-        }
     }
 
     companion object {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-6077
Fjerner den gamle løsningen rundt tekstene til nedtrekksmeny hvor man velger begrunnelser.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke noen ny funksjonalitet


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ x] Nei
