### PR TITLE
Returner bedre feilmeldinger til veiledere som prøver å hente brev som ikke er genererte

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangUtils.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ba.sak.sikkerhet
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
+
+fun validerBrevGenerert(vedtak: Vedtak, rolletilgang: Int) {
+    if (vedtak.stønadBrevPdF == null) {
+        val feilmelding = "Brev er ikke generert."
+        throw if (rolletilgang < BehandlerRolle.SAKSBEHANDLER.nivå) {
+            FunksjonellFeil("$feilmelding Veiledere har ikke tilgang til å generere brev.")
+        } else Feil(feilmelding)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -202,11 +202,12 @@ fun tilfeldigSøker(
         målform = Målform.NB
     ).apply { sivilstander = mutableListOf(GrSivilstand(type = SIVILSTAND.UGIFT, person = this)) }
 
-fun lagVedtak(behandling: Behandling = lagBehandling()) =
+fun lagVedtak(behandling: Behandling = lagBehandling(), stønadBrevPdF: ByteArray? = null) =
     Vedtak(
         id = nesteVedtakId(),
         behandling = behandling,
-        vedtaksdato = LocalDateTime.now()
+        vedtaksdato = LocalDateTime.now(),
+        stønadBrevPdF = stønadBrevPdF,
     )
 
 fun lagAndelTilkjentYtelse(

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTestDev
+import no.nav.familie.ba.sak.config.RolleConfig
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -20,6 +21,8 @@ class DokumentControllerTest(
     private val dokumentService: DokumentService,
     @Autowired
     private val behandlingService: BehandlingService,
+    @Autowired
+    private val rolleConfig: RolleConfig,
 ) : AbstractSpringIntegrationTestDev() {
 
     private val mockDokumentService: DokumentService = mockk()
@@ -28,14 +31,15 @@ class DokumentControllerTest(
     private val tilgangService: TilgangService = mockk(relaxed = true)
     val mockDokumentController =
         DokumentController(
-            mockDokumentService,
-            vedtakService,
-            behandlingService,
-            fagsakService,
-            tilgangService,
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true)
+            dokumentService = mockDokumentService,
+            vedtakService = vedtakService,
+            behandlingService = behandlingService,
+            fagsakService = fagsakService,
+            tilgangService = tilgangService,
+            persongrunnlagService = mockk(relaxed = true),
+            arbeidsfordelingService = mockk(relaxed = true),
+            utvidetBehandlingService = mockk(relaxed = true),
+            rolleConfig = rolleConfig,
         )
 
     @Test
@@ -51,7 +55,7 @@ class DokumentControllerTest(
     @Test
     @Tag("integration")
     fun `Test hent pdf vedtak`() {
-        every { vedtakService.hent(any()) } returns lagVedtak()
+        every { vedtakService.hent(any()) } returns lagVedtak(stønadBrevPdF = "pdf".toByteArray())
         every { mockDokumentService.hentBrevForVedtak(any()) } returns Ressurs.success("pdf".toByteArray())
 
         val response = mockDokumentController.hentVedtaksbrev(1)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Fix for [denne feilen](https://sentry.gc.nav.no/organizations/nav/issues/44971/?environment=prod&project=112&query=is%3Aunresolved).

Gir funksjonell feil dersom veileder prøver å hente brev før det er generert.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Kun feilmelding


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
