### PR TITLE
Utvider response tilbake til ba-migrering til for å identifisere stønad migrert

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -116,7 +116,11 @@ class MigreringService(
                 behandlingId = behandlingEtterVilkårsvurdering.id,
                 infotrygdStønadId = løpendeSak.stønad?.id,
                 infotrygdSakId = løpendeSak.id,
-                virkningFom = førsteUtbetalingsperiode.fom.toYearMonth()
+                virkningFom = førsteUtbetalingsperiode.fom.toYearMonth(),
+                infotrygdTkNr = løpendeSak.tkNr,
+                infotrygdIverksattFom = løpendeSak.stønad?.iverksattFom,
+                infotrygdVirkningFom = løpendeSak.stønad?.virkningFom,
+                infotrygdRegion = løpendeSak.region
             )
             secureLog.info("Ferdig migrert $personIdent. Response til familie-ba-migrering: $migreringResponseDto")
             return migreringResponseDto

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/domene/MigreringResponseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/domene/MigreringResponseDto.kt
@@ -8,4 +8,9 @@ data class MigreringResponseDto(
     val infotrygdStønadId: Long? = null,
     val infotrygdSakId: Long? = null,
     val virkningFom: YearMonth? = null,
+    //følgende 4 felt brukes som unik key i infotrygd stønad
+    val infotrygdTkNr: String? = null,
+    val infotrygdVirkningFom: String? = null,
+    val infotrygdIverksattFom: String? = null,
+    val infotrygdRegion: String? = null,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/domene/MigreringResponseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/domene/MigreringResponseDto.kt
@@ -8,7 +8,7 @@ data class MigreringResponseDto(
     val infotrygdStønadId: Long? = null,
     val infotrygdSakId: Long? = null,
     val virkningFom: YearMonth? = null,
-    //følgende 4 felt brukes som unik key i infotrygd stønad
+    // følgende 4 felt brukes som unik key i infotrygd stønad
     val infotrygdTkNr: String? = null,
     val infotrygdVirkningFom: String? = null,
     val infotrygdIverksattFom: String? = null,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Utvider responseDto til å ha med mer info om migrert stønad, slik at det blir identifisert den uten bruk av id som kan endre seg. 

Merges ikke ned før ting er ID er klart


### 🔎️ Er det noe spesielt du ønsker å fremheve?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
