### PR TITLE
Ikke gå via famlile-brev når vi bare skal hente data om begrunnelsene

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -86,6 +86,8 @@ spec:
           cluster: dev-gcp
         - application: familie-ba-migrering
           cluster: dev-gcp
+      external:
+        - host: xsrv1mh6.api.sanity.io
   replicas:
     min: 2
     max: 4

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -85,6 +85,8 @@ spec:
           cluster: prod-gcp
         - application: familie-ba-migrering
           cluster: prod-gcp
+      external:
+        - host: xsrv1mh6.api.sanity.io
   replicas:
     min: 2
     max: 4

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityService.kt
@@ -20,15 +20,5 @@ class SanityService(
         maxAttempts = 3,
         backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS),
     )
-    fun hentSanityBegrunnelser(): List<SanityBegrunnelse> {
-        val erIMiljø = environment.activeProfiles.any {
-            listOf("preprod", "prod").contains(it.trim(' '))
-        }
-
-        return if (erIMiljø) {
-            brevKlient.hentSanityBegrunnelser()
-        } else {
-            cachedSanityKlient.hentSanityBegrunnelserCached()
-        }
-    }
+    fun hentSanityBegrunnelser(): List<SanityBegrunnelse> = cachedSanityKlient.hentSanityBegrunnelserCached()
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevKlient.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.common.kallEksternTjeneste
-import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brev
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.BegrunnelseData
 import no.nav.familie.http.client.AbstractRestClient
@@ -28,18 +26,6 @@ class BrevKlient(
         return kallEksternTjeneste(FAMILIE_BREV_TJENESTENAVN, uri, "Hente pdf for vedtaksbrev") {
             postForEntity(uri, brev.data)
         }
-    }
-
-    @Cacheable("begrunnelsestekster-for-nedtreksmeny", cacheManager = "shortCache")
-    fun hentSanityBegrunnelser(): List<SanityBegrunnelse> {
-        val uri = URI.create("$familieBrevUri/ba-sak/begrunnelser")
-
-        val restSanityBegrunnelser =
-            kallEksternTjeneste(FAMILIE_BREV_TJENESTENAVN, uri, "Henter begrunnelser fra sanity via familie brev") {
-                getForEntity<List<RestSanityBegrunnelse>>(uri)
-            }
-
-        return restSanityBegrunnelser.map { it.tilSanityBegrunnelse() }
     }
 
     @Cacheable("begrunnelsestekst", cacheManager = "shortCache")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tidligere har vi hentet begrunnelsene fra sanity ved å gå via familie-brev, selv om vi ikke trengte å flette inn noen brukerdata. Dette er fordi ba-sak en gang i tiden kjørte on-prem hvor det var vanskelig å nå saniyt fra, mens familie-brev kjørte fra gcp. Nå som ba-sak kjører på gcp kan vi hente begrunnelsene direkte fra sanity. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
