### PR TITLE
Chore: Sentry + sett på vent feilmelding

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/SentryConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/SentryConfiguration.kt
@@ -14,14 +14,16 @@ import org.springframework.core.NestedExceptionUtils
 class SentryConfiguration(
     @Value("\${sentry.environment}") val environment: String,
     @Value("\${sentry.dsn}") val dsn: String,
+    @Value("\${sentry.logging.enabled}") val enabled: Boolean
 ) {
     init {
         Sentry.init { options ->
-            options.dsn = dsn
+            options.dsn = if (enabled) dsn else "" // Tom streng betryr at Sentry er disabled
             options.environment = environment
             options.beforeSend = SentryOptions.BeforeSendCallback { event, _ ->
                 Sentry.configureScope { scope ->
                     scope.user = User().apply {
+                        id = SikkerhetContext.hentSaksbehandler()
                         email = SikkerhetContext.hentSaksbehandlerEpost()
                         username = SikkerhetContext.hentSaksbehandler()
                     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -55,8 +55,6 @@ class UtvidetBehandlingService(
 
         val vedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandling.id)
 
-        if (behandling.id == 999954L) error("Test feil")
-
         val personResultater = vilkårsvurderingService.hentAktivForBehandling(behandling.id)?.personResultater
 
         val andelerTilkjentYtelse =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -55,6 +55,8 @@ class UtvidetBehandlingService(
 
         val vedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandling.id)
 
+        if (behandling.id == 999954L) error("Test feil")
+
         val personResultater = vilkårsvurderingService.hentAktivForBehandling(behandling.id)?.personResultater
 
         val andelerTilkjentYtelse =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
@@ -85,7 +85,12 @@ class SettPåVentService(
 
     fun gjenopptaBehandling(behandlingId: Long, nå: LocalDate = LocalDate.now()): SettPåVent {
         val behandling = behandlingService.hent(behandlingId)
-        val aktivSettPåVent = finnAktivSettPåVentPåBehandlingThrows(behandlingId)
+        val aktivSettPåVent =
+            finnAktivSettPåVentPåBehandling(behandlingId)
+                ?: throw FunksjonellFeil(
+                    melding = "Behandling $behandlingId er ikke satt på vent.",
+                    frontendFeilmelding = "Behandlingen er ikke på vent og det er ikke mulig å gjenoppta behandling."
+                )
 
         loggService.gjenopptaBehandlingLogg(behandling)
         logger.info("Gjenopptar behandling $behandlingId")


### PR DESCRIPTION
Bruker enabled fra config til å styre om Sentry skal være påskrudd eller ikke. Endrer feilhåndtering for gjenoppta behandling på vent.
