### PR TITLE
Bruk eksisterende flettefelt for barnas fødselsdatoer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/InnhenteOpplysningerOmBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/InnhenteOpplysningerOmBarn.kt
@@ -37,7 +37,7 @@ data class InnhenteOpplysningerOmBarnData(
         override val navn: Flettefelt,
         override val fodselsnummer: Flettefelt,
         override val brevOpprettetDato: Flettefelt = flettefelt(LocalDate.now().tilDagMånedÅr()),
-        val barnasFodselsdager: Flettefelt,
+        val barnasFodselsdatoer: Flettefelt,
         val dokumentliste: Flettefelt,
     ) : FlettefelterForDokument {
 
@@ -49,7 +49,7 @@ data class InnhenteOpplysningerOmBarnData(
         ) : this(
             navn = flettefelt(navn),
             fodselsnummer = flettefelt(fodselsnummer),
-            barnasFodselsdager = flettefelt(barnasFødselsdager),
+            barnasFodselsdatoer = flettefelt(barnasFødselsdager),
             dokumentliste = flettefelt(dokumentliste)
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/brevperioder/VarselbrevMedÅrsakerOgBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/brevperioder/VarselbrevMedÅrsakerOgBarn.kt
@@ -45,7 +45,7 @@ data class VarselbrevMedÅrsakerOgBarnData(
         override val fodselsnummer: Flettefelt,
         override val brevOpprettetDato: Flettefelt = flettefelt(LocalDate.now().tilDagMånedÅr()),
         val varselAarsaker: Flettefelt,
-        val barnasFodselsdager: Flettefelt,
+        val barnasFodselsdatoer: Flettefelt,
     ) : FlettefelterForDokument {
 
         constructor(
@@ -57,7 +57,7 @@ data class VarselbrevMedÅrsakerOgBarnData(
             navn = flettefelt(navn),
             fodselsnummer = flettefelt(fodselsnummer),
             varselAarsaker = flettefelt(varselÅrsaker),
-            barnasFodselsdager = flettefelt(barnasFødselsdager)
+            barnasFodselsdatoer = flettefelt(barnasFødselsdager)
         )
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dette er en fortsettelse av #2458 
Endrer til å bruke et eksisterende flettefelt for barnas fødselsdatoer som jeg fant i Sanity, heller enn å lage et nytt som er helt identisk.

Her er det i sanity:
![image](https://user-images.githubusercontent.com/2379098/171163111-ed482ff3-e73c-4ae7-a13f-8e315ea3d0ad.png)


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
