### PR TITLE
Tillate flere delytelser ved migrering for saker av type utvidet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -314,8 +314,16 @@ class MigreringService(
     }
 
     private fun kastfeilHvisIkkeEnDelytelseIInfotrygd(sak: Sak) {
-        when (sak.stønad!!.delytelse.filter { it.tom == null }.size) {
-            1 -> return
+        when {
+            sak.valg == "OR" && sak.stønad!!.delytelse.filter { it.tom == null }.size == 1 -> {
+                return
+            }
+            sak.valg == "UT" && sak.stønad!!.delytelse.filter { it.tom == null }.size == 1 -> {
+                return
+            }
+            sak.valg == "UT" && sak.stønad!!.delytelse.filter { it.tom == null }.size == 2 -> {
+                return
+            }
             else -> {
                 kastOgTellMigreringsFeil(MigreringsfeilType.UGYLDIG_ANTALL_DELYTELSER_I_INFOTRYGD)
             }
@@ -417,8 +425,7 @@ class MigreringService(
         val førsteutbetalingsperiode = finnFørsteUtbetalingsperiode(behandlingId)
         val førsteUtbetalingsbeløp = førsteutbetalingsperiode.value
         val beløpFraInfotrygd =
-            infotrygdSak.stønad!!.delytelse.singleOrNull { it.tom == null }?.beløp?.toInt()
-                ?: kastOgTellMigreringsFeil(MigreringsfeilType.FLERE_DELYTELSER_I_INFOTRYGD)
+            infotrygdSak.stønad!!.delytelse.filter { it.tom == null }.sumOf { it.beløp }.toInt()
 
         if (førsteUtbetalingsbeløp != beløpFraInfotrygd) {
             val beløpfeilType = if (infotrygdSak.undervalg == "MD")

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Datagenerator.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Datagenerator.kt
@@ -66,3 +66,34 @@ fun lagInfotrygdSak(beløp: Double, identBarn: List<String>, valg: String? = "OR
         undervalg = undervalg
     )
 }
+
+fun lagInfotrygdSakMedSmåbarnstillegg(
+    beløp: Double,
+    identBarn: List<String>,
+): Sak {
+    return Sak(
+        stønad = Stønad(
+            barn = identBarn.map { Barn(it, barnetrygdTom = "000000") },
+            delytelse = listOf(
+                Delytelse(
+                    fom = LocalDate.now(),
+                    tom = null,
+                    beløp = beløp,
+                    typeDelytelse = "MS",
+                    typeUtbetaling = "M",
+                ),
+                Delytelse(
+                    fom = LocalDate.now(),
+                    tom = null,
+                    beløp = 660.0,
+                    typeDelytelse = "SM",
+                    typeUtbetaling = "M",
+                )
+            ),
+            opphørsgrunn = "0"
+        ),
+        status = "FB",
+        valg = "UT",
+        undervalg = "EF"
+    )
+}

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
@@ -83,7 +83,12 @@ class MigrerFraInfotrygdTest(
     @Test
     fun `skal migrere delt bosted med 1 barn under 6 år`() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
+                any()
+            )
+        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -139,7 +144,12 @@ class MigrerFraInfotrygdTest(
     @Test
     fun `skal migrere delt bosted med 1 barn over 6 år`() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
+                any()
+            )
+        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -195,7 +205,12 @@ class MigrerFraInfotrygdTest(
     @Test
     fun `skal migrere delt bosted med 3 barn over 6 år`() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
+                any()
+            )
+        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -261,7 +276,12 @@ class MigrerFraInfotrygdTest(
     @Test
     fun `skal migrere delt bosted med 2 barn over 6 år og 1 under`() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
+                any()
+            )
+        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -327,7 +347,12 @@ class MigrerFraInfotrygdTest(
     @Test
     fun `skal feile migrere fordi beregnet beløp er ulikt beregnet beløp i ba-sak `() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
+                any()
+            )
+        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -377,7 +402,12 @@ class MigrerFraInfotrygdTest(
     @Test
     fun `skal migrere utvidet barnetrygd med delt bosted for ett barn over 6 år`() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED,
+                any()
+            )
+        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -431,9 +461,73 @@ class MigrerFraInfotrygdTest(
     }
 
     @Test
+    fun `skal migrere utvidet barnetrygd for ett barn under 3 år`() {
+        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED,
+                any()
+            )
+        } returns true
+        every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
+
+        val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
+            RestScenario(
+                søker = RestScenarioPerson(
+                    fødselsdato = "1996-01-12",
+                    fornavn = "Mor",
+                    etternavn = "Søker"
+                ),
+                barna = listOf(
+                    RestScenarioPerson(
+                        fødselsdato = LocalDate.now().minusYears(1).toString(),
+                        fornavn = "Barn2",
+                        etternavn = "Barnesen2"
+                    )
+                )
+            )
+        )
+
+        val sakKlarForMigreringScenario = mockServerKlient().lagScenario(
+            RestScenario(
+                søker = RestScenarioPerson(
+                    fødselsdato = "1996-01-12",
+                    fornavn = "Mor",
+                    etternavn = "Søker",
+                    infotrygdSaker = InfotrygdSøkResponse(
+                        bruker = listOf(
+                            lagInfotrygdSakMedSmåbarnstillegg(
+                                HALV_UTVIDET_BARNETRYGD_SATS * 2 + HALV_BARNETRYGD_SATS_UNDER_6_ÅR * 2,
+                                barnPåInfotrygdSøknadScenario.barna.map { it.ident.toString() }
+                            )
+                        ),
+                        barn = emptyList()
+                    )
+                ),
+                barna = emptyList()
+            )
+        )
+
+        val migreringsresponse = migreringService.migrer(sakKlarForMigreringScenario.søker.ident!!)
+
+        val restFagsakEtterBehandlingAvsluttet =
+            familieBaSakKlient().hentFagsak(fagsakId = migreringsresponse.fagsakId)
+        generellAssertFagsak(
+            restFagsak = restFagsakEtterBehandlingAvsluttet,
+            fagsakStatus = FagsakStatus.OPPRETTET,
+            behandlingStegType = StegType.IVERKSETT_MOT_OPPDRAG
+        )
+    }
+
+    @Test
     fun `skal feile migrering av utvidet barnetrygd med delt bosted fordi det er mer enn ett barn`() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_FOSTERBARN, any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED, any()) } returns true
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED,
+                any()
+            )
+        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -489,5 +583,6 @@ class MigrerFraInfotrygdTest(
         const val HALV_BARNETRYGD_SATS_UNDER_6_ÅR = 838.0
         const val HALV_BARNETRYGD_SATS_OVER_6_ÅR = 527.0
         const val HALV_UTVIDET_BARNETRYGD_SATS = 527.0
+        const val SMÅBARNSTILLEGG = 660.0
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Støtte for migrering av utvidet med småbarnstøtte. Disse har 2 delytelser i infotrygd hvor den ene er småbarnstillegget, og den andre er barnetrygd for alle barn +utvidet

Testet i preprod med fnr i email
https://barnetrygd.dev.intern.nav.no/fagsak/100058301/100071351/tilkjent-ytelse

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
nope

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
