### PR TITLE
Herder beskjæring av tidslinjer. 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.minsteAv
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.størsteAv
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
 
 /**
@@ -23,7 +25,9 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.beskjærEtter(tidslinje: Tidslinje<*, T>)
  * Etter beskjæringen vil tidslinjen maksimalt strekke seg fra innsendt [fraOgMed] og til [tilOgMed]
  * Perioder som ligger helt utenfor grensene vil forsvinne.
  * Perioden i hver ende som ligger delvis innenfor, vil forkortes.
- * Hvis ny og eksisterende grenseverdi begge er uendelige, vil den nye benyttes
+ * Uendelige endepunkter vil beskjæres til endelig hvis [fraOgMed] eller [tilOgMed] er endelige
+ * Endelige endepunkter som beskjæres mot uendelige endepunkter, beholdes
+ * Hvis ny og eksisterende grenseverdi begge er uendelige, vil den mest ekstreme benyttes
  */
 fun <I, T : Tidsenhet> Tidslinje<I, T>.beskjær(fraOgMed: Tidspunkt<T>, tilOgMed: Tidspunkt<T>): Tidslinje<I, T> {
 
@@ -36,12 +40,34 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.beskjær(fraOgMed: Tidspunkt<T>, tilOgMed
             return tidslinje.perioder()
                 .filter { it.fraOgMed <= tilOgMed && it.tilOgMed >= fraOgMed }
                 .map {
-                    when {
-                        it.fraOgMed <= fraOgMed -> Periode(fraOgMed, it.tilOgMed, it.innhold)
-                        it.tilOgMed >= tilOgMed -> Periode(it.fraOgMed, tilOgMed, it.innhold)
-                        else -> it
-                    }
+                    Periode(
+                        størsteFraOgMed(fraOgMed, it.fraOgMed),
+                        minsteTilOgMed(tilOgMed, it.tilOgMed),
+                        it.innhold
+                    )
                 }
         }
     }
+}
+
+/**
+ * Finner tidspunkt som representerer største (seneste) fra-og-med fra tidspunktene [t1] og [t2]
+ * Tilfellet der både [t1] og [t2] er uendelig lenge siden må håndteres spesielt.
+ * Da vil de betraktes som like, men vi velger den der det underliggende tidspunktet er minst/først
+ * for å få lengst mulig underliggende tidslinje
+ */
+fun <T : Tidsenhet> størsteFraOgMed(t1: Tidspunkt<T>, t2: Tidspunkt<T>) = when {
+    t1.erUendeligLengeSiden() && t2.erUendeligLengeSiden() -> minsteAv(t1, t2)
+    else -> størsteAv(t1, t2)
+}
+
+/**
+ * Finner tidspunkt som representerer minste (tidligste) til-og-med fra tidspunktene [t1] og [t2]
+ * Tilfellet der både [t1] og [t2] er uendelig lenge til må håndteres spesielt.
+ * Da vil de betraktes som like, men vi velger den der det underliggende tidspunktet er størst/sist
+ * for å få lengst mulig underliggende tidslinje
+ */
+fun <T : Tidsenhet> minsteTilOgMed(t1: Tidspunkt<T>, t2: Tidspunkt<T>) = when {
+    t1.erUendeligLengeTil() && t2.erUendeligLengeTil() -> størsteAv(t1, t2) // Riktig med største
+    else -> minsteAv(t1, t2)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/EndreTid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/EndreTid.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdForTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
 
@@ -31,5 +32,23 @@ fun <I, R> Tidslinje<I, Dag>.tilMåned(mapper: (List<I?>) -> R?): Tidslinje<R, M
                 Periode(måned, måned, mapper(innholdAlleDager))
             }
         }
+    }
+}
+
+/**
+ * Extension-metode for å konvertere en tidslinje med uendelig fra-og-med og/eller til-og-med
+ * til en endelig tidslinje basert på de underliggende tidspunktene
+ * Tidslinjen
+ * '<aaa bbbb   d>'
+ * vil etter konvertering se slik ut
+ * aaa bbbb   d
+ */
+fun <I, T : Tidsenhet> Tidslinje<I, T>.somEndelig(): Tidslinje<I, T> {
+    val tidslinje = this
+    return object : Tidslinje<I, T>() {
+        override fun lagPerioder(): Collection<Periode<I, T>> =
+            tidslinje.perioder().map {
+                Periode(it.fraOgMed.somEndelig(), it.tilOgMed.somEndelig(), it.innhold)
+            }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinjeTest.kt
@@ -1,0 +1,128 @@
+package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
+
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.tilCharTidslinje
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class BeskjæreTidslinjeTest {
+
+    @Test
+    fun `skal beskjære endelig tidslinje på begge sider`() {
+        val hovedlinje = "aaaaaa".tilCharTidslinje(des(2001))
+        val beskjæring = "bbb".tilCharTidslinje(feb(2002))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "aaa".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+    }
+
+    @Test
+    fun `skal beholde tidslinje som allerede er innenfor beskjæring`() {
+        val hovedlinje = "aaa".tilCharTidslinje(feb(2002))
+        val beskjæring = "bbbbbbbbb".tilCharTidslinje(des(2001))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "aaa".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+    }
+
+    @Test
+    fun `skal beholde tidslinje som er innenfor en uendelig beskjæring`() {
+        val hovedlinje = "aaa".tilCharTidslinje(feb(2002))
+        val beskjæring = "<b>".tilCharTidslinje(mar(2002))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "aaa".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+    }
+
+    @Test
+    fun `beskjæring utenfor tidslinjen skal gi tom tidslinje`() {
+        val hovedlinje = "aaaaaa".tilCharTidslinje(des(2001))
+        val beskjæring = "bbb".tilCharTidslinje(feb(2009))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+
+        assertEquals(TomTidslinje<Char, Måned>(), faktisk)
+    }
+
+    @Test
+    fun `skal beskjære uendelig tidslinje begge veier mot endelig tidsline`() {
+        val hovedlinje = "<aaaaaa>".tilCharTidslinje(des(2002))
+        val beskjæring = "bbb".tilCharTidslinje(feb(2002))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "aaa".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+        assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+    }
+
+    @Test
+    fun `skal beskjære tidslinje som går fra uendelig lenge siden til et endelig tidspunkt i fremtiden`() {
+        val hovedlinje = "<aaaaaa".tilCharTidslinje(des(2038))
+        val beskjæring = "bbbbb".tilCharTidslinje(feb(2002))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "aaaaa".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+        assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+    }
+
+    @Test
+    fun `skal beskjære tidslinje som går fra et endelig tidspunkt i fortiden til uendelig lenge til`() {
+        val hovedlinje = "aaaaaa>".tilCharTidslinje(des(1993))
+        val beskjæring = "bbbbb".tilCharTidslinje(feb(2002))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "aaaaa".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+        assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+    }
+
+    @Test
+    fun `skal beskjære uendelig fremtid slik at den kortest mulig`() {
+        val hovedlinje = "aaaaaa>".tilCharTidslinje(des(1993))
+        val beskjæring = "bbb>".tilCharTidslinje(feb(2002))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "aaa>".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+        assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+    }
+
+    @Test
+    fun `skal beskjære uendelig fortid slik at den inneholder tidligste fra-og-med, beskjæring er tidligst`() {
+        val hovedlinje = "<a".tilCharTidslinje(des(2038))
+        val beskjæring = "<bbb".tilCharTidslinje(feb(2002))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "<aaa".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+        assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+    }
+
+    @Test
+    fun `skal beskjære uendelig fortid slik at den inneholder tidligste fra-og-med, beskjæring er senest`() {
+        val hovedlinje = "<bbb".tilCharTidslinje(feb(2002))
+        val beskjæring = "<a".tilCharTidslinje(des(2038))
+
+        val faktisk = hovedlinje.beskjærEtter(beskjæring)
+        val forventet = "<bbb".tilCharTidslinje(feb(2002))
+
+        assertEquals(forventet, faktisk)
+        assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Beskjæring av tidsliner har fått en overhaling. Tidligere variant håndterte ikke uendelig på en sikker måte, og manglet tester

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Uendelige tidspunkter er en utfordring. Nå er "uendelig" basert på at det finnes et underliggende tidspunkt, som representerer en praktisk grense. Kanskje et riktigere konsept hadde vært hhv "herfra og tidligere" eller "herfra og senere", ikke "uendelig med en grense". Men da begynner det egentlig å likne på en _periode_, der enten fra-og-med eller til-og-med er "ekte" uendelig. Men det løser ikke alle problemer, det heller. 

Rotproblemet er effektiv kombinasjoner av tidslinjer, der null, én, flere eller alle kan være helt eller delvis uendelige. Uendelige tidspunkter var ment å pakke inn problematikken, og i hvert fall slippe å håndtere null overalt. Men beskjæring er da et eksempel der uendelighet blør igjennom, og skaper en del kompleksitet. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
