### PR TITLE
Håndter null som statsborgerperiode ved vurdering av medlemsskap

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/StatsborgerskapService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/StatsborgerskapService.kt
@@ -39,6 +39,24 @@ class StatsborgerskapService(
         val grStatsborgerskap = ArrayList<GrStatsborgerskap>()
         var datoFra = statsborgerskap.hentFom()
 
+        if (datoFra == null && statsborgerskap.gyldigTilOgMed == null) {
+            val idag = LocalDate.now()
+            grStatsborgerskap += GrStatsborgerskap(
+                gyldigPeriode = DatoIntervallEntitet(
+                    fom = idag,
+                    tom = null
+                ),
+                landkode = statsborgerskap.land,
+                medlemskap = finnMedlemskap(
+                    statsborgerskap,
+                    alleEØSLandInkludertHistoriske,
+                    idag
+                ),
+                person = person
+            )
+            return grStatsborgerskap
+        }
+
         hentMedlemskapsIntervaller(
             alleEØSLandInkludertHistoriske,
             statsborgerskap.hentFom(),

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/StatsborgerskapServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/StatsborgerskapServiceTest.kt
@@ -57,7 +57,7 @@ internal class StatsborgerskapServiceTest {
     }
 
     @Test
-    fun `Skal evaluere polske statsborgere med ujkent periode som EØS-borgere`() {
+    fun `Skal evaluere polske statsborgere med ukjent periode som EØS-borgere`() {
         val statsborgerPolenUtenPeriode = Statsborgerskap(
             "POL",
             gyldigFraOgMed = null,
@@ -141,7 +141,10 @@ internal class StatsborgerskapServiceTest {
         assertEquals(1, grStatsborgerskapUtenPeriode.size)
         assertEquals(Medlemskap.TREDJELANDSBORGER, grStatsborgerskapUtenPeriode.single().medlemskap)
         assertTrue(grStatsborgerskapUtenPeriode.single().gjeldendeNå())
+    }
 
+    @Test
+    fun `Skal evaluere britiske statsborgere etter brexit som tredjelandsborgere`() {
         val statsborgerStorbritanniaMedPeriodeEtterBrexit = Statsborgerskap(
             "GBR",
             gyldigFraOgMed = LocalDate.of(2022, 3, 1),
@@ -154,8 +157,11 @@ internal class StatsborgerskapServiceTest {
         )
         assertEquals(1, grStatsborgerskapEtterBrexit.size)
         assertEquals(Medlemskap.TREDJELANDSBORGER, grStatsborgerskapEtterBrexit.single().medlemskap)
-        assertTrue(grStatsborgerskapUtenPeriode.single().gjeldendeNå())
+        assertTrue(grStatsborgerskapEtterBrexit.single().gjeldendeNå())
+    }
 
+    @Test
+    fun `Skal evaluere britiske statsborgere under Brexit som først EØS, nå tredjelandsborgere`() {
         val statsborgerStorbritanniaMedPeriodeUnderBrexit = Statsborgerskap(
             "GBR",
             gyldigFraOgMed = LocalDate.of(1989, 3, 1),


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8419
Vi prøver å løse at statsborgere fra Storbritannia med periode `(fra=null, til=null)` blir håndtert som EØS-borgere. Ifølge Anna og Birgitte skal disse håndteres som tredjelandsborgere.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Kanskje med å lese testene og se om dere er enige i at de oppfyller behovet fra favrooppgaven, at det ikke er noe jeg har glemt å tenke på. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
