### PR TITLE
Kaster feil dersom EØS-utvidet og Norge er sekundærland.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -110,6 +110,7 @@ class FeatureToggleConfig(
 
         const val KAN_BEHANDLE_EØS_SEKUNDERLAND = "familie-ba-sak.behandling.eos-sekunderland"
         const val KAN_BEHANDLE_EØS_TO_PRIMERLAND = "familie-ba-sak.behandling.eos-to-primerland"
+        const val KAN_IKKE_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND = "familie-ba-sak.behandling.utvidet-eos-sekunderland"
 
         private val logger = LoggerFactory.getLogger(FeatureToggleConfig::class.java)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -110,7 +110,7 @@ class FeatureToggleConfig(
 
         const val KAN_BEHANDLE_EØS_SEKUNDERLAND = "familie-ba-sak.behandling.eos-sekunderland"
         const val KAN_BEHANDLE_EØS_TO_PRIMERLAND = "familie-ba-sak.behandling.eos-to-primerland"
-        const val KAN_IKKE_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND = "familie-ba-sak.behandling.utvidet-eos-sekunderland"
+        const val KAN_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND = "familie-ba-sak.behandling.utvidet-eos-sekunderland"
 
         private val logger = LoggerFactory.getLogger(FeatureToggleConfig::class.java)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestKompetanse
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.tilKompetanse
 import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
@@ -34,7 +35,8 @@ class KompetanseController(
     private val featureToggleService: FeatureToggleService,
     private val kompetanseService: KompetanseService,
     private val personidentService: PersonidentService,
-    private val utvidetBehandlingService: UtvidetBehandlingService
+    private val utvidetBehandlingService: UtvidetBehandlingService,
+    private val tilkjentYtelseRepository: AndelTilkjentYtelseRepository
 ) {
 
     @PutMapping(path = ["{behandlingId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -48,6 +50,7 @@ class KompetanseController(
         val barnAktører = restKompetanse.barnIdenter.map { personidentService.hentAktør(it) }
         val kompetanse = restKompetanse.tilKompetanse(barnAktører = barnAktører)
 
+        validerUtvidedEøsOgSekundærland(kompetanse, behandlingId)
         validerOppdatering(kompetanse)
 
         kompetanseService.oppdaterKompetanse(BehandlingId(behandlingId), kompetanse)
@@ -124,5 +127,14 @@ class KompetanseController(
                 "Oppdaterer barn som ikke er knyttet til kompetansen",
                 httpStatus = HttpStatus.BAD_REQUEST
             )
+    }
+
+    private fun validerUtvidedEøsOgSekundærland(kompetanse: Kompetanse, behandlingId: Long) {
+        if (kompetanse.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND && featureToggleService.isEnabled(FeatureToggleConfig.KAN_IKKE_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND)) {
+            val utvidetEllerSmåbarnstillegg = tilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId).any { andelTilkjentYtelse -> andelTilkjentYtelse.erSøkersAndel() }
+            if (utvidetEllerSmåbarnstillegg) {
+                throw FunksjonellFeil("Støtter foreløpig ikke utvidet barnetrygd og/eller småbarnstillegg i kombinasjon med sekundærland.", "Søker har utvidet barnetrygd og/eller småbarnstillegg. Dette er ikke støttet i sekundærlandssaker enda. Ta kontakt med Team Familie", HttpStatus.BAD_REQUEST)
+            }
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
@@ -130,7 +130,7 @@ class KompetanseController(
     }
 
     private fun validerUtvidedEøsOgSekundærland(kompetanse: Kompetanse, behandlingId: Long) {
-        if (kompetanse.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND && featureToggleService.isEnabled(FeatureToggleConfig.KAN_IKKE_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND)) {
+        if (kompetanse.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND && !featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND)) {
             val utvidetEllerSmåbarnstillegg = tilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId).any { andelTilkjentYtelse -> andelTilkjentYtelse.erSøkersAndel() }
             if (utvidetEllerSmåbarnstillegg) {
                 throw FunksjonellFeil("Støtter foreløpig ikke utvidet barnetrygd og/eller småbarnstillegg i kombinasjon med sekundærland.", "Søker har utvidet barnetrygd og/eller småbarnstillegg. Dette er ikke støttet i sekundærlandssaker enda. Ta kontakt med Team Familie", HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
Lenke til sak i Favro: [TEA-9011](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9011)

### 💰 Hva skal gjøres, og hvorfor?
Vi ønsker å stoppe behandlinger hvor søker har utvidet barnetrygd og Norge er sekundærland.

Har lagt inn en ekstra validering ved oppdatering av kompetanse, som sjekker om resultat er "Norge er sekundærland" og om søker har utvidet barnetrygd. Kaster feil med feilmelding dersom begge kriteriene er oppfylt. Sjekken styres også av en feature-toggle.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
