### PR TITLE
Forenkler vilkårsvurdering-dag-tidslinje ved å fjerne tilfeldig satte grenseverdier

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/Tidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/Tidslinjer.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.eøs.tidslinjer
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -28,9 +27,7 @@ class Tidslinjer(
     private val barna: List<Aktør> = personopplysningGrunnlag.barna.map { it.aktør }
     private val søker: Aktør = personopplysningGrunnlag.søker.aktør
 
-    val søkersFødselsdato = personopplysningGrunnlag.søker.fødselsdato
-    val yngsteBarnFødselsdato = personopplysningGrunnlag.yngsteBarnSinFødselsdato
-    val barnOgFødselsdatoer = personopplysningGrunnlag.barna.associate { it.aktør to it.fødselsdato }
+    internal val barnOgFødselsdatoer = personopplysningGrunnlag.barna.associate { it.aktør to it.fødselsdato }
 
     private val aktørTilPersonResultater =
         vilkårsvurdering.personResultater.associateBy { it.aktør }
@@ -39,21 +36,7 @@ class Tidslinjer(
         .entries.associate { (aktør, personResultat) ->
             aktør to personResultat.vilkårResultater.groupBy { it.vilkårType }
                 .map {
-                    if (personResultat.erSøkersResultater()) {
-                        VilkårsresultatDagTidslinje(
-                            vilkårsresultater = it.value,
-                            praktiskTidligsteDato = søkersFødselsdato,
-                            praktiskSenesteDato = yngsteBarnFødselsdato.til18ÅrsVilkårsdato()
-                        )
-                    } else {
-                        val barnFødselsdato =
-                            barnOgFødselsdatoer[aktør] ?: throw Feil("Finner ikke fødselsdato på barn")
-                        VilkårsresultatDagTidslinje(
-                            vilkårsresultater = it.value,
-                            praktiskTidligsteDato = barnFødselsdato,
-                            praktiskSenesteDato = barnFødselsdato.til18ÅrsVilkårsdato()
-                        )
-                    }
+                    VilkårsresultatDagTidslinje(vilkårsresultater = it.value)
                 }
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/VilkårsresultatDagTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/VilkårsresultatDagTidslinje.kt
@@ -4,11 +4,15 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilTidspunktEllerDefault
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.dagForUendeligLengeSiden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.dagMedUendeligLengeTil
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerUendeligLengeSiden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerUendeligLengeTil
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.minsteEllerNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.størsteEllerNull
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import java.time.LocalDate
 
 data class VilkårRegelverkResultat(
     val vilkår: Vilkår,
@@ -17,30 +21,25 @@ data class VilkårRegelverkResultat(
 )
 
 class VilkårsresultatDagTidslinje(
-    private val vilkårsresultater: List<VilkårResultat>,
-    private val praktiskTidligsteDato: LocalDate,
-    private val praktiskSenesteDato: LocalDate
+    private val vilkårsresultater: List<VilkårResultat>
 ) : Tidslinje<VilkårRegelverkResultat, Dag>() {
 
-    override fun fraOgMed() = vilkårsresultater.minOf {
-        it.periodeFom.tilTidspunktEllerDefault { praktiskTidligsteDato }
-    }
+    override fun fraOgMed() = vilkårsresultater.map {
+        it.periodeFom.tilTidspunktEllerUendeligLengeSiden { it.periodeTom }
+    }.minsteEllerNull() ?: dagForUendeligLengeSiden()
 
-    override fun tilOgMed() = vilkårsresultater.maxOf {
-        it.periodeTom.tilTidspunktEllerDefault { praktiskSenesteDato }
-    }
+    override fun tilOgMed() = vilkårsresultater.map {
+        it.periodeTom.tilTidspunktEllerUendeligLengeTil { it.periodeFom }
+    }.størsteEllerNull() ?: dagMedUendeligLengeTil()
 
     override fun lagPerioder(): Collection<Periode<VilkårRegelverkResultat, Dag>> {
-        return vilkårsresultater.map { it.tilPeriode(praktiskTidligsteDato, praktiskSenesteDato) }
+        return vilkårsresultater.map { it.tilPeriode() }
     }
 }
 
-fun VilkårResultat.tilPeriode(
-    praktiskTidligsteDato: LocalDate,
-    praktiskSenesteDato: LocalDate
-): Periode<VilkårRegelverkResultat, Dag> {
-    val fom = periodeFom.tilTidspunktEllerDefault { praktiskTidligsteDato }
-    val tom = periodeTom.tilTidspunktEllerDefault { praktiskSenesteDato }
+fun VilkårResultat.tilPeriode(): Periode<VilkårRegelverkResultat, Dag> {
+    val fom = periodeFom.tilTidspunktEllerUendeligLengeSiden { periodeTom }
+    val tom = periodeTom.tilTidspunktEllerUendeligLengeTil { periodeFom }
     return Periode(
         fom, tom,
         VilkårRegelverkResultat(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tid/DagTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tid/DagTidspunkt.kt
@@ -114,5 +114,23 @@ data class DagTidspunkt internal constructor(
 
     companion object {
         fun nå() = DagTidspunkt(LocalDate.now(), Uendelighet.INGEN)
+
+        internal fun LocalDate?.tilTidspunktEllerUendeligLengeSiden(default: () -> LocalDate?) =
+            this.tilTidspunktEllerUendelig(default, Uendelighet.FORTID)
+
+        internal fun LocalDate?.tilTidspunktEllerUendeligLengeTil(default: () -> LocalDate?) =
+            this.tilTidspunktEllerUendelig(default, Uendelighet.FREMTID)
+
+        private fun LocalDate?.tilTidspunktEllerUendelig(default: () -> LocalDate?, uendelighet: Uendelighet) =
+            this?.let { DagTidspunkt(it, Uendelighet.INGEN) } ?: DagTidspunkt(
+                default() ?: LocalDate.now(),
+                uendelighet
+            )
+
+        fun dagForUendeligLengeSiden(dato: LocalDate = LocalDate.now()) =
+            DagTidspunkt(dato, uendelighet = Uendelighet.FORTID)
+
+        fun dagMedUendeligLengeTil(dato: LocalDate = LocalDate.now()) =
+            DagTidspunkt(dato, uendelighet = Uendelighet.FREMTID)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tid/Tidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tid/Tidspunkt.kt
@@ -118,14 +118,7 @@ fun <T : Tidsenhet> minsteAv(t1: Tidspunkt<T>, t2: Tidspunkt<T>): Tidspunkt<T> =
         minOf(t1, t2)
 
 fun <T : Tidsenhet> Iterable<Tidspunkt<T>>.størsteEllerNull() =
-    this.reduceOrNull { acc, neste ->
-        størsteAv(acc, neste)
-    }
+    this.reduceOrNull { acc, neste -> størsteAv(acc, neste) }
 
 fun <T : Tidsenhet> Iterable<Tidspunkt<T>>.minsteEllerNull() =
     this.reduceOrNull { acc, neste -> minsteAv(acc, neste) }
-
-fun LocalDate?.tilTidspunktEllerDefault(default: () -> LocalDate) =
-    this?.let { DagTidspunkt(this, Uendelighet.INGEN) } ?: DagTidspunkt(default(), Uendelighet.INGEN)
-
-fun YearMonth.tilTidspunkt() = MånedTidspunkt(this, Uendelighet.INGEN)

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/VilkårsresultatMånedTidslinjeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/VilkårsresultatMånedTidslinjeTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.eøs.tidslinjer
 
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.oppfyltVilkår
-import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.eøs.util.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.konkatenerTidslinjer
@@ -10,10 +9,10 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.aug
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.print
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk.EØS_FORORDNINGEN
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk.NASJONALE_REGLER
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOSATT_I_RIKET
@@ -39,7 +38,6 @@ class VilkårsresultatMånedTidslinjeTest {
     fun `Back to back perioder i månedsskiftet gir sammenhengende perioder`() {
         val periodeFom = LocalDate.of(2022, 4, 15)
         val periodeFom2 = LocalDate.of(2022, 7, 1)
-        val senesteDato = periodeFom.til18ÅrsVilkårsdato() // 2040-04-14
         val vilkårsresultatMånedTidslinje = VilkårsresultatDagTidslinje(
             vilkårsresultater = listOf(
                 lagVilkårResultat(
@@ -52,13 +50,11 @@ class VilkårsresultatMånedTidslinjeTest {
                     periodeFom = periodeFom2,
                     periodeTom = null
                 )
-            ),
-            praktiskTidligsteDato = periodeFom,
-            praktiskSenesteDato = senesteDato
-        ).tilVilkårsresultaterMånedTidslinje().also { it.print() }
+            )
+        ).tilVilkårsresultaterMånedTidslinje()
 
         val forventetMånedstidslinje: Tidslinje<VilkårRegelverkResultat, Måned> =
-            (mai(2022)..apr(2040)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET) }
+            (mai(2022)..aug(2022).somUendeligLengeTil()).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET) }
 
         assertEquals(forventetMånedstidslinje, vilkårsresultatMånedTidslinje)
     }
@@ -80,14 +76,14 @@ class VilkårsresultatMånedTidslinjeTest {
         val dagvilkårtidslinje = konkatenerTidslinjer(
             (26.feb(2020)..7.mar(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
             (21.mar(2020)..13.mai(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) },
-        ).also { it.print() }
+        )
 
         val forventetMånedstidslinje = konkatenerTidslinjer(
             mar(2020).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
             (apr(2020)..mai(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) },
-        ).also { it.print() }
+        )
 
-        val faktiskMånedstidslinje = dagvilkårtidslinje.tilVilkårsresultaterMånedTidslinje().also { it.print() }
+        val faktiskMånedstidslinje = dagvilkårtidslinje.tilVilkårsresultaterMånedTidslinje()
         assertEquals(forventetMånedstidslinje, faktiskMånedstidslinje)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Litt mye som kreves av en klient som skal bruke vilkårvurdering-dag-tidslinjen. Verdiene som sendes inn er litt tilfeldig valgt, og burde være unødvendig. Fjerner det og tilpasser tester

_Jeg har ikke skrevet tester fordi:_ De dekkes av tidligere tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
