### PR TITLE
Bug: Sammenslåing av hjemler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -214,11 +214,12 @@ fun hentHjemmeltekst(
         )
 
     val alleHjemlerForBegrunnelser = hentAlleTyperHjemler(
-        hjemlerSeparasjonsavtaleStorbritannia = sanityEøsBegrunnelser.flatMap { it.hjemlerSeperasjonsavtalenStorbritannina },
-        ordinæreHjemler = ordinæreHjemler,
-        hjemlerFraFolketrygdloven = sanityStandardbegrunnelser.flatMap { it.hjemlerFolketrygdloven } + sanityEøsBegrunnelser.flatMap { it.hjemlerFolketrygdloven },
-        hjemlerEØSForordningen883 = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen883 },
-        hjemlerEØSForordningen987 = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen987 },
+        hjemlerSeparasjonsavtaleStorbritannia = sanityEøsBegrunnelser.flatMap { it.hjemlerSeperasjonsavtalenStorbritannina }.distinct(),
+        ordinæreHjemler = ordinæreHjemler.distinct(),
+        hjemlerFraFolketrygdloven = (sanityStandardbegrunnelser.flatMap { it.hjemlerFolketrygdloven } + sanityEøsBegrunnelser.flatMap { it.hjemlerFolketrygdloven })
+            .distinct(),
+        hjemlerEØSForordningen883 = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen883 }.distinct(),
+        hjemlerEØSForordningen987 = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen987 }.distinct(),
         målform = målform
     )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -228,7 +228,17 @@ fun hentHjemmeltekst(
 private fun slåSammenHjemlerAvUlikeTyper(hjemler: List<String>) = when (hjemler.size) {
     0 -> throw FunksjonellFeil("Ingen hjemler var knyttet til begrunnelsen(e) som er valgt. Du må velge minst én begrunnelse som er knyttet til en hjemmel.")
     1 -> hjemler.single()
-    else -> Utils.slåSammen(hjemler)
+    else -> slåSammenListeMedHjemler(hjemler)
+}
+
+private fun slåSammenListeMedHjemler(hjemler: List<String>): String {
+    return hjemler.reduceIndexed { index, acc, s ->
+        when (index) {
+            0 -> acc + s
+            hjemler.size - 1 -> "$acc og $s"
+            else -> "$acc, $s"
+        }
+    }
 }
 
 private fun hentAlleTyperHjemler(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtilsTest.kt
@@ -735,6 +735,79 @@ internal class BrevUtilsTest {
     }
 
     @Test
+    fun `Skal slå sammen hjemlene riktig når det er 3 eller flere hjemler på "siste" hjemmeltype`() {
+        val utvidetVedtaksperioderMedBegrunnelser = listOf(
+            lagUtvidetVedtaksperiodeMedBegrunnelser(
+                begrunnelser = listOf(
+                    lagVedtaksbegrunnelse(
+                        standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET
+                    )
+                ),
+                eøsBegrunnelser = listOf(
+                    EØSBegrunnelse(
+                        vedtaksperiodeMedBegrunnelser = mockk(),
+                        begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR
+                    )
+                ),
+                utbetalingsperiodeDetaljer = listOf(lagUtbetalingsperiodeDetalj())
+            ),
+            lagUtvidetVedtaksperiodeMedBegrunnelser(
+                begrunnelser = listOf(
+                    lagVedtaksbegrunnelse(
+                        standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING
+                    )
+                ),
+                eøsBegrunnelser = listOf(
+                    EØSBegrunnelse(
+                        vedtaksperiodeMedBegrunnelser = mockk(),
+                        begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE
+                    )
+                ),
+                utbetalingsperiodeDetaljer = listOf(lagUtbetalingsperiodeDetalj())
+            )
+        )
+
+        val sanityBegrunnelser = listOf(
+            lagSanityBegrunnelse(
+                apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                hjemler = listOf("11", "4"),
+            ),
+            lagSanityBegrunnelse(
+                apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                hjemler = listOf("10"),
+            )
+        )
+
+        val sanityEøsBegrunnelser = listOf(
+            lagSanityEøsBegrunnelse(
+                apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                hjemler = listOf("4"),
+                hjemlerEØSForordningen883 = listOf("2", "11-16", "67", "68"),
+                hjemlerSeperasjonsavtalenStorbritannina = listOf("29")
+            ),
+            lagSanityEøsBegrunnelse(
+                apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                hjemler = listOf("11"),
+            )
+        )
+
+        Assertions.assertEquals(
+            "Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, barnetrygdlova §§ 4, 10 og 11 og EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68",
+            hentHjemmeltekst(
+                målform = Målform.NN,
+                minimerteVedtaksperioder = utvidetVedtaksperioderMedBegrunnelser.map {
+                    it.tilMinimertVedtaksperiode(
+                        sanityBegrunnelser = sanityBegrunnelser,
+                        sanityEØSBegrunnelser = sanityEøsBegrunnelser
+                    )
+                },
+                sanityBegrunnelser = sanityBegrunnelser,
+                opplysningspliktHjemlerSkalMedIBrev = false
+            )
+        )
+    }
+
+    @Test
     fun `Skal gi riktig dato for opphørstester`() {
         val sisteFom = LocalDate.now().minusMonths(2)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtilsTest.kt
@@ -808,6 +808,84 @@ internal class BrevUtilsTest {
     }
 
     @Test
+    fun `Skal kun ta med en hjemmel 1 gang hvis flere begrunnelser er knyttet til samme hjemmel`() {
+        val utvidetVedtaksperioderMedBegrunnelser = listOf(
+            lagUtvidetVedtaksperiodeMedBegrunnelser(
+                begrunnelser = listOf(
+                    lagVedtaksbegrunnelse(
+                        standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET
+                    )
+                ),
+                eøsBegrunnelser = listOf(
+                    EØSBegrunnelse(
+                        vedtaksperiodeMedBegrunnelser = mockk(),
+                        begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR
+                    )
+                ),
+                utbetalingsperiodeDetaljer = listOf(lagUtbetalingsperiodeDetalj())
+            ),
+            lagUtvidetVedtaksperiodeMedBegrunnelser(
+                begrunnelser = listOf(
+                    lagVedtaksbegrunnelse(
+                        standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING
+                    )
+                ),
+                eøsBegrunnelser = listOf(
+                    EØSBegrunnelse(
+                        vedtaksperiodeMedBegrunnelser = mockk(),
+                        begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE
+                    )
+                ),
+                utbetalingsperiodeDetaljer = listOf(lagUtbetalingsperiodeDetalj())
+            )
+        )
+
+        val sanityBegrunnelser = listOf(
+            lagSanityBegrunnelse(
+                apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                hjemler = listOf("11", "4"),
+            ),
+            lagSanityBegrunnelse(
+                apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                hjemler = listOf("10"),
+            )
+        )
+
+        val sanityEøsBegrunnelser = listOf(
+            lagSanityEøsBegrunnelse(
+                apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                hjemler = listOf("4"),
+                hjemlerEØSForordningen883 = listOf("2", "11-16", "67", "68"),
+                hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                hjemlerEØSForordningen987 = listOf("58")
+            ),
+            lagSanityEøsBegrunnelse(
+                apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                hjemler = listOf("11"),
+                hjemlerEØSForordningen883 = listOf("2", "67", "68"),
+                hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                hjemlerEØSForordningen987 = listOf("58")
+
+            )
+        )
+
+        Assertions.assertEquals(
+            "Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, barnetrygdlova §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68 og EØS-forordning 987/2009 artikkel 58",
+            hentHjemmeltekst(
+                målform = Målform.NN,
+                minimerteVedtaksperioder = utvidetVedtaksperioderMedBegrunnelser.map {
+                    it.tilMinimertVedtaksperiode(
+                        sanityBegrunnelser = sanityBegrunnelser,
+                        sanityEØSBegrunnelser = sanityEøsBegrunnelser
+                    )
+                },
+                sanityBegrunnelser = sanityBegrunnelser,
+                opplysningspliktHjemlerSkalMedIBrev = false
+            )
+        )
+    }
+
+    @Test
     fun `Skal gi riktig dato for opphørstester`() {
         val sisteFom = LocalDate.now().minusMonths(2)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Feilen:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/25459913/172769276-12cb34fc-2c94-4e67-a395-15ed279cf12c.png">

Brukte tidligere enn funksjon for å slå sammen som gjorde om hele listen til en streng og byttet ut siste komma med et og. Det funker ikke med listen jeg sendte inn. Skriver derfor min egen funksjon.

Tar kun også med distinkte hjemler så vi ikke får med flere av samme hjemmel hvis flere begrunnelser er koblet til samme hjemmel.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
