### PR TITLE
Bug: får ikke henlagt teknisk endring-behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -185,11 +185,11 @@ data class Behandling(
 
     fun leggTilHenleggStegOmDetIkkeFinnesFraFør(): Behandling {
         leggTilStegOmDetIkkeFinnesFraFør(StegType.HENLEGG_BEHANDLING)
-        fjernStegFraBehandlingStegTilstandSomSkalSkjeEtterHenleggSteg()
+        fjernStegSomSkalSkjeEtterHenleggStegFraBehandlingStegTilstand()
         return this
     }
 
-    fun fjernStegFraBehandlingStegTilstandSomSkalSkjeEtterHenleggSteg(): Behandling {
+    fun fjernStegSomSkalSkjeEtterHenleggStegFraBehandlingStegTilstand(): Behandling {
         val ferdigstillBehandlingSteg =
             this.behandlingStegTilstand.find { it.behandlingSteg == StegType.FERDIGSTILLE_BEHANDLING && it.behandlingStegStatus == BehandlingStegStatus.IKKE_UTFØRT }
         if (ferdigstillBehandlingSteg != null) this.behandlingStegTilstand.remove(ferdigstillBehandlingSteg)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -185,11 +185,11 @@ data class Behandling(
 
     fun leggTilHenleggStegOmDetIkkeFinnesFraFør(): Behandling {
         leggTilStegOmDetIkkeFinnesFraFør(StegType.HENLEGG_BEHANDLING)
-        fjernStegSomSkjerEtterHenleggSteg()
+        fjernStegFraBehandlingStegTilstandSomSkalSkjeEtterHenleggSteg()
         return this
     }
 
-    fun fjernStegSomSkjerEtterHenleggSteg(): Behandling {
+    fun fjernStegFraBehandlingStegTilstandSomSkalSkjeEtterHenleggSteg(): Behandling {
         val ferdigstillBehandlingSteg =
             this.behandlingStegTilstand.find { it.behandlingSteg == StegType.FERDIGSTILLE_BEHANDLING && it.behandlingStegStatus == BehandlingStegStatus.IKKE_UTFØRT }
         if (ferdigstillBehandlingSteg != null) this.behandlingStegTilstand.remove(ferdigstillBehandlingSteg)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -185,6 +185,14 @@ data class Behandling(
 
     fun leggTilHenleggStegOmDetIkkeFinnesFraFør(): Behandling {
         leggTilStegOmDetIkkeFinnesFraFør(StegType.HENLEGG_BEHANDLING)
+        fjernStegSomSkjerEtterHenleggSteg()
+        return this
+    }
+
+    fun fjernStegSomSkjerEtterHenleggSteg(): Behandling {
+        val ferdigstillBehandlingSteg =
+            this.behandlingStegTilstand.find { it.behandlingSteg == StegType.FERDIGSTILLE_BEHANDLING && it.behandlingStegStatus == BehandlingStegStatus.IKKE_UTFØRT }
+        if (ferdigstillBehandlingSteg != null) this.behandlingStegTilstand.remove(ferdigstillBehandlingSteg)
         return this
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

### ✨TLDR; Hvis man henlegger en behandling som er på ferdigstille behandling-steget, vil man få en feilmelding. Dette skjer fordi henlegge behandling-steget sender oss videre til ferdigstille behandling-steget, men listen som holder styr på utførte og inneværende steg bruker siste steg i listen som inneværende steg. Dette vil være henlegge behandling, og ikke ferdigstille behandling, siden behandlingen var innom (men ikke utførte) ferdigstille behandling før den ble henlagt. Da vil det se ut som man prøver å utføre "ferdigstille behandling"-steget, mens man er på "henlegge behandling"-steget, noe som ikke skal være lov. Løsning: fjerne "ferdigstille behandling"-steget fra listen over steg hvis det er inneværende steg når behandlingen henlegges. ✨ 

Veldig vanskelig å forklare skriftlig. Har prøvd meg på en forklaring under, men bare pling på meg hvis det er noe du lurer på. Forklarer med glede 😃 

### **Backstory**
Det er en (lang) historie bak bugen, tar det i korte trekk her så det er lettere å sette seg inn i casen. Vet ikke om alt her er så relevant for å forstå casen, men skriver det ned i korte trekk uansett.
- Det var en behandling i prod som manglet to vilkår på søker. Vi rettet opp feilen, men for å få tilbake vilkårene på saken i prod så ble vi enige om at Anna og Birgitte skulle lage en teknisk endring-behandling hvor disse to vilkårene dukker opp igjen. 
- Denne behandlingen fikk da resultat fortsatt innvilget, noe som ikke var støttet som resultat for teknisk endring behandlinger, fordi den gikk videre til iverksetting mot økonomi uansett (noe som feiler ved fortsatt innvilget). 
- Halvor og jeg la derfor på funksjonalitet i teknisk endring behandlinger for å støtte fortsatt innvilget: hoppe over iverksetting mot økonomi og journalføring når resultatet er fortsatt innvilget på en teknisk endring behandling (dvs. gå rett til ferdigstille behandling fra beslutte vedtak). Disse to PRene: https://github.com/navikt/familie-ba-sak/pull/2449 https://github.com/navikt/familie-ba-sak/pull/2426
- Når vi rettet denne bugen glemte vi en viktig detalj, nemlig det å lagre ned tasken som ferdigstiller behandling. Det gjorde at behandlingen som Anna og Birgitte besluttet i prod hang seg fast med "Iverksetter vedtak" som status, fordi tasken aldri ble kjørt. Dette ble rettet her: https://github.com/navikt/familie-ba-sak/pull/2474
- Tanken var derfor at Anna og Birgitte skulle henlegge behandlingen som hadde hengt seg opp, og lage ny behandling etter at buggen med lagring av task var fikset. Problemet nå var at Anna ikke får til å henlegge saken. Hun fikk denne feilmeldingen når hun prøvde å henlegge 
![image](https://user-images.githubusercontent.com/25459913/169538387-6c23eb7e-f891-4c99-8058-4005e01671ad.png)

### **Nice to know før du leser videre**
- Dette er rekkefølgen på stegene ved teknisk endring-behandling. Hvis resultatet er fortsatt innvilget, avslått, fortsatt opphørt eller endret uten utbetaling hopper vi over iverksetting og går direkte til FERDIGSTILLE_BEHANDLING fra BESLUTTE_VEDTAK.
![image](https://user-images.githubusercontent.com/25459913/169543165-29691d26-c770-4b60-89fe-9d8c6cfb2af9.png)
![image](https://user-images.githubusercontent.com/25459913/169543494-621af527-a845-432e-86dc-2cf14caf11fe.png)
- Hvis vi er på HENLEGG_BEHANDLING steget, så vil neste steg alltid være FERDIGSTILLE_BEHANDLING
![image](https://user-images.githubusercontent.com/25459913/169543613-f4d295df-de9a-4ee0-9a28-8547b67b2425.png)_

### **Forklaring av det som feiler nå**
Vi bygger opp en liste med steg som behandlingen har gått igjennom, samt inneværende steg. Denne listen heter behandlingStegTilstand. For eksempel, for en vanlig søknad, når du er på behandlingsresultat-steget, vil den se sånn ca sånn her ut: `[{REGISTRERE_PERSONGRUNNLAG, UTFØRT}, {REGISTRERE_SØKNAD, UTFØRT}, {VILKÅRSVURDERING, UTFØRT}, {BEHANDLINGSRESULTAT, IKKE_UTFØRT}]`.
Når du henlegger en behandling legger du til HENLEGG_BEHANDLING som et steg i behandlingStegTilstand-listen, og for alle behandlingstyper vil det neste steget etter HENLEGG_BEHANDLING være FERDIGSTILLE_BEHANDLING.

Problemet som oppsto når Anna prøvde å henlegge behandlingen er at behandlingen allerede er i steg FERDIGSTILLE_BEHANDLING når vi prøver å henlegge. Sånn steg-funksjonaliteten vår fungerer er at det siste steget som ligger i behandlingStegTilstand er det "aktive" steget som behandlingen er på. Siden FERDIGSTILLE_BEHANDLING allerede ligger som et steg i BehandlingStegTilstand blir det ikke lagt til på nytt, og når vi går videre til Ferdigstille behandling-steget så tror vi fortsatt at behandlingen har steg=HENLEGG_BEHANDLING siden dette er steget som ligger nederst i listen. 

Noe som er greit å merke seg er at dette egentlig aldri vil skje. Det har kun skjedd fordi jeg glemte å lagre ned tasken. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Hele flyten med steg og stegTilstand er ganske komplisert å skjønne. Tok meg ganske lang tid (og litt hjelp av Halvor) å skjønne hva som var gærent her😬 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Koster ganske mye å skrive en godt dekkende test her, og dette er et tilfelle som egentlig aldri vil skje, så føler ikke at det er verdt å skrive test. Har testet det godt lokalt!

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
Det er litt vanskelig å forklare problemet, så kan gjerne ta en gjennomgang om ønskelig 😄 
