### PR TITLE
Filtrering av siste opprettet periode.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -33,6 +33,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                         WHERE f.status = 'LØPENDE'
                           AND ty.utbetalingsoppdrag IS NOT NULL
                           AND f.arkivert = false
+                          AND b.id = (select max(id) from behandling b2 where b2.fk_fagsak_id = f.id)
                         GROUP BY fagsakid)
                         select sum(aty.kalkulert_utbetalingsbelop) from andel_tilkjent_ytelse aty
                         where aty.stonad_fom <= :måned
@@ -55,6 +56,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                             WHERE f.status = 'LØPENDE'
                               AND ty.utbetalingsoppdrag IS NOT NULL
                               AND f.arkivert = false
+                              AND b.id = (select max(id) from behandling b2 where b2.fk_fagsak_id = f.id)
                             GROUP BY fagsakid)
                         
                         SELECT behandlingid FROM sisteiverksattebehandlingfraløpendefagsak""",
@@ -71,6 +73,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                             WHERE f.status = 'LØPENDE'
                               AND ty.utbetalingsoppdrag IS NOT NULL
                               AND f.arkivert = false
+                              AND b.id = (select max(id) from behandling b2 where b2.fk_fagsak_id = f.id)
                             GROUP BY fagsakid)
                         
                         SELECT behandlingid FROM sisteiverksattebehandlingfraløpendefagsak""",
@@ -82,6 +85,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                             WHERE f.status = 'LØPENDE'
                               AND ty.utbetalingsoppdrag IS NOT NULL
                               AND f.arkivert = false
+                              AND b.id = (select max(id) from behandling b2 where b2.fk_fagsak_id = f.id)
                             GROUP BY fagsakid)
                         
                         SELECT count(behandlingid) FROM sisteiverksattebehandlingfraløpendefagsak""",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -45,6 +45,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
                                 where ty.utbetalingsoppdrag IS NOT NULL
                                   and f.status = 'LØPENDE'
                                   and f.arkivert = false
+                                  and b.id = (select max(id) from behandling b2 where b2.fk_fagsak_id = f.id)
                                 group by b.id)
                             select sisteIverksatte.fagsakId
                             from sisteIverksatte


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ved filtrering for å finne sist opprettet behandling har id til behandling blitt brukt men antagelsen at høyest nummer er sist opprettet, men den antakelsen har vist seg å ikke være riktig. Derfor er disse spøringene endret til å filtrere på opprettet dato med antakelse om at sist opprrettet har tidligst opprettet dato.  

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det er bare nativ SQL som er endret, noe vi ikke tester i enhetstester. 


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
