### PR TITLE
Retter behandlingsresultat ved flytting av opphørsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonUtils.kt
@@ -182,7 +182,7 @@ object YtelsePersonUtils {
             val opphører = stønadSlutt.isBefore(inneværendeMåned.plusMonths(1))
             val sisteForrigeAndel = segmenterFjernet.maxByOrNull { it.fom }
             val ingenFjernetFørStønadslutt = segmenterFjernet.none { it.fom.isBefore(stønadSlutt.toLocalDate()) }
-            opphører && ingenFjernetFørStønadslutt && sisteForrigeAndel != null
+            opphører && ingenFjernetFørStønadslutt && sisteForrigeAndel != null && sisteForrigeAndel.tom.toYearMonth() >= inneværendeMåned
         } else {
             false
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonUtils.kt
@@ -182,7 +182,7 @@ object YtelsePersonUtils {
             val opphører = stønadSlutt.isBefore(inneværendeMåned.plusMonths(1))
             val sisteForrigeAndel = segmenterFjernet.maxByOrNull { it.fom }
             val ingenFjernetFørStønadslutt = segmenterFjernet.none { it.fom.isBefore(stønadSlutt.toLocalDate()) }
-            opphører && ingenFjernetFørStønadslutt && sisteForrigeAndel != null && sisteForrigeAndel.tom.toYearMonth() > inneværendeMåned
+            opphører && ingenFjernetFørStønadslutt && sisteForrigeAndel != null
         } else {
             false
         }

--- a/src/test/resources/behandlingsresultatPersoner/RV14_OPPHØRT_SAMME_OPPHØRDATO_ALLE_TY.json
+++ b/src/test/resources/behandlingsresultatPersoner/RV14_OPPHØRT_SAMME_OPPHØRDATO_ALLE_TY.json
@@ -1,0 +1,45 @@
+{
+  "beskrivelse": "RV: Vi har motatt nye opplysninger om søker og barn. Vi opphører hele ytelsen fra ny dato.",
+  "inneværendeMåned": "2021-09",
+  "personer": [
+    {
+      "personType": "SØKER",
+      "søktForPerson": false,
+      "eksplisittAvslått": false,
+      "forrigeAndeler": [
+        {
+          "stønadFom": "2021-03",
+          "stønadTom": "2021-09",
+          "kalkulertUtbetalingsbeløp": 1054
+        }
+      ],
+      "andeler": [
+        {
+          "stønadFom": "2021-03",
+          "stønadTom": "2021-05",
+          "kalkulertUtbetalingsbeløp": 1355
+        }
+      ]
+    },
+    {
+      "personType": "BARN",
+      "søktForPerson": false,
+      "eksplisittAvslått": false,
+      "forrigeAndeler": [
+        {
+          "stønadFom": "2021-01",
+          "stønadTom": "2021-09",
+          "kalkulertUtbetalingsbeløp": 1354
+        }
+      ],
+      "andeler": [
+        {
+          "stønadFom": "2021-01",
+          "stønadTom": "2021-05",
+          "kalkulertUtbetalingsbeløp": 1355
+        }
+      ]
+    }
+  ],
+  "forventetResultat": "OPPHØRT"
+}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
legger til test med opphørsdato lik inneværendeMåned, og opphør tilbake i tid

forsøker å fikse ved å endre på regler i YtelsePersonUtils