### PR TITLE
BisysService: Fikser beløp-mapping 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysService.kt
@@ -75,7 +75,7 @@ class BisysService(
                     stønadstype = BisysStønadstype.UTVIDET,
                     fomMåned = it.stønadFom,
                     tomMåned = it.stønadTom,
-                    beløp = it.sats.toDouble(),
+                    beløp = it.kalkulertUtbetalingsbeløp.toDouble(),
                     manueltBeregnet = false,
                     deltBosted = it.erDeltBosted()
                 )

--- a/src/test/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
@@ -17,6 +17,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -129,6 +130,7 @@ internal class BisysServiceTest {
 
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling).copy(utbetalingsoppdrag = "utbetalt")
 
+        val kalkulertbeløp = 660
         val andelTilkjentYtelse =
             lagAndelTilkjentYtelseUtvidet(
                 fom = "2020-01",
@@ -136,8 +138,9 @@ internal class BisysServiceTest {
                 ytelseType = YtelseType.UTVIDET_BARNETRYGD,
                 behandling = behandling,
                 tilkjentYtelse = tilkjentYtelse,
-                beløp = 660
-            )
+                beløp = kalkulertbeløp
+            ).copy(prosent = BigDecimal.valueOf(50), sats = 2 * kalkulertbeløp)
+
         tilkjentYtelse.andelerTilkjentYtelse.add(andelTilkjentYtelse)
         every { mockPersonidentService.hentAktør(any()) } answers { andelTilkjentYtelse.aktør }
         every { mockPersonidentService.hentAlleFødselsnummerForEnAktør(any()) } answers { listOf(andelTilkjentYtelse.aktør.aktivFødselsnummer()) }
@@ -148,7 +151,7 @@ internal class BisysServiceTest {
             YearMonth.of(2019, 12),
             660.0,
             manueltBeregnet = false,
-            deltBosted = false
+            deltBosted = true
         )
         every {
             mockInfotrygdClient.hentUtvidetBarnetrygd(
@@ -188,7 +191,7 @@ internal class BisysServiceTest {
                 behandling = behandling,
                 tilkjentYtelse = tilkjentYtelse,
                 beløp = 660
-            )
+            ).copy(prosent = BigDecimal.valueOf(50), sats = 2 * 660)
         tilkjentYtelse.andelerTilkjentYtelse.add(andelTilkjentYtelse)
 
         every { mockPersonidentService.hentAktør(any()) } answers { andelTilkjentYtelse.aktør }

--- a/src/test/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
@@ -191,7 +191,7 @@ internal class BisysServiceTest {
                 behandling = behandling,
                 tilkjentYtelse = tilkjentYtelse,
                 beløp = 660
-            ).copy(prosent = BigDecimal.valueOf(50), sats = 2 * 660)
+            )
         tilkjentYtelse.andelerTilkjentYtelse.add(andelTilkjentYtelse)
 
         every { mockPersonidentService.hentAktør(any()) } answers { andelTilkjentYtelse.aktør }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Setter beløp fra "kalkulertUtbetalingsbeløp", og ikke "sats" som blir feil ved delt bosted.