### PR TITLE
Reversert nasjonaltPeriodebeløp til å være nullable igjen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -110,7 +110,7 @@ data class AndelTilkjentYtelse(
     var forrigePeriodeOffset: Long? = null,
 
     @Column(name = "nasjonalt_periodebelop")
-    val nasjonaltPeriodebeløp: Int,
+    val nasjonaltPeriodebeløp: Int?,
 
     @Column(name = "differanseberegnet_periodebelop")
     val differanseberegnetPeriodebeløp: Int? = null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -42,7 +42,7 @@ private fun AndelTilkjentYtelse.medDifferanseberegning(
     val avrundetUtenlandskPeriodebeløp = utenlandskPeriodebeløpINorskeKroner
         .toBigInteger().intValueExact() // Fjern desimaler for å gi fordel til søker
 
-    val nyttDifferanseberegnetBeløp = nasjonaltPeriodebeløp - avrundetUtenlandskPeriodebeløp
+    val nyttDifferanseberegnetBeløp = (nasjonaltPeriodebeløp ?: kalkulertUtbetalingsbeløp) - avrundetUtenlandskPeriodebeløp
 
     return copy(
         id = 0,
@@ -54,7 +54,7 @@ private fun AndelTilkjentYtelse.medDifferanseberegning(
 private fun AndelTilkjentYtelse.utenDifferanseberegning(): AndelTilkjentYtelse {
     return copy(
         id = 0,
-        kalkulertUtbetalingsbeløp = nasjonaltPeriodebeløp,
+        kalkulertUtbetalingsbeløp = nasjonaltPeriodebeløp ?: this.kalkulertUtbetalingsbeløp,
         differanseberegnetPeriodebeløp = null
     )
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det har oppstått litt utfordringer med nasjonaltPeriodebeløp som notNullable for eksisterende behandlinger. Setter feltet tilbake til å være nullable.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
