### PR TITLE
Ikke opprett oppgave på småbarnstillegsaker der fagsaken var migrert forrige måned

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
@@ -27,7 +27,7 @@ class RestartAvSmåbarnstilleggServiceTest {
     )
 
     @Test
-    fun `Skal ikke finne saker migrert forrige måned`() {
+    fun `Skal ikke inkludere saker som er migrert forrige måned ved opprettelse av restartet småbarnstillegg oppgave`() {
         every { behandlingHentOgPersisterService.partitionByIverksatteBehandlinger<Long>(any()) } returns
             listOf(0L, 1L, 2L)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
@@ -1,0 +1,52 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingMigreringsinfoRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class RestartAvSmåbarnstilleggServiceTest {
+
+    private val fagsakRepository = mockk<FagsakRepository>()
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val behandlingMigreringsinfoRepository = mockk<BehandlingMigreringsinfoRepository>()
+    private val restartAvSmåbarnstilleggService = spyk(
+        RestartAvSmåbarnstilleggService(
+            fagsakRepository = fagsakRepository,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            opprettTaskService = mockk(),
+            vedtakService = mockk(),
+            vedtaksperiodeService = mockk(),
+            behandlingMigreringsinfoRepository = behandlingMigreringsinfoRepository,
+        )
+    )
+
+    @Test
+    fun `Skal ikke finne saker migrert forrige måned`() {
+        every { behandlingHentOgPersisterService.partitionByIverksatteBehandlinger<Long>(any()) } returns
+            listOf(0L, 1L, 2L)
+
+        every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(0L) } returns LocalDate.now()
+
+        every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(1L) } returns LocalDate.now()
+            .minusMonths(1)
+        every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(2L) } returns LocalDate.now()
+            .minusMonths(2)
+
+        every {
+            restartAvSmåbarnstilleggService.periodeMedRestartetSmåbarnstilleggErAlleredeBegrunnet(any(), any())
+        } returns false
+
+        every { restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned(any()) } answers { callOriginal() }
+
+        Assertions.assertEquals(
+            listOf(0L, 2L),
+            restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned()
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
@@ -42,8 +42,6 @@ class RestartAvSmåbarnstilleggServiceTest {
             restartAvSmåbarnstilleggService.periodeMedRestartetSmåbarnstilleggErAlleredeBegrunnet(any(), any())
         } returns false
 
-        every { restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned(any()) } answers { callOriginal() }
-
         Assertions.assertEquals(
             listOf(0L, 2L),
             restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
**Favro:** https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8621

**Hvorfor skal bør denne endringen komme inn?**
Nå oppretter vi en oppgave til saksbehandler for alle saker der vi har oppstart av småbarnstillegg inneværende måned. For saker som er migrert fra Infotrygd vil det alltid se ut som småbarnstillegg ble oppstartet måneden etter. 

**Hva endrer denne PRen?**
Ignorerer saker som ble migrert fra Infotrygd forrige måned når vi henter saker der vi skal varsle bruker at vi gjennoppstarter småbarnstilleg.  

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
