### PR TITLE
BUG: Spør aldri integrasjoner om tilgang når man er i systemkontekst.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.kjerne.brev.hentOverstyrtDokumenttittel
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.OpprettTaskService.Companion.RETRY_BACKOFF_5000MS
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.Fagsystem
@@ -542,6 +543,10 @@ class IntegrasjonClient(
         UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_TILGANG_PERSON).build().toUri()
 
     fun sjekkTilgangTilPersoner(personIdenter: List<String>): Tilgang {
+        if (SikkerhetContext.erSystemKontekst()) {
+            return Tilgang(true, null)
+        }
+
         return postForEntity<List<Tilgang>>(
             tilgangPersonUri,
             personIdenter,
@@ -552,6 +557,10 @@ class IntegrasjonClient(
     }
 
     fun sjekkTilgangTilPersonMedRelasjoner(personIdent: String): Tilgang {
+        if (SikkerhetContext.erSystemKontekst()) {
+            return Tilgang(true, null)
+        }
+
         return postForEntity(
             tilgangRelasjonerUri, PersonIdent(personIdent),
             HttpHeaders().also {

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/SikkerhetContext.kt
@@ -9,6 +9,8 @@ object SikkerhetContext {
     const val SYSTEM_FORKORTELSE = "VL"
     const val SYSTEM_NAVN = "System"
 
+    fun erSystemKontekst() = hentSaksbehandler() == SYSTEM_FORKORTELSE
+
     fun hentSaksbehandler(): String {
         return Result.runCatching { SpringTokenValidationContextHolder().tokenValidationContext }
             .fold(

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -91,11 +91,7 @@ class TilgangService(
      * @param verdi verdiet som man ønsket å hente cache for, eks behandlingId, eller personIdent
      */
     private fun <T> harSaksbehandlerTilgang(cacheName: String, verdi: T, hentVerdi: () -> Boolean): Boolean {
-        if (SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
-                rolleConfig,
-                null
-            ) == BehandlerRolle.SYSTEM
-        ) return true
+        if (SikkerhetContext.erSystemKontekst()) return true
 
         val cache = cacheManager.getCache(cacheName) ?: error("Finner ikke cache=$cacheName")
         return cache.get(Pair(verdi, SikkerhetContext.hentSaksbehandler())) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter overgang til nye endepunkter i familie-integrasjoner sjekker den ting på en litt annen måte som gjør at det feiler for enkelte personer. Endrer slik at vi aldri spør familie-integrasjoner når man er i systemkontekst.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Dette er egentlig en revert fra før omskrivningen.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
