### PR TITLE
Splitt opprettelse av konsistensavstemming datatasker i subtransaksjoner.

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -100,5 +100,8 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: preprod
+
+    - name: JAVA_OPTS
+      value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError"
   kafka:
     pool: nav-dev

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -101,5 +101,8 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod
+
+    - name: JAVA_OPTS
+      value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError"
   kafka:
     pool: nav-prod

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
@@ -160,12 +160,10 @@ class AvstemmingService(
         taskRepository.save(konsistensavstemmingAvsluttTask)
     }
 
-    fun hentSisteIverksatteBehandlingerFraLøpendeFagsaker() =
-        behandlingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(
-            Pageable.ofSize(
-                KONSISTENSAVSTEMMING_DATA_CHUNK_STORLEK
-            ),
-        )
+    fun hentSisteIverksatteBehandlingerFraLøpendeFagsaker(
+        pageable: Pageable = Pageable.ofSize(KONSISTENSAVSTEMMING_DATA_CHUNK_STORLEK)
+    ) =
+        behandlingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(pageable)
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun opprettKonsistensavstemmingDataTask(
@@ -174,7 +172,7 @@ class AvstemmingService(
         batchId: Long,
         transaksjonsId: UUID,
         chunkNr: Int
-    ): Page<BigInteger> {
+    ) {
         val perioderTilAvstemming =
             hentDataForKonsistensavstemming(
                 avstemmingsdato,
@@ -196,8 +194,6 @@ class AvstemmingService(
         )
         taskRepository.save(konsistensavstemmingDataTask)
         dataChunkRepository.save(DataChunk(batch = batch, transaksjonsId = transaksjonsId, chunkNr = chunkNr))
-
-        return behandlingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(relevanteBehandlinger.nextPageable())
     }
 
     private fun hentDataForKonsistensavstemming(

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/DataChunkRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/DataChunkRepository.kt
@@ -8,4 +8,5 @@ import java.util.UUID
 interface DataChunkRepository : JpaRepository<DataChunk, Long> {
     fun findByTransaksjonsIdAndChunkNr(transaksjonsId: UUID, chunkNr: Int): DataChunk
     fun findByTransaksjonsId(transaksjonsId: UUID): List<DataChunk>
+    fun findByErSendt(erSendt: Boolean): List<DataChunk>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
@@ -23,10 +23,25 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
             objectMapper.readValue(task.payload, KonsistensavstemmingStartTaskDTO::class.java)
         val transaksjonsId = UUID.randomUUID()
 
-        avstemmingService.konsistensavstemOppdragStart(
-            batchId = konsistensavstemmingTask.batchId,
-            avstemmingsdato = konsistensavstemmingTask.avstemmingdato,
-            transaksjonsId = transaksjonsId
+        avstemmingService.nullstillDataChunk()
+        avstemmingService.sendKonsistensavstemmingStart(konsistensavstemmingTask.avstemmingdato, transaksjonsId)
+
+        var relevanteBehandlinger = avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
+
+        for (chunkNr in 1..relevanteBehandlinger.totalPages) {
+            relevanteBehandlinger = avstemmingService.opprettKonsistensavstemmingDataTask(
+                konsistensavstemmingTask.avstemmingdato,
+                relevanteBehandlinger,
+                konsistensavstemmingTask.batchId,
+                transaksjonsId,
+                chunkNr
+            )
+        }
+
+        avstemmingService.opprettKonsistensavstemmingAvsluttTask(
+            konsistensavstemmingTask.batchId,
+            transaksjonsId,
+            konsistensavstemmingTask.avstemmingdato
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
@@ -29,13 +29,15 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
         var relevanteBehandlinger = avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
 
         for (chunkNr in 1..relevanteBehandlinger.totalPages) {
-            relevanteBehandlinger = avstemmingService.opprettKonsistensavstemmingDataTask(
+            avstemmingService.opprettKonsistensavstemmingDataTask(
                 konsistensavstemmingTask.avstemmingdato,
                 relevanteBehandlinger,
                 konsistensavstemmingTask.batchId,
                 transaksjonsId,
                 chunkNr
             )
+            relevanteBehandlinger =
+                avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(relevanteBehandlinger.nextPageable())
         }
 
         avstemmingService.opprettKonsistensavstemmingAvsluttTask(

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
@@ -157,13 +157,15 @@ class AvstemmingServiceTest {
             avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
 
         for (chunkNr in 1..relevanteBehandlinger.totalPages) {
-            relevanteBehandlinger = avstemmingService.opprettKonsistensavstemmingDataTask(
+            avstemmingService.opprettKonsistensavstemmingDataTask(
                 avstemmingsdato,
                 relevanteBehandlinger,
                 batchId,
                 transaksjonsId,
                 chunkNr
             )
+            relevanteBehandlinger =
+                avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(relevanteBehandlinger.nextPageable())
         }
 
         avstemmingService.opprettKonsistensavstemmingAvsluttTask(batchId, transaksjonsId, avstemmingsdato)

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
@@ -83,7 +83,7 @@ class AvstemmingServiceTest {
             )
         } returns Ressurs.Companion.success("")
 
-        avstemmingService.konsistensavstemOppdragStart(
+        konsistensavstemOppdragStart(
             batchId = batchId,
             avstemmingsdato = avstemmingsdato,
             transaksjonsId = transaksjonsId
@@ -146,5 +146,26 @@ class AvstemmingServiceTest {
         assertEquals(1, dataChunkSlot.captured.chunkNr)
         assertEquals(transaksjonsId, dataChunkSlot.captured.transaksjonsId)
         assertEquals(true, dataChunkSlot.captured.erSendt)
+    }
+
+    private fun konsistensavstemOppdragStart(batchId: Long, avstemmingsdato: LocalDateTime, transaksjonsId: UUID) {
+        avstemmingService.nullstillDataChunk()
+
+        avstemmingService.sendKonsistensavstemmingStart(avstemmingsdato, transaksjonsId)
+
+        var relevanteBehandlinger =
+            avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
+
+        for (chunkNr in 1..relevanteBehandlinger.totalPages) {
+            relevanteBehandlinger = avstemmingService.opprettKonsistensavstemmingDataTask(
+                avstemmingsdato,
+                relevanteBehandlinger,
+                batchId,
+                transaksjonsId,
+                chunkNr
+            )
+        }
+
+        avstemmingService.opprettKonsistensavstemmingAvsluttTask(batchId, transaksjonsId, avstemmingsdato)
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Opprettelse av konsistensavstemming datatasker viste seg å bruke mer minne en tilgjengelig, derfor har opprettelsen blitt splittet i subtransaksjoner.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
