### PR TITLE
Håndtere reduksjon fra forrige iverksatte behandling for småbarnstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
@@ -163,9 +163,9 @@ fun identifiserReduksjonsperioderFraSistIverksatteBehandling(
                     nåSegment.overlapper(gammeltSegment) && gammeltAndelerTyForSegment.any { gammelAndelTyForSegment ->
                         val fom = nåSegment.fom
                         nåAndelTilkjentYtelserForSegment.all { nåAndelTyForSegment ->
-                            // Når et av barna mister utbetaling på et segment i behandling
-                            nåAndelTyForSegment.aktør.aktørId != gammelAndelTyForSegment.aktør.aktørId &&
-                                // Når det barnet som mister utbetaling ikke har en utbetaling i forrige måned
+                            // Når en person mister utbetaling på et segment i behandling
+                            !(nåAndelTyForSegment.aktør.aktørId == gammelAndelTyForSegment.aktør.aktørId && nåAndelTyForSegment.type == gammelAndelTyForSegment.type) &&
+                                // Når den personen som mister utbetaling ikke har en utbetaling av samme type i forrige måned
                                 utbetalingsperioder.none { utbetalingsperiode ->
                                     utbetalingsperiode.tom == fom.minusDays(1) &&
                                         utbetalingsperiode.hentUtbetalingsperiodeDetaljer(
@@ -174,7 +174,7 @@ fun identifiserReduksjonsperioderFraSistIverksatteBehandling(
                                         )
                                             .any {
                                                 it.person.personIdent ==
-                                                    gammelAndelTyForSegment.aktør.aktivFødselsnummer()
+                                                    gammelAndelTyForSegment.aktør.aktivFødselsnummer() && it.ytelseType == gammelAndelTyForSegment.type
                                             }
                                 }
                         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
@@ -1,0 +1,259 @@
+package no.nav.familie.ba.sak.kjerne.verdikjedetester
+
+import io.mockk.every
+import no.nav.familie.ba.sak.common.lagSøknadDTO
+import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
+import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
+import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedStandardbegrunnelser
+import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
+import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
+import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.integrasjoner.`ef-sak`.EfSakRestClient
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
+import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
+import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenarioPerson
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
+import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
+import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import java.time.LocalDate
+
+class ReduksjonFraForrigeIverksatteBehandlingTest(
+    @Autowired private val fagsakService: FagsakService,
+    @Autowired private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    @Autowired private val vedtakService: VedtakService,
+    @Autowired private val vedtaksperiodeService: VedtaksperiodeService,
+    @Autowired private val stegService: StegService,
+    @Autowired private val efSakRestClient: EfSakRestClient,
+) : AbstractVerdikjedetest() {
+
+    private val barnFødselsdato: LocalDate = LocalDate.now().minusYears(2)
+
+    @Test
+    fun `Skal lage reduksjon fra sist iverksatte behandling-periode når småbarnstillegg blir borte`() {
+        val personScenario: RestScenario = lagScenario(barnFødselsdato)
+        val fagsak: RestMinimalFagsak = lagFagsak(personScenario)
+
+        val osFom = LocalDate.of(2022, 6, 1)
+        val osTom = LocalDate.of(2022, 8, 31)
+
+        val behandling1 = fullførBehandlingMedOvergangsstønad(
+            fagsak = fagsak, personScenario = personScenario, barnFødselsdato = barnFødselsdato,
+            overgangsstønadPerioder = listOf(
+                PeriodeOvergangsstønad(
+                    personIdent = personScenario.søker.ident!!,
+                    fomDato = osFom,
+                    tomDato = osTom,
+                    datakilde = PeriodeOvergangsstønad.Datakilde.EF
+                )
+            )
+        )
+        val perioderBehandling1 = vedtaksperiodeService.hentUtvidetVedtaksperiodeMedBegrunnelser(vedtak = vedtakService.hentAktivForBehandling(behandling1.id)!!)
+
+        Assertions.assertEquals(1, perioderBehandling1.filter { it.utbetalingsperiodeDetaljer.any { it.ytelseType == YtelseType.SMÅBARNSTILLEGG } }.size)
+
+        val behandling2 = fullførRevurderingUtenOvergangstonad(
+            fagsak = fagsak,
+            personScenario = personScenario,
+            barnFødselsdato = barnFødselsdato
+        )
+
+        val perioderBehandling2 = vedtaksperiodeService.hentUtvidetVedtaksperiodeMedBegrunnelser(vedtak = vedtakService.hentAktivForBehandling(behandling2.id)!!)
+        val periodeMedReduksjon = perioderBehandling2.single { it.type == Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING }
+
+        Assertions.assertEquals(0, perioderBehandling2.filter { it.utbetalingsperiodeDetaljer.any { it.ytelseType == YtelseType.SMÅBARNSTILLEGG } }.size)
+        Assertions.assertNotNull(periodeMedReduksjon)
+        Assertions.assertEquals(osFom, periodeMedReduksjon.fom)
+        Assertions.assertEquals(osTom, periodeMedReduksjon.tom)
+    }
+
+    fun lagScenario(barnFødselsdato: LocalDate): RestScenario = mockServerKlient().lagScenario(
+        RestScenario(
+            søker = RestScenarioPerson(fødselsdato = "1996-01-12", fornavn = "Mor", etternavn = "Søker"),
+            barna = listOf(
+                RestScenarioPerson(
+                    fødselsdato = barnFødselsdato.toString(),
+                    fornavn = "Barn",
+                    etternavn = "Barnesen",
+                    bostedsadresser = emptyList()
+                )
+            )
+        )
+    )
+
+    fun lagFagsak(personScenario: RestScenario): RestMinimalFagsak {
+        return familieBaSakKlient().opprettFagsak(søkersIdent = personScenario.søker.ident!!).data!!
+    }
+
+    fun fullførBehandlingMedOvergangsstønad(
+        fagsak: RestMinimalFagsak,
+        personScenario: RestScenario,
+        barnFødselsdato: LocalDate,
+        overgangsstønadPerioder: List<PeriodeOvergangsstønad>
+    ): Behandling {
+
+        val behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING
+        every { efSakRestClient.hentPerioderMedFullOvergangsstønad(any()) } returns PerioderOvergangsstønadResponse(
+            perioder = overgangsstønadPerioder
+        )
+
+        val restBehandling: Ressurs<RestUtvidetBehandling> =
+            familieBaSakKlient().opprettBehandling(
+                søkersIdent = fagsak.søkerFødselsnummer,
+                behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
+                behandlingType = behandlingType
+            )
+        val behandling = behandlingHentOgPersisterService.hent(restBehandling.data!!.behandlingId)
+        val restRegistrerSøknad =
+            RestRegistrerSøknad(
+                søknad = lagSøknadDTO(
+                    søkerIdent = fagsak.søkerFødselsnummer,
+                    barnasIdenter = personScenario.barna.map { it.ident!! },
+                    underkategori = BehandlingUnderkategori.UTVIDET
+                ),
+                bekreftEndringerViaFrontend = false
+            )
+        val restUtvidetBehandling: Ressurs<RestUtvidetBehandling> =
+            familieBaSakKlient().registrererSøknad(
+                behandlingId = behandling.id,
+                restRegistrerSøknad = restRegistrerSøknad
+            )
+
+        return fullførRestenAvBehandlingen(
+            restUtvidetBehandling = restUtvidetBehandling.data!!,
+            personScenario = personScenario,
+            fagsak = fagsak
+        )
+    }
+
+    fun fullførRevurderingUtenOvergangstonad(
+        fagsak: RestMinimalFagsak,
+        personScenario: RestScenario,
+        barnFødselsdato: LocalDate,
+    ): Behandling {
+
+        val behandlingType = BehandlingType.REVURDERING
+        val behandlingÅrsak = BehandlingÅrsak.SMÅBARNSTILLEGG
+
+        every { efSakRestClient.hentPerioderMedFullOvergangsstønad(any()) } returns PerioderOvergangsstønadResponse(
+            perioder = emptyList()
+        )
+
+        val restUtvidetBehandling: Ressurs<RestUtvidetBehandling> =
+            familieBaSakKlient().opprettBehandling(
+                søkersIdent = fagsak.søkerFødselsnummer,
+                behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
+                behandlingType = behandlingType,
+                behandlingÅrsak = behandlingÅrsak
+            )
+
+        return fullførRestenAvBehandlingen(
+            restUtvidetBehandling = restUtvidetBehandling.data!!,
+            personScenario = personScenario,
+            fagsak = fagsak
+        )
+    }
+
+    fun fullførRestenAvBehandlingen(
+        restUtvidetBehandling: RestUtvidetBehandling,
+        personScenario: RestScenario,
+        fagsak: RestMinimalFagsak
+    ): Behandling {
+        settAlleVilkårTilOppfylt(
+            restUtvidetBehandling = restUtvidetBehandling,
+            barnFødselsdato = barnFødselsdato
+        )
+
+        familieBaSakKlient().validerVilkårsvurdering(
+            behandlingId = restUtvidetBehandling.behandlingId
+        )
+
+        val restUtvidetBehandlingEtterBehandlingsResultat =
+            familieBaSakKlient().behandlingsresultatStegOgGåVidereTilNesteSteg(
+                behandlingId = restUtvidetBehandling.behandlingId
+            )
+
+        val restUtvidetBehandlingEtterVurderTilbakekreving =
+            familieBaSakKlient().lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                restUtvidetBehandlingEtterBehandlingsResultat.data!!.behandlingId,
+                RestTilbakekreving(Tilbakekrevingsvalg.IGNORER_TILBAKEKREVING, begrunnelse = "begrunnelse")
+            )
+
+        val utvidetVedtaksperiodeMedBegrunnelser =
+            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.vedtak!!.vedtaksperioderMedBegrunnelser.sortedBy { it.fom }
+                .first()
+
+        familieBaSakKlient().oppdaterVedtaksperiodeMedStandardbegrunnelser(
+            vedtaksperiodeId = utvidetVedtaksperiodeMedBegrunnelser.id,
+            restPutVedtaksperiodeMedStandardbegrunnelser = RestPutVedtaksperiodeMedStandardbegrunnelser(
+                standardbegrunnelser = utvidetVedtaksperiodeMedBegrunnelser.gyldigeBegrunnelser.map { it.toString() }
+            )
+        )
+        val restUtvidetBehandlingEtterSendTilBeslutter =
+            familieBaSakKlient().sendTilBeslutter(behandlingId = restUtvidetBehandlingEtterVurderTilbakekreving.data!!.behandlingId)
+
+        familieBaSakKlient().iverksettVedtak(
+            behandlingId = restUtvidetBehandlingEtterSendTilBeslutter.data!!.behandlingId,
+            restBeslutningPåVedtak = RestBeslutningPåVedtak(
+                Beslutning.GODKJENT
+            ),
+            beslutterHeaders = HttpHeaders().apply {
+                setBearerAuth(
+                    token(
+                        mapOf(
+                            "groups" to listOf("SAKSBEHANDLER", "BESLUTTER"),
+                            "azp" to "azp-test",
+                            "name" to "Mock McMockface Beslutter",
+                            "NAVident" to "Z0000"
+                        )
+                    )
+                )
+            }
+        )
+        return håndterIverksettingAvBehandling(
+            behandlingEtterVurdering = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = fagsak.id)!!,
+            søkerFnr = personScenario.søker.ident!!,
+            fagsakService = fagsakService,
+            vedtakService = vedtakService,
+            stegService = stegService
+        )
+    }
+
+    fun settAlleVilkårTilOppfylt(restUtvidetBehandling: RestUtvidetBehandling, barnFødselsdato: LocalDate) {
+        restUtvidetBehandling.personResultater.forEach { restPersonResultat ->
+            restPersonResultat.vilkårResultater.filter { it.resultat == Resultat.IKKE_VURDERT }.forEach {
+                familieBaSakKlient().putVilkår(
+                    behandlingId = restUtvidetBehandling.behandlingId,
+                    vilkårId = it.id,
+                    restPersonResultat =
+                    RestPersonResultat(
+                        personIdent = restPersonResultat.personIdent,
+                        vilkårResultater = listOf(
+                            it.copy(
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = barnFødselsdato
+                            )
+                        )
+                    )
+                )
+            }
+        }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
@@ -1,7 +1,9 @@
 package no.nav.familie.ba.sak.kjerne.verdikjedetester
 
 import io.mockk.every
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.lagSøknadDTO
+import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedStandardbegrunnelser
@@ -51,8 +53,8 @@ class ReduksjonFraForrigeIverksatteBehandlingTest(
         val personScenario: RestScenario = lagScenario(barnFødselsdato)
         val fagsak: RestMinimalFagsak = lagFagsak(personScenario)
 
-        val osFom = LocalDate.of(2022, 6, 1)
-        val osTom = LocalDate.of(2022, 8, 31)
+        val osFom = LocalDate.now().førsteDagIInneværendeMåned()
+        val osTom = LocalDate.now().plusMonths(2).sisteDagIMåned()
 
         val behandling1 = fullførBehandlingMedOvergangsstønad(
             fagsak = fagsak, personScenario = personScenario, barnFødselsdato = barnFødselsdato,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
@@ -76,11 +76,11 @@ class ReduksjonFraForrigeIverksatteBehandlingTest(
         )
 
         val perioderBehandling2 = vedtaksperiodeService.hentUtvidetVedtaksperiodeMedBegrunnelser(vedtak = vedtakService.hentAktivForBehandling(behandling2.id)!!)
-        val periodeMedReduksjon = perioderBehandling2.single { it.type == Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING }
+        val periodeMedReduksjon = perioderBehandling2.singleOrNull { it.type == Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING }
 
         Assertions.assertEquals(0, perioderBehandling2.filter { it.utbetalingsperiodeDetaljer.any { it.ytelseType == YtelseType.SMÅBARNSTILLEGG } }.size)
         Assertions.assertNotNull(periodeMedReduksjon)
-        Assertions.assertEquals(osFom, periodeMedReduksjon.fom)
+        Assertions.assertEquals(osFom, periodeMedReduksjon!!.fom)
         Assertions.assertEquals(osTom, periodeMedReduksjon.tom)
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har en task som feiler fordi vedtaksperiodene blir generert feil når man reduserer småbarnstillegg. Det skulle i utgangspunktet ha dukket opp en "utbetaling med reduksjon fra forrige iverksatte behandling"-periode, men det gjør det ikke. Automatisk kjøring finner derfor ikke en periode å begrunne, da denne perioden blir slått sammen med to andre perioder fordi innholdet er likt, og man ikke klarer å identifisere reduksjonsperioden. Se eksempel under:

Skulle ha fått disse periodene: 
|---før---|---utbetaling med reduksjon---|--etter--|

Men vi får:
|---------------------utbetaling-------------------|

TIdligere så vi kun på om en person ble borte, og om en person ikke hadde utbetaling i forrige periode. Vi ønsker egentlig å se på om det er en spesifikk utbetaling for en person som er borte, og ikke eksisterer i forrige periode. Dette er fordi når man reduserer småbarnstillegg blir man sittende igjen med utvidet på søker, og det blir det ikke fanget opp i koden i dag siden personen som blir redusert fortsatt er der (men utbetalingen det er snakk om ikke er der lenger).

**Skal skrive om koden som identifiserer reduksjonsperioder straks, men retter opp denne feilen først**

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Litt mye copy paste fra testen "AutobrevSmåbarnstilleggOpphørTest" for å få riktig oppsett, men usikker på hvordan jeg skal trekke det ut da omtrent alle funksjonene bruker familieBaSakKlient(). Tar gjerne i mot tips her 👍

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
