### PR TITLE
fikset slik at det ikke viser oppdater første endringstidspunkt lenke når det finnes ingen endringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -42,9 +42,9 @@ class EndringstidspunktService(
             if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
                 val kompetansePerioder = kompetanseRepository.finnFraBehandlingId(nyBehandling.id)
                 val forrigeKompetansePerioder = kompetanseRepository.finnFraBehandlingId(sistIverksatteBehandling.id)
-                val førsteEndingstidspunkt = kompetansePerioder.finnFørsteEndringstidspunkt(forrigeKompetansePerioder)
-                if (førsteEndingstidspunkt != TIDENES_ENDE.toYearMonth()) {
-                    førsteEndingstidspunkt.førsteDagIInneværendeMåned()
+                val førsteEndringstidspunkt = kompetansePerioder.finnFørsteEndringstidspunkt(forrigeKompetansePerioder)
+                if (førsteEndringstidspunkt != TIDENES_ENDE.toYearMonth()) {
+                    førsteEndringstidspunkt.førsteDagIInneværendeMåned()
                 } else {
                     TIDENES_ENDE
                 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils
@@ -41,7 +42,12 @@ class EndringstidspunktService(
             if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
                 val kompetansePerioder = kompetanseRepository.finnFraBehandlingId(nyBehandling.id)
                 val forrigeKompetansePerioder = kompetanseRepository.finnFraBehandlingId(sistIverksatteBehandling.id)
-                kompetansePerioder.finnFørsteEndringstidspunkt(forrigeKompetansePerioder).førsteDagIInneværendeMåned()
+                val førsteEndingstidspunkt = kompetansePerioder.finnFørsteEndringstidspunkt(forrigeKompetansePerioder)
+                if (førsteEndingstidspunkt != TIDENES_ENDE.toYearMonth()) {
+                    førsteEndingstidspunkt.førsteDagIInneværendeMåned()
+                } else {
+                    TIDENES_ENDE
+                }
             } else TIDENES_ENDE
 
         return minOf(førsteEndringstidspunktFraAndelTilkjentYtelse, førsteEndringstidspunktIKompetansePerioder)


### PR DESCRIPTION
… 

### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._

når det ikke finnes noen endring i kompetanse perioder, sendte det første månedsdag av TIDENES_ENDE til frontend, da viser frontend en feil dato på dato-modal. Frontend bør ikke vise noe i det hele tatt når det finnes endringer. Fikset slik at det returnerer null og da viser frontend ikke oppdater førsteendringstidspunkt lenke

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
