### PR TITLE
Ta hensyn også til eøs begrunnelser når man validerer fritekst

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -109,7 +109,7 @@ data class VedtaksperiodeMedBegrunnelser(
     }
 
     fun harFriteksterUtenStandardbegrunnelser(): Boolean {
-        return (type == Vedtaksperiodetype.OPPHØR || type == Vedtaksperiodetype.AVSLAG) && fritekster.isNotEmpty() && begrunnelser.isEmpty()
+        return (type == Vedtaksperiodetype.OPPHØR || type == Vedtaksperiodetype.AVSLAG) && fritekster.isNotEmpty() && begrunnelser.isEmpty() && eøsBegrunnelser.isEmpty()
     }
 
     fun harFriteksterOgStandardbegrunnelser(): Boolean {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9027

Fikk ikke lov til å legge til fritekst når man hadde eøs-begrunnelse. Dette var fordi funksjonen som så om det var valgt en begrunnelse kun så på vanlige begrunnelser. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Vet ikke om det er nødvendig?

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
