### PR TITLE
Persisterte aktørid søker og barn tidelig i migrering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -102,8 +102,8 @@ class MigreringService(
 
             val barnasIdenter = finnBarnMedLøpendeStønad(løpendeSak)
 
-            val personAktør = personidentService.hentAktør(personIdent)
-            val barnasAktør = personidentService.hentAktørIder(barnasIdenter)
+            val personAktør = personidentService.hentOgLagreAktør(personIdent, true)
+            val barnasAktør = personidentService.hentOgLagreAktørIder(barnasIdenter, true)
 
             validerStøttetGradering(personAktør) // Midlertidig skrudd av støtte for kode 6 inntil det kan behandles
 
@@ -287,7 +287,10 @@ class MigreringService(
         return barnasIdenter
     }
 
-    private fun forsøkSettPerioderFomTilpassetInfotrygdKjøreplan(vilkårsvurdering: Vilkårsvurdering, migreringsdato: LocalDate) {
+    private fun forsøkSettPerioderFomTilpassetInfotrygdKjøreplan(
+        vilkårsvurdering: Vilkårsvurdering,
+        migreringsdato: LocalDate
+    ) {
         vilkårsvurdering.personResultater.forEach { personResultat ->
             personResultat.vilkårResultater.forEach {
                 it.periodeFom = it.periodeFom ?: migreringsdato


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
DB-spørringer trigger i Hibernate flushing av objekter til  db. Det kan da oppstå problemer om endringer som bare er gyldige i korrekt rekkefølge kommer i samme batch, da kan rekkefølgen bli feil og årsake db-constraint feil. Dette er caset i migreringskoden som fikses med endringen i denne PRen

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Endringen er av en type som ikke trenger testes.


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
