### PR TITLE
Lagt til kalkulertMånedligBeløp på UtenlandskPeriobebeløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtenlandskPeriodebeløp.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.erSkuddår
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.konverterBeløpTilMånedlig
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.MånedTidspunkt.Companion.tilTidspunkt
 import java.math.BigDecimal
 import java.time.YearMonth
 
@@ -36,12 +34,19 @@ fun RestUtenlandskPeriodebeløp.tilUtenlandskPeriodebeløp(barnAktører: List<Ak
     kalkulertMånedligBeløp = this.tilKalkulertMånedligBeløp()
 )
 
-fun RestUtenlandskPeriodebeløp.tilKalkulertMånedligBeløp() =
-    if (this.intervall != null && this.beløp != null && this.fom != null) {
-        this.intervall.konverterBeløpTilMånedlig(
-            this.beløp, this.fom.tilTidspunkt().erSkuddår()
-        )
-    } else null
+fun RestUtenlandskPeriodebeløp.tilKalkulertMånedligBeløp(): BigDecimal? {
+    if (this.beløp == null || this.intervall == null)
+        return null
+
+    return this.intervall.konverterBeløpTilMånedlig(this.beløp)
+}
+
+fun UtenlandskPeriodebeløp.tilKalkulertMånedligBeløp(): BigDecimal? {
+    if (this.beløp == null || this.intervall == null)
+        return null
+
+    return this.intervall.konverterBeløpTilMånedlig(this.beløp)
+}
 
 fun UtenlandskPeriodebeløp.tilRestUtenlandskPeriodebeløp() = RestUtenlandskPeriodebeløp(
     id = this.id,

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtenlandskPeriodebeløp.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import java.math.BigDecimal
@@ -12,7 +13,7 @@ data class RestUtenlandskPeriodebeløp(
     val barnIdenter: List<String>,
     val beløp: BigDecimal?,
     val valutakode: String?,
-    val intervall: String?,
+    val intervall: Intervall?,
     val utbetalingsland: String?,
     override val status: UtfyltStatus = UtfyltStatus.IKKE_UTFYLT
 ) : AbstractUtfyltStatus<RestUtenlandskPeriodebeløp>() {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -2,16 +2,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
 import java.math.BigDecimal
-
-fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal, erSkuddår: Boolean) = when (this) {
-    Intervall.ÅRLIG -> beløp / 12.toBigDecimal()
-    Intervall.KVARTALSVIS -> beløp / 3.toBigDecimal()
-    Intervall.MÅNEDLIG -> beløp
-    Intervall.UKENTLIG -> konverterFraUkentligTilMånedligBeløp(beløp, erSkuddår)
-}
 
 fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal) = when (this) {
     Intervall.ÅRLIG -> beløp / 12.toBigDecimal()
@@ -19,23 +10,6 @@ fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal) = when (this) {
     Intervall.MÅNEDLIG -> beløp
     Intervall.UKENTLIG -> beløp.multiply(4.35.toBigDecimal())
 }
-
-/***
- * Det finnes ingen offisiell dokumentasjon på hvordan vi skal konvertere fra ukentlig til
- * månedlig betaling i NAV per dags dato (19.05.2022). Til nå har saksbehandlere gjort dette manuelt og
- * brukt 52/12=4.33 for å konvertere fra ukentlig til månedlige beløp. Teamet har blitt enige om at vi burde
- * ta utgangspunkt i antall dager i et år. Siden valutajusteringen kun skjer en gang i året bruker
- * vi et gjennomsnitt for hver måned, slik at vi konverterer likt for måneder med forskjellig lengde.
- ***/
-private fun konverterFraUkentligTilMånedligBeløp(beløp: BigDecimal, erSkuddår: Boolean): BigDecimal {
-    val dagerIÅret: Double = if (erSkuddår) 366.0 else 365.0
-    val ukerIÅret: Double = dagerIÅret / 7.0
-    val ukerIEnMåned: Double = ukerIÅret / 12.0
-
-    return beløp.multiply(BigDecimal.valueOf(ukerIEnMåned))
-}
-
-fun <T : Tidsenhet> Tidspunkt<T>.erSkuddår() = this.tilLocalDateEllerNull()?.isLeapYear ?: false
 
 /**
  * Kalkulerer nytt utbetalingsbeløp fra [utenlandskPeriodebeløpINorskeKroner]

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -13,6 +13,13 @@ fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal, erSkuddår: Boolea
     Intervall.UKENTLIG -> konverterFraUkentligTilMånedligBeløp(beløp, erSkuddår)
 }
 
+fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal) = when (this) {
+    Intervall.ÅRLIG -> beløp / 12.toBigDecimal()
+    Intervall.KVARTALSVIS -> beløp / 3.toBigDecimal()
+    Intervall.MÅNEDLIG -> beløp
+    Intervall.UKENTLIG -> beløp.multiply(4.35.toBigDecimal())
+}
+
 /***
  * Det finnes ingen offisiell dokumentasjon på hvordan vi skal konvertere fra ukentlig til
  * månedlig betaling i NAV per dags dato (19.05.2022). Til nå har saksbehandlere gjort dette manuelt og

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegning.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tidspunktKombinerMed
 
 fun beregnDifferanse(
     tilkjentYtelse: TilkjentYtelse,
@@ -34,10 +33,7 @@ fun beregnDifferanse(
         val valutakursTidslinje = valutakursTidslinjer.getOrDefault(aktør, TomTidslinje())
         val andelTilkjentYtelseTidslinje = andelTilkjentYtelseTidslinjer.getOrDefault(aktør, TomTidslinje())
 
-        val utenlandskePeriodebeløpINorskeKroner = utenlandskePeriodebeløpTidslinje
-            .tidspunktKombinerMed(valutakursTidslinje) { tidspunkt, upb, vk ->
-                upb.tilMånedligValutabeløp(tidspunkt) * vk.tilKronerPerValutaenhet()
-            }
+        val utenlandskePeriodebeløpINorskeKroner = utenlandskePeriodebeløpTidslinje.kombinerMed(valutakursTidslinje) { upb, valutakurs -> upb.tilMånedligValutabeløp() * valutakurs.tilKronerPerValutaenhet() }
 
         andelTilkjentYtelseTidslinje.kombinerMed(utenlandskePeriodebeløpINorskeKroner) { aty, beløp ->
             beløp?.let { aty.kalkulerFraUtenlandskPeriodebeløp(it) } ?: aty

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
@@ -33,7 +33,7 @@ fun <T : Tidsenhet> UtenlandskPeriodebeløp?.tilMånedligValutabeløp(tidspunkt:
         return null
 
     val månedligBeløp =
-        Intervall.valueOf(this.intervall).konverterBeløpTilMånedlig(this.beløp, tidspunkt.erSkuddår())
+        this.intervall.konverterBeløpTilMånedlig(this.beløp, tidspunkt.erSkuddår())
 
     return Valutabeløp(månedligBeløp, this.valutakode)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
@@ -1,11 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene
 
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.erSkuddår
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.konverterBeløpTilMånedlig
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
 import java.math.BigDecimal
 
 data class KronerPerValutaenhet(
@@ -28,14 +24,11 @@ operator fun Valutabeløp?.times(kronerPerValutaenhet: KronerPerValutaenhet?): B
     return this.beløp * kronerPerValutaenhet.kronerPerValutaenhet
 }
 
-fun <T : Tidsenhet> UtenlandskPeriodebeløp?.tilMånedligValutabeløp(tidspunkt: Tidspunkt<T>): Valutabeløp? {
-    if (this?.beløp == null || this.intervall == null || this.valutakode == null)
+fun UtenlandskPeriodebeløp?.tilMånedligValutabeløp(): Valutabeløp? {
+    if (this?.kalkulertMånedligBeløp == null || this.valutakode == null)
         return null
 
-    val månedligBeløp =
-        this.intervall.konverterBeløpTilMånedlig(this.beløp, tidspunkt.erSkuddår())
-
-    return Valutabeløp(månedligBeløp, this.valutakode)
+    return Valutabeløp(this.kalkulertMånedligBeløp, this.valutakode)
 }
 
 fun Valutakurs?.tilKronerPerValutaenhet(): KronerPerValutaenhet? {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
@@ -71,7 +71,8 @@ data class UtenlandskPeriodebeløp(
     override fun utenInnhold(): UtenlandskPeriodebeløp = copy(
         beløp = null,
         valutakode = null,
-        intervall = null
+        intervall = null,
+        kalkulertMånedligBeløp = null
     )
 
     override fun kopier(fom: YearMonth?, tom: YearMonth?, barnAktører: Set<Aktør>) = copy(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
@@ -52,6 +52,9 @@ data class UtenlandskPeriodebeløp(
 
     @Column(name = "utbetalingsland")
     val utbetalingsland: String? = null,
+
+    @Column(name = "kalkulert_maanedlig_beloep")
+    val kalkulertMånedligBeløp: BigDecimal? = null
 ) : PeriodeOgBarnSkjemaEntitet<UtenlandskPeriodebeløp>() {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "utenlandsk_periodebeloep_seq_generator")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
 
 import no.nav.familie.ba.sak.common.YearMonthConverter
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
@@ -47,7 +48,7 @@ data class UtenlandskPeriodebeløp(
     val valutakode: String? = null,
 
     @Column(name = "intervall")
-    val intervall: String? = null,
+    val intervall: Intervall? = null,
 
     @Column(name = "utbetalingsland")
     val utbetalingsland: String? = null,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpController.kt
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 class UtenlandskPeriodebeløpController(
     private val featureToggleService: FeatureToggleService,
     private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService,
+    private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
     private val personidentService: PersonidentService,
     private val utvidetBehandlingService: UtvidetBehandlingService
 ) {
@@ -40,12 +41,15 @@ class UtenlandskPeriodebeløpController(
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build()
 
         val barnAktører = restUtenlandskPeriodebeløp.barnIdenter.map { personidentService.hentAktør(it) }
-        val utenlandskPeriodebeløp = restUtenlandskPeriodebeløp.tilUtenlandskPeriodebeløp(barnAktører = barnAktører)
+
+        val eksisterendeUtenlandskPeriodeBeløp = utenlandskPeriodebeløpRepository.getById(restUtenlandskPeriodebeløp.id)
+
+        val utenlandskPeriodebeløp = restUtenlandskPeriodebeløp.tilUtenlandskPeriodebeløp(barnAktører, eksisterendeUtenlandskPeriodeBeløp)
 
         utenlandskPeriodebeløpService
             .oppdaterUtenlandskPeriodebeløp(BehandlingId(behandlingId), utenlandskPeriodebeløp)
 
-        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
+        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId)))
     }
 
     @DeleteMapping(path = ["{behandlingId}/{utenlandskPeriodebeløpId}"], produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/resources/db/migration/V213__kalkulert_maanedlig_belop_upb.sql
+++ b/src/main/resources/db/migration/V213__kalkulert_maanedlig_belop_upb.sql
@@ -1,0 +1,1 @@
+ALTER TABLE utenlandsk_periodebeloep ADD COLUMN kalkulert_maanedlig_beloep DECIMAL;

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Valutabeløp
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilMånedligValutabeløp
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.times
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -44,7 +43,7 @@ class DifferanseberegningsUtilsTest {
     fun `Skal konvertere årlig utenlandsk periodebeløp til månedlig`() {
 
         val månedligValutabeløp = 1200.i("EUR").somUtenlandskPeriodebeløp(ÅRLIG)
-            .tilMånedligValutabeløp(jan(2021))
+            .tilMånedligValutabeløp()
 
         Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
@@ -53,7 +52,7 @@ class DifferanseberegningsUtilsTest {
     fun `Skal konvertere kvartalsvis utenlandsk periodebeløp til månedlig`() {
 
         val månedligValutabeløp = 300.i("EUR").somUtenlandskPeriodebeløp(KVARTALSVIS)
-            .tilMånedligValutabeløp(jan(2021))
+            .tilMånedligValutabeløp()
 
         Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
@@ -62,7 +61,7 @@ class DifferanseberegningsUtilsTest {
     fun `Månedlig utenlandsk periodebeløp skal ikke endres`() {
 
         val månedligValutabeløp = 100.i("EUR").somUtenlandskPeriodebeløp(MÅNEDLIG)
-            .tilMånedligValutabeløp(jan(2021))
+            .tilMånedligValutabeløp()
 
         Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
@@ -71,24 +70,15 @@ class DifferanseberegningsUtilsTest {
     fun `Skal konvertere ukentlig utenlandsk periodebeløp til månedlig`() {
 
         val månedligValutabeløp = 25.i("EUR").somUtenlandskPeriodebeløp(UKENTLIG)
-            .tilMånedligValutabeløp(jan(2021))?.rundNed(5)
+            .tilMånedligValutabeløp()?.rundNed(5)
 
-        Assertions.assertEquals(108.63.i("EUR"), månedligValutabeløp)
-    }
-
-    @Test
-    fun `Skal konvertere ukentlig utenlandsk periodebeløp til månedlig i skuddår`() {
-
-        val månedligValutabeløp = 25.i("EUR").somUtenlandskPeriodebeløp(UKENTLIG)
-            .tilMånedligValutabeløp(jan(2020))?.rundNed(5)
-
-        Assertions.assertEquals(108.92.i("EUR"), månedligValutabeløp)
+        Assertions.assertEquals(108.75.i("EUR"), månedligValutabeløp)
     }
 
     @Test
     fun `Skal ha presisjon i kronekonverteringen til norske kroner`() {
         val månedligValutabeløp = 0.0123767453453.i("EUR").somUtenlandskPeriodebeløp(ÅRLIG)
-            .tilMånedligValutabeløp(jan(2021))?.rundNed(10)
+            .tilMånedligValutabeløp()?.rundNed(10)
 
         Assertions.assertEquals(0.001031395445.i("EUR"), månedligValutabeløp)
     }
@@ -148,7 +138,8 @@ fun Valutabeløp.somUtenlandskPeriodebeløp(intervall: Intervall): UtenlandskPer
         tom = null,
         beløp = this.beløp,
         valutakode = this.valutakode,
-        intervall = intervall
+        intervall = intervall,
+        kalkulertMånedligBeløp = intervall.konverterBeløpTilMånedlig(this.beløp)
     )
 
 fun Valutabeløp.rundNed(presisjon: Int) =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
@@ -148,7 +148,7 @@ fun Valutabeløp.somUtenlandskPeriodebeløp(intervall: Intervall): UtenlandskPer
         tom = null,
         beløp = this.beløp,
         valutakode = this.valutakode,
-        intervall = intervall.name
+        intervall = intervall
     )
 
 fun Valutabeløp.rundNed(presisjon: Int) =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Datagenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Datagenerator.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene
 
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -53,7 +54,7 @@ fun lagUtenlandskPeriodebeløp(
     barnAktører: Set<Aktør> = emptySet(),
     beløp: BigDecimal? = null,
     valutakode: String? = null,
-    intervall: String? = null,
+    intervall: Intervall? = null,
     utbetalingsland: String = ""
 ) = UtenlandskPeriodebeløp(
     fom = fom,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassUtenlandskePeriodebeløpTilKompetanserService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
@@ -91,6 +92,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
         assertNull(faktiskUtenlandskPeriodebeløp.beløp)
         assertNull(faktiskUtenlandskPeriodebeløp.valutakode)
         assertNull(faktiskUtenlandskPeriodebeløp.intervall)
+        assertNull(faktiskUtenlandskPeriodebeløp.kalkulertMånedligBeløp)
         assertEquals(lagretUtenlandskPeriodebeløp.fom, faktiskUtenlandskPeriodebeløp.fom)
         assertEquals(lagretUtenlandskPeriodebeløp.tom, faktiskUtenlandskPeriodebeløp.tom)
         assertEquals(lagretUtenlandskPeriodebeløp.barnAktører, faktiskUtenlandskPeriodebeløp.barnAktører)
@@ -104,10 +106,11 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
         UtenlandskPeriodebeløpBuilder(jan(2020), behandlingId)
             .medBeløp("4>", "EUR", "SE", barn1)
+            .medIntervall(Intervall.UKENTLIG)
             .lagreTil(utenlandskPeriodebeløpRepository).single()
 
         // Oppdaterer UtenlandskPeriodeBeløp med identisk innhold, men med lukket tom for andre mnd.
-        val oppdatertUtenlandskPeriodebeløp = UtenlandskPeriodebeløpBuilder(jan(2020)).medBeløp("44", "EUR", "SE", barn1).bygg().first()
+        val oppdatertUtenlandskPeriodebeløp = UtenlandskPeriodebeløpBuilder(jan(2020)).medBeløp("44", "EUR", "SE", barn1).medIntervall(Intervall.UKENTLIG).bygg().first()
         utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(behandlingId, oppdatertUtenlandskPeriodebeløp)
 
         // Forventer en liste på 2 elementer hvor det første dekker 2 mnd og det andre dekker fra mnd 3 og til uendelig (null). Det siste elementet skal ha beløp, valutakode og intervall satt til null, mens utbetalingsland skal være "SE".
@@ -119,6 +122,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
         assertNull(faktiskUtenlandskPeriodebeløp.elementAt(1).beløp)
         assertNull(faktiskUtenlandskPeriodebeløp.elementAt(1).valutakode)
         assertNull(faktiskUtenlandskPeriodebeløp.elementAt(1).intervall)
+        assertNull(faktiskUtenlandskPeriodebeløp.elementAt(1).kalkulertMånedligBeløp)
         assertEquals("SE", faktiskUtenlandskPeriodebeløp.elementAt(1).utbetalingsland)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/SkjemaBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/SkjemaBuilder.kt
@@ -37,6 +37,15 @@ abstract class SkjemaBuilder<S, B>(
         return this as B
     }
 
+    protected fun medTransformasjon(transformasjon: (S) -> S): B {
+        val transformerteSkjemaer = skjemaer.map { skjema -> transformasjon(skjema) }
+        skjemaer.clear()
+        skjemaer.addAll(transformerteSkjemaer)
+
+        @Suppress("UNCHECKED_CAST")
+        return this as B
+    }
+
     fun bygg(): Collection<S> = skjemaer
         .map { skjema -> skjema.also { it.behandlingId = behandlingId.id } }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/UtenlandskPeriodebeløpBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/UtenlandskPeriodebeløpBuilder.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.eøs.util
 
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -23,7 +24,7 @@ class UtenlandskPeriodebeløpBuilder(
                     UtenlandskPeriodebeløp.NULL.copy(
                         beløp = it?.digitToInt()?.toBigDecimal(),
                         valutakode = valutakode,
-                        intervall = "MÅNEDLIG",
+                        intervall = Intervall.MÅNEDLIG,
                         utbetalingsland = utbetalingsland
                     )
                 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/UtenlandskPeriodebeløpBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/UtenlandskPeriodebeløpBuilder.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.eøs.util
 
+import no.nav.familie.ba.sak.ekstern.restDomene.tilKalkulertMånedligBeløp
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
@@ -25,10 +26,13 @@ class UtenlandskPeriodebeløpBuilder(
                         beløp = it?.digitToInt()?.toBigDecimal(),
                         valutakode = valutakode,
                         intervall = Intervall.MÅNEDLIG,
-                        utbetalingsland = utbetalingsland
+                        utbetalingsland = utbetalingsland,
+                        kalkulertMånedligBeløp = it?.digitToInt()?.toBigDecimal()
                     )
                 }
                 else -> null
             }
         }
+    fun medIntervall(intervall: Intervall) =
+        medTransformasjon { utenlandskPeriodebeløp -> utenlandskPeriodebeløp.copy(intervall = intervall) }.medTransformasjon { utenlandskPeriodebeløp -> utenlandskPeriodebeløp.copy(kalkulertMånedligBeløp = utenlandskPeriodebeløp.tilKalkulertMånedligBeløp()) }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
@@ -61,7 +62,7 @@ class UtenlandskPeriodebeløpRepositoryTest(
                 tom = YearMonth.of(2021, 12),
                 beløp = BigDecimal.valueOf(1_234),
                 valutakode = "EUR",
-                intervall = "UKE"
+                intervall = Intervall.UKENTLIG
             )
         )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
@@ -15,7 +15,7 @@ class UtenlandskePeriodebeløpUtfyltTest {
         val utenlandskPeriodebeløp = lagUtenlandskPeriodebeløp(
             beløp = BigDecimal.valueOf(500),
             valutakode = "NOK",
-            intervall = Intervall.MÅNEDLIG.name
+            intervall = Intervall.MÅNEDLIG
         )
 
         val restUtenlandskPeriodebeløp = utenlandskPeriodebeløp.tilRestUtenlandskPeriodebeløp()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
* Feltet `kalkulertMånedligBeløp` er lagt til på `UtenlandskPeriodebeløp` og beregnes ved oppdatering gitt at `beløp` og `intervall` er satt.
* DB-migrering for feltet i UPB-tabellen.
* Beregning av månedlig beløp tar ikke lenger hensyn til skuddår dersom intervall er `UKENTLIG`, men bruker multiplikator 4.35 istedenfor.
* Differanseberegning er justert og bruker nå feltet `kalkulertMånedligBeløp` direkte fremfor å beregne beløpet selv.
* Endret type på feltet `intervall` fra `string` til `Intervall`.
* Justert tester som er berørt av endringene.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei