### PR TITLE
Fjernet validering som sjekker om endring på delt bosted ytelse og utvidet ytelse i samme periode er lik

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
@@ -214,17 +214,6 @@ fun validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(
                     "${endretPåUtvidetUtbetalinger.tom} eller fjern endringen på den utvidede ytelsen."
             throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
         }
-
-        val erForskjelligEndringPåutvidetOgDeltBostedISammePeriode =
-            deltBostedEndringerISammePeriode.any { endretPåUtvidetUtbetalinger.prosent != it.prosent }
-
-        if (erForskjelligEndringPåutvidetOgDeltBostedISammePeriode) {
-            val feilmelding =
-                "Endring på delt bosted ytelse og utvidet ytelse i samme periode må være lik, " +
-                    "men endringene i perioden ${endretPåUtvidetUtbetalinger.fom} til ${endretPåUtvidetUtbetalinger.tom} " +
-                    "er forskjellige."
-            throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
-        }
     }
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -640,8 +640,20 @@ class EndretUtbetalingAndelValideringTest {
         val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
 
         vilkårsvurdering.personResultater = setOf(
-            lagPersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = person.aktør, periodeFom = LocalDate.now().minusMonths(7), periodeTom = LocalDate.now(), resultat = Resultat.OPPFYLT),
-            lagPersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = randomAktørId(), periodeFom = LocalDate.now().minusMonths(4), periodeTom = LocalDate.now(), resultat = Resultat.OPPFYLT)
+            lagPersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = person.aktør,
+                periodeFom = LocalDate.now().minusMonths(7),
+                periodeTom = LocalDate.now(),
+                resultat = Resultat.OPPFYLT
+            ),
+            lagPersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = randomAktørId(),
+                periodeFom = LocalDate.now().minusMonths(4),
+                periodeTom = LocalDate.now(),
+                resultat = Resultat.OPPFYLT
+            )
         )
 
         val deltBostedPerioder = finnDeltBostedPerioder(person = person, vilkårsvurdering = vilkårsvurdering)
@@ -711,28 +723,6 @@ class EndretUtbetalingAndelValideringTest {
         Assertions.assertThrows(FunksjonellFeil::class.java) {
             validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(
                 listOf(endretUtbetalingAndelUtvidetNullutbetaling)
-            )
-        }
-    }
-
-    @Test
-    fun `skal kaste feil dersom det er en endring på utvidet ytelse og delt bosted med forskjellig prosent`() {
-
-        Assertions.assertThrows(FunksjonellFeil::class.java) {
-            validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(
-                listOf(
-                    endretUtbetalingAndelUtvidetNullutbetaling,
-                    endretUtbetalingAndelDeltBostedFullUtbetaling
-                )
-            )
-        }
-
-        Assertions.assertThrows(FunksjonellFeil::class.java) {
-            validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(
-                listOf(
-                    endretUtbetalingAndelUtvidetFullUtbetaling,
-                    endretUtbetalingAndelDeltBostedNullutbetaling
-                )
             )
         }
     }
@@ -880,7 +870,12 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste feil hvis perioden skal utbetales, men årsak er 'endre mottaker' eller 'allerede utbetalt'`() {
-        assertThrows<FunksjonellFeil> { validerUtbetalingMotÅrsak(årsak = Årsak.ALLEREDE_UTBETALT, skalUtbetales = true) }
+        assertThrows<FunksjonellFeil> {
+            validerUtbetalingMotÅrsak(
+                årsak = Årsak.ALLEREDE_UTBETALT,
+                skalUtbetales = true
+            )
+        }
         assertThrows<FunksjonellFeil> { validerUtbetalingMotÅrsak(årsak = Årsak.ENDRE_MOTTAKER, skalUtbetales = true) }
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8910
I dag er validering sånn at det kaster feil når minst et av de barn har forskjellige endring på delt bosted ytelse og utvidet ytelse i samme periode. Etter å diskutere det med Anna fjernet denne valideringen fordi det kan være alle barn på en utvidet sak har delt bosted men ingen utbetaling. På denne tilfellen bør saken ikke stoppes

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
