### PR TITLE
Forbedring: flyt ved manuell behandling av autovedtak småbarnstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
@@ -243,7 +243,10 @@ fun hentNesteSteg(behandling: Behandling, utførendeStegType: StegType): StegTyp
             when (utførendeStegType) {
                 REGISTRERE_PERSONGRUNNLAG -> VILKÅRSVURDERING
                 VILKÅRSVURDERING -> BEHANDLINGSRESULTAT
-                BEHANDLINGSRESULTAT -> if (behandling.status == BehandlingStatus.IVERKSETTER_VEDTAK) IVERKSETT_MOT_OPPDRAG else VURDER_TILBAKEKREVING
+                BEHANDLINGSRESULTAT -> {
+                    if (!behandling.skalBehandlesAutomatisk) VURDER_TILBAKEKREVING
+                    else if (behandling.skalBehandlesAutomatisk && behandling.status == BehandlingStatus.IVERKSETTER_VEDTAK) IVERKSETT_MOT_OPPDRAG else BEHANDLINGSRESULTAT
+                }
                 VURDER_TILBAKEKREVING -> SEND_TIL_BESLUTTER
                 SEND_TIL_BESLUTTER -> BESLUTTE_VEDTAK
                 BESLUTTE_VEDTAK -> hentNesteStegTypeBasertPåBehandlingsresultat(behandling.resultat)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når vi ikke klarer å automatisk behandle småbarnstillegg så kaster vi den til manuell behandling. Ved å sende SB til vurder tilbakekreving har vi ikke hentet simuleringen. Ved å sende til behandlingsresultat derimot så vil SB hente simuleringen selv.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Finnes fra før

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
