### PR TITLE
BUG: filtrering visningstekster for begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -279,7 +279,6 @@ fun vedtakBegrunnelseSpesifikasjonerTilNedtrekksmenytekster(
         .groupBy { it.vedtakBegrunnelseType }
         .mapValues { begrunnelseGruppe ->
             begrunnelseGruppe.value
-                .filter { it.tilSanityBegrunnelse(sanityBegrunnelser)?.tilTriggesAv()?.valgbar ?: false }
                 .flatMap { vedtakBegrunnelse ->
                     vedtakBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
                         sanityBegrunnelser,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Select tekster trenger ikke å filtreres ettersom det er gyldigeBegrunnelser som bestemmer hvilke begrunnelser som kan velges for en gitt periode.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7422
