### PR TITLE
Legg til begrunnelse for etter endret utbetaling - etterbetaling 3 år som kun gjelder utvidet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -1235,6 +1235,10 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
     ETTER_ENDRET_UTBETALING_ETTERBETALING {
         override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreAarTilbakeITid"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
+    },
+    ETTER_ENDRET_UTBETALING_ETTERBETALING_UTVIDET {
+        override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreAarTilbakeITidKunUtvidetDel"
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
     };
 
     override val kanDelesOpp: Boolean = false


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til en del feil vi har fått: "Flettefeltet "barnasFodselsdatoer" mangler for begrunnelse etterEndretUtbetalingEtterbetalingTreAarTilbakeITid"

Dette har vært i tilfeller hvor det kun er den utvidede delen som er endret, og vi finner derfor ingen barn i begrunnelsen. I disse tilfellene skal derfor denne nye begrunnelsen brukes.

F.eks. denne: https://sentry.gc.nav.no/organizations/nav/issues/57820/?environment=prod&project=112&query=is%3Aunresolved

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
