### PR TITLE
Bug validering - endre migreringsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -108,7 +108,7 @@ class MigreringService(
 
             validerAtBarnErIRelasjonMedPersonident(personAktør, barnasAktør)
 
-            val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(personIdent)
+            fagsakService.hentEllerOpprettFagsakForPersonIdent(personIdent)
                 .also { kastFeilDersomAlleredeMigrert(it) }
 
             val behandling = runCatching {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -467,8 +467,9 @@ class BehandlingService(
         val forrigeMigreringsdato =
             behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(fagsakId = behandling.fagsak.id)
 
-        if (forrigeMigreringsdato != null && migreringsdato.toYearMonth()
-            .isSameOrAfter(forrigeMigreringsdato.toYearMonth())
+        if (behandling.erManuellMigreringForEndreMigreringsdato() &&
+            forrigeMigreringsdato != null &&
+            migreringsdato.toYearMonth().isSameOrAfter(forrigeMigreringsdato.toYearMonth())
         ) {
             throw FunksjonellFeil("Migreringsdatoen du har lagt inn er lik eller senere enn eksisterende migreringsdato. Du må velge en tidligere migreringsdato for å fortsette.")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlag.kt
@@ -46,8 +46,6 @@ class RegistrerPersongrunnlag(
                 behandling = behandling,
                 målform = forrigeMålform
             )
-            // Lagre ned migreringsdato
-            kopierOgLagreNedMigeringsdatoFraSisteVedtattBehandling(forrigeBehandlingSomErVedtatt, behandling)
         } else {
             persongrunnlagService.hentOgLagreSøkerOgBarnINyttGrunnlag(
                 aktør = aktør,
@@ -92,24 +90,11 @@ class RegistrerPersongrunnlag(
         return hentNesteStegForNormalFlyt(behandling)
     }
 
-    private fun kopierOgLagreNedMigeringsdatoFraSisteVedtattBehandling(
-        forrigeBehandlingSomErVedtatt: Behandling,
-        behandling: Behandling
-    ) {
-        if (forrigeBehandlingSomErVedtatt.erMigrering()) {
-            val migreringsdato = behandlingService.hentMigreringsdatoIBehandling(forrigeBehandlingSomErVedtatt.id)
-            if (migreringsdato != null) {
-                behandlingService.lagreNedMigreringsdato(migreringsdato, behandling)
-            }
-        }
-    }
-
     override fun stegType(): StegType {
         return StegType.REGISTRERE_PERSONGRUNNLAG
     }
 
     companion object {
-
         private val logger = LoggerFactory.getLogger(this::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -161,7 +161,10 @@ class StegService(
     ): Behandling =
         fullførSøknadsHåndtering(behandling = behandling, restRegistrerSøknad = restRegistrerSøknad)
 
-    private fun fullførSøknadsHåndtering(behandling: Behandling, restRegistrerSøknad: RestRegistrerSøknad): Behandling {
+    private fun fullførSøknadsHåndtering(
+        behandling: Behandling,
+        restRegistrerSøknad: RestRegistrerSøknad
+    ): Behandling {
         val behandlingSteg: RegistrereSøknad = hentBehandlingSteg(StegType.REGISTRERE_SØKNAD) as RegistrereSøknad
         val søknadDTO = restRegistrerSøknad.søknad
 
@@ -256,13 +259,19 @@ class StegService(
             behandlingSteg.utførStegOgAngiNeste(behandling, behandlendeEnhet)
         }
         if (behandlingEtterBeslutterSteg.erManuellMigrering()) {
-            return håndterBeslutningForVedtak(behandlingEtterBeslutterSteg, RestBeslutningPåVedtak(Beslutning.GODKJENT))
+            return håndterBeslutningForVedtak(
+                behandlingEtterBeslutterSteg,
+                RestBeslutningPåVedtak(Beslutning.GODKJENT)
+            )
         }
         return behandlingEtterBeslutterSteg
     }
 
     @Transactional
-    fun håndterBeslutningForVedtak(behandling: Behandling, restBeslutningPåVedtak: RestBeslutningPåVedtak): Behandling {
+    fun håndterBeslutningForVedtak(
+        behandling: Behandling,
+        restBeslutningPåVedtak: RestBeslutningPåVedtak
+    ): Behandling {
         val behandlingSteg: BeslutteVedtak =
             hentBehandlingSteg(StegType.BESLUTTE_VEDTAK) as BeslutteVedtak
 
@@ -272,7 +281,10 @@ class StegService(
     }
 
     @Transactional
-    fun håndterHenleggBehandling(behandling: Behandling, henleggBehandlingInfo: RestHenleggBehandlingInfo): Behandling {
+    fun håndterHenleggBehandling(
+        behandling: Behandling,
+        henleggBehandlingInfo: RestHenleggBehandlingInfo
+    ): Behandling {
         val behandlingSteg: HenleggBehandling =
             hentBehandlingSteg(StegType.HENLEGG_BEHANDLING) as HenleggBehandling
 
@@ -296,7 +308,10 @@ class StegService(
     }
 
     @Transactional
-    fun håndterStatusFraØkonomi(behandling: Behandling, statusFraOppdragMedTask: StatusFraOppdragMedTask): Behandling {
+    fun håndterStatusFraØkonomi(
+        behandling: Behandling,
+        statusFraOppdragMedTask: StatusFraOppdragMedTask
+    ): Behandling {
         val behandlingSteg: StatusFraOppdrag =
             hentBehandlingSteg(StegType.VENTE_PÅ_STATUS_FRA_ØKONOMI) as StatusFraOppdrag
 
@@ -329,7 +344,10 @@ class StegService(
     }
 
     @Transactional
-    fun håndterDistribuerVedtaksbrev(behandling: Behandling, distribuerDokumentDTO: DistribuerDokumentDTO): Behandling {
+    fun håndterDistribuerVedtaksbrev(
+        behandling: Behandling,
+        distribuerDokumentDTO: DistribuerDokumentDTO
+    ): Behandling {
         val behandlingSteg: DistribuerVedtaksbrev =
             hentBehandlingSteg(StegType.DISTRIBUER_VEDTAKSBREV) as DistribuerVedtaksbrev
 
@@ -356,7 +374,10 @@ class StegService(
     ): Behandling {
         try {
             logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} håndterer ${behandlingSteg.stegType()} på behandling ${behandling.id}")
-            tilgangService.validerTilgangTilBehandling(behandlingId = behandling.id, event = AuditLoggerEvent.UPDATE)
+            tilgangService.validerTilgangTilBehandling(
+                behandlingId = behandling.id,
+                event = AuditLoggerEvent.UPDATE
+            )
             if (behandling.erManuellMigrering() && behandlingSteg.stegType() == StegType.BESLUTTE_VEDTAK) {
                 verifiserBeslutteVedtakForManuellMigrering(behandlingSteg)
             } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -124,7 +124,7 @@ class VilkårService(
                 melding = "${vilkårResultat.vilkårType} kan ikke endres før $migreringsdato " +
                     "for fagsak=${behandling.fagsak.id}",
                 frontendFeilmelding = "F.o.m. kan ikke settes tidligere " +
-                    "enn migreringsdato ${migreringsdato.tilKortString()} " +
+                    "enn migreringsdato ${migreringsdato.tilKortString()}. " +
                     "Ved behov for vurdering før dette, må behandlingen henlegges, " +
                     "og migreringstidspunktet endres ved å opprette en ny migreringsbehandling."
             )
@@ -239,7 +239,7 @@ class VilkårService(
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id)
             ?: throw IllegalStateException("Fant ikke personopplysninggrunnlag for behandling ${behandling.id}")
         if (personopplysningGrunnlag.søkerOgBarn
-            .single { it.aktør == personidentService.hentAktør(restNyttVilkår.personIdent) }.type != PersonType.SØKER
+                .single { it.aktør == personidentService.hentAktør(restNyttVilkår.personIdent) }.type != PersonType.SØKER
         ) {
             throw FunksjonellFeil(
                 melding = "${Vilkår.UTVIDET_BARNETRYGD.beskrivelse} kan ikke legges til for BARN",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -239,7 +239,7 @@ class VilkårService(
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id)
             ?: throw IllegalStateException("Fant ikke personopplysninggrunnlag for behandling ${behandling.id}")
         if (personopplysningGrunnlag.søkerOgBarn
-                .single { it.aktør == personidentService.hentAktør(restNyttVilkår.personIdent) }.type != PersonType.SØKER
+            .single { it.aktør == personidentService.hentAktør(restNyttVilkår.personIdent) }.type != PersonType.SØKER
         ) {
             throw FunksjonellFeil(
                 melding = "${Vilkår.UTVIDET_BARNETRYGD.beskrivelse} kan ikke legges til for BARN",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -115,14 +115,14 @@ class VilkårService(
         vilkårResultat: VilkårResultat,
     ) {
         val behandling = vilkårsvurdering.behandling
-        val migreringsdato = behandlingService.hentMigreringsdatoIBehandling(behandling.id)
+        val migreringsdato = behandlingService.hentMigreringsdatoPåFagsak(fagsakId = behandling.fagsak.id)
         if (migreringsdato != null &&
             vilkårResultat.vilkårType !in listOf(Vilkår.UNDER_18_ÅR, Vilkår.GIFT_PARTNERSKAP) &&
             vilkårResultat.periodeFom?.isBefore(migreringsdato) == true
         ) {
             throw FunksjonellFeil(
                 melding = "${vilkårResultat.vilkårType} kan ikke endres før $migreringsdato " +
-                    "for behandling=${behandling.id}",
+                    "for fagsak=${behandling.fagsak.id}",
                 frontendFeilmelding = "F.o.m. kan ikke settes tidligere " +
                     "enn migreringsdato ${migreringsdato.tilKortString()} " +
                     "Ved behov for vurdering før dette, må behandlingen henlegges, " +
@@ -244,32 +244,6 @@ class VilkårService(
             throw FunksjonellFeil(
                 melding = "${Vilkår.UTVIDET_BARNETRYGD.beskrivelse} kan ikke legges til for BARN",
                 frontendFeilmelding = "${Vilkår.UTVIDET_BARNETRYGD.beskrivelse} kan ikke legges til for BARN",
-            )
-        }
-
-        validerUtvidetVilkårIkkeFørMigreringsdato(behandling, vilkårsvurdering)
-    }
-
-    private fun validerUtvidetVilkårIkkeFørMigreringsdato(
-        behandling: Behandling,
-        vilkårsvurdering: Vilkårsvurdering
-    ) {
-        val migreringsdato = behandlingService.hentMigreringsdatoIBehandling(behandling.id)
-        if (migreringsdato != null &&
-            vilkårsvurdering.personResultater.any {
-                it.vilkårResultater.any { vilkårResultat ->
-                    vilkårResultat.vilkårType == Vilkår.UTVIDET_BARNETRYGD &&
-                        vilkårResultat.periodeFom?.isBefore(migreringsdato) == true
-                }
-            }
-        ) {
-            throw FunksjonellFeil(
-                melding = "${Vilkår.UTVIDET_BARNETRYGD} kan ikke endres før $migreringsdato " +
-                    "for behandling=${behandling.id}",
-                frontendFeilmelding = "F.o.m. kan ikke settes tidligere " +
-                    "enn migreringsdato ${migreringsdato.tilKortString()} " +
-                    "Ved behov for vurdering før dette, må behandlingen henlegges, " +
-                    "og migreringstidspunktet endres ved å opprette en ny migreringsbehandling."
             )
         }
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -69,7 +69,7 @@ class VilkårServiceTest(
     @Autowired
     private val personidentService: PersonidentService,
 
-) : AbstractSpringIntegrationTest() {
+    ) : AbstractSpringIntegrationTest() {
 
     @BeforeAll
     fun init() {
@@ -1473,7 +1473,7 @@ class VilkårServiceTest(
         }
         assertEquals(
             "${Vilkår.BOR_MED_SØKER} kan ikke endres før $nyMigreringsdato " +
-                "for behandling=${behandling.id}",
+                "for fagsak=${behandling.fagsak.id}",
             exception.message
         )
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -69,7 +69,7 @@ class VilkårServiceTest(
     @Autowired
     private val personidentService: PersonidentService,
 
-    ) : AbstractSpringIntegrationTest() {
+) : AbstractSpringIntegrationTest() {
 
     @BeforeAll
     fun init() {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Lagrer kun migreringsdato på behandlinger som påvirker migreringsdatoen. Bruker tidligste migreringsdato på fagsakId til alt annet enn å populere utvidet behandling.



### 🔎️ Er det noe spesielt du ønsker å fremheve?
Validerer nå også ny migreringsdato for endre migreringsdato-behandlinger, men usikker på om det trengs. Det gir aldri mening å legge til ny migreringsdato som er lik eller senere uavhengig av hvilken behandling man er på.

Lurer også på hvorfor vi alltid må kopiere over migreringsdatoen. Det spiller jo ingen rolle for funksjonalitet - annet enn en melding til SB på vilkårsvurderingen. Men samtidig gir det heller ikke noe verdi for SB om X år å ha med denne informasjonen videre.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke skrevet tester da jeg stort sett fjerner kode.

### 🤷‍♀ ️Hvor er det lurt å starte?
alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
