### PR TITLE
Bug: for mange barn kommer med i "etter endret utbetaling"-begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlagMedPersoner.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlagMedPersoner.kt
@@ -40,7 +40,7 @@ data class BrevBegrunnelseGrunnlagMedPersoner(
         this.standardbegrunnelse == Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN ->
             uregistrerteBarn.mapNotNull { it.fødselsdato }
 
-        gjelderSøker && this.vedtakBegrunnelseType != VedtakBegrunnelseType.ENDRET_UTBETALING -> {
+        gjelderSøker && this.vedtakBegrunnelseType != VedtakBegrunnelseType.ENDRET_UTBETALING && this.vedtakBegrunnelseType != VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING -> {
             if (this.vedtakBegrunnelseType == VedtakBegrunnelseType.AVSLAG) {
                 personerIBehandling
                     .filter { it.type == PersonType.BARN }

--- a/src/test/resources/brevperiodeCaser/ETTER_ENDRET_UTBETALING.json
+++ b/src/test/resources/brevperiodeCaser/ETTER_ENDRET_UTBETALING.json
@@ -1,0 +1,115 @@
+{
+  "beskrivelse": "Innvilget delt bosted barn og utvidet. Barn og utvidet endret utbetaling i forrige periode.",
+  "fom": "2019-07-01",
+  "tom": "2020-02-29",
+  "vedtaksperiodetype": "UTBETALING",
+  "begrunnelser": [
+    {
+      "standardbegrunnelse": "ETTER_ENDRET_UTBETALING_HAR_AVTALE_DELT_BOSTED"
+    }
+  ],
+  "fritekster": [],
+  "utvidetScenario": "IKKE_UTVIDET_YTELSE",
+  "uregistrerteBarn": [],
+  "erFørsteVedtaksperiodePåFagsak": false,
+  "brevMålform": "NB",
+  "personerPåBehandling": [
+    {
+      "fødselsdato": "2015-01-20",
+      "type": "BARN",
+      "overstyrteVilkårresultater": [
+        {
+          "vilkårType": "BOR_MED_SØKER",
+          "resultat": "OPPFYLT",
+          "periodeFom": "2019-05-01",
+          "periodeTom": null,
+          "utdypendeVilkårsvurderinger": [
+            "DELT_BOSTED"
+          ],
+          "erEksplisittAvslagPåSøknad": false
+        }
+      ],
+      "andreVurderinger": [],
+      "endredeUtbetalinger": [
+        {
+          "periode": {
+            "fom": "2019-06",
+            "tom": "2019-06"
+          },
+          "årsak": "DELT_BOSTED",
+          "søknadstidspunkt": "2021-01-31",
+          "avtaletidspunktDeltBosted": "2021-04-02"
+        }
+      ],
+      "utbetalinger": [
+        {
+          "ytelseType": "ORDINÆR_BARNETRYGD",
+          "utbetaltPerMnd": 527,
+          "erPåvirketAvEndring": false,
+          "prosent": 50
+        }
+      ]
+    },
+    {
+      "fødselsdato": "2012-06-13",
+      "type": "BARN",
+      "overstyrteVilkårresultater": [],
+      "andreVurderinger": [],
+      "endredeUtbetalinger": [],
+      "utbetalinger": [
+        {
+          "ytelseType": "ORDINÆR_BARNETRYGD",
+          "utbetaltPerMnd": 1054,
+          "erPåvirketAvEndring": false,
+          "prosent": 100
+        }
+      ]
+    },
+    {
+      "fødselsdato": "1993-08-10",
+      "type": "SØKER",
+      "overstyrteVilkårresultater": [],
+      "andreVurderinger": [],
+      "endredeUtbetalinger": [{
+        "periode": {
+          "fom": "2019-06",
+          "tom": "2019-06"
+        },
+        "årsak": "DELT_BOSTED",
+        "søknadstidspunkt": "2021-01-31",
+        "avtaletidspunktDeltBosted": "2021-04-02"
+      }],
+      "utbetalinger": [{
+        "ytelseType": "UTVIDET_BARNETRYGD",
+        "utbetaltPerMnd": 527,
+        "erPåvirketAvEndring": false,
+        "prosent": 50
+      }]
+    }
+  ],
+  "forventetOutput": {
+    "fom": "1. juli 2019",
+    "tom": "til 29. februar 2020 ",
+    "belop": 2108,
+    "antallBarn": 2,
+    "barnasFodselsdager": "13.06.12 og 20.01.15",
+    "begrunnelser": [
+      {
+        "gjelderSoker": true,
+        "barnasFodselsdatoer": "20.01.15",
+        "fodselsdatoerBarnOppfyllerTriggereOgHarUtbetaling": "20.01.15",
+        "fodselsdatoerBarnOppfyllerTriggereOgHarNullutbetaling": "",
+        "antallBarn": 1,
+        "antallBarnOppfyllerTriggereOgHarUtbetaling": 1,
+        "antallBarnOppfyllerTriggereOgHarNullutbetaling": 0,
+        "maanedOgAarBegrunnelsenGjelderFor": "juni 2019",
+        "maalform": "bokmaal",
+        "apiNavn": "etterEndretUtbetalingAvtaleDeltBosted",
+        "belop": 2108,
+        "soknadstidspunkt": "31.01.21",
+        "sokersRettTilUtvidet": "sokerFaarUtvidet"
+      }
+    ],
+    "type": "innvilgelse"
+  }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro (nederste bug): https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8721

**Opplevd feil**
Får med for mange barn i begrunnelse for etter endret utbetaling. Skulle ha kun hatt med barn som i forrige periode hadde endret utbetaling, men opplever å få med alle barna i perioden.

**Årsak**
Hvis søker er med i personerPåBegrunnelse så la vi tidligere på alle barna med utbetaling i tillegg, så lenge det ikke var endret utbetaling eller avslag. 

**Løsning**
Gir heller ikke mening å legge på alle barn hvis det er "etter endret utbetaling"-begrunnelse heller, fordi man da gjerne vil snakke om samme barn som i "endret utbetaling". Sørger derfor for at man kun sender med de personene som vi har funnet som relevante for begrunnelsen.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nop. Eller det er litt mye spesiallogikk her nå, men vet ikke hvor lett det er å endre på uten å skrive om hele brevriggen.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
