### PR TITLE
Legg til støtte for endrede utbetalingsperioder over satsendringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevService.kt
@@ -35,6 +35,7 @@ import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.slåSammenEtterfølgendeEndringsperioderMedSammeBegrunnelserOgPersoner
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.sorter
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -183,15 +184,19 @@ class BrevService(
         val andelTilkjentYtelser =
             andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtak.behandling.id)
 
-        val brevperioder = utvidetVedtaksperioderMedBegrunnelser.sorter().mapNotNull {
-            it.tilBrevPeriode(
-                personerIPersongrunnlag = grunnlagOgSignaturData.grunnlag.personer.toList(),
-                målform = målform,
-                uregistrerteBarn = søknadGrunnlagService.hentAktiv(behandlingId = vedtak.behandling.id)
-                    ?.hentUregistrerteBarn() ?: emptyList(),
-                utvidetScenario = andelTilkjentYtelser.hentUtvidetYtelseScenario(it.hentMånedPeriode())
-            )
-        }
+        val brevperioder =
+            utvidetVedtaksperioderMedBegrunnelser
+                .slåSammenEtterfølgendeEndringsperioderMedSammeBegrunnelserOgPersoner()
+                .sorter()
+                .mapNotNull {
+                    it.tilBrevPeriode(
+                        personerIPersongrunnlag = grunnlagOgSignaturData.grunnlag.personer.toList(),
+                        målform = målform,
+                        uregistrerteBarn = søknadGrunnlagService.hentAktiv(behandlingId = vedtak.behandling.id)
+                            ?.hentUregistrerteBarn() ?: emptyList(),
+                        utvidetScenario = andelTilkjentYtelser.hentUtvidetYtelseScenario(it.hentMånedPeriode())
+                    )
+                }
 
         return VedtakFellesfelter(
             enhet = grunnlagOgSignaturData.enhet,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtil.kt
@@ -33,7 +33,7 @@ import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.EndretUtbetalingBrevPe
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.AvslagBrevPeriode
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.AvslagUtenPeriodeBrevPeriode
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.BrevPeriode
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.EndretUtbetalingBernetrygtType
+import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.EndretUtbetalingBarnetrygdType
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.EndretUtbetalingBrevPeriode
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.FortsattInnvilgetBrevPeriode
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.InnvilgelseBrevPeriode
@@ -254,9 +254,10 @@ fun UtvidetVedtaksperiodeMedBegrunnelser.tilBrevPeriode(
         Vedtaksperiodetype.UTBETALING -> hentInnvilgelseBrevPeriode(tomDato, begrunnelserOgFritekster)
 
         Vedtaksperiodetype.ENDRET_UTBETALING -> hentEndretUtbetalingBrevPeriode(
-            tomDato,
-            begrunnelserOgFritekster,
-            utvidetScenario
+            tomDato = tomDato,
+            begrunnelserOgFritekster = begrunnelserOgFritekster,
+            utvidetScenario = utvidetScenario,
+            målform = målform,
         )
 
         Vedtaksperiodetype.AVSLAG -> hentAvslagBrevPeriode(tomDato, begrunnelserOgFritekster)
@@ -285,6 +286,7 @@ fun UtvidetVedtaksperiodeMedBegrunnelser.hentEndretUtbetalingBrevPeriode(
     tomDato: String?,
     begrunnelserOgFritekster: List<Begrunnelse>,
     utvidetScenario: UtvidetScenario = UtvidetScenario.IKKE_UTVIDET_YTELSE,
+    målform: Målform = Målform.NB,
 ): EndretUtbetalingBrevPeriode {
     val ingenUtbetaling =
         utbetalingsperiodeDetaljer.all { it.prosent == BigDecimal.ZERO }
@@ -303,9 +305,11 @@ fun UtvidetVedtaksperiodeMedBegrunnelser.hentEndretUtbetalingBrevPeriode(
                 EndretUtbetalingBrevPeriodeType.ENDRET_UTBETALINGSPERIODE
         },
         typeBarnetrygd = if (utvidetScenario == UtvidetScenario.IKKE_UTVIDET_YTELSE)
-            EndretUtbetalingBernetrygtType.DELT
-        else
-            EndretUtbetalingBernetrygtType.DELT_UTVIDET
+            EndretUtbetalingBarnetrygdType.DELT
+        else when (målform) {
+            Målform.NB -> EndretUtbetalingBarnetrygdType.DELT_UTVIDET_NB
+            Målform.NN -> EndretUtbetalingBarnetrygdType.DELT_UTVIDET_NN
+        }
     )
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/brevperioder/EndretUtbetalingBrevPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/dokument/domene/maler/brevperioder/EndretUtbetalingBrevPeriode.kt
@@ -24,7 +24,7 @@ data class EndretUtbetalingBrevPeriode(
         barnasFodselsdager: String,
         begrunnelser: List<Begrunnelse>,
         type: EndretUtbetalingBrevPeriodeType,
-        typeBarnetrygd: EndretUtbetalingBernetrygtType,
+        typeBarnetrygd: EndretUtbetalingBarnetrygdType,
     ) : this(
         fom = flettefelt(fom),
         tom = flettefelt(if (tom.isNullOrBlank()) "" else "til $tom "),
@@ -43,7 +43,8 @@ data class EndretUtbetalingBrevPeriode(
     )
 }
 
-enum class EndretUtbetalingBernetrygtType(val navn: String) {
+enum class EndretUtbetalingBarnetrygdType(val navn: String) {
     DELT("delt"),
-    DELT_UTVIDET("delt utvidet"),
+    DELT_UTVIDET_NB("delt utvidet"),
+    DELT_UTVIDET_NN("delt utvida"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.NullableMånedPeriode
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
@@ -132,4 +133,23 @@ class BegrunnelseComparator : Comparator<Vedtaksbegrunnelse> {
             -1
         } else 1
     }
+}
+
+fun VedtaksperiodeMedBegrunnelser.finnBegrunnelserForSegment(
+    andelerForSegment: List<AndelTilkjentYtelse>
+): List<Vedtaksbegrunnelse> {
+    val endretUtbetalingAndeler =
+        andelerForSegment.flatMap { it.endretUtbetalingAndeler }
+
+    return endretUtbetalingAndeler
+        .flatMap { it.vedtakBegrunnelseSpesifikasjoner }.toSet()
+        .map { vedtakBegrunnelseSpesifikasjon ->
+            Vedtaksbegrunnelse(
+                vedtaksperiodeMedBegrunnelser = this,
+                vedtakBegrunnelseSpesifikasjon = vedtakBegrunnelseSpesifikasjon,
+                personIdenter = endretUtbetalingAndeler.filter {
+                    it.harVedtakBegrunnelseSpesifikasjon(vedtakBegrunnelseSpesifikasjon)
+                }.mapNotNull { it.person?.personIdent?.ident }
+            )
+        }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -39,6 +39,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -190,6 +191,7 @@ class VedtaksperiodeService(
         }
     }
 
+    @Transactional
     fun oppdaterVedtakMedVedtaksperioder(vedtak: Vedtak) {
 
         slettVedtaksperioderFor(vedtak)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/dokument/BrevUtilsTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.EndretUtbetalingBrevPeriodeType
-import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.EndretUtbetalingBernetrygtType
+import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.brevperioder.EndretUtbetalingBarnetrygdType
 import no.nav.familie.ba.sak.kjerne.dokument.domene.maler.flettefelt
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.steg.StegType
@@ -427,7 +427,7 @@ internal class BrevUtilsTest {
             begrunnelser[0].type?.single()
         )
         Assertions.assertEquals(
-            EndretUtbetalingBernetrygtType.DELT.navn + " ",
+            EndretUtbetalingBarnetrygdType.DELT.navn + " ",
             begrunnelser[0].typeBarnetrygd?.single()
         )
 
@@ -436,7 +436,7 @@ internal class BrevUtilsTest {
             begrunnelser[1].type?.single()
         )
         Assertions.assertEquals(
-            EndretUtbetalingBernetrygtType.DELT_UTVIDET.navn + " ",
+            EndretUtbetalingBarnetrygdType.DELT_UTVIDET_NB.navn + " ",
             begrunnelser[1].typeBarnetrygd?.single()
         )
 
@@ -445,7 +445,7 @@ internal class BrevUtilsTest {
             begrunnelser[2].type?.single()
         )
         Assertions.assertEquals(
-            EndretUtbetalingBernetrygtType.DELT_UTVIDET.navn + " ",
+            EndretUtbetalingBarnetrygdType.DELT_UTVIDET_NB.navn + " ",
             begrunnelser[2].typeBarnetrygd?.single()
         )
 
@@ -461,7 +461,7 @@ internal class BrevUtilsTest {
             deltBostedEndringFullUtbetalingTilkjentYtelseUtenEndring.type?.single()
         )
         Assertions.assertEquals(
-            EndretUtbetalingBernetrygtType.DELT_UTVIDET.navn + " ",
+            EndretUtbetalingBarnetrygdType.DELT_UTVIDET_NB.navn + " ",
             deltBostedEndringFullUtbetalingTilkjentYtelseUtenEndring.typeBarnetrygd?.single()
         )
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7077

Dersom en utbetalingsendring strekker seg over en satsendring skal ikke endringsperioden splittes i to i brevet. De må likevel splittes for å få riktig tilkjent ytelse til økonomi. 

Denne endringen gjør derfor at vi slår sammen endringsperiodene over satsendring når vi genererer brevperiodene. 


### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
