### PR TITLE
Fikset slik at ba-sak ikke leser EF HentFagsystemsbehandlingRequest fra familie-tilbake

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.ekstern.tilbakekreving
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.tilbakekreving.HentFagsystemsbehandlingRequest
 import no.nav.familie.kontrakter.felles.tilbakekreving.HentFagsystemsbehandlingRespons
+import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -37,6 +38,10 @@ class HentFagsystemsbehandlingRequestConsumer(private val fagsystemsbehandlingSe
         val key: String = consumerRecord.key()
         val request: HentFagsystemsbehandlingRequest =
             objectMapper.readValue(data, HentFagsystemsbehandlingRequest::class.java)
+
+        if (request.ytelsestype != Ytelsestype.BARNETRYGD) {
+            return
+        }
 
         val fagsystemsbehandling = try {
             fagsystemsbehandlingService.hentFagsystemsbehandling(request)

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
@@ -31,9 +31,6 @@ class HentFagsystemsbehandlingRequestConsumer(private val fagsystemsbehandlingSe
         containerFactory = "concurrentKafkaListenerContainerFactory"
     )
     fun listen(consumerRecord: ConsumerRecord<String, String>, ack: Acknowledgment) {
-        logger.info("HentFagsystemsbehandlingRequest er mottatt i kafka $consumerRecord")
-        secureLogger.info("HentFagsystemsbehandlingRequest er mottatt i kafka $consumerRecord")
-
         val data: String = consumerRecord.value()
         val key: String = consumerRecord.key()
         val request: HentFagsystemsbehandlingRequest =
@@ -42,6 +39,8 @@ class HentFagsystemsbehandlingRequestConsumer(private val fagsystemsbehandlingSe
         if (request.ytelsestype != Ytelsestype.BARNETRYGD) {
             return
         }
+        logger.info("HentFagsystemsbehandlingRequest er mottatt i kafka $consumerRecord")
+        secureLogger.info("HentFagsystemsbehandlingRequest er mottatt i kafka $consumerRecord")
 
         val fagsystemsbehandling = try {
             fagsystemsbehandlingService.hentFagsystemsbehandling(request)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Vi fikk spor på logg at hent fagsystemsbehandling request for EF fra familie-tilbake leses av familie-ba-sak. Det skjer fordi groupId er forskjellige og topicnavn er samme. Topic i kafka sender alle meldinger til alle grupper(når groupId er forskjellige). For å fikse det la jeg til en tilleggsvalidering som unngår EF meldinger. Samme sjekk finnes i EF.


### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
