### PR TITLE
Send ukrainske tredjelansdborgere til manuell oppfølging

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -169,7 +169,7 @@ data class VurderPersonHarLovligOpphold(
                 val morErUkrainskStatsborger = morLovligOppholdFaktaEØS.statsborgerskap.any { it.landkode == "UKR" }
                 // Midlertidig regel for Ukrainakonflikten
                 if (morErUkrainskStatsborger)
-                    Evaluering.ikkeVurdert(VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN_MANUELT)
+                    Evaluering.ikkeVurdert(VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN)
                 else if (opphold.gyldigGjeldendeOppholdstillatelseFødselshendelse()) {
                     Evaluering.oppfylt(VilkårOppfyltÅrsak.TREDJELANDSBORGER_MED_LOVLIG_OPPHOLD)
                 } else Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.TREDJELANDSBORGER_UTEN_LOVLIG_OPPHOLD)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -169,7 +169,7 @@ data class VurderPersonHarLovligOpphold(
                 val morErUkrainskStatsborger = morLovligOppholdFaktaEØS.statsborgerskap.any { it.landkode == "UKR" }
                 // Midlertidig regel for Ukrainakonflikten
                 if (morErUkrainskStatsborger)
-                    Evaluering.ikkeVurdert(VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_IKKE_MULIG_Å_FASTSETTE)
+                    Evaluering.ikkeVurdert(VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN_MANUELT)
                 else if (opphold.gyldigGjeldendeOppholdstillatelseFødselshendelse()) {
                     Evaluering.oppfylt(VilkårOppfyltÅrsak.TREDJELANDSBORGER_MED_LOVLIG_OPPHOLD)
                 } else Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.TREDJELANDSBORGER_UTEN_LOVLIG_OPPHOLD)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -166,7 +166,11 @@ data class VurderPersonHarLovligOpphold(
         return when (morLovligOppholdFaktaEØS.statsborgerskap.hentSterkesteMedlemskap()) {
             Medlemskap.NORDEN -> Evaluering.oppfylt(VilkårOppfyltÅrsak.NORDISK_STATSBORGER)
             Medlemskap.TREDJELANDSBORGER -> {
-                if (opphold.gyldigGjeldendeOppholdstillatelseFødselshendelse()) {
+                val morErUkrainskStatsborger = morLovligOppholdFaktaEØS.statsborgerskap.any { it.landkode == "UKR" }
+                // Midlertidig regel for Ukrainakonflikten
+                if (morErUkrainskStatsborger)
+                    Evaluering.ikkeVurdert(VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_IKKE_MULIG_Å_FASTSETTE)
+                else if (opphold.gyldigGjeldendeOppholdstillatelseFødselshendelse()) {
                     Evaluering.oppfylt(VilkårOppfyltÅrsak.TREDJELANDSBORGER_MED_LOVLIG_OPPHOLD)
                 } else Evaluering.ikkeOppfylt(VilkårIkkeOppfyltÅrsak.TREDJELANDSBORGER_UTEN_LOVLIG_OPPHOLD)
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/utfall/VilkårKanskjeOppfyltÅrsak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/utfall/VilkårKanskjeOppfyltÅrsak.kt
@@ -6,6 +6,10 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 enum class VilkårKanskjeOppfyltÅrsak(val beskrivelse: String, val vilkår: Vilkår) : EvalueringÅrsak {
 
     // Lovlig opphold
+    LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN_MANUELT(
+        "Må vurdere lengden på oppholdstillatelsen manuelt.",
+        Vilkår.LOVLIG_OPPHOLD
+    ),
     LOVLIG_OPPHOLD_IKKE_MULIG_Å_FASTSETTE("Kan ikke avgjøre om personen har lovlig opphold.", Vilkår.LOVLIG_OPPHOLD),
     LOVLIG_OPPHOLD_ANNEN_FORELDER_IKKE_MULIG_Å_FASTSETTE(
         "Kan ikke avgjøre om annen har lovlig opphold.",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/utfall/VilkårKanskjeOppfyltÅrsak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/utfall/VilkårKanskjeOppfyltÅrsak.kt
@@ -6,8 +6,8 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 enum class VilkårKanskjeOppfyltÅrsak(val beskrivelse: String, val vilkår: Vilkår) : EvalueringÅrsak {
 
     // Lovlig opphold
-    LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN_MANUELT(
-        "Må vurdere lengden på oppholdstillatelsen manuelt.",
+    LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN(
+        "Må vurdere lengden på oppholdstillatelsen.",
         Vilkår.LOVLIG_OPPHOLD
     ),
     LOVLIG_OPPHOLD_IKKE_MULIG_Å_FASTSETTE("Kan ikke avgjøre om personen har lovlig opphold.", Vilkår.LOVLIG_OPPHOLD),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -415,8 +415,8 @@ class FødselshendelseHenleggelseTest(
             opprettTaskService.opprettOppgaveTask(
                 behandlingId = behandling.id,
                 oppgavetype = Oppgavetype.VurderLivshendelse,
-                beskrivelse = "Fødselshendelse: ${VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN_MANUELT.beskrivelse}",
+                beskrivelse = "Fødselshendelse: ${VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN.beskrivelse}",
             )
-        }s
+        }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -415,8 +415,8 @@ class FødselshendelseHenleggelseTest(
             opprettTaskService.opprettOppgaveTask(
                 behandlingId = behandling.id,
                 oppgavetype = Oppgavetype.VurderLivshendelse,
-                beskrivelse = "Fødselshendelse: ${VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_IKKE_MULIG_Å_FASTSETTE.beskrivelse}",
+                beskrivelse = "Fødselshendelse: ${VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN_MANUELT.beskrivelse}",
             )
-        }
+        }s
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9035

**Hvorfor:**
Vi har krav om at
> moren ved fødselen har oppholdt seg eller skal oppholde seg i Norge i mer enn 12 måneder. Se barnetrygdloven § 4, 1. ledd, bokstav a)

I og med at vi ikke gjør noe kontroll mot hvor lenge mor har bodd i Norge eller hvilken periode hun har fått oppholdstillatelse for, kontrollerer vi ikke om hun har oppholdt seg i Norge i 12 måneder.

Konsekvensen er at noen får barnetrygd automatisk uten å ha krav på det.

Dette gjelder blant annet statsborgere fra Ukraina.

I og med at det for tiden er stort fokus på statsborgerne fra Ukraina, og at disse borgeren ikke har rett til barnetrygd før de har oppholdt seg i Norge i mer enn 12 måneder, må vi gjøre noe med dette så fort som mulig.

Vi må derfor skille ut statsborgere fra Ukraina. Dersom statsborgerskap er Ukraina, skal det opprettes oppgave for manuell saksbehandling.

**Hva:**
Setter  lovlig opphold til "ikke vurdert" for tredjelandsborgere som har ukrainsk statsborgerskap, henleger den automatiske behandlingen og oppretter en "Vurder livshendelse oppgave" med begrunnelse "Fødselshendelse: Må vurdere lengden på oppholdstillatelsen."

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
