### PR TITLE
Fjern begrunnelse opphor ikke mottat opplysninger

### DIFF
--- a/src/main/resources/db/migration/V192__delete_begrunnelse_opphor_ikke_mottat_opplysninger.sql
+++ b/src/main/resources/db/migration/V192__delete_begrunnelse_opphor_ikke_mottat_opplysninger.sql
@@ -1,0 +1,2 @@
+delete from vedtaksbegrunnelse
+where vedtak_begrunnelse_spesifikasjon = 'OPPHØR_IKKE_MOTTATT_OPPLYSNINGER';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'e
Begrunnelses enum som blitt fjernet gjøre at vedtaksperioder for disse behandlingen som refererer til begrunnelsene ikke kan vises. Fjern derfor begrunnelser som blitt fjernet, i dette tilfelde: opphør ikke mottat opplysninger