### PR TITLE
Bugfix autovedtak: Håndter åpen behandling med status fatter vedtak 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -117,7 +117,7 @@ class AutovedtakStegService(
         }
 
         return if (åpenBehandling == null) false
-        else if (åpenBehandling.status == BehandlingStatus.UTREDES) {
+        else if (åpenBehandling.status == BehandlingStatus.UTREDES || åpenBehandling.status == BehandlingStatus.FATTER_VEDTAK) {
             antallAutovedtakÅpenBehandling[autovedtaktype]?.increment()
 
             oppgaveService.opprettOppgaveForManuellBehandling(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
@@ -57,6 +57,28 @@ class AutobrevStegServiceTest {
     }
 
     @Test
+    fun `Skal stoppe autovedtak og opprette oppgave ved åpen behandling med status Fatter vedtak`() {
+        val aktør = randomAktørId()
+        val fagsak = defaultFagsak(aktør)
+        val behandling = lagBehandling(fagsak).also {
+            it.status = BehandlingStatus.FATTER_VEDTAK
+        }
+
+        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
+        every { fagsakService.hent(aktør) } returns fagsak
+        every { behandlingHentOgPersisterService.hentAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
+        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) } returns ""
+
+        autovedtakStegService.kjørBehandling(
+            mottakersAktør = aktør,
+            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
+            behandlingsdata = aktør
+        )
+
+        verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) }
+    }
+
+    @Test
     fun `Skal stoppe autovedtak ved å kaste feil ved åpen behandling som iverksettes`() {
         val aktør = randomAktørId()
         val fagsak = defaultFagsak(aktør)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
**Favro**: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8634
**Hva**: Vi skal håndtere autovedtak for åpen behandling med status _Fatter vedtak_ likt som ved status _Utredes_
**Hvorfor**: Autovedtakskjøring stanser dersom fagsak har en åpen behandling med status _Fatter vedtak_, og oppretter en task til manuell oppfølging av vakt. Vi har ikke tidligere lagt inn håndtering av status _Fatter vedtak_

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
