### PR TITLE
Bug/skatt perioder migrering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenService.kt
@@ -95,9 +95,9 @@ class SkatteetatenService(
                 val ident = period.getIdent()
                 val nyList = listOf(
                     SkatteetatenPeriode(
-                        fraMaaned = period.getFom().format(DateTimeFormatter.ofPattern("YYYY-MM")),
+                        fraMaaned = period.getFom().format(DateTimeFormatter.ofPattern("yyyy-MM")),
                         delingsprosent = period.getProsent().tilDelingsprosent(),
-                        tomMaaned = period.getTom().format(DateTimeFormatter.ofPattern("YYYY-MM"))
+                        tomMaaned = period.getTom().format(DateTimeFormatter.ofPattern("yyyy-MM"))
                     )
                 )
                 val samletPerioder = if (perioderMap.containsKey(ident))

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.ekstern.skatteetaten
 
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.secureLogger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.eksterne.kontrakter.skatteetaten.SkatteetatenPeriode
@@ -86,9 +85,6 @@ class SkatteetatenService(
         år: String
     ): List<SkatteetatenPerioder> {
         val stonadPerioder = hentUtvidetStonadPerioderForPersoner(personer, år)
-        stonadPerioder.forEach {
-            secureLogger.info("hentPerioderMedUtvidetBarnetrygdFraBaSak() andelTilkjentYtelsePeriode id=${it.getId()} fom=${it.getFom()} tom=${it.getTom()} prosent=${it.getProsent()} ident=${it.getIdent()} endretDato=${it.getEndretDato()}") // TODO: remove
-        }
 
         val skatteetatenPerioderMap =
             stonadPerioder.fold(mutableMapOf<String, SkatteetatenPerioder>()) { perioderMap, period ->
@@ -106,7 +102,6 @@ class SkatteetatenService(
                 perioderMap[ident] = SkatteetatenPerioder(ident, period.getEndretDato(), samletPerioder)
                 perioderMap
             }
-        secureLogger.info("hentPerioderMedUtvidetBarnetrygdFraBaSak() hentet {} $skatteetatenPerioderMap") // TOOD: remove
 
         return skatteetatenPerioderMap.toList().map {
             // Slå sammen perioder basert på delingsprosent

--- a/src/test/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenServiceIntegrationTest.kt
@@ -311,22 +311,6 @@ class SkatteetatenServiceIntegrationTest : AbstractSpringIntegrationTest() {
         assertThat(resultat.brukere.first().perioder.first().delingsprosent).isEqualTo(SkatteetatenPeriode.Delingsprosent._0)
         assertThat(resultat.brukere.first().ident).isEqualTo(fnr)
         assertThat(resultat.brukere.first().sisteVedtakPaaIdent).isEqualTo(LocalDate.of(2022, 2, 6).atStartOfDay())
-        // assertThat(samletResultat.brukere.find { it.ident == fnr }!!.perioder).hasSize(2)
-        // assertThat(
-        //     samletResultat.brukere.find { it.ident == fnr }!!.perioder.find {
-        //         it.fraMaaned == "2020-08"
-        //     }!!.delingsprosent
-        // ).isEqualTo(
-        //     SkatteetatenPeriode.Delingsprosent._50
-        // )
-        // assertThat(
-        //     samletResultat.brukere.find { it.ident == fnr }!!.perioder.find {
-        //         it.tomMaaned == "2020-07"
-        //     }!!.delingsprosent
-        // ).isEqualTo(
-        //     SkatteetatenPeriode.Delingsprosent._0
-        // )
-        // assertThat(samletResultat.brukere.find { it.ident == testDataInfotrygd[1].fnr }!!.perioder).hasSize(1)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser ett par bugs i tjenester for skatt i forbindelse med henting av perioder:
- perioder fra infotrygd ble ignorert hvis det fantes perioder fra ba-sak. Nå kombineres de
- feil i datetimeformatter på år slik at i enkelte tilfeller fikk man feil år i parsing av dato

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
