### PR TITLE
Rett opp og forebygg feil type argumenter til kjøring av autovedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.internal
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
-import no.nav.familie.ba.sak.kjerne.autovedtak.Autovedtaktype
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutobrevScheduler
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
@@ -72,9 +71,8 @@ class TestVerktøyController(
     fun mottaHendelseOmVedtakOmOvergangsstønad(@RequestBody personIdent: PersonIdent): ResponseEntity<Ressurs<String>> {
         return if (envService.erPreprod() || envService.erDev()) {
             val aktør = personidentService.hentAktør(personIdent.ident)
-            val melding = autovedtakStegService.kjørBehandling(
+            val melding = autovedtakStegService.kjørBehandlingSmåbarnstillegg(
                 mottakersAktør = aktør,
-                autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
                 behandlingsdata = aktør
             )
             ResponseEntity.ok(Ressurs.success(melding))

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -48,7 +48,31 @@ class AutovedtakStegService(
         Metrics.counter("behandling.saksbehandling.autovedtak.aapen_behandling", "type", it.name)
     }
 
-    fun <Behandlingsdata> kjørBehandling(
+    fun kjørBehandlingFødselshendelse(mottakersAktør: Aktør, behandlingsdata: NyBehandlingHendelse): String {
+        return kjørBehandling(
+            mottakersAktør = mottakersAktør,
+            autovedtaktype = Autovedtaktype.FØDSELSHENDELSE,
+            behandlingsdata = behandlingsdata
+        )
+    }
+
+    fun kjørBehandlingOmregning(mottakersAktør: Aktør, behandlingsdata: AutovedtakBrevBehandlingsdata): String {
+        return kjørBehandling(
+            mottakersAktør = mottakersAktør,
+            autovedtaktype = Autovedtaktype.OMREGNING_BREV,
+            behandlingsdata = behandlingsdata
+        )
+    }
+
+    fun kjørBehandlingSmåbarnstillegg(mottakersAktør: Aktør, behandlingsdata: Aktør): String {
+        return kjørBehandling(
+            mottakersAktør = mottakersAktør,
+            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
+            behandlingsdata = behandlingsdata
+        )
+    }
+
+    private fun <Behandlingsdata> kjørBehandling(
         mottakersAktør: Aktør,
         autovedtaktype: Autovedtaktype,
         behandlingsdata: Behandlingsdata
@@ -111,7 +135,7 @@ class AutovedtakStegService(
         return resultatAvKjøring
     }
 
-    fun håndterÅpenBehandlingOgAvbrytAutovedtak(aktør: Aktør, autovedtaktype: Autovedtaktype): Boolean {
+    private fun håndterÅpenBehandlingOgAvbrytAutovedtak(aktør: Aktør, autovedtaktype: Autovedtaktype): Boolean {
         val åpenBehandling = fagsakService.hent(aktør)?.let {
             behandlingHentOgPersisterService.hentAktivOgÅpenForFagsak(it.id)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.omregning
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
-import no.nav.familie.ba.sak.kjerne.autovedtak.Autovedtaktype
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -63,9 +62,8 @@ class Autobrev6og18ÅrService(
             return
         }
 
-        autovedtakStegService.kjørBehandling(
+        autovedtakStegService.kjørBehandlingOmregning(
             mottakersAktør = behandling.fagsak.aktør,
-            autovedtaktype = Autovedtaktype.OMREGNING_BREV,
             behandlingsdata = AutovedtakBrevBehandlingsdata(
                 aktør = behandling.fagsak.aktør,
                 behandlingsårsak = behandlingsårsak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.omregning
 
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
-import no.nav.familie.ba.sak.kjerne.autovedtak.Autovedtaktype
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -64,9 +63,8 @@ class AutobrevOpphørSmåbarnstilleggService(
             return
         }
 
-        autovedtakStegService.kjørBehandling(
+        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = behandling.fagsak.aktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
             behandlingsdata = behandling.fagsak.aktør
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
@@ -67,11 +67,7 @@ class AutobrevOpphørSmåbarnstilleggService(
         autovedtakStegService.kjørBehandling(
             mottakersAktør = behandling.fagsak.aktør,
             autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
-            behandlingsdata = AutovedtakBrevBehandlingsdata(
-                aktør = behandling.fagsak.aktør,
-                behandlingsårsak = behandlingsårsak,
-                standardbegrunnelse = standardbegrunnelse
-            )
+            behandlingsdata = behandling.fagsak.aktør
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevTask.kt
@@ -45,16 +45,17 @@ class AutobrevTask(
     }
 
     private fun opprettTaskerForReduksjonSmåbarnstillegg() {
-        behandlingHentOgPersisterService.partitionByIverksatteBehandlinger {
+        val berørteFagsaker = behandlingHentOgPersisterService.partitionByIverksatteBehandlinger {
             fagsakRepository.finnAlleFagsakerMedOpphørSmåbarnstilleggIMåned(
                 iverksatteLøpendeBehandlinger = it,
             )
         }
-            .forEach { fagsakId ->
-                opprettTaskService.opprettAutovedtakForOpphørSmåbarnstilleggTask(
-                    fagsakId = fagsakId
-                )
-            }
+        logger.info("Oppretter tasker for ${berørteFagsaker.size} fagsaker med opphør av småbarnstillegg.")
+        berørteFagsaker.forEach { fagsakId ->
+            opprettTaskService.opprettAutovedtakForOpphørSmåbarnstilleggTask(
+                fagsakId = fagsakId
+            )
+        }
     }
 
     private fun finnAlleBarnMedFødselsdagInneværendeMåned(alder: Long): Set<Fagsak> =

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdFeedService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
-import no.nav.familie.ba.sak.kjerne.autovedtak.Autovedtaktype
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.FagsystemRegelVurdering
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.VelgFagSystemService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
@@ -56,11 +55,10 @@ class BehandleFødselshendelseTask(
         }
 
         when (velgFagsystemService.velgFagsystem(nyBehandling).first) {
-            FagsystemRegelVurdering.SEND_TIL_BA -> autovedtakStegService.kjørBehandling(
+            FagsystemRegelVurdering.SEND_TIL_BA -> autovedtakStegService.kjørBehandlingFødselshendelse(
                 mottakersAktør = personidentService.hentAktør(
                     nyBehandling.morsIdent
                 ),
-                autovedtaktype = Autovedtaktype.FØDSELSHENDELSE,
                 behandlingsdata = nyBehandling
             )
             FagsystemRegelVurdering.SEND_TIL_INFOTRYGD -> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/VedtakOmOvergangsstønadTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/VedtakOmOvergangsstønadTask.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.task
 
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
-import no.nav.familie.ba.sak.kjerne.autovedtak.Autovedtaktype
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -28,12 +27,11 @@ class VedtakOmOvergangsstønadTask(
 
         val aktør = personidentService.hentAktør(personIdent)
 
-        val responeFraService = autovedtakStegService.kjørBehandling(
+        val responseFraService = autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
             behandlingsdata = aktør
         )
-        secureLogger.info("Håndterte vedtak om overgangsstønad for person $personIdent:\n$responeFraService")
+        secureLogger.info("Håndterte vedtak om overgangsstønad for person $personIdent:\n$responseFraService")
     }
 
     companion object {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
@@ -8,17 +8,13 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.AutovedtakFødselshendelseService
-import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevBehandlingsdata
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.AutovedtakSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.prosessering.error.RekjørSenereException
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
 class AutobrevStegServiceTest {
@@ -51,46 +47,12 @@ class AutobrevStegServiceTest {
         every { behandlingHentOgPersisterService.hentAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
         every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) } returns ""
 
-        autovedtakStegService.kjørBehandling(
+        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
             behandlingsdata = aktør
         )
 
         verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) }
-    }
-
-    @Test
-    fun `Skal kun ta inn aktør som behandlingsdata for opphør av småbarnstillegg`() {
-        val aktør = randomAktørId()
-        val fagsak = defaultFagsak(aktør)
-        val behandling = lagBehandling(fagsak).also {
-            it.status = BehandlingStatus.AVSLUTTET
-        }
-
-        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
-        every { autovedtakSmåbarnstilleggService.kjørBehandling(aktør) } returns ""
-        every { fagsakService.hent(aktør) } returns fagsak
-        every { behandlingHentOgPersisterService.hentAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns null
-
-        assertThrows<ClassCastException> {
-            autovedtakStegService.kjørBehandling(
-                mottakersAktør = aktør,
-                autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
-                behandlingsdata = AutovedtakBrevBehandlingsdata(
-                    aktør = behandling.fagsak.aktør,
-                    behandlingsårsak = BehandlingÅrsak.OMREGNING_SMÅBARNSTILLEGG,
-                    standardbegrunnelse = Standardbegrunnelse.REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_FULL_OVERGANGSSTØNAD
-                )
-            )
-        }
-        assertDoesNotThrow {
-            autovedtakStegService.kjørBehandling(
-                mottakersAktør = aktør,
-                autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
-                behandlingsdata = aktør
-            )
-        }
     }
 
     @Test
@@ -106,9 +68,8 @@ class AutobrevStegServiceTest {
         every { behandlingHentOgPersisterService.hentAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
         every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) } returns ""
 
-        autovedtakStegService.kjørBehandling(
+        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
             behandlingsdata = aktør
         )
 
@@ -129,9 +90,8 @@ class AutobrevStegServiceTest {
         every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) } returns ""
 
         assertThrows<RekjørSenereException> {
-            autovedtakStegService.kjørBehandling(
+            autovedtakStegService.kjørBehandlingSmåbarnstillegg(
                 mottakersAktør = aktør,
-                autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
                 behandlingsdata = aktør
             )
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
@@ -124,13 +124,12 @@ internal class Autobrev6og18ÅrServiceTest {
         every { persongrunnlagService.hentSøker(any()) } returns tilfeldigSøker()
         every { vedtaksperiodeService.oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(any(), any()) } just runs
         every { taskRepository.save(any()) } returns Task(type = "test", payload = "")
-        every { autovedtakStegService.kjørBehandling<Any>(any(), any(), any()) } returns ""
+        every { autovedtakStegService.kjørBehandlingOmregning(any(), any()) } returns ""
 
         autobrev6og18ÅrService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrev6og18ÅrDTO)
 
         verify(exactly = 1) {
-            autovedtakStegService.kjørBehandling<Any>(
-                any(),
+            autovedtakStegService.kjørBehandlingOmregning(
                 any(),
                 any()
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
@@ -86,14 +86,13 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
         every { stegService.håndterVilkårsvurdering(any()) } returns behandling
         every { stegService.håndterNyBehandling(any()) } returns behandling
         every { vedtaksperiodeService.oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(any(), any()) } just runs
-        every { autovedtakStegService.kjørBehandling<Any>(any(), any(), any()) } returns ""
+        every { autovedtakStegService.kjørBehandlingSmåbarnstillegg(any(), any()) } returns ""
 
         autobrevOpphørSmåbarnstilleggService
             .kjørBehandlingOgSendBrevForOpphørAvSmåbarnstillegg(fagsakId = behandling.fagsak.id)
 
         verify(exactly = 1) {
-            autovedtakStegService.kjørBehandling<Any>(
-                any(),
+            autovedtakStegService.kjørBehandlingSmåbarnstillegg(
                 any(),
                 any()
             )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -14,7 +14,6 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.integrasjoner.`ef-sak`.EfSakRestClient
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
-import no.nav.familie.ba.sak.kjerne.autovedtak.Autovedtaktype
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
@@ -280,9 +279,8 @@ class BehandleSmåbarnstilleggTest(
         settOppefSakMockForDeFørste2Testene(søkersIdent)
 
         val søkersAktør = personidentService.hentAktør(søkersIdent)
-        autovedtakStegService.kjørBehandling(
+        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
             behandlingsdata = søkersAktør
         )
         val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør)
@@ -310,9 +308,8 @@ class BehandleSmåbarnstilleggTest(
                 ),
             )
         )
-        autovedtakStegService.kjørBehandling(
+        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
             behandlingsdata = søkersAktør
         )
 
@@ -367,9 +364,8 @@ class BehandleSmåbarnstilleggTest(
                 ),
             )
         )
-        autovedtakStegService.kjørBehandling(
+        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
             behandlingsdata = søkersAktør
         )
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8654

`autovedtakStegService.kjørBehandling` tar inn et argument `behandlingsdata` som ikke er strengt typet, men som har en forventet type vi kan utlede fra argumentet `autovedtaktype`. I ett tilfelle mottar `autovedtakStegService.kjørBehandling` en `behandlingsdata` og en `autovedtaktype` som ikke matcher med hverandre og vi kaster `ClassCastException`.

```java
java.lang.ClassCastException: class no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevBehandlingsdata cannot be cast to class no.nav.familie.ba.sak.kjerne.personident.Aktør (no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevBehandlingsdata and no.nav.familie.ba.sak.kjerne.personident.Aktør are in unnamed module of loader org.springframework.boot.loader.LaunchedURLClassLoader @7106e68e)
	at no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService.kjørBehandling(AutovedtakStegService.kt:67)
	at no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutobrevOpphørSmåbarnstilleggService.kjørBehandlingOgSendBrevForOpphørAvSmåbarnstillegg(AutobrevOpphørSmåbarnstilleggService.kt:67)
```

I første commit har jeg laget en test som bekrefter feilen vi ser, og rettet feilen. I andre commit har jeg pakket inn `autovedtakStegService.kjørBehandling` slik at den kun kalles fra inngangsfunksjoner for hver `Autovedtaktype` der argumentene er strengt typet, for å unngå at dette skjer igjen.

Grunnen til at det ikke har blitt oppdaget i tester tidligere er at testene for `AutovedtakStegService` bruker riktig typede argumenter, og testene til tjenestene som bruker `AutovedtakStegService` mocker denne ut

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Endringen er dekket av eksisterende tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
