### PR TITLE
Bruk nye metoder for kall mot EF

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ef-sak/EfSakRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ef-sak/EfSakRestClient.kt
@@ -1,17 +1,15 @@
 package no.nav.familie.ba.sak.integrasjoner.`ef-sak`
 
-import no.nav.familie.ba.sak.common.convertDataClassToJson
+import no.nav.familie.ba.sak.common.kallEksternTjeneste
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.http.util.UriUtil
 import no.nav.familie.kontrakter.felles.PersonIdent
-import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
-import no.nav.familie.kontrakter.felles.getDataOrThrow
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
-import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
 @Component
@@ -21,20 +19,14 @@ class EfSakRestClient(
 ) : AbstractRestClient(restTemplate, "ef-sak") {
 
     fun hentPerioderMedFullOvergangsstønad(personIdent: String): PerioderOvergangsstønadResponse {
-        val uri =
-            UriComponentsBuilder.fromUri(efSakBaseUrl)
-                .path("/ekstern/perioder/full-overgangsstonad")
-                .build()
-                .toUri()
 
-        try {
-            val response = postForEntity<Ressurs<PerioderOvergangsstønadResponse>>(uri, PersonIdent(personIdent))
-            secureLogger.info("Response fra ef-sak ved henting av perioder med full overgangsstønad på person $personIdent: ${response.toSecureString()}, ${response.data?.convertDataClassToJson()}")
+        val uri = UriUtil.uri(efSakBaseUrl, "/ekstern/perioder/full-overgangsstonad")
 
-            return response.getDataOrThrow()
-        } catch (e: Exception) {
-            throw RuntimeException("Feil ved henting av full overgangsstønadsperioder fra ef-sak", e)
-        }
+        return kallEksternTjeneste(
+            tjeneste = "tilgangskontroll",
+            uri = uri,
+            formål = "Hente perioder med full overgangsstønad"
+        ) { postForEntity(uri, PersonIdent(personIdent)) }
     }
 
     companion object {


### PR DESCRIPTION
Synes feilmeldingen [her](https://sentry.gc.nav.no/organizations/nav/issues/44437/?environment=prod&project=112&query=is%3Aignored) var litt kryptisk, så oppdaterer metode for kall mot ef