### PR TITLE
Legg på cron-job 18 april som oppdaterer fagsagstatuser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -31,6 +31,12 @@ class FagsakStatusScheduler(val taskRepository: TaskRepositoryWrapper) {
         }
     }
 
+    // Kan fjernes etter 18.04.22 klokka 7.
+    @Scheduled(cron = "0 0 7 18 4 *")
+    fun oppdaterFagsakStatuser18April() {
+        oppdaterFagsakStatuser()
+    }
+
     companion object {
 
         private val logger = LoggerFactory.getLogger(FagsakStatusScheduler::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -31,8 +31,8 @@ class FagsakStatusScheduler(val taskRepository: TaskRepositoryWrapper) {
         }
     }
 
-    // Kan fjernes etter 19.04.22 klokka 7.
-    @Scheduled(cron = "0 0 7 19 4 *")
+    // Kan fjernes etter 08.04.22 klokka 14.30.
+    @Scheduled(cron = "0 30 14 8 4 *")
     fun oppdaterFagsakStatuser18April() {
         oppdaterFagsakStatuser()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -31,8 +31,8 @@ class FagsakStatusScheduler(val taskRepository: TaskRepositoryWrapper) {
         }
     }
 
-    // Kan fjernes etter 18.04.22 klokka 7.
-    @Scheduled(cron = "0 0 7 18 4 *")
+    // Kan fjernes etter 19.04.22 klokka 7.
+    @Scheduled(cron = "0 0 7 19 4 *")
     fun oppdaterFagsakStatuser18April() {
         oppdaterFagsakStatuser()
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi har hatt en bug der tilkjent ytelse har hatt feil tom-datoer. Siden vi bruker dette til å avgjøre om en fagsak er avsluttet eller ikke er det derfor noen fagsaker som står som løpende, men som brude vært avsluttet. Siden bugen vedrørende tilkjent ytelse er rettet opp kjører vi derfor scriptet som avslutter fagsaker 08.04.22 14.30. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Det er viktig at dette skjer før månedsskiftet fordi vi bruker detter til å avgjøre hvem "Autobrev 6 og 18 år" skal sendes ut. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
