### PR TITLE
Oppdater tilkjent ytelse tom der den er ulik maks andel tilkjent ytelse tom

### DIFF
--- a/src/main/resources/db/migration/V203__oppdater_tilkjent_ytelse_stonad_tom_fra_andel_tilkjent_ytelse.sql
+++ b/src/main/resources/db/migration/V203__oppdater_tilkjent_ytelse_stonad_tom_fra_andel_tilkjent_ytelse.sql
@@ -1,0 +1,14 @@
+with ny_stonad_tom (tilkjent_ytelse_id, ny_stonad_tom) as (
+    select ty.id,
+           grouped_aty.max_stonad_tom
+    from (select tilkjent_ytelse_id, MAX(stonad_tom) as max_stonad_tom
+          from andel_tilkjent_ytelse
+          group by tilkjent_ytelse_id) grouped_aty
+             join tilkjent_ytelse ty on grouped_aty.tilkjent_ytelse_id = ty.id
+    where grouped_aty.max_stonad_tom != ty.stonad_tom
+)
+
+update tilkjent_ytelse ty
+set stonad_tom = st.ny_stonad_tom
+from ny_stonad_tom st
+where st.tilkjent_ytelse_id = ty.id;


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8441

Fikser feil der siste andel tilkjent ytelse tom dato var forskjellig fra tom datoen til tilkjent ytelse

Vi har et problem der den seneste til og med datoen på andeler tilkjent ytelse ikke samsvarer med til og med datoen på tilkjent ytelse. Endrer derfor på tom-datoen til tilkjent ytelse til å være samme som seneste tom-dato på de tilknyttede andelene.

