### PR TITLE
Bug: hent siste behandling som ikke er henlagt istedet for siste iverksatte behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -255,12 +255,6 @@ class BehandlingService(
         return behandlingRepository.finnIverksatteBehandlinger(fagsakId = fagsakId)
     }
 
-    fun hentSisteBehandlingSomIkkeErHenlagt(fagsakId: Long): Behandling? {
-        return behandlingRepository.finnBehandlinger(fagsakId)
-            .filter { !it.erHenlagt() }
-            .maxByOrNull { it.opprettetTidspunkt }
-    }
-
     /**
      * Henter siste iverksatte behandling på fagsak
      */
@@ -292,12 +286,18 @@ class BehandlingService(
         return Behandlingutils.hentForrigeIverksatteBehandling(iverksatteBehandlinger, behandling)
     }
 
+    fun hentSisteBehandlingSomErVedtatt(fagsakId: Long): Behandling? {
+        return behandlingRepository.finnBehandlinger(fagsakId)
+            .filter { !it.erHenlagt() && it.status == AVSLUTTET }
+            .maxByOrNull { it.opprettetTidspunkt }
+    }
+
     /**
-     * Henter siste behandling som ikke er henlagt FØR en gitt behandling
+     * Henter siste behandling som er vedtatt FØR en gitt behandling
      */
-    fun hentForrigeBehandlingSomIkkeErHenlagt(behandling: Behandling): Behandling? {
+    fun hentForrigeBehandlingSomErVedtatt(behandling: Behandling): Behandling? {
         val behandlinger = behandlingRepository.finnBehandlinger(behandling.fagsak.id)
-        return Behandlingutils.hentForrigeBehandlingSomIkkeErHenlagt(behandlinger, behandling)
+        return Behandlingutils.hentForrigeBehandlingSomErVedtatt(behandlinger, behandling)
     }
 
     fun lagreEllerOppdater(behandling: Behandling, sendTilDvh: Boolean = true): Behandling {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -283,11 +283,21 @@ class BehandlingService(
             } ?: emptyList()
 
     /**
-     * Henter siste iverksatte behandling FØR en gitt behandling
+     * Henter siste iverksatte behandling FØR en gitt behandling.
+     * Bør kun brukes i forbindelse med oppdrag mot økonomisystemet
+     * eller ved behandlingsresultat.
      */
     fun hentForrigeBehandlingSomErIverksatt(behandling: Behandling): Behandling? {
         val iverksatteBehandlinger = hentIverksatteBehandlinger(behandling.fagsak.id)
         return Behandlingutils.hentForrigeIverksatteBehandling(iverksatteBehandlinger, behandling)
+    }
+
+    /**
+     * Henter siste behandling som ikke er henlagt FØR en gitt behandling
+     */
+    fun hentForrigeBehandlingSomIkkeErHenlagt(behandling: Behandling): Behandling? {
+        val behandlinger = behandlingRepository.finnBehandlinger(behandling.fagsak.id)
+        return Behandlingutils.hentForrigeBehandlingSomIkkeErHenlagt(behandlinger, behandling)
     }
 
     fun lagreEllerOppdater(behandling: Behandling, sendTilDvh: Boolean = true): Behandling {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
@@ -16,6 +16,16 @@ object Behandlingutils {
             .findLast { it.steg == StegType.BEHANDLING_AVSLUTTET }
     }
 
+    fun hentForrigeBehandlingSomIkkeErHenlagt(
+        behandlinger: List<Behandling>,
+        behandlingFørFølgende: Behandling
+    ): Behandling? {
+        return behandlinger
+            .filter { it.opprettetTidspunkt.isBefore(behandlingFørFølgende.opprettetTidspunkt) }
+            .sortedBy { it.opprettetTidspunkt }
+            .findLast { it.steg == StegType.BEHANDLING_AVSLUTTET && !it.erHenlagt() }
+    }
+
     fun hentSisteBehandlingSomIkkeErTekniskOpphør(behandlinger: List<Behandling>): Behandling? =
         behandlinger.sortedBy { it.opprettetTidspunkt }.findLast { !it.erTekniskOpphør() }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
@@ -12,31 +12,29 @@ object Behandlingutils {
 
     fun hentSisteBehandlingSomErIverksatt(iverksatteBehandlinger: List<Behandling>): Behandling? {
         return iverksatteBehandlinger
-            .sortedBy { it.opprettetTidspunkt }
-            .findLast { it.steg == StegType.BEHANDLING_AVSLUTTET }
+            .filter { it.steg == StegType.BEHANDLING_AVSLUTTET }
+            .maxByOrNull { it.opprettetTidspunkt }
     }
 
-    fun hentForrigeBehandlingSomIkkeErHenlagt(
+    fun hentForrigeBehandlingSomErVedtatt(
         behandlinger: List<Behandling>,
         behandlingFørFølgende: Behandling
     ): Behandling? {
         return behandlinger
-            .filter { it.opprettetTidspunkt.isBefore(behandlingFørFølgende.opprettetTidspunkt) }
-            .sortedBy { it.opprettetTidspunkt }
-            .findLast { it.steg == StegType.BEHANDLING_AVSLUTTET && !it.erHenlagt() }
+            .filter { it.opprettetTidspunkt.isBefore(behandlingFørFølgende.opprettetTidspunkt) && it.steg == StegType.BEHANDLING_AVSLUTTET && !it.erHenlagt() }
+            .maxByOrNull { it.opprettetTidspunkt }
     }
 
     fun hentSisteBehandlingSomIkkeErTekniskOpphør(behandlinger: List<Behandling>): Behandling? =
-        behandlinger.sortedBy { it.opprettetTidspunkt }.findLast { !it.erTekniskOpphør() }
+        behandlinger.filter { !it.erTekniskOpphør() }.maxByOrNull { it.opprettetTidspunkt }
 
     fun hentForrigeIverksatteBehandling(
         iverksatteBehandlinger: List<Behandling>,
         behandlingFørFølgende: Behandling
     ): Behandling? {
         return iverksatteBehandlinger
-            .filter { it.opprettetTidspunkt.isBefore(behandlingFørFølgende.opprettetTidspunkt) }
-            .sortedBy { it.opprettetTidspunkt }
-            .findLast { it.steg == StegType.BEHANDLING_AVSLUTTET }
+            .filter { it.opprettetTidspunkt.isBefore(behandlingFørFølgende.opprettetTidspunkt) && it.steg == StegType.BEHANDLING_AVSLUTTET }
+            .maxByOrNull { it.opprettetTidspunkt }
     }
 
     fun bestemKategori(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -135,19 +135,19 @@ class PersongrunnlagService(
     fun registrerBarnFraSøknad(
         søknadDTO: SøknadDTO,
         behandling: Behandling,
-        forrigeBehandlingSomIkkeErHenlagt: Behandling? = null
+        forrigeBehandlingSomErVedtatt: Behandling? = null
     ) {
         val søkerIdent = søknadDTO.søkerMedOpplysninger.ident
         val valgteBarnsIdenter =
             søknadDTO.barnaMedOpplysninger.filter { it.inkludertISøknaden && it.erFolkeregistrert }
                 .map { barn -> barn.ident }
 
-        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomIkkeErHenlagt != null) {
-            val forrigePersongrunnlag = hentAktiv(behandlingId = forrigeBehandlingSomIkkeErHenlagt.id)
+        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomErVedtatt != null) {
+            val forrigePersongrunnlag = hentAktiv(behandlingId = forrigeBehandlingSomErVedtatt.id)
             val forrigePersongrunnlagBarna = forrigePersongrunnlag?.barna?.map { it.personIdent.ident }
                 ?.filter {
                     andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlingOgBarn(
-                        forrigeBehandlingSomIkkeErHenlagt.id,
+                        forrigeBehandlingSomErVedtatt.id,
                         it
                     )
                         .isNotEmpty()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -123,7 +123,8 @@ class PersongrunnlagService(
     fun finnNyeBarn(behandling: Behandling, forrigeBehandling: Behandling?): List<Person> {
         val barnIForrigeGrunnlag = forrigeBehandling?.let { hentAktiv(behandlingId = it.id)?.barna } ?: emptySet()
         val barnINyttGrunnlag =
-            behandling.let { hentAktiv(behandlingId = it.id)?.barna } ?: throw Feil("Fant ikke personopplysningsgrunnlag")
+            behandling.let { hentAktiv(behandlingId = it.id)?.barna }
+                ?: throw Feil("Fant ikke personopplysningsgrunnlag")
 
         return barnINyttGrunnlag.filter { barn -> barnIForrigeGrunnlag.none { barn.personIdent == it.personIdent } }
     }
@@ -131,17 +132,22 @@ class PersongrunnlagService(
     /**
      * Registrerer barn valgt i søknad og barn fra forrige behandling
      */
-    fun registrerBarnFraSøknad(søknadDTO: SøknadDTO, behandling: Behandling, forrigeBehandling: Behandling? = null) {
+    fun registrerBarnFraSøknad(
+        søknadDTO: SøknadDTO,
+        behandling: Behandling,
+        forrigeBehandlingSomIkkeErHenlagt: Behandling? = null
+    ) {
         val søkerIdent = søknadDTO.søkerMedOpplysninger.ident
         val valgteBarnsIdenter =
-            søknadDTO.barnaMedOpplysninger.filter { it.inkludertISøknaden && it.erFolkeregistrert }.map { barn -> barn.ident }
+            søknadDTO.barnaMedOpplysninger.filter { it.inkludertISøknaden && it.erFolkeregistrert }
+                .map { barn -> barn.ident }
 
-        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandling != null) {
-            val forrigePersongrunnlag = hentAktiv(behandlingId = forrigeBehandling.id)
+        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomIkkeErHenlagt != null) {
+            val forrigePersongrunnlag = hentAktiv(behandlingId = forrigeBehandlingSomIkkeErHenlagt.id)
             val forrigePersongrunnlagBarna = forrigePersongrunnlag?.barna?.map { it.personIdent.ident }
                 ?.filter {
                     andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlingOgBarn(
-                        forrigeBehandling.id,
+                        forrigeBehandlingSomIkkeErHenlagt.id,
                         it
                     )
                         .isNotEmpty()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
@@ -46,7 +46,7 @@ class FerdigstillBehandling(
                 fagsakService.oppdaterStatus(behandling.fagsak, FagsakStatus.AVSLUTTET)
             }
             behandlingService.hentAktivForFagsak(behandling.fagsak.id)?.aktiv = false
-            behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)?.apply {
+            behandlingService.hentSisteBehandlingSomIkkeErHenlagt(behandling.fagsak.id)?.apply {
                 aktiv = true
                 behandlingService.lagreEllerOppdater(this)
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
@@ -46,7 +46,7 @@ class FerdigstillBehandling(
                 fagsakService.oppdaterStatus(behandling.fagsak, FagsakStatus.AVSLUTTET)
             }
             behandlingService.hentAktivForFagsak(behandling.fagsak.id)?.aktiv = false
-            behandlingService.hentSisteBehandlingSomIkkeErHenlagt(behandling.fagsak.id)?.apply {
+            behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)?.apply {
                 aktiv = true
                 behandlingService.lagreEllerOppdater(this)
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
@@ -22,11 +22,15 @@ class RegistrerPersongrunnlag(
         behandling: Behandling,
         data: RegistrerPersongrunnlagDTO
     ): StegType {
-        val forrigeBehandlingSomErIverksatt =
-            behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
-        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomErIverksatt != null) {
-            val forrigePersongrunnlagBarna = behandlingService.finnBarnFraBehandlingMedTilkjentYtsele(behandlingId = forrigeBehandlingSomErIverksatt.id)
-            val forrigeMålform = persongrunnlagService.hentSøkersMålform(behandlingId = forrigeBehandlingSomErIverksatt.id)
+        val forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
+            behandling
+        )
+
+        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomIkkeErHenlagt != null) {
+            val forrigePersongrunnlagBarna =
+                behandlingService.finnBarnFraBehandlingMedTilkjentYtsele(behandlingId = forrigeBehandlingSomIkkeErHenlagt.id)
+            val forrigeMålform =
+                persongrunnlagService.hentSøkersMålform(behandlingId = forrigeBehandlingSomIkkeErHenlagt.id)
 
             persongrunnlagService.hentOgLagreSøkerOgBarnINyttGrunnlag(
                 data.ident,
@@ -45,15 +49,18 @@ class RegistrerPersongrunnlag(
                 Målform.NB
             )
         }
+
         if (!(
-            behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD ||
-                behandling.opprettetÅrsak == BehandlingÅrsak.FØDSELSHENDELSE
-            )
+                behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD ||
+                    behandling.opprettetÅrsak == BehandlingÅrsak.FØDSELSHENDELSE
+                )
         ) {
             vilkårService.initierVilkårsvurderingForBehandling(
                 behandling = behandling,
                 bekreftEndringerViaFrontend = true,
-                forrigeBehandling = forrigeBehandlingSomErIverksatt
+                forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
+                    behandling
+                )
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
@@ -22,15 +22,15 @@ class RegistrerPersongrunnlag(
         behandling: Behandling,
         data: RegistrerPersongrunnlagDTO
     ): StegType {
-        val forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
+        val forrigeBehandlingSomErVedtatt = behandlingService.hentForrigeBehandlingSomErVedtatt(
             behandling
         )
 
-        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomIkkeErHenlagt != null) {
+        if (behandling.type == BehandlingType.REVURDERING && forrigeBehandlingSomErVedtatt != null) {
             val forrigePersongrunnlagBarna =
-                behandlingService.finnBarnFraBehandlingMedTilkjentYtsele(behandlingId = forrigeBehandlingSomIkkeErHenlagt.id)
+                behandlingService.finnBarnFraBehandlingMedTilkjentYtsele(behandlingId = forrigeBehandlingSomErVedtatt.id)
             val forrigeMålform =
-                persongrunnlagService.hentSøkersMålform(behandlingId = forrigeBehandlingSomIkkeErHenlagt.id)
+                persongrunnlagService.hentSøkersMålform(behandlingId = forrigeBehandlingSomErVedtatt.id)
 
             persongrunnlagService.hentOgLagreSøkerOgBarnINyttGrunnlag(
                 data.ident,
@@ -58,7 +58,7 @@ class RegistrerPersongrunnlag(
             vilkårService.initierVilkårsvurderingForBehandling(
                 behandling = behandling,
                 bekreftEndringerViaFrontend = true,
-                forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
+                forrigeBehandlingSomErVedtatt = behandlingService.hentForrigeBehandlingSomErVedtatt(
                     behandling
                 )
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
@@ -51,9 +51,9 @@ class RegistrerPersongrunnlag(
         }
 
         if (!(
-                behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD ||
-                    behandling.opprettetÅrsak == BehandlingÅrsak.FØDSELSHENDELSE
-                )
+            behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD ||
+                behandling.opprettetÅrsak == BehandlingÅrsak.FØDSELSHENDELSE
+            )
         ) {
             vilkårService.initierVilkårsvurderingForBehandling(
                 behandling = behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
@@ -44,11 +44,11 @@ class RegistrereSøknad(
             )
         )
 
-        val forrigeBehandlingSomErIverksatt =
-            behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
+        val forrigeBehandlingSomIkkeErHenlagt =
+            behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(behandling = behandling)
         persongrunnlagService.registrerBarnFraSøknad(
             behandling = behandlingService.hent(behandlingId = behandling.id),
-            forrigeBehandling = forrigeBehandlingSomErIverksatt,
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomIkkeErHenlagt,
             søknadDTO = søknadDTO
         )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
@@ -44,11 +44,11 @@ class RegistrereSøknad(
             )
         )
 
-        val forrigeBehandlingSomIkkeErHenlagt =
-            behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(behandling = behandling)
+        val forrigeBehandlingSomErVedtatt =
+            behandlingService.hentForrigeBehandlingSomErVedtatt(behandling = behandling)
         persongrunnlagService.registrerBarnFraSøknad(
             behandling = behandlingService.hent(behandlingId = behandling.id),
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomIkkeErHenlagt,
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErVedtatt,
             søknadDTO = søknadDTO
         )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -78,7 +78,7 @@ class StegService(
             )
         } else if (nyBehandling.behandlingType == BehandlingType.REVURDERING || nyBehandling.behandlingType == BehandlingType.TEKNISK_ENDRING) {
             val sisteBehandling = behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
-                ?: behandlingService.hentSisteBehandlingSomIkkeErHenlagt(behandling.fagsak.id)
+                ?: behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
                 ?: throw Feil("Forsøker å opprette en revurdering eller teknisk endring, men kan ikke finne tidligere behandling på fagsak ${behandling.fagsak.id}")
 
             val barnFraSisteBehandlingMedUtbetalinger =
@@ -321,12 +321,12 @@ class StegService(
             }
 
             if (behandlingSteg.stegType().erSaksbehandlerSteg() && behandlingSteg.stegType()
-                .kommerEtter(behandling.steg)
+                    .kommerEtter(behandling.steg)
             ) {
                 error(
                     "${SikkerhetContext.hentSaksbehandlerNavn()} prøver å utføre steg '${
-                    behandlingSteg.stegType()
-                        .displayName()
+                        behandlingSteg.stegType()
+                            .displayName()
                     }', men behandlingen er på steg '${behandling.steg.displayName()}'"
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -321,12 +321,12 @@ class StegService(
             }
 
             if (behandlingSteg.stegType().erSaksbehandlerSteg() && behandlingSteg.stegType()
-                    .kommerEtter(behandling.steg)
+                .kommerEtter(behandling.steg)
             ) {
                 error(
                     "${SikkerhetContext.hentSaksbehandlerNavn()} prøver å utføre steg '${
-                        behandlingSteg.stegType()
-                            .displayName()
+                    behandlingSteg.stegType()
+                        .displayName()
                     }', men behandlingen er på steg '${behandling.steg.displayName()}'"
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
@@ -25,12 +25,12 @@ class TilbakestillBehandlingService(
         behandling: Behandling,
         bekreftEndringerViaFrontend: Boolean = true
     ) {
-
-        val forrigeBehandlingSomErIverksatt = behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
         vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = bekreftEndringerViaFrontend,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
+                behandling
+            )
         )
 
         val vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingId = behandling.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
@@ -28,7 +28,7 @@ class TilbakestillBehandlingService(
         vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = bekreftEndringerViaFrontend,
-            forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
+            forrigeBehandlingSomErVedtatt = behandlingService.hentForrigeBehandlingSomErVedtatt(
                 behandling
             )
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -32,7 +32,7 @@ class VilkårsvurderingSteg(
             vilkårService.initierVilkårsvurderingForBehandling(
                 behandling = behandling,
                 bekreftEndringerViaFrontend = true,
-                forrigeBehandling = behandlingService.hentForrigeBehandlingSomErIverksatt(
+                forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
                     behandling
                 )
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -32,7 +32,7 @@ class VilkårsvurderingSteg(
             vilkårService.initierVilkårsvurderingForBehandling(
                 behandling = behandling,
                 bekreftEndringerViaFrontend = true,
-                forrigeBehandlingSomIkkeErHenlagt = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(
+                forrigeBehandlingSomErVedtatt = behandlingService.hentForrigeBehandlingSomErVedtatt(
                     behandling
                 )
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -131,7 +131,7 @@ class VilkårService(
     fun initierVilkårsvurderingForBehandling(
         behandling: Behandling,
         bekreftEndringerViaFrontend: Boolean,
-        forrigeBehandlingSomIkkeErHenlagt: Behandling? = null
+        forrigeBehandlingSomErVedtatt: Behandling? = null
     ): Vilkårsvurdering {
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id)
             ?: throw IllegalStateException("Fant ikke personopplysninggrunnlag for behandling ${behandling.id}")
@@ -154,16 +154,16 @@ class VilkårService(
                 barnaSomAlleredeErVurdert = barnaSomAlleredeErVurdert
             )
 
-        return if (forrigeBehandlingSomIkkeErHenlagt != null && aktivVilkårsvurdering == null) {
+        return if (forrigeBehandlingSomErVedtatt != null && aktivVilkårsvurdering == null) {
             val vilkårsvurdering =
                 genererInitiellVilkårsvurderingFraAnnenBehandling(
                     initiellVilkårsvurdering = initiellVilkårsvurdering,
-                    annenBehandling = forrigeBehandlingSomIkkeErHenlagt
+                    annenBehandling = forrigeBehandlingSomErVedtatt
                 )
 
             endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
                 behandling,
-                forrigeBehandlingSomIkkeErHenlagt
+                forrigeBehandlingSomErVedtatt
             )
 
             return vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
@@ -173,8 +173,8 @@ class VilkårService(
                     initiellVilkårsvurdering = initiellVilkårsvurdering,
                     aktivVilkårsvurdering = aktivVilkårsvurdering,
                     løpendeUnderkategori = behandlingService.hentLøpendeUnderkategori(initiellVilkårsvurdering.behandling.fagsak.id),
-                    forrigeBehandlingVilkårsvurdering = if (forrigeBehandlingSomIkkeErHenlagt != null) hentVilkårsvurdering(
-                        forrigeBehandlingSomIkkeErHenlagt.id
+                    forrigeBehandlingVilkårsvurdering = if (forrigeBehandlingSomErVedtatt != null) hentVilkårsvurdering(
+                        forrigeBehandlingSomErVedtatt.id
                     ) else null
                 )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -131,7 +131,7 @@ class VilkårService(
     fun initierVilkårsvurderingForBehandling(
         behandling: Behandling,
         bekreftEndringerViaFrontend: Boolean,
-        forrigeBehandling: Behandling? = null
+        forrigeBehandlingSomIkkeErHenlagt: Behandling? = null
     ): Vilkårsvurdering {
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id)
             ?: throw IllegalStateException("Fant ikke personopplysninggrunnlag for behandling ${behandling.id}")
@@ -154,14 +154,17 @@ class VilkårService(
                 barnaSomAlleredeErVurdert = barnaSomAlleredeErVurdert
             )
 
-        return if (forrigeBehandling != null && aktivVilkårsvurdering == null) {
+        return if (forrigeBehandlingSomIkkeErHenlagt != null && aktivVilkårsvurdering == null) {
             val vilkårsvurdering =
                 genererInitiellVilkårsvurderingFraAnnenBehandling(
                     initiellVilkårsvurdering = initiellVilkårsvurdering,
-                    annenBehandling = forrigeBehandling
+                    annenBehandling = forrigeBehandlingSomIkkeErHenlagt
                 )
 
-            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(behandling, forrigeBehandling)
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling,
+                forrigeBehandlingSomIkkeErHenlagt
+            )
 
             return vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
         } else {
@@ -170,8 +173,8 @@ class VilkårService(
                     initiellVilkårsvurdering = initiellVilkårsvurdering,
                     aktivVilkårsvurdering = aktivVilkårsvurdering,
                     løpendeUnderkategori = behandlingService.hentLøpendeUnderkategori(initiellVilkårsvurdering.behandling.fagsak.id),
-                    forrigeBehandlingVilkårsvurdering = if (forrigeBehandling != null) hentVilkårsvurdering(
-                        forrigeBehandling.id
+                    forrigeBehandlingVilkårsvurdering = if (forrigeBehandlingSomIkkeErHenlagt != null) hentVilkårsvurdering(
+                        forrigeBehandlingSomIkkeErHenlagt.id
                     ) else null
                 )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -51,7 +51,7 @@ class SaksstatistikkService(
 
     fun mapTilBehandlingDVH(behandlingId: Long): BehandlingDVH? {
         val behandling = behandlingService.hent(behandlingId)
-        val forrigeBehandlingId = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(behandling)
+        val forrigeBehandlingId = behandlingService.hentForrigeBehandlingSomErVedtatt(behandling)
             .takeIf { erRevurderingEllerTekniskBehandling(behandling) }?.id
 
         if (behandling.opprettetÅrsak == FØDSELSHENDELSE && !envService.skalIverksetteBehandling()) return null

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -51,7 +51,7 @@ class SaksstatistikkService(
 
     fun mapTilBehandlingDVH(behandlingId: Long): BehandlingDVH? {
         val behandling = behandlingService.hent(behandlingId)
-        val forrigeBehandlingId = behandlingService.hentForrigeBehandlingSomErIverksatt(behandling)
+        val forrigeBehandlingId = behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(behandling)
             .takeIf { erRevurderingEllerTekniskBehandling(behandling) }?.id
 
         if (behandling.opprettetÅrsak == FØDSELSHENDELSE && !envService.skalIverksetteBehandling()) return null

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -67,7 +67,7 @@ class BehandlingServiceTest(
             )
 
         val forrigeBehandling =
-            behandlingService.hentForrigeBehandlingSomErIverksatt(behandling = revurderingInnvilgetBehandling)
+            behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(behandling = revurderingInnvilgetBehandling)
         Assertions.assertNotNull(forrigeBehandling)
         Assertions.assertEquals(behandling.id, forrigeBehandling?.id)
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -67,7 +67,7 @@ class BehandlingServiceTest(
             )
 
         val forrigeBehandling =
-            behandlingService.hentForrigeBehandlingSomIkkeErHenlagt(behandling = revurderingInnvilgetBehandling)
+            behandlingService.hentForrigeBehandlingSomErVedtatt(behandling = revurderingInnvilgetBehandling)
         Assertions.assertNotNull(forrigeBehandling)
         Assertions.assertEquals(behandling.id, forrigeBehandling?.id)
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -74,7 +74,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = null
+            forrigeBehandlingSomErVedtatt = null
         )
 
         vilkårsvurdering.personResultater.map { personResultat ->
@@ -144,7 +144,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandlingRevurdering,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = iverksattBehandling
+            forrigeBehandlingSomErVedtatt = iverksattBehandling
         )
 
         val kopierteEndredeUtbetalingAndeler = endretUtbetalingAndelService.hentForBehandling(behandlingRevurdering.id)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -45,7 +45,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
     @Autowired
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
 
-) : AbstractVerdikjedetest() {
+    ) : AbstractVerdikjedetest() {
     @Test
     fun `Endrede utbetalingsandeler fra forrige behandling kopieres riktig`() {
 
@@ -74,7 +74,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = null
+            forrigeBehandlingSomIkkeErHenlagt = null
         )
 
         vilkårsvurdering.personResultater.map { personResultat ->
@@ -144,7 +144,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandlingRevurdering,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = iverksattBehandling
+            forrigeBehandlingSomIkkeErHenlagt = iverksattBehandling
         )
 
         val kopierteEndredeUtbetalingAndeler = endretUtbetalingAndelService.hentForBehandling(behandlingRevurdering.id)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -45,7 +45,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
     @Autowired
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
 
-    ) : AbstractVerdikjedetest() {
+) : AbstractVerdikjedetest() {
     @Test
     fun `Endrede utbetalingsandeler fra forrige behandling kopieres riktig`() {
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -72,7 +72,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
         )
         vilkårsvurdering.personResultater.forEach { personResultat ->
             personResultat.vilkårResultater.forEach { vilkårResultat ->
@@ -101,7 +101,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
         )
         val under18ÅrVilkårForBarn =
             vilkårsvurdering.personResultater.find { it.personIdent == barnFnr }
@@ -147,7 +147,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
         )
         Assertions.assertEquals(2, vilkårsvurdering.personResultater.size)
 
@@ -158,7 +158,7 @@ class VilkårServiceTest(
         val behandlingResultatMedEkstraBarn = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
         )
         Assertions.assertEquals(3, behandlingResultatMedEkstraBarn.personResultater.size)
     }
@@ -193,7 +193,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
         )
             .also {
                 it.personResultater
@@ -234,7 +234,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
         )
         Assertions.assertEquals(2, vilkårsvurdering.personResultater.size)
 
@@ -270,7 +270,7 @@ class VilkårServiceTest(
         val vilkårsvurdering2 = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling2,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = behandling
+            forrigeBehandlingSomIkkeErHenlagt = behandling
         )
 
         Assertions.assertEquals(3, vilkårsvurdering2.personResultater.size)
@@ -304,7 +304,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
         )
 
         val barn: Person = personopplysningGrunnlag.barna.find { it.personIdent.ident == barnFnr }!!
@@ -325,7 +325,7 @@ class VilkårServiceTest(
         val behandlingResultat2 = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling2,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandling = behandling
+            forrigeBehandlingSomIkkeErHenlagt = behandling
         )
 
         Assertions.assertEquals(3, behandlingResultat2.personResultater.size)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -72,7 +72,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErIverksatt
         )
         vilkårsvurdering.personResultater.forEach { personResultat ->
             personResultat.vilkårResultater.forEach { vilkårResultat ->
@@ -101,7 +101,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErIverksatt
         )
         val under18ÅrVilkårForBarn =
             vilkårsvurdering.personResultater.find { it.personIdent == barnFnr }
@@ -147,7 +147,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErIverksatt
         )
         Assertions.assertEquals(2, vilkårsvurdering.personResultater.size)
 
@@ -158,7 +158,7 @@ class VilkårServiceTest(
         val behandlingResultatMedEkstraBarn = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErIverksatt
         )
         Assertions.assertEquals(3, behandlingResultatMedEkstraBarn.personResultater.size)
     }
@@ -193,7 +193,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErIverksatt
         )
             .also {
                 it.personResultater
@@ -234,7 +234,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErIverksatt
         )
         Assertions.assertEquals(2, vilkårsvurdering.personResultater.size)
 
@@ -270,7 +270,7 @@ class VilkårServiceTest(
         val vilkårsvurdering2 = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling2,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = behandling
+            forrigeBehandlingSomErVedtatt = behandling
         )
 
         Assertions.assertEquals(3, vilkårsvurdering2.personResultater.size)
@@ -304,7 +304,7 @@ class VilkårServiceTest(
         val vilkårsvurdering = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = forrigeBehandlingSomErIverksatt
+            forrigeBehandlingSomErVedtatt = forrigeBehandlingSomErIverksatt
         )
 
         val barn: Person = personopplysningGrunnlag.barna.find { it.personIdent.ident == barnFnr }!!
@@ -325,7 +325,7 @@ class VilkårServiceTest(
         val behandlingResultat2 = vilkårService.initierVilkårsvurderingForBehandling(
             behandling = behandling2,
             bekreftEndringerViaFrontend = true,
-            forrigeBehandlingSomIkkeErHenlagt = behandling
+            forrigeBehandlingSomErVedtatt = behandling
         )
 
         Assertions.assertEquals(3, behandlingResultat2.personResultater.size)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Endrer fra forrige iverksatte til forrige behandling som ikke er henlagt flere steder da det gir mer mening å bygge videre på disse fremfor den siste som er iverksatt.

Denne endringen har jeg gjort fordi at i en revurdering jeg så på i prod så hentet vi vilkårsvurdering fra forrige iverksatte behandling og ikke den siste behandlingen med endringer.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Kan det være behov for å kun se på de iverksatte barna i enkelte tilfeller hvor jeg har endret nå?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Endret der det trengs.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
