### PR TITLE
Bug: bruk omregningsbrev og -årsak ved "opphør av småbarnstillegg"-autovedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
@@ -63,9 +63,13 @@ class AutobrevOpphørSmåbarnstilleggService(
             return
         }
 
-        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
+        autovedtakStegService.kjørBehandlingOmregning(
             mottakersAktør = behandling.fagsak.aktør,
-            behandlingsdata = behandling.fagsak.aktør
+            behandlingsdata = AutovedtakBrevBehandlingsdata(
+                aktør = behandling.fagsak.aktør,
+                behandlingsårsak = behandlingsårsak,
+                standardbegrunnelse = standardbegrunnelse
+            )
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
@@ -86,13 +86,13 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
         every { stegService.håndterVilkårsvurdering(any()) } returns behandling
         every { stegService.håndterNyBehandling(any()) } returns behandling
         every { vedtaksperiodeService.oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(any(), any()) } just runs
-        every { autovedtakStegService.kjørBehandlingSmåbarnstillegg(any(), any()) } returns ""
+        every { autovedtakStegService.kjørBehandlingOmregning(any(), any()) } returns ""
 
         autobrevOpphørSmåbarnstilleggService
             .kjørBehandlingOgSendBrevForOpphørAvSmåbarnstillegg(fagsakId = behandling.fagsak.id)
 
         verify(exactly = 1) {
-            autovedtakStegService.kjørBehandlingSmåbarnstillegg(
+            autovedtakStegService.kjørBehandlingOmregning(
                 any(),
                 any()
             )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Retter opp en liten feil som ble innført her: https://github.com/navikt/familie-ba-sak/pull/2421

Ved opphør av småbarnstillegg skal man bruke "omregning brev" som autovedtak-type + "omregning småbarnstillegg" skal være behandlingsårsaken. Dette er fordi opphør av småbarnstillegg skal fungere på samme måte som ved omregning 6/18år. 

Sånn koden er før mine endringer i denne PRen ville man ha brukt småbarnstillegg-løypa for autobrev, som ikke fungerer når det er opphør.

(Dette er PRen som innførte omregning småbarnstillegg som en årsak hvis noen skulle være interessert i å etterforske litt: https://github.com/navikt/familie-ba-sak/pull/1863)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Litt vanskelig å forstå småbarnstillegg vs. omregning småbarnstillegg. Noen forslag for å gjøre det enklere å skjønne?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Vet ikke om det gir så mye verdi

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
