### PR TITLE
Ved migrering så sammenlign med aktive delytelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -203,7 +203,7 @@ class MigreringService(
         if (!(sak.valg == "OR" && sak.undervalg == "OS")) {
             kastOgTellMigreringsFeil(MigreringsfeilType.IKKE_STØTTET_SAKSTYPE)
         }
-        when (sak.stønad!!.delytelse.size) {
+        when (sak.stønad!!.delytelse.filter { it.tom == null }.size) {
             1 -> return
             else -> {
                 kastOgTellMigreringsFeil(MigreringsfeilType.UGYLDIG_ANTALL_DELYTELSER_I_INFOTRYGD)
@@ -295,7 +295,7 @@ class MigreringService(
         infotrygdStønad: Stønad,
     ) {
         val beløpFraInfotrygd =
-            infotrygdStønad.delytelse.singleOrNull()?.beløp?.toInt()
+            infotrygdStønad.delytelse.filter { it.tom == null }.singleOrNull()?.beløp?.toInt()
                 ?: kastOgTellMigreringsFeil(MigreringsfeilType.FLERE_DELYTELSER_I_INFOTRYGD)
 
         if (førsteUtbetalingsbeløp != beløpFraInfotrygd) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Støtte for flere delytelser i infotrygd ved migrering. Tar i bruk den som har tom == null. Ved flere delytelser med tom==null, så beholder man eksisterende feilsjekk

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
