### PR TITLE
unngikk validering med barnasFødselsdatoer for AVSLAG_UREGISTRERT_BARN

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -150,11 +150,13 @@ fun BrevBegrunnelseGrunnlagMedPersoner.tilBrevBegrunnelse(
     val søknadstidspunkt = endringsperioder.sortedBy { it.søknadstidspunkt }
         .firstOrNull { this.triggesAv.endringsaarsaker.contains(it.årsak) }?.søknadstidspunkt
 
-    val søkersRettTilUtvidet = finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer)
+    val søkersRettTilUtvidet =
+        finnUtOmSøkerFårUtbetaltEllerHarRettPåUtvidet(minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer)
 
     this.validerBrevbegrunnelse(
         gjelderSøker = gjelderSøker,
         barnasFødselsdatoer = barnasFødselsdatoer,
+        standardbegrunnelse = this.standardbegrunnelse
     )
 
     return BegrunnelseData(
@@ -220,8 +222,12 @@ fun Standardbegrunnelse.hentRelevanteEndringsperioderForBegrunnelse(
 private fun BrevBegrunnelseGrunnlagMedPersoner.validerBrevbegrunnelse(
     gjelderSøker: Boolean,
     barnasFødselsdatoer: List<LocalDate>,
+    standardbegrunnelse: Standardbegrunnelse
 ) {
-    if (!gjelderSøker && barnasFødselsdatoer.isEmpty() && !this.triggesAv.satsendring) {
+    val standardbegrunnelseKreverBarnasFødselsdato =
+        standardbegrunnelse != Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN &&
+            barnasFødselsdatoer.isEmpty()
+    if (!gjelderSøker && standardbegrunnelseKreverBarnasFødselsdato && !this.triggesAv.satsendring) {
         throw IllegalStateException("Ingen personer på brevbegrunnelse")
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
I prod feiler vedtaksbrev når førstegangsbehandling kun har ett barn som er uregistrert. Validering på vedtaksbrevet feiler fordi denne krever barnasfødselsdato. Siden brev ikke bruker barnasfødselsdato i denne tilfellen, kan det unngås.

https://sentry.gc.nav.no/organizations/nav/issues/56596/?referrer=slack

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
