### PR TITLE
Gi behandlingsresultat opphørt dersom personresultatene er opphørt og fortsatt opphørt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -36,7 +36,6 @@ object BehandlingsresultatUtils {
         tilkjentYtelse: TilkjentYtelse,
         erEksplisittAvslag: Boolean
     ): BehandlingsresultatPerson {
-
         val aktør = person.aktør
 
         return BehandlingsresultatPerson(
@@ -68,7 +67,7 @@ object BehandlingsresultatUtils {
                         )
                     }
             },
-            eksplisittAvslag = erEksplisittAvslag,
+            eksplisittAvslag = erEksplisittAvslag
         )
     }
 
@@ -110,7 +109,8 @@ object BehandlingsresultatUtils {
             samledeResultater == setOf(YtelsePersonResultat.ENDRET_UTBETALING) -> Behandlingsresultat.ENDRET_UTBETALING
             samledeResultater == setOf(YtelsePersonResultat.ENDRET_UTEN_UTBETALING) -> Behandlingsresultat.ENDRET_UTEN_UTBETALING
             samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(emptySet()) -> Behandlingsresultat.ENDRET_OG_OPPHØRT
-            samledeResultater == setOf(YtelsePersonResultat.OPPHØRT) -> Behandlingsresultat.OPPHØRT
+            samledeResultater == setOf(YtelsePersonResultat.OPPHØRT, YtelsePersonResultat.FORTSATT_OPPHØRT) ||
+                samledeResultater == setOf(YtelsePersonResultat.OPPHØRT) -> Behandlingsresultat.OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.INNVILGET) -> Behandlingsresultat.INNVILGET
             samledeResultater.matcherAltOgHarOpphørtResultat(setOf(YtelsePersonResultat.INNVILGET)) -> Behandlingsresultat.INNVILGET_OG_OPPHØRT
             samledeResultater.matcherAltOgHarEndretResultat(setOf(YtelsePersonResultat.INNVILGET)) -> Behandlingsresultat.INNVILGET_OG_ENDRET
@@ -134,7 +134,7 @@ object BehandlingsresultatUtils {
             samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(
                 setOf(
                     YtelsePersonResultat.INNVILGET,
-                    YtelsePersonResultat.AVSLÅTT,
+                    YtelsePersonResultat.AVSLÅTT
                 )
             ) -> Behandlingsresultat.DELVIS_INNVILGET_ENDRET_OG_OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.AVSLÅTT) -> Behandlingsresultat.AVSLÅTT
@@ -173,7 +173,6 @@ object BehandlingsresultatUtils {
             ) ||
             (behandling.type == BehandlingType.REVURDERING && resultat == Behandlingsresultat.IKKE_VURDERT)
         ) {
-
             val feilmelding = "Behandlingsresultatet ${resultat.displayName.lowercase()} " +
                 "er ugyldig i kombinasjon med behandlingstype '${behandling.type.visningsnavn}'."
             throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
@@ -193,19 +192,22 @@ object BehandlingsresultatUtils {
 }
 
 private fun validerYtelsePersoner(ytelsePersoner: List<YtelsePerson>) {
-    if (ytelsePersoner.flatMap { it.resultater }.any { it == YtelsePersonResultat.IKKE_VURDERT })
+    if (ytelsePersoner.flatMap { it.resultater }.any { it == YtelsePersonResultat.IKKE_VURDERT }) {
         throw Feil(message = "Minst én ytelseperson er ikke vurdert")
+    }
 
-    if (ytelsePersoner.any { it.ytelseSlutt == null })
+    if (ytelsePersoner.any { it.ytelseSlutt == null }) {
         throw Feil(message = "YtelseSlutt ikke satt ved utledning av behandlingsresultat")
+    }
 
     if (ytelsePersoner.any {
         it.resultater.contains(YtelsePersonResultat.OPPHØRT) && it.ytelseSlutt?.isAfter(
                 inneværendeMåned()
             ) == true
     }
-    )
+    ) {
         throw Feil(message = "Minst én ytelseperson har fått opphør som resultat og ytelseSlutt etter inneværende måned")
+    }
 }
 
 private fun kombinerOverlappendeAndelerForSøker(andeler: List<AndelTilkjentYtelse>): List<BehandlingsresultatAndelTilkjentYtelse> {

--- a/src/test/resources/behandlingsresultatPersoner/RV18_OPPHØRT_OG_FORTSATT_OPPHØRT.json
+++ b/src/test/resources/behandlingsresultatPersoner/RV18_OPPHØRT_OG_FORTSATT_OPPHØRT.json
@@ -1,0 +1,53 @@
+{
+  "beskrivelse": "Revurdering med opphørt og fortsatt opphørt. RV: Ytelsen er opphørt",
+  "inneværendeMåned": "2022-08",
+  "personer": [
+    {
+      "personType": "BARN",
+      "aktør": {
+        "fødselsnummer": "12345678910",
+        "aktørId": "1234567891011"
+      },
+      "søktForPerson": false,
+      "eksplisittAvslått": false,
+      "forrigeAndeler": [
+        {
+          "stønadFom": "2020-09",
+          "stønadTom": "2027-12",
+          "kalkulertUtbetalingsbeløp": 1054
+        }
+      ],
+      "andeler": [
+        {
+          "stønadFom": "2020-09",
+          "stønadTom": "2020-11",
+          "kalkulertUtbetalingsbeløp": 1054
+        }
+      ]
+    },
+    {
+      "personType": "BARN",
+      "aktør": {
+        "fødselsnummer": "34567891011",
+        "aktørId": "3456789101112"
+      },
+      "søktForPerson": false,
+      "eksplisittAvslått": false,
+      "forrigeAndeler": [
+        {
+          "stønadFom": "2020-09",
+          "stønadTom": "2020-11",
+          "kalkulertUtbetalingsbeløp": 1054
+        }
+      ],
+      "andeler": [
+        {
+          "stønadFom": "2020-09",
+          "stønadTom": "2020-11",
+          "kalkulertUtbetalingsbeløp": 1054
+        }
+      ]
+    }
+  ],
+  "forventetResultat": "OPPHØRT"
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9130

Vi har et case der et barn får resultat opphørt og et annet barn får resultatet fortsatt opphørt. Dette er ikke støttet i løsningen i dag. Vi ønsker at behandlingsresultatet skal bli "opphørt". 

Endrer så behandlingsresultatet blir "opphørt" ved personresultater "opphørt" og "fortsatt opphørt"

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
