### PR TITLE
Vedtaksbrev med perioder for fortsatt innvilget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVedtaksperiodeMedBegrunnelser.kt
@@ -9,3 +9,8 @@ data class RestPutVedtaksperiodeMedFritekster(
 data class RestPutVedtaksperiodeMedStandardbegrunnelser(
     val standardbegrunnelser: List<Standardbegrunnelse>,
 )
+
+data class RestPutGenererFortsattInnvilgetVedtaksperioder(
+    val skalGenererePerioderForFortsattInnvilget: Boolean,
+    val behandlingId: Long
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -1,11 +1,13 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutGenererFortsattInnvilgetVedtaksperioder
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedFritekster
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedStandardbegrunnelser
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.brev.BrevKlient
 import no.nav.familie.ba.sak.kjerne.brev.BrevPeriodeService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
@@ -110,6 +112,11 @@ class VedtaksperiodeMedBegrunnelserController(
             handling = "oppdater vedtaksperioder fortsatt innvilget"
         )
         val vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId = restPutGenererFortsattInnvilgetVedtaksperioder.behandlingId)
+        if (vedtak.behandling.resultat != Behandlingsresultat.FORTSATT_INNVILGET) {
+            throw FunksjonellFeil(
+                melding = "Kan ikke overstyre vedtaksperioder når resultatet ikke er fortsatt innvilget."
+            )
+        }
         vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(vedtak = vedtak, skalOverstyreFortsattInnvilget = restPutGenererFortsattInnvilgetVedtaksperioder.skalGenererePerioderForFortsattInnvilget)
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = vedtak.behandling.id)))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -95,7 +95,13 @@ class VedtaksperiodeMedBegrunnelserController(
         return ResponseEntity.ok(Ressurs.Companion.success(begrunnelser))
     }
 
-    @PutMapping("/fortsatt-innvilget")
+    /*
+    * Dette endepunktet brukes for å overstyre hva slags vedtaksperioder man ønsker når resultatet er fortsatt innvilget.
+    * Muligheter:
+    * - skalGenererePerioderForFortsattInnvilget = false -> det blir kun generert 1 periode, uten dato (default valg for fortsatt innvilget)
+    * - skalGenererePerioderForFortsattInnvilget = true -> det blir generert 'vanlige' perioder (overstyrer default for fortsatt innvilget)
+    */
+    @PutMapping("/overstyr-fortsatt-innvilget-vedtaksperioder")
     fun genererFortsattInnvilgetVedtaksperioder(
         @RequestBody restPutGenererFortsattInnvilgetVedtaksperioder: RestPutGenererFortsattInnvilgetVedtaksperioder
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -104,7 +104,7 @@ class VedtaksperiodeMedBegrunnelserController(
             handling = "oppdater vedtaksperioder fortsatt innvilget"
         )
         val vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId = restPutGenererFortsattInnvilgetVedtaksperioder.behandlingId)
-        vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(vedtak = vedtak, skalGenererePerioderForFortsattInnvilget = restPutGenererFortsattInnvilgetVedtaksperioder.skalGenererePerioderForFortsattInnvilget)
+        vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(vedtak = vedtak, skalOverstyreFortsattInnvilget = restPutGenererFortsattInnvilgetVedtaksperioder.skalGenererePerioderForFortsattInnvilget)
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = vedtak.behandling.id)))
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -231,10 +231,10 @@ class VedtaksperiodeService(
     }
 
     @Transactional
-    fun oppdaterVedtakMedVedtaksperioder(vedtak: Vedtak, skalGenererePerioderForFortsattInnvilget: Boolean = false) {
+    fun oppdaterVedtakMedVedtaksperioder(vedtak: Vedtak, skalOverstyreFortsattInnvilget: Boolean = false) {
 
         slettVedtaksperioderFor(vedtak)
-        if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET && !skalGenererePerioderForFortsattInnvilget) {
+        if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET && !skalOverstyreFortsattInnvilget) {
 
             val vedtaksbrevmal = hentVedtaksbrevmal(vedtak.behandling)
             val erAutobrevFor6Og18ÅrOgSmåbarnstillegg =
@@ -257,7 +257,7 @@ class VedtaksperiodeService(
                 )
             )
         } else {
-            lagre(genererVedtaksperioderMedBegrunnelser(vedtak, gjelderFortsattInnvilget = skalGenererePerioderForFortsattInnvilget))
+            lagre(genererVedtaksperioderMedBegrunnelser(vedtak, gjelderFortsattInnvilget = skalOverstyreFortsattInnvilget))
         }
     }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8209

Lager endepunkt som oppdaterer vedtaksperiodene på en behandling. Skal brukes for fortsatt innvilget behandlinger, hvor man kan velge om man vil ha med eller uten perioder. Default er uten perioder (sånn som det er i dag). Hvis man vil ha med perioder brukes samme logikk som for de andre behandlingsresultatene i dag. Endringstidspunkt skal ikke tas høyde for for fortsatt innvilget (er jo ingen endringer). Ønsker man vedtaksbrev med perioder skal man få alle periodene.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Tar gjerne imot tips til navn på endepunktet.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
