### PR TITLE
Bug: behandler for mange vedtak om overgangsstønad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -285,8 +285,6 @@ fun List<AndelTilkjentYtelse>.lagVertikaleSegmenter(): Map<LocalDateSegment<Int>
 }
 
 fun List<AndelTilkjentYtelse>.erUlike(andreAndeler: List<AndelTilkjentYtelse>): Boolean {
-    if (this.size != andreAndeler.size) return true
-
     return this.hentPerioderMedEndringerFra(andreAndeler).isNotEmpty()
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
@@ -288,6 +288,57 @@ class SmåbarnstilleggUtilsTest {
     }
 
     @Test
+    fun `skal ikke behandle vedtak om overgangsstønad når vedtaket ikke fører til endring i utbetaling`() {
+        val personIdent = randomAktørId()
+        val barnIdent = randomAktørId()
+
+        val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
+            småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
+                behandlingId = 1L,
+                tilkjentYtelse = mockk()
+            ),
+            nyePerioderMedFullOvergangsstønad = listOf(
+                InternPeriodeOvergangsstønad(
+                    personIdent = personIdent.aktørId,
+                    fomDato = LocalDate.now().minusMonths(10),
+                    tomDato = LocalDate.now().minusMonths(1),
+                ),
+                InternPeriodeOvergangsstønad(
+                    personIdent = personIdent.aktørId,
+                    fomDato = LocalDate.now(),
+                    tomDato = LocalDate.now().plusMonths(6),
+                )
+            ),
+            forrigeAndelerTilkjentYtelse = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.now().minusMonths(10),
+                    tom = YearMonth.now().plusMonths(10),
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    person = tilfeldigPerson(aktør = barnIdent),
+                    aktør = barnIdent,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.now().minusMonths(10),
+                    tom = YearMonth.now().plusMonths(10),
+                    ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    person = tilfeldigPerson(aktør = personIdent),
+                    aktør = personIdent,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.now().minusMonths(10),
+                    tom = YearMonth.now().plusMonths(6),
+                    ytelseType = YtelseType.SMÅBARNSTILLEGG,
+                    person = tilfeldigPerson(aktør = personIdent),
+                    aktør = personIdent,
+                ),
+            ),
+            barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
+        )
+
+        assertFalse(påvirkerFagsak)
+    }
+
+    @Test
     fun `Skal legge til innvilgelsesbegrunnelse for småbarnstillegg`() {
         val vedtaksperiodeMedBegrunnelser = lagVedtaksperiodeMedBegrunnelser(
             fom = LocalDate.now().førsteDagIInneværendeMåned(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
@@ -339,6 +339,57 @@ class SmåbarnstilleggUtilsTest {
     }
 
     @Test
+    fun `skal behandle vedtak om overgangsstønad når vedtaket fører til endring i utbetaling`() {
+        val personIdent = randomAktørId()
+        val barnIdent = randomAktørId()
+
+        val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
+            småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
+                behandlingId = 1L,
+                tilkjentYtelse = mockk()
+            ),
+            nyePerioderMedFullOvergangsstønad = listOf(
+                InternPeriodeOvergangsstønad(
+                    personIdent = personIdent.aktørId,
+                    fomDato = LocalDate.now().minusMonths(10),
+                    tomDato = LocalDate.now().minusMonths(1),
+                ),
+                InternPeriodeOvergangsstønad(
+                    personIdent = personIdent.aktørId,
+                    fomDato = LocalDate.now(),
+                    tomDato = LocalDate.now().plusMonths(8),
+                )
+            ),
+            forrigeAndelerTilkjentYtelse = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.now().minusMonths(10),
+                    tom = YearMonth.now().plusMonths(10),
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    person = tilfeldigPerson(aktør = barnIdent),
+                    aktør = barnIdent,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.now().minusMonths(10),
+                    tom = YearMonth.now().plusMonths(10),
+                    ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    person = tilfeldigPerson(aktør = personIdent),
+                    aktør = personIdent,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.now().minusMonths(10),
+                    tom = YearMonth.now().plusMonths(6),
+                    ytelseType = YtelseType.SMÅBARNSTILLEGG,
+                    person = tilfeldigPerson(aktør = personIdent),
+                    aktør = personIdent,
+                ),
+            ),
+            barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
+        )
+
+        assertTrue(påvirkerFagsak)
+    }
+
+    @Test
     fun `Skal legge til innvilgelsesbegrunnelse for småbarnstillegg`() {
         val vedtaksperiodeMedBegrunnelser = lagVedtaksperiodeMedBegrunnelser(
             fom = LocalDate.now().førsteDagIInneværendeMåned(),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har tre vedtakOmOvergangsstønad-tasker som feiler fordi ef har gjort et fortsatt innvilget-vedtak. Hos oss har disse tre taskene kommet forbi testen som sjekker om vedtaket om overgangsstønad påvirker fagsaken. Dette har skjedd fordi splitten i andel tilkjent ytelse er annerledes nå enn tidligere. Eksempel:
- Tidligere hadde du andel tilkjent ytelse for småbarnstillegg fra jan 22 - sept 22
- Kommer fortsatt innvilget-vedtak i mai som sier at personen fortsatt får overgangsstønad jun 22 - sept 22
- Vi har logikk som slår sammen tidligere OS-perioder, men ikke de som er frem i tid. Dvs. når vi skal generere nye andel tilkjent ytelse vil vi få jan 22 - mai 22 og jun 22 - sept 22. 
- Utbetalingene vil forbli de samme, men fordelt på to perioder. Dette er ikke endringer som skal påvirke fagsak, så lenge utbetalingene nå og tidligere er like.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
Si ifra hvis du ikke skjønner problemstillingen, kan gjerne ta det muntlig 👍 