### PR TITLE
Endepunkt for validering av behandlingsresultatsteg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
@@ -10,12 +10,15 @@ import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils.validerhenleggels
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingResultat
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.kjerne.steg.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -65,6 +68,29 @@ class BehandlingStegController(
         stegService.håndterVilkårsvurdering(behandling)
 
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandling.id)))
+    }
+
+    @GetMapping(path = ["behandlingsresultat/valider"])
+    fun validerBehandlingsresultat(@PathVariable behandlingId: Long): ResponseEntity<Ressurs<Boolean>> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "validere behandlingsresultat"
+        )
+
+        val behandling = behandlingService.hent(behandlingId)
+        val behandlingSteg: BehandlingsresultatSteg =
+            stegService.hentBehandlingSteg(StegType.BEHANDLINGSRESULTAT) as BehandlingsresultatSteg
+
+        behandlingSteg.preValiderSteg(
+            behandling = behandling,
+            stegService = stegService
+        )
+
+        return ResponseEntity.ok(
+            Ressurs.success(
+                true
+            )
+        )
     }
 
     @PostMapping(path = ["behandlingsresultat"])


### PR DESCRIPTION


### 💰 Hva forsøker du å løse i denne PR'en
Legger til endepunkt for å manuelt kjøre valideringsmetoden for behandlingsresultatsteget. Dette skal brukes frontend for å vise meldingen på noen behandlinger som slipper den strenge valideringen backend.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7769

Mulig fag ønsker den aktuelle feilmeldingen i oppgaven og ikke den vi allerede har. Endret isåfall.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Kun testet manuelt lokalt

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
