### PR TITLE
BUG: Håndterer behandlingsresultat-aktør bedre ved uregistrerte barn.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -86,7 +86,6 @@ class BehandlingsresultatService(
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
             behandlingsresultatPersoner = behandlingsresultatPersoner,
-            personidentService = personidentService,
             uregistrerteBarn = søknadGrunnlag?.hentUregistrerteBarn()?.map {
                 MinimertUregistrertBarn(
                     personIdent = it.ident,
@@ -127,7 +126,7 @@ class BehandlingsresultatService(
         forrigeBehandling: Behandling?
     ): List<Aktør> {
         val barnFraSøknad = søknadDTO?.barnaMedOpplysninger
-            ?.filter { it.inkludertISøknaden }
+            ?.filter { it.inkludertISøknaden && it.erFolkeregistrert }
             ?.map { personidentService.hentOgLagreAktør(it.ident) }
             ?: emptyList()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonUtils.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.overlapperHeltEllerDelvisMed
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ba.sak.kjerne.personident.dummyAktør
 import no.nav.fpsak.tidsserie.LocalDateSegment
 import no.nav.fpsak.tidsserie.LocalDateTimeline
 import java.time.YearMonth
@@ -26,7 +26,6 @@ object YtelsePersonUtils {
         behandlingsresultatPersoner: List<BehandlingsresultatPerson>,
         uregistrerteBarn: List<MinimertUregistrertBarn> = emptyList(),
         inneværendeMåned: YearMonth = YearMonth.now(),
-        personidentService: PersonidentService,
     ): List<YtelsePerson> {
         return behandlingsresultatPersoner.map { behandlingsresultatPerson ->
             val forrigeAndelerTidslinje = behandlingsresultatPerson.forrigeAndeler.tilTidslinje()
@@ -81,7 +80,7 @@ object YtelsePersonUtils {
             )
         } + uregistrerteBarn.map {
             YtelsePerson(
-                aktør = personidentService.hentOgLagreAktør(it.personIdent),
+                aktør = dummyAktør,
                 resultater = setOf(YtelsePersonResultat.AVSLÅTT),
                 ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
                 ytelseSlutt = TIDENES_MORGEN.toYearMonth(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/Aktør.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/Aktør.kt
@@ -68,3 +68,5 @@ data class Aktør(
         private val VALID = java.util.regex.Pattern.compile(VALID_REGEXP)
     }
 }
+
+val dummyAktør = Aktør("0000000000000")

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultaterTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultaterTest.kt
@@ -43,7 +43,6 @@ class BehandlingsresultaterTest {
                     behandlingsresultatPersoner = behandlingsresultatPersonTestConfig.personer,
                     uregistrerteBarn = behandlingsresultatPersonTestConfig.uregistrerteBarn,
                     inneværendeMåned = YearMonth.parse(behandlingsresultatPersonTestConfig.inneværendeMåned),
-                    personidentService,
                 )
 
             val behandlingsresultat =

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonResultatTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/YtelsePersonResultatTest.kt
@@ -7,7 +7,9 @@ import no.nav.familie.ba.sak.common.inneværendeMåned
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ba.sak.kjerne.personident.dummyAktør
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class YtelsePersonResultatTest {
@@ -24,7 +26,6 @@ class YtelsePersonResultatTest {
     @Test
     fun `Skal utelede INNVILGET første gang krav for et barn fremstilles med løpende periode`() {
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -64,7 +65,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -109,7 +109,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -159,7 +158,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -212,7 +210,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -254,7 +251,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -291,7 +287,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -314,9 +309,8 @@ class YtelsePersonResultatTest {
      * AVSLÅTT
      */
     @Test
-    fun `Skal utelede AVSLÅTT første gang krav for barn fremstilles`() {
+    fun `Skal utlede AVSLÅTT første gang krav for barn fremstilles`() {
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -336,6 +330,33 @@ class YtelsePersonResultatTest {
     }
 
     @Test
+    fun `Skal utelede AVSLÅTT første gang krav for uregistrert barn fremstilles`() {
+        val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
+            behandlingsresultatPersoner = emptyList(),
+            uregistrerteBarn = listOf(
+                MinimertUregistrertBarn(
+                    personIdent = "",
+                    navn = "",
+                    fødselsdato = null
+                ),
+                MinimertUregistrertBarn(
+                    personIdent = "",
+                    navn = "",
+                    fødselsdato = null
+                )
+            )
+        )
+
+        assertEquals(
+            2,
+            ytelsePersonerMedResultat.filter { it.aktør == dummyAktør }.size
+        )
+        assertTrue(
+            ytelsePersonerMedResultat.all { it.resultater == setOf(YtelsePersonResultat.AVSLÅTT) }
+        )
+    }
+
+    @Test
     fun `Skal utlede AVSLÅTT og OPPHØRT på søknad for nytt barn i revurdering`() {
         val forrigeAndelBarn1 = lagBehandlingsresultatAndelTilkjentYtelse(
             inneværendeMåned().minusYears(4).toString(),
@@ -344,7 +365,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -388,7 +408,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -427,7 +446,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -464,7 +482,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -503,7 +520,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -547,7 +563,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -579,7 +594,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -622,7 +636,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -656,7 +669,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -695,7 +707,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -733,7 +744,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,
@@ -778,7 +788,6 @@ class YtelsePersonResultatTest {
         )
 
         val ytelsePersonerMedResultat = YtelsePersonUtils.utledYtelsePersonerMedResultat(
-            personidentService = personidentService,
             behandlingsresultatPersoner = listOf(
                 BehandlingsresultatPerson(
                     aktør = barn1.aktør,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Dersom det registreres barn uten fnr vil PDL svare med "ugyldig ident" og behandlingen vil stoppe. Det er helt ok om denne blir håndtert med dummyAktør for behandlingsresultat.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
