### PR TITLE
Filtreringsregel fødselshendelse, mor mottar utvidet barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/Filtreringsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/Filtreringsregel.kt
@@ -15,6 +15,7 @@ enum class Filtreringsregel(val vurder: FiltreringsreglerFakta.() -> Evaluering)
     MER_ENN_5_MND_SIDEN_FORRIGE_BARN(vurder = { merEnn5mndEllerMindreEnnFemDagerSidenForrigeBarn(this) }),
     MOR_ER_OVER_18_ÅR(vurder = { morErOver18år(this) }),
     MOR_HAR_IKKE_VERGE(vurder = { morHarIkkeVerge(this) }),
+    MOR_MOTTAR_IKKE_LØPENDE_UTVIDET(vurder = { morMottarIkkeLøpendeUtvidet(this) })
 }
 
 fun evaluerFiltreringsregler(fakta: FiltreringsreglerFakta) = Filtreringsregel.values()
@@ -72,6 +73,13 @@ fun morHarIkkeVerge(fakta: FiltreringsreglerFakta): Evaluering = if (!fakta.morH
 ) else Evaluering.ikkeOppfylt(
     FiltreringsregelIkkeOppfylt.MOR_ER_UMYNDIG
 )
+
+fun morMottarIkkeLøpendeUtvidet(fakta: FiltreringsreglerFakta): Evaluering =
+    if (!fakta.morMottarLøpendeUtvidet) Evaluering.oppfylt(
+        FiltreringsregelOppfylt.MOR_MOTTAR_IKKE_LØPENDE_UTVIDET
+    ) else Evaluering.ikkeOppfylt(
+        FiltreringsregelIkkeOppfylt.MOR_MOTTAR_LØPENDE_UTVIDET
+    )
 
 fun merEnn5mndEllerMindreEnnFemDagerSidenForrigeBarn(fakta: FiltreringsreglerFakta): Evaluering {
     return when (

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsreglerFakta.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsreglerFakta.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 
 data class FiltreringsreglerFakta(
     val mor: Person,
+    val morMottarLøpendeUtvidet: Boolean = false,
     val barnaFraHendelse: List<Person>,
     val restenAvBarna: List<PersonInfo>,
     val morLever: Boolean,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsreglerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsreglerService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregle
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregler.domene.FødselshendelsefiltreringResultatRepository
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -91,6 +92,7 @@ class FiltreringsreglerService(
 
         val fakta = FiltreringsreglerFakta(
             mor = personopplysningGrunnlag.søker,
+            morMottarLøpendeUtvidet = behandling.underkategori == BehandlingUnderkategori.UTVIDET,
             barnaFraHendelse = barnaFraHendelse,
             restenAvBarna = finnRestenAvBarnasPersonInfo(morsAktørId, barnaFraHendelse),
             morLever = !personopplysningerService.hentDødsfall(morsAktørId).erDød,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/utfall/FiltreringsregelIkkeOppfylt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/utfall/FiltreringsregelIkkeOppfylt.kt
@@ -10,6 +10,7 @@ enum class FiltreringsregelIkkeOppfylt(val beskrivelse: String, private val filt
     BARN_HAR_UGYLDIG_FNR("Barn har ugyldig fødselsnummer", Filtreringsregel.BARN_GYLDIG_FNR),
     MOR_ER_UNDER_18_ÅR("Mor er under 18 år.", Filtreringsregel.MOR_ER_OVER_18_ÅR),
     MOR_ER_UMYNDIG("Mor er umyndig.", Filtreringsregel.MOR_HAR_IKKE_VERGE),
+    MOR_MOTTAR_LØPENDE_UTVIDET("Mor mottar utvidet barnetrygd.", Filtreringsregel.MOR_MOTTAR_IKKE_LØPENDE_UTVIDET),
     MOR_LEVER_IKKE("Det er registrert dødsdato på mor.", Filtreringsregel.MOR_LEVER),
     BARNET_LEVER_IKKE("Det er registrert dødsdato på barnet.", Filtreringsregel.BARN_LEVER),
     MINDRE_ENN_5_MND_SIDEN_FORRIGE_BARN_UTFALL(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/utfall/FiltreringsregelOppfylt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/utfall/FiltreringsregelOppfylt.kt
@@ -10,6 +10,10 @@ enum class FiltreringsregelOppfylt(val beskrivelse: String, private val filtreri
     BARN_HAR_GYLDIG_FNR("Barn har gyldig fødselsnummer", Filtreringsregel.BARN_GYLDIG_FNR),
     MOR_ER_OVER_18_ÅR("Mor er over 18 år.", Filtreringsregel.MOR_ER_OVER_18_ÅR),
     MOR_ER_MYNDIG("Mor er myndig.", Filtreringsregel.MOR_HAR_IKKE_VERGE),
+    MOR_MOTTAR_IKKE_LØPENDE_UTVIDET(
+        "Mor mottar ikke utvidet barnetrygd.",
+        Filtreringsregel.MOR_MOTTAR_IKKE_LØPENDE_UTVIDET
+    ),
     MOR_LEVER("Det er ikke registrert dødsdato på mor.", Filtreringsregel.MOR_LEVER),
     BARNET_LEVER("Det er ikke registrert dødsdato på barnet.", Filtreringsregel.BARN_LEVER),
     MER_ENN_5_MND_SIDEN_FORRIGE_BARN_UTFALL(

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -611,12 +611,13 @@ fun kjørStegprosessForFGB(
     vilkårsvurderingService: VilkårsvurderingService,
     stegService: StegService,
     vedtaksperiodeService: VedtaksperiodeService,
+    behandlingUnderkategori: BehandlingUnderkategori = BehandlingUnderkategori.ORDINÆR
 ): Behandling {
     fagsakService.hentEllerOpprettFagsakForPersonIdent(søkerFnr)
     val behandling = stegService.håndterNyBehandling(
         NyBehandling(
             kategori = BehandlingKategori.NASJONAL,
-            underkategori = BehandlingUnderkategori.ORDINÆR,
+            underkategori = behandlingUnderkategori,
             behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
             behandlingÅrsak = BehandlingÅrsak.SØKNAD,
             søkersIdent = søkerFnr,
@@ -630,7 +631,8 @@ fun kjørStegprosessForFGB(
             restRegistrerSøknad = RestRegistrerSøknad(
                 søknad = lagSøknadDTO(
                     søkerIdent = søkerFnr,
-                    barnasIdenter = barnasIdenter
+                    barnasIdenter = barnasIdenter,
+                    underkategori = behandlingUnderkategori
                 ),
                 bekreftEndringerViaFrontend = true
             )

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelForFlereBarnTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelForFlereBarnTest.kt
@@ -290,9 +290,9 @@ class FiltreringsregelForFlereBarnTest {
         )
 
         return FiltreringsreglerFakta(
-            mor,
-            barn,
-            restenAvBarna,
+            mor = mor,
+            barnaFraHendelse = barn,
+            restenAvBarna = restenAvBarna,
             morLever = true,
             barnaLever = true,
             morHarVerge = false,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelTest.kt
@@ -26,9 +26,9 @@ internal class FiltreringsregelTest {
 
         val evalueringer = evaluerFiltreringsregler(
             FiltreringsreglerFakta(
-                mor,
-                listOf(barnet),
-                restenAvBarna,
+                mor = mor,
+                barnaFraHendelse = listOf(barnet),
+                restenAvBarna = restenAvBarna,
                 morLever = true,
                 barnaLever = true,
                 morHarVerge = false
@@ -39,6 +39,28 @@ internal class FiltreringsregelTest {
     }
 
     @Test
+    fun `Regelevaluering skal resultere i NEI når mor mottar utvidet barnetrygd`() {
+        val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
+        val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
+        val restenAvBarna: List<PersonInfo> = listOf()
+
+        val evalueringer = evaluerFiltreringsregler(
+            FiltreringsreglerFakta(
+                mor = mor,
+                morMottarLøpendeUtvidet = true,
+                barnaFraHendelse = listOf(barnet),
+                restenAvBarna = restenAvBarna,
+                morLever = true,
+                barnaLever = true,
+                morHarVerge = false
+            )
+        )
+
+        assertThat(evalueringer.erOppfylt()).isFalse
+        assertEnesteRegelMedResultatNei(evalueringer, Filtreringsregel.MOR_MOTTAR_IKKE_LØPENDE_UTVIDET)
+    }
+
+    @Test
     fun `Regelevaluering skal resultere i NEI når mor er under 18 år`() {
         val mor = tilfeldigPerson(LocalDate.now().minusYears(17)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
@@ -46,9 +68,9 @@ internal class FiltreringsregelTest {
 
         val evalueringer = evaluerFiltreringsregler(
             FiltreringsreglerFakta(
-                mor,
-                listOf(barnet),
-                restenAvBarna,
+                mor = mor,
+                barnaFraHendelse = listOf(barnet),
+                restenAvBarna = restenAvBarna,
                 morLever = true,
                 barnaLever = true,
                 morHarVerge = false
@@ -71,9 +93,9 @@ internal class FiltreringsregelTest {
 
         val evaluering = Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.vurder(
             FiltreringsreglerFakta(
-                mor,
-                listOf(barnet1, barnet2),
-                restenAvBarna,
+                mor = mor,
+                barnaFraHendelse = listOf(barnet1, barnet2),
+                restenAvBarna = restenAvBarna,
                 morLever = true,
                 barnaLever = true,
                 morHarVerge = false
@@ -94,9 +116,9 @@ internal class FiltreringsregelTest {
 
         val evaluering = Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.vurder(
             FiltreringsreglerFakta(
-                mor,
-                listOf(barnet1, barnet2),
-                restenAvBarna,
+                mor = mor,
+                barnaFraHendelse = listOf(barnet1, barnet2),
+                restenAvBarna = restenAvBarna,
                 morLever = true,
                 barnaLever = true,
                 morHarVerge = false
@@ -114,9 +136,9 @@ internal class FiltreringsregelTest {
 
         val evalueringer = evaluerFiltreringsregler(
             FiltreringsreglerFakta(
-                mor,
-                listOf(barnet),
-                restenAvBarna,
+                mor = mor,
+                barnaFraHendelse = listOf(barnet),
+                restenAvBarna = restenAvBarna,
                 morLever = false,
                 barnaLever = true,
                 morHarVerge = false
@@ -135,9 +157,9 @@ internal class FiltreringsregelTest {
 
         val evalueringer = evaluerFiltreringsregler(
             FiltreringsreglerFakta(
-                mor,
-                listOf(barnet),
-                restenAvBarna,
+                mor = mor,
+                barnaFraHendelse = listOf(barnet),
+                restenAvBarna = restenAvBarna,
                 morLever = true,
                 barnaLever = false,
                 morHarVerge = false
@@ -156,9 +178,9 @@ internal class FiltreringsregelTest {
 
         val evalueringer = evaluerFiltreringsregler(
             FiltreringsreglerFakta(
-                mor,
-                listOf(barnet),
-                restenAvBarna,
+                mor = mor,
+                barnaFraHendelse = listOf(barnet),
+                restenAvBarna = restenAvBarna,
                 morLever = true,
                 barnaLever = true,
                 morHarVerge = true
@@ -226,7 +248,7 @@ internal class FiltreringsregelTest {
 
     @Test
     fun `Tvillinger født på samme dag skal gi oppfylt`() {
-        val søkerPerson =
+        val mor =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), personIdent = PersonIdent(randomFnr()))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), personIdent = PersonIdent(randomFnr()))
@@ -234,9 +256,9 @@ internal class FiltreringsregelTest {
 
         val evaluering = Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.vurder(
             FiltreringsreglerFakta(
-                søkerPerson,
-                listOf(barn1Person),
-                listOf(barn2PersonInfo),
+                mor = mor,
+                barnaFraHendelse = listOf(barn1Person),
+                restenAvBarna = listOf(barn2PersonInfo),
                 morLever = true,
                 barnaLever = true,
                 morHarVerge = false
@@ -442,6 +464,7 @@ internal class FiltreringsregelTest {
             Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN,
             Filtreringsregel.MOR_ER_OVER_18_ÅR,
             Filtreringsregel.MOR_HAR_IKKE_VERGE,
+            Filtreringsregel.MOR_MOTTAR_IKKE_LØPENDE_UTVIDET
         )
         assertThat(Filtreringsregel.values().size).isEqualTo(fagbestemtFiltreringsregelrekkefølge.size)
         assertThat(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Implementerer filtreringsregel for å ikke automatisk innvilge fødselshendelser der mor mottar utvidet barnetrygd.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7141

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
