### PR TITLE
Konverterer uendelig til et tidspunkt langt inne i fremtiden

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/rest/RestTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/tidslinjer/rest/RestTidslinjer.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.PRAKTISK_SENESTE_DAG
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærEtter
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import java.time.LocalDate
@@ -52,7 +53,7 @@ fun Tidslinje<Regelverk, Måned>.tilRestRegelverkTidslinje(): List<RestTidslinje
     this.perioder().map { periode ->
         RestTidslinjePeriode(
             fraOgMed = periode.fraOgMed.tilFørsteDagIMåneden().tilLocalDate(),
-            tilOgMed = periode.tilOgMed.tilSisteDagIMåneden().tilLocalDate(),
+            tilOgMed = periode.tilOgMed.tilSisteDagIMåneden().tilLocalDateEllerNull() ?: PRAKTISK_SENESTE_DAG,
             innhold = periode.innhold
         )
     }
@@ -61,7 +62,7 @@ fun Tidslinje<Resultat, Måned>.tilRestOppfyllerVilkårTidslinje(): List<RestTid
     this.perioder().map { periode ->
         RestTidslinjePeriode(
             fraOgMed = periode.fraOgMed.tilFørsteDagIMåneden().tilLocalDate(),
-            tilOgMed = periode.tilOgMed.tilSisteDagIMåneden().tilLocalDate(),
+            tilOgMed = periode.tilOgMed.tilSisteDagIMåneden().tilLocalDateEllerNull() ?: PRAKTISK_SENESTE_DAG,
             innhold = periode.innhold!!
         )
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tidslinjer som er åpne, dvs går mot uendelig, feiler i konverteringen til rest-tidslinjer, der det må være en endelig LocalDate.
Legger på en quickfix, som setter en dato langt inne i fremtiden. Men det er ikke en endelig løsning. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ Det er en quickfix for en funksjonalitet som bare brukes som debug/test

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
