### PR TITLE
Bugfix: Generering av utvidet-andeler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -110,6 +110,7 @@ class FeatureToggleConfig(
         const val FØRSTE_ENDRINGSTIDSPUNKT = "familie-ba-sak.behandling.forste-endringstidspunkt.utgivelse"
         const val ETTERBETALING_3ÅR = "familie-ba-sak.utgivelse.behandling.etterbetaling-3-aar"
         const val NY_DELT_BOSTED_BEGRUNNELSE = "familie-ba-sak.utgivelse.behandling.delt-bosted-begrunnelse-avtaletidspunkt"
+        const val NY_MÅTE_Å_GENERERE_UTVIDET_ANDELER = "familie-ba-sak.utgivelse.behandling.generer-utvidet-andeler"
 
         const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -36,7 +38,8 @@ class BeregningService(
     private val behandlingRepository: BehandlingRepository,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
-    private val småbarnstilleggService: SmåbarnstilleggService
+    private val småbarnstilleggService: SmåbarnstilleggService,
+    private val featureToggleService: FeatureToggleService
 ) {
     fun slettTilkjentYtelseForBehandling(behandlingId: Long) =
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
@@ -164,7 +167,8 @@ class BeregningService(
             .beregnTilkjentYtelse(
                 vilkårsvurdering = vilkårsvurdering,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                behandling = behandling
+                behandling = behandling,
+                skalBrukeNyMåteÅLageUtvidetAndeler = featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_GENERERE_UTVIDET_ANDELER)
             ) { aktørId ->
                 småbarnstilleggService.hentOgLagrePerioderMedFullOvergangsstønad(
                     aktør = aktørId,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -40,7 +40,8 @@ object TilkjentYtelseUtils {
         vilkårsvurdering: Vilkårsvurdering,
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         behandling: Behandling,
-        hentPerioderMedFullOvergangsstønad: (aktør: Aktør) -> List<InternPeriodeOvergangsstønad> = { _ -> emptyList() }
+        skalBrukeNyMåteÅLageUtvidetAndeler: Boolean = true,
+        hentPerioderMedFullOvergangsstønad: (aktør: Aktør) -> List<InternPeriodeOvergangsstønad> = { _ -> emptyList() },
     ): TilkjentYtelse {
         val identBarnMap = personopplysningGrunnlag.barna.associateBy { it.aktør.aktørId }
 
@@ -91,7 +92,8 @@ object TilkjentYtelseUtils {
 
         val andelerTilkjentYtelseSøker = UtvidetBarnetrygdGenerator(
             behandlingId = vilkårsvurdering.behandling.id,
-            tilkjentYtelse = tilkjentYtelse
+            tilkjentYtelse = tilkjentYtelse,
+            skalBrukeNyMåteÅLageUtvidetAndeler = skalBrukeNyMåteÅLageUtvidetAndeler
         )
             .lagUtvidetBarnetrygdAndeler(
                 utvidetVilkår = vilkårsvurdering.personResultater

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -255,7 +255,7 @@ object TilkjentYtelseUtils {
             minimum(overlappendePerioderesultatSøker.periodeTom, periodeResultatBarn.periodeTom)
 
         val barnetsPeriodeLøperVidere =
-            if (periodeResultatBarn.periodeTom == null) true else periodeResultatBarn.periodeTom.toYearMonth() > minsteTom.toYearMonth()
+            periodeResultatBarn.periodeTom == null || periodeResultatBarn.periodeTom.toYearMonth() > minsteTom.toYearMonth()
 
         val skalVidereføresEnMånedEkstra =
             innvilgedePeriodeResultatBarna.any { periodeResultat ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -158,39 +158,32 @@ data class UtvidetBarnetrygdGenerator(
 
     private fun slåSammenEtterfølgendeSegmenterMedLikProsent(sammenlagtTidslinjeForBarna: LocalDateTimeline<List<PeriodeData>>): List<LocalDateSegment<List<PeriodeData>>> {
         return sammenlagtTidslinjeForBarna.toSegments()
-            .fold(mutableListOf<LocalDateSegment<List<PeriodeData>>>()) { sammenslåttePerioder, nestePeriode ->
+            .fold(listOf<LocalDateSegment<List<PeriodeData>>>()) { sammenslåttePerioder, nestePeriode ->
                 val sistePeriodeSomErSammenslått = sammenslåttePerioder.lastOrNull()
-                if (sistePeriodeSomErSammenslått?.tom?.toYearMonth() == nestePeriode.fom.forrigeMåned() && sistePeriodeSomErSammenslått.value.maxOf { it.prosent } == nestePeriode.value.maxOf { it.prosent }) {
-                    sammenslåttePerioder.apply {
-                        removeLast()
-                        val prosentForPeriode = sistePeriodeSomErSammenslått.value.maxOf { it.prosent }
-                        add(
-                            LocalDateSegment(
-                                sistePeriodeSomErSammenslått.fom,
-                                nestePeriode.tom,
-                                listOf(
-                                    PeriodeData(
-                                        rolle = PersonType.BARN,
-                                        prosent = prosentForPeriode
-                                    )
-                                )
-                            )
-                        )
-                    }
-                } else sammenslåttePerioder.apply {
-                    add(
-                        LocalDateSegment(
-                            nestePeriode.fom,
-                            nestePeriode.tom,
-                            listOf(
-                                PeriodeData(
-                                    rolle = PersonType.BARN,
-                                    prosent = nestePeriode.value.maxOf { it.prosent }
-                                )
+                val segmenterErEtterfølgendeOgHarSammeProsent = sistePeriodeSomErSammenslått?.tom?.toYearMonth() == nestePeriode.fom.forrigeMåned() && sistePeriodeSomErSammenslått.value.maxOf { it.prosent } == nestePeriode.value.maxOf { it.prosent }
+                if (sistePeriodeSomErSammenslått != null && segmenterErEtterfølgendeOgHarSammeProsent) {
+                    val prosentForPeriode = sistePeriodeSomErSammenslått.value.maxOf { it.prosent }
+                    sammenslåttePerioder.dropLast(1) + LocalDateSegment(
+                        sistePeriodeSomErSammenslått.fom,
+                        nestePeriode.tom,
+                        listOf(
+                            PeriodeData(
+                                rolle = PersonType.BARN,
+                                prosent = prosentForPeriode
                             )
                         )
                     )
-                }
+                } else
+                    sammenslåttePerioder + LocalDateSegment(
+                        nestePeriode.fom,
+                        nestePeriode.tom,
+                        listOf(
+                            PeriodeData(
+                                rolle = PersonType.BARN,
+                                prosent = nestePeriode.value.maxOf { it.prosent }
+                            )
+                        )
+                    )
             }.toList()
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -86,7 +86,7 @@ data class UtvidetBarnetrygdGenerator(
     }
 
     private fun utledTidslinjeForBarna(andelerBarna: List<AndelTilkjentYtelse>): LocalDateTimeline<List<PeriodeData>> {
-        val barnasTidslinjer: List<LocalDateTimeline<List<PeriodeData>>> = andelerBarna
+        val barnasTidslinjer = andelerBarna
             .groupBy { it.aktør }
             .map { identMedAndeler ->
                 LocalDateTimeline(
@@ -109,9 +109,10 @@ data class UtvidetBarnetrygdGenerator(
             (kombinerTidslinjer(sammenlagt, neste))
         }
 
-        val barnasSegmenterSlåttSammenPåProsent =
+        val barnasSegmenterSlåttSammenHvisLikProsent =
             slåSammenEtterfølgendeSegmenterMedLikProsent(sammenlagtTidslinjeForBarna)
-        return LocalDateTimeline(barnasSegmenterSlåttSammenPåProsent)
+
+        return LocalDateTimeline(barnasSegmenterSlåttSammenHvisLikProsent)
     }
 
     private fun slåSammenEtterfølgendeSegmenterMedLikProsent(sammenlagtTidslinjeForBarna: LocalDateTimeline<List<PeriodeData>>) =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -116,6 +116,8 @@ data class UtvidetBarnetrygdGenerator(
         )
     }
 
+    data class PeriodeData(val rolle: PersonType, val prosent: BigDecimal = BigDecimal.ZERO)
+
     private fun skalUtvidetAndelerSlåsSammen(
         førsteAndel: AndelTilkjentYtelse,
         nesteAndel: AndelTilkjentYtelse
@@ -190,8 +192,6 @@ data class UtvidetBarnetrygdGenerator(
                     )
                 }
             }.toList()
-
-    data class PeriodeData(val rolle: PersonType, val prosent: BigDecimal = BigDecimal.ZERO)
 
     private fun kombinerTidslinjer(
         sammenlagtTidslinje: LocalDateTimeline<List<PeriodeData>>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.Utils.avrundetHeltallAvProsent
 import no.nav.familie.ba.sak.common.erBack2BackIMånedsskifte
+import no.nav.familie.ba.sak.common.erDagenFør
 import no.nav.familie.ba.sak.common.forrigeMåned
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
@@ -12,6 +13,7 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseUtils.slåSammenPerioderSomIkkeSkulleHaVærtSplittet
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -26,7 +28,8 @@ import java.time.LocalDate
 
 data class UtvidetBarnetrygdGenerator(
     val behandlingId: Long,
-    val tilkjentYtelse: TilkjentYtelse
+    val tilkjentYtelse: TilkjentYtelse,
+    val skalBrukeNyMåteÅLageUtvidetAndeler: Boolean = true
 ) {
 
     fun lagUtvidetBarnetrygdAndeler(
@@ -45,10 +48,35 @@ data class UtvidetBarnetrygdGenerator(
 
         val utvidaTidslinje = LocalDateTimeline(datoSegmenter)
 
-        val barnasTidslinje =
-            utledTidslinjeForBarna(andelerBarna)
+        val sammenslåttTidslinje = if (skalBrukeNyMåteÅLageUtvidetAndeler) {
+            val barnasTidslinje =
+                utledTidslinjeForBarna(andelerBarna)
 
-        val sammenslåttTidslinje = kombinerTidslinjer(utvidaTidslinje, barnasTidslinje)
+            kombinerTidslinjer(utvidaTidslinje, barnasTidslinje)
+        } else {
+            val barnasTidslinjer: List<LocalDateTimeline<List<PeriodeData>>> = andelerBarna
+                .groupBy { it.aktør }
+                .map { identMedAndeler ->
+                    LocalDateTimeline(
+                        identMedAndeler.value.map {
+                            LocalDateSegment(
+                                it.stønadFom.førsteDagIInneværendeMåned(),
+                                it.stønadTom.sisteDagIInneværendeMåned(),
+                                listOf(
+                                    PeriodeData(
+                                        rolle = PersonType.BARN,
+                                        prosent = it.prosent
+                                    )
+                                )
+                            )
+                        }
+                    )
+                }
+
+            barnasTidslinjer.fold(utvidaTidslinje) { sammenlagt, neste ->
+                (kombinerTidslinjer(sammenlagt, neste))
+            }
+        }
 
         val utvidetAndeler = sammenslåttTidslinje.toSegments()
             .filter { segment -> segment.value.any { it.rolle == PersonType.BARN } && segment.value.any { it.rolle == PersonType.SØKER } }
@@ -82,8 +110,19 @@ data class UtvidetBarnetrygdGenerator(
             )
         }
 
-        return utvidetAndeler
+        return if (skalBrukeNyMåteÅLageUtvidetAndeler) utvidetAndeler else return slåSammenPerioderSomIkkeSkulleHaVærtSplittet(
+            andelerTilkjentYtelse = utvidetAndeler.toMutableList(),
+            skalAndelerSlåsSammen = ::skalUtvidetAndelerSlåsSammen
+        )
     }
+
+    private fun skalUtvidetAndelerSlåsSammen(
+        førsteAndel: AndelTilkjentYtelse,
+        nesteAndel: AndelTilkjentYtelse
+    ): Boolean =
+        førsteAndel.stønadTom.sisteDagIInneværendeMåned()
+            .erDagenFør(nesteAndel.stønadFom.førsteDagIInneværendeMåned()) &&
+            førsteAndel.kalkulertUtbetalingsbeløp == nesteAndel.kalkulertUtbetalingsbeløp
 
     private fun utledTidslinjeForBarna(andelerBarna: List<AndelTilkjentYtelse>): LocalDateTimeline<List<PeriodeData>> {
         val barnasTidslinjer = andelerBarna

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -156,8 +156,8 @@ data class UtvidetBarnetrygdGenerator(
         return LocalDateTimeline(barnasSegmenterSlåttSammenHvisLikProsent)
     }
 
-    private fun slåSammenEtterfølgendeSegmenterMedLikProsent(sammenlagtTidslinjeForBarna: LocalDateTimeline<List<PeriodeData>>) =
-        sammenlagtTidslinjeForBarna.toSegments()
+    private fun slåSammenEtterfølgendeSegmenterMedLikProsent(sammenlagtTidslinjeForBarna: LocalDateTimeline<List<PeriodeData>>): List<LocalDateSegment<List<PeriodeData>>> {
+        return sammenlagtTidslinjeForBarna.toSegments()
             .fold(mutableListOf<LocalDateSegment<List<PeriodeData>>>()) { sammenslåttePerioder, nestePeriode ->
                 val sistePeriodeSomErSammenslått = sammenslåttePerioder.lastOrNull()
                 if (sistePeriodeSomErSammenslått?.tom?.toYearMonth() == nestePeriode.fom.forrigeMåned() && sistePeriodeSomErSammenslått.value.maxOf { it.prosent } == nestePeriode.value.maxOf { it.prosent }) {
@@ -192,6 +192,7 @@ data class UtvidetBarnetrygdGenerator(
                     )
                 }
             }.toList()
+    }
 
     private fun kombinerTidslinjer(
         sammenlagtTidslinje: LocalDateTimeline<List<PeriodeData>>,

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -76,7 +76,8 @@ class BeregningServiceTest {
             behandlingRepository,
             personopplysningGrunnlagRepository,
             endretUtbetalingAndelRepository,
-            småbarnstilleggService
+            småbarnstilleggService,
+            featureToggleService
         )
 
         every { tilkjentYtelseRepository.slettTilkjentYtelseFor(any()) } just Runs

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -451,15 +451,13 @@ internal class UtvidetBarnetrygdTest {
     }
 
     @Test
-    fun `Utvidet andel blir ikke splittet opp hvis det er back2back i månedskifte`() {
+    fun `Utvidet andel blir splittet opp på endring i utvidet vilkåret`() {
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =
             OppfyltPeriode(fom = søkerOrdinær.fom, tom = søkerOrdinær.tom, rolle = PersonType.BARN)
-
         val b2bTom = LocalDate.of(2020, 2, 29)
         val b2bFom = LocalDate.of(2020, 3, 1)
-
         val behandling = lagBehandling()
         val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
         val søkerResultat = PersonResultat(
@@ -500,7 +498,6 @@ internal class UtvidetBarnetrygdTest {
                     )
                 )
             }
-
         val barnResultater =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -518,6 +515,116 @@ internal class UtvidetBarnetrygdTest {
                     )
                 }
         vilkårsvurdering.apply { personResultater = listOf(søkerResultat, barnResultater).toSet() }
+        val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
+            .apply {
+                personer.addAll(listOf(søkerOrdinær, barnOppfylt).lagGrunnlagPersoner(this))
+            }
+        val andeler = TilkjentYtelseUtils.beregnTilkjentYtelse(
+            vilkårsvurdering = vilkårsvurdering,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            behandling = behandling
+        )
+            .andelerTilkjentYtelse.toList().sortedBy { it.type }
+
+        assertEquals(3, andeler.size)
+
+        val andelBarn = andeler[0]
+        val andelUtvidet1 = andeler[1]
+        val andelUtvidet2 = andeler[2]
+
+        assertEquals(barnOppfylt.ident, andelBarn.aktør.aktivFødselsnummer())
+        assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn.stønadTom)
+
+        assertEquals(søkerOrdinær.ident, andelUtvidet1.aktør.aktivFødselsnummer())
+        assertEquals(søkerOrdinær.ident, andelUtvidet2.aktør.aktivFødselsnummer())
+        assertEquals(søkerOrdinær.fom.plusMonths(1).toYearMonth(), andelUtvidet1.stønadFom)
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelUtvidet2.stønadFom)
+        assertEquals(b2bTom.toYearMonth().plusMonths(1), andelUtvidet1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(søkerOrdinær.tom.toYearMonth(), andelUtvidet2.stønadTom)
+    }
+
+    @Test
+    fun `Utvidet andel blir ikke splittet opp på endring i barnas vilkår som ikke er delt bosted`() {
+        val søkerOrdinær =
+            OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
+        val barnOppfylt =
+            OppfyltPeriode(fom = søkerOrdinær.fom, tom = søkerOrdinær.tom, rolle = PersonType.BARN)
+
+        val behandling = lagBehandling()
+        val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val søkerResultat = PersonResultat(
+            vilkårsvurdering = vilkårsvurdering,
+            aktør = søkerOrdinær.aktør
+        )
+            .apply {
+                vilkårResultater.addAll(
+                    oppfylteVilkårFor(
+                        personResultat = this,
+                        vilkårOppfyltFom = søkerOrdinær.fom,
+                        vilkårOppfyltTom = søkerOrdinær.tom,
+                        personType = PersonType.SØKER
+                    )
+                )
+                vilkårResultater.addAll(
+                    setOf(
+                        VilkårResultat(
+                            personResultat = this,
+                            vilkårType = Vilkår.UTVIDET_BARNETRYGD,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = søkerOrdinær.fom,
+                            periodeTom = søkerOrdinær.tom,
+                            begrunnelse = "",
+                            behandlingId = this.vilkårsvurdering.behandling.id,
+                            utdypendeVilkårsvurderinger = emptyList()
+                        )
+                    )
+                )
+            }
+
+        val b2bTom = LocalDate.of(2020, 2, 29)
+        val b2bFom = LocalDate.of(2020, 3, 1)
+
+        val barnResultater =
+            PersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = barnOppfylt.aktør
+            )
+                .apply {
+                    vilkårResultater.addAll(
+                        oppfylteVilkårFor(
+                            personResultat = this,
+                            vilkårOppfyltFom = barnOppfylt.fom,
+                            vilkårOppfyltTom = barnOppfylt.tom,
+                            personType = PersonType.BARN,
+                            erDeltBosted = barnOppfylt.erDeltBosted
+                        )
+                    )
+                    vilkårResultater.addAll(
+                        setOf(
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = søkerOrdinær.fom,
+                                periodeTom = b2bTom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = emptyList()
+                            ),
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = b2bFom,
+                                periodeTom = søkerOrdinær.tom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = emptyList()
+                            )
+                        )
+                    )
+                }
+        vilkårsvurdering.apply { personResultater = listOf(søkerResultat, barnResultater).toSet() }
 
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
             .apply {
@@ -531,17 +638,145 @@ internal class UtvidetBarnetrygdTest {
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 
-        assertEquals(2, andeler.size)
+        assertEquals(3, andeler.size)
 
-        val andelBarn = andeler[0]
-        val andelUtvidet = andeler[1]
+        val andelBarn1 = andeler[0]
+        val andelBarn2 = andeler[1]
+        val andelUtvidet = andeler[2]
 
-        assertEquals(barnOppfylt.ident, andelBarn.aktør.aktivFødselsnummer())
-        assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn.stønadTom)
+        assertEquals(barnOppfylt.ident, andelBarn1.aktør.aktivFødselsnummer())
+        assertEquals(barnOppfylt.fom.plusMonths(1).toYearMonth(), andelBarn1.stønadFom)
+        assertEquals(b2bTom.plusMonths(1).toYearMonth(), andelBarn1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelBarn2.stønadFom)
+        assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn2.stønadTom)
 
         assertEquals(søkerOrdinær.ident, andelUtvidet.aktør.aktivFødselsnummer())
         assertEquals(søkerOrdinær.fom.plusMonths(1).toYearMonth(), andelUtvidet.stønadFom)
         assertEquals(søkerOrdinær.tom.toYearMonth(), andelUtvidet.stønadTom)
+    }
+
+    @Test
+    fun `Utvidet andel blir splittet opp på endring i barnas vilkår som er delt bosted`() {
+        val søkerOrdinær =
+            OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
+        val barnOppfylt =
+            OppfyltPeriode(fom = søkerOrdinær.fom, tom = søkerOrdinær.tom, rolle = PersonType.BARN)
+
+        val behandling = lagBehandling()
+        val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val søkerResultat = PersonResultat(
+            vilkårsvurdering = vilkårsvurdering,
+            aktør = søkerOrdinær.aktør
+        )
+            .apply {
+                vilkårResultater.addAll(
+                    oppfylteVilkårFor(
+                        personResultat = this,
+                        vilkårOppfyltFom = søkerOrdinær.fom,
+                        vilkårOppfyltTom = søkerOrdinær.tom,
+                        personType = PersonType.SØKER
+                    )
+                )
+                vilkårResultater.addAll(
+                    setOf(
+                        VilkårResultat(
+                            personResultat = this,
+                            vilkårType = Vilkår.UTVIDET_BARNETRYGD,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = søkerOrdinær.fom,
+                            periodeTom = søkerOrdinær.tom,
+                            begrunnelse = "",
+                            behandlingId = this.vilkårsvurdering.behandling.id,
+                            utdypendeVilkårsvurderinger = emptyList()
+                        )
+                    )
+                )
+            }
+
+        val b2bTom = LocalDate.of(2020, 2, 29)
+        val b2bFom = LocalDate.of(2020, 3, 1)
+
+        val barnResultater =
+            PersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = barnOppfylt.aktør
+            )
+                .apply {
+                    vilkårResultater.addAll(
+                        oppfylteVilkårFor(
+                            personResultat = this,
+                            vilkårOppfyltFom = barnOppfylt.fom,
+                            vilkårOppfyltTom = barnOppfylt.tom,
+                            personType = PersonType.BARN,
+                            erDeltBosted = barnOppfylt.erDeltBosted
+                        )
+                    )
+                    vilkårResultater.removeIf { it.vilkårType == Vilkår.BOR_MED_SØKER }
+                    vilkårResultater.addAll(
+                        setOf(
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = søkerOrdinær.fom,
+                                periodeTom = b2bTom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.DELT_BOSTED)
+                            ),
+                            VilkårResultat(
+                                personResultat = this,
+                                vilkårType = Vilkår.BOR_MED_SØKER,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = b2bFom,
+                                periodeTom = søkerOrdinær.tom,
+                                begrunnelse = "",
+                                behandlingId = this.vilkårsvurdering.behandling.id,
+                                utdypendeVilkårsvurderinger = emptyList()
+                            )
+                        )
+                    )
+                }
+        vilkårsvurdering.apply { personResultater = listOf(søkerResultat, barnResultater).toSet() }
+
+        val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
+            .apply {
+                personer.addAll(listOf(søkerOrdinær, barnOppfylt).lagGrunnlagPersoner(this))
+            }
+
+        val andeler = TilkjentYtelseUtils.beregnTilkjentYtelse(
+            vilkårsvurdering = vilkårsvurdering,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            behandling = behandling
+        )
+            .andelerTilkjentYtelse.toList().sortedBy { it.type }
+
+        assertEquals(4, andeler.size)
+
+        val andelBarn1 = andeler[0]
+        val andelBarn2 = andeler[1]
+        val andelUtvidet1 = andeler[2]
+        val andelUtvidet2 = andeler[3]
+
+        assertEquals(barnOppfylt.ident, andelBarn1.aktør.aktivFødselsnummer())
+        assertEquals(barnOppfylt.fom.plusMonths(1).toYearMonth(), andelBarn1.stønadFom)
+        assertEquals(b2bTom.plusMonths(1).toYearMonth(), andelBarn1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(BigDecimal(50), andelBarn1.prosent)
+
+        assertEquals(barnOppfylt.ident, andelBarn2.aktør.aktivFødselsnummer())
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelBarn2.stønadFom)
+        assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn2.stønadTom)
+        assertEquals(BigDecimal(100), andelBarn2.prosent)
+
+        assertEquals(søkerOrdinær.ident, andelUtvidet1.aktør.aktivFødselsnummer())
+        assertEquals(søkerOrdinær.fom.plusMonths(1).toYearMonth(), andelUtvidet1.stønadFom)
+        assertEquals(b2bTom.plusMonths(1).toYearMonth(), andelUtvidet1.stønadTom) // Legger på 1mnd pga back2back
+        assertEquals(BigDecimal(50), andelUtvidet1.prosent)
+
+        assertEquals(søkerOrdinær.ident, andelUtvidet2.aktør.aktivFødselsnummer())
+        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelUtvidet2.stønadFom)
+        assertEquals(søkerOrdinær.tom.toYearMonth(), andelUtvidet2.stønadTom)
+        assertEquals(BigDecimal(100), andelUtvidet2.prosent)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -648,7 +648,6 @@ internal class UtvidetBarnetrygdTest {
         assertThrows<FunksjonellFeil> {
             utvidetVilkårResultat.tilDatoSegment(
                 utvidetVilkår = listOf(utvidetVilkårResultat),
-                søkerAktør = randomAktørId()
             )
         }
     }
@@ -660,7 +659,6 @@ internal class UtvidetBarnetrygdTest {
         assertDoesNotThrow {
             utvidetVilkårResultat.tilDatoSegment(
                 utvidetVilkår = listOf(utvidetVilkårResultat, lagVilkårResultat(vilkårType = Vilkår.UTVIDET_BARNETRYGD, periodeFom = LocalDate.of(2022, 3, 1), periodeTom = null)),
-                søkerAktør = randomAktørId()
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Forsøk nr. 2 på denne: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8456

Kombinere barnas andeler til 1 tidslinje som kun er splittet ved ulik prosent før man kombinerer barnas andeler med utvidet-tidslinjen.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Påvirker alle utvidet-saker, så må testes nøye.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [x] Nei
Kan godt gå gjennom muntlig hvis det er ønskelig!