### PR TITLE
Bedre innhenting av relasjoner

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -50,6 +50,8 @@ class RolleTilgangskontrollFeil(
 
 class PdlRequestException(message: String) : Feil(message)
 class PdlNotFoundException : FunksjonellFeil("Fant ikke person")
+class PdlPersonKanIkkeBehandlesIFagsystem(val årsak: String) :
+    FunksjonellFeil("Person kan ikke behandles i fagsystem: $årsak")
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder(value = ["melding", "path", "timestamp", "status", "exception", "stackTrace"])

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -64,10 +64,12 @@ class PdlRestClient(
             ident = aktør.aktivFødselsnummer(),
             pdlResponse = pdlResponse
         ) { pdlPerson ->
+            pdlPerson.person!!.validerOmPersonKanBehandlesIFagsystem()
+
             val forelderBarnRelasjon: Set<ForelderBarnRelasjon> =
                 when (personInfoQuery) {
                     PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON -> {
-                        pdlPerson.person!!.forelderBarnRelasjon.map { relasjon ->
+                        pdlPerson.person.forelderBarnRelasjon.map { relasjon ->
                             val relatertAktør =
                                 personidentService.hentAktør(relasjon.relatertPersonsIdent)
                             ForelderBarnRelasjon(
@@ -79,9 +81,9 @@ class PdlRestClient(
                     else -> emptySet()
                 }
 
-            pdlPerson.person!!.let {
+            pdlPerson.person.let {
                 PersonInfo(
-                    fødselsdato = LocalDate.parse(it.foedsel.first().foedselsdato!!),
+                    fødselsdato = LocalDate.parse(it.foedsel.first().foedselsdato),
                     navn = it.navn.firstOrNull()?.fulltNavn(),
                     kjønn = it.kjoenn.firstOrNull()?.kjoenn,
                     forelderBarnRelasjon = forelderBarnRelasjon,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.pdl.domene
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import no.nav.familie.ba.sak.common.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.kontrakter.felles.personopplysning.Adressebeskyttelse
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
@@ -13,6 +14,7 @@ data class PdlHentPersonResponse(val person: PdlPersonData?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlPersonData(
+    val folkeregisteridentifikator: List<PdlFolkeregisteridentifikator>,
     val foedsel: List<PdlFødselsDato>,
     val navn: List<PdlNavn> = emptyList(),
     val kjoenn: List<PdlKjoenn> = emptyList(),
@@ -24,7 +26,24 @@ data class PdlPersonData(
     val statsborgerskap: List<Statsborgerskap> = emptyList(),
     val doedsfall: List<Doedsfall> = emptyList(),
     val kontaktinformasjonForDoedsbo: List<PdlKontaktinformasjonForDødsbo> = emptyList()
+) {
+    fun validerOmPersonKanBehandlesIFagsystem() {
+        if (foedsel.isEmpty()) throw PdlPersonKanIkkeBehandlesIFagsystem("mangler fødselsdato")
+        if (folkeregisteridentifikator.firstOrNull()?.status == FolkeregisteridentifikatorStatus.OPPHOERT) throw PdlPersonKanIkkeBehandlesIFagsystem(
+            "er opphørt"
+        )
+    }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PdlFolkeregisteridentifikator(
+    val identifikasjonsnummer: String?,
+    val status: FolkeregisteridentifikatorStatus,
+    val type: FolkeregisteridentifikatorType?
 )
+
+enum class FolkeregisteridentifikatorStatus { I_BRUK, OPPHOERT }
+enum class FolkeregisteridentifikatorType { FNR, DNR }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlFødselsDato(val foedselsdato: String?)

--- a/src/main/resources/pdl/hentperson-enkel.graphql
+++ b/src/main/resources/pdl/hentperson-enkel.graphql
@@ -1,4 +1,9 @@
 query($ident: ID!) {person: hentPerson(ident: $ident) {
+    folkeregisteridentifikator {
+        identifikasjonsnummer
+        status
+        type
+    }
     foedsel {
         foedselsdato
     }

--- a/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
+++ b/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
@@ -1,4 +1,9 @@
 query($ident: ID!) {person: hentPerson(ident: $ident) {
+    folkeregisteridentifikator {
+        identifikasjonsnummer
+        status
+        type
+    }
     foedsel {
         foedselsdato
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/mockserver/domene/RestScenarioPerson.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/mockserver/domene/RestScenarioPerson.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene
 
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlFolkeregisteridentifikator
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
 import no.nav.familie.kontrakter.ba.infotrygd.Sak
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
@@ -11,7 +12,8 @@ import java.time.Period
 data class RestScenarioPerson(
     val ident: String? = null, // Settes av mock-server
     val aktørId: String? = null, // Settes av mock-server
-    val forelderBarnRelasjon: List<ForelderBarnRelasjon>? = emptyList(), // Settes av mock-server
+    val forelderBarnRelasjon: List<ForelderBarnRelasjon> = emptyList(), // Settes av mock-server
+    val folkeregisteridentifikator: List<PdlFolkeregisteridentifikator> = emptyList(), // Settes av mock-server
     val fødselsdato: String, // yyyy-mm-dd
     val fornavn: String,
     val etternavn: String,

--- a/src/test/resources/pdl/PdlIntegrasjon/gyldigRequestForBarnMedOpphørtStatus.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/gyldigRequestForBarnMedOpphørtStatus.json
@@ -1,0 +1,6 @@
+{
+  "variables": {
+    "ident": "92345678901"
+  },
+  "query": "GRAPHQL-PLACEHOLDER"
+}

--- a/src/test/resources/pdl/PdlIntegrasjon/gyldigRequestForBarnUtenFødselsdato.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/gyldigRequestForBarnUtenFødselsdato.json
@@ -1,0 +1,6 @@
+{
+  "variables": {
+    "ident": "92345678902"
+  },
+  "query": "GRAPHQL-PLACEHOLDER"
+}

--- a/src/test/resources/pdl/PdlIntegrasjon/gyldigRequestForMor3Barn1Opphørt1UtenFødselsdato.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/gyldigRequestForMor3Barn1Opphørt1UtenFødselsdato.json
@@ -1,0 +1,6 @@
+{
+  "variables": {
+    "ident": "94556612349"
+  },
+  "query": "GRAPHQL-PLACEHOLDER"
+}

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarn.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarn.json
@@ -10,6 +10,13 @@
       ]
     },
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "32345678901",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "BARN",

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedAdressebeskyttelse.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedAdressebeskyttelse.json
@@ -10,6 +10,13 @@
       ]
     },
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "32345678902",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "REAL",

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedOpphørtStatus.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedOpphørtStatus.json
@@ -3,44 +3,34 @@
     "pdlIdenter": {
       "identer": [
         {
-          "ident": "22345678901",
+          "ident": "92345678901",
           "historisk": false,
           "gruppe": "FOLKEREGISTERIDENT"
-        },
-        {
-          "ident": "2872543507203",
-          "historisk": false,
-          "gruppe": "AKTORID"
-        },
-        {
-          "ident": "2872543000000",
-          "historisk": true,
-          "gruppe": "AKTORID"
         }
       ]
     },
     "person": {
       "folkeregisteridentifikator": [
         {
-          "identifikasjonsnummer": "44556612345",
-          "status": "I_BRUK",
+          "identifikasjonsnummer": "92345678901",
+          "status": "OPPHOERT",
           "type": "FNR"
         }
       ],
       "navn": [
         {
-          "fornavn": "ENGASJERT",
+          "fornavn": "BARN",
           "etternavn": "FYR"
         }
       ],
       "foedsel": [
         {
-          "foedselsdato": "1955-09-13"
+          "foedselsdato": "2005-01-17"
         }
       ],
       "kjoenn": [
         {
-          "kjoenn": "KVINNE"
+          "kjoenn": "MANN"
         }
       ],
       "bostedsadresse": [
@@ -66,8 +56,8 @@
       ],
       "forelderBarnRelasjon": [
         {
-          "relatertPersonsIdent": "32345678901",
-          "relatertPersonsRolle": "BARN"
+          "relatertPersonsIdent": "22345678901",
+          "relatertPersonsRolle": "MOR"
         }
       ],
       "adressebeskyttelse": [
@@ -76,12 +66,10 @@
         }
       ],
       "statsborgerskap": [
-      ],
-      "opphold": [
         {
-          "type": "MIDLERTIDIG",
-          "oppholdFra": "2010-01-20",
-          "oppholdTil": "2022-01-20"
+          "land": "NOR",
+          "gyldigFraOgMed": "2005-01-20",
+          "gyldigTilOgMed": null
         }
       ],
       "doedsfall": [],

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnUtenFødselsdato.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnUtenFødselsdato.json
@@ -3,44 +3,30 @@
     "pdlIdenter": {
       "identer": [
         {
-          "ident": "22345678901",
+          "ident": "92345678902",
           "historisk": false,
           "gruppe": "FOLKEREGISTERIDENT"
-        },
-        {
-          "ident": "2872543507203",
-          "historisk": false,
-          "gruppe": "AKTORID"
-        },
-        {
-          "ident": "2872543000000",
-          "historisk": true,
-          "gruppe": "AKTORID"
         }
       ]
     },
     "person": {
       "folkeregisteridentifikator": [
         {
-          "identifikasjonsnummer": "44556612345",
+          "identifikasjonsnummer": "92345678902",
           "status": "I_BRUK",
           "type": "FNR"
         }
       ],
       "navn": [
         {
-          "fornavn": "ENGASJERT",
+          "fornavn": "BARN",
           "etternavn": "FYR"
         }
       ],
-      "foedsel": [
-        {
-          "foedselsdato": "1955-09-13"
-        }
-      ],
+      "foedsel": [],
       "kjoenn": [
         {
-          "kjoenn": "KVINNE"
+          "kjoenn": "MANN"
         }
       ],
       "bostedsadresse": [
@@ -66,8 +52,8 @@
       ],
       "forelderBarnRelasjon": [
         {
-          "relatertPersonsIdent": "32345678901",
-          "relatertPersonsRolle": "BARN"
+          "relatertPersonsIdent": "22345678901",
+          "relatertPersonsRolle": "MOR"
         }
       ],
       "adressebeskyttelse": [
@@ -76,12 +62,10 @@
         }
       ],
       "statsborgerskap": [
-      ],
-      "opphold": [
         {
-          "type": "MIDLERTIDIG",
-          "oppholdFra": "2010-01-20",
-          "oppholdTil": "2022-01-20"
+          "land": "NOR",
+          "gyldigFraOgMed": "2005-01-20",
+          "gyldigTilOgMed": null
         }
       ],
       "doedsfall": [],

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForDødMor.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForDødMor.json
@@ -10,6 +10,13 @@
       ]
     },
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "44556612345",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "MOR",
@@ -71,9 +78,11 @@
       ],
       "opphold": [
       ],
-      "doedsfall": [{
-        "doedsdato": "2020-04-04"
-      }],
+      "doedsfall": [
+        {
+          "doedsdato": "2020-04-04"
+        }
+      ],
       "kontaktinformasjonForDoedsbo": [
         {
           "adresse": {

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMor3Barn1Opphørt1UtenFødselsdato.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMor3Barn1Opphørt1UtenFødselsdato.json
@@ -3,39 +3,29 @@
     "pdlIdenter": {
       "identer": [
         {
-          "ident": "22345678901",
+          "ident": "94556612349",
           "historisk": false,
           "gruppe": "FOLKEREGISTERIDENT"
-        },
-        {
-          "ident": "2872543507203",
-          "historisk": false,
-          "gruppe": "AKTORID"
-        },
-        {
-          "ident": "2872543000000",
-          "historisk": true,
-          "gruppe": "AKTORID"
         }
       ]
     },
     "person": {
       "folkeregisteridentifikator": [
         {
-          "identifikasjonsnummer": "44556612345",
+          "identifikasjonsnummer": "94556612349",
           "status": "I_BRUK",
           "type": "FNR"
         }
       ],
       "navn": [
         {
-          "fornavn": "ENGASJERT",
+          "fornavn": "MOR",
           "etternavn": "FYR"
         }
       ],
       "foedsel": [
         {
-          "foedselsdato": "1955-09-13"
+          "foedselsdato": "1990-01-17"
         }
       ],
       "kjoenn": [
@@ -68,6 +58,14 @@
         {
           "relatertPersonsIdent": "32345678901",
           "relatertPersonsRolle": "BARN"
+        },
+        {
+          "relatertPersonsIdent": "92345678901",
+          "relatertPersonsRolle": "BARN"
+        },
+        {
+          "relatertPersonsIdent": "92345678902",
+          "relatertPersonsRolle": "BARN"
         }
       ],
       "adressebeskyttelse": [
@@ -76,16 +74,28 @@
         }
       ],
       "statsborgerskap": [
-      ],
-      "opphold": [
         {
-          "type": "MIDLERTIDIG",
-          "oppholdFra": "2010-01-20",
-          "oppholdTil": "2022-01-20"
+          "land": "XXX",
+          "gyldigFraOgMed": null,
+          "gyldigTilOgMed": null
         }
       ],
-      "doedsfall": [],
-      "kontaktinformasjonForDoedsbo": []
+      "opphold": [
+      ],
+      "doedsfall": [
+        {
+          "doedsdato": "2020-04-04"
+        }
+      ],
+      "kontaktinformasjonForDoedsbo": [
+        {
+          "adresse": {
+            "adresselinje1": "Gatenavn 1",
+            "postnummer": "1234",
+            "poststedsnavn": "Oslo"
+          }
+        }
+      ]
     }
   }
 }

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedUkjentStatsborgerskap.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedUkjentStatsborgerskap.json
@@ -20,6 +20,13 @@
       ]
     },
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "44556612345",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "ENGASJERT",

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedXXXStatsborgerskap.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedXXXStatsborgerskap.json
@@ -20,6 +20,13 @@
       ]
     },
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "44556612345",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "ENGASJERT",

--- a/src/test/resources/pdl/pdlManglerFoedselResponse.json
+++ b/src/test/resources/pdl/pdlManglerFoedselResponse.json
@@ -1,6 +1,13 @@
 {
   "data": {
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "1234",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "ENGASJERT",

--- a/src/test/resources/pdl/pdlMatrikkelAdresseOkResponse.json
+++ b/src/test/resources/pdl/pdlMatrikkelAdresseOkResponse.json
@@ -1,6 +1,13 @@
 {
   "data": {
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "1234",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "ENGASJERT",

--- a/src/test/resources/pdl/pdlOkResponse.json
+++ b/src/test/resources/pdl/pdlOkResponse.json
@@ -1,6 +1,13 @@
 {
   "data": {
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "1234",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "ENGASJERT",

--- a/src/test/resources/pdl/pdlTomAdresseOkResponse.json
+++ b/src/test/resources/pdl/pdlTomAdresseOkResponse.json
@@ -1,6 +1,13 @@
 {
   "data": {
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "1234",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "ENGASJERT",

--- a/src/test/resources/pdl/pdlUkjentBostedAdresseOkResponse.json
+++ b/src/test/resources/pdl/pdlUkjentBostedAdresseOkResponse.json
@@ -1,6 +1,13 @@
 {
   "data": {
     "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "1234",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
       "navn": [
         {
           "fornavn": "ENGASJERT",


### PR DESCRIPTION
Kaster feil på personer uten fødselsdato eller har opphørt status. Filtrerer bort slike personer i mapping så vi sitter igjen med relasjoner som kan behandles i løsningen.

### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8377

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Er en del testfiler som man stort sett kan se bort i fra da det kun er data som trengs for at pdl->ba-sak modell ikke skal brekke.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
