### PR TITLE
Fjernet dobbeltfnutter fra metodenavn. Ville ikke kompilere på Windows.

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -35,7 +35,7 @@ internal class DokumentServiceEnhetstest {
     )
 
     @Test
-    fun `Skal kalle "loggBrevIkkeDistribuertUkjentAdresse" ved 400 kode og "Mottaker har ukjent adresse" melding`() {
+    fun `Skal kalle 'loggBrevIkkeDistribuertUkjentAdresse' ved 400 kode og 'Mottaker har ukjent adresse' melding`() {
         every { dokumentService.håndterMottakerDødIngenAdressePåBehandling(any(), any(), any()) } returns Unit
         every {
             integrasjonClient.distribuerBrev(any(), any())
@@ -57,7 +57,7 @@ internal class DokumentServiceEnhetstest {
     }
 
     @Test
-    fun `Skal kalle "håndterMottakerDødIngenAdressePåBehandling" ved 410 Gone svar under distribuering"`() {
+    fun `Skal kalle 'håndterMottakerDødIngenAdressePåBehandling' ved 410 Gone svar under distribuering`() {
         every { dokumentService.håndterMottakerDødIngenAdressePåBehandling(any(), any(), any()) } returns Unit
         every {
             integrasjonClient.distribuerBrev(any(), any())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Koden ville ikke la seg kompilere på Windows. Fjernet dobbeltfnutt og erstattet med enkeltfnutt.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
