### PR TITLE
fikser setting av behandlingskategori under registrering av søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
+import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.writeValueAsString
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -26,11 +27,12 @@ class RegistrereSøknad(
         data: RestRegistrerSøknad
     ): StegType {
         val aktivSøknadGrunnlagFinnes = søknadGrunnlagService.hentAktiv(behandlingId = behandling.id) != null
-        val søknadDTO = data.søknad
+        val søknadDTO: SøknadDTO = data.søknad
         val innsendtSøknad = søknadDTO.writeValueAsString()
 
         behandlingService.oppdaterBehandlingstema(
             behandling = behandlingService.hent(behandlingId = behandling.id),
+            nyBehandlingKategori = behandling.kategori, // Hvis søknadDTO får feltet kategori, så må denne endres til søknadDTO.kategori
             nyBehandlingUnderkategori = søknadDTO.underkategori
         )
 
@@ -42,7 +44,8 @@ class RegistrereSøknad(
             )
         )
 
-        val forrigeBehandlingSomErIverksatt = behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
+        val forrigeBehandlingSomErIverksatt =
+            behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
         persongrunnlagService.registrerBarnFraSøknad(
             behandling = behandlingService.hent(behandlingId = behandling.id),
             forrigeBehandling = forrigeBehandlingSomErIverksatt,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ved registrering av søknad til GrunnlagController endepunkt 
```"/{behandlingId}/registrere-søknad-og-hent-persongrunnlag"```
så overskrives oppgavens kategori med Nasjonal uansett om den var satt til EØS ved oppretting av oppgaven. Fikser dette her