### PR TITLE
fikset slik at systemet støtter AVSLÅTT og FORTSATT_OPPHØRT

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -137,7 +137,19 @@ object BehandlingsresultatUtils {
                 )
             ) -> Behandlingsresultat.DELVIS_INNVILGET_ENDRET_OG_OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.AVSLÅTT) -> Behandlingsresultat.AVSLÅTT
-            samledeResultater.matcherAltOgHarOpphørtResultat(setOf(YtelsePersonResultat.AVSLÅTT)) -> Behandlingsresultat.AVSLÅTT_OG_OPPHØRT
+            samledeResultater == setOf(
+                YtelsePersonResultat.AVSLÅTT,
+                YtelsePersonResultat.FORTSATT_OPPHØRT
+            ) -> Behandlingsresultat.AVSLÅTT // for å få riktig brevmål AVSLÅTT siden det var ingen endring fra forrige
+            samledeResultater == setOf(
+                YtelsePersonResultat.AVSLÅTT,
+                YtelsePersonResultat.OPPHØRT
+            ) -> Behandlingsresultat.AVSLÅTT_OG_OPPHØRT
+            samledeResultater == setOf(
+                YtelsePersonResultat.AVSLÅTT,
+                YtelsePersonResultat.OPPHØRT,
+                YtelsePersonResultat.FORTSATT_OPPHØRT
+            ) -> Behandlingsresultat.AVSLÅTT_OG_OPPHØRT
             samledeResultater.matcherAltOgHarEndretResultat(setOf(YtelsePersonResultat.AVSLÅTT)) -> Behandlingsresultat.AVSLÅTT_OG_ENDRET
             samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(
                 setOf(YtelsePersonResultat.AVSLÅTT)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -108,40 +108,21 @@ object BehandlingsresultatUtils {
             samledeResultater == setOf(YtelsePersonResultat.FORTSATT_OPPHØRT) -> Behandlingsresultat.FORTSATT_OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.ENDRET_UTBETALING) -> Behandlingsresultat.ENDRET_UTBETALING
             samledeResultater == setOf(YtelsePersonResultat.ENDRET_UTEN_UTBETALING) -> Behandlingsresultat.ENDRET_UTEN_UTBETALING
-            samledeResultater.matcherAltOgHarEndretResultat(setOf(YtelsePersonResultat.OPPHØRT)) -> Behandlingsresultat.ENDRET_OG_OPPHØRT
-            samledeResultater.matcherAltOgHarEndretResultat(setOf(YtelsePersonResultat.FORTSATT_OPPHØRT)) -> Behandlingsresultat.ENDRET_OG_OPPHØRT
-            samledeResultater.matcherAltOgHarEndretResultat(
-                setOf(
-                    YtelsePersonResultat.OPPHØRT,
-                    YtelsePersonResultat.FORTSATT_OPPHØRT
-                )
-            ) -> Behandlingsresultat.ENDRET_OG_OPPHØRT
+            samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(emptySet()) -> Behandlingsresultat.ENDRET_OG_OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.OPPHØRT) -> Behandlingsresultat.OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.INNVILGET) -> Behandlingsresultat.INNVILGET
-            samledeResultater == setOf(
-                YtelsePersonResultat.INNVILGET,
-                YtelsePersonResultat.OPPHØRT
-            ) -> Behandlingsresultat.INNVILGET_OG_OPPHØRT
-            samledeResultater == setOf(
-                YtelsePersonResultat.INNVILGET,
-                YtelsePersonResultat.OPPHØRT,
-                YtelsePersonResultat.FORTSATT_OPPHØRT
-            ) -> Behandlingsresultat.INNVILGET_OG_OPPHØRT
+            samledeResultater.matcherAltOgHarOpphørtResultat(setOf(YtelsePersonResultat.INNVILGET)) -> Behandlingsresultat.INNVILGET_OG_OPPHØRT
             samledeResultater.matcherAltOgHarEndretResultat(setOf(YtelsePersonResultat.INNVILGET)) -> Behandlingsresultat.INNVILGET_OG_ENDRET
-            samledeResultater.matcherAltOgHarEndretResultat(
-                setOf(
-                    YtelsePersonResultat.INNVILGET,
-                    YtelsePersonResultat.OPPHØRT
-                )
-            ) -> Behandlingsresultat.INNVILGET_ENDRET_OG_OPPHØRT
+            samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(setOf(YtelsePersonResultat.INNVILGET)) -> Behandlingsresultat.INNVILGET_ENDRET_OG_OPPHØRT
             samledeResultater == setOf(
                 YtelsePersonResultat.INNVILGET,
                 YtelsePersonResultat.AVSLÅTT
             ) -> Behandlingsresultat.DELVIS_INNVILGET
-            samledeResultater == setOf(
-                YtelsePersonResultat.INNVILGET,
-                YtelsePersonResultat.AVSLÅTT,
-                YtelsePersonResultat.OPPHØRT
+            samledeResultater.matcherAltOgHarOpphørtResultat(
+                setOf(
+                    YtelsePersonResultat.INNVILGET,
+                    YtelsePersonResultat.AVSLÅTT
+                )
             ) -> Behandlingsresultat.DELVIS_INNVILGET_OG_OPPHØRT
             samledeResultater.matcherAltOgHarEndretResultat(
                 setOf(
@@ -149,24 +130,17 @@ object BehandlingsresultatUtils {
                     YtelsePersonResultat.AVSLÅTT
                 )
             ) -> Behandlingsresultat.DELVIS_INNVILGET_OG_ENDRET
-            samledeResultater.matcherAltOgHarEndretResultat(
+            samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(
                 setOf(
                     YtelsePersonResultat.INNVILGET,
                     YtelsePersonResultat.AVSLÅTT,
-                    YtelsePersonResultat.OPPHØRT
                 )
             ) -> Behandlingsresultat.DELVIS_INNVILGET_ENDRET_OG_OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.AVSLÅTT) -> Behandlingsresultat.AVSLÅTT
-            samledeResultater == setOf(
-                YtelsePersonResultat.AVSLÅTT,
-                YtelsePersonResultat.OPPHØRT
-            ) -> Behandlingsresultat.AVSLÅTT_OG_OPPHØRT
+            samledeResultater.matcherAltOgHarOpphørtResultat(setOf(YtelsePersonResultat.AVSLÅTT)) -> Behandlingsresultat.AVSLÅTT_OG_OPPHØRT
             samledeResultater.matcherAltOgHarEndretResultat(setOf(YtelsePersonResultat.AVSLÅTT)) -> Behandlingsresultat.AVSLÅTT_OG_ENDRET
-            samledeResultater.matcherAltOgHarEndretResultat(
-                setOf(
-                    YtelsePersonResultat.AVSLÅTT,
-                    YtelsePersonResultat.OPPHØRT,
-                )
+            samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(
+                setOf(YtelsePersonResultat.AVSLÅTT)
             ) -> Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT
             else -> throw ikkeStøttetFeil
         }
@@ -267,4 +241,20 @@ fun Set<YtelsePersonResultat>.matcherAltOgHarEndretResultat(andreElementer: Set<
             it == YtelsePersonResultat.ENDRET_UTEN_UTBETALING
     } ?: return false
     return this == setOf(endretResultat) + andreElementer
+}
+
+fun Set<YtelsePersonResultat>.matcherAltOgHarOpphørtResultat(andreElementer: Set<YtelsePersonResultat>): Boolean {
+    val opphørtResultat = this.intersect(setOf(YtelsePersonResultat.OPPHØRT, YtelsePersonResultat.FORTSATT_OPPHØRT))
+    return this == andreElementer + opphørtResultat
+}
+
+fun Set<YtelsePersonResultat>.matcherAltOgHarBådeEndretOgOpphørtResultat(andreElementer: Set<YtelsePersonResultat>): Boolean {
+    val endretResultat = this.singleOrNull {
+        it == YtelsePersonResultat.ENDRET_UTBETALING ||
+            it == YtelsePersonResultat.ENDRET_UTEN_UTBETALING
+    } ?: return false
+
+    val opphørtResultat = this.intersect(setOf(YtelsePersonResultat.OPPHØRT, YtelsePersonResultat.FORTSATT_OPPHØRT))
+
+    return this == setOf(endretResultat) + opphørtResultat + andreElementer
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -245,7 +245,7 @@ fun Set<YtelsePersonResultat>.matcherAltOgHarEndretResultat(andreElementer: Set<
 
 fun Set<YtelsePersonResultat>.matcherAltOgHarOpphørtResultat(andreElementer: Set<YtelsePersonResultat>): Boolean {
     val opphørtResultat = this.intersect(setOf(YtelsePersonResultat.OPPHØRT, YtelsePersonResultat.FORTSATT_OPPHØRT))
-    return this == andreElementer + opphørtResultat
+    return if (opphørtResultat.isEmpty()) false else this == andreElementer + opphørtResultat
 }
 
 fun Set<YtelsePersonResultat>.matcherAltOgHarBådeEndretOgOpphørtResultat(andreElementer: Set<YtelsePersonResultat>): Boolean {
@@ -256,5 +256,5 @@ fun Set<YtelsePersonResultat>.matcherAltOgHarBådeEndretOgOpphørtResultat(andre
 
     val opphørtResultat = this.intersect(setOf(YtelsePersonResultat.OPPHØRT, YtelsePersonResultat.FORTSATT_OPPHØRT))
 
-    return this == setOf(endretResultat) + opphørtResultat + andreElementer
+    return if (opphørtResultat.isEmpty()) false else this == setOf(endretResultat) + opphørtResultat + andreElementer
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.YearMonth
 
 class BehandlingsresultatUtilsTest {
 
@@ -66,4 +67,78 @@ class BehandlingsresultatUtilsTest {
         }
         assertTrue(feil.message?.contains("ugyldig") ?: false)
     }
+
+    @Test
+    fun `skal returnere AVSLÅTT_OG_OPPHØRT behandlingsresultat`() {
+
+        val personer = listOf(
+            lagYtelsePerson(YtelsePersonResultat.AVSLÅTT),
+            lagYtelsePerson(YtelsePersonResultat.OPPHØRT),
+            lagYtelsePerson(YtelsePersonResultat.FORTSATT_OPPHØRT),
+        )
+
+        assertEquals(
+            Behandlingsresultat.AVSLÅTT_OG_OPPHØRT,
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
+        )
+    }
+
+    @Test
+    fun `skal returnere AVSLÅTT_OG_OPPHØRT behandlingsresultat når et barn har fortsatt opphørt og søker har avslått`() {
+
+        val personer = listOf(
+            lagYtelsePerson(YtelsePersonResultat.AVSLÅTT),
+            lagYtelsePerson(YtelsePersonResultat.FORTSATT_OPPHØRT),
+        )
+
+        assertEquals(
+            Behandlingsresultat.AVSLÅTT_OG_OPPHØRT,
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
+        )
+    }
+
+    @Test
+    fun `skal returnere ENDRET_OG_OPPHØRT behandlingsresultat`() {
+
+        val personer = listOf(
+            lagYtelsePerson(YtelsePersonResultat.ENDRET_UTBETALING),
+            lagYtelsePerson(YtelsePersonResultat.OPPHØRT),
+            lagYtelsePerson(YtelsePersonResultat.FORTSATT_OPPHØRT),
+        )
+
+        assertEquals(
+            Behandlingsresultat.ENDRET_OG_OPPHØRT,
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
+        )
+    }
+
+    @Test
+    fun `skal returnere AVSLÅTT_ENDRET_OG_OPPHØRT behandlingsresultat`() {
+
+        val personer = listOf(
+            lagYtelsePerson(YtelsePersonResultat.ENDRET_UTBETALING),
+            lagYtelsePerson(YtelsePersonResultat.AVSLÅTT),
+            lagYtelsePerson(YtelsePersonResultat.FORTSATT_OPPHØRT),
+        )
+
+        assertEquals(
+            Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT,
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
+        )
+    }
+}
+
+private fun lagYtelsePerson(
+    resultat: YtelsePersonResultat,
+    ytelseSlutt: YearMonth? = YearMonth.now().minusMonths(2)
+): YtelsePerson {
+    val ytelseType = YtelseType.ORDINÆR_BARNETRYGD
+    val kravOpprinnelse = listOf(KravOpprinnelse.TIDLIGERE, KravOpprinnelse.INNEVÆRENDE)
+    return YtelsePerson(
+        aktør = randomAktørId(),
+        ytelseType = ytelseType,
+        kravOpprinnelse = kravOpprinnelse,
+        resultater = setOf(resultat),
+        ytelseSlutt = ytelseSlutt
+    )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -92,7 +92,7 @@ class BehandlingsresultatUtilsTest {
         )
 
         assertEquals(
-            Behandlingsresultat.AVSLÅTT_OG_OPPHØRT,
+            Behandlingsresultat.AVSLÅTT,
             BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
         )
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
I dag støtter systemet kun kombinasjon AVSLÅTT og OPPHØRT som YtelsePersonResultat, men AVSLÅTT og FORTSATT_OPPHØRT bør støttes og skulle utlede behandlingsresultat som AVSLÅTT_OG_OPPHØRT

Fagsystem: https://jira.adeo.no/browse/FAGSYSTEM-221341

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
