### PR TITLE
Flytter filtreringsregler fra ba-infotrygd til ba-sak, rydder opp i toggles som er skrudd på

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -115,10 +115,6 @@ class FeatureToggleConfig(
         const val LAG_REDUKSJONSPERIODER_FRA_INNVILGELSESTIDSPUNKT =
             "familie-ba-sak.lag.reduksjonsperioder.fra.innvilgelsestidspunkt"
 
-        const val SKAL_MIGRERE_ORDINÆR_DELT_BOSTED = "familie-ba-sak.migrer-delt-bosted"
-
-        const val SKAL_MIGRERE_UTVIDET_DELT_BOSTED = "familie-ba-sak.migrer-utvidet-delt-bosted"
-
         const val KAN_MANUELT_MIGRERE_ANNET_ENN_DELT_BOSTED = "familie-ba-sak.manuell-migrering-ikke-delt-bosted"
 
         private val logger = LoggerFactory.getLogger(FeatureToggleConfig::class.java)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.integrasjoner.infotrygd
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.commons.foedselsnummer.testutils.FoedselsnummerGenerator
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
@@ -13,8 +14,6 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.AbstractMockkSpringRunner
 import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
@@ -127,9 +126,6 @@ class MigreringServiceTest(
     @Autowired
     private val envService: EnvService,
 
-    @Autowired
-    private val featureToggleService: FeatureToggleService,
-
 ) : AbstractMockkSpringRunner() {
 
     lateinit var migreringServiceMock: MigreringService
@@ -170,9 +166,6 @@ class MigreringServiceTest(
             mockk(),
             mockk(),
             mockk(),
-            mockk(),
-            mockk(),
-            mockk(relaxed = true),
             mockk(relaxed = true),
         ) // => env.erDev() = env.erE2E() = false
     }
@@ -271,7 +264,6 @@ class MigreringServiceTest(
             listOf(opprettSakMedBeløp(SAK_BELØP_2_BARN_1_UNDER_6 / 2).copy(undervalg = "MD")),
             emptyList()
         )
-        every { featureToggleService.isEnabled(SKAL_MIGRERE_ORDINÆR_DELT_BOSTED, any()) } returns true
 
         val migreringResponseDto = migreringService.migrer(ClientMocks.søkerFnr[0])
 
@@ -376,6 +368,8 @@ class MigreringServiceTest(
 
     @Test
     fun `migrering skal feile dersom person registrert på stønad er også registrert som barn, Det er da mest sannsynlig institusjon`() {
+        val fødselsnrBarn = FoedselsnummerGenerator().foedselsnummer(LocalDate.now()).asString
+
         every {
             infotrygdBarnetrygdClient.hentSaker(any(), any())
         } returns InfotrygdSøkResponse(
@@ -383,7 +377,55 @@ class MigreringServiceTest(
                 Sak(
                     stønad = Stønad(
                         barn = listOf(
-                            Barn(ClientMocks.søkerFnr[0], barnetrygdTom = "000000")
+                            Barn(
+                                fødselsnrBarn,
+                                barnetrygdTom = "000000"
+                            )
+                        ),
+                        antallBarn = 1,
+                        delytelse = listOf(
+                            Delytelse(
+                                fom = LocalDate.now(),
+                                tom = null,
+                                beløp = 2048.0,
+                                typeDelytelse = "MS",
+                                typeUtbetaling = "J",
+                            )
+                        ),
+                        opphørsgrunn = "0"
+                    ),
+                    status = "FB",
+                    valg = "OR",
+                    undervalg = "OS"
+                )
+
+            ),
+            emptyList()
+        )
+
+        assertThatThrownBy {
+            migreringService.migrer(fødselsnrBarn)
+        }.isInstanceOf(KanIkkeMigrereException::class.java)
+            .hasMessage(null)
+            .extracting("feiltype").isEqualTo(MigreringsfeilType.INSTITUSJON)
+    }
+
+    @Test
+    fun `migrering skal feile dersom har barn er 18 år`() {
+        val fødselsnrBarn =
+            FoedselsnummerGenerator().foedselsnummer(LocalDate.now().minusYears(18)).asString
+
+        every {
+            infotrygdBarnetrygdClient.hentSaker(any(), any())
+        } returns InfotrygdSøkResponse(
+            listOf(
+                Sak(
+                    stønad = Stønad(
+                        barn = listOf(
+                            Barn(
+                                fødselsnrBarn,
+                                barnetrygdTom = "000000"
+                            )
                         ),
                         antallBarn = 1,
                         delytelse = listOf(
@@ -410,7 +452,7 @@ class MigreringServiceTest(
             migreringService.migrer(ClientMocks.søkerFnr[0])
         }.isInstanceOf(KanIkkeMigrereException::class.java)
             .hasMessage(null)
-            .extracting("feiltype").isEqualTo(MigreringsfeilType.INSTITUSJON)
+            .extracting("feiltype").isEqualTo(MigreringsfeilType.HAR_BARN_OVER_18_PÅ_INFOTRYGDSAK)
     }
 
     @Test
@@ -473,7 +515,7 @@ class MigreringServiceTest(
         every { infotrygdBarnetrygdClient.hentSaker(any(), any()) } returns
             InfotrygdSøkResponse(listOf(opprettSakMedBeløp(SAK_BELØP_2_BARN_1_UNDER_6, 660.0)), emptyList())
         assertThatThrownBy { migreringService.migrer(ClientMocks.søkerFnr[0]) }.isInstanceOf(KanIkkeMigrereException::class.java)
-            .hasMessage(null)
+            .hasMessage("Fant ugylding antall delytelser 2")
             .extracting("feiltype").isEqualTo(MigreringsfeilType.UGYLDIG_ANTALL_DELYTELSER_I_INFOTRYGD)
     }
 
@@ -597,7 +639,6 @@ class MigreringServiceTest(
             mockk(),
             mockk(),
             mockk(),
-            mockk(),
             mockkPersonidentService,
             mockk(),
             mockk(),
@@ -606,9 +647,7 @@ class MigreringServiceTest(
             mockk(),
             mockk(),
             mockk(),
-            mockk(),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
+            mockk(relaxed = true)
         )
 
         val aktivFnr = randomFnr()
@@ -636,9 +675,7 @@ class MigreringServiceTest(
             env = mockk(),
             fagsakService = mockk(),
             infotrygdBarnetrygdClient = infotrygdBarnetrygdClient,
-            pdlRestClient = mockk(),
             personidentService = mockkPersonidentService,
-            personopplysningerService = mockk(),
             stegService = mockk(),
             taskRepository = mockk(),
             tilkjentYtelseRepository = mockk(),
@@ -647,7 +684,6 @@ class MigreringServiceTest(
             vilkårService = mockk(),
             vilkårsvurderingService = mockk(),
             migreringRestClient = mockk(relaxed = true),
-            featureToggleService = mockk(relaxed = true),
         )
 
         val ident = randomFnr()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.verdikjedetester
 
 import io.mockk.every
 import no.nav.familie.ba.sak.common.LocalDateService
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.KanIkkeMigrereException
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.MigreringService
@@ -81,12 +80,7 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal migrere delt bosted med 1 barn under 6 år`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
-                any()
-            )
-        } returns true
+
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -141,12 +135,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal migrere delt bosted med 1 barn over 6 år`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -201,12 +189,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal migrere delt bosted med 3 barn over 6 år`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -271,12 +253,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal migrere delt bosted med 2 barn over 6 år og 1 under`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -341,12 +317,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal feile migrere fordi beregnet beløp er ulikt beregnet beløp i ba-sak `() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_ORDINÆR_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -395,12 +365,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal migrere utvidet barnetrygd med delt bosted for ett barn over 6 år`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -455,12 +419,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal migrere utvidet barnetrygd for ett barn under 3 år`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -513,12 +471,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal feile migrering av utvidet barnetrygd med delt bosted pga ulikt antall barn når et av barna er over 18`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(
@@ -572,12 +524,6 @@ class MigrerFraInfotrygdTest(
 
     @Test
     fun `skal feile migrering dersom ikke småbarnstillegg stemmer overens`() {
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.SKAL_MIGRERE_UTVIDET_DELT_BOSTED,
-                any()
-            )
-        } returns true
         every { mockLocalDateService.now() } returns LocalDate.of(2021, 12, 12) andThen LocalDate.now()
 
         val barnPåInfotrygdSøknadScenario = mockServerKlient().lagScenario(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
@@ -519,7 +519,7 @@ class MigrerFraInfotrygdTest(
 
         val exception =
             assertThrows<KanIkkeMigrereException> { migreringService.migrer(sakKlarForMigreringScenario.søker.ident!!) }
-        assertThat(exception.feiltype).isEqualTo(MigreringsfeilType.DIFF_BARN_INFOTRYGD_OG_BA_SAK)
+        assertThat(exception.feiltype).isEqualTo(MigreringsfeilType.HAR_BARN_OVER_18_PÅ_INFOTRYGDSAK)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Flytter filtreringsregler til ba-sak fra infotrygd ved migrering og litt opprydding av toggles

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
