### PR TITLE
BUG: Filtrer bort sivilstand historikk uten fom-dato.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -105,10 +105,12 @@ data class VurderBarnErUgift(
 ) : Vilkårsregel {
 
     override fun vurder(): Evaluering {
+        val sivilstanderMedGyldigFom = sivilstander.filter { it.harGyldigFom() }
+
         return when {
-            sivilstander.singleOrNull { it.type == SIVILSTAND.UOPPGITT } != null ->
+            sivilstanderMedGyldigFom.singleOrNull { it.type == SIVILSTAND.UOPPGITT } != null ->
                 Evaluering.oppfylt(VilkårOppfyltÅrsak.BARN_MANGLER_SIVILSTAND)
-            sivilstander.any { it.type == SIVILSTAND.GIFT || it.type == SIVILSTAND.REGISTRERT_PARTNER } ->
+            sivilstanderMedGyldigFom.any { it.type == SIVILSTAND.GIFT || it.type == SIVILSTAND.REGISTRERT_PARTNER } ->
                 Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.BARN_ER_GIFT_ELLER_HAR_PARTNERSKAP)
             else -> Evaluering.oppfylt(VilkårOppfyltÅrsak.BARN_ER_IKKE_GIFT_ELLER_HAR_PARTNERSKAP)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/sivilstand/GrSivilstand.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/sivilstand/GrSivilstand.kt
@@ -55,11 +55,13 @@ data class GrSivilstand(
                                                                      .replace("_", " ")
                                                                      .storForbokstav())
 
+    fun harGyldigFom() = this.fom != null
+
     companion object {
 
         fun List<GrSivilstand>.sisteSivilstand(): GrSivilstand? {
-            if (this.filter { it.fom == null }.size > 1) throw Feil("Finnes flere sivilstander uten fom-dato")
-            return this.sortedBy { it.fom }.lastOrNull()
+            val sivilstandMedFom = this.filter { it.harGyldigFom() }
+            return sivilstandMedFom.maxByOrNull { it.fom!! }
         }
 
         fun fraSivilstand(sivilstand: Sivilstand, person: Person) =

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -539,23 +539,23 @@ class ClientMocks {
                                                                                    gyldigTilOgMed = null))),
                 søkerFnr[1] to PersonInfo(fødselsdato = LocalDate.of(1995, 2, 19),
                                           bostedsadresser = mutableListOf(),
-                                          sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT)),
+                                          sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8))),
                                           kjønn = Kjønn.MANN,
                                           navn = "Far Faresen"),
                 søkerFnr[2] to PersonInfo(fødselsdato = LocalDate.of(1985, 7, 10),
                                           bostedsadresser = mutableListOf(),
-                                          sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT)),
+                                          sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8))),
                                           kjønn = Kjønn.KVINNE,
                                           navn = "Moder Jord",
                                           adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT),
                 barnFnr[0] to PersonInfo(fødselsdato = barnFødselsdatoer[0],
                                          bostedsadresser = mutableListOf(bostedsadresse),
-                                         sivilstander = listOf(Sivilstand(type = SIVILSTAND.UOPPGITT)),
+                                         sivilstander = listOf(Sivilstand(type = SIVILSTAND.UOPPGITT, gyldigFraOgMed = LocalDate.now().minusMonths(8))),
                                          kjønn = Kjønn.MANN,
                                          navn = "Gutten Barnesen"),
                 barnFnr[1] to PersonInfo(fødselsdato = barnFødselsdatoer[1],
                                          bostedsadresser = mutableListOf(bostedsadresse),
-                                         sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT)),
+                                         sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8))),
                                          kjønn = Kjønn.KVINNE,
                                          navn = "Jenta Barnesen",
                                          adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.FORTROLIG),
@@ -572,7 +572,7 @@ class ClientMocks {
                 ),
                 BARN_DET_IKKE_GIS_TILGANG_TIL_FNR to PersonInfo(fødselsdato = LocalDate.of(2019, 6, 22),
                                                                 bostedsadresser = mutableListOf(bostedsadresse),
-                                                                sivilstander = listOf(Sivilstand(type = SIVILSTAND.UGIFT)),
+                                                                sivilstander = listOf(Sivilstand(type = SIVILSTAND.UGIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8))),
                                                                 kjønn = Kjønn.KVINNE,
                                                                 navn = "Maskert Banditt",
                                                                 adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)
@@ -587,7 +587,7 @@ fun mockHentPersoninfoForMedIdenter(mockPersonopplysningerService: Personopplysn
     } returns PersonInfo(fødselsdato = LocalDate.of(2018, 5, 1),
                          kjønn = Kjønn.KVINNE,
                          navn = "Barn Barnesen",
-                         sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT)))
+                         sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8))))
 
     every {
         mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(søkerFnr))

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
@@ -96,7 +97,7 @@ class OppgaveIntegrationTest : AbstractSpringIntegrationTest() {
 
 
     companion object {
-        private val SØKER_FNR = ClientMocks.søkerFnr[0]
+        private val SØKER_FNR = randomFnr()
         private val BARN_FNR = ClientMocks.barnFnr[0]
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/DokumentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/DokumentServiceTest.kt
@@ -116,7 +116,7 @@ class DokumentServiceTest(
     fun `Hent vedtaksbrev`() {
         val behandlingEtterVilkårsvurderingSteg = kjørStegprosessForFGB(
                 tilSteg = StegType.VURDER_TILBAKEKREVING,
-                søkerFnr = ClientMocks.søkerFnr[0],
+                søkerFnr = randomFnr(),
                 barnasIdenter = listOf(ClientMocks.barnFnr[0]),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -146,7 +146,7 @@ class DokumentServiceTest(
     fun `Skal generere vedtaksbrev`() {
         val behandlingEtterVilkårsvurderingSteg = kjørStegprosessForFGB(
                 tilSteg = StegType.VURDER_TILBAKEKREVING,
-                søkerFnr = ClientMocks.søkerFnr[0],
+                søkerFnr = randomFnr(),
                 barnasIdenter = listOf(ClientMocks.barnFnr[0]),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -180,7 +180,7 @@ class DokumentServiceTest(
 
         val behandlingEtterVilkårsvurderingSteg = kjørStegprosessForFGB(
                 tilSteg = StegType.VILKÅRSVURDERING,
-                søkerFnr = ClientMocks.søkerFnr[0],
+                søkerFnr = randomFnr(),
                 barnasIdenter = listOf(ClientMocks.barnFnr[0]),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -233,7 +233,7 @@ class DokumentServiceTest(
     fun `Skal verifisere at man ikke får generert brev etter at behandlingen er sendt fra beslutter`() {
         val behandlingEtterVedtakBesluttet = kjørStegprosessForFGB(
                 tilSteg = StegType.BESLUTTE_VEDTAK,
-                søkerFnr = ClientMocks.søkerFnr[0],
+                søkerFnr = randomFnr(),
                 barnasIdenter = listOf(ClientMocks.barnFnr[0]),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/fødselshendelse/VilkårVurderingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/fødselshendelse/VilkårVurderingTest.kt
@@ -134,7 +134,9 @@ class VilkårVurderingTest(
                       navn = "navn",
                       kjønn = kjønn,
                       bostedsadresser = grBostedsadresse?.let { mutableListOf(grBostedsadresse) } ?: mutableListOf())
-                .apply { this.sivilstander = listOf(GrSivilstand(type = sivilstand, person = this)) }
+                .apply {
+                    this.sivilstander = listOf(GrSivilstand(type = sivilstand, person = this, fom = LocalDate.of(1991, 1, 1)))
+                }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -106,7 +106,7 @@ class StegServiceTest(
 
     @Test
     fun `Skal sette default-verdier på gift-vilkår for barn`() {
-        val søkerFnr = ClientMocks.søkerFnr[0]
+        val søkerFnr = randomFnr()
         val barnFnr1 = ClientMocks.barnFnr[0]
         val barnFnr2 = ClientMocks.barnFnr[1]
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/sikkerhet/RolletilgangTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/sikkerhet/RolletilgangTest.kt
@@ -23,7 +23,18 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.postForEntity
 
 
-@ActiveProfiles("postgres", "mock-pdl", "mock-infotrygd-barnetrygd", "mock-scheduling")
+@ActiveProfiles(
+        "postgres",
+        "mock-pdl",
+        "mock-infotrygd-barnetrygd",
+        "mock-tilbakekreving-klient",
+        "mock-brev-klient",
+        "mock-økonomi",
+        "mock-infotrygd-feed",
+        "mock-rest-template-config",
+        "mock-task-repository",
+        "mock-task-service"
+)
 class RolletilgangTest(
         @Autowired
         private val fagsakService: FagsakService

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.e2e.DatabaseCleanupService
@@ -79,7 +80,7 @@ class FerdigstillBehandlingTaskTest : AbstractSpringIntegrationTest() {
     }
 
     private fun kjørSteg(resultat: Resultat): Behandling {
-        val fnr = ClientMocks.søkerFnr[0]
+        val fnr = randomFnr()
         val fnrBarn = ClientMocks.barnFnr[0]
 
         val behandling = kjørStegprosessForFGB(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-6406

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Kan vi miste gyldig data med denne filtreringen? Jeg mener nei ettersom vi ikke kan vite når historisk datagrunnlag er gjeldende uten fom-dato.
