### PR TITLE
Legg til felt i BegrunnelseData som sier om utvidet er utbetalt eller ikke på søker i perioden

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -92,7 +92,7 @@ data class BegrunnelseData(
     val belop: String,
     val soknadstidspunkt: String,
     val avtaletidspunktDeltBosted: String,
-    val sokerFaarUtbetaltUtvidetIPerioden: String
+    val sokersRettTilUtvidet: String
 ) : Begrunnelse
 
 data class FritekstBegrunnelse(val fritekst: String) : Begrunnelse
@@ -150,7 +150,7 @@ fun BrevBegrunnelseGrunnlagMedPersoner.tilBrevBegrunnelse(
     val søknadstidspunkt = endringsperioder.sortedBy { it.søknadstidspunkt }
         .firstOrNull { this.triggesAv.endringsaarsaker.contains(it.årsak) }?.søknadstidspunkt
 
-    val utvidetPåSøkerIPerioden = finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer)
+    val søkersRettTilUtvidet = finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer)
 
     this.validerBrevbegrunnelse(
         gjelderSøker = gjelderSøker,
@@ -173,23 +173,23 @@ fun BrevBegrunnelseGrunnlagMedPersoner.tilBrevBegrunnelse(
         belop = Utils.formaterBeløp(beløp),
         soknadstidspunkt = søknadstidspunkt?.tilKortString() ?: "",
         avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted?.tilKortString() ?: "",
-        sokerFaarUtbetaltUtvidetIPerioden = utvidetPåSøkerIPerioden.tilSanityFormat()
+        sokersRettTilUtvidet = søkersRettTilUtvidet.tilSanityFormat()
     )
 }
 
-private fun finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>): UtvidetPåSøker {
+private fun finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>): SøkersRettTilUtvidet {
     val utvidetUtbetalingsdetaljerPåSøker =
         minimerteUtbetalingsperiodeDetaljer.filter { it.person.type == PersonType.SØKER && it.ytelseType == YtelseType.UTVIDET_BARNETRYGD }
 
     return when {
-        utvidetUtbetalingsdetaljerPåSøker.any { it.utbetaltPerMnd > 0 } -> UtvidetPåSøker.SØKER_FÅR_UTVIDET
+        utvidetUtbetalingsdetaljerPåSøker.any { it.utbetaltPerMnd > 0 } -> SøkersRettTilUtvidet.SØKER_FÅR_UTVIDET
         utvidetUtbetalingsdetaljerPåSøker.isNotEmpty() &&
-            utvidetUtbetalingsdetaljerPåSøker.all { it.utbetaltPerMnd == 0 } -> UtvidetPåSøker.SØKER_HAR_RETT_MEN_FÅR_IKKE
-        else -> UtvidetPåSøker.SØKER_HAR_IKKE_RETT
+            utvidetUtbetalingsdetaljerPåSøker.all { it.utbetaltPerMnd == 0 } -> SøkersRettTilUtvidet.SØKER_HAR_RETT_MEN_FÅR_IKKE
+        else -> SøkersRettTilUtvidet.SØKER_HAR_IKKE_RETT
     }
 }
 
-enum class UtvidetPåSøker {
+enum class SøkersRettTilUtvidet {
     SØKER_FÅR_UTVIDET,
     SØKER_HAR_RETT_MEN_FÅR_IKKE,
     SØKER_HAR_IKKE_RETT;

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.brev.domene.BrevBegrunnelseGrunnlagMedPersoner
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertRestEndretAndel
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertUtbetalingsperiodeDetalj
@@ -91,6 +92,7 @@ data class BegrunnelseData(
     val belop: String,
     val soknadstidspunkt: String,
     val avtaletidspunktDeltBosted: String,
+    val sokerFaarUtbetaltUtvidetIPerioden: Boolean
 ) : Begrunnelse
 
 data class FritekstBegrunnelse(val fritekst: String) : Begrunnelse
@@ -148,6 +150,9 @@ fun BrevBegrunnelseGrunnlagMedPersoner.tilBrevBegrunnelse(
     val søknadstidspunkt = endringsperioder.sortedBy { it.søknadstidspunkt }
         .firstOrNull { this.triggesAv.endringsaarsaker.contains(it.årsak) }?.søknadstidspunkt
 
+    val søkerFårUtbetaltUtvidetIPerioden =
+        minimerteUtbetalingsperiodeDetaljer.any { it.person.type == PersonType.SØKER && it.ytelseType == YtelseType.UTVIDET_BARNETRYGD && it.utbetaltPerMnd > 0 }
+
     this.validerBrevbegrunnelse(
         gjelderSøker = gjelderSøker,
         barnasFødselsdatoer = barnasFødselsdatoer,
@@ -168,7 +173,8 @@ fun BrevBegrunnelseGrunnlagMedPersoner.tilBrevBegrunnelse(
         apiNavn = this.standardbegrunnelse.sanityApiNavn,
         belop = Utils.formaterBeløp(beløp),
         soknadstidspunkt = søknadstidspunkt?.tilKortString() ?: "",
-        avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted?.tilKortString() ?: ""
+        avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted?.tilKortString() ?: "",
+        sokerFaarUtbetaltUtvidetIPerioden = søkerFårUtbetaltUtvidetIPerioden
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
@@ -141,7 +141,8 @@ data class BegrunnelseDataTestConfig(
     val apiNavn: String,
     val belop: Int,
     val soknadstidspunkt: String?,
-    val avtaletidspunktDeltBosted: String?
+    val avtaletidspunktDeltBosted: String?,
+    val sokerFaarUtbetaltUtvidetIPerioden: Boolean
 ) : TestBegrunnelse {
 
     fun tilBegrunnelseData() = BegrunnelseData(
@@ -157,7 +158,8 @@ data class BegrunnelseDataTestConfig(
         maalform = this.maalform,
         apiNavn = this.apiNavn,
         soknadstidspunkt = this.soknadstidspunkt ?: "",
-        avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted ?: ""
+        avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted ?: "",
+        sokerFaarUtbetaltUtvidetIPerioden = this.sokerFaarUtbetaltUtvidetIPerioden
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
@@ -21,7 +21,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.tilSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.BegrunnelseData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
-import no.nav.familie.ba.sak.kjerne.vedtak.domene.UtvidetPåSøker
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.SøkersRettTilUtvidet
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import java.math.BigDecimal
@@ -150,7 +150,7 @@ data class BegrunnelseDataTestConfig(
     val belop: Int,
     val soknadstidspunkt: String?,
     val avtaletidspunktDeltBosted: String?,
-    val sokerFaarUtbetaltUtvidetIPerioden: String?
+    val sokersRettTilUtvidet: String?
 ) : TestBegrunnelse {
 
     fun tilBegrunnelseData() = BegrunnelseData(
@@ -167,8 +167,8 @@ data class BegrunnelseDataTestConfig(
         apiNavn = this.apiNavn,
         soknadstidspunkt = this.soknadstidspunkt ?: "",
         avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted ?: "",
-        sokerFaarUtbetaltUtvidetIPerioden = this.sokerFaarUtbetaltUtvidetIPerioden
-            ?: UtvidetPåSøker.SØKER_HAR_IKKE_RETT.tilSanityFormat()
+        sokersRettTilUtvidet = this.sokersRettTilUtvidet
+            ?: SøkersRettTilUtvidet.SØKER_HAR_IKKE_RETT.tilSanityFormat()
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.tilSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.BegrunnelseData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.UtvidetPåSøker
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import java.math.BigDecimal
@@ -142,7 +143,7 @@ data class BegrunnelseDataTestConfig(
     val belop: Int,
     val soknadstidspunkt: String?,
     val avtaletidspunktDeltBosted: String?,
-    val sokerFaarUtbetaltUtvidetIPerioden: Boolean
+    val sokerFaarUtbetaltUtvidetIPerioden: String?
 ) : TestBegrunnelse {
 
     fun tilBegrunnelseData() = BegrunnelseData(
@@ -160,6 +161,7 @@ data class BegrunnelseDataTestConfig(
         soknadstidspunkt = this.soknadstidspunkt ?: "",
         avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted ?: "",
         sokerFaarUtbetaltUtvidetIPerioden = this.sokerFaarUtbetaltUtvidetIPerioden
+            ?: UtvidetPåSøker.SØKER_HAR_IKKE_RETT.tilSanityFormat()
     )
 }
 

--- a/src/test/resources/brevperiodeCaser/REDUKSJON_BOR_MED_SØKER_OG_DELT_BOSTED.json
+++ b/src/test/resources/brevperiodeCaser/REDUKSJON_BOR_MED_SØKER_OG_DELT_BOSTED.json
@@ -125,7 +125,8 @@
         "maanedOgAarBegrunnelsenGjelderFor": "oktober 2021",
         "maalform": "bokmaal",
         "apiNavn": "reduksjonFlyttetBarn",
-        "belop": 0
+        "belop": 0,
+        "sokerFaarUtbetaltUtvidetIPerioden": true
       },
       {
         "gjelderSoker": false,
@@ -138,7 +139,8 @@
         "maanedOgAarBegrunnelsenGjelderFor": "oktober 2021",
         "maalform": "bokmaal",
         "apiNavn": "reduksjonDeltBarnetrygdAnnenForelderSokt",
-        "belop": 827
+        "belop": 827,
+        "sokerFaarUtbetaltUtvidetIPerioden": true
       }
     ],
     "type": "innvilgelse"

--- a/src/test/resources/brevperiodeCaser/REDUKSJON_BOR_MED_SØKER_OG_DELT_BOSTED.json
+++ b/src/test/resources/brevperiodeCaser/REDUKSJON_BOR_MED_SØKER_OG_DELT_BOSTED.json
@@ -126,7 +126,7 @@
         "maalform": "bokmaal",
         "apiNavn": "reduksjonFlyttetBarn",
         "belop": 0,
-        "sokerFaarUtbetaltUtvidetIPerioden": true
+        "sokerFaarUtbetaltUtvidetIPerioden": "sokerFaarUtvidet"
       },
       {
         "gjelderSoker": false,
@@ -140,7 +140,7 @@
         "maalform": "bokmaal",
         "apiNavn": "reduksjonDeltBarnetrygdAnnenForelderSokt",
         "belop": 827,
-        "sokerFaarUtbetaltUtvidetIPerioden": true
+        "sokerFaarUtbetaltUtvidetIPerioden": "sokerFaarUtvidet"
       }
     ],
     "type": "innvilgelse"

--- a/src/test/resources/brevperiodeCaser/REDUKSJON_BOR_MED_SØKER_OG_DELT_BOSTED.json
+++ b/src/test/resources/brevperiodeCaser/REDUKSJON_BOR_MED_SØKER_OG_DELT_BOSTED.json
@@ -126,7 +126,7 @@
         "maalform": "bokmaal",
         "apiNavn": "reduksjonFlyttetBarn",
         "belop": 0,
-        "sokerFaarUtbetaltUtvidetIPerioden": "sokerFaarUtvidet"
+        "sokersRettTilUtvidet": "sokerFaarUtvidet"
       },
       {
         "gjelderSoker": false,
@@ -140,7 +140,7 @@
         "maalform": "bokmaal",
         "apiNavn": "reduksjonDeltBarnetrygdAnnenForelderSokt",
         "belop": 827,
-        "sokerFaarUtbetaltUtvidetIPerioden": "sokerFaarUtvidet"
+        "sokersRettTilUtvidet": "sokerFaarUtvidet"
       }
     ],
     "type": "innvilgelse"

--- a/src/test/resources/brevperiodeCaser/SMÅBARNSTILLEGG.json
+++ b/src/test/resources/brevperiodeCaser/SMÅBARNSTILLEGG.json
@@ -101,7 +101,7 @@
         "maalform": "bokmaal",
         "apiNavn": "reduksjonSmaabarnstilleggIkkeLengerFullOvergangsstonad",
         "belop": 2708,
-        "sokerFaarUtbetaltUtvidetIPerioden": "sokerFaarUtvidet"
+        "sokersRettTilUtvidet": "sokerFaarUtvidet"
       }
     ],
     "type": "innvilgelse"

--- a/src/test/resources/brevperiodeCaser/SMÅBARNSTILLEGG.json
+++ b/src/test/resources/brevperiodeCaser/SMÅBARNSTILLEGG.json
@@ -100,7 +100,8 @@
         "maanedOgAarBegrunnelsenGjelderFor": "august 2021",
         "maalform": "bokmaal",
         "apiNavn": "reduksjonSmaabarnstilleggIkkeLengerFullOvergangsstonad",
-        "belop": 2708
+        "belop": 2708,
+        "sokerFaarUtbetaltUtvidetIPerioden": true
       }
     ],
     "type": "innvilgelse"

--- a/src/test/resources/brevperiodeCaser/SMÅBARNSTILLEGG.json
+++ b/src/test/resources/brevperiodeCaser/SMÅBARNSTILLEGG.json
@@ -101,7 +101,7 @@
         "maalform": "bokmaal",
         "apiNavn": "reduksjonSmaabarnstilleggIkkeLengerFullOvergangsstonad",
         "belop": 2708,
-        "sokerFaarUtbetaltUtvidetIPerioden": true
+        "sokerFaarUtbetaltUtvidetIPerioden": "sokerFaarUtvidet"
       }
     ],
     "type": "innvilgelse"


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8367

Knyttet til denne PRen: https://github.com/navikt/familie-brev/pull/258

Må sende med felt som sier om søker får utbetalt utvidet eller ikke i perioden. Dette er for å velge riktig for valgfeltet "du får/har rett til".

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
~Vet ikke om dette er beste måte å løse problemet på. Tidligere versjon sendte med beløp som ble utbetalt på søker, men det ble feil, da vi skal se bort fra småbarnstillegg. I stedet for å sende med beløp utbetalt for utvidet på søker, tenkte jeg det var like enkelt å sende med en boolsk verdi. Men er egentlig ikke så veldig fan av at vi sender med så mange spesifikke verdier i BegrunnelseData-objektet. Men vanskelig å gjøre noe med det før vi tar et steg tilbake og evaluerer hele brev-løsningen~ 🤔 

**Tar gjerne i mot tips på navngivning av funksjoner, variabler og enum!!**

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Blir dekket av json-testene vi allerede har. Lagt til feltet på de testene hvor det er utbetaling av utvidet.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
Kan gå gjennom hvis noen ønsker!
