### PR TITLE
Rette opp i feilmeldinger ved validering av sett på vent

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
@@ -12,8 +12,8 @@ fun validerBehandlingKanSettesPåVent(
     behandling: Behandling
 ) {
     if (gammelSettPåVent != null) {
-        throw Feil(
-            message = "Behandling ${behandling.id} er allerede satt på vent.",
+        throw FunksjonellFeil(
+            melding = "Behandling ${behandling.id} er allerede satt på vent.",
             frontendFeilmelding = "Behandlingen er allerede satt på vent."
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
@@ -13,7 +13,8 @@ fun validerBehandlingKanSettesPåVent(
 ) {
     if (gammelSettPåVent != null) {
         throw Feil(
-            "Behandling ${behandling.id} er allerede satt på vent."
+            message = "Behandling ${behandling.id} er allerede satt på vent.",
+            frontendFeilmelding = "Behandlingen er allerede satt på vent."
         )
     }
 
@@ -25,8 +26,9 @@ fun validerBehandlingKanSettesPåVent(
     }
 
     if (behandling.status == BehandlingStatus.AVSLUTTET) {
-        throw Feil(
-            "Behandling ${behandling.id} er avsluttet og kan ikke settes på vent."
+        throw FunksjonellFeil(
+            melding = "Behandling ${behandling.id} er avsluttet og kan ikke settes på vent.",
+            frontendFeilmelding = "Kan ikke sette en avsluttet behandling på vent."
         )
     }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Gjøre om til funksjonell feil så vi ikke får innslag i loggen når saksbehandler prøver å sette en behandling som er avsluttet på vent.

Sende med frontend-feilmelding når behandlingen allerede er satt på vent. (Kan denne også gjøres om til funksjonell feil eller vil vi ha innslag i loggen hvis det skjer?)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
