### PR TITLE
Fikser et par bugs i sammenslåinger av perioder for skatt på migrerte saker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/AndelTilkjentYtelsePeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/AndelTilkjentYtelsePeriode.kt
@@ -15,4 +15,6 @@ interface AndelTilkjentYtelsePeriode {
     fun getProsent(): String
 
     fun getEndretDato(): LocalDateTime
+
+    fun getBehandlingId(): Long
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenService.kt
@@ -132,7 +132,7 @@ class SkatteetatenService(
             .fold(mutableListOf()) { sammenslåttePerioder, nesteUtbetaling ->
                 val nesteUtbetalingFraaMåned = YearMonth.parse(nesteUtbetaling.fraMaaned)
                 if (sammenslåttePerioder.lastOrNull()?.tomMaaned == nesteUtbetalingFraaMåned.minusMonths(1)
-                    .toString()
+                    .toString() || (sammenslåttePerioder.isNotEmpty() && sammenslåttePerioder.lastOrNull()?.tomMaaned == null)
                 ) {
                     sammenslåttePerioder.apply { add(removeLast().copy(tomMaaned = nesteUtbetaling.tomMaaned)) }
                 } else sammenslåttePerioder.apply { add(nesteUtbetaling) }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -36,7 +36,8 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
                      aty.stonad_tom                     tom,
                      aty.prosent                    prosent,
                      aty.tilkjent_ytelse_id         aty_tyid,
-                     aty.id
+                     aty.id, 
+                     aty.fk_behandling_id           behandling_id   
               FROM andel_tilkjent_ytelse aty
               JOIN personident personident on personident.fk_aktoer_id = aty.fk_aktoer_id
               WHERE aty.type = 'UTVIDET_BARNETRYGD'
@@ -58,7 +59,8 @@ SELECT qualified.id             AS id,
        qualified.prosent        AS prosent,
        qualified.endret_dato AS endretDato,
        qualified.fom            AS fom,
-       qualified.tom            AS tom
+       qualified.tom            AS tom,
+       qualified.behandling_id  AS behandlingId
 FROM (SELECT ident, MAX(endret_dato) dato
       FROM qualified
       GROUP BY ident

--- a/src/test/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenServiceIntegrationTest.kt
@@ -65,7 +65,12 @@ class SkatteetatenServiceIntegrationTest : AbstractSpringIntegrationTest() {
     @BeforeAll
     fun init() {
         skatteetatenService =
-            SkatteetatenService(infotrygdBarnetrygdClientMock, fagsakRepository, andelTilkjentYtelseRepository)
+            SkatteetatenService(
+                infotrygdBarnetrygdClientMock,
+                fagsakRepository,
+                andelTilkjentYtelseRepository,
+                behandlingRepository
+            )
     }
 
     data class PerioderTestData(

--- a/src/test/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.defaultFagsak
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.eksterne.kontrakter.skatteetaten.SkatteetatenPerson
@@ -17,6 +18,7 @@ internal class SkatteetatenServiceTest {
     private val infotrygdBarnetrygdClient: InfotrygdBarnetrygdClient = mockk()
     private val fagsakRepository: FagsakRepository = mockk()
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository = mockk()
+    private val behandlingRepository: BehandlingRepository = mockk()
 
     @Test
     fun `finnPersonerMedUtvidetBarnetrygd() skal returnere person fra fagsystem med nyeste vedtaksdato`() {
@@ -35,7 +37,12 @@ internal class SkatteetatenServiceTest {
         )
 
         val skatteetatenService =
-            SkatteetatenService(infotrygdBarnetrygdClient, fagsakRepository, andelTilkjentYtelseRepository)
+            SkatteetatenService(
+                infotrygdBarnetrygdClient,
+                fagsakRepository,
+                andelTilkjentYtelseRepository,
+                behandlingRepository
+            )
 
         assertThat(skatteetatenService.finnPersonerMedUtvidetBarnetrygd(nyesteVedtaksdato.year.toString()).brukere).hasSize(
             2
@@ -69,7 +76,12 @@ internal class SkatteetatenServiceTest {
         )
 
         val skatteetatenService =
-            SkatteetatenService(infotrygdBarnetrygdClient, fagsakRepository, andelTilkjentYtelseRepository)
+            SkatteetatenService(
+                infotrygdBarnetrygdClient,
+                fagsakRepository,
+                andelTilkjentYtelseRepository,
+                behandlingRepository
+            )
         val personerMedUtvidetBarnetrygd =
             skatteetatenService.finnPersonerMedUtvidetBarnetrygd(vedtaksdato.year.toString())
 
@@ -106,7 +118,12 @@ internal class SkatteetatenServiceTest {
             )
 
         val skatteetatenService =
-            SkatteetatenService(infotrygdBarnetrygdClient, fagsakRepository, andelTilkjentYtelseRepository)
+            SkatteetatenService(
+                infotrygdBarnetrygdClient,
+                fagsakRepository,
+                andelTilkjentYtelseRepository,
+                behandlingRepository
+            )
         val personerMedUtvidetBarnetrygd =
             skatteetatenService.finnPersonerMedUtvidetBarnetrygd(vedtaksdato.year.toString())
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
- Slår sammen perioder selv om infotrygd sin siste periode tom er null
- Oppretter perioder fra kun AndelTilkjentYtelse til den siste iverksatte behandling, som kan være forskjellig ved endret migreringsdato.

Gammel response til høyre. Ny til venstrre
<img width="971" alt="Screenshot 2022-03-04 at 08 58 30" src="https://user-images.githubusercontent.com/1121978/156722962-edd1c505-f692-41d6-9c8f-094e7549ac17.png">

Denne har 2 andel tilkjent ytelse og viser nå kun den siste iverkastte
<img width="300" alt="Screenshot 2022-03-04 at 08 59 52" src="https://user-images.githubusercontent.com/1121978/156723168-91447204-f722-43c5-9003-7f36ee60c4f8.png">


### 🔎️ Er det noe spesielt du ønsker å fremheve?
ser ikke ut til at sjekk mot behandling på virker ytelsen i noe særlig grad



### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
