### PR TITLE
Hopp over validering for om vi har barnas fødselsdager dersom begrunnelsen er AVSLAG_UREGISTRERT_BARN

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -150,7 +150,8 @@ fun BrevBegrunnelseGrunnlagMedPersoner.tilBrevBegrunnelse(
     val søknadstidspunkt = endringsperioder.sortedBy { it.søknadstidspunkt }
         .firstOrNull { this.triggesAv.endringsaarsaker.contains(it.årsak) }?.søknadstidspunkt
 
-    val søkersRettTilUtvidet = finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer)
+    val søkersRettTilUtvidet =
+        finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer)
 
     this.validerBrevbegrunnelse(
         gjelderSøker = gjelderSøker,
@@ -221,7 +222,10 @@ private fun BrevBegrunnelseGrunnlagMedPersoner.validerBrevbegrunnelse(
     gjelderSøker: Boolean,
     barnasFødselsdatoer: List<LocalDate>,
 ) {
-    if (!gjelderSøker && barnasFødselsdatoer.isEmpty() && !this.triggesAv.satsendring) {
+    if (!gjelderSøker && barnasFødselsdatoer.isEmpty() &&
+        !this.triggesAv.satsendring &&
+        this.standardbegrunnelse != Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN
+    ) {
         throw IllegalStateException("Ingen personer på brevbegrunnelse")
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Etter diskusjon på slack:  https://nav-it.slack.com/archives/C036C6VAWH3/p1653030760824749

Hvorfor: 
Ser det er en validering som forventer at vi skal ha minst en fødselsdato med om ikke begrunnelsen gjelder søker, men i dette tilfellet har vi ingen fødselsdatoer.
Begrunnelsen det gjelder er “13. Barn uten fødselsnummer”. Ser fødselsdagene ikke blir brukt der, så antar vi kan skippe valideringen om det er snakk om den begrunnelsen

Hva: Hopper over valideringen som sjekker at vi sender med minst ett av barna sine fødselsdager dersom vi bruker begrunnelse "13. Barn uten fødselsnummer" (heter AVSLAG_UREGISTRERT_BARN i ba-sak)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
