### PR TITLE
Bevar format på enum for annen forelders aktivitet når det sendes til brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -74,7 +74,7 @@ class BrevPeriodeGenerator(
                 EØSBegrunnelseData(
                     vedtakBegrunnelseType = begrunnelse.vedtakBegrunnelseType,
                     apiNavn = begrunnelse.sanityApiNavn,
-                    annenForeldersAktivitet = kompetanse.annenForeldersAktivitet.tilTekst(),
+                    annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
                     annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetslandNavn?.navn,
                     barnetsBostedsland = kompetanse.barnetsBostedslandNavn.navn,
                     barnasFodselsdatoer = Utils.slåSammen(kompetanse.personer.map { it.fødselsdato.tilKortString() }),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -127,18 +127,7 @@ enum class AnnenForeldersAktivitet {
     FORSIKRET_I_BOSTEDSLAND,
     MOTTAR_PENSJON,
     INAKTIV,
-    IKKE_AKTUELT;
-
-    fun tilTekst(): String {
-        return when (this) {
-            I_ARBEID -> "i arbeid"
-            MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN -> "mottar utbetaling som erstatter lønn"
-            FORSIKRET_I_BOSTEDSLAND -> "forsikret i bostedsland"
-            MOTTAR_PENSJON -> "mottar pensjon"
-            INAKTIV -> "inaktiv"
-            IKKE_AKTUELT -> "ikke aktuelt"
-        }
-    }
+    IKKE_AKTUELT
 }
 
 enum class KompetanseResultat {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertRestEndretAndel
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertUtbetalingsperiodeDetalj
 import no.nav.familie.ba.sak.kjerne.brev.domene.beløpUtbetaltFor
 import no.nav.familie.ba.sak.kjerne.brev.domene.totaltUtbetalt
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.SøkersAktivitet
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
@@ -136,7 +137,7 @@ data class EØSBegrunnelseData(
     override val vedtakBegrunnelseType: VedtakBegrunnelseType,
     override val apiNavn: String,
 
-    val annenForeldersAktivitet: String,
+    val annenForeldersAktivitet: AnnenForeldersAktivitet,
     val annenForeldersAktivitetsland: String?,
     val barnetsBostedsland: String,
     val barnasFodselsdatoer: String,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevPeriodeTestKlasser.kt
@@ -214,7 +214,7 @@ data class BegrunnelseDataTestConfig(
 
 data class EØSBegrunnelseTestConfig(
     val apiNavn: String,
-    val annenForeldersAktivitet: String,
+    val annenForeldersAktivitet: AnnenForeldersAktivitet,
     val annenForeldersAktivitetsland: String,
     val barnetsBostedsland: String,
     val barnasFodselsdatoer: String,

--- a/src/test/resources/brevperiodeCaser/EØS_INNVILGET.json
+++ b/src/test/resources/brevperiodeCaser/EØS_INNVILGET.json
@@ -58,7 +58,7 @@
     "begrunnelser": [
       {
         "apiNavn": "innvilgetPrimarlandStandard",
-        "annenForeldersAktivitet": "inaktiv",
+        "annenForeldersAktivitet": "INAKTIV",
         "annenForeldersAktivitetsland": "Sverige",
         "barnetsBostedsland": "Sverige",
         "barnasFodselsdatoer": "20.01.20",


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8968
Henger sammen med denne endringen i familie-brev: https://github.com/navikt/familie-brev/pull/284

Problemet med at vi nå har enumen `.tilTekst()` som output til `EØSBegrunnelseData` er at vi fletter inn den teksten i begrunnelsesbrev, men tekstene er på bokmål, ikke i klarspråk og har forskjellig grammatisk form

Vi endrer til å bevare format på enum for annen forelders aktivitet når det sendes til brev. Enumen plukkes opp i familie-brev og fører til et valgfelt slik at vi får riktig målform og grammatikk

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

**OBS**: Når dette merges vil begrunnelsene som bruker `EØS-flettefelt` for `Annen forelders aktivitet` til å bruke rene enumverdier, inntil vi får endret disse begrunnelsene til å bruke det nye valgfeltet for `Annen forelders aktivitet`

Rop ut om jeg har gjort noe dumt 😇 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har bare oppdatert slik at riktig type forventes for verdiene for `annenForeldersAktivitet`

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
