### PR TITLE
BUG: Ferdigstill alle oppgaver av en gitt type

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/SentryConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/SentryConfiguration.kt
@@ -42,8 +42,14 @@ class SentryConfiguration(
                     prosess,
                     event.transaction,
                     mostSpecificThrowable?.message,
-                    metodeSomFeiler,
                 )
+
+                if (metodeSomFeiler != UKJENT_METODE_SOM_FEILER) {
+                    event.fingerprints = (event.fingerprints ?: emptyList()) + listOf(
+                        metodeSomFeiler
+                    )
+                }
+
                 event
             }
         }
@@ -61,10 +67,11 @@ class SentryConfiguration(
             val className = firstElement.className.split(".").lastOrNull()
             return "$className::${firstElement.methodName}(${firstElement.lineNumber})"
         }
-        return e?.cause?.let { finnMetodeSomFeiler(it) } ?: "(Ukjent metode som feiler)"
+        return e?.cause?.let { finnMetodeSomFeiler(it) } ?: UKJENT_METODE_SOM_FEILER
     }
 
     companion object {
         val logger = LoggerFactory.getLogger(SentryConfiguration::class.java)
+        const val UKJENT_METODE_SOM_FEILER = "(Ukjent metode som feiler)"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.integrasjoner.oppgave
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.DbOppgave
@@ -127,8 +128,8 @@ class OppgaveService(
         return integrasjonClient.finnOppgaveMedId(oppgaveId)
     }
 
-    fun hentOppgaveSomIkkeErFerdigstilt(oppgavetype: Oppgavetype, behandling: Behandling): DbOppgave? {
-        return oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(oppgavetype, behandling)
+    fun hentOppgaverSomIkkeErFerdigstilt(oppgavetype: Oppgavetype, behandling: Behandling): List<DbOppgave> {
+        return oppgaveRepository.finnOppgaverSomSkalFerdigstilles(oppgavetype, behandling)
     }
 
     fun hentOppgaverSomIkkeErFerdigstilt(behandling: Behandling): List<DbOppgave> {
@@ -139,21 +140,22 @@ class OppgaveService(
         return integrasjonClient.finnOppgaveMedId(oppgaveId)
     }
 
-    fun ferdigstillOppgave(behandlingId: Long, oppgavetype: Oppgavetype) {
-        val oppgave = oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(
+    fun ferdigstillOppgaver(behandlingId: Long, oppgavetype: Oppgavetype) {
+        oppgaveRepository.finnOppgaverSomSkalFerdigstilles(
             oppgavetype,
             behandlingRepository.finnBehandling(
                 behandlingId
             )
-        )
+        ).forEach {
+            try {
+                integrasjonClient.ferdigstillOppgave(it.gsakId.toLong())
 
-        if (oppgave == null) {
-            logger.info("Finner ingen oppgaver av type $oppgavetype på behandling $behandlingId som kan ferdigstilles")
-        } else {
-            integrasjonClient.ferdigstillOppgave(oppgave.gsakId.toLong())
-
-            oppgave.erFerdigstilt = true
-            oppgaveRepository.save(oppgave)
+                it.erFerdigstilt = true
+                // Her sørger vi for at oppgaver som blir ferdigstilt riktig får samme status hos oss selv om en av de andre dbOppgavene feiler.
+                oppgaveRepository.saveAndFlush(it)
+            } catch (exception: Exception) {
+                throw Feil(message = "Klarte ikke å ferdigstille oppgave med id ${it.gsakId}.", cause = exception)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/domene/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/domene/OppgaveRepository.kt
@@ -12,6 +12,9 @@ interface OppgaveRepository : JpaRepository<DbOppgave, Long> {
     @Query(value = "SELECT o FROM Oppgave o WHERE o.erFerdigstilt = false AND o.behandling = :behandling AND o.type = :oppgavetype")
     fun findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(oppgavetype: Oppgavetype, behandling: Behandling): DbOppgave?
 
+    @Query(value = "SELECT o FROM Oppgave o WHERE o.erFerdigstilt = false AND o.behandling = :behandling AND o.type = :oppgavetype")
+    fun finnOppgaverSomSkalFerdigstilles(oppgavetype: Oppgavetype, behandling: Behandling): List<DbOppgave>
+
     @Query(value = "SELECT o FROM Oppgave o WHERE o.erFerdigstilt = false AND o.behandling = :behandling")
     fun findByBehandlingAndIkkeFerdigstilt(behandling: Behandling): List<DbOppgave>
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -17,7 +17,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
-import no.nav.familie.ba.sak.task.FerdigstillOppgave
+import no.nav.familie.ba.sak.task.FerdigstillOppgaver
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
 import no.nav.familie.ba.sak.task.JournalførVedtaksbrevTask
 import no.nav.familie.ba.sak.task.OpprettOppgaveTask
@@ -122,7 +122,7 @@ class BeslutteVedtak(
         loggService.opprettBeslutningOmVedtakLogg(behandling, beslutning.beslutning, beslutning.begrunnelse)
         if (!behandling.erManuellMigrering()) {
             val ferdigstillGodkjenneVedtakTask =
-                FerdigstillOppgave.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak)
+                FerdigstillOppgaver.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak)
             taskRepository.save(ferdigstillGodkjenneVedtakTask)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -37,7 +37,7 @@ class HenleggBehandling(
         }
 
         oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling).forEach {
-            oppgaveService.ferdigstillOppgave(behandling.id, it.type)
+            oppgaveService.ferdigstillOppgaver(behandling.id, it.type)
         }
 
         loggService.opprettHenleggBehandling(behandling, data.årsak.beskrivelse, data.begrunnelse)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -12,7 +12,7 @@ import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
-import no.nav.familie.ba.sak.task.FerdigstillOppgave
+import no.nav.familie.ba.sak.task.FerdigstillOppgaver
 import no.nav.familie.ba.sak.task.OpprettOppgaveTask
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.springframework.stereotype.Service
@@ -70,9 +70,11 @@ class SendTilBeslutter(
             Oppgavetype.BehandleUnderkjentVedtak,
             Oppgavetype.VurderLivshendelse
         ).forEach { oppgavetype ->
-            oppgaveService.hentOppgaveSomIkkeErFerdigstilt(oppgavetype, behandling)?.also {
-                val ferdigstillOppgaveTask = FerdigstillOppgave.opprettTask(behandling.id, oppgavetype)
-                taskRepository.save(ferdigstillOppgaveTask)
+            oppgaveService.hentOppgaverSomIkkeErFerdigstilt(oppgavetype, behandling).also {
+                if (it.isNotEmpty()) {
+                    val ferdigstillOppgaverTask = FerdigstillOppgaver.opprettTask(behandling.id, oppgavetype)
+                    taskRepository.save(ferdigstillOppgaverTask)
+                }
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/FerdigstillOppgaver.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/FerdigstillOppgaver.kt
@@ -11,17 +11,17 @@ import org.springframework.stereotype.Service
 
 @Service
 @TaskStepBeskrivelse(
-    taskStepType = FerdigstillOppgave.TASK_STEP_TYPE,
-    beskrivelse = "Ferdigstill oppgave i GOSYS for behandling",
+    taskStepType = FerdigstillOppgaver.TASK_STEP_TYPE,
+    beskrivelse = "Ferdigstill oppgaver i GOSYS for behandling",
     maxAntallFeil = 3
 )
-class FerdigstillOppgave(
+class FerdigstillOppgaver(
     private val oppgaveService: OppgaveService
 ) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
         val ferdigstillOppgave = objectMapper.readValue(task.payload, FerdigstillOppgaveDTO::class.java)
-        oppgaveService.ferdigstillOppgave(
+        oppgaveService.ferdigstillOppgaver(
             behandlingId = ferdigstillOppgave.behandlingId, oppgavetype = ferdigstillOppgave.oppgavetype
         )
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
@@ -75,7 +75,7 @@ class OppgaveIntegrationTest : AbstractSpringIntegrationTest() {
         Assertions.assertFalse(opprettetOppgave.erFerdigstilt)
         Assertions.assertEquals(godkjenneVedtakOppgaveId, opprettetOppgave.gsakId)
 
-        oppgaveService.ferdigstillOppgave(behandling.id, Oppgavetype.GodkjenneVedtak)
+        oppgaveService.ferdigstillOppgaver(behandling.id, Oppgavetype.GodkjenneVedtak)
 
         Assertions.assertNull(
             oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(

--- a/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -72,12 +72,12 @@ class OppgaveServiceTest {
     @Test
     fun `Opprett oppgave skal lage oppgave med enhetsnummer fra behandlingen`() {
         every { behandlingRepository.finnBehandling(BEHANDLING_ID) } returns lagTestBehandling(aktørId = AKTØR_ID_FAGSAK)
-        every { behandlingRepository.save(any<Behandling>()) } returns lagTestBehandling()
-        every { oppgaveRepository.save(any<DbOppgave>()) } returns lagTestOppgave()
+        every { behandlingRepository.save(any()) } returns lagTestBehandling()
+        every { oppgaveRepository.save(any()) } returns lagTestOppgave()
         every {
             oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(
-                any<Oppgavetype>(),
-                any<Behandling>()
+                any(),
+                any()
             )
         } returns null
         every { personidentService.hentAktør(any()) } returns Aktør(AKTØR_ID_FAGSAK)
@@ -118,16 +118,16 @@ class OppgaveServiceTest {
     fun `Ferdigstill oppgave`() {
         every { behandlingRepository.finnBehandling(BEHANDLING_ID) } returns mockk {}
         every {
-            oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(
-                any<Oppgavetype>(),
-                any<Behandling>()
+            oppgaveRepository.finnOppgaverSomSkalFerdigstilles(
+                any(),
+                any()
             )
-        } returns lagTestOppgave()
-        every { oppgaveRepository.save(any<DbOppgave>()) } returns lagTestOppgave()
+        } returns listOf(lagTestOppgave())
+        every { oppgaveRepository.saveAndFlush(any()) } returns lagTestOppgave()
         val slot = slot<Long>()
         every { integrasjonClient.ferdigstillOppgave(capture(slot)) } just runs
 
-        oppgaveService.ferdigstillOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak)
+        oppgaveService.ferdigstillOppgaver(BEHANDLING_ID, Oppgavetype.BehandleSak)
         assertThat(slot.captured).isEqualTo(OPPGAVE_ID.toLong())
     }
 

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -26,7 +26,7 @@ import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
-import no.nav.familie.ba.sak.task.FerdigstillOppgave
+import no.nav.familie.ba.sak.task.FerdigstillOppgaver
 import no.nav.familie.ba.sak.task.OpprettOppgaveTask
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
@@ -101,12 +101,12 @@ class BeslutteVedtakTest {
         val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
 
         every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
-        mockkObject(FerdigstillOppgave.Companion)
-        every { FerdigstillOppgave.opprettTask(any(), any()) } returns Task(FerdigstillOppgave.TASK_STEP_TYPE, "")
+        mockkObject(FerdigstillOppgaver.Companion)
+        every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
-        verify(exactly = 1) { FerdigstillOppgave.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak) }
+        verify(exactly = 1) { FerdigstillOppgaver.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak) }
         Assertions.assertEquals(StegType.IVERKSETT_MOT_OPPDRAG, nesteSteg)
     }
 
@@ -118,9 +118,9 @@ class BeslutteVedtakTest {
         val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.UNDERKJENT)
 
         every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
-        mockkObject(FerdigstillOppgave.Companion)
+        mockkObject(FerdigstillOppgaver.Companion)
         mockkObject(OpprettOppgaveTask.Companion)
-        every { FerdigstillOppgave.opprettTask(any(), any()) } returns Task(FerdigstillOppgave.TASK_STEP_TYPE, "")
+        every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
         every {
             OpprettOppgaveTask.opprettTask(
                 any(),
@@ -132,7 +132,7 @@ class BeslutteVedtakTest {
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
-        verify(exactly = 1) { FerdigstillOppgave.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak) }
+        verify(exactly = 1) { FerdigstillOppgaver.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak) }
         verify(exactly = 1) {
             OpprettOppgaveTask.opprettTask(
                 behandling.id,
@@ -153,9 +153,9 @@ class BeslutteVedtakTest {
         val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.UNDERKJENT)
 
         every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
-        mockkObject(FerdigstillOppgave.Companion)
+        mockkObject(FerdigstillOppgaver.Companion)
         mockkObject(OpprettOppgaveTask.Companion)
-        every { FerdigstillOppgave.opprettTask(any(), any()) } returns Task(FerdigstillOppgave.TASK_STEP_TYPE, "")
+        every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
         every { OpprettOppgaveTask.opprettTask(any(), any(), any()) } returns Task(
             OpprettOppgaveTask.TASK_STEP_TYPE,
             ""
@@ -174,9 +174,9 @@ class BeslutteVedtakTest {
         val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
 
         every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
-        mockkObject(FerdigstillOppgave.Companion)
-        every { FerdigstillOppgave.opprettTask(any(), any()) } returns Task(
-            type = FerdigstillOppgave.TASK_STEP_TYPE,
+        mockkObject(FerdigstillOppgaver.Companion)
+        every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(
+            type = FerdigstillOppgaver.TASK_STEP_TYPE,
             payload = ""
         )
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ferdigstiller alle oppgaver av en gitt type på en behandling. Bruker save and flush i tilfelle ferdigstillelse av oppgave #2 feiler. Fikser også sentry der man ikke finner metode som feiler slik at fingerprint ikke blir lik.
