### PR TITLE
Bytter til familie-ba-infotrygd fra infotrygd-barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdBarnetrygdClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdBarnetrygdClient.kt
@@ -28,10 +28,10 @@ import java.time.YearMonth
 
 @Component
 class InfotrygdBarnetrygdClient(
-    @Value("\${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}") private val clientUri: URI,
+    @Value("\${FAMILIE_BA_INFOTRYGD_API_URL}") private val clientUri: URI,
     @Qualifier("jwtBearerMedLangTimeout") restOperations: RestOperations,
     private val environment: Environment
-) : AbstractRestClient(restOperations, "infotrygd_barnetrygd") {
+) : AbstractRestClient(restOperations, "infotrygd") {
 
     fun harLøpendeSakIInfotrygd(søkersIdenter: List<String>, barnasIdenter: List<String> = emptyList()): Boolean {
         if (environment.activeProfiles.contains("e2e")) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -50,11 +50,11 @@ no.nav.security.jwt:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-onbehalfof:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-onbehalfof:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
@@ -68,11 +68,11 @@ no.nav.security.jwt:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-clientcredentials:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-clientcredentials:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
         grant-type: client_credentials
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
@@ -143,7 +143,7 @@ DAGLIG_KVOTE_FØDSELSHENDELSER: 1000
 
 FAMILIE_INTEGRASJONER_API_URL: http://localhost:8085/api
 FAMILIE_BA_INFOTRYGD_FEED_API_URL: http://localhost:8092/api
-FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL: http://localhost:8093
+FAMILIE_BA_INFOTRYGD_API_URL: http://localhost:8093
 FAMILIE_TILBAKE_API_URL: http://localhost:8030/api
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087/api
 PDL_URL: "dummy"

--- a/src/main/resources/application-e2e.yaml
+++ b/src/main/resources/application-e2e.yaml
@@ -50,20 +50,20 @@ no.nav.security.jwt:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-onbehalfof:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-onbehalfof:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: http://mock-oauth2-server:1111/v2.0/token
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-clientcredentials:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-clientcredentials:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: http://mock-oauth2-server:1111/v2.0/token
         grant-type: client_credentials
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
@@ -128,7 +128,7 @@ FAMILIE_OPPDRAG_API_URL: http://familie-oppdrag:8087/api
 FAMILIE_INTEGRASJONER_API_URL: http://familie-integrasjoner:8085/api
 FAMILIE_TILBAKE_API_URL: dummy
 NORG2_BASE_URL: http://familie-mock-server:1337/rest/api/norg2
-FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL: http://familie-mock-server:1337/rest/api/infotrygd/ba
+FAMILIE_BA_INFOTRYGD_API_URL: http://familie-mock-server:1337/rest/api/infotrygd/ba
 FAMILIE_BA_INFOTRYGD_FEED_API_URL: http://familie-ba-infotrygd-feed:8092/api
 PDL_URL: http://familie-mock-server:1337/rest/api/pdl
 CREDENTIAL_USERNAME: srvfamilie-ba-sak

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -60,20 +60,20 @@ no.nav.security.jwt:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-onbehalfof:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-onbehalfof:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-clientcredentials:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-clientcredentials:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
         grant-type: client_credentials
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -63,20 +63,20 @@ no.nav.security.jwt:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-onbehalfof:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-onbehalfof:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0/token
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-clientcredentials:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-clientcredentials:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0/token
         grant-type: client_credentials
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,7 +84,7 @@ BA_SKATTEETATEN_CLIENT_ID: "dummy"
 NORG2_BASE_URL: http://localhost:1337/rest/api/norg2
 FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_BA_INFOTRYGD_FEED_API_URL: http://familie-ba-infotrygd-feed/api
-FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL: http://infotrygd-barnetrygd.infotrygd
+FAMILIE_BA_INFOTRYGD_API_URL: http://familie-ba-infotrygd
 FAMILIE_TILBAKE_API_URL: http://familie-tilbake/api
 PDL_URL: http://pdl-api.default
 FAMILIE_INTEGRASJONER_API_URL: http://familie-integrasjoner/api

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
@@ -17,7 +17,7 @@ class VerdikjedetesterPropertyOverrideContextInitializer : ApplicationContextIni
     override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
         TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
             configurableApplicationContext,
-            "FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL: http://localhost:1337/rest/api/infotrygd/ba",
+            "FAMILIE_BA_INFOTRYGD_API_URL: http://localhost:1337/rest/api/infotrygd/ba",
             "PDL_URL: http://localhost:1337/rest/api/pdl"
         )
     }

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -68,11 +68,11 @@ no.nav.security.jwt:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-onbehalfof:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-onbehalfof:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
@@ -86,11 +86,11 @@ no.nav.security.jwt:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      familie-ba-infotrygd-barnetrygd-clientcredentials:
-        resource-url: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL}
+      familie-ba-infotrygd-clientcredentials:
+        resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
         token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
         grant-type: client_credentials
-        scope: ${FAMILIE_BA_INFOTRYGD_BARNETRYGD_SCOPE}
+        scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
           client-id: ${BA_SAK_CLIENT_ID}
           client-secret: ${CLIENT_SECRET}
@@ -169,7 +169,7 @@ FAMILIE_OPPDRAG_API_URL: http://localhost:8087/api
 FAMILIE_INTEGRASJONER_API_URL: http://localhost:28085/api
 FAMILIE_TILBAKE_API_URL: http://localhost:8030/api
 FAMILIE_BA_SAK_API_URL: http://localhost:8086/api
-FAMILIE_BA_INFOTRYGD_BARNETRYGD_API_URL: http://localhost:28085
+FAMILIE_BA_INFOTRYGD_API_URL: http://localhost:28085
 CREDENTIAL_USERNAME: not-a-real-srvuser
 CREDENTIAL_PASSWORD: not-a-real-pw
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ba-sak tar i bruk familie-ba-infotrygd

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Renamet konfig. Alle FAMILIE_BA_INFOTRYGD_BARNETRYGD config endres til FAMILIE_BA_INFOTRYGD. Kjører man mot infotrygd-barnetrygd lokalt, så må de endres med nytt scope.
Konfigendring lagt til i preprod/prod. De gamle slettes fra vault etter at denne er merget.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Gjennomført manuell test i preprod


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
