### PR TITLE
Legger på funksjonsbrytere på differanseberegning, utvider tester og herder logikken for lagring av oppdatert tilkjent ytelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/AndelTilkjentYtelsePraktiskLikhet.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/AndelTilkjentYtelsePraktiskLikhet.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+
+object AndelTilkjentYtelsePraktiskLikhet {
+    internal fun Iterable<AndelTilkjentYtelse>.erIPraksisLik(oppdaterteAndeler: Iterable<AndelTilkjentYtelse>): Boolean {
+        val venstre = this.andelerSomKanSammenliknes().toSet()
+        val høyre = oppdaterteAndeler.andelerSomKanSammenliknes().toSet()
+
+        return venstre == høyre
+    }
+
+    internal fun Iterable<AndelTilkjentYtelse>.inneholderIPraksis(andelTilkjentYtelse: AndelTilkjentYtelse): Boolean {
+        return this.andelerSomKanSammenliknes().contains(andelTilkjentYtelse.andelSomKanSammenliknes())
+    }
+
+    private fun Iterable<AndelTilkjentYtelse>.andelerSomKanSammenliknes() = this.map { it.andelSomKanSammenliknes() }
+
+    private fun AndelTilkjentYtelse.andelSomKanSammenliknes() =
+        copy(
+            id = 0, // Er med i hashCode, men ikke i equals i AndelTilkjentYtelse
+            // Andre felter som er funksjonelt viktige for praktisk likhet er med i equals og hashCode
+        )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -1,10 +1,13 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseEndretAbonnent
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.erIPraksisLik
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.inneholderIPraksis
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEndringAbonnent
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
@@ -31,7 +34,7 @@ class TilpassDifferanseberegningEtterTilkjentYtelseService(
             tilkjentYtelse.andelerTilkjentYtelse, utenlandskePeriodebeløp, valutakurser
         )
 
-        if (featureToggleService.isEnabled("Må stoppe potensielle feil asap"))
+        if (featureToggleService.kanHåndtereEøsUtenomPrimærland())
             tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
     }
 }
@@ -39,7 +42,8 @@ class TilpassDifferanseberegningEtterTilkjentYtelseService(
 @Service
 class TilpassDifferanseberegningEtterUtenlandskPeriodebeløpService(
     private val valutakursRepository: PeriodeOgBarnSkjemaRepository<Valutakurs>,
-    private val tilkjentYtelseRepository: TilkjentYtelseRepository
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+    private val featureToggleService: FeatureToggleService
 ) : PeriodeOgBarnSkjemaEndringAbonnent<UtenlandskPeriodebeløp> {
     @Transactional
     override fun skjemaerEndret(
@@ -53,14 +57,16 @@ class TilpassDifferanseberegningEtterUtenlandskPeriodebeløpService(
             tilkjentYtelse.andelerTilkjentYtelse, utenlandskePeriodebeløp, valutakurser
         )
 
-        tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
+        if (featureToggleService.kanHåndtereEøsUtenomPrimærland())
+            tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
     }
 }
 
 @Service
 class TilpassDifferanseberegningEtterValutakursService(
     private val utenlandskPeriodebeløpRepository: PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp>,
-    private val tilkjentYtelseRepository: TilkjentYtelseRepository
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+    private val featureToggleService: FeatureToggleService
 ) : PeriodeOgBarnSkjemaEndringAbonnent<Valutakurs> {
 
     @Transactional
@@ -72,28 +78,45 @@ class TilpassDifferanseberegningEtterValutakursService(
             tilkjentYtelse.andelerTilkjentYtelse, utenlandskePeriodebeløp, valutakurser
         )
 
-        tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
+        if (featureToggleService.kanHåndtereEøsUtenomPrimærland())
+            tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
     }
 }
 
 /**
- * En litt risikabel funksjon, som lener seg på at AndelTilkjentYtelse.equals() fortsetter å sjekke _funksjonell_ likhet,
- * dvs utelukker [id], [tilkjentYtelse] og [endretUtbetalingAndeler], blant annet
- * Merk også at det er en inkonsistens mellom hashCode() og equals(), som potensielt gjør likhetssjekk ustabil
+ * En litt risikabel funksjon, som benytter "funksjonell likhet" for å sjekke etter endringer
+ * på andel tilkjent ytelse
  */
 fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
     tilkjentYtelse: TilkjentYtelse,
     oppdaterteAndeler: List<AndelTilkjentYtelse>
 ) {
-    val gamleAndeler = tilkjentYtelse.andelerTilkjentYtelse
-    if (gamleAndeler.size == oppdaterteAndeler.size && gamleAndeler.containsAll(oppdaterteAndeler))
+    if (tilkjentYtelse.andelerTilkjentYtelse.erIPraksisLik(oppdaterteAndeler))
         return
 
-    val skalFjernes = gamleAndeler - oppdaterteAndeler
-    val skalLeggesTil = oppdaterteAndeler - gamleAndeler
+    // Her er det viktig å beholde de originale andelene, som styres av JPA og har alt av innhold
+    val skalBeholdes = tilkjentYtelse.andelerTilkjentYtelse
+        .filter { oppdaterteAndeler.inneholderIPraksis(it) }
 
-    gamleAndeler.removeAll(skalFjernes)
-    gamleAndeler.addAll(skalLeggesTil)
+    val skalLeggesTil = oppdaterteAndeler
+        .filter { !tilkjentYtelse.andelerTilkjentYtelse.inneholderIPraksis(it) }
+
+    // Forsikring: Sjekk at det ikke oppstår eller forsvinner andeler når de sjekkes for likhet
+    if (oppdaterteAndeler.size != (skalBeholdes.size + skalLeggesTil.size))
+        throw IllegalStateException("Avvik mellom antall innsendte andeler og kalkulerte endringer")
+
+    tilkjentYtelse.andelerTilkjentYtelse.clear()
+    tilkjentYtelse.andelerTilkjentYtelse.addAll(skalBeholdes + skalLeggesTil)
+
+    // Ekstra forsikring: Bygger tidslinjene på nytt for å sjekke at det ikke er introdusert feil
+    // Krasjer med TidslinjeException hvis det forekommer perioder (per barn) som overlapper
+    // Bør fjernes hvis det ikke forekommer feil
+    tilkjentYtelse.andelerTilkjentYtelse.tilSeparateTidslinjerForBarna()
 
     this.saveAndFlush(tilkjentYtelse)
 }
+
+fun FeatureToggleService.kanHåndtereEøsUtenomPrimærland() =
+    this.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS) &&
+        this.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS_SEKUNDERLAND) &&
+        this.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS_TO_PRIMERLAND)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingTestController.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingTestController.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassKompetanserTilRegelverkService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
@@ -45,6 +46,7 @@ class VilkårsvurderingTestController(
     private val utvidetBehandlingService: UtvidetBehandlingService,
     private val fagsakService: FagsakService,
     private val behandlingService: BehandlingService,
+    private val beregningService: BeregningService,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val behandlingRepository: BehandlingRepository,
     private val vilkårsvurderingService: VilkårsvurderingService,
@@ -90,7 +92,9 @@ class VilkårsvurderingTestController(
             vilkårsvurdering
         )
 
+        beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
+
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandling.id)))
     }
 
@@ -110,6 +114,7 @@ class VilkårsvurderingTestController(
 
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(nyVilkårsvurdering)
 
+        beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
 
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Prøver å unngå feil som kan oppstå når endring i tilkjent ytelse trigger differanseberegning, hovedsakelig

- [x] Legge  på funksjonsbrytere på veiene inn til risikabel kode
- [ ] Skrive om logikken rundt lagring av endringer
- [ ] Utvide integrasjonstesten (som alt feilet i IntelliJ, men ikke i Maven)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Håndtering av AndelTilkjentYtelse er et gjentakende kilde til problemer, kanskje spesielt i kombinasjon med tidslinjer. Trenger en grundig gjennomgang av løsning og alternativer

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
