### PR TITLE
Endre periodetype dersom du har en ikke-endret utvidet ytelse delt bosted endring med full utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
@@ -295,7 +295,7 @@ fun UtvidetVedtaksperiodeMedBegrunnelser.hentEndretUtbetalingBrevPeriode(
         barnasFodselsdager = this.utbetalingsperiodeDetaljer.tilBarnasFødselsdatoer(),
         begrunnelser = begrunnelserOgFritekster,
         type = when {
-            utvidetScenario == UtvidetScenario.UTVIDET_YTELSE_IKKE_ENDRET ->
+            ingenUtbetaling && utvidetScenario == UtvidetScenario.UTVIDET_YTELSE_IKKE_ENDRET ->
                 EndretUtbetalingBrevPeriodeType.ENDRET_UTBETALINGSPERIODE_DELVIS_UTBETALING
             ingenUtbetaling ->
                 EndretUtbetalingBrevPeriodeType.ENDRET_UTBETALINGSPERIODE_INGEN_UTBETALING

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
@@ -133,7 +133,7 @@ internal class BrevUtilsTest {
     }
 
     @Test
-    fun `test hentManuellVedtaksbrevtype kaster exception for ikke-støttede behandlingsresultater ved førstegangsbehandling`() {
+    fun `skal kaste exception for ikke-støttede behandlingsresultater ved førstegangsbehandling`() {
         val ikkeStøttedeBehandlingsersultater =
             BehandlingResultat.values().subtract(støttedeBehandlingsersultaterFørstegangsbehandling)
 
@@ -402,6 +402,13 @@ internal class BrevUtilsTest {
                     lagUtbetalingsperiodeDetalj(prosent = BigDecimal.ZERO)
                 )
             )
+        val utvidetVedtaksperiodeMedBegrunnelserFullUtbetaling =
+            lagUtvidetVedtaksperiodeMedBegrunnelser(
+                type = Vedtaksperiodetype.ENDRET_UTBETALING,
+                utbetalingsperiodeDetaljer = listOf(
+                    lagUtbetalingsperiodeDetalj(prosent = BigDecimal.valueOf(100))
+                )
+            )
 
         val begrunnelser = listOf(
             UtvidetScenario.IKKE_UTVIDET_YTELSE,
@@ -440,6 +447,22 @@ internal class BrevUtilsTest {
         Assertions.assertEquals(
             EndretUtbetalingBernetrygtType.DELT_UTVIDET.navn + " ",
             begrunnelser[2].typeBarnetrygd?.single()
+        )
+
+        val deltBostedEndringFullUtbetalingTilkjentYtelseUtenEndring =
+            utvidetVedtaksperiodeMedBegrunnelserFullUtbetaling.hentEndretUtbetalingBrevPeriode(
+                "",
+                emptyList(),
+                utvidetScenario = UtvidetScenario.UTVIDET_YTELSE_IKKE_ENDRET
+            )
+
+        Assertions.assertEquals(
+            EndretUtbetalingBrevPeriodeType.ENDRET_UTBETALINGSPERIODE.apiNavn,
+            deltBostedEndringFullUtbetalingTilkjentYtelseUtenEndring.type?.single()
+        )
+        Assertions.assertEquals(
+            EndretUtbetalingBernetrygtType.DELT_UTVIDET.navn + " ",
+            deltBostedEndringFullUtbetalingTilkjentYtelseUtenEndring.typeBarnetrygd?.single()
         )
     }
 }


### PR DESCRIPTION
Gi periodetype for full utbetaling dersom du har en delt bosted endring som er endret til full utbetaling samtidig som en utvidet tilkjent ytelse som ikke er endret

Oppdaterer testene