### PR TITLE
Legg til logging av OS-perioder fra EF ved autovedtak småbarnstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsst
 import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.tilPeriodeOvergangsstønadGrunnlag
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -56,6 +57,8 @@ class SmåbarnstilleggService(
             hentPerioderMedFullOvergangsstønad(aktør = fagsak.aktør).map { it.tilInternPeriodeOvergangsstønad() }
                 .slåSammenTidligerePerioder()
 
+        secureLogger.info("Perioder med overgangsstønad fra EF: ${nyePerioderMedFullOvergangsstønad.map { "Periode(fom=${it.fomDato}, tom=${it.tomDato})" }}")
+
         return vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
                 behandlingId = sistIverksatteBehandling.id,
@@ -76,5 +79,9 @@ class SmåbarnstilleggService(
         return efSakRestClient.hentPerioderMedFullOvergangsstønad(
             aktør.aktivFødselsnummer()
         ).perioder
+    }
+
+    companion object {
+        private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når vedtakOmOvergangsstønadTasker som feiler, er det noen ganger vanskelig å debugge fordi vi ikke vet hvilke perioder EF har sendt over. Legger derfor på logging, slik at vi ikke trenger å spørre EF om disse periodene når vi skal debugge.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bare logging

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
