### PR TITLE
Logger andelTilkjentYtelse til securelogs ved feil på beløp i migrering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -145,7 +145,7 @@ data class AndelTilkjentYtelse(
     }
 
     override fun toString(): String {
-        return "AndelTilkjentYtelse(id = $id, behandling = $behandlingId, " +
+        return "AndelTilkjentYtelse(id = $id, behandling = $behandlingId, type = $type, prosent = $prosent," +
             "beløp = $kalkulertUtbetalingsbeløp, stønadFom = $stønadFom, stønadTom = $stønadTom, periodeOffset = $periodeOffset)"
     }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ved feil i validering av beløp ved migrering fra infotrygd ønsker vi å logge andel tilkjent ytelse slik at det er mulig å sammenligne resultat i ba-sak med infotrygd.

