### PR TITLE
Ikke migrer hvis det alt er en migreringsbehandling for denne dagen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -268,6 +268,12 @@ class MigreringService(
                     }
                 }
             } ?: kastOgTellMigreringsFeil(MigreringsfeilType.AKTIV_BEHANDLING)
+
+            // Ikke migrer hvis det er en annen dagsaktuell migreringsebehandling. Infotrygd leser ikke fra feed før om kvelden.
+            // For å forhindre dobbelt migrerte saker, som at saksbehandler migrer og henlegger sak samme dag, og den automatisk migreres senere
+            if (behandlinger.any { it.type == BehandlingType.MIGRERING_FRA_INFOTRYGD && it.opprettetTidspunkt.toLocalDate() == LocalDate.now() }) {
+                kastOgTellMigreringsFeil(MigreringsfeilType.KUN_ETT_MIGRERINGFORSØK_PER_DAG)
+            }
         }
     }
 
@@ -476,6 +482,7 @@ enum class MigreringsfeilType(val beskrivelse: String) {
     UKJENT("Ukjent migreringsfeil"),
     ÅPEN_SAK_INFOTRYGD("Bruker har åpen behandling i Infotrygd"),
     INSTITUSJON("Midlertidig ignoerert fordi det er en institusjon"),
+    KUN_ETT_MIGRERINGFORSØK_PER_DAG("Migrering allerede påbegynt i dag. Vent minst en dag før man prøver igjen"),
 }
 
 open class KanIkkeMigrereException(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Forhindrer at saksbehandler migrerer en sak og opphører den umiddelbart i ba-sak, og at en maskinell migrering trigges senere på samme sak. Den maskinelle migreringen vil stoppe med KUN_ETT_MIGRERINGFORSØK_PER_DAG feil den dagen. Ved rekjøring neste dag så vil infotrygd ha lest fra fil og avsluttet saken. Siden noen saker flyttes tilbake manuelt, så forhindrer man ikke migrering ved senere dato. Da vil den bli stoppet av at det ikke finnes sak i infotrygd hvis den alt er migrert, eller så kan man migrere.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
