### PR TITLE
Trunkere dagens datum ved henting av løpende tilkjente ytelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -14,7 +14,7 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
     @Query(value = "SELECT aty FROM AndelTilkjentYtelse aty WHERE aty.behandlingId = :behandlingId AND aty.personIdent = :barnIdent")
     fun finnAndelerTilkjentYtelseForBehandlingOgBarn(behandlingId: Long, barnIdent: String): List<AndelTilkjentYtelse>
 
-    @Query(value = "SELECT aty FROM AndelTilkjentYtelse aty WHERE aty.behandlingId IN :behandlingIder AND aty.stønadTom >= CURRENT_TIMESTAMP")
+    @Query(value = "SELECT aty FROM AndelTilkjentYtelse aty WHERE aty.behandlingId IN :behandlingIder AND aty.stønadTom >= DATE_TRUNC('day', CURRENT_TIMESTAMP)")
     fun finnLøpendeAndelerTilkjentYtelseForBehandlinger(behandlingIder: List<Long>): List<AndelTilkjentYtelse>
 
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Det er avvik på konsistensavstemming mellom økonomi og ba-sak.
Årsaken ser ut å være at ved henting av løpende tilkjenteytelser så sammenlignes den faktiske timestampem med timestampen ved midnatt.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
