### PR TITLE
Bugfix: Splitt utvidet-andeler når det er satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -124,10 +124,10 @@ data class UtvidetBarnetrygdGenerator(
             error("Finner ikke sats for periode fom=${segment.fom}, tom=${segment.tom}")
         }
 
-        return ordinæreSatserForPeriode.map { satsperiode ->
-            val prosentForPeriode =
-                segment.value.maxByOrNull { data -> data.prosent }?.prosent ?: error("Finner ikke prosent")
+        val prosentForPeriode =
+            segment.value.maxByOrNull { data -> data.prosent }?.prosent ?: error("Finner ikke prosent for periode fom=${segment.fom}, tom=${segment.tom}")
 
+        return ordinæreSatserForPeriode.map { satsperiode ->
             AndelTilkjentYtelse(
                 behandlingId = behandlingId,
                 tilkjentYtelse = tilkjentYtelse,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til denne oppgaven på favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8456

Påbygg på denne PRen: https://github.com/navikt/familie-ba-sak/pull/2347

Etter de nye endringene (se PR over) ble ikke utvidet-andeler splittet opp ved satsendring. Denne PRen sørger for at vi deler opp utvidet-andeler ved satsendring. Det har kun vært 1 satsendring som har påvirket utvidet barnetrygd tidligere, og den var i 2019, så vi oppdaget ikke at dette var en mangel før koden fikk levd litt i prod. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nop.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan gå gjennom muntlig hvis noen ønsker det 🦺 
