### PR TITLE
Håndterer aktør-krasj i databasen ved å plukke opp constraint exception og logger warning.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -135,7 +135,7 @@ class MigreringService(
                     .also { kastFeilDersomAlleredeMigrert(it) }
             } catch (exception: Exception) {
                 if (exception is ConstraintViolationException) {
-                    logger.warn("Migrering: Klarte ikke å opprette fagsak på grunn av krasj i databasen, prøver igjen om 15 minutter. Feilmelding: ${exception.message}.")
+                    logger.warn("Migrering: Klarte ikke å opprette fagsak på grunn av krasj i databasen, prøver igjen senere. Feilmelding: ${exception.message}.")
                     kastOgTellMigreringsFeil(MigreringsfeilType.UKJENT)
                 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fra tid til annen opplever vi alarm fra migreringsløypa når vi prøver å behandle en fødselshendelse OG migrering på samme person 🤯  Vi har løst dette ved å catche og rekjøre task på fødselshendelseløypa og tror det er fint å gjøre det samme her. Må også da unngå å lagre aktør før opprettelse av fagsak (gjøres i metoden man kaller uansett)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke aktuelt

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
