### PR TITLE
skrur på Point in Time Recovery i preprod

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -30,6 +30,7 @@ spec:
         tier: db-custom-1-3840
         name: familie-ba-sak
         autoBackupTime: "02:00"
+        pointInTimeRecovery: true
         diskAutoresize: true
         highAvailability: false
         databases:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Skru på PITR for å minimere datatap ved behov for restore av database.