### PR TITLE
Fjern validering av avslag uten perioder for "bor med søker"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -92,12 +92,15 @@ object VilkårsvurderingUtils {
         val resultaterPåVilkår =
             personSomEndres.vilkårResultater.filter { it.vilkårType == vilkårSomEndres.vilkårType && it.id != vilkårSomEndres.id }
         when {
-            vilkårSomEndres.erAvslagUtenPeriode() && resultaterPåVilkår.any { it.resultat == Resultat.OPPFYLT && it.harFremtidigTom() } ->
+            // For bor med søker-vilkåret kan avslag og innvilgelse være overlappende, da man kan f.eks. avslå full barnetrygd, men innvilge delt
+            vilkårSomEndres.erAvslagUtenPeriode() && resultaterPåVilkår.any { it.resultat == Resultat.OPPFYLT && it.harFremtidigTom() } &&
+                vilkårSomEndres.vilkårType != Vilkår.BOR_MED_SØKER ->
                 throw FunksjonellFeil(
                     "Finnes løpende oppfylt ved forsøk på å legge til avslag uten periode ",
                     "Du kan ikke legge til avslag uten datoer fordi det finnes oppfylt løpende periode på vilkåret."
                 )
-            vilkårSomEndres.harFremtidigTom() && resultaterPåVilkår.any { it.erAvslagUtenPeriode() } ->
+            vilkårSomEndres.harFremtidigTom() && resultaterPåVilkår.any { it.erAvslagUtenPeriode() } &&
+                vilkårSomEndres.vilkårType != Vilkår.BOR_MED_SØKER ->
                 throw FunksjonellFeil(
                     "Finnes avslag uten periode ved forsøk på å legge til løpende oppfylt",
                     "Du kan ikke legge til løpende periode fordi det er vurdert avslag uten datoer på vilkåret."

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -93,14 +93,13 @@ object VilkårsvurderingUtils {
             personSomEndres.vilkårResultater.filter { it.vilkårType == vilkårSomEndres.vilkårType && it.id != vilkårSomEndres.id }
         when {
             // For bor med søker-vilkåret kan avslag og innvilgelse være overlappende, da man kan f.eks. avslå full barnetrygd, men innvilge delt
-            vilkårSomEndres.erAvslagUtenPeriode() && resultaterPåVilkår.any { it.resultat == Resultat.OPPFYLT && it.harFremtidigTom() } &&
-                vilkårSomEndres.vilkårType != Vilkår.BOR_MED_SØKER ->
+            vilkårSomEndres.vilkårType == Vilkår.BOR_MED_SØKER -> return
+            vilkårSomEndres.erAvslagUtenPeriode() && resultaterPåVilkår.any { it.resultat == Resultat.OPPFYLT && it.harFremtidigTom() } ->
                 throw FunksjonellFeil(
                     "Finnes løpende oppfylt ved forsøk på å legge til avslag uten periode ",
                     "Du kan ikke legge til avslag uten datoer fordi det finnes oppfylt løpende periode på vilkåret."
                 )
-            vilkårSomEndres.harFremtidigTom() && resultaterPåVilkår.any { it.erAvslagUtenPeriode() } &&
-                vilkårSomEndres.vilkårType != Vilkår.BOR_MED_SØKER ->
+            vilkårSomEndres.harFremtidigTom() && resultaterPåVilkår.any { it.erAvslagUtenPeriode() } ->
                 throw FunksjonellFeil(
                     "Finnes avslag uten periode ved forsøk på å legge til løpende oppfylt",
                     "Du kan ikke legge til løpende periode fordi det er vurdert avslag uten datoer på vilkåret."

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -30,7 +30,7 @@ class VilkårsvurderingUtilsTest {
             personResultat = personResultat,
             periodeFom = LocalDate.of(2020, 1, 1),
             periodeTom = null,
-            vilkårType = Vilkår.BOR_MED_SØKER,
+            vilkårType = Vilkår.LOVLIG_OPPHOLD,
             resultat = Resultat.OPPFYLT,
             begrunnelse = "",
             behandlingId = 0
@@ -39,7 +39,7 @@ class VilkårsvurderingUtilsTest {
 
         val avslagUtenPeriode = RestVilkårResultat(
             id = 123,
-            vilkårType = Vilkår.BOR_MED_SØKER,
+            vilkårType = Vilkår.LOVLIG_OPPHOLD,
             resultat = Resultat.IKKE_OPPFYLT,
             periodeFom = null,
             periodeTom = null,
@@ -68,7 +68,7 @@ class VilkårsvurderingUtilsTest {
             personResultat = personResultat,
             periodeFom = null,
             periodeTom = null,
-            vilkårType = Vilkår.BOR_MED_SØKER,
+            vilkårType = Vilkår.LOVLIG_OPPHOLD,
             resultat = Resultat.IKKE_OPPFYLT,
             begrunnelse = "",
             behandlingId = 0,
@@ -78,7 +78,7 @@ class VilkårsvurderingUtilsTest {
 
         val løpendeOppfylt = RestVilkårResultat(
             id = 123,
-            vilkårType = Vilkår.BOR_MED_SØKER,
+            vilkårType = Vilkår.LOVLIG_OPPHOLD,
             resultat = Resultat.OPPFYLT,
             periodeFom = LocalDate.of(2020, 1, 1),
             periodeTom = null,
@@ -92,6 +92,44 @@ class VilkårsvurderingUtilsTest {
             VilkårsvurderingUtils.validerAvslagUtenPeriodeMedLøpende(
                 personSomEndres = personResultat,
                 vilkårSomEndres = løpendeOppfylt
+            )
+        }
+    }
+
+    @Test
+    fun `skal ikke kaste feil hvis vilkåret er bor med søker`() {
+        val personResultat = PersonResultat(
+            vilkårsvurdering = uvesentligVilkårsvurdering,
+            aktør = randomAktørId()
+        )
+        val løpendeOppfylt = VilkårResultat(
+            personResultat = personResultat,
+            periodeFom = LocalDate.of(2020, 1, 1),
+            periodeTom = null,
+            vilkårType = Vilkår.BOR_MED_SØKER,
+            resultat = Resultat.OPPFYLT,
+            begrunnelse = "",
+            behandlingId = 0
+        )
+        personResultat.vilkårResultater.add(løpendeOppfylt)
+
+        val avslagUtenPeriode = RestVilkårResultat(
+            id = 123,
+            vilkårType = Vilkår.BOR_MED_SØKER,
+            resultat = Resultat.IKKE_OPPFYLT,
+            periodeFom = null,
+            periodeTom = null,
+            begrunnelse = "",
+            endretAv = "",
+            endretTidspunkt = LocalDateTime.now(),
+            behandlingId = 0,
+            erEksplisittAvslagPåSøknad = true
+        )
+
+        assertDoesNotThrow {
+            VilkårsvurderingUtils.validerAvslagUtenPeriodeMedLøpende(
+                personSomEndres = personResultat,
+                vilkårSomEndres = avslagUtenPeriode
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til denne bugen: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8680

Fjerner validering av avslag uten perioder for vilkåret "bor med søker". Dette for å tillate at man kan ha et avslag uten periode, i kombinasjon med en løpende oppfylt periode. 

For "bor med søker"-vilkåret kan man nemlig ønske å sette vilkåret til både oppfylt og ikke oppfylt i samme periode. Eksempel:
- Søker søker om full barnetrygd
- Men, avtale om delt bosted skal fortsatt følges. Derfor:
- Vi avslår full barnetrygd (avslag uten periode)
- Vi innvilger delt barnetryd

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nop

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
