### PR TITLE
Setter triggertid til 06:XX i stedet for 06:00 for alle behandleFødselshendelse saker.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/TaskUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/TaskUtils.kt
@@ -52,8 +52,8 @@ fun erKlokkenMellom21Og06(localTime: LocalTime = LocalTime.now()): Boolean {
 fun kl06IdagEllerNesteDag(): LocalDateTime {
     val now = LocalDateTime.now()
     return if (now.toLocalTime().isBefore(LocalTime.of(6, 0))) {
-        now.toLocalDate().atTime(6, 0)
+        now.withHour(6)
     } else {
-        now.toLocalDate().plusDays(1).atTime(6, 0)
+        now.withHour(6).plusDays(1)
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter uheldig oppførsel i prod prøver vi å endre til at taskene ikke starter samtidig 06:00, men får det samme "delayet" som da de ble mottatt i ba-sak.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Er det andre endringer vi kan gjøre for å unngå at taskene for samme person kjører samtidig?
