### PR TITLE
Bugfix: Unngå unødvendig error-logging 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -76,7 +76,7 @@ data class RestSanityBegrunnelse(
             },
             hjemler = hjemler ?: emptyList(),
             endretUtbetalingsperiodeDeltBostedUtbetalingTrigger =
-            finnEnumverdi(endretUtbetalingsperiodeDeltBostedUtbetalingTrigger ?: "", EndretUtbetalingsperiodeDeltBostedTriggere.values(), apiNavn),
+            if (endretUtbetalingsperiodeDeltBostedUtbetalingTrigger != null) finnEnumverdi(endretUtbetalingsperiodeDeltBostedUtbetalingTrigger, EndretUtbetalingsperiodeDeltBostedTriggere.values(), apiNavn) else null,
             endretUtbetalingsperiodeTriggere = endretUtbetalingsperiodeTriggere?.mapNotNull {
                 finnEnumverdi(it, EndretUtbetalingsperiodeTrigger.values(), apiNavn)
             },


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fikse alle feilene i loggene som ligner på denne `på begrunnelsen innvilgetEnighetOmAtAvtalenOmDeltBostedErOpphort er ikke blant verdiene til enumen EndretUtbetalingsperiodeDeltBostedTriggere[]`.

Har ikke ført til feil for saksbehandler, men fyller opp loggene våre med error-logging som ikke skal være der.

Løsningen er å ikke prøve å map til enum hvis verdien fra sanity er null. Det er funksjonen `finnEnumverdi` som logger error hvis stringen ikke finnes blandt enumverdiene man prøver å mappe til. Det vil alltid skje når man sender inn tom streng som jeg hadde gjort i utgangspunktet. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ganske triviell endring.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
