### PR TITLE
Bugfix: sammenslåing av utvidet-andeler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -47,7 +47,12 @@ data class UtvidetBarnetrygdGenerator(
 
         val utvidaTidslinje = LocalDateTimeline(datoSegmenter)
 
-        val barnasTidslinjer: List<LocalDateTimeline<List<PeriodeData>>> = andelerBarna
+        val andelerBarnaSlåttSammen = slåSammenPerioderSomIkkeSkulleHaVærtSplittet(
+            andelerTilkjentYtelse = andelerBarna.toMutableList(),
+            skalAndelerSlåsSammen = ::skalBarnasAndelerSlåsSammenForUtvidet
+        )
+
+        val barnasTidslinjer: List<LocalDateTimeline<List<PeriodeData>>> = andelerBarnaSlåttSammen
             .groupBy { it.aktør }
             .map { identMedAndeler ->
                 LocalDateTimeline(
@@ -103,21 +108,18 @@ data class UtvidetBarnetrygdGenerator(
             )
         }
 
-        return slåSammenPerioderSomIkkeSkulleHaVærtSplittet(
-            andelerTilkjentYtelse = utvidetAndeler.toMutableList(),
-            skalAndelerSlåsSammen = ::skalUtvidetAndelerSlåsSammen
-        )
+        return utvidetAndeler
     }
 
     data class PeriodeData(val aktør: Aktør, val rolle: PersonType, val prosent: BigDecimal = BigDecimal.ZERO)
 
-    private fun skalUtvidetAndelerSlåsSammen(
+    private fun skalBarnasAndelerSlåsSammenForUtvidet(
         førsteAndel: AndelTilkjentYtelse,
         nesteAndel: AndelTilkjentYtelse
     ): Boolean =
         førsteAndel.stønadTom.sisteDagIInneværendeMåned()
             .erDagenFør(nesteAndel.stønadFom.førsteDagIInneværendeMåned()) &&
-            førsteAndel.kalkulertUtbetalingsbeløp == nesteAndel.kalkulertUtbetalingsbeløp
+            førsteAndel.prosent == nesteAndel.prosent
 
     private fun kombinerTidslinjer(
         sammenlagtTidslinje: LocalDateTimeline<List<PeriodeData>>,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -451,7 +451,7 @@ internal class UtvidetBarnetrygdTest {
     }
 
     @Test
-    fun `Utvidet andel blir ikke splittet opp hvis det er back2back i månedskifte`() {
+    fun `Utvidet andel blir splittet opp basert på utvidet vilkår-segmenter uavhengig om de henger sammen eller ikke`() {
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =
@@ -531,17 +531,257 @@ internal class UtvidetBarnetrygdTest {
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 
-        assertEquals(2, andeler.size)
+        assertEquals(3, andeler.size)
 
         val andelBarn = andeler[0]
-        val andelUtvidet = andeler[1]
+        val andelUtvidet1 = andeler[1]
+        val andelUtvidet2 = andeler[2]
 
         assertEquals(barnOppfylt.ident, andelBarn.aktør.aktivFødselsnummer())
         assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn.stønadTom)
 
+        assertEquals(søkerOrdinær.ident, andelUtvidet1.aktør.aktivFødselsnummer())
+        assertEquals(søkerOrdinær.ident, andelUtvidet2.aktør.aktivFødselsnummer())
+        assertEquals(søkerOrdinær.fom.plusMonths(1).toYearMonth(), andelUtvidet1.stønadFom)
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelUtvidet2.stønadFom)
+        assertEquals(b2bTom.toYearMonth().plusMonths(1), andelUtvidet1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(søkerOrdinær.tom.toYearMonth(), andelUtvidet2.stønadTom)
+    }
+
+    @Test
+    fun `Utvidet andel blir ikke splittet opp på endring i barnas vilkår som ikke er delt bosted`() {
+        val søkerOrdinær =
+            OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
+        val barnOppfylt =
+            OppfyltPeriode(fom = søkerOrdinær.fom, tom = søkerOrdinær.tom, rolle = PersonType.BARN)
+
+        val behandling = lagBehandling()
+        val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val søkerResultat = PersonResultat(
+            vilkårsvurdering = vilkårsvurdering,
+            aktør = søkerOrdinær.aktør
+        )
+            .apply {
+                vilkårResultater.addAll(
+                    oppfylteVilkårFor(
+                        personResultat = this,
+                        vilkårOppfyltFom = søkerOrdinær.fom,
+                        vilkårOppfyltTom = søkerOrdinær.tom,
+                        personType = PersonType.SØKER
+                    )
+                )
+                vilkårResultater.addAll(
+                    setOf(
+                        VilkårResultat(
+                            personResultat = this,
+                            vilkårType = Vilkår.UTVIDET_BARNETRYGD,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = søkerOrdinær.fom,
+                            periodeTom = søkerOrdinær.tom,
+                            begrunnelse = "",
+                            behandlingId = this.vilkårsvurdering.behandling.id,
+                            utdypendeVilkårsvurderinger = emptyList()
+                        )
+                    )
+                )
+            }
+
+        val b2bTom = LocalDate.of(2020, 2, 29)
+        val b2bFom = LocalDate.of(2020, 3, 1)
+
+        val barnResultater =
+            PersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = barnOppfylt.aktør
+            )
+                .apply {
+                    vilkårResultater.addAll(
+                        oppfylteVilkårFor(
+                            personResultat = this,
+                            vilkårOppfyltFom = barnOppfylt.fom,
+                            vilkårOppfyltTom = barnOppfylt.tom,
+                            personType = PersonType.BARN,
+                            erDeltBosted = barnOppfylt.erDeltBosted
+                        )
+                    )
+                    vilkårResultater.addAll(
+                        setOf(
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = søkerOrdinær.fom,
+                                periodeTom = b2bTom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = emptyList()
+                            ),
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = b2bFom,
+                                periodeTom = søkerOrdinær.tom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = emptyList()
+                            )
+                        )
+                    )
+                }
+        vilkårsvurdering.apply { personResultater = listOf(søkerResultat, barnResultater).toSet() }
+
+        val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
+            .apply {
+                personer.addAll(listOf(søkerOrdinær, barnOppfylt).lagGrunnlagPersoner(this))
+            }
+
+        val andeler = TilkjentYtelseUtils.beregnTilkjentYtelse(
+            vilkårsvurdering = vilkårsvurdering,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            behandling = behandling
+        )
+            .andelerTilkjentYtelse.toList().sortedBy { it.type }
+
+        assertEquals(3, andeler.size)
+
+        val andelBarn1 = andeler[0]
+        val andelBarn2 = andeler[1]
+        val andelUtvidet = andeler[2]
+
+        assertEquals(barnOppfylt.ident, andelBarn1.aktør.aktivFødselsnummer())
+        assertEquals(barnOppfylt.fom.plusMonths(1).toYearMonth(), andelBarn1.stønadFom)
+        assertEquals(b2bTom.plusMonths(1).toYearMonth(), andelBarn1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelBarn2.stønadFom)
+        assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn2.stønadTom)
+
         assertEquals(søkerOrdinær.ident, andelUtvidet.aktør.aktivFødselsnummer())
         assertEquals(søkerOrdinær.fom.plusMonths(1).toYearMonth(), andelUtvidet.stønadFom)
         assertEquals(søkerOrdinær.tom.toYearMonth(), andelUtvidet.stønadTom)
+    }
+
+    @Test
+    fun `Utvidet andel blir splittet opp på endring i barnas vilkår som er delt bosted`() {
+        val søkerOrdinær =
+            OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
+        val barnOppfylt =
+            OppfyltPeriode(fom = søkerOrdinær.fom, tom = søkerOrdinær.tom, rolle = PersonType.BARN)
+
+        val behandling = lagBehandling()
+        val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val søkerResultat = PersonResultat(
+            vilkårsvurdering = vilkårsvurdering,
+            aktør = søkerOrdinær.aktør
+        )
+            .apply {
+                vilkårResultater.addAll(
+                    oppfylteVilkårFor(
+                        personResultat = this,
+                        vilkårOppfyltFom = søkerOrdinær.fom,
+                        vilkårOppfyltTom = søkerOrdinær.tom,
+                        personType = PersonType.SØKER
+                    )
+                )
+                vilkårResultater.addAll(
+                    setOf(
+                        VilkårResultat(
+                            personResultat = this,
+                            vilkårType = Vilkår.UTVIDET_BARNETRYGD,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = søkerOrdinær.fom,
+                            periodeTom = søkerOrdinær.tom,
+                            begrunnelse = "",
+                            behandlingId = this.vilkårsvurdering.behandling.id,
+                            utdypendeVilkårsvurderinger = emptyList()
+                        )
+                    )
+                )
+            }
+
+        val b2bTom = LocalDate.of(2020, 2, 29)
+        val b2bFom = LocalDate.of(2020, 3, 1)
+
+        val barnResultater =
+            PersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = barnOppfylt.aktør
+            )
+                .apply {
+                    vilkårResultater.addAll(
+                        oppfylteVilkårFor(
+                            personResultat = this,
+                            vilkårOppfyltFom = barnOppfylt.fom,
+                            vilkårOppfyltTom = barnOppfylt.tom,
+                            personType = PersonType.BARN,
+                            erDeltBosted = barnOppfylt.erDeltBosted
+                        )
+                    )
+                    vilkårResultater.removeIf { it.vilkårType == Vilkår.BOR_MED_SØKER }
+                    vilkårResultater.addAll(
+                        setOf(
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = søkerOrdinær.fom,
+                                periodeTom = b2bTom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.DELT_BOSTED)
+                            ),
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = b2bFom,
+                                periodeTom = søkerOrdinær.tom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = emptyList()
+                            )
+                        )
+                    )
+                }
+        vilkårsvurdering.apply { personResultater = listOf(søkerResultat, barnResultater).toSet() }
+
+        val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
+            .apply {
+                personer.addAll(listOf(søkerOrdinær, barnOppfylt).lagGrunnlagPersoner(this))
+            }
+
+        val andeler = TilkjentYtelseUtils.beregnTilkjentYtelse(
+            vilkårsvurdering = vilkårsvurdering,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            behandling = behandling
+        )
+            .andelerTilkjentYtelse.toList().sortedBy { it.type }
+
+        assertEquals(4, andeler.size)
+
+        val andelBarn1 = andeler[0]
+        val andelBarn2 = andeler[1]
+        val andelUtvidet1 = andeler[2]
+        val andelUtvidet2 = andeler[3]
+
+        assertEquals(barnOppfylt.ident, andelBarn1.aktør.aktivFødselsnummer())
+        assertEquals(barnOppfylt.fom.plusMonths(1).toYearMonth(), andelBarn1.stønadFom)
+        assertEquals(b2bTom.plusMonths(1).toYearMonth(), andelBarn1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(BigDecimal(50), andelBarn1.prosent)
+
+        assertEquals(barnOppfylt.ident, andelBarn2.aktør.aktivFødselsnummer())
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelBarn2.stønadFom)
+        assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn2.stønadTom)
+        assertEquals(BigDecimal(100), andelBarn2.prosent)
+
+        assertEquals(søkerOrdinær.ident, andelUtvidet1.aktør.aktivFødselsnummer())
+        assertEquals(søkerOrdinær.fom.plusMonths(1).toYearMonth(), andelUtvidet1.stønadFom)
+        assertEquals(b2bTom.plusMonths(1).toYearMonth(), andelUtvidet1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(BigDecimal(50), andelUtvidet1.prosent)
+
+        assertEquals(søkerOrdinær.ident, andelUtvidet2.aktør.aktivFødselsnummer())
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelUtvidet2.stønadFom)
+        assertEquals(søkerOrdinær.tom.toYearMonth(), andelUtvidet2.stønadTom)
+        assertEquals(BigDecimal(100), andelUtvidet2.prosent)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -451,7 +451,7 @@ internal class UtvidetBarnetrygdTest {
     }
 
     @Test
-    fun `Utvidet andel blir splittet opp basert på utvidet vilkår-segmenter uavhengig om de henger sammen eller ikke`() {
+    fun `Utvidet andel blir splittet opp på endring i utvidet vilkåret`() {
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8456

Slå sammen periodene til barna som har samme prosent og er etterfølgende.

Før slo vi sammen utvidet-andelene til søker som hadde samme beløp og var etterfølgende. Dette blir feil da vi ønsker å reflektere splittene i utvidet-vilkåret. Slår derfor istedet sammen barnas andeler før disse "merges" med utvidet periodene. Dette gjør at vi kun får splitter på utvidet-andelene hvis det er endring i utvidet vilkåret, eller endring i prosent på barnas andeler (delt bosted).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Må testes godt.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
