### PR TITLE
Sjekk om ident er aktiv før man migrering, og kast feil hvis den er historisk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -80,6 +80,8 @@ class MigreringService(
     @Transactional
     fun migrer(personIdent: String): MigreringResponseDto {
         try {
+            validerAtIdentErAktiv(personIdent)
+
             val løpendeSak = hentLøpendeSakFraInfotrygd(personIdent)
 
             kastFeilDersomSakIkkeErOrdinær(løpendeSak)
@@ -136,6 +138,16 @@ class MigreringService(
         } catch (e: Exception) {
             if (e is KanIkkeMigrereException) throw e
             kastOgTellMigreringsFeil(MigreringsfeilType.UKJENT, e.message, e)
+        }
+    }
+
+    private fun validerAtIdentErAktiv(personIdent: String) {
+        val søkerIdenter = personidentService.hentIdenter(personIdent = personIdent, historikk = true)
+            .filter { it.gruppe == "FOLKEREGISTERIDENT" }
+
+        if (søkerIdenter.filter { it.ident == personIdent }.single().historisk) {
+            secureLog.warn("Personident $personIdent er historisk, og kan ikke brukes til å migrere$søkerIdenter")
+            kastOgTellMigreringsFeil(MigreringsfeilType.IDENT_IKKE_LENGER_AKTIV)
         }
     }
 
@@ -344,6 +356,7 @@ enum class MigreringsfeilType(val beskrivelse: String) {
     UGYLDIG_ANTALL_DELYTELSER_I_INFOTRYGD("Kan kun migrere ordinære saker med nøyaktig ett utbetalingsbeløp"),
     UKJENT("Ukjent migreringsfeil"),
     ÅPEN_SAK_INFOTRYGD("Bruker har åpen behandling i Infotrygd"),
+    IDENT_IKKE_LENGER_AKTIV("Ident ikke lenger aktiv"),
 }
 
 open class KanIkkeMigrereException(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Lagt inn validering av om identen som skal migreres er en aktiv ident. Dette fordi man oppdager barnetrygdsaker i infotrygd på historiske identer og man ikke har lyst til å migrere disse akkurat nå.

Senere ønsker vi kanskje å legge inn sjekk på om det kun er 1 løpende sak totalt på alle identene til en person, men dette blir bestemt etter en analyse fase.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
altiett
### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
