### PR TITLE
Feature/differanseberegning tjenester

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -36,7 +36,8 @@ class BeregningService(
     private val behandlingRepository: BehandlingRepository,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
-    private val småbarnstilleggService: SmåbarnstilleggService
+    private val småbarnstilleggService: SmåbarnstilleggService,
+    private val tilkjentYtelseEndretAbonnenter: List<TilkjentYtelseEndretAbonnent> = emptyList()
 ) {
     fun slettTilkjentYtelseForBehandling(behandlingId: Long) =
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
@@ -179,7 +180,9 @@ class BeregningService(
         tilkjentYtelse.andelerTilkjentYtelse.clear()
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerTilkjentYtelse)
 
-        return tilkjentYtelseRepository.save(tilkjentYtelse)
+        val lagretTilkjentYtelse = tilkjentYtelseRepository.save(tilkjentYtelse)
+        tilkjentYtelseEndretAbonnenter.forEach { it.endretTilkjentYtelse(lagretTilkjentYtelse) }
+        return lagretTilkjentYtelse
     }
 
     fun oppdaterTilkjentYtelseMedUtbetalingsoppdrag(
@@ -277,4 +280,8 @@ class BeregningService(
             this.opphørFom = opphørsdato?.toYearMonth()
         }
     }
+}
+
+interface TilkjentYtelseEndretAbonnent {
+    fun endretTilkjentYtelse(tilkjentYtelse: TilkjentYtelse)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -57,7 +57,7 @@ data class AndelTilkjentYtelse(
     @Column(name = "fk_behandling_id", nullable = false, updatable = false)
     val behandlingId: Long,
 
-    @ManyToOne
+    @ManyToOne(cascade = [CascadeType.MERGE])
     @JoinColumn(name = "tilkjent_ytelse_id", nullable = false, updatable = false)
     var tilkjentYtelse: TilkjentYtelse,
 
@@ -107,8 +107,13 @@ data class AndelTilkjentYtelse(
     var periodeOffset: Long? = null, // Brukes for å koble seg på tidligere kjeder sendt til økonomi
 
     @Column(name = "forrige_periode_offset")
-    var forrigePeriodeOffset: Long? = null
+    var forrigePeriodeOffset: Long? = null,
 
+    @Column(name = "nasjonalt_periodebelop")
+    val nasjonaltPeriodebeløp: Int? = null,
+
+    @Column(name = "differanseberegnet_periodebelop")
+    val differanseberegnetPeriodebeløp: Int? = null
 ) : BaseEntitet() {
 
     val periode
@@ -127,7 +132,9 @@ data class AndelTilkjentYtelse(
             Objects.equals(kalkulertUtbetalingsbeløp, annen.kalkulertUtbetalingsbeløp) &&
             Objects.equals(stønadFom, annen.stønadFom) &&
             Objects.equals(stønadTom, annen.stønadTom) &&
-            Objects.equals(aktør, annen.aktør)
+            Objects.equals(aktør, annen.aktør) &&
+            Objects.equals(nasjonaltPeriodebeløp, annen.nasjonaltPeriodebeløp) &&
+            Objects.equals(differanseberegnetPeriodebeløp, annen.differanseberegnetPeriodebeløp)
     }
 
     override fun hashCode(): Int {
@@ -138,13 +145,16 @@ data class AndelTilkjentYtelse(
             kalkulertUtbetalingsbeløp,
             stønadFom,
             stønadTom,
-            aktør
+            aktør,
+            nasjonaltPeriodebeløp,
+            differanseberegnetPeriodebeløp
         )
     }
 
     override fun toString(): String {
         return "AndelTilkjentYtelse(id = $id, behandling = $behandlingId, type = $type, prosent = $prosent," +
-            "beløp = $kalkulertUtbetalingsbeløp, stønadFom = $stønadFom, stønadTom = $stønadTom, periodeOffset = $periodeOffset)"
+            "beløp = $kalkulertUtbetalingsbeløp, stønadFom = $stønadFom, stønadTom = $stønadTom, periodeOffset = $periodeOffset), " +
+            "nasjonaltPeriodebeløp = $nasjonaltPeriodebeløp, differanseberegnetBeløp = $differanseberegnetPeriodebeløp"
     }
 
     fun erTilsvarendeForUtbetaling(other: AndelTilkjentYtelse): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelse.kt
@@ -66,7 +66,8 @@ data class TilkjentYtelse(
     @OneToMany(
         fetch = FetchType.EAGER,
         mappedBy = "tilkjentYtelse",
-        cascade = [CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE]
+        cascade = [CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE],
+        orphanRemoval = true
     )
     val andelerTilkjentYtelse: MutableSet<AndelTilkjentYtelse> = mutableSetOf()
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -23,6 +23,7 @@ import javax.persistence.Entity
 import javax.persistence.EntityListeners
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -75,7 +76,7 @@ data class EndretUtbetalingAndel(
     @Column(name = "begrunnelse")
     var begrunnelse: String? = null,
 
-    @ManyToMany(mappedBy = "endretUtbetalingAndeler")
+    @ManyToMany(mappedBy = "endretUtbetalingAndeler", fetch = FetchType.EAGER)
     val andelTilkjentYtelser: MutableList<AndelTilkjentYtelse> = mutableListOf(),
 
     @Column(name = "vedtak_begrunnelse_spesifikasjoner")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
+import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.MånedTidspunkt.Companion.tilTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
+import java.time.YearMonth
+
+fun TilkjentYtelse.tilSeparateTidslinjerForBarna(): Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>> {
+
+    return this.andelerTilkjentYtelse
+        .filter { !it.erSøkersAndel() }
+        .groupBy { it.aktør }
+        .mapValues { (_, andeler) -> tidslinje { andeler.map { it.tilPeriode() } } }
+}
+
+fun Iterable<Tidslinje<AndelTilkjentYtelse, Måned>>.tilAndelerTilkjentYtelse(): List<AndelTilkjentYtelse> {
+    return this.flatMap { it.tilAndelTilkjentYtelse() }
+}
+
+fun Tidslinje<AndelTilkjentYtelse, Måned>.tilAndelTilkjentYtelse(): List<AndelTilkjentYtelse> {
+    return this
+        .perioder().map {
+            it.innhold?.medPeriode(it.fraOgMed.tilYearMonth(), it.tilOgMed.tilYearMonth())
+        }.filterNotNull()
+}
+
+fun AndelTilkjentYtelse.tilPeriode() = Periode(
+    this.stønadFom.tilTidspunkt(),
+    this.stønadTom.tilTidspunkt(),
+    // Ta bort periode, slik at det ikke blir med på innholdet som vurderes for likhet
+    this.medPeriode(null, null)
+)
+
+fun AndelTilkjentYtelse.medPeriode(fraOgMed: YearMonth?, tilOgMed: YearMonth?) =
+    copy(
+        id = 0,
+        stønadFom = fraOgMed ?: MIN_MÅNED,
+        stønadTom = tilOgMed ?: MAX_MÅNED
+    ).also { versjon = this.versjon }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -1,55 +1,63 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
-import kotlin.math.roundToInt
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
 
-enum class Intervall {
-    ÅRLIG,
-    KVARTALSVIS,
-    MÅNEDLIG,
-    UKENTLIG;
-
-    fun konverterBeløpTilMånedlig(beløp: Double, erSkuddår: Boolean) = when (this) {
-        ÅRLIG -> beløp / 12
-        KVARTALSVIS -> beløp / 4
-        MÅNEDLIG -> beløp
-        UKENTLIG -> konverterFraUkentligTilMånedligBeløp(beløp, erSkuddår)
-    }
-
-    /***
-     * Det finnes ingen offisiell dokumentasjon på hvordan vi skal konvertere fra ukentlig til
-     * månedlig betaling i NAV per dags dato (19.05.2022). Til nå har saksbehandlere gjort dette manuelt og
-     * brukt 52/12=4.33 for å konvertere fra ukentlig til månedlige beløp. Teamet har blitt enige om at vi burde
-     * ta utgangspunkt i antall dager i et år. Siden valutajusteringen kun skjer en gang i året bruker
-     * vi et gjennomsnitt for hver måned, slik at vi konverterer likt for måneder med forskjellig lengde.
-     ***/
-    private fun konverterFraUkentligTilMånedligBeløp(beløp: Double, erSkuddår: Boolean): Double {
-        val dagerIÅret: Double = if (erSkuddår) 366.0 else 365.0
-        val ukerIÅret: Double = dagerIÅret / 7.0
-        val ukerIEnMåned: Double = ukerIÅret / 12.0
-
-        return beløp * ukerIEnMåned
-    }
+fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal, erSkuddår: Boolean) = when (this) {
+    Intervall.ÅRLIG -> beløp / 12.toBigDecimal()
+    Intervall.KVARTALSVIS -> beløp / 3.toBigDecimal()
+    Intervall.MÅNEDLIG -> beløp
+    Intervall.UKENTLIG -> konverterFraUkentligTilMånedligBeløp(beløp, erSkuddår)
 }
 
-fun beregnDifferanseOrdinær(utbetalingsbeløpNorge: Int, utbetalingsbeløpUtlandINok: Int): Int {
-    val differanse = utbetalingsbeløpNorge - utbetalingsbeløpUtlandINok
+/***
+ * Det finnes ingen offisiell dokumentasjon på hvordan vi skal konvertere fra ukentlig til
+ * månedlig betaling i NAV per dags dato (19.05.2022). Til nå har saksbehandlere gjort dette manuelt og
+ * brukt 52/12=4.33 for å konvertere fra ukentlig til månedlige beløp. Teamet har blitt enige om at vi burde
+ * ta utgangspunkt i antall dager i et år. Siden valutajusteringen kun skjer en gang i året bruker
+ * vi et gjennomsnitt for hver måned, slik at vi konverterer likt for måneder med forskjellig lengde.
+ ***/
+private fun konverterFraUkentligTilMånedligBeløp(beløp: BigDecimal, erSkuddår: Boolean): BigDecimal {
+    val dagerIÅret: Double = if (erSkuddår) 366.0 else 365.0
+    val ukerIÅret: Double = dagerIÅret / 7.0
+    val ukerIEnMåned: Double = ukerIÅret / 12.0
 
-    return if (differanse < 0) 0
-    else differanse
+    return beløp.multiply(BigDecimal.valueOf(ukerIEnMåned))
 }
 
-fun beregnMånedligUtbetalingsbeløpUtlandINok(
-    satsUtland: Int,
-    kurs: Double,
-    intervall: Intervall,
-    erSkuddår: Boolean
-): Int {
-    val beløpINorskeKroner = satsUtland * kurs
-    val utbetalingsbeløpUtlandINok = intervall.konverterBeløpTilMånedlig(
-        beløp = beløpINorskeKroner,
-        erSkuddår = erSkuddår
+fun <T : Tidsenhet> Tidspunkt<T>.erSkuddår() = this.tilLocalDateEllerNull()?.isLeapYear ?: false
+
+/**
+ * Kalkulerer nytt utbetalingsbeløp fra [utenlandskPeriodebeløpINorskeKroner]
+ * Må håndtere tilfellet der [kalkulertUtebetalngsbeløp] blir modifisert andre steder i koden, men antar at det aldri vil være negativt
+ * [nasjonaltPeriodebeløp] settes til den originale, nasjonale beregningen (aldri negativt)
+ * [differanseberegnetBeløp] er differansen mellom [nasjonaltPeriodebeløp] og (avrundet) [utenlandskPeriodebeløpINorskeKroner] (kan bli negativt)
+ * [kalkulertUtebetalngsbeløp] blir satt til [differanseberegnetBeløp], med mindre det er negativt. Da blir det 0 (null)
+ */
+fun AndelTilkjentYtelse?.kalkulerFraUtenlandskPeriodebeløp(utenlandskPeriodebeløpINorskeKroner: BigDecimal): AndelTilkjentYtelse? {
+    if (this == null)
+        return null
+
+    val nyttNasjonaltPeriodebeløp = when {
+        differanseberegnetPeriodebeløp == null || nasjonaltPeriodebeløp == null -> kalkulertUtbetalingsbeløp
+        differanseberegnetPeriodebeløp < 0 && kalkulertUtbetalingsbeløp > 0 -> kalkulertUtbetalingsbeløp
+        differanseberegnetPeriodebeløp != kalkulertUtbetalingsbeløp -> kalkulertUtbetalingsbeløp
+        else -> nasjonaltPeriodebeløp
+    }
+
+    val avrundetUtenlandskPeriodebeløp = utenlandskPeriodebeløpINorskeKroner
+        .round(MathContext(0, RoundingMode.DOWN)).intValueExact() // Rund ned for å gi fordel til bruker
+    val nyttDifferanseberegnetBeløp = nyttNasjonaltPeriodebeløp - avrundetUtenlandskPeriodebeløp
+
+    return copy(
+        id = 0, // Lager en ny instans
+        kalkulertUtbetalingsbeløp = maxOf(nyttDifferanseberegnetBeløp, 0),
+        nasjonaltPeriodebeløp = nyttNasjonaltPeriodebeløp,
+        differanseberegnetPeriodebeløp = nyttDifferanseberegnetBeløp
     )
-    val avrundetUtbetalingsbeløpUtlandINok = utbetalingsbeløpUtlandINok.roundToInt()
-
-    return avrundetUtbetalingsbeløpUtlandINok
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegning.kt
@@ -1,0 +1,73 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilKronerPerValutaenhet
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilMånedligValutabeløp
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.times
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tidspunktKombinerMed
+
+fun beregnDifferanse(
+    tilkjentYtelse: TilkjentYtelse,
+    utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>,
+    valutakurser: Collection<Valutakurs>
+): TilkjentYtelse {
+
+    if (utenlandskePeriodebeløp.isEmpty() || valutakurser.isEmpty())
+        return tilkjentYtelse
+
+    val utenlandskePeriodebeløpTidslinjer = utenlandskePeriodebeløp.tilSeparateTidslinjerForBarna()
+    val valutakursTidslinjer = valutakurser.tilSeparateTidslinjerForBarna()
+    val andelTilkjentYtelseTidslinjer = tilkjentYtelse.tilSeparateTidslinjerForBarna()
+
+    val alleBarna: Set<Aktør> =
+        utenlandskePeriodebeløpTidslinjer.keys + valutakursTidslinjer.keys + andelTilkjentYtelseTidslinjer.keys
+
+    val barnasDifferanseberegnetAndelTilkjentYtelseTidslinjer = alleBarna.map { aktør ->
+        val utenlandskePeriodebeløpTidslinje = utenlandskePeriodebeløpTidslinjer.getOrDefault(aktør, TomTidslinje())
+        val valutakursTidslinje = valutakursTidslinjer.getOrDefault(aktør, TomTidslinje())
+        val andelTilkjentYtelseTidslinje = andelTilkjentYtelseTidslinjer.getOrDefault(aktør, TomTidslinje())
+
+        val utenlandskePeriodebeløpINorskeKroner = utenlandskePeriodebeløpTidslinje
+            .tidspunktKombinerMed(valutakursTidslinje) { tidspunkt, upb, vk ->
+                upb.tilMånedligValutabeløp(tidspunkt) * vk.tilKronerPerValutaenhet()
+            }
+
+        andelTilkjentYtelseTidslinje.kombinerMed(utenlandskePeriodebeløpINorskeKroner) { aty, beløp ->
+            beløp?.let { aty.kalkulerFraUtenlandskPeriodebeløp(it) } ?: aty
+        }
+    }
+
+    val barnasAndeler = barnasDifferanseberegnetAndelTilkjentYtelseTidslinjer.tilAndelerTilkjentYtelse()
+    val søkersAndeler = tilkjentYtelse.søkersAndeler()
+
+    validarSøkersYtelserMotEventueltNegativeAndelerForBarna(søkersAndeler, barnasAndeler)
+
+    return tilkjentYtelse.medAndeler(søkersAndeler + barnasAndeler)
+}
+
+private fun validarSøkersYtelserMotEventueltNegativeAndelerForBarna(
+    søkersAndelerTilkjentYtelse: List<AndelTilkjentYtelse>,
+    barnasAndelerTilkjentYtelse: List<AndelTilkjentYtelse>
+) {
+    val barnasSumNegativeDifferansebeløp = barnasAndelerTilkjentYtelse
+        .map { minOf(it.differanseberegnetPeriodebeløp ?: 0, 0) }
+        .sum()
+
+    val søkersSumUtbetalingsbeløp = søkersAndelerTilkjentYtelse
+        .map { it.kalkulertUtbetalingsbeløp }
+        .sum()
+
+    if (barnasSumNegativeDifferansebeløp < 0 && søkersSumUtbetalingsbeløp > 0)
+        TODO(
+            "Søker har småbarnstillegg og/elleer utvidet barnetrygd, " +
+                "samtidig som ett eller flere barn har endt med negative utbetalingsbeløp etter differanseberegning. " +
+                "Det er ikke støttet ennå"
+        )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseUtil.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+
+fun TilkjentYtelse.medAndeler(andeler: Iterable<AndelTilkjentYtelse>): TilkjentYtelse {
+    this.andelerTilkjentYtelse.clear()
+    this.andelerTilkjentYtelse.addAll(andeler)
+    return this
+}
+
+fun TilkjentYtelse.søkersAndeler() = this.andelerTilkjentYtelse.filter { it.erSøkersAndel() }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -1,0 +1,64 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseEndretAbonnent
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEndringAbonnent
+import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TilpassDifferanseberegningEtterTilkjentYtelseService(
+    private val valutakursRepository: PeriodeOgBarnSkjemaRepository<Valutakurs>,
+    private val utenlandskPeriodebeløpRepository: PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp>,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository
+) : TilkjentYtelseEndretAbonnent {
+
+    @Transactional
+    override fun endretTilkjentYtelse(tilkjentYtelse: TilkjentYtelse) {
+        val behandlingId = BehandlingId(tilkjentYtelse.behandling.id)
+        val valutakurser = valutakursRepository.finnFraBehandlingId(behandlingId.id)
+        val utenlandskePeriodebeløp = utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id)
+
+        val oppdatertTilkjentYtelse = beregnDifferanse(tilkjentYtelse, utenlandskePeriodebeløp, valutakurser)
+        tilkjentYtelseRepository.saveAndFlush(oppdatertTilkjentYtelse)
+    }
+}
+
+@Service
+class TilpassDifferanseberegningEtterUtenlandskPeriodebeløpService(
+    private val valutakursRepository: PeriodeOgBarnSkjemaRepository<Valutakurs>,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository
+) : PeriodeOgBarnSkjemaEndringAbonnent<UtenlandskPeriodebeløp> {
+    @Transactional
+    override fun skjemaerEndret(
+        behandlingId: BehandlingId,
+        utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>
+    ) {
+        val tilkjentYtelse = tilkjentYtelseRepository.findByBehandlingOptional(behandlingId.id) ?: return
+        val valutakurser = valutakursRepository.finnFraBehandlingId(behandlingId.id)
+
+        val oppdatertTilkjentYtelse = beregnDifferanse(tilkjentYtelse, utenlandskePeriodebeløp, valutakurser)
+        tilkjentYtelseRepository.saveAndFlush(oppdatertTilkjentYtelse)
+    }
+}
+
+@Service
+class TilpassDifferanseberegningEtterValutakursService(
+    private val utenlandskPeriodebeløpRepository: PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp>,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository
+) : PeriodeOgBarnSkjemaEndringAbonnent<Valutakurs> {
+
+    @Transactional
+    override fun skjemaerEndret(behandlingId: BehandlingId, valutakurser: Collection<Valutakurs>) {
+        val tilkjentYtelse = tilkjentYtelseRepository.findByBehandlingOptional(behandlingId.id) ?: return
+        val utenlandskePeriodebeløp = utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id)
+
+        val oppdatertTilkjentYtelse = beregnDifferanse(tilkjentYtelse, utenlandskePeriodebeløp, valutakurser)
+        tilkjentYtelseRepository.saveAndFlush(oppdatertTilkjentYtelse)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Intervall.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Intervall.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene
+
+enum class Intervall {
+    ÅRLIG,
+    KVARTALSVIS,
+    MÅNEDLIG,
+    UKENTLIG;
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene
+
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.erSkuddår
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.konverterBeløpTilMånedlig
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
+import java.math.BigDecimal
+
+data class KronerPerValutaenhet(
+    val kronerPerValutaenhet: BigDecimal,
+    val valutakode: String,
+)
+
+data class Valutabeløp(
+    val beløp: BigDecimal,
+    val valutakode: String
+)
+
+operator fun Valutabeløp?.times(kronerPerValutaenhet: KronerPerValutaenhet?): BigDecimal? {
+    if (this == null || kronerPerValutaenhet == null)
+        return null
+
+    if (this.valutakode != kronerPerValutaenhet.valutakode)
+        throw IllegalArgumentException("Valutabeløp har valutakode $valutakode, som avviker fra ${kronerPerValutaenhet.valutakode}")
+
+    return this.beløp * kronerPerValutaenhet.kronerPerValutaenhet
+}
+
+fun <T : Tidsenhet> UtenlandskPeriodebeløp?.tilMånedligValutabeløp(tidspunkt: Tidspunkt<T>): Valutabeløp? {
+    if (this?.beløp == null || this.intervall == null || this.valutakode == null)
+        return null
+
+    val månedligBeløp =
+        Intervall.valueOf(this.intervall).konverterBeløpTilMånedlig(this.beløp, tidspunkt.erSkuddår())
+
+    return Valutabeløp(månedligBeløp, this.valutakode)
+}
+
+fun Valutakurs?.tilKronerPerValutaenhet(): KronerPerValutaenhet? {
+    if (this?.kurs == null || this.valutakode == null)
+        return null
+
+    return KronerPerValutaenhet(this.kurs, this.valutakode)
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
@@ -28,6 +28,34 @@ fun <V, H, R, T : Tidsenhet> Tidslinje<V, T>.kombinerMed(
 }
 
 /**
+ * Extension-metode for å kombinere to tidslinjer
+ * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
+ * fra minste fraOgMed til største tilOgMed fra begge tidslinjene
+ * Tidsenhet (T) må være av samme type
+ * Hver av tidslinjene kan ha ulik innholdstype, hhv V og H
+ * Hvis innholdet V eller H er null returneres null
+ * Kombintor-funksjonen tar ellers V og H og returnerer (nullable) R
+ * Resultatet er en tidslinje med tidsenhet T og innhold R
+ */
+fun <V, H, R, T : Tidsenhet> Tidslinje<V, T>.kombinerUtenNullMed(
+    høyreTidslinje: Tidslinje<H, T>,
+    kombinator: (V, H) -> R?
+): Tidslinje<R, T> {
+    val venstreTidslinje = this
+    return object : TidslinjeSomStykkerOppTiden<R, T>(venstreTidslinje, høyreTidslinje) {
+        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? {
+            val venstre = venstreTidslinje.innholdForTidspunkt(tidspunkt)
+            val høyre = høyreTidslinje.innholdForTidspunkt(tidspunkt)
+
+            return when {
+                venstre == null || høyre == null -> null
+                else -> kombinator(venstre, høyre)
+            }
+        }
+    }
+}
+
+/**
  * Extension-metode for å kombinere liste av tidslinjer
  * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
  * fra minste fraOgMed til største fraOgMed() fra alle tidslinjene
@@ -43,5 +71,29 @@ fun <I, R, T : Tidsenhet> Collection<Tidslinje<I, T>>.kombinerUtenNull(
     return object : TidslinjeSomStykkerOppTiden<R, T>(tidslinjer) {
         override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? =
             listeKombinator(tidslinjer.map { it.innholdForTidspunkt(tidspunkt) }.filterNotNull())
+    }
+}
+
+/**
+ * Extension-metode for å kombinere to tidslinjer
+ * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
+ * fra minste fraOgMed til største tilOgMed fra begge tidslinjene
+ * Tidsenhet (T) må være av samme type
+ * Hver av tidslinjene kan ha ulik innholdstype, hhv V og H
+ * Kombintor-funksjonen tar inn tidspunktet og (nullable) av V og H og returnerer (nullable) R
+ * Resultatet er en tidslinje med tidsenhet T og innhold R
+ */
+fun <V, H, R, T : Tidsenhet> Tidslinje<V, T>.tidspunktKombinerMed(
+    høyreTidslinje: Tidslinje<H, T>,
+    kombinator: (Tidspunkt<T>, V?, H?) -> R?
+): Tidslinje<R, T> {
+    val venstreTidslinje = this
+    return object : TidslinjeSomStykkerOppTiden<R, T>(venstreTidslinje, høyreTidslinje) {
+        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? =
+            kombinator(
+                tidspunkt,
+                venstreTidslinje.innholdForTidspunkt(tidspunkt),
+                høyreTidslinje.innholdForTidspunkt(tidspunkt)
+            )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tid/MånedTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tid/MånedTidspunkt.kt
@@ -84,6 +84,8 @@ data class MånedTidspunkt internal constructor(
     companion object {
         fun nå() = MånedTidspunkt(YearMonth.now(), Uendelighet.INGEN)
 
+        internal fun YearMonth.tilTidspunkt() = MånedTidspunkt(this, Uendelighet.INGEN)
+
         internal fun YearMonth?.tilTidspunktEllerTidligereEnn(tidspunkt: YearMonth?) =
             tilTidspunktEllerUendelig(tidspunkt ?: YearMonth.now(), Uendelighet.FORTID)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
@@ -1,18 +1,19 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
 
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TidslinjeMedAvhengigheter
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TidslinjeSomStykkerOppTiden
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdForTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
 
 /**
  * Extension-metode for å map'e innhold fra en type og verdi til en annen
+ * Hvis det nå oppstår tilgrensende perioder med samme innhold, slås de sammen
  */
 fun <I, T : Tidsenhet, R> Tidslinje<I, T>.map(mapper: (I?) -> R?): Tidslinje<R, T> {
     val tidslinje = this
-    return object : TidslinjeMedAvhengigheter<R, T>(listOf(tidslinje)) {
-        override fun lagPerioder() = tidslinje.perioder().map {
-            Periode(it.fraOgMed, it.tilOgMed, mapper(it.innhold))
-        }
+    return object : TidslinjeSomStykkerOppTiden<R, T>(listOf(tidslinje)) {
+        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>) =
+            mapper(tidslinje.innholdForTidspunkt(tidspunkt))
     }
 }

--- a/src/main/resources/db/migration/V211__kolonner_for_differanseberegning_paa_andel_tilkjent_ytelse.sql
+++ b/src/main/resources/db/migration/V211__kolonner_for_differanseberegning_paa_andel_tilkjent_ytelse.sql
@@ -1,0 +1,3 @@
+ALTER TABLE andel_tilkjent_ytelse
+    ADD COLUMN nasjonalt_periodebelop          numeric,
+    ADD COLUMN differanseberegnet_periodebelop numeric

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -948,6 +948,15 @@ fun lagVilkårResultat(
 
 val guttenBarnesenFødselsdato = LocalDate.now().withDayOfMonth(10).minusYears(6)
 
+fun lagEndretUtbetalingAndel(behandlingId: Long, barn: Person, fom: YearMonth, tom: YearMonth, prosent: Int) =
+    lagEndretUtbetalingAndel(
+        behandlingId = behandlingId,
+        person = barn,
+        fom = fom,
+        tom = tom,
+        prosent = BigDecimal(prosent)
+    )
+
 fun lagEndretUtbetalingAndel(
     id: Long = 0,
     behandlingId: Long = 0,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsEndretUtbetalingAndelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsEndretUtbetalingAndelTest.kt
@@ -2,12 +2,11 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -79,7 +78,7 @@ internal class TilkjentYtelseUtilsEndretUtbetalingAndelTest {
             MånedPeriode(YearMonth.of(2018, 4), YearMonth.of(2018, 4))
         )
             .map {
-                lagEndretUtbetalingAndel(barn1, it.fom, it.tom, 50)
+                lagEndretUtbetalingAndel(behandling.id, barn1, it.fom, it.tom, 50)
             }
 
         val endretUtbetalingerForBarn2 = listOf(
@@ -88,7 +87,7 @@ internal class TilkjentYtelseUtilsEndretUtbetalingAndelTest {
             MånedPeriode(YearMonth.of(2021, 11), YearMonth.of(2021, 12))
         )
             .map {
-                lagEndretUtbetalingAndel(barn2, it.fom, it.tom, 50)
+                lagEndretUtbetalingAndel(behandling.id, barn2, it.fom, it.tom, 50)
             }
 
         val andelerTilkjentYtelserEtterEUA =
@@ -264,17 +263,4 @@ internal class TilkjentYtelseUtilsEndretUtbetalingAndelTest {
         sats = beløp.toInt(),
         prosent = BigDecimal(100)
     )
-
-    private fun lagEndretUtbetalingAndel(barn: Person, fom: YearMonth, tom: YearMonth, prosent: Int) =
-        EndretUtbetalingAndel(
-            behandlingId = behandling.id,
-            person = barn,
-            prosent = BigDecimal(prosent),
-            fom = fom,
-            tom = tom,
-            årsak = Årsak.DELT_BOSTED,
-            begrunnelse = "Begrunnelse for endring",
-            søknadstidspunkt = LocalDate.now(),
-            avtaletidspunktDeltBosted = LocalDate.now()
-        )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
@@ -1,94 +1,145 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall.KVARTALSVIS
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall.MÅNEDLIG
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall.UKENTLIG
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall.ÅRLIG
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.KronerPerValutaenhet
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Valutabeløp
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilMånedligValutabeløp
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.times
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.MathContext
+import java.math.RoundingMode
+import java.time.YearMonth
 
 class DifferanseberegningsUtilsTest {
     val utbetalingsbeløpNorge = 2000
 
     @Test
-    fun `Skal gi riktig differanse for årlig utbetaling ved ordinær sekundærlandssak`() {
+    fun `Skal multiplisere valutabeløp med valutakurs`() {
 
-        val utenlandskSatsÅrlig = 1200
+        val valutabeløp = 1200.i("EUR")
+        val kurs = 9.731.kronerPer("EUR")
 
-        val utbetalingsbeløpUtlandINok = beregnMånedligUtbetalingsbeløpUtlandINok(
-            satsUtland = utenlandskSatsÅrlig, kurs = 10.0, intervall = Intervall.ÅRLIG, erSkuddår = false
-        )
-
-        Assertions.assertEquals(1000, utbetalingsbeløpUtlandINok)
-        Assertions.assertEquals(1000, beregnDifferanseOrdinær(utbetalingsbeløpNorge, utbetalingsbeløpUtlandINok))
+        Assertions.assertEquals(11_677.toBigDecimal(), (valutabeløp * kurs)?.round(MathContext(5)))
     }
 
     @Test
-    fun `Skal gi riktig differanse for kvartalvis utbetaling ved ordinær sekundærlandssak`() {
+    fun `Skal ikke multiplisere valutabeløp med valutakurs når valuta er forskjellig`() {
 
-        val utenlandskSatsKvartalsvis = 400
+        val valutabeløp = 1200.i("EUR")
+        val kurs = 9.73.kronerPer("DKK")
 
-        val utbetalingsbeløpUtlandINok = beregnMånedligUtbetalingsbeløpUtlandINok(
-            satsUtland = utenlandskSatsKvartalsvis, kurs = 10.0, intervall = Intervall.KVARTALSVIS, erSkuddår = false
-        )
-
-        Assertions.assertEquals(1000, utbetalingsbeløpUtlandINok)
-        Assertions.assertEquals(1000, beregnDifferanseOrdinær(utbetalingsbeløpNorge, utbetalingsbeløpUtlandINok))
+        assertThrows<IllegalArgumentException> { valutabeløp * kurs }
     }
 
     @Test
-    fun `Skal gi riktig differanse for månedlig utbetaling ved ordinær sekundærlandssak`() {
+    fun `Skal konvertere årlig utenlandsk periodebeløp til månedlig`() {
 
-        val utenlandskSatsMåendlig = 100
+        val månedligValutabeløp = 1200.i("EUR").somUtenlandskPeriodebeløp(ÅRLIG)
+            .tilMånedligValutabeløp(jan(2021))
 
-        val utbetalingsbeløpUtlandINok = beregnMånedligUtbetalingsbeløpUtlandINok(
-            satsUtland = utenlandskSatsMåendlig, kurs = 10.0, intervall = Intervall.MÅNEDLIG, erSkuddår = false
-        )
-
-        Assertions.assertEquals(1000, utbetalingsbeløpUtlandINok)
-        Assertions.assertEquals(1000, beregnDifferanseOrdinær(utbetalingsbeløpNorge, utbetalingsbeløpUtlandINok))
+        Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
 
     @Test
-    fun `Skal gi riktig differanse for ukentlig utbetaling ved ordinær sekundærlandssak`() {
+    fun `Skal konvertere kvartalsvis utenlandsk periodebeløp til månedlig`() {
 
-        val utenlandskSatsUkentlig = 25
+        val månedligValutabeløp = 300.i("EUR").somUtenlandskPeriodebeløp(KVARTALSVIS)
+            .tilMånedligValutabeløp(jan(2021))
 
-        val utbetalingsbeløpUtlandINok = beregnMånedligUtbetalingsbeløpUtlandINok(
-            satsUtland = utenlandskSatsUkentlig, kurs = 10.0, intervall = Intervall.UKENTLIG, erSkuddår = false
-        )
-
-        Assertions.assertEquals(1086, utbetalingsbeløpUtlandINok)
-        Assertions.assertEquals(914, beregnDifferanseOrdinær(utbetalingsbeløpNorge, utbetalingsbeløpUtlandINok))
+        Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
 
     @Test
-    fun `Skal gi riktig differanse for ukentlig utbetaling ved skuddår ved ordinær sekundærlandssak`() {
+    fun `Månedlig utenlandsk periodebeløp skal ikke endres`() {
 
-        val utenlandskSatsUkentlig = 25
+        val månedligValutabeløp = 100.i("EUR").somUtenlandskPeriodebeløp(MÅNEDLIG)
+            .tilMånedligValutabeløp(jan(2021))
 
-        val utbetalingsbeløpUtlandINok = beregnMånedligUtbetalingsbeløpUtlandINok(
-            satsUtland = utenlandskSatsUkentlig, kurs = 10.0, intervall = Intervall.UKENTLIG, erSkuddår = true
-        )
+        Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
+    }
 
-        Assertions.assertEquals(1089, utbetalingsbeløpUtlandINok)
-        Assertions.assertEquals(911, beregnDifferanseOrdinær(utbetalingsbeløpNorge, utbetalingsbeløpUtlandINok))
+    @Test
+    fun `Skal konvertere ukentlig utenlandsk periodebeløp til månedlig`() {
+
+        val månedligValutabeløp = 25.i("EUR").somUtenlandskPeriodebeløp(UKENTLIG)
+            .tilMånedligValutabeløp(jan(2021))?.rundNed(5)
+
+        Assertions.assertEquals(108.63.i("EUR"), månedligValutabeløp)
+    }
+
+    @Test
+    fun `Skal konvertere ukentlig utenlandsk periodebeløp til månedlig i skuddår`() {
+
+        val månedligValutabeløp = 25.i("EUR").somUtenlandskPeriodebeløp(UKENTLIG)
+            .tilMånedligValutabeløp(jan(2020))?.rundNed(5)
+
+        Assertions.assertEquals(108.92.i("EUR"), månedligValutabeløp)
     }
 
     @Test
     fun `Skal ha presisjon i kronekonverteringen til norske kroner`() {
+        val månedligValutabeløp = 0.0123767453453.i("EUR").somUtenlandskPeriodebeløp(ÅRLIG)
+            .tilMånedligValutabeløp(jan(2021))?.rundNed(10)
 
-        val utenlandskSatsÅrlig = 12000000
-
-        val utbetalingsbeløpUtlandINok = beregnMånedligUtbetalingsbeløpUtlandINok(
-            satsUtland = utenlandskSatsÅrlig, kurs = 12.3456775, intervall = Intervall.ÅRLIG, erSkuddår = false
-        )
-
-        Assertions.assertEquals(12345678, utbetalingsbeløpUtlandINok)
+        Assertions.assertEquals(0.001031395445.i("EUR"), månedligValutabeløp)
     }
 
     @Test
-    fun `Skal gi null dersom utenlandsk beløp er større en det norske når det ikke er småbarnstilleg eller utvidet`() {
+    fun `Skal håndtere gjentakende endring og differanseberegning på andel tilkjent ytelse`() {
+        val aty1 = lagAndelTilkjentYtelse(beløp = 50)
+            .kalkulerFraUtenlandskPeriodebeløp(100.toBigDecimal())
 
-        Assertions.assertEquals(
-            0,
-            beregnDifferanseOrdinær(utbetalingsbeløpNorge = 1000, utbetalingsbeløpUtlandINok = 2000)
-        )
+        Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
+        Assertions.assertEquals(-50, aty1?.differanseberegnetPeriodebeløp)
+        Assertions.assertEquals(50, aty1?.nasjonaltPeriodebeløp)
+
+        val aty2 = aty1?.copy(kalkulertUtbetalingsbeløp = 1)
+            ?.kalkulerFraUtenlandskPeriodebeløp(75.toBigDecimal())
+
+        Assertions.assertEquals(0, aty2?.kalkulertUtbetalingsbeløp)
+        Assertions.assertEquals(-74, aty2?.differanseberegnetPeriodebeløp)
+        Assertions.assertEquals(1, aty2?.nasjonaltPeriodebeløp)
+
+        val aty3 = aty2?.copy(kalkulertUtbetalingsbeløp = 250)
+            ?.kalkulerFraUtenlandskPeriodebeløp(75.toBigDecimal())
+
+        Assertions.assertEquals(175, aty3?.kalkulertUtbetalingsbeløp)
+        Assertions.assertEquals(175, aty3?.differanseberegnetPeriodebeløp)
+        Assertions.assertEquals(250, aty3?.nasjonaltPeriodebeløp)
     }
 }
+
+fun lagAndelTilkjentYtelse(beløp: Int) = lagAndelTilkjentYtelse(
+    fom = YearMonth.now(),
+    tom = YearMonth.now().plusYears(1),
+    beløp = beløp
+)
+
+fun Double.kronerPer(valuta: String) = KronerPerValutaenhet(
+    valutakode = valuta,
+    kronerPerValutaenhet = this.toBigDecimal()
+)
+
+fun Double.i(valuta: String) = Valutabeløp(this.toBigDecimal(), valuta)
+fun Int.i(valuta: String) = Valutabeløp(this.toBigDecimal(), valuta)
+
+fun Valutabeløp.somUtenlandskPeriodebeløp(intervall: Intervall): UtenlandskPeriodebeløp =
+    UtenlandskPeriodebeløp(
+        fom = null,
+        tom = null,
+        beløp = this.beløp,
+        valutakode = this.valutakode,
+        intervall = intervall.name
+    )
+
+fun Valutabeløp.rundNed(presisjon: Int) =
+    Valutabeløp(this.beløp.round(MathContext(presisjon, RoundingMode.DOWN)), this.valutakode)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.util.DeltBostedBuilder
+import no.nav.familie.ba.sak.kjerne.eøs.util.UtenlandskPeriodebeløpBuilder
+import no.nav.familie.ba.sak.kjerne.eøs.util.ValutakursBuilder
+import no.nav.familie.ba.sak.kjerne.eøs.util.byggTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.VilkårsvurderingBuilder
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.byggTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOR_MED_SØKER
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOSATT_I_RIKET
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.GIFT_PARTNERSKAP
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.LOVLIG_OPPHOLD
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.UNDER_18_ÅR
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TilkjentYtelseDifferanseberegningTest {
+
+    @Test
+    fun `skal gjøre differanseberegning på en tilkjent ytelse med endringsperioder`() {
+
+        val barnsFødselsdato = 13.jan(2020)
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato.tilLocalDate())
+        val barn2 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato.tilLocalDate())
+
+        val behandling = lagBehandling()
+        val behandlingId = BehandlingId(behandling.id)
+        val startMåned = barnsFødselsdato.tilInneværendeMåned()
+
+        val vilkårsvurderingBygger = VilkårsvurderingBuilder<Måned>(behandling)
+            .forPerson(søker, startMåned)
+            .medVilkår("EEEEEEEEEEEEEEEEEEEEEEE", BOSATT_I_RIKET)
+            .medVilkår("EEEEEEEEEEEEEEEEEEEEEEE", LOVLIG_OPPHOLD)
+            .forPerson(barn1, startMåned)
+            .medVilkår("+>", UNDER_18_ÅR, GIFT_PARTNERSKAP)
+            .medVilkår("E>", BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER)
+            .forPerson(barn2, startMåned)
+            .medVilkår("+>", UNDER_18_ÅR, GIFT_PARTNERSKAP)
+            .medVilkår("E>", BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER)
+            .byggPerson()
+
+        val tilkjentYtelse = vilkårsvurderingBygger.byggTilkjentYtelse()
+
+        assertEquals(6, tilkjentYtelse.andelerTilkjentYtelse.size)
+
+        val tilkjentYtelseMedEndringer = DeltBostedBuilder(startMåned, tilkjentYtelse)
+            .medDeltBosted(" //////000000000011111>", barn1, barn2)
+            .byggTilkjentYtelse()
+
+        assertEquals(8, tilkjentYtelseMedEndringer.andelerTilkjentYtelse.size)
+
+        val utenlandskePeriodebeløp = UtenlandskPeriodebeløpBuilder(startMåned, behandlingId)
+            .medBeløp(" 44555666>", "EUR", "fr", barn1, barn2)
+            .bygg()
+
+        val valutakurser = ValutakursBuilder(startMåned, behandlingId)
+            .medKurs(" 888899999>", "EUR", barn1, barn2)
+            .bygg()
+
+        val differanseBeregnetTilkjentYtelse =
+            beregnDifferanse(tilkjentYtelseMedEndringer, utenlandskePeriodebeløp, valutakurser)
+
+        assertEquals(14, differanseBeregnetTilkjentYtelse.andelerTilkjentYtelse.size)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/DeltBostedBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/DeltBostedBuilder.kt
@@ -1,0 +1,79 @@
+package no.nav.familie.ba.sak.kjerne.eøs.util
+
+import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseUtils
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.medAndeler
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import java.time.YearMonth
+
+class DeltBostedBuilder(
+    startMåned: Tidspunkt<Måned> = jan(2020),
+    val tilkjentYtelse: TilkjentYtelse
+) : SkjemaBuilder<DeltBosted, DeltBostedBuilder>(startMåned, BehandlingId(tilkjentYtelse.behandling.id)) {
+
+    fun medDeltBosted(k: String, vararg barn: Person) = medSkjema(k, barn.toList()) {
+        when (it) {
+            '0' -> DeltBosted(prosent = 0, barnPersoner = barn.toList())
+            '/' -> DeltBosted(prosent = 50, barnPersoner = barn.toList())
+            '1' -> DeltBosted(prosent = 100, barnPersoner = barn.toList())
+            else -> null
+        }
+    }
+}
+
+data class DeltBosted(
+    override val fom: YearMonth? = null,
+    override val tom: YearMonth? = null,
+    override val barnAktører: Set<Aktør> = emptySet(),
+    val prosent: Int?,
+    internal val barnPersoner: List<Person> = emptyList()
+) : PeriodeOgBarnSkjemaEntitet<DeltBosted>() {
+    override fun utenInnhold() = copy(prosent = null)
+    override fun kopier(fom: YearMonth?, tom: YearMonth?, barnAktører: Set<Aktør>) =
+        copy(
+            fom = fom,
+            tom = tom,
+            barnAktører = barnAktører.map { it.copy() }.toSet(),
+            barnPersoner = this.barnPersoner.filter { barnAktører.contains(it.aktør) }
+        ).also {
+            if (barnAktører.size != barnPersoner.size)
+                throw Error("Ikke samsvar mellom antall aktører og barn lenger")
+        }
+
+    override var id: Long = 0
+    override var behandlingId: Long = 0
+}
+
+fun DeltBostedBuilder.byggTilkjentYtelse(): TilkjentYtelse {
+    val andelerTilkjentYtelserEtterEUA =
+        TilkjentYtelseUtils.oppdaterTilkjentYtelseMedEndretUtbetalingAndeler(
+            tilkjentYtelse.andelerTilkjentYtelse,
+            bygg().tilEndreteUtebetalingAndeler()
+        )
+
+    return tilkjentYtelse.medAndeler(andelerTilkjentYtelserEtterEUA)
+}
+
+fun Iterable<DeltBosted>.tilEndreteUtebetalingAndeler(): List<EndretUtbetalingAndel> {
+    return this
+        .filter { deltBosted -> deltBosted.fom != null && deltBosted.tom != null && deltBosted.prosent != null }
+        .flatMap { deltBosted ->
+            deltBosted.barnPersoner.map {
+                lagEndretUtbetalingAndel(
+                    deltBosted.behandlingId,
+                    it,
+                    deltBosted.fom!!,
+                    deltBosted.tom!!,
+                    deltBosted.prosent!!
+                )
+            }
+        }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/UtenlandskPeriodebeløpBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/UtenlandskPeriodebeløpBuilder.kt
@@ -11,19 +11,23 @@ class UtenlandskPeriodebeløpBuilder(
     startMåned: Tidspunkt<Måned> = jan(2020),
     behandlingId: BehandlingId = BehandlingId(1)
 ) : SkjemaBuilder<UtenlandskPeriodebeløp, UtenlandskPeriodebeløpBuilder>(startMåned, behandlingId) {
-    fun medBeløp(k: String, valutakode: String?, utbetalingsland: String, vararg barn: Person) = medSkjema(k, barn.toList()) {
-        when {
-            it == '-' -> UtenlandskPeriodebeløp.NULL.copy(utbetalingsland = utbetalingsland)
-            it == '$' -> UtenlandskPeriodebeløp.NULL.copy(valutakode = valutakode, utbetalingsland = utbetalingsland)
-            it?.isDigit() ?: false -> {
-                UtenlandskPeriodebeløp.NULL.copy(
-                    beløp = it?.digitToInt()?.toBigDecimal(),
+    fun medBeløp(k: String, valutakode: String?, utbetalingsland: String, vararg barn: Person) =
+        medSkjema(k, barn.toList()) {
+            when {
+                it == '-' -> UtenlandskPeriodebeløp.NULL.copy(utbetalingsland = utbetalingsland)
+                it == '$' -> UtenlandskPeriodebeløp.NULL.copy(
                     valutakode = valutakode,
-                    intervall = "MND",
                     utbetalingsland = utbetalingsland
                 )
+                it?.isDigit() ?: false -> {
+                    UtenlandskPeriodebeløp.NULL.copy(
+                        beløp = it?.digitToInt()?.toBigDecimal(),
+                        valutakode = valutakode,
+                        intervall = "MÅNEDLIG",
+                        utbetalingsland = utbetalingsland
+                    )
+                }
+                else -> null
             }
-            else -> null
         }
-    }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningIntegrasjonTest.kt
@@ -1,0 +1,88 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseTestController
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpTestController
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursTestController
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingTestController
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class DifferanseberegningIntegrasjonTest : AbstractSpringIntegrationTest() {
+
+    @Autowired
+    lateinit var vilkårsvurderingTestController: VilkårsvurderingTestController
+
+    @Autowired
+    lateinit var tilkjentYtelseTestController: TilkjentYtelseTestController
+
+    @Autowired
+    lateinit var kompetanseTestController: KompetanseTestController
+
+    @Autowired
+    lateinit var utenlandskPeriodebeløpTestController: UtenlandskPeriodebeløpTestController
+
+    @Autowired
+    lateinit var valutakursTestController: ValutakursTestController
+
+    @Test
+    fun `vilkårsvurdering med EØS-perioder + kompetanser med sekundærland fører til skjemaer med valutakurser`() {
+        val søkerStartdato = 1.jan(2020).tilLocalDate()
+        val barnStartdato = 2.jan(2020).tilLocalDate()
+
+        val vilkårsvurderingRequest = mapOf(
+            søkerStartdato to mapOf(
+                Vilkår.BOSATT_I_RIKET /*    */ to "EEEEEEEEEEEEEEEE",
+                Vilkår.LOVLIG_OPPHOLD /*    */ to "EEEEEEEEEEEEEEEE"
+            ),
+            barnStartdato to mapOf(
+                Vilkår.UNDER_18_ÅR /*       */ to "++++++++++++++++",
+                Vilkår.GIFT_PARTNERSKAP /*  */ to "++++++++++++++++",
+                Vilkår.BOSATT_I_RIKET /*    */ to "EEEEEEEEEEEEEEEE",
+                Vilkår.LOVLIG_OPPHOLD /*    */ to "EEEEEEEEEEEEEEEE",
+                Vilkår.BOR_MED_SØKER /*     */ to "EEEEEEEEEEEEEEEE"
+            )
+        )
+
+        val deltBosteRequest = mapOf(
+            barnStartdato /*                */ to "/////00000011111"
+        )
+
+        val kompetanseRequest = mapOf(
+            barnStartdato /*                */ to "PPPSSSSSSPPSSS--"
+        )
+
+        val utenlandskPeriodebeløpRequest = mapOf(
+            barnStartdato /*                */ to "3333444566677777"
+        )
+
+        val valutakursRequest = mapOf(
+            barnStartdato /*                */ to "5555566644234489"
+        )
+
+        val utvidetBehandling1 =
+            vilkårsvurderingTestController.opprettBehandlingMedVilkårsvurdering(vilkårsvurderingRequest)
+                .body?.data!!
+
+        // tilkjentYtelseTestController.lagInitiellTilkjentYtelse(utvidetBehandling1.behandlingId)
+        tilkjentYtelseTestController.oppdaterEndretUtebetalingAndeler(
+            utvidetBehandling1.behandlingId, deltBosteRequest
+        )
+
+        kompetanseTestController.endreKompetanser(utvidetBehandling1.behandlingId, kompetanseRequest)
+        utenlandskPeriodebeløpTestController.endreUtenlandskePeriodebeløp(
+            utvidetBehandling1.behandlingId,
+            utenlandskPeriodebeløpRequest
+        )
+
+        val utvidetbehandling2 = valutakursTestController
+            .endreValutakurser(utvidetBehandling1.behandlingId, valutakursRequest)
+            .body?.data!!
+
+        Assertions.assertEquals(3, utvidetbehandling2.endretUtbetalingAndeler.size)
+        Assertions.assertEquals(10, utvidetbehandling2.utbetalingsperioder.size)
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseTestController.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseTestController.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
+import no.nav.familie.ba.sak.kjerne.eøs.util.DeltBostedBuilder
+import no.nav.familie.ba.sak.kjerne.eøs.util.tilEndreteUtebetalingAndeler
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.MånedTidspunkt.Companion.tilMånedTidspunkt
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/test/tilkjentytelse")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+@Profile("!prod")
+class TilkjentYtelseTestController(
+    private val utvidetBehandlingService: UtvidetBehandlingService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val beregningService: BeregningService,
+    private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+    private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository
+) {
+    @PutMapping(path = ["{behandlingId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun oppdaterEndretUtebetalingAndeler(
+        @PathVariable behandlingId: Long,
+        @RequestBody restDeltBosted: Map<LocalDate, String>
+    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)!!
+
+        val tilkjentYtelse = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
+
+        restDeltBosted.tilEndretUtbetalingAndeler(personopplysningGrunnlag, tilkjentYtelse).forEach {
+            val lagretEndretUtbetalingAndel = endretUtbetalingAndelRepository.saveAndFlush(it)
+
+            beregningService.oppdaterBehandlingMedBeregning(
+                behandling, personopplysningGrunnlag, lagretEndretUtbetalingAndel
+            )
+        }
+
+        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
+    }
+}
+
+private fun Map<LocalDate, String>.tilEndretUtbetalingAndeler(
+    personopplysningGrunnlag: PersonopplysningGrunnlag,
+    tilkjentYtelse: TilkjentYtelse
+): Collection<EndretUtbetalingAndel> {
+    return this.map { (dato, tidslinje) ->
+        val person = personopplysningGrunnlag.personer.first { it.fødselsdato == dato }
+        DeltBostedBuilder(dato.tilMånedTidspunkt(), tilkjentYtelse)
+            .medDeltBosted(tidslinje, person)
+            .bygg().tilEndreteUtebetalingAndeler()
+    }.flatten()
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpTestController.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpTestController.kt
@@ -1,0 +1,60 @@
+package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
+
+import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.slåSammen
+import no.nav.familie.ba.sak.kjerne.eøs.util.UtenlandskPeriodebeløpBuilder
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.MånedTidspunkt.Companion.tilMånedTidspunkt
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/test/utenlandskeperiodebeløp")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+@Profile("!prod")
+class UtenlandskPeriodebeløpTestController(
+    private val utvidetBehandlingService: UtvidetBehandlingService,
+    private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+    private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService
+) {
+
+    @PutMapping(path = ["{behandlingId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun endreUtenlandskePeriodebeløp(
+        @PathVariable behandlingId: Long,
+        @RequestBody restUtenlandskePeriodebeløp: Map<LocalDate, String>
+    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
+        val behandlingId = BehandlingId(behandlingId)
+        val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId.id)!!
+        restUtenlandskePeriodebeløp.tilUtenlandskePeriodebeløp(behandlingId, personopplysningGrunnlag).forEach {
+            utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(behandlingId, it)
+        }
+
+        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId.id)))
+    }
+}
+
+private fun Map<LocalDate, String>.tilUtenlandskePeriodebeløp(
+    behandlingId: BehandlingId,
+    personopplysningGrunnlag: PersonopplysningGrunnlag
+): Collection<UtenlandskPeriodebeløp> {
+    return this.map { (dato, tidslinje) ->
+        val person = personopplysningGrunnlag.personer.first { it.fødselsdato == dato }
+        UtenlandskPeriodebeløpBuilder(dato.tilMånedTidspunkt(), behandlingId)
+            .medBeløp(tidslinje, "EUR", "fr", person)
+            .bygg()
+    }.flatten().slåSammen()
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
 
 import no.nav.familie.ba.sak.ekstern.restDomene.UtfyltStatus
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestUtenlandskPeriodebeløp
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagUtenlandskPeriodebeløp
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTestController.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTestController.kt
@@ -1,0 +1,60 @@
+package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
+
+import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.slåSammen
+import no.nav.familie.ba.sak.kjerne.eøs.util.ValutakursBuilder
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.MånedTidspunkt.Companion.tilMånedTidspunkt
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/test/valutakurser")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+@Profile("!prod")
+class ValutakursTestController(
+    private val utvidetBehandlingService: UtvidetBehandlingService,
+    private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+    private val valutakursService: ValutakursService
+) {
+
+    @PutMapping(path = ["{behandlingId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun endreValutakurser(
+        @PathVariable behandlingId: Long,
+        @RequestBody restValutakurser: Map<LocalDate, String>
+    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
+        val behandlingId = BehandlingId(behandlingId)
+        val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId.id)!!
+        restValutakurser.tilValutakurser(behandlingId, personopplysningGrunnlag).forEach {
+            valutakursService.oppdaterValutakurs(behandlingId, it)
+        }
+
+        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId.id)))
+    }
+}
+
+private fun Map<LocalDate, String>.tilValutakurser(
+    behandlingId: BehandlingId,
+    personopplysningGrunnlag: PersonopplysningGrunnlag
+): Collection<Valutakurs> {
+    return this.map { (dato, tidslinje) ->
+        val person = personopplysningGrunnlag.personer.first { it.fødselsdato == dato }
+        ValutakursBuilder(dato.tilMånedTidspunkt(), behandlingId)
+            .medKurs(tidslinje, "EUR", person)
+            .bygg()
+    }.flatten().slåSammen()
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Logikk og infrastruktur for å gjøre differanseberegning når det skjer endringer i en av:
* Tilkjent ytelse
* Utenlandsk periodebeløp
* Valutakurs

Det opprettes to nye felter på `AndelTilkjentYtelse` for å lagre informasjon knyttet til differanseberegningen:
* Nasjonalt periodebeløp: Utbetalingen som beregnes i det nasjonale løpet, inklusive endringsperioder
* Differanseberegnet periodebeløp: Det uavkortede resultatet av differanseberegningen

**BØR leses commit for commit**

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei, er vel ikke. Min største usikkerhet er knyttet til JPA-biten. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
