### PR TITLE
Teller for samme oppdrag allerede sendt konflikt

### DIFF
--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiServiceTest.kt
@@ -18,7 +18,7 @@ internal class ØkonomiServiceTest {
     val søker = randomFnr()
     val behandling = lagBehandling()
     val vedtakDato = LocalDate.now()
-    val økonomiService = ØkonomiService(mockk(), mockk(), mockk(), mockk(), mockk())
+    val økonomiService = ØkonomiService(mockk(), mockk(), mockk(), mockk())
 
     @Test
     fun `valider opphør med lovlige perioder`() {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
En toggle regulerte om oppdrag allerede sendt skulle kaste feil. Men så sluttet Toggelen å virke derfor er toggelen erstattet med et teller. Telleren skal det settes et larm på.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Skriver ikke tester på tellere.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
