### PR TITLE
[DRAFT] Ny delt bosted begrunnelse med nye krav til flettefelt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlag.kt
@@ -3,8 +3,11 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.NullablePeriode
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnelse
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.hentRelevanteEndringsperioderForBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestVedtaksbegrunnelse
 
@@ -22,7 +25,23 @@ data class BrevBegrunnelseGrunnlag(
         barnPersonIdentMedReduksjon: List<String>,
         erIngenOverlappVedtaksperiodeTogglePå: Boolean,
         minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>,
-    ): BrevBegrunnelseGrunnlagMedPersoner {
+    ): List<BrevBegrunnelseGrunnlagMedPersoner> {
+
+        if (this.standardbegrunnelse == Standardbegrunnelse.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_ENDRET_UTBETALING) {
+            val deltBostedEndringsperioder = this.standardbegrunnelse.hentRelevanteEndringsperioderForBegrunnelse(minimerteRestEndredeAndeler = restBehandlingsgrunnlagForBrev.minimerteEndredeUtbetalingAndeler, vedtaksperiode = periode).filter { it.årsak == Årsak.DELT_BOSTED }
+            val deltBostedEndringsperioderGruppertPåAvtaledato = deltBostedEndringsperioder.filter { endringsperiode -> restBehandlingsgrunnlagForBrev.personerPåBehandling.find { person -> person.personIdent == endringsperiode.personIdent }?.type == PersonType.BARN }.groupBy { it.avtaletidspunktDeltBosted }
+
+            return deltBostedEndringsperioderGruppertPåAvtaledato.map {
+                BrevBegrunnelseGrunnlagMedPersoner(
+                    standardbegrunnelse = this.standardbegrunnelse,
+                    vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
+                    triggesAv = this.triggesAv,
+                    personIdenter = it.value.map { endringsperiode -> endringsperiode.personIdent },
+                    avtaletidspunktDeltBosted = it.key
+                )
+            }
+        }
+
         val personidenterGjeldendeForBegrunnelse: Set<String> = hentPersonidenterGjeldendeForBegrunnelse(
             triggesAv = this.triggesAv,
             vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
@@ -46,11 +65,13 @@ data class BrevBegrunnelseGrunnlag(
             )
         }
 
-        return BrevBegrunnelseGrunnlagMedPersoner(
-            standardbegrunnelse = this.standardbegrunnelse,
-            vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
-            triggesAv = this.triggesAv,
-            personIdenter = personidenterGjeldendeForBegrunnelse.toList()
+        return listOf(
+            BrevBegrunnelseGrunnlagMedPersoner(
+                standardbegrunnelse = this.standardbegrunnelse,
+                vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
+                triggesAv = this.triggesAv,
+                personIdenter = personidenterGjeldendeForBegrunnelse.toList()
+            )
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlagMedPersoner.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlagMedPersoner.kt
@@ -13,6 +13,7 @@ data class BrevBegrunnelseGrunnlagMedPersoner(
     val vedtakBegrunnelseType: VedtakBegrunnelseType,
     val triggesAv: TriggesAv,
     val personIdenter: List<String>,
+    val avtaletidspunktDeltBosted: LocalDate? = null
 ) : Comparable<BrevBegrunnelseGrunnlagMedPersoner> {
     fun hentAntallBarnForBegrunnelse(
         uregistrerteBarn: List<MinimertUregistrertBarn>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/MinimertRestEndretAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/MinimertRestEndretAndel.kt
@@ -19,7 +19,8 @@ data class MinimertRestEndretAndel(
     val periode: MånedPeriode,
     val personIdent: String,
     val årsak: Årsak,
-    val søknadstidspunkt: LocalDate
+    val søknadstidspunkt: LocalDate,
+    val avtaletidspunktDeltBosted: LocalDate?
 ) {
     fun erOverlappendeMed(nullableMånedPeriode: NullableMånedPeriode): Boolean {
         return MånedPeriode(
@@ -50,5 +51,11 @@ fun EndretUtbetalingAndel.tilMinimertRestEndretUtbetalingAndel() = MinimertRestE
     søknadstidspunkt = this.søknadstidspunkt ?: throw Feil(
         "Har ikke søknadstidspunk på endretUtbetalingsandel  ${this.id} " +
             "ved konvertering til minimertRestEndretUtbetalingsandel"
-    )
+    ),
+    avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted ?: (
+        if (this.årsakErDeltBosted()) throw Feil(
+            "Har ikke avtaletidspunktDeltBosted på endretUtbetalingsandel  ${this.id} " +
+                "ved konvertering til minimertRestEndretUtbetalingsandel"
+        ) else null
+        )
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/MinimertVedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/MinimertVedtaksperiode.kt
@@ -28,7 +28,7 @@ data class MinimertVedtaksperiode(
             fom = this.fom,
             tom = this.tom,
             type = this.type,
-            begrunnelser = this.begrunnelser.map {
+            begrunnelser = this.begrunnelser.flatMap {
                 it.tilBrevBegrunnelseGrunnlagMedPersoner(
                     periode = NullablePeriode(
                         fom = this.fom,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -1166,6 +1166,10 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
         override val sanityApiNavn = "endretUtbetalingMottattFullOrdinaerFaarEtterbetaltUtvidet"
     },
+    ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_ENDRET_UTBETALING {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
+        override val sanityApiNavn = "endretUtbetalingDeltBostedEndretUtbetaling"
+    },
     ETTER_ENDRET_UTBETALING_RETTSAVGJØRELSE_DELT_BOSTED {
         override val sanityApiNavn = "etterEndretUtbetalingRettsavgjorelseDeltBosted"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
@@ -1206,5 +1210,6 @@ val nyeEndretUtbetalingsperiodeBegrunnelser = listOf<Standardbegrunnelse>(
     Standardbegrunnelse.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY,
     Standardbegrunnelse.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_FULL_UTBETALING_FØR_SOKNAD_NY,
     Standardbegrunnelse.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_KUN_ETTERBETALT_UTVIDET_NY,
-    Standardbegrunnelse.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_MOTTATT_FULL_ORDINÆR_ETTERBETALT_UTVIDET_NY
+    Standardbegrunnelse.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_MOTTATT_FULL_ORDINÆR_ETTERBETALT_UTVIDET_NY,
+    Standardbegrunnelse.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_ENDRET_UTBETALING
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -89,7 +89,8 @@ data class BegrunnelseData(
     val maalform: String,
     val apiNavn: String,
     val belop: String,
-    val soknadstidspunkt: String
+    val soknadstidspunkt: String,
+    val avtaletidspunktDeltBosted: String,
 ) : Begrunnelse
 
 data class FritekstBegrunnelse(val fritekst: String) : Begrunnelse
@@ -165,11 +166,12 @@ fun BrevBegrunnelseGrunnlagMedPersoner.tilBrevBegrunnelse(
         maalform = brevMålform.tilSanityFormat(),
         apiNavn = this.standardbegrunnelse.sanityApiNavn,
         belop = Utils.formaterBeløp(beløp),
-        soknadstidspunkt = søknadstidspunkt?.tilKortString() ?: ""
+        soknadstidspunkt = søknadstidspunkt?.tilKortString() ?: "",
+        avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted?.tilKortString() ?: ""
     )
 }
 
-private fun Standardbegrunnelse.hentRelevanteEndringsperioderForBegrunnelse(
+fun Standardbegrunnelse.hentRelevanteEndringsperioderForBegrunnelse(
     minimerteRestEndredeAndeler: List<MinimertRestEndretAndel>,
     vedtaksperiode: NullablePeriode
 ) = when (this.vedtakBegrunnelseType) {

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
@@ -106,14 +106,16 @@ data class UtbetalingPåPerson(
 data class EndretRestUtbetalingAndelPåPerson(
     val periode: MånedPeriode,
     val årsak: Årsak,
-    val søknadstidspunkt: LocalDate = LocalDate.now()
+    val søknadstidspunkt: LocalDate = LocalDate.now(),
+    val avtaletidspunktDeltBosted: LocalDate? = null
 ) {
     fun tilMinimertRestEndretUtbetalingAndel(personIdent: String) =
         MinimertRestEndretAndel(
             personIdent = personIdent,
             periode = periode,
             årsak = årsak,
-            søknadstidspunkt = søknadstidspunkt
+            søknadstidspunkt = søknadstidspunkt,
+            avtaletidspunktDeltBosted = avtaletidspunktDeltBosted
         )
 }
 
@@ -141,6 +143,7 @@ data class BegrunnelseDataTestConfig(
     val apiNavn: String,
     val belop: Int,
     val soknadstidspunkt: String?,
+    val avtaletidspunktDeltBosted: String?
 ) : TestBegrunnelse {
 
     fun tilBegrunnelseData() = BegrunnelseData(
@@ -155,7 +158,8 @@ data class BegrunnelseDataTestConfig(
         maanedOgAarBegrunnelsenGjelderFor = this.maanedOgAarBegrunnelsenGjelderFor,
         maalform = this.maalform,
         apiNavn = this.apiNavn,
-        soknadstidspunkt = this.soknadstidspunkt ?: ""
+        soknadstidspunkt = this.soknadstidspunkt ?: "",
+        avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted ?: ""
     )
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8425

**Ønske**
Legge til ny delt bosted begrunnelse som skal ha litt ny oppførsel:
- Legge til nytt flettefelt avtaletidspunktDeltBosted (https://github.com/navikt/familie-sanity-brev/pull/174)
- Slå sammen begrunnelsen for barn som har samme avtaledato
- Splitte opp begrunnelsen i flere hvis det er ulik avtaledato

**Ting som er litt uklart (må avklares med fag før merge)**
- Hvordan overstyrte delt bosted perioder på søker skal vises mtp. at barnasfødselsdatoer da blir tom streng. 

**Spørsmål/tanker om mulig forbedring av dette utkastet**
Nå har jeg hardkodet inn hvilken begrunnelse dette gjelder. Det er ikke spesielt bærekraftig.
Tanker om mulig løsning på dette:
- Lage trigger i sanity (checkbox) som sier om begrunnelsen muligens skal splittes i flere av samme begrunnelse, og isåfall hvilket flettefelt det skal splittes på. I tilfellet med denne begrunnelsen ville man krysset av ja, og valgt avtaletidspunktDeltBosted. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Funker sånn koden er nå, men det er ikke spesielt pent. Ønsker derfor å diskutere mulige løsninger for å gjøre det på en bedre måte før merge. Derfor er dette en draft!

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Venter til det er avklart hvordan oppgaven skal løses.

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
