### PR TITLE
Bug: Kast feil hvis tom er før fom på utvidet-vilkåret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.Utils.avrundetHeltallAvProsent
 import no.nav.familie.ba.sak.common.erDagenFør
@@ -42,9 +43,12 @@ data class UtvidetBarnetrygdGenerator(
             .filter { it.resultat == Resultat.OPPFYLT }
             .map {
                 if (it.periodeFom == null) throw Feil("Fom må være satt på søkers periode ved utvida barnetrygd")
+                val fraOgMedDato = it.periodeFom!!.førsteDagINesteMåned()
+                val tilOgMedDato = finnTilOgMedDatoForUtvidetSegment(tilOgMed = it.periodeTom, vilkårResultater = utvidetVilkår)
+                if (tilOgMedDato.toYearMonth() == fraOgMedDato.toYearMonth().minusMonths(1)) throw FunksjonellFeil("Du kan ikke legge inn fom. og tom. innenfor samme kalendermåned.")
                 LocalDateSegment(
-                    it.periodeFom!!.førsteDagINesteMåned(),
-                    finnTilOgMedDatoForUtvidetSegment(tilOgMed = it.periodeTom, vilkårResultater = utvidetVilkår),
+                    fraOgMedDato,
+                    tilOgMedDato,
                     listOf(PeriodeData(aktør = søkerAktør, rolle = PersonType.SØKER))
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -42,15 +42,7 @@ data class UtvidetBarnetrygdGenerator(
         val datoSegmenter = utvidetVilkår
             .filter { it.resultat == Resultat.OPPFYLT }
             .map {
-                if (it.periodeFom == null) throw Feil("Fom må være satt på søkers periode ved utvida barnetrygd")
-                val fraOgMedDato = it.periodeFom!!.førsteDagINesteMåned()
-                val tilOgMedDato = finnTilOgMedDatoForUtvidetSegment(tilOgMed = it.periodeTom, vilkårResultater = utvidetVilkår)
-                if (tilOgMedDato.toYearMonth() == fraOgMedDato.toYearMonth().minusMonths(1)) throw FunksjonellFeil("Du kan ikke legge inn fom. og tom. innenfor samme kalendermåned.")
-                LocalDateSegment(
-                    fraOgMedDato,
-                    tilOgMedDato,
-                    listOf(PeriodeData(aktør = søkerAktør, rolle = PersonType.SØKER))
-                )
+                it.tilDatoSegment(utvidetVilkår, søkerAktør)
             }
 
         val utvidaTidslinje = LocalDateTimeline(datoSegmenter)
@@ -110,7 +102,7 @@ data class UtvidetBarnetrygdGenerator(
         )
     }
 
-    private data class PeriodeData(val aktør: Aktør, val rolle: PersonType, val prosent: BigDecimal = BigDecimal.ZERO)
+    data class PeriodeData(val aktør: Aktør, val rolle: PersonType, val prosent: BigDecimal = BigDecimal.ZERO)
 
     private fun skalUtvidetAndelerSlåsSammen(
         førsteAndel: AndelTilkjentYtelse,
@@ -137,23 +129,40 @@ data class UtvidetBarnetrygdGenerator(
             }
         )
     }
+}
 
-    private fun finnTilOgMedDatoForUtvidetSegment(
-        tilOgMed: LocalDate?,
-        vilkårResultater: List<VilkårResultat>
-    ): LocalDate {
-        // LocalDateTimeline krasjer i isTimelineOutsideInterval funksjonen dersom vi sender med TIDENES_ENDE,
-        // så bruker tidenes ende minus én dag.
-        if (tilOgMed == null) return TIDENES_ENDE.minusDays(1)
-        val utvidetSkalVidereføresEnMndEkstra = vilkårResultater.any { vilkårResultat ->
-            erBack2BackIMånedsskifte(
-                tilOgMed = tilOgMed,
-                fraOgMed = vilkårResultat.periodeFom
-            )
-        }
+fun VilkårResultat.tilDatoSegment(
+    utvidetVilkår: List<VilkårResultat>,
+    søkerAktør: Aktør
+): LocalDateSegment<List<UtvidetBarnetrygdGenerator.PeriodeData>> {
+    if (this.periodeFom == null) throw Feil("Fom må være satt på søkers periode ved utvida barnetrygd")
+    val fraOgMedDato = this.periodeFom!!.førsteDagINesteMåned()
+    val tilOgMedDato = finnTilOgMedDatoForUtvidetSegment(tilOgMed = this.periodeTom, vilkårResultater = utvidetVilkår)
+    if (tilOgMedDato.toYearMonth() == fraOgMedDato.toYearMonth()
+        .minusMonths(1)
+    ) throw FunksjonellFeil("Du kan ikke legge inn fom. og tom. innenfor samme kalendermåned.")
+    return LocalDateSegment(
+        fraOgMedDato,
+        tilOgMedDato,
+        listOf(UtvidetBarnetrygdGenerator.PeriodeData(aktør = søkerAktør, rolle = PersonType.SØKER))
+    )
+}
 
-        return if (utvidetSkalVidereføresEnMndEkstra) {
-            tilOgMed.plusMonths(1).sisteDagIMåned()
-        } else tilOgMed.sisteDagIMåned()
+private fun finnTilOgMedDatoForUtvidetSegment(
+    tilOgMed: LocalDate?,
+    vilkårResultater: List<VilkårResultat>
+): LocalDate {
+    // LocalDateTimeline krasjer i isTimelineOutsideInterval funksjonen dersom vi sender med TIDENES_ENDE,
+    // så bruker tidenes ende minus én dag.
+    if (tilOgMed == null) return TIDENES_ENDE.minusDays(1)
+    val utvidetSkalVidereføresEnMndEkstra = vilkårResultater.any { vilkårResultat ->
+        erBack2BackIMånedsskifte(
+            tilOgMed = tilOgMed,
+            fraOgMed = vilkårResultat.periodeFom
+        )
     }
+
+    return if (utvidetSkalVidereføresEnMndEkstra) {
+        tilOgMed.plusMonths(1).sisteDagIMåned()
+    } else tilOgMed.sisteDagIMåned()
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -921,7 +921,7 @@ fun lagVilkårResultat(
 )
 
 fun lagVilkårResultat(
-    personResultat: PersonResultat,
+    personResultat: PersonResultat? = null,
     vilkårType: Vilkår = Vilkår.BOSATT_I_RIKET,
     resultat: Resultat = Resultat.OPPFYLT,
     periodeFom: LocalDate = LocalDate.of(2009, 12, 24),

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.YearMonth
@@ -641,6 +642,18 @@ internal class UtvidetBarnetrygdTest {
         assertThrows<FunksjonellFeil> {
             utvidetVilkårResultat.tilDatoSegment(
                 utvidetVilkår = listOf(utvidetVilkårResultat),
+                søkerAktør = randomAktørId()
+            )
+        }
+    }
+
+    @Test
+    fun `Skal ikke kaste feil hvis fom og tom er i samme måned, men tom er siste dag i mnd og nytt utvidet-vilkår starter første dag i neste mnd`() {
+        val utvidetVilkårResultat = lagVilkårResultat(vilkårType = Vilkår.UTVIDET_BARNETRYGD, periodeFom = LocalDate.of(2022, 2, 1), periodeTom = LocalDate.of(2022, 2, 28))
+
+        assertDoesNotThrow {
+            utvidetVilkårResultat.tilDatoSegment(
+                utvidetVilkår = listOf(utvidetVilkårResultat, lagVilkårResultat(vilkårType = Vilkår.UTVIDET_BARNETRYGD, periodeFom = LocalDate.of(2022, 3, 1), periodeTom = null)),
                 søkerAktør = randomAktørId()
             )
         }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -1,7 +1,10 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.nesteMåned
+import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.tilAktør
@@ -20,7 +23,9 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
+import java.time.YearMonth
 
 internal class UtvidetBarnetrygdTest {
 
@@ -627,6 +632,18 @@ internal class UtvidetBarnetrygdTest {
 
         assertEquals(søkerOrdinær.ident, andelUtvidet2.aktør.aktivFødselsnummer())
         assertEquals(utvidetAndrePeriodeFom.plusMonths(1).toYearMonth(), andelUtvidet2.stønadFom)
+    }
+
+    @Test
+    fun `Skal kaste feil hvis fom og tom er satt i samme måned`() {
+        val utvidetVilkårResultat = lagVilkårResultat(vilkår = Vilkår.UTVIDET_BARNETRYGD, fom = YearMonth.of(2022, 2), tom = YearMonth.of(2022, 2))
+
+        assertThrows<FunksjonellFeil> {
+            utvidetVilkårResultat.tilDatoSegment(
+                utvidetVilkår = listOf(utvidetVilkårResultat),
+                søkerAktør = randomAktørId()
+            )
+        }
     }
 
     private data class OppfyltPeriode(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7961

Etter samtaler med Eivind og Anna ble det bestemt at vi i første omgang kun skal gi saksbehandler eksplisitt beskjed om hva som er galt, så de kan rette det opp. Er en veldig corner-case som så og si aldri vil skje, og hvis det vil skje er det gjerne i kombo med migrering. Da kan det fikses opp ved å endre migreringsdato lenger tilbake i tid.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
