### PR TITLE
Håndter forlenget overgangsstønadsperiode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
@@ -52,6 +52,11 @@ class BehandlingHentOgPersisterService(
         return Behandlingutils.hentForrigeIverksatteBehandling(iverksatteBehandlinger, behandling)
     }
 
+    fun hentForrigeBehandlingSomErIverksattFraBehandlingsId(behandlingId: Long): Behandling? {
+        val behandling = hent(behandlingId)
+        return hentForrigeBehandlingSomErIverksatt(behandling)
+    }
+
     /**
      * Henter iverksatte behandlinger FØR en gitt behandling.
      * Bør kun brukes i forbindelse med oppdrag mot økonomisystemet

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.slåSammenTidligerePerioder
+import no.nav.familie.ba.sak.kjerne.beregning.domene.splitFramtidigePerioderFraForrigeBehandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilInternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -39,7 +40,22 @@ class SmåbarnstilleggService(
             }
         )
 
-        return periodeOvergangsstønad.map { it.tilInternPeriodeOvergangsstønad() }.slåSammenTidligerePerioder()
+        return periodeOvergangsstønad
+            .map { it.tilInternPeriodeOvergangsstønad() }
+            .slåSammenTidligerePerioder()
+            .splitFramtidigePerioderFraForrigeBehandling(
+                gamleOvergangsstønadPerioder = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId)
+            )
+    }
+
+    private fun hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId: Long): List<InternPeriodeOvergangsstønad> {
+        val forrigeIverksatteBehandling =
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksattFraBehandlingsId(behandlingId = behandlingId)
+
+        return if (forrigeIverksatteBehandling != null) periodeOvergangsstønadGrunnlagRepository.findByBehandlingId(
+            behandlingId = forrigeIverksatteBehandling.id
+        ).map { it.tilInternPeriodeOvergangsstønad() }
+        else emptyList()
     }
 
     fun vedtakOmOvergangsstønadPåvirkerFagsak(fagsak: Fagsak): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.beregning.domene
 
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.forrigeMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.common.toYearMonth
@@ -51,6 +52,11 @@ fun List<InternPeriodeOvergangsstønad>.slåSammenSammenhengendePerioder(): List
 fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandling(
     gamleOvergangsstønadPerioder: List<InternPeriodeOvergangsstønad>
 ): List<InternPeriodeOvergangsstønad> {
+    val erOvergangsstønadForMerEnnEnPerson =
+        (this + gamleOvergangsstønadPerioder).map { it.personIdent }.toSet().size > 1
+    if (erOvergangsstønadForMerEnnEnPerson)
+        throw Feil("Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn en person.")
+
     val tidligerePerioder = this.filter { it.tomDato.isSameOrBefore(LocalDate.now()) }
     val framtidigePerioder = this.minus(tidligerePerioder)
     val nyeOvergangsstønadTidslinje = InternPeriodeOvergangsstønadTidslinje(framtidigePerioder)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønadTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønadTidslinje.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.beregning.domene
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
@@ -12,9 +11,6 @@ open class InternPeriodeOvergangsstønadTidslinje(
 ) : Tidslinje<InternPeriodeOvergangsstønad, Dag>() {
 
     override fun lagPerioder(): List<Periode<InternPeriodeOvergangsstønad, Dag>> {
-        val erOvergangsstønadForMerEnnEnPerson = internePeriodeOvergangsstønader.map { it.personIdent }.toSet().size > 1
-        if (erOvergangsstønadForMerEnnEnPerson) throw Feil("Fant overgangsstønad for mer enn en person.")
-
         return internePeriodeOvergangsstønader.map {
             Periode(
                 fraOgMed = it.fomDato.tilTidspunktEllerUendeligLengeSiden(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønadTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønadTidslinje.kt
@@ -1,0 +1,34 @@
+package no.nav.familie.ba.sak.kjerne.beregning.domene
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerUendeligLengeSiden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerUendeligLengeTil
+
+open class InternPeriodeOvergangsstønadTidslinje(
+    private val internePeriodeOvergangsstønader: List<InternPeriodeOvergangsstønad>,
+) : Tidslinje<InternPeriodeOvergangsstønad, Dag>() {
+
+    override fun lagPerioder(): List<Periode<InternPeriodeOvergangsstønad, Dag>> {
+        val erOvergangsstønadForMerEnnEnPerson = internePeriodeOvergangsstønader.map { it.personIdent }.toSet().size > 1
+        if (erOvergangsstønadForMerEnnEnPerson) throw Feil("Fant overgangsstønad for mer enn en person.")
+
+        return internePeriodeOvergangsstønader.map {
+            Periode(
+                fraOgMed = it.fomDato.tilTidspunktEllerUendeligLengeSiden(),
+                tilOgMed = it.tomDato.tilTidspunktEllerUendeligLengeTil(),
+                innhold = it
+            )
+        }
+    }
+}
+
+fun Tidslinje<InternPeriodeOvergangsstønad, Dag>.lagInternePerioderOvergangsstønad(): List<InternPeriodeOvergangsstønad> =
+    this.perioder().mapNotNull {
+        it.innhold?.copy(
+            fomDato = it.fraOgMed.tilFørsteDagIMåneden().tilLocalDate(),
+            tomDato = it.tilOgMed.tilSisteDagIMåneden().tilLocalDate()
+        )
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/småbarnstillegg/PeriodeOvergangsstønadGrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/småbarnstillegg/PeriodeOvergangsstønadGrunnlag.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg
 
 import no.nav.familie.ba.sak.common.BaseEntitet
+import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
@@ -50,7 +51,13 @@ class PeriodeOvergangsstønadGrunnlag(
     @Enumerated(EnumType.STRING)
     @Column(name = "datakilde", nullable = false)
     val datakilde: PeriodeOvergangsstønad.Datakilde,
-) : BaseEntitet()
+) : BaseEntitet() {
+    fun tilInternPeriodeOvergangsstønad() = InternPeriodeOvergangsstønad(
+        personIdent = this.aktør.aktivFødselsnummer(),
+        fomDato = this.fom,
+        tomDato = this.tom
+    )
+}
 
 fun PeriodeOvergangsstønad.tilPeriodeOvergangsstønadGrunnlag(behandlingId: Long, aktør: Aktør) =
     PeriodeOvergangsstønadGrunnlag(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -475,7 +475,7 @@ class BehandleSmåbarnstilleggTest(
     }
 
     @Test
-    fun `Skal kunne begrunne utvidet periode når overgangsstønad blir utvidet`() {
+    fun `Skal kunne begrunne ny periode når overgangsstønad blir forlenget`() {
         val testScenario = mockServerKlient().lagScenario(restScenario)
 
         val fomDato = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -484,9 +484,8 @@ class BehandleSmåbarnstilleggTest(
     fun `Skal kunne begrunne utvidet periode når overgangsstønad blir utvidet`() {
         val testScenario = mockServerKlient().lagScenario(restScenario)
 
-        val fomDato1 = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned()
+        val fomDato = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned()
         val tomDato1 = LocalDate.now().sisteDagIMåned()
-        val fomDato2 = fomDato1
         val tomDato2 = barnFødselsdato.plusYears(3)
 
         val søkersIdent2 = testScenario.søker.ident!!
@@ -497,7 +496,7 @@ class BehandleSmåbarnstilleggTest(
                 perioder = listOf(
                     PeriodeOvergangsstønad(
                         personIdent = søkersIdent2,
-                        fomDato = fomDato1,
+                        fomDato = fomDato,
                         tomDato = tomDato1,
                         datakilde = PeriodeOvergangsstønad.Datakilde.EF
                     ),
@@ -512,7 +511,7 @@ class BehandleSmåbarnstilleggTest(
             perioder = listOf(
                 PeriodeOvergangsstønad(
                     personIdent = søkersIdent2,
-                    fomDato = fomDato2,
+                    fomDato = fomDato,
                     tomDato = tomDato2,
                     datakilde = PeriodeOvergangsstønad.Datakilde.EF
                 ),
@@ -534,10 +533,10 @@ class BehandleSmåbarnstilleggTest(
         val småbarnstilleggAndeler = andelerTilkjentYtelse.filter { it.erSmåbarnstillegg() }
 
         assertEquals(2, småbarnstilleggAndeler.size)
-        assertEquals(fomDato2, småbarnstilleggAndeler.first().stønadFom)
-        assertEquals(tomDato1, småbarnstilleggAndeler.first().stønadTom)
-        assertEquals(tomDato1.plusDays(1), småbarnstilleggAndeler.last().stønadFom)
-        assertEquals(tomDato2, småbarnstilleggAndeler.last().stønadTom)
+        assertEquals(fomDato.toYearMonth(), småbarnstilleggAndeler.first().stønadFom)
+        assertEquals(tomDato1.toYearMonth(), småbarnstilleggAndeler.first().stønadTom)
+        assertEquals(tomDato1.plusDays(1).toYearMonth(), småbarnstilleggAndeler.last().stønadFom)
+        assertEquals(tomDato2.toYearMonth(), småbarnstilleggAndeler.last().stønadTom)
     }
 
     private fun opprettOgKjørGjennomUtvidetBehandling(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -29,7 +29,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService.sisteSmåbarnstilleggSatsTilTester
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService.sisteUtvidetSatsTilTester
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService.tilleggOrdinærSatsTilTester
@@ -51,14 +50,12 @@ import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScena
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
-import no.nav.familie.prosessering.domene.TaskRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -92,9 +89,6 @@ class BehandleSmåbarnstilleggTest(
     @Autowired private val vilkårsvurderingService: VilkårsvurderingService,
     @Autowired private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
     @Autowired private val persongrunnlagService: PersongrunnlagService,
-    @Autowired private val taskRepository: TaskRepository,
-    @Autowired private val iverksettMotOppdragTask: IverksettMotOppdragTask,
-    @Autowired private val beregningService: BeregningService,
 ) : AbstractVerdikjedetest() {
 
     private val barnFødselsdato = LocalDate.now().minusYears(2)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -488,14 +488,14 @@ class BehandleSmåbarnstilleggTest(
         val tomDato1 = LocalDate.now().sisteDagIMåned()
         val tomDato2 = barnFødselsdato.plusYears(3)
 
-        val søkersIdent2 = testScenario.søker.ident!!
-        val søkersAktør2 = personidentService.hentAktør(søkersIdent2)
+        val søkersIdent = testScenario.søker.ident!!
+        val søkersAktør = personidentService.hentAktør(søkersIdent)
 
         every { efSakRestClient.hentPerioderMedFullOvergangsstønad(any()) } returns
             PerioderOvergangsstønadResponse(
                 perioder = listOf(
                     PeriodeOvergangsstønad(
-                        personIdent = søkersIdent2,
+                        personIdent = søkersIdent,
                         fomDato = fomDato,
                         tomDato = tomDato1,
                         datakilde = PeriodeOvergangsstønad.Datakilde.EF
@@ -510,7 +510,7 @@ class BehandleSmåbarnstilleggTest(
         every { efSakRestClient.hentPerioderMedFullOvergangsstønad(any()) } returns PerioderOvergangsstønadResponse(
             perioder = listOf(
                 PeriodeOvergangsstønad(
-                    personIdent = søkersIdent2,
+                    personIdent = søkersIdent,
                     fomDato = fomDato,
                     tomDato = tomDato2,
                     datakilde = PeriodeOvergangsstønad.Datakilde.EF
@@ -518,19 +518,16 @@ class BehandleSmåbarnstilleggTest(
             )
         )
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
-            mottakersAktør = søkersAktør2,
-            behandlingsdata = søkersAktør2
+            mottakersAktør = søkersAktør,
+            behandlingsdata = søkersAktør
         )
 
-        val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør2)
+        val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør)
         val aktivBehandling = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = fagsak!!.id)!!
 
-        val andelerTilkjentYtelse =
-            andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(
-                behandlingId = aktivBehandling.id
-            )
-
-        val småbarnstilleggAndeler = andelerTilkjentYtelse.filter { it.erSmåbarnstillegg() }
+        val småbarnstilleggAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(
+            behandlingId = aktivBehandling.id
+        ).filter { it.erSmåbarnstillegg() }
 
         assertEquals(2, småbarnstilleggAndeler.size)
         assertEquals(fomDato.toYearMonth(), småbarnstilleggAndeler.first().stønadFom)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -1,13 +1,18 @@
 package no.nav.familie.ba.sak.kjerne.verdikjedetester
 
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.lagSøknadDTO
+import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.nesteMåned
+import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.EfSakRestClientMock
 import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.dataGenerator.behandling.kjørStegprosessForBehandling
+import no.nav.familie.ba.sak.dataGenerator.vilkårsvurdering.lagVilkårsvurderingFraRestScenario
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedStandardbegrunnelser
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
@@ -19,17 +24,22 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.RestHenleggBehandlingInfo
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService.sisteSmåbarnstilleggSatsTilTester
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService.sisteUtvidetSatsTilTester
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService.tilleggOrdinærSatsTilTester
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
@@ -38,12 +48,17 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenarioPerson
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
+import no.nav.familie.prosessering.domene.TaskRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -73,29 +88,35 @@ class BehandleSmåbarnstilleggTest(
     @Autowired private val efSakRestClient: EfSakRestClient,
     @Autowired private val autovedtakStegService: AutovedtakStegService,
     @Autowired private val vedtaksperiodeService: VedtaksperiodeService,
-    @Autowired private val opprettTaskService: OpprettTaskService
+    @Autowired private val opprettTaskService: OpprettTaskService,
+    @Autowired private val vilkårsvurderingService: VilkårsvurderingService,
+    @Autowired private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
+    @Autowired private val persongrunnlagService: PersongrunnlagService,
+    @Autowired private val taskRepository: TaskRepository,
+    @Autowired private val iverksettMotOppdragTask: IverksettMotOppdragTask,
+    @Autowired private val beregningService: BeregningService,
 ) : AbstractVerdikjedetest() {
 
     private val barnFødselsdato = LocalDate.now().minusYears(2)
     private val periodeMedFullOvergangsstønadFom = barnFødselsdato.plusYears(1)
 
+    val restScenario = RestScenario(
+        søker = RestScenarioPerson(fødselsdato = "1996-01-12", fornavn = "Mor", etternavn = "Søker"),
+        barna = listOf(
+            RestScenarioPerson(
+                fødselsdato = barnFødselsdato.toString(),
+                fornavn = "Barn",
+                etternavn = "Barnesen",
+                bostedsadresser = emptyList()
+            )
+        )
+    )
+
     lateinit var scenario: RestScenario
 
     @BeforeAll
     fun init() {
-        scenario = mockServerKlient().lagScenario(
-            RestScenario(
-                søker = RestScenarioPerson(fødselsdato = "1996-01-12", fornavn = "Mor", etternavn = "Søker"),
-                barna = listOf(
-                    RestScenarioPerson(
-                        fødselsdato = barnFødselsdato.toString(),
-                        fornavn = "Barn",
-                        etternavn = "Barnesen",
-                        bostedsadresser = emptyList()
-                    )
-                )
-            )
-        )
+        scenario = mockServerKlient().lagScenario(restScenario)
     }
 
     private fun settOppefSakMockForDeFørste2Testene(søkersIdent: String) {
@@ -457,5 +478,104 @@ class BehandleSmåbarnstilleggTest(
 
         assertNotNull(aktuellVedtaksperiode)
         assertTrue(aktuellVedtaksperiode?.begrunnelser?.any { it.standardbegrunnelse == Standardbegrunnelse.INNVILGET_SMÅBARNSTILLEGG } == true)
+    }
+
+    @Test
+    fun `Skal kunne begrunne utvidet periode når overgangsstønad blir utvidet`() {
+        val testScenario = mockServerKlient().lagScenario(restScenario)
+
+        val fomDato1 = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned()
+        val tomDato1 = LocalDate.now().sisteDagIMåned()
+        val fomDato2 = fomDato1
+        val tomDato2 = barnFødselsdato.plusYears(3)
+
+        val søkersIdent2 = testScenario.søker.ident!!
+        val søkersAktør2 = personidentService.hentAktør(søkersIdent2)
+
+        every { efSakRestClient.hentPerioderMedFullOvergangsstønad(any()) } returns
+            PerioderOvergangsstønadResponse(
+                perioder = listOf(
+                    PeriodeOvergangsstønad(
+                        personIdent = søkersIdent2,
+                        fomDato = fomDato1,
+                        tomDato = tomDato1,
+                        datakilde = PeriodeOvergangsstønad.Datakilde.EF
+                    ),
+                )
+            )
+        opprettOgKjørGjennomUtvidetBehandling(
+            testScenario,
+            LocalDate.parse(testScenario.barna.single().fødselsdato)
+        )
+
+        every { efSakRestClient.hentPerioderMedFullOvergangsstønad(any()) } returns PerioderOvergangsstønadResponse(
+            perioder = listOf(
+                PeriodeOvergangsstønad(
+                    personIdent = søkersIdent2,
+                    fomDato = fomDato2,
+                    tomDato = tomDato2,
+                    datakilde = PeriodeOvergangsstønad.Datakilde.EF
+                ),
+            )
+        )
+        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
+            mottakersAktør = søkersAktør2,
+            behandlingsdata = søkersAktør2
+        )
+
+        val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør2)
+        val aktivBehandling = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = fagsak!!.id)!!
+
+        val andelerTilkjentYtelse =
+            andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(
+                behandlingId = aktivBehandling.id
+            )
+
+        val småbarnstilleggAndeler = andelerTilkjentYtelse.filter { it.erSmåbarnstillegg() }
+
+        assertEquals(2, småbarnstilleggAndeler.size)
+        assertEquals(fomDato2, småbarnstilleggAndeler.first().stønadFom)
+        assertEquals(tomDato1, småbarnstilleggAndeler.first().stønadTom)
+        assertEquals(tomDato1.plusDays(1), småbarnstilleggAndeler.last().stønadFom)
+        assertEquals(tomDato2, småbarnstilleggAndeler.last().stønadTom)
+    }
+
+    private fun opprettOgKjørGjennomUtvidetBehandling(
+        scenario: RestScenario,
+        utvidetPeriodeFom: LocalDate
+    ): Behandling {
+        val overstyrendeVilkårResultaterFGB =
+            scenario.barna.associate { it.aktørId!! to emptyList<VilkårResultat>() }.toMutableMap()
+
+        overstyrendeVilkårResultaterFGB[scenario.søker.aktørId!!] = listOf(
+            lagVilkårResultat(
+                vilkårType = Vilkår.UTVIDET_BARNETRYGD,
+                periodeFom = utvidetPeriodeFom,
+                periodeTom = null,
+                personResultat = mockk(relaxed = true),
+            )
+        )
+
+        return kjørStegprosessForBehandling(
+            tilSteg = StegType.BEHANDLING_AVSLUTTET,
+            søkerFnr = scenario.søker.ident!!,
+            barnasIdenter = listOf(scenario.barna.first().ident!!),
+            underkategori = BehandlingUnderkategori.UTVIDET,
+            behandlingÅrsak = BehandlingÅrsak.SØKNAD,
+            overstyrendeVilkårsvurdering = lagVilkårsvurderingFraRestScenario(
+                scenario,
+                overstyrendeVilkårResultaterFGB
+            ),
+            behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+
+            vedtakService = vedtakService,
+            vilkårsvurderingService = vilkårsvurderingService,
+            stegService = stegService,
+            vedtaksperiodeService = vedtaksperiodeService,
+            endretUtbetalingAndelService = endretUtbetalingAndelService,
+            fagsakService = fagsakService,
+            persongrunnlagService = persongrunnlagService,
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+        )
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9148

**Hvorfor:**
Vi har en feil der vi ikke klarer å finne hvilken periode som får småbarnstillegg. Dette skjer fordi en overgangsstønad-periode utvides. Til nå har vi antatt av dersom det blir mer overgangsstønad vil dette komme som en ny periode.

**Hva endres i denne PRen:**
Dersom vi i en behandling har overgangsstønad i tre måneder:
`|OOO-----|`
som fører til småbarnstillegg.
Og så utvides overgangsstønadsperioden i neste behandling til fem måneder:
`|OOOOO---|`
som fører til småbarnstillegg i alle månedene.
Ønsker vi å kunne begrunne de to siste månedene med småbarnstillegg.
Splitter derfor opp overgangsstønadsperioden slik at vi kan begrunne endringen for søker i riktig periode.
`|OOO-----|`
`|---OO---|`

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Burde dette håndeters når vi lager vedtaksperiodene? Alt vi ønsker å gjøre er jo å lage en vi vedtaksperiode som vi ønsker å begrunne. 

Argumentet for å splitte opp overgangsstønadsperioden er at da kan vi bruke samme logikk som vi har brukt for resten av småbarnstillegg og vi får samlet småbarnsstøtte/overgansgsstønads-logikken

Argumentet mot er at dette endrer på veldig mye for å kunne lage en ny vedtaksperiode. Dersom man ser på vedtaksperiodene blir det veldig vanskelig å jobbe seg tilbake til det som endret splitten. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
