### PR TITLE
WIP

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingScheduler.kt
@@ -24,7 +24,7 @@ class KonsistensavstemmingScheduler(
     val featureToggleService: FeatureToggleService,
 ) {
 
-    @Scheduled(cron = "0 0 17 * * *")
+    @Scheduled(cron = "0 0 22 * * *")
     fun utførKonsistensavstemming() {
         val inneværendeMåned = YearMonth.from(now())
         val plukketBatch = batchService.plukkLedigeBatchKjøringerFor(dato = now()) ?: return


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Flytter tidspunktet for konsistensavstemmingen til kl 22. Årsaken er at ba-sak ikke låser uttrekket til tidspunktet for starten av avstemmingen og derfor rapporterer ba-sak ibland fler oppdrag enn økonomi.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
