### PR TITLE
Filtrere vekk barn over 18, så lenge antall barn stemmer overens med antall barn under 18

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -308,7 +308,7 @@ class MigreringService(
             .map { it.barnFnr!! }
             .partition { ident -> FoedselsNr(ident).foedselsdato.isSameOrBefore(LocalDate.now().minusYears(18L)) }
 
-        if (barnUnder18.size != barnOver18.size) {
+        if (barnOver18.size > 0) {
             secureLog.warn("Det er barn på stønaden i infotrygd som er over 18 år. Disse vil bli ignorert.  $barnOver18 sak=$løpendeSak")
         }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/MigrerFraInfotrygdTest.kt
@@ -519,7 +519,7 @@ class MigrerFraInfotrygdTest(
 
         val exception =
             assertThrows<KanIkkeMigrereException> { migreringService.migrer(sakKlarForMigreringScenario.søker.ident!!) }
-        assertThat(exception.feiltype).isEqualTo(MigreringsfeilType.HAR_BARN_OVER_18_PÅ_INFOTRYGDSAK)
+        assertThat(exception.feiltype).isEqualTo(MigreringsfeilType.OPPGITT_ANTALL_BARN_ULIKT_ANTALL_BARNIDENTER)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- Åpner opp for å migrere stønader som har barn over 18, men kun de som har antall barn under 18 lik antall barn på stønaden
- Saker uten barn og uten delytelse til egen feiltype. Disse skal nok aldri migreres

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
