### PR TITLE
Baser utbetalingssjekk på persontype

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
@@ -58,6 +58,8 @@ object SatsService {
                 .filter { it.fraOgMed <= it.tilOgMed }
     }
 
+    internal fun hentAllesatser() = satser
+
     private fun finnAlleSatserFor(type: SatsType): List<Sats> = satser.filter { it.type == type }
 
     data class SatsPeriode(

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtbetalingssikkerhetTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtbetalingssikkerhetTest.kt
@@ -4,6 +4,8 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.common.*
+import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -252,5 +254,18 @@ class UtbetalingssikkerhetTest {
                                                                                        listOf(Pair(barn, listOf(tilkjentYtelse))),
                                                                                        personopplysningGrunnlag2)
         }
+    }
+
+    /**
+     * Kontroller og eventuelt oppdater TilkjentYtelseValidering.maksBeløp() dersom nye satstyper legges til
+     */
+    @Test
+    fun `Alle satstyper er tatt hensyn til`() {
+        val støttedeSatstyper = setOf(SatsType.SMA,
+                                      SatsType.TILLEGG_ORBA,
+                                      SatsType.FINN_SVAL,
+                                      SatsType.ORBA)
+        assertTrue(støttedeSatstyper.containsAll(SatsType.values().toSet()))
+        assertEquals(støttedeSatstyper.size, SatsType.values().size)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtbetalingssikkerhetTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtbetalingssikkerhetTest.kt
@@ -256,6 +256,13 @@ class UtbetalingssikkerhetTest {
         }
     }
 
+    @Test
+    fun `Korrekt maksbeløp gis for persontype`() {
+        assertEquals(1054 + 660, TilkjentYtelseValidering.maksBeløp(personType = PersonType.SØKER))
+        assertEquals(1654, TilkjentYtelseValidering.maksBeløp(personType = PersonType.BARN))
+        assertThrows<Feil> { TilkjentYtelseValidering.maksBeløp(personType = PersonType.ANNENPART) }
+    }
+
     /**
      * Kontroller og eventuelt oppdater TilkjentYtelseValidering.maksBeløp() dersom nye satstyper legges til
      */


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sikkerheten per nå sørger for at en person ikke kan ha mer enn 2 andeler og utbetaling opp til 2500kr samme periode. 
Foreslått endring gjør at kun persontype med småbarnstillegg kan ha 2 andeler og sum er maks av hypotetisk sats man kunne fått, basert på satsliste.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Det stemmer at småbarnstillegget legges på søker? Hvis ikke må man bare bytte barn og søkers sjekk

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
