### PR TITLE
Beholder valutakode på skjemaer som tømmes for innhold

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -62,8 +62,8 @@ data class Valutakurs(
     @Column(name = "fk_behandling_id", updatable = false, nullable = false)
     override var behandlingId: Long = 0
 
+    // Valutakode skal alltid være satt (muligens til null), så den slettes ikke
     override fun utenInnhold() = copy(
-        valutakode = null,
         valutakursdato = null,
         kurs = null
     )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Sletting av valutakurs-skjema er litt for aggressivt når det fjerner valutakoden. Passer på å beholde valutakoden i alle tilfeller der skjemaet tømmes for innhold

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
