### PR TITLE
Forbedring bosatt i riket

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.isBetween
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.isSameOrBefore
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Evaluering
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.vilkårsvurdering.utfall.VilkårIkkeOppfyltÅrsak
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.vilkårsvurdering.utfall.VilkårKanskjeOppfyltÅrsak
@@ -35,16 +36,6 @@ data class VurderPersonErBosattIRiket(
 ) : Vilkårsregel {
 
     override fun vurder(): Evaluering {
-        if (adresser.size == 1 && !adresser.single().harGyldigFom()) {
-            /**
-             * Bruker har kun en adresse og den er uten fom som betyr at vedkommende har bodd på samme
-             * adresse hele livet.
-             */
-            return Evaluering.oppfylt(VilkårOppfyltÅrsak.BOR_I_RIKET_EN_ADRESSE_HELE_LIVET)
-        } else if (adresser.filter { !it.harGyldigFom() }.size > 1) {
-            return Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.BOR_IKKE_I_RIKET_FLERE_ADRESSER_UTEN_FOM)
-        }
-
         if (adresser.any { !it.harGyldigFom() }) {
             val person = adresser.first().person
             secureLogger.info(
@@ -54,6 +45,12 @@ data class VurderPersonErBosattIRiket(
                 }"
             )
         }
+
+        if (harPersonKunAdresserUtenFom(adresser)) return Evaluering.oppfylt(VilkårOppfyltÅrsak.BOR_I_RIKET_KUN_ADRESSER_UTEN_FOM)
+        else if (harPersonBoddPåSisteAdresseMinstFraVurderingstidspunkt(adresser, vurderFra)) return Evaluering.oppfylt(
+            VilkårOppfyltÅrsak.BOR_I_RIKET
+        )
+        else if (adresser.filter { !it.harGyldigFom() }.size > 1) return Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.BOR_IKKE_I_RIKET_FLERE_ADRESSER_UTEN_FOM)
 
         val adresserMedGyldigFom = adresser.filter { it.harGyldigFom() }
 
@@ -69,6 +66,25 @@ data class VurderPersonErBosattIRiket(
         )
             Evaluering.oppfylt(VilkårOppfyltÅrsak.BOR_I_RIKET)
         else Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.BOR_IKKE_I_RIKET)
+    }
+
+    /**
+     * Bruker har kun adresser uten fom som betyr at vedkommende har bodd på samme
+     * adresse hele livet eller flyttet før man innførte fom ved flytting.
+     */
+    private fun harPersonKunAdresserUtenFom(adresser: List<GrBostedsadresse>): Boolean =
+        adresser.all { !it.harGyldigFom() }
+
+    private fun harPersonBoddPåSisteAdresseMinstFraVurderingstidspunkt(
+        adresser: List<GrBostedsadresse>,
+        vurderFra: LocalDate
+    ): Boolean {
+        val sisteAdresse = adresser
+            .filter { it.harGyldigFom() }
+            .maxByOrNull { it.periode?.fom!! } ?: return false
+
+        return sisteAdresse.periode?.fom!!.toYearMonth()
+            .isBefore(vurderFra.toYearMonth()) && sisteAdresse.periode?.tom == null
     }
 
     private fun erPersonBosattFraVurderingstidspunktet(adresser: List<GrBostedsadresse>, vurderFra: LocalDate) =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -46,6 +46,7 @@ data class VurderPersonErBosattIRiket(
             )
         }
 
+        if (adresser.isEmpty()) return Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.BOR_IKKE_I_RIKET)
         if (harPersonKunAdresserUtenFom(adresser)) return Evaluering.oppfylt(VilkårOppfyltÅrsak.BOR_I_RIKET_KUN_ADRESSER_UTEN_FOM)
         else if (harPersonBoddPåSisteAdresseMinstFraVurderingstidspunkt(adresser, vurderFra)) return Evaluering.oppfylt(
             VilkårOppfyltÅrsak.BOR_I_RIKET

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/utfall/VilkårOppfyltÅrsak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/utfall/VilkårOppfyltÅrsak.kt
@@ -21,7 +21,10 @@ enum class VilkårOppfyltÅrsak(val beskrivelse: String, val vilkår: Vilkår) :
 
     // Bosatt i riket
     BOR_I_RIKET("Er bosatt i riket", Vilkår.BOSATT_I_RIKET),
-    BOR_I_RIKET_EN_ADRESSE_HELE_LIVET("Er bosatt i riket - samme adresse hele livet", Vilkår.BOSATT_I_RIKET),
+    BOR_I_RIKET_KUN_ADRESSER_UTEN_FOM(
+        "Er bosatt i riket - har kun adresser uten fra- og med dato",
+        Vilkår.BOSATT_I_RIKET
+    ),
 
     // Lovlig opphold
     AUTOMATISK_VURDERING_BARN_LOVLIG_OPPHOLD(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/StartSatsendringForAlleBehandlingerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/StartSatsendringForAlleBehandlingerTask.kt
@@ -7,7 +7,6 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.springframework.stereotype.Service
 import java.time.YearMonth
-import java.util.Properties
 
 @Service
 @TaskStepBeskrivelse(
@@ -34,11 +33,7 @@ class StartSatsendringForAlleBehandlingerTask(
         fun opprettTask(gammelSats: Long): Task {
             return Task(
                 type = TASK_STEP_TYPE,
-                payload = gammelSats.toString(),
-                properties = Properties().apply {
-                    this["måned"] = YearMonth.now()
-                    this["gammelSats"] = gammelSats.toString()
-                }
+                payload = gammelSats.toString()
             )
         }
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/BosattIRiketVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/BosattIRiketVilkårTest.kt
@@ -261,7 +261,7 @@ class BosattIRiketVilkårTest {
         ).vurder()
 
         assertEquals(Resultat.OPPFYLT, evaluering.resultat)
-        assertEquals(VilkårOppfyltÅrsak.BOR_I_RIKET_EN_ADRESSE_HELE_LIVET, evaluering.evalueringÅrsaker.single())
+        assertEquals(VilkårOppfyltÅrsak.BOR_I_RIKET_KUN_ADRESSER_UTEN_FOM, evaluering.evalueringÅrsaker.single())
     }
 
     @Test
@@ -284,7 +284,7 @@ class BosattIRiketVilkårTest {
                 ),
                 GrBostedsadresse.fraBostedsadresse(
                     defaultAdresse.copy(
-                        angittFlyttedato = LocalDate.now().minusMonths(7),
+                        angittFlyttedato = LocalDate.now().minusMonths(3),
                     ),
                     søker
                 ),

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -181,6 +181,17 @@ class FødselshendelseHenleggelseTest(
                                 kommunenummer = "2231"
                             )
                         ),
+                        Bostedsadresse(
+                            angittFlyttedato = now(),
+                            gyldigTilOgMed = null,
+                            matrikkeladresse = Matrikkeladresse(
+                                matrikkelId = 123L,
+                                bruksenhetsnummer = "H301",
+                                tilleggsnavn = "navn",
+                                postnummer = "0202",
+                                kommunenummer = "2231"
+                            )
+                        ),
                     )
                 ),
                 barna = listOf(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Forbedrer regel for vurdering om søker er bosatt i riket basert på funksjonelle krav.

1. Finnes det kun adresser uten fom -> OPPFYLT
2. Har siste adresse fom før vurderingstidspunktet (altså fra barnets fødselsdato) og tom=null (altså ikke utflyttet) -> OPPFYLT
3. Finnes det nå flere adresser uten fom betyr det at vedkommende ikke har bodd på samme adresse fra vurderingstidspunktet og saksbehandler bør se på saken -> IKKE_OPPFYLT
4. Vurder som vanlig basert på adresser med fom.


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
