### PR TITLE
Hvis det kun er fortsatt opphørt resultater ønsker vi ikke å legge til endret-resultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -86,6 +86,7 @@ object BehandlingsresultatUtils {
                 ytelsePersoner.filter { it.resultater != setOf(YtelsePersonResultat.AVSLÅTT) }
                     .groupBy { it.ytelseSlutt }.size == 1 || erAvslått
                 )
+        val kunFortsattOpphørt = ytelsePersoner.all { it.resultater == setOf(YtelsePersonResultat.FORTSATT_OPPHØRT) }
         val noeOpphørerPåTidligereBarn = ytelsePersoner.any {
             it.resultater.contains(YtelsePersonResultat.OPPHØRT) && !it.kravOpprinnelse.contains(KravOpprinnelse.INNEVÆRENDE)
         }
@@ -94,7 +95,7 @@ object BehandlingsresultatUtils {
             samledeResultater.add(YtelsePersonResultat.ENDRET_UTBETALING)
         }
 
-        val opphørSomFørerTilEndring = altOpphører && !opphørPåSammeTid && !erKunFremstilKravIDenneBehandling
+        val opphørSomFørerTilEndring = altOpphører && !opphørPåSammeTid && !erKunFremstilKravIDenneBehandling && !kunFortsattOpphørt
         if (opphørSomFørerTilEndring) {
             samledeResultater.add(YtelsePersonResultat.ENDRET_UTBETALING)
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -126,6 +126,25 @@ class BehandlingsresultatUtilsTest {
             BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
         )
     }
+
+    @Test
+    fun `Skal returnere FORTSATT_OPPHØRT behandlingsresultat hvis ytelsen opphører på forskjellig tidspunkt`() {
+        val personer = listOf(
+            lagYtelsePerson(
+                resultat = YtelsePersonResultat.FORTSATT_OPPHØRT,
+                ytelseSlutt = YearMonth.now().minusMonths(1)
+            ),
+            lagYtelsePerson(
+                resultat = YtelsePersonResultat.FORTSATT_OPPHØRT,
+                ytelseSlutt = YearMonth.now()
+            )
+        )
+
+        assertEquals(
+            Behandlingsresultat.FORTSATT_OPPHØRT,
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
+        )
+    }
 }
 
 private fun lagYtelsePerson(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9136

Vi har en autobrev task som feiler fordi man får behandlingsresultatet endret og opphørt når man egentlig forventer å få fortsatt innvilget (evt. i dette tilfellet fortsatt opphørt). Grunnen til at det blir endret og opphørt er fordi hvis alt opphører, og det ikke opphører på samme tid, samt at det ikke kun er fremstilt krav i inneværende behandling så legger vi til ENDRET_UTBETALING som et resultat. Derfor blir behandlingsresultatet endret og opphørt. 

Tanken bak denne PRen er at det ikke gir mening å legge til endret utbetaling som resultat hvis alle personresultatene er fortsatt opphørt. Dette vil gjør at man til slutt ender opp med fortsatt opphørt som resultat.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Vil dette funke for alle caser? Jeg tror ja, men fint om noen andre også tenker litt gjennom det.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
