### PR TITLE
Utvider sikkerhetsnettet til også å sjekke søkers andeler for duplikater

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -99,7 +99,7 @@ class TilpassDifferanseberegningEtterValutakursService(
  */
 fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
     tilkjentYtelse: TilkjentYtelse,
-    oppdaterteAndeler: List<AndelTilkjentYtelse>
+    oppdaterteAndeler: Collection<AndelTilkjentYtelse>
 ) {
     if (tilkjentYtelse.andelerTilkjentYtelse.erIPraksisLik(oppdaterteAndeler)) {
         return
@@ -129,13 +129,13 @@ fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
 }
 
 @Deprecated("Brukes som sikkerhetsnett for å sjekke at det ikke oppstår duplikater. Burde være unødvendig")
-private fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
+internal fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
 
     try {
         // Det skal ikke være overlapp i andeler for en gitt ytelsestype og aktør
         this.groupBy { it.aktør.aktørId + it.type }
             .mapValues { (_, andeler) -> tidslinje { andeler.map { it.tilPeriode() } } }
-            .values
+            .values.forEach { it.perioder() }
     } catch (throwable: Throwable) {
         throw IllegalStateException(
             "Endring av andeler tilkjent ytelse i differanseberegning holder på å introdusere duplikater",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEndringAbonne
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -119,12 +120,28 @@ fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
     tilkjentYtelse.andelerTilkjentYtelse.clear()
     tilkjentYtelse.andelerTilkjentYtelse.addAll(skalBeholdes + skalLeggesTil)
 
-    // Ekstra forsikring: Bygger tidslinjene på nytt for å sjekke at det ikke er introdusert feil
-    // Krasjer med TidslinjeException hvis det forekommer perioder (per barn) som overlapper
+    // Ekstra forsikring: Bygger tidslinjene på nytt for å sjekke at det ikke er introdusert duplikater
+    // Krasjer med Exception hvis det forekommer perioder per aktør og ytelsetype som overlapper
     // Bør fjernes hvis det ikke forekommer feil
-    tilkjentYtelse.andelerTilkjentYtelse.tilSeparateTidslinjerForBarna()
+    tilkjentYtelse.andelerTilkjentYtelse.sjekkForDuplikater()
 
     this.saveAndFlush(tilkjentYtelse)
+}
+
+@Deprecated("Brukes som sikkerhetsnett for å sjekke at det ikke oppstår duplikater. Burde være unødvendig")
+private fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
+
+    try {
+        // Det skal ikke være overlapp i andeler for en gitt ytelsestype og aktør
+        this.groupBy { it.aktør.aktørId + it.type }
+            .mapValues { (_, andeler) -> tidslinje { andeler.map { it.tilPeriode() } } }
+            .values
+    } catch (throwable: Throwable) {
+        throw IllegalStateException(
+            "Endring av andeler tilkjent ytelse i differanseberegning holder på å introdusere duplikater",
+            throwable
+        )
+    }
 }
 
 fun FeatureToggleService.kanHåndtereEøsUtenomPrimærland() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -130,7 +130,6 @@ fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
 
 @Deprecated("Brukes som sikkerhetsnett for å sjekke at det ikke oppstår duplikater. Burde være unødvendig")
 internal fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
-
     try {
         // Det skal ikke være overlapp i andeler for en gitt ytelsestype og aktør
         this.groupBy { it.aktør.aktørId + it.type }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
@@ -1,0 +1,91 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.util.TilkjentYtelseBuilder
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
+
+    val barnsFødselsdato = 13.jan(2020)
+    val startMåned = barnsFødselsdato.tilInneværendeMåned()
+
+    val søker = tilfeldigPerson(personType = PersonType.SØKER)
+    val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato.tilLocalDate())
+
+    val tilkjentYtelseRepository: TilkjentYtelseRepository = mockk(relaxed = true)
+
+    @Test
+    fun `skal kaste exception hvis tilkjent ytelse oppdateres med overlappende andel tilkjent ytelse for et barn`() {
+
+        val behandling = lagBehandling()
+
+        val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling).bygg()
+
+        val nyTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling)
+            .forPersoner(barn1)
+            .medOrdinær(" $$$$$$")
+            .medOrdinær("      $$$$$")
+            .bygg()
+
+        assertThrows<IllegalStateException> {
+            tilkjentYtelseRepository.oppdaterTilkjentYtelse(
+                forrigeTilkjentYtelse,
+                nyTilkjentYtelse.andelerTilkjentYtelse
+            )
+        }
+    }
+
+    @Test
+    fun `skal kaste exception hvis tilkjent ytelse oppdateres med overlappende andel tilkjent ytelse for søker`() {
+
+        val behandling = lagBehandling()
+
+        val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling).bygg()
+
+        val nyTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling)
+            .forPersoner(søker)
+            .medUtvidet(" $$$$$$")
+            .medUtvidet("      $$$$$")
+            .bygg()
+
+        assertThrows<IllegalStateException> {
+            tilkjentYtelseRepository.oppdaterTilkjentYtelse(
+                forrigeTilkjentYtelse,
+                nyTilkjentYtelse.andelerTilkjentYtelse
+            )
+        }
+    }
+
+    @Test
+    fun `skal ikke kaste exception hvis tilkjent ytelse oppdateres med gyldige andeler`() {
+
+        val behandling = lagBehandling()
+
+        val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling)
+            .bygg()
+
+        val nyTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling)
+            .forPersoner(søker)
+            .medUtvidet(" $$$$$$$$$$")
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$$$$")
+            .bygg()
+
+        every { tilkjentYtelseRepository.saveAndFlush(any()) } returns nyTilkjentYtelse
+
+        tilkjentYtelseRepository.oppdaterTilkjentYtelse(
+            forrigeTilkjentYtelse,
+            nyTilkjentYtelse.andelerTilkjentYtelse
+        )
+
+        verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(any()) }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
@@ -24,7 +24,6 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
 
     @Test
     fun `skal kaste exception hvis tilkjent ytelse oppdateres med overlappende andel tilkjent ytelse for et barn`() {
-
         val behandling = lagBehandling()
 
         val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling).bygg()
@@ -45,7 +44,6 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
 
     @Test
     fun `skal kaste exception hvis tilkjent ytelse oppdateres med overlappende andel tilkjent ytelse for søker`() {
-
         val behandling = lagBehandling()
 
         val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling).bygg()
@@ -66,7 +64,6 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
 
     @Test
     fun `skal ikke kaste exception hvis tilkjent ytelse oppdateres med gyldige andeler`() {
-
         val behandling = lagBehandling()
 
         val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/TilkjentYtelseBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/TilkjentYtelseBuilder.kt
@@ -12,6 +12,8 @@ import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.tilAndelerTilkjentY
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
@@ -40,12 +42,50 @@ class TilkjentYtelseBuilder(
         return this
     }
 
+    fun medSmåbarn(
+        s: String,
+        kalkulert: (Int) -> Int = { it }
+    ) = medYtelse(s = s, type = YtelseType.SMÅBARNSTILLEGG, kalkulert = kalkulert) {
+        satstypeTidslinje(SatsType.SMA)
+    }
+        .also { gjeldendePersoner.single { it.type == PersonType.SØKER } }
+
+    fun medUtvidet(
+        s: String,
+        kalkulert: (Int) -> Int = { it }
+    ) = medYtelse(s = s, type = YtelseType.UTVIDET_BARNETRYGD, kalkulert = kalkulert) {
+        satstypeTidslinje(SatsType.ORBA)
+    }
+        .also { gjeldendePersoner.single { it.type == PersonType.SØKER } }
+
     fun medOrdinær(
         s: String,
         prosent: Long = 100,
         nasjonalt: (Int) -> Int? = { null },
         differanse: (Int) -> Int? = { null },
         kalkulert: (Int) -> Int = { it }
+    ) = medYtelse(
+        s,
+        YtelseType.ORDINÆR_BARNETRYGD,
+        prosent,
+        nasjonalt,
+        differanse,
+        kalkulert
+    ) {
+        val orbaTidslinje = satstypeTidslinje(SatsType.ORBA)
+        val tilleggOrbaTidslinje = satstypeTidslinje(SatsType.TILLEGG_ORBA)
+            .filtrerMed(erUnder6ÅrTidslinje(it))
+        orbaTidslinje.kombinerMed(tilleggOrbaTidslinje) { orba, tillegg -> tillegg ?: orba }
+    }
+
+    private fun medYtelse(
+        s: String,
+        type: YtelseType,
+        prosent: Long = 100,
+        nasjonalt: (Int) -> Int? = { null },
+        differanse: (Int) -> Int? = { null },
+        kalkulert: (Int) -> Int = { it },
+        satsTidslinje: (Person) -> Tidslinje<Int, Måned>
     ): TilkjentYtelseBuilder {
         val andeler = gjeldendePersoner
             .map { person ->
@@ -63,16 +103,11 @@ class TilkjentYtelseBuilder(
                             differanseberegnetPeriodebeløp = null, // Overskrives under
                             prosent = BigDecimal.valueOf(prosent),
                             sats = 0, // Overskrives under
-                            type = YtelseType.ORDINÆR_BARNETRYGD
+                            type = type
                         )
                     }
 
-                val orbaTidslinje = satstypeTidslinje(SatsType.ORBA)
-                val tilleggOrbaTidslinje = satstypeTidslinje(SatsType.TILLEGG_ORBA)
-                    .filtrerMed(erUnder6ÅrTidslinje(person))
-                val satsTidslinje = orbaTidslinje.kombinerMed(tilleggOrbaTidslinje) { orba, tillegg -> tillegg ?: orba }
-
-                andelTilkjentYtelseTidslinje.kombinerUtenNullMed(satsTidslinje) { aty, sats ->
+                andelTilkjentYtelseTidslinje.kombinerUtenNullMed(satsTidslinje(person)) { aty, sats ->
                     aty.copy(
                         sats = sats,
                         kalkulertUtbetalingsbeløp = kalkulert(sats),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Sikkerhetsnettet rundt EØS og endring av andeler tilkjent ytelse, sjekker nå for duplikater hos barna. Denne sjekker også for duplikater hos søker. Her må ytelsestype være med fordi utvidet barnetrygd og småbarnstillegg kan overlappe i tid.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_  Det _burde_ være dekket av tidligere tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
