### PR TITLE
Justerer versjon fra 0 til 1 på task som opprettes i migrerering V174

### DIFF
--- a/src/main/resources/db/migration/V179__korreksjon_av_versjon_satsendring_06_01_2022.sql
+++ b/src/main/resources/db/migration/V179__korreksjon_av_versjon_satsendring_06_01_2022.sql
@@ -1,0 +1,9 @@
+DO
+$$
+    BEGIN
+        UPDATE task
+        set versjon=1
+        WHERE versjon = 0
+          AND metadata = 'callId=startsatsendringforallebehandlinger-06.01.2022';
+    END
+$$;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikk trøbbel med å starte app'en lokalt fra tom DB. Virket som spring tolket task'en opprettet i migrering V174 som en ny task når taskrammeverket skulle oppdatere tilstand til PLUKKET. Endre versjon fra 0 til 1 virker å ha løst det.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Alltid bekymret for DB-endringer ....

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ Burde ikke påvirke funksjonalitet, bare om app'en starter eller ikke

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x ] Nei
