### PR TITLE
Bug: behandlingstema ved endre migreringsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -102,6 +102,7 @@ class BehandlingService(
             val underkategori = bestemUnderkategori(
                 nyUnderkategori = nyBehandling.underkategori,
                 nyBehandlingType = nyBehandling.behandlingType,
+                nyBehandlingÅrsak = nyBehandling.behandlingÅrsak,
                 løpendeUnderkategori = hentLøpendeUnderkategori(fagsakId = fagsak.id)
             )
 
@@ -176,6 +177,7 @@ class BehandlingService(
             else bestemUnderkategori(
                 nyUnderkategori = nyUnderkategori,
                 nyBehandlingType = behandling.type,
+                nyBehandlingÅrsak = behandling.opprettetÅrsak,
                 løpendeUnderkategori = hentLøpendeUnderkategori(fagsakId = behandling.fagsak.id)
             )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
@@ -62,13 +62,14 @@ object Behandlingutils {
     fun bestemUnderkategori(
         nyUnderkategori: BehandlingUnderkategori?,
         nyBehandlingType: BehandlingType,
+        nyBehandlingÅrsak: BehandlingÅrsak,
         løpendeUnderkategori: BehandlingUnderkategori?
     ): BehandlingUnderkategori {
         if (nyUnderkategori == null && løpendeUnderkategori == null) return BehandlingUnderkategori.ORDINÆR
         return when {
             nyUnderkategori == BehandlingUnderkategori.UTVIDET -> nyUnderkategori
 
-            nyBehandlingType == BehandlingType.REVURDERING ->
+            nyBehandlingType == BehandlingType.REVURDERING || nyBehandlingÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO ->
                 løpendeUnderkategori
                     ?: (nyUnderkategori ?: BehandlingUnderkategori.ORDINÆR)
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingUtilsTest.kt
@@ -30,6 +30,7 @@ class BehandlingUtilsTest {
             Behandlingutils.bestemUnderkategori(
                 nyUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 nyBehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                nyBehandlingÅrsak = BehandlingÅrsak.SØKNAD,
                 løpendeUnderkategori = null
             )
         )
@@ -42,6 +43,7 @@ class BehandlingUtilsTest {
             Behandlingutils.bestemUnderkategori(
                 nyUnderkategori = BehandlingUnderkategori.UTVIDET,
                 nyBehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                nyBehandlingÅrsak = BehandlingÅrsak.SØKNAD,
                 løpendeUnderkategori = null
             )
         )
@@ -54,6 +56,7 @@ class BehandlingUtilsTest {
             Behandlingutils.bestemUnderkategori(
                 nyUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 nyBehandlingType = BehandlingType.REVURDERING,
+                nyBehandlingÅrsak = BehandlingÅrsak.SØKNAD,
                 løpendeUnderkategori = BehandlingUnderkategori.UTVIDET
             )
         )
@@ -66,6 +69,7 @@ class BehandlingUtilsTest {
             Behandlingutils.bestemUnderkategori(
                 nyUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 nyBehandlingType = BehandlingType.REVURDERING,
+                nyBehandlingÅrsak = BehandlingÅrsak.SØKNAD,
                 løpendeUnderkategori = BehandlingUnderkategori.ORDINÆR
             )
         )
@@ -78,6 +82,29 @@ class BehandlingUtilsTest {
             Behandlingutils.bestemUnderkategori(
                 nyUnderkategori = BehandlingUnderkategori.UTVIDET,
                 nyBehandlingType = BehandlingType.REVURDERING,
+                nyBehandlingÅrsak = BehandlingÅrsak.SØKNAD,
+                løpendeUnderkategori = BehandlingUnderkategori.ORDINÆR
+            )
+        )
+    }
+
+    @Test
+    fun `Skal velge den løpende underkategorien ved 'endre migreringsdato'`() {
+        assertEquals(
+            BehandlingUnderkategori.UTVIDET,
+            Behandlingutils.bestemUnderkategori(
+                nyUnderkategori = null,
+                nyBehandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+                nyBehandlingÅrsak = BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
+                løpendeUnderkategori = BehandlingUnderkategori.UTVIDET
+            )
+        )
+        assertEquals(
+            BehandlingUnderkategori.ORDINÆR,
+            Behandlingutils.bestemUnderkategori(
+                nyUnderkategori = null,
+                nyBehandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+                nyBehandlingÅrsak = BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
                 løpendeUnderkategori = BehandlingUnderkategori.ORDINÆR
             )
         )


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8247

Vi får nyUnderkategori = null fra frontend når årsak er "endre migreringsdato". Siden behandlingTypen til en "endre migreringsdato" behandling er MIGRERING_FRA_INFOTRYGD (og ikke revurdering), endte disse behandlingene opp med å treffe else clausen. Dvs. at siden den nye underkategorien = null, ble underkategorien satt til ordinær.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Er bare antagelse, har ikke fått testet om det er faktisk det som skjer, men ganske sikker.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
