### PR TITLE
Forbedring: opprett behandle sak oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -163,7 +163,7 @@ class OppgaveService(
             ""
         } +
             "----- Opprettet av familie-ba-sak ${LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)} --- \n" +
-            "https://barnetrygd.nais.adeo.no/fagsak/$fagsakId"
+            "https://barnetrygd.intern.nav.no/fagsak/$fagsakId"
     }
 
     fun hentOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -42,7 +42,7 @@ class StegService(
     private val søknadGrunnlagService: SøknadGrunnlagService,
     private val skyggesakService: SkyggesakService,
     private val tilgangService: TilgangService,
-    val infotrygdFeedService: InfotrygdFeedService,
+    private val infotrygdFeedService: InfotrygdFeedService,
 ) {
 
     private val stegSuksessMetrics: Map<StegType, Counter> = initStegMetrikker("suksess")

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -399,9 +399,6 @@ fun lagSøknadDTO(
 
 fun lagPersonResultaterForSøkerOgToBarn(
     vilkårsvurdering: Vilkårsvurdering,
-    søkerFnr: String,
-    barn1Fnr: String,
-    barn2Fnr: String,
     søkerAktør: Aktør,
     barn1Aktør: Aktør,
     barn2Aktør: Aktør,
@@ -509,7 +506,6 @@ fun vurderVilkårsvurderingTilInnvilget(vilkårsvurdering: Vilkårsvurdering, ba
 }
 
 fun lagVilkårsvurdering(
-    søkerFnr: String,
     søkerAktør: Aktør,
     behandling: Behandling,
     resultat: Resultat,

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
@@ -91,12 +91,11 @@ internal class TidTest {
 
     @Test
     fun `skal bestemme om periode er etterfølgende periode`() {
-        val personIdent = randomFnr()
         val personAktørId = randomAktørId()
         val behandling = lagBehandling()
         val resultat: Resultat = mockk()
         val vilkår: Vilkår = mockk(relaxed = true)
-        val vilkårsvurdering = lagVilkårsvurdering(personIdent, personAktørId, behandling, resultat)
+        val vilkårsvurdering = lagVilkårsvurdering(personAktørId, behandling, resultat)
 
         val personResultat = PersonResultat(
             vilkårsvurdering = vilkårsvurdering,

--- a/src/test/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
@@ -11,6 +11,8 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiKlient
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingKlient
+import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.TaskRepositoryTestConfig
 import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -47,6 +49,12 @@ abstract class AbstractMockkSpringRunner {
 
     @Autowired
     private lateinit var mockInfotrygdBarnetrygdClient: InfotrygdBarnetrygdClient
+
+    @Autowired
+    private lateinit var mockTaskRepository: TaskRepositoryWrapper
+
+    @Autowired
+    private lateinit var mockOpprettTaskService: OpprettTaskService
 
     @Autowired
     private lateinit var applicationContext: ConfigurableApplicationContext
@@ -105,6 +113,14 @@ abstract class AbstractMockkSpringRunner {
 
         if (isMockKMock(mockInfotrygdBarnetrygdClient)) {
             InfotrygdBarnetrygdClientMock.clearInfotrygdBarnetrygdMocks(mockInfotrygdBarnetrygdClient)
+        }
+
+        if (isMockKMock(mockTaskRepository)) {
+            TaskRepositoryTestConfig.clearMockTaskRepository(mockTaskRepository)
+        }
+
+        if (isMockKMock(mockOpprettTaskService)) {
+            TaskRepositoryTestConfig.clearMockTaskService(mockOpprettTaskService)
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/Datagenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/Datagenerator.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner
 
+import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.DEFAULT_JOURNALFØRENDE_ENHET
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Sakstype
 import no.nav.familie.ba.sak.task.dto.FAGSYSTEM
@@ -95,7 +96,7 @@ fun lagTestOppgaveDTO(
 ): Oppgave {
     return Oppgave(
         id = oppgaveId,
-        aktoerId = "1234",
+        aktoerId = randomAktørId().aktørId,
         identer = listOf(OppgaveIdentV2("11111111111", IdentGruppe.FOLKEREGISTERIDENT)),
         journalpostId = "1234",
         tildeltEnhetsnr = tildeltEnhetsnr,

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -110,7 +110,7 @@ class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.BAR)
-        assertThat(slot.captured.beskrivelse).contains("https://barnetrygd.nais.adeo.no/fagsak/$FAGSAK_ID")
+        assertThat(slot.captured.beskrivelse).contains("https://barnetrygd.intern.nav.no/fagsak/$FAGSAK_ID")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
@@ -67,7 +67,7 @@ class ØkonomiIntegrasjonTest(
         val barnAktørId = personidentService.hentOgLagreAktør(barnFnr, true)
 
         val vilkårsvurdering =
-            lagBehandlingResultat(behandling, fnr, barnFnr, fagsak.aktør, barnAktørId, stønadFom, stønadTom)
+            lagBehandlingResultat(behandling, fagsak.aktør, barnAktørId, stønadFom, stønadTom)
 
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
         Assertions.assertNotNull(behandling.fagsak.id)
@@ -128,7 +128,7 @@ class ØkonomiIntegrasjonTest(
         behandlingService.opprettOgInitierNyttVedtakForBehandling(behandling)
 
         val vilkårsvurdering =
-            lagBehandlingResultat(behandling, fnr, barnFnr, fagsak.aktør, barnAktørId, stønadFom, stønadTom)
+            lagBehandlingResultat(behandling, fagsak.aktør, barnAktørId, stønadFom, stønadTom)
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
 
         beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
@@ -146,8 +146,6 @@ class ØkonomiIntegrasjonTest(
 
     private fun lagBehandlingResultat(
         behandling: Behandling,
-        søkerFnr: String,
-        barnFnr: String,
         søkerAktør: Aktør,
         barnAktør: Aktør,
         stønadFom: LocalDate,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
@@ -452,9 +452,6 @@ class BehandlingIntegrationTest(
             Vilkårsvurdering(behandling = behandling)
         behandlingResultat1.personResultater = lagPersonResultaterForSøkerOgToBarn(
             behandlingResultat1,
-            søkerFnr,
-            barn1Fnr,
-            barn2Fnr,
             søkerAktørId,
             barn1AktørId,
             barn2AktørId,
@@ -469,9 +466,6 @@ class BehandlingIntegrationTest(
             Vilkårsvurdering(behandling = behandling)
         behandlingResultat2.personResultater = lagPersonResultaterForSøkerOgToBarn(
             behandlingResultat2,
-            søkerFnr,
-            barn1Fnr,
-            barn3Fnr,
             søkerAktørId,
             barn1AktørId,
             barn3AktørId,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.behandling
 
 import io.mockk.every
+import io.mockk.verify
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPersonResultat
 import no.nav.familie.ba.sak.common.lagPersonResultaterForSøkerOgToBarn
@@ -11,10 +12,10 @@ import no.nav.familie.ba.sak.common.toLocalDate
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestPersonerMedAndeler
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
-import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.internal.PersonInfo
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -49,7 +50,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.domene.SaksstatistikkMellomlagringRepository
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.domene.SaksstatistikkMellomlagringType
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
@@ -61,7 +61,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -108,16 +107,16 @@ class BehandlingIntegrationTest(
     private val databaseCleanupService: DatabaseCleanupService,
 
     @Autowired
-    private val oppgaveService: OppgaveService,
-
-    @Autowired
     private val saksstatistikkMellomlagringRepository: SaksstatistikkMellomlagringRepository,
 
     @Autowired
     private val infotrygdBarnetrygdClient: InfotrygdBarnetrygdClient,
 
     @Autowired
-    private val personidentService: PersonidentService
+    private val personidentService: PersonidentService,
+
+    @Autowired
+    private val taskRepository: TaskRepositoryWrapper
 ) : AbstractSpringIntegrationTest() {
 
     @BeforeEach
@@ -209,14 +208,11 @@ class BehandlingIntegrationTest(
         val fnr = randomFnr()
 
         fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
-        val behandling = behandlingService.opprettBehandling(nyOrdinærBehandling(fnr))
+        behandlingService.opprettBehandling(nyOrdinærBehandling(fnr))
 
-        assertNotNull(
-            oppgaveService.hentOppgaveSomIkkeErFerdigstilt(
-                oppgavetype = Oppgavetype.BehandleSak,
-                behandling = behandling
-            )
-        )
+        verify(exactly = 1) {
+            taskRepository.save(any())
+        }
     }
 
     @Test
@@ -234,7 +230,7 @@ class BehandlingIntegrationTest(
         val fnr = randomFnr()
 
         fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
-        val behandling = behandlingService.opprettBehandling(
+        behandlingService.opprettBehandling(
             NyBehandling(
                 kategori = BehandlingKategori.NASJONAL,
                 underkategori = BehandlingUnderkategori.ORDINÆR,
@@ -244,12 +240,9 @@ class BehandlingIntegrationTest(
             )
         )
 
-        assertNull(
-            oppgaveService.hentOppgaveSomIkkeErFerdigstilt(
-                oppgavetype = Oppgavetype.BehandleSak,
-                behandling = behandling
-            )
-        )
+        verify(exactly = 0) {
+            taskRepository.save(any())
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -233,9 +233,6 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
         val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
         vilkårsvurdering.personResultater = lagPersonResultaterForSøkerOgToBarn(
             vilkårsvurdering,
-            søkerFnr,
-            barn1Fnr,
-            barn2Fnr,
             søkerAktørId,
             barn1AktørId,
             barn2AktørId,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
@@ -522,7 +522,6 @@ internal class TilkjentYtelseUtilsTest {
         val behandling = lagBehandling()
 
         val vilkårsvurdering = lagVilkårsvurdering(
-            søkerFnr = søkerFnr,
             søkerAktør = søkerAktørId,
             behandling = behandling,
             resultat = Resultat.OPPFYLT,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktørId
-import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -71,7 +70,7 @@ class SendTilBeslutterTest {
     @Test
     fun `Sjekk validering som inneholder annen vurdering som ikke er vurdert`() {
         val vilkårsvurdering =
-            lagVilkårsvurdering(randomFnr(), randomAktørId(), lagBehandling(), Resultat.IKKE_VURDERT)
+            lagVilkårsvurdering(randomAktørId(), lagBehandling(), Resultat.IKKE_VURDERT)
 
         assertThrows<FunksjonellFeil> {
             vilkårsvurdering.validerAtAlleAnndreVurderingerErVurdert()
@@ -81,7 +80,7 @@ class SendTilBeslutterTest {
     @Test
     fun `Sjekk validering som inneholder annen vurdering hvor alle er vurdert`() {
         val vilkårsvurdering =
-            lagVilkårsvurdering(randomFnr(), randomAktørId(), lagBehandling(), Resultat.IKKE_OPPFYLT)
+            lagVilkårsvurdering(randomAktørId(), lagBehandling(), Resultat.IKKE_OPPFYLT)
 
         vilkårsvurdering.validerAtAlleAnndreVurderingerErVurdert()
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -231,7 +231,6 @@ class StegServiceTest(
         val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(
             lagVilkårsvurdering(
-                søkerFnr,
                 søkerAktørId,
                 behandling,
                 Resultat.OPPFYLT

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
@@ -98,6 +99,9 @@ class VedtakServiceTest(
 
     @Autowired
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+
+    @Autowired
+    private val taskRepository: TaskRepositoryWrapper
 ) : AbstractSpringIntegrationTest() {
 
     lateinit var behandlingService: BehandlingService
@@ -126,10 +130,10 @@ class VedtakServiceTest(
             infotrygdService,
             vedtaksperiodeService,
             personidentService,
-            featureToggleService
+            featureToggleService,
+            taskRepository
         )
 
-        val personIdent = randomFnr()
         val personAktørId = randomAktørId()
 
         behandling = lagBehandling()
@@ -137,7 +141,7 @@ class VedtakServiceTest(
         vilkår = Vilkår.LOVLIG_OPPHOLD
         resultat = Resultat.OPPFYLT
 
-        vilkårsvurdering = lagVilkårsvurdering(personIdent, personAktørId, behandling, resultat)
+        vilkårsvurdering = lagVilkårsvurdering(personAktørId, behandling, resultat)
 
         personResultat = PersonResultat(
             vilkårsvurdering = vilkårsvurdering,
@@ -180,7 +184,7 @@ class VedtakServiceTest(
 
         val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
 
-        val vilkårsvurdering = lagVilkårsvurdering(fnr, fnrAktørNr, behandling, Resultat.OPPFYLT)
+        val vilkårsvurdering = lagVilkårsvurdering(fnrAktørNr, behandling, Resultat.OPPFYLT)
 
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseSpesifikasjonTest.kt
@@ -35,7 +35,7 @@ internal class VedtakBegrunnelseSpesifikasjonTest {
         utbetalingsperiodeDetaljer = listOf(lagUtbetalingsperiodeDetalj()),
     )
     private val vilkårsvurdering =
-        lagVilkårsvurdering(søker.aktør.aktivFødselsnummer(), søker.aktør, lagBehandling(), Resultat.OPPFYLT)
+        lagVilkårsvurdering(søker.aktør, lagBehandling(), Resultat.OPPFYLT)
     val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søker, barn)
 
     private val aktørerMedUtbetaling = listOf(søker.aktør, barn.aktør)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -260,7 +260,6 @@ class VedtaksperiodeServiceUtilsTest {
             lagTestPersonopplysningGrunnlag(behandlingId = behandling.id, personer = arrayOf(søker, barn))
         val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD))
         val vilkårsvurdering = lagVilkårsvurdering(
-            søkerFnr = søker.aktør.aktivFødselsnummer(),
             søkerAktør = søker.aktør,
             behandling = behandling,
             resultat = Resultat.OPPFYLT
@@ -302,7 +301,6 @@ class VedtaksperiodeServiceUtilsTest {
             lagTestPersonopplysningGrunnlag(behandlingId = behandling.id, personer = arrayOf(søker, barn2))
         val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD))
         val vilkårsvurdering = lagVilkårsvurdering(
-            søkerFnr = søker.aktør.aktivFødselsnummer(),
             søkerAktør = søker.aktør,
             behandling = behandling,
             resultat = Resultat.OPPFYLT

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
@@ -58,7 +58,7 @@ class AutobrevSmåbarnstilleggOpphørTest(
 
         val personScenario1: RestScenario = lagScenario(barnFødselsdato)
         val fagsak1: RestMinimalFagsak = lagFagsak(personScenario = personScenario1)
-        val fagsak1behanding1: Behandling = fullførBehandling(
+        fullførBehandling(
             fagsak = fagsak1,
             personScenario = personScenario1,
             barnFødselsdato = barnFødselsdato,
@@ -68,7 +68,7 @@ class AutobrevSmåbarnstilleggOpphørTest(
             personScenario = personScenario1,
             barnFødselsdato = barnFødselsdato,
         )
-        val fagsak1behandling3åpen: Behandling = startEnRevurderingNyeOpplysningerMenIkkeFullfør(
+        startEnRevurderingNyeOpplysningerMenIkkeFullfør(
             fagsak = fagsak1,
             personScenario = personScenario1,
             barnFødselsdato = barnFødselsdato,
@@ -76,7 +76,7 @@ class AutobrevSmåbarnstilleggOpphørTest(
 
         val personScenario2: RestScenario = lagScenario(barnFødselsdato)
         val fagsak2: RestMinimalFagsak = lagFagsak(personScenario = personScenario2)
-        val fagsak2behandling1: Behandling = fullførBehandling(
+        fullførBehandling(
             fagsak = fagsak2,
             personScenario = personScenario2,
             barnFødselsdato = barnFødselsdato,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/PeriodeMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/PeriodeMapperTest.kt
@@ -54,7 +54,7 @@ class PeriodeMapperTest {
             it.behandlingStegTilstand.add(BehandlingStegTilstand(0, it, FØRSTE_STEG))
         }
 
-        vilkårsvurdering = lagVilkårsvurdering("", randomAktørId(), behandling, Resultat.IKKE_VURDERT)
+        vilkårsvurdering = lagVilkårsvurdering(randomAktørId(), behandling, Resultat.IKKE_VURDERT)
     }
 
     @Test
@@ -247,7 +247,6 @@ class PeriodeMapperTest {
 
     @Test
     fun `Perioderesultat skal gi riktig svar for samlet vilkårsresultat for barn`() {
-        val barnFnr = randomFnr()
         val periodeFom = LocalDate.of(2020, 4, 8)
         val periodeFom18ÅrsVilkår = LocalDate.of(2020, 5, 15)
         val periodeTom18ÅrsVilkår = LocalDate.of(2038, 5, 15)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårVurderingMatcherTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårVurderingMatcherTest.kt
@@ -25,7 +25,7 @@ class VilkårVurderingMatcherTest {
 
     @Test
     fun `Kopierte vilkår matches og returneres som par`() {
-        val vilkårsvurderingOriginal = lagVilkårsvurdering(søkerFnr, søkerAktørId, randomBehandling, Resultat.OPPFYLT)
+        val vilkårsvurderingOriginal = lagVilkårsvurdering(søkerAktørId, randomBehandling, Resultat.OPPFYLT)
         val vilkårsvurderingKopi = vilkårsvurderingOriginal.kopier()
         val vilkårPar = VilkårsvurderingService.matchVilkårResultater(vilkårsvurderingOriginal, vilkårsvurderingKopi)
         assertTrue(vilkårPar.all { likeVilkårResultater(it.first, it.second) })
@@ -33,8 +33,8 @@ class VilkårVurderingMatcherTest {
 
     @Test
     fun `Vilkår som kun finnes i den ene vilkårsvurderingen returneres alene`() {
-        val vilkårsvurderingOriginal = lagVilkårsvurdering(søkerFnr, søkerAktørId, randomBehandling, Resultat.OPPFYLT)
-        val vilkårsvurderingUlik = lagVilkårsvurdering(søkerFnr, søkerAktørId, randomBehandling, Resultat.IKKE_OPPFYLT)
+        val vilkårsvurderingOriginal = lagVilkårsvurdering(søkerAktørId, randomBehandling, Resultat.OPPFYLT)
+        val vilkårsvurderingUlik = lagVilkårsvurdering(søkerAktørId, randomBehandling, Resultat.IKKE_OPPFYLT)
         val vilkårPar = VilkårsvurderingService.matchVilkårResultater(vilkårsvurderingOriginal, vilkårsvurderingUlik)
         assertTrue(vilkårPar.any { it.first == null && it.second != null })
         assertTrue(vilkårPar.any { it.first != null && it.second == null })

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingStegUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingStegUtilsTest.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktørId
-import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.toPeriode
 import no.nav.familie.ba.sak.ekstern.restDomene.RestVilkårResultat
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -37,7 +36,6 @@ class VilkårsvurderingStegUtilsTest {
 
     @BeforeEach
     fun init() {
-        val personIdent = randomFnr()
         val personAktørId = randomAktørId()
 
         behandling = lagBehandling()
@@ -45,7 +43,7 @@ class VilkårsvurderingStegUtilsTest {
         vilkår = Vilkår.BOR_MED_SØKER
         resultat = Resultat.OPPFYLT
 
-        vilkårsvurdering = lagVilkårsvurdering(personIdent, personAktørId, behandling, resultat)
+        vilkårsvurdering = lagVilkårsvurdering(personAktørId, behandling, resultat)
 
         personResultat = PersonResultat(
             vilkårsvurdering = vilkårsvurdering,
@@ -378,15 +376,13 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke bort ikke oppfylte perioder når det gjelder samme behandling`() {
-        val søker = randomFnr()
         val søkerAktørId = randomAktørId()
         val behandling = lagBehandling()
 
         val initiellVilkårvurdering =
-            lagVilkårsvurderingMedForskelligeResultat(søker, søkerAktørId, behandling, listOf(Resultat.OPPFYLT))
+            lagVilkårsvurderingMedForskelligeResultat(søkerAktørId, behandling, listOf(Resultat.OPPFYLT))
         val aktivVilkårsvurdering =
             lagVilkårsvurderingMedForskelligeResultat(
-                søker,
                 søkerAktørId,
                 behandling,
                 listOf(Resultat.IKKE_OPPFYLT, Resultat.OPPFYLT)
@@ -409,16 +405,14 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke oppfylt om oppfylt finnes ved kopiering fra forrige behandling`() {
-        val søker = randomFnr()
         val søkerAktørId = randomAktørId()
         val behandling = lagBehandling()
         val behandling2 = lagBehandling()
 
         val initiellVilkårvurdering =
-            lagVilkårsvurderingMedForskelligeResultat(søker, søkerAktørId, behandling, listOf(Resultat.OPPFYLT))
+            lagVilkårsvurderingMedForskelligeResultat(søkerAktørId, behandling, listOf(Resultat.OPPFYLT))
         val aktivVilkårsvurdering =
             lagVilkårsvurderingMedForskelligeResultat(
-                søker,
                 søkerAktørId,
                 behandling2,
                 listOf(Resultat.IKKE_OPPFYLT, Resultat.OPPFYLT)
@@ -438,15 +432,13 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke ikke oppfylt om oppfylt ikke finnes`() {
-        val søker = randomFnr()
         val søkerAktørId = randomAktørId()
         val behandling = lagBehandling()
 
         val initiellVilkårsvurdering =
-            lagVilkårsvurderingMedForskelligeResultat(søker, søkerAktørId, behandling, listOf(Resultat.OPPFYLT))
+            lagVilkårsvurderingMedForskelligeResultat(søkerAktørId, behandling, listOf(Resultat.OPPFYLT))
         val activeVilkårvurdering =
             lagVilkårsvurderingMedForskelligeResultat(
-                søker,
                 søkerAktørId,
                 behandling,
                 listOf(Resultat.IKKE_OPPFYLT, Resultat.IKKE_OPPFYLT)
@@ -465,7 +457,6 @@ class VilkårsvurderingStegUtilsTest {
     }
 
     fun lagVilkårsvurderingMedForskelligeResultat(
-        søkerFnr: String,
         søkerAktør: Aktør,
         behandling: Behandling,
         resultater: List<Resultat>

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktørId
-import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.ekstern.restDomene.RestVilkårResultat
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -19,7 +18,7 @@ import java.time.LocalDateTime
 class VilkårsvurderingUtilsTest {
 
     private val uvesentligVilkårsvurdering =
-        lagVilkårsvurdering(randomFnr(), randomAktørId(), lagBehandling(), Resultat.IKKE_VURDERT)
+        lagVilkårsvurdering(randomAktørId(), lagBehandling(), Resultat.IKKE_VURDERT)
 
     @Test
     fun `feil kastes når det finnes løpende oppfylt ved forsøk på å legge til avslag uten periode`() {

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
@@ -89,7 +89,7 @@ class FerdigstillBehandlingTaskTest : AbstractSpringIntegrationTest() {
         )
 
         return if (resultat == Resultat.IKKE_OPPFYLT) {
-            val vilkårsvurdering = lagVilkårsvurdering(fnr, aktørId, behandling, resultat)
+            val vilkårsvurdering = lagVilkårsvurdering(aktørId, behandling, resultat)
 
             vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
             val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)

--- a/src/test/kotlin/no/nav/familie/ba/sak/task/TaskRepositoryTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/task/TaskRepositoryTestConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.task
 
+import io.mockk.clearMocks
 import io.mockk.mockk
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import org.springframework.boot.test.context.TestConfiguration
@@ -14,7 +15,7 @@ class TaskRepositoryTestConfig {
     @Profile("mock-task-repository")
     fun mockTaskRepository(): TaskRepositoryWrapper {
 
-        return mockk(relaxed = true)
+        return clearMockTaskRepository(mockk(relaxed = true))
     }
 
     @Bean
@@ -22,6 +23,20 @@ class TaskRepositoryTestConfig {
     @Primary
     fun mockTaskService(): OpprettTaskService {
 
-        return mockk(relaxed = true)
+        return clearMockTaskService(mockk(relaxed = true))
+    }
+
+    companion object {
+        fun clearMockTaskRepository(mockTaskRepository: TaskRepositoryWrapper): TaskRepositoryWrapper {
+            clearMocks(mockTaskRepository)
+
+            return mockTaskRepository
+        }
+
+        fun clearMockTaskService(mockTaskService: OpprettTaskService): OpprettTaskService {
+            clearMocks(mockTaskService)
+
+            return mockTaskService
+        }
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7660

Endrer opprett oppgave til taskbasert slik at dersom _noe_ feiler ved opprettelse av behandling eller etter i samme transaksjon så opretter vi ikke behandle sak oppgave på behandlinger som rollbackes.

Forbedringen gjelder i alle tilfeller hvor man oppretter behandling, men ble oppdaget gjennom journalføring.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Jeg har ikke skrevet noen tester på dette da jeg ser for meg at det egentlig bare blir testing av rammeverk (spring og task) som er unødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
