### PR TITLE
Bug/generering av vedtaksperioder med tidslinje

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/ReduksjonsperioderFraForrigeBehandlingTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/ReduksjonsperioderFraForrigeBehandlingTidslinje.kt
@@ -2,9 +2,8 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.PRAKTISK_SENESTE_DAG
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.PRAKTISK_TIDLIGSTE_DAG
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilTidspunktEllerDefault
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerUendeligLengeSiden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerUendeligLengeTil
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 
 class ReduksjonsperioderFraForrigeBehandlingTidslinje(
@@ -14,8 +13,8 @@ class ReduksjonsperioderFraForrigeBehandlingTidslinje(
     override fun lagPerioder(): List<Periode<VedtaksperiodeMedBegrunnelser, Dag>> =
         vedtaksperioderMedBegrunnelser.map {
             Periode(
-                fraOgMed = it.fom.tilTidspunktEllerDefault { PRAKTISK_TIDLIGSTE_DAG },
-                tilOgMed = it.tom.tilTidspunktEllerDefault { PRAKTISK_SENESTE_DAG },
+                fraOgMed = it.fom.tilTidspunktEllerUendeligLengeSiden(),
+                tilOgMed = it.tom.tilTidspunktEllerUendeligLengeTil(),
                 innhold = it.copy(fom = null, tom = null) // Gjør at perioder med samme innhold blir slått sammen
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserTidslinje.kt
@@ -16,7 +16,7 @@ open class VedtaksperiodeMedBegrunnelserTidslinje(
         it.fom.tilTidspunktEllerUendeligLengeSiden()
     }
 
-    override fun tilOgMed(): Tidspunkt<Dag> = vedtaksperioderMedBegrunnelser.minOf {
+    override fun tilOgMed(): Tidspunkt<Dag> = vedtaksperioderMedBegrunnelser.maxOf {
         it.tom.tilTidspunktEllerUendeligLengeTil()
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
@@ -62,7 +62,9 @@ fun oppdaterUtbetalingsperioderMedReduksjonFraForrigeBehandling(
         val kombinertTidslinje = utbetalingsperioderTidslinje.snittKombinerMed(
             reduksjonsperioderTidslinje
         ) { utbetalingsperiode, reduksjonsperiode ->
-            reduksjonsperiode ?: utbetalingsperiode
+            if (reduksjonsperiode != null && utbetalingsperiode == null) reduksjonsperiode
+            else if (reduksjonsperiode != null && utbetalingsperiode != null) utbetalingsperiode.copy(type = reduksjonsperiode.type)
+            else utbetalingsperiode
         }
         return kombinertTidslinje.lagVedtaksperioderMedBegrunnelser()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
@@ -62,9 +62,11 @@ fun oppdaterUtbetalingsperioderMedReduksjonFraForrigeBehandling(
         val kombinertTidslinje = utbetalingsperioderTidslinje.snittKombinerMed(
             reduksjonsperioderTidslinje
         ) { utbetalingsperiode, reduksjonsperiode ->
-            if (reduksjonsperiode != null && utbetalingsperiode == null) reduksjonsperiode
-            else if (reduksjonsperiode != null && utbetalingsperiode != null) utbetalingsperiode.copy(type = reduksjonsperiode.type)
-            else utbetalingsperiode
+            when {
+                reduksjonsperiode != null && utbetalingsperiode == null -> reduksjonsperiode
+                reduksjonsperiode != null && utbetalingsperiode != null -> utbetalingsperiode.copy(type = reduksjonsperiode.type)
+                else -> utbetalingsperiode
+            }
         }
         return kombinertTidslinje.lagVedtaksperioderMedBegrunnelser()
     }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
@@ -88,9 +88,16 @@ class VedtaksperiodeUtilTest {
     fun `Skal kun lage en vedtaksperiode med type UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING hvis reduksjonsperiodene er sammenhengende`() {
         val vedtak = lagVedtak()
 
-        val utbetalingsperiode = VedtaksperiodeMedBegrunnelser(
+        val b2bFomUtbetalingsperiode = LocalDate.now().minusYears(2).førsteDagIInneværendeMåned()
+        val utbetalingsperiode1 = VedtaksperiodeMedBegrunnelser(
             vedtak = vedtak,
-            fom = LocalDate.now().minusYears(1).førsteDagIInneværendeMåned(),
+            fom = LocalDate.now().minusYears(3).førsteDagIInneværendeMåned(),
+            tom = b2bFomUtbetalingsperiode.minusMonths(1).sisteDagIMåned(),
+            type = Vedtaksperiodetype.UTBETALING
+        )
+        val utbetalingsperiode2 = VedtaksperiodeMedBegrunnelser(
+            vedtak = vedtak,
+            fom = b2bFomUtbetalingsperiode,
             tom = LocalDate.now().plusYears(1).sisteDagIMåned(),
             type = Vedtaksperiodetype.UTBETALING
         )
@@ -118,26 +125,31 @@ class VedtaksperiodeUtilTest {
         )
 
         val oppdaterteUtbetalingsperioder = oppdaterUtbetalingsperioderMedReduksjonFraForrigeBehandling(
-            utbetalingsperioder = listOf(utbetalingsperiode),
+            utbetalingsperioder = listOf(utbetalingsperiode1, utbetalingsperiode2),
             reduksjonsperioder = listOf(reduksjonsperiode1, reduksjonsperiode2, reduksjonsperiode3)
         )
 
-        Assertions.assertEquals(3, oppdaterteUtbetalingsperioder.size)
+        Assertions.assertEquals(4, oppdaterteUtbetalingsperioder.size)
 
         val periode1 = oppdaterteUtbetalingsperioder[0]
         val periode2 = oppdaterteUtbetalingsperioder[1]
         val periode3 = oppdaterteUtbetalingsperioder[2]
+        val periode4 = oppdaterteUtbetalingsperioder[3]
 
         Assertions.assertEquals(Vedtaksperiodetype.UTBETALING, periode1.type)
-        Assertions.assertEquals(utbetalingsperiode.fom, periode1.fom)
-        Assertions.assertEquals(reduksjonsperiode1.fom?.minusMonths(1)?.sisteDagIMåned(), periode1.tom)
+        Assertions.assertEquals(utbetalingsperiode1.fom, periode1.fom)
+        Assertions.assertEquals(b2bFomUtbetalingsperiode.minusMonths(1)?.sisteDagIMåned(), periode1.tom)
 
-        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING, periode2.type)
-        Assertions.assertEquals(reduksjonsperiode1.fom, periode2.fom)
-        Assertions.assertEquals(reduksjonsperiode3.tom, periode2.tom)
+        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING, periode2.type)
+        Assertions.assertEquals(b2bFomUtbetalingsperiode, periode2.fom)
+        Assertions.assertEquals(reduksjonsperiode1.fom?.minusMonths(1)?.sisteDagIMåned(), periode2.tom)
 
-        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING, periode3.type)
-        Assertions.assertEquals(reduksjonsperiode3.tom?.plusMonths(1)?.førsteDagIInneværendeMåned(), periode3.fom)
-        Assertions.assertEquals(utbetalingsperiode.tom, periode3.tom)
+        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING, periode3.type)
+        Assertions.assertEquals(reduksjonsperiode1.fom, periode3.fom)
+        Assertions.assertEquals(reduksjonsperiode3.tom, periode3.tom)
+
+        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING, periode4.type)
+        Assertions.assertEquals(reduksjonsperiode3.tom?.plusMonths(1)?.førsteDagIInneværendeMåned(), periode4.fom)
+        Assertions.assertEquals(utbetalingsperiode2.tom, periode4.tom)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
@@ -88,7 +88,7 @@ class VedtaksperiodeUtilTest {
     }
 
     @Test
-    fun `Skal kun lage en vedtaksperiode med type UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING hvis reduksjonsperiodene er sammenhengende`() {
+    fun `Skal kun lage en vedtaksperiode med type UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING hvis reduksjonsperiodene er sammenhengende og ikke krysser utbetalingsperiode-splitt`() {
         val vedtak = lagVedtak()
 
         val b2bFomUtbetalingsperiode = LocalDate.now().minusYears(2).førsteDagIInneværendeMåned()

--- a/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
@@ -75,7 +75,10 @@ class VedtaksperiodeUtilTest {
         Assertions.assertEquals(utbetalingsperiode.fom, periode1.fom)
         Assertions.assertEquals(reduksjonsperiode.fom?.minusMonths(1)?.sisteDagIMåned(), periode1.tom)
 
-        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING, periode2.type)
+        Assertions.assertEquals(
+            Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING,
+            periode2.type
+        )
         Assertions.assertEquals(reduksjonsperiode.fom, periode2.fom)
         Assertions.assertEquals(reduksjonsperiode.tom, periode2.tom)
 
@@ -144,12 +147,104 @@ class VedtaksperiodeUtilTest {
         Assertions.assertEquals(b2bFomUtbetalingsperiode, periode2.fom)
         Assertions.assertEquals(reduksjonsperiode1.fom?.minusMonths(1)?.sisteDagIMåned(), periode2.tom)
 
-        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING, periode3.type)
+        Assertions.assertEquals(
+            Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING,
+            periode3.type
+        )
         Assertions.assertEquals(reduksjonsperiode1.fom, periode3.fom)
         Assertions.assertEquals(reduksjonsperiode3.tom, periode3.tom)
 
         Assertions.assertEquals(Vedtaksperiodetype.UTBETALING, periode4.type)
         Assertions.assertEquals(reduksjonsperiode3.tom?.plusMonths(1)?.førsteDagIInneværendeMåned(), periode4.fom)
         Assertions.assertEquals(utbetalingsperiode2.tom, periode4.tom)
+    }
+
+    @Test
+    fun `Skal ikke slå sammen reduksjonsperioder som overlapper med utbetalingsperioder`() {
+        val vedtak = lagVedtak()
+
+        val fom1 = LocalDate.now().minusYears(1).førsteDagIInneværendeMåned()
+        val fomReduksjon = fom1.plusMonths(1).førsteDagIInneværendeMåned()
+        val fom2 = fomReduksjon.plusMonths(2).førsteDagIInneværendeMåned()
+        val fom3 = fom2.plusMonths(3).førsteDagIInneværendeMåned()
+        val sisteTom = fom3.plusMonths(5).sisteDagIMåned()
+
+        val utbetalingsperioder = listOf(
+            VedtaksperiodeMedBegrunnelser(
+                vedtak = vedtak,
+                fom = fom1,
+                tom = fom2.minusMonths(1).sisteDagIMåned(),
+                type = Vedtaksperiodetype.UTBETALING
+            ),
+            VedtaksperiodeMedBegrunnelser(
+                vedtak = vedtak,
+                fom = fom2,
+                tom = fom3.minusMonths(1).sisteDagIMåned(),
+                type = Vedtaksperiodetype.UTBETALING
+            ),
+            VedtaksperiodeMedBegrunnelser(
+                vedtak = vedtak,
+                fom = fom3,
+                tom = sisteTom,
+                type = Vedtaksperiodetype.UTBETALING
+            )
+        )
+        val reduksjonsperioder = listOf(
+            VedtaksperiodeMedBegrunnelser(
+                vedtak = vedtak,
+                fom = fomReduksjon,
+                tom = fom2.minusMonths(1).sisteDagIMåned(),
+                type = Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING
+            ),
+            VedtaksperiodeMedBegrunnelser(
+                vedtak = vedtak,
+                fom = fom2,
+                tom = fom3.minusMonths(1).sisteDagIMåned(),
+                type = Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING
+            ),
+            VedtaksperiodeMedBegrunnelser(
+                vedtak = vedtak,
+                fom = fom3,
+                tom = sisteTom,
+                type = Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING
+            )
+        )
+
+        val oppdaterteUtbetalingsperioder = oppdaterUtbetalingsperioderMedReduksjonFraForrigeBehandling(
+            utbetalingsperioder = utbetalingsperioder,
+            reduksjonsperioder = reduksjonsperioder
+        )
+
+        Assertions.assertEquals(4, oppdaterteUtbetalingsperioder.size)
+
+        val periode1 = oppdaterteUtbetalingsperioder[0]
+        val periode2 = oppdaterteUtbetalingsperioder[1]
+        val periode3 = oppdaterteUtbetalingsperioder[2]
+        val periode4 = oppdaterteUtbetalingsperioder[3]
+
+        Assertions.assertEquals(Vedtaksperiodetype.UTBETALING, periode1.type)
+        Assertions.assertEquals(fom1, periode1.fom)
+        Assertions.assertEquals(fomReduksjon.minusDays(1), periode1.tom)
+
+        Assertions.assertEquals(
+            Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING,
+            periode2.type
+        )
+        Assertions.assertEquals(fomReduksjon, periode2.fom)
+        Assertions.assertEquals(fom2.minusDays(1), periode2.tom)
+
+        Assertions.assertEquals(
+            Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING,
+            periode3.type
+        )
+        Assertions.assertEquals(fom2, periode3.fom)
+        Assertions.assertEquals(fom3.minusDays(1), periode3.tom)
+
+        Assertions.assertEquals(
+            Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING,
+            periode4.type
+        )
+        Assertions.assertEquals(fom3, periode4.fom)
+        Assertions.assertEquals(sisteTom, periode4.tom)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Rette en bug som gjorde at noen vedtaksperioder manglet:
![image](https://user-images.githubusercontent.com/25459913/165749023-1664b1ce-f81f-43e5-a8f7-18d592c57ae1.png)

Feilen oppsto fordi vi hentet ut minste tom-dato blant periodene for tidslinjen, og ikke største tom-dato, når vi skulle sette tom-dato for selve tidslinjen. Det gjorde tidslinjen så kortere ut enn den egentlig var, hvis den bestod av flere perioder. Skriver også om en av testene til å dekke dette caset.

Endret i tillegg på kombinatoren, så perioder som er reduksjon på tvers av behandling ikke slås sammen i den kombinerte tidslinjen hvis de overlapper med en utbetalingsperioder. Dette er fordi vi ønsker å ha med oss alle splittene fra utbetalingsperioder-tidslinjen. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nop

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
