### PR TITLE
Bug: Kun splitte vilkår-perioder som er strengt i mellom

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
@@ -115,8 +115,12 @@ fun Periode.kanErstatte(other: Periode): Boolean {
     return this.fom.isSameOrBefore(other.fom) && this.tom.isSameOrAfter(other.tom)
 }
 
+fun LocalDate.erMellomIkkeLik(other: Periode): Boolean {
+    return this.isAfter(other.fom) && this.isBefore(other.tom)
+}
+
 fun Periode.kanSplitte(other: Periode): Boolean {
-    return this.fom.isBetween(other) && this.tom.isBetween(other) &&
+    return this.fom.erMellomIkkeLik(other) && this.tom.erMellomIkkeLik(other) &&
         (this.tom != TIDENES_ENDE || other.tom != TIDENES_ENDE)
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7900

Koden som sjekket om en ny vilkårperiode splittet en eksisterende periode brukte funksjonen isBetween() som så på om dato var lik eller større/mindre. Dette blir feil, da eksisterende periode kun blir splittet hvis den er strengt i mellom.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
