### PR TITLE
Sørger for at intervall lagres med ENUM-navn og ikke ordinal-tall

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
@@ -11,6 +11,8 @@ import javax.persistence.Column
 import javax.persistence.Convert
 import javax.persistence.Entity
 import javax.persistence.EntityListeners
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
@@ -48,6 +50,7 @@ data class UtenlandskPeriodebeløp(
     val valutakode: String? = null,
 
     @Column(name = "intervall")
+    @Enumerated(EnumType.STRING)
     val intervall: Intervall? = null,
 
     @Column(name = "utbetalingsland")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ved endring fra type `string` til type `Intervall` på feltet `intervall` i `UtenlandskPeriodebeløp` ble intervall lagret som ordinal-tallet til enumen fremfor navnet. Denne PR'en sørger for at navnet er det som lagres ned. Skapte problemer da gamle UtenlandskePeriodeBeløp ikke lenger kunne hentes frem. 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
