### PR TITLE
Bug: "Ikke tilgang til å se person"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerService.kt
@@ -29,10 +29,12 @@ class PersonopplysningerService(
 
         val identerMedAdressebeskyttelse = mutableSetOf<Pair<Aktør, FORELDERBARNRELASJONROLLE>>()
 
-        val erUnder18År = Period.between(personinfo.fødselsdato, LocalDate.now()).years < 18
+        val personErUnder18År = Period.between(personinfo.fødselsdato, LocalDate.now()).years < 18
 
         val forelderBarnRelasjon = personinfo.forelderBarnRelasjon.filter {
-            erUnder18År || it.relasjonsrolle == FORELDERBARNRELASJONROLLE.BARN
+            // Hvis personen vi ser på er under 18 år ønsker vi å ha med alle relasjoner
+            // Hvis personen er over 18 år ønsker vi kun å se på barna til personen
+            personErUnder18År || it.relasjonsrolle == FORELDERBARNRELASJONROLLE.BARN
         }.mapNotNull {
             val harTilgang =
                 familieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf(it.aktør.aktivFødselsnummer()))


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til denne bugen: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8850

Får "Ikke tilgang til å se person"-feil fra PDL når f.eks. faren til søker er ansatt i NAV. Trenger egentlig aldri å sjekke om vi har tilgang til faren til søker, da denne personen ikke er relevant for behandling. Men, det er ikke nødvendigvis så lett å vite om vi søker på et barn eller en søker (mor/far). Etter diskusjon med Fredrik har jeg kommet frem til at vi kan anta at hvis en person er over 18 år, så vil vi ikke hente inn mor/far/medmor-relasjonene til denne personen.

Har testet det med de ulike casene det kunne ha skapt et problem for, men alt ser ut til å funke bra.
Det jeg har sjekket er:
- At oppførselen når du søker på et barn som det ikke betales ut barnetrygd for er lik som før. Søker du opp et barn (person under 18 år) som verken har fagsak selv, eller har en mor/far med fagsak, så dukker kun barnet opp. Dette var tilfellet både før og etter denne endringen.
- Barn som er over 18 år og har sak hvor det tidligere er løpt barnetrygd: når du søker opp dette barnet dukker både mor og barnet selv opp. Dette var tilfellet både før og etter denne endringen.

Ganske sikker på at denne endringen derfor ikke vil føre til noen endringer i funksjonalitet, annet enn at vi ikke sjekker tilgang på "unødvendige" foreldre.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Har jeg løst det på en god måte? 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Vet ikke hvor nyttig det er i akkurat dette tilfellet

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
