### PR TITLE
Cancel workflow action på samme branch

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,7 +7,7 @@ env:
   IMAGE: ghcr.io/navikt/familie-ba-sak:${{ github.sha }}
 jobs:
   avslutt-andre-workflows-samme-branch:
-    name: Avslutt andre workflows på samme branch test
+    name: Avslutt andre workflows på samme branch
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,14 +6,18 @@ on:
 env:
   IMAGE: ghcr.io/navikt/familie-ba-sak:${{ github.sha }}
 jobs:
-  build-jar-docker:
-    name: Bygg app/image, push til github
+  avslutt-andre-workflows-samme-branch:
+    name: Avslutt andre workflows på samme branch
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
+  build-jar-docker:
+    name: Bygg app/image, push til github
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.1
         with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,6 +10,10 @@ jobs:
     name: Bygg app/image, push til github
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.1
         with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,6 +9,8 @@ jobs:
   avslutt-andre-workflows-samme-branch:
     name: Avslutt andre workflows på samme branch
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,7 +7,7 @@ env:
   IMAGE: ghcr.io/navikt/familie-ba-sak:${{ github.sha }}
 jobs:
   avslutt-andre-workflows-samme-branch:
-    name: Avslutt andre workflows på samme branch
+    name: Avslutt andre workflows på samme branch test
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,7 +7,7 @@ env:
   IMAGE: ghcr.io/navikt/familie-ba-sak:${{ github.sha }}
 jobs:
   avslutt-andre-workflows-samme-branch:
-    name: Avslutt andre workflows på samme branch test
+    name: Avslutt andre workflows på samme branch
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,7 +7,7 @@ env:
   IMAGE: ghcr.io/navikt/familie-ba-sak:${{ github.sha }}
 jobs:
   avslutt-andre-workflows-samme-branch:
-    name: Avslutt andre workflows på samme branch
+    name: Avslutt andre workflows på samme branch test
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
Legg til stopping av workflow actions på samme branch.

Tilgangene for workflowen skal være så restriktive som mulig siden kun `permissions.actions` er satt skal alt annet bli satt til `no access`. https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token