### PR TITLE
Endret logikk for barn død begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityKlient.kt
@@ -16,7 +16,7 @@ data class SanityBegrunnelserRespons(
     val result: List<RestSanityBegrunnelse>
 )
 
-const val sanityBaseUrl = "https://xsrv1mh6.apicdn.sanity.io/v2021-06-07/data/query"
+const val sanityBaseUrl = "https://xsrv1mh6.api.sanity.io/v1/data/query"
 
 fun hentBegrunnelser(datasett: String = "ba-brev"): List<SanityBegrunnelse> {
     val sanityUrl = "$sanityBaseUrl/$datasett"

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityKlient.kt
@@ -16,7 +16,7 @@ data class SanityBegrunnelserRespons(
     val result: List<RestSanityBegrunnelse>
 )
 
-const val sanityBaseUrl = "https://xsrv1mh6.api.sanity.io/v1/data/query"
+const val sanityBaseUrl = "https://xsrv1mh6.api.sanity.io/v2021-06-07/data/query"
 
 fun hentBegrunnelser(datasett: String = "ba-brev"): List<SanityBegrunnelse> {
     val sanityUrl = "$sanityBaseUrl/$datasett"

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/sanityQueries.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/sanityQueries.kt
@@ -1,9 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.sanity
 
 const val hentBegrunnelser =
-    "*[_type == \"begrunnelse\" && behandlingstema != \"EØS\" && apiNavn != null && navnISystem != null && (_id in path(\"drafts.**\") || !defined(*[_id == \"drafts.\" + ^._id][0]))]{" +
-        "_id," +
-        "_updatedAt," +
+    "*[_type == \"begrunnelse\" && behandlingstema != \"EØS\" && apiNavn != null && navnISystem != null]{" +
         "apiNavn," +
         "navnISystem," +
         "hjemler," +

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/sanityQueries.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/sanityQueries.kt
@@ -1,7 +1,9 @@
 package no.nav.familie.ba.sak.integrasjoner.sanity
 
 const val hentBegrunnelser =
-    "*[_type == \"begrunnelse\" && behandlingstema != \"EØS\" && apiNavn != null && navnISystem != null]{" +
+    "*[_type == \"begrunnelse\" && behandlingstema != \"EØS\" && apiNavn != null && navnISystem != null && (_id in path(\"drafts.**\") || !defined(*[_id == \"drafts.\" + ^._id][0]))]{" +
+        "_id," +
+        "_updatedAt," +
         "apiNavn," +
         "navnISystem," +
         "hjemler," +

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
@@ -19,7 +19,6 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.barnMedSeksårsdagPåFom
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
-import no.nav.familie.ba.sak.task.nesteGyldigeTriggertidForBehandlingIHverdager
 
 fun hentPersonidenterGjeldendeForBegrunnelse(
     triggesAv: TriggesAv,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.RestBehandlingsgrunnlagForBrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.harPersonerSomManglerOpplysninger
 import no.nav.familie.ba.sak.kjerne.brev.domene.somOverlapper
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.hentPersonerForEtterEndretUtbetalingsperiode
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
@@ -18,6 +19,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.barnMedSeksårsdagPåFom
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.task.nesteGyldigeTriggertidForBehandlingIHverdager
 
 fun hentPersonidenterGjeldendeForBegrunnelse(
     triggesAv: TriggesAv,
@@ -29,6 +31,7 @@ fun hentPersonidenterGjeldendeForBegrunnelse(
     erFørsteVedtaksperiodePåFagsak: Boolean,
     identerMedReduksjonPåPeriode: List<String> = emptyList(),
     minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>,
+    barnIBehandling: List<Person>
 ): Set<String> {
 
     val erFortsattInnvilgetBegrunnelse = vedtakBegrunnelseType == VedtakBegrunnelseType.FORTSATT_INNVILGET
@@ -92,6 +95,8 @@ fun hentPersonidenterGjeldendeForBegrunnelse(
                 fom = periode.fom,
                 endringsaarsaker = triggesAv.endringsaarsaker
             )
+
+        triggesAv.barnDød -> barnIBehandling.filter { barn -> barn.erDød() }.map { barn -> barn.aktør.aktivFødselsnummer() }
 
         else -> hentPersonerForUtgjørendeVilkår()
     }.toSet()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.NullablePeriode
 import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertRestEndretAndel
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertUtbetalingsperiodeDetalj
@@ -11,10 +12,11 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.RestBehandlingsgrunnlagForBrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.harPersonerSomManglerOpplysninger
 import no.nav.familie.ba.sak.kjerne.brev.domene.somOverlapper
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.hentPersonerForEtterEndretUtbetalingsperiode
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.dødeBarnForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.barnMedSeksårsdagPåFom
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
@@ -30,7 +32,8 @@ fun hentPersonidenterGjeldendeForBegrunnelse(
     erFørsteVedtaksperiodePåFagsak: Boolean,
     identerMedReduksjonPåPeriode: List<String> = emptyList(),
     minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>,
-    barnIBehandling: List<Person>
+    ytelserForrigePeriode: List<AndelTilkjentYtelse>,
+    barnIBehandling: List<MinimertPerson>
 ): Set<String> {
 
     val erFortsattInnvilgetBegrunnelse = vedtakBegrunnelseType == VedtakBegrunnelseType.FORTSATT_INNVILGET
@@ -95,7 +98,7 @@ fun hentPersonidenterGjeldendeForBegrunnelse(
                 endringsaarsaker = triggesAv.endringsaarsaker
             )
 
-        triggesAv.barnDød -> barnIBehandling.filter { barn -> barn.erDød() }.map { barn -> barn.aktør.aktivFødselsnummer() }
+        triggesAv.barnDød -> dødeBarnForrigePeriode(ytelserForrigePeriode, barnIBehandling).map { barn -> barn.aktivPersonIdent }
 
         else -> hentPersonerForUtgjørendeVilkår()
     }.toSet()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.common.NullablePeriode
 import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertRestEndretAndel
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertUtbetalingsperiodeDetalj
@@ -15,8 +14,6 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.hentPersonerForEtter
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.dødeBarnForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.barnMedSeksårsdagPåFom
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
@@ -32,8 +29,7 @@ fun hentPersonidenterGjeldendeForBegrunnelse(
     erFørsteVedtaksperiodePåFagsak: Boolean,
     identerMedReduksjonPåPeriode: List<String> = emptyList(),
     minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>,
-    ytelserForrigePeriode: List<AndelTilkjentYtelse>,
-    barnIBehandling: List<MinimertPerson>
+    dødeBarnForrigePeriode: List<String>
 ): Set<String> {
 
     val erFortsattInnvilgetBegrunnelse = vedtakBegrunnelseType == VedtakBegrunnelseType.FORTSATT_INNVILGET
@@ -98,7 +94,7 @@ fun hentPersonidenterGjeldendeForBegrunnelse(
                 endringsaarsaker = triggesAv.endringsaarsaker
             )
 
-        triggesAv.barnDød -> dødeBarnForrigePeriode(ytelserForrigePeriode, barnIBehandling).map { barn -> barn.aktivPersonIdent }
+        triggesAv.barnDød -> dødeBarnForrigePeriode
 
         else -> hentPersonerForUtgjørendeVilkår()
     }.toSet()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.erSenereEnnInneværendeMåned
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.BrevBegrunnelseGrunnlagMedPersoner
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertKompetanse
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertVedtaksperiode
@@ -17,10 +18,10 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriode
 import no.nav.familie.ba.sak.kjerne.brev.domene.totaltUtbetalt
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.EØSBegrunnelseData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.FritekstBegrunnelse
@@ -38,7 +39,8 @@ class BrevPeriodeGenerator(
     private val barnMedReduksjonFraForrigeBehandlingIdent: List<String>,
     private val minimerteKompetanserForPeriode: List<MinimertKompetanse>,
     private val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>,
-    private val barnIBehandling: List<Person>
+    private val ytelserForrigePeriode: List<AndelTilkjentYtelse>,
+    private val barnIBehandling: List<MinimertPerson>
 ) {
 
     fun genererBrevPeriode(): BrevPeriode? {
@@ -115,6 +117,7 @@ class BrevPeriodeGenerator(
             erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
             erUregistrerteBarnPåbehandling = uregistrerteBarn.isNotEmpty(),
             barnMedReduksjonFraForrigeBehandlingIdent = barnMedReduksjonFraForrigeBehandlingIdent,
+            ytelserForrigePeriode = ytelserForrigePeriode,
             barnIBehandling = barnIBehandling
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.common.erSenereEnnInneværendeMåned
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.BrevBegrunnelseGrunnlagMedPersoner
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertKompetanse
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertVedtaksperiode
@@ -21,7 +20,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.EØSBegrunnelseData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.FritekstBegrunnelse
@@ -39,8 +37,7 @@ class BrevPeriodeGenerator(
     private val barnMedReduksjonFraForrigeBehandlingIdent: List<String>,
     private val minimerteKompetanserForPeriode: List<MinimertKompetanse>,
     private val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>,
-    private val ytelserForrigePeriode: List<AndelTilkjentYtelse>,
-    private val barnIBehandling: List<MinimertPerson>
+    private val dødeBarnForrigePeriode: List<String>
 ) {
 
     fun genererBrevPeriode(): BrevPeriode? {
@@ -117,8 +114,7 @@ class BrevPeriodeGenerator(
             erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
             erUregistrerteBarnPåbehandling = uregistrerteBarn.isNotEmpty(),
             barnMedReduksjonFraForrigeBehandlingIdent = barnMedReduksjonFraForrigeBehandlingIdent,
-            ytelserForrigePeriode = ytelserForrigePeriode,
-            barnIBehandling = barnIBehandling
+            dødeBarnForrigePeriode = dødeBarnForrigePeriode
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriode
 import no.nav.familie.ba.sak.kjerne.brev.domene.totaltUtbetalt
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
@@ -36,7 +37,8 @@ class BrevPeriodeGenerator(
     private val minimertVedtaksperiode: MinimertVedtaksperiode,
     private val barnMedReduksjonFraForrigeBehandlingIdent: List<String>,
     private val minimerteKompetanserForPeriode: List<MinimertKompetanse>,
-    private val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>
+    private val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>,
+    private val barnIBehandling: List<Person>
 ) {
 
     fun genererBrevPeriode(): BrevPeriode? {
@@ -113,6 +115,7 @@ class BrevPeriodeGenerator(
             erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
             erUregistrerteBarnPåbehandling = uregistrerteBarn.isNotEmpty(),
             barnMedReduksjonFraForrigeBehandlingIdent = barnMedReduksjonFraForrigeBehandlingIdent,
+            barnIBehandling = barnIBehandling
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -161,7 +161,8 @@ class BrevPeriodeService(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     landkoderISO2 = landkoderISO2
                 )
-            }
+            },
+            barnIBehandling = personopplysningGrunnlag.barna
         )
 
         if (skalLogge) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -27,11 +27,13 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Personopplysning
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.SanityEØSBegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.tilMinimertePersoner
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.erFørsteVedtaksperiodePåFagsak
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.ytelseErFraForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.fpsak.tidsserie.LocalDateSegment
 import no.nav.fpsak.tidsserie.LocalDateTimeline
@@ -125,6 +127,8 @@ class BrevPeriodeService(
             andelerTilkjentYtelse = andelerTilkjentYtelse,
         )
 
+        val ytelserForrigePeriode = andelerTilkjentYtelse.filter { ytelseErFraForrigePeriode(it, utvidetVedtaksperiodeMedBegrunnelse) }
+
         val minimertVedtaksperiode =
             utvidetVedtaksperiodeMedBegrunnelse.tilMinimertVedtaksperiode(
                 sanityBegrunnelser = sanityBegrunnelser,
@@ -162,7 +166,8 @@ class BrevPeriodeService(
                     landkoderISO2 = landkoderISO2
                 )
             },
-            barnIBehandling = personopplysningGrunnlag.barna
+            ytelserForrigePeriode = ytelserForrigePeriode,
+            barnIBehandling = personopplysningGrunnlag.barna.tilMinimertePersoner()
         )
 
         if (skalLogge) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -28,6 +28,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.tilMinimertePersoner
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.dødeBarnForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPersisterService
@@ -129,6 +130,8 @@ class BrevPeriodeService(
 
         val ytelserForrigePeriode = andelerTilkjentYtelse.filter { ytelseErFraForrigePeriode(it, utvidetVedtaksperiodeMedBegrunnelse) }
 
+        val dødeBarnForrigePeriode = dødeBarnForrigePeriode(ytelserForrigePeriode, personopplysningGrunnlag.barna.tilMinimertePersoner())
+
         val minimertVedtaksperiode =
             utvidetVedtaksperiodeMedBegrunnelse.tilMinimertVedtaksperiode(
                 sanityBegrunnelser = sanityBegrunnelser,
@@ -166,8 +169,7 @@ class BrevPeriodeService(
                     landkoderISO2 = landkoderISO2
                 )
             },
-            ytelserForrigePeriode = ytelserForrigePeriode,
-            barnIBehandling = personopplysningGrunnlag.barna.tilMinimertePersoner()
+            dødeBarnForrigePeriode = dødeBarnForrigePeriode
         )
 
         if (skalLogge) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
@@ -2,12 +2,10 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.NullablePeriode
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.delOpp
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 
@@ -24,8 +22,7 @@ data class BegrunnelseMedTriggere(
         erUregistrerteBarnPåbehandling: Boolean,
         barnMedReduksjonFraForrigeBehandlingIdent: List<String>,
         minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>,
-        ytelserForrigePeriode: List<AndelTilkjentYtelse>,
-        barnIBehandling: List<MinimertPerson>
+        dødeBarnForrigePeriode: List<String>
     ): List<BrevBegrunnelseGrunnlagMedPersoner> {
 
         return if (this.standardbegrunnelse.kanDelesOpp) {
@@ -45,8 +42,7 @@ data class BegrunnelseMedTriggere(
                 erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
                 identerMedReduksjonPåPeriode = barnMedReduksjonFraForrigeBehandlingIdent,
                 minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer,
-                ytelserForrigePeriode = ytelserForrigePeriode,
-                barnIBehandling = barnIBehandling
+                dødeBarnForrigePeriode = dødeBarnForrigePeriode
             )
 
             if (

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
@@ -2,11 +2,12 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.NullablePeriode
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnelse
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.delOpp
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 
@@ -23,7 +24,8 @@ data class BegrunnelseMedTriggere(
         erUregistrerteBarnPåbehandling: Boolean,
         barnMedReduksjonFraForrigeBehandlingIdent: List<String>,
         minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>,
-        barnIBehandling: List<Person>
+        ytelserForrigePeriode: List<AndelTilkjentYtelse>,
+        barnIBehandling: List<MinimertPerson>
     ): List<BrevBegrunnelseGrunnlagMedPersoner> {
 
         return if (this.standardbegrunnelse.kanDelesOpp) {
@@ -43,6 +45,7 @@ data class BegrunnelseMedTriggere(
                 erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
                 identerMedReduksjonPåPeriode = barnMedReduksjonFraForrigeBehandlingIdent,
                 minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer,
+                ytelserForrigePeriode = ytelserForrigePeriode,
                 barnIBehandling = barnIBehandling
             )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.NullablePeriode
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnelse
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.delOpp
@@ -22,6 +23,7 @@ data class BegrunnelseMedTriggere(
         erUregistrerteBarnPåbehandling: Boolean,
         barnMedReduksjonFraForrigeBehandlingIdent: List<String>,
         minimerteUtbetalingsperiodeDetaljer: List<MinimertUtbetalingsperiodeDetalj>,
+        barnIBehandling: List<Person>
     ): List<BrevBegrunnelseGrunnlagMedPersoner> {
 
         return if (this.standardbegrunnelse.kanDelesOpp) {
@@ -41,6 +43,7 @@ data class BegrunnelseMedTriggere(
                 erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
                 identerMedReduksjonPåPeriode = barnMedReduksjonFraForrigeBehandlingIdent,
                 minimerteUtbetalingsperiodeDetaljer = minimerteUtbetalingsperiodeDetaljer,
+                barnIBehandling = barnIBehandling
             )
 
             if (

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
 import no.nav.familie.ba.sak.kjerne.brev.BrevPeriodeGenerator
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 
@@ -15,7 +16,8 @@ data class BrevperiodeData(
     val minimertVedtaksperiode: MinimertVedtaksperiode,
     val barnMedReduksjonFraForrigeBehandlingIdent: List<String> = emptyList(),
     val minimerteKompetanserForPeriode: List<MinimertKompetanse>,
-    val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>
+    val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>,
+    val barnIBehandling: List<Person>
 ) : Comparable<BrevperiodeData> {
 
     fun tilBrevPeriodeGenerator() = BrevPeriodeGenerator(
@@ -26,7 +28,8 @@ data class BrevperiodeData(
         minimertVedtaksperiode = minimertVedtaksperiode,
         barnMedReduksjonFraForrigeBehandlingIdent = barnMedReduksjonFraForrigeBehandlingIdent,
         minimerteKompetanserForPeriode = minimerteKompetanserForPeriode,
-        minimerteKompetanserSomStopperRettFørPeriode = minimerteKompetanserSomStopperRettFørPeriode
+        minimerteKompetanserSomStopperRettFørPeriode = minimerteKompetanserSomStopperRettFørPeriode,
+        barnIBehandling = barnIBehandling
     )
 
     fun hentBegrunnelserOgFritekster(): List<Begrunnelse> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
@@ -2,9 +2,10 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.BrevPeriodeGenerator
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 
@@ -17,7 +18,8 @@ data class BrevperiodeData(
     val barnMedReduksjonFraForrigeBehandlingIdent: List<String> = emptyList(),
     val minimerteKompetanserForPeriode: List<MinimertKompetanse>,
     val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>,
-    val barnIBehandling: List<Person>
+    val ytelserForrigePeriode: List<AndelTilkjentYtelse>,
+    val barnIBehandling: List<MinimertPerson>
 ) : Comparable<BrevperiodeData> {
 
     fun tilBrevPeriodeGenerator() = BrevPeriodeGenerator(
@@ -29,6 +31,7 @@ data class BrevperiodeData(
         barnMedReduksjonFraForrigeBehandlingIdent = barnMedReduksjonFraForrigeBehandlingIdent,
         minimerteKompetanserForPeriode = minimerteKompetanserForPeriode,
         minimerteKompetanserSomStopperRettFørPeriode = minimerteKompetanserSomStopperRettFørPeriode,
+        ytelserForrigePeriode = ytelserForrigePeriode,
         barnIBehandling = barnIBehandling
     )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
@@ -2,10 +2,8 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.BrevPeriodeGenerator
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 
@@ -18,8 +16,7 @@ data class BrevperiodeData(
     val barnMedReduksjonFraForrigeBehandlingIdent: List<String> = emptyList(),
     val minimerteKompetanserForPeriode: List<MinimertKompetanse>,
     val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>,
-    val ytelserForrigePeriode: List<AndelTilkjentYtelse>,
-    val barnIBehandling: List<MinimertPerson>
+    val dødeBarnForrigePeriode: List<String>
 ) : Comparable<BrevperiodeData> {
 
     fun tilBrevPeriodeGenerator() = BrevPeriodeGenerator(
@@ -31,8 +28,7 @@ data class BrevperiodeData(
         barnMedReduksjonFraForrigeBehandlingIdent = barnMedReduksjonFraForrigeBehandlingIdent,
         minimerteKompetanserForPeriode = minimerteKompetanserForPeriode,
         minimerteKompetanserSomStopperRettFørPeriode = minimerteKompetanserSomStopperRettFørPeriode,
-        ytelserForrigePeriode = ytelserForrigePeriode,
-        barnIBehandling = barnIBehandling
+        dødeBarnForrigePeriode = dødeBarnForrigePeriode
     )
 
     fun hentBegrunnelserOgFritekster(): List<Begrunnelse> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -34,6 +34,8 @@ data class SanityBegrunnelse(
 )
 
 data class RestSanityBegrunnelse(
+    val _id: String? = "",
+    val _updatedAt: String? = "",
     val apiNavn: String?,
     val navnISystem: String,
     val vilkaar: List<String>? = emptyList(),
@@ -147,6 +149,7 @@ enum class ØvrigTrigger {
     ENDRET_UTBETALING,
     GJELDER_FØRSTE_PERIODE,
     GJELDER_FRA_INNVILGELSESTIDSPUNKT,
+    BARN_DØD
 }
 
 enum class EndretUtbetalingsperiodeTrigger {
@@ -198,7 +201,8 @@ fun SanityBegrunnelse.tilTriggesAv(): TriggesAv {
         endringsaarsaker = this.endringsaarsaker?.toSet() ?: emptySet(),
         småbarnstillegg = this.inneholderUtvidetBarnetrygdTrigger(UtvidetBarnetrygdTrigger.SMÅBARNSTILLEGG),
         gjelderFørstePeriode = this.inneholderØvrigTrigger(ØvrigTrigger.GJELDER_FØRSTE_PERIODE),
-        gjelderFraInnvilgelsestidspunkt = this.inneholderØvrigTrigger(ØvrigTrigger.GJELDER_FRA_INNVILGELSESTIDSPUNKT)
+        gjelderFraInnvilgelsestidspunkt = this.inneholderØvrigTrigger(ØvrigTrigger.GJELDER_FRA_INNVILGELSESTIDSPUNKT),
+        barnDød = this.inneholderØvrigTrigger(ØvrigTrigger.BARN_DØD)
     )
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -34,8 +34,6 @@ data class SanityBegrunnelse(
 )
 
 data class RestSanityBegrunnelse(
-    val _id: String? = "",
-    val _updatedAt: String? = "",
     val apiNavn: String?,
     val navnISystem: String,
     val vilkaar: List<String>? = emptyList(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
@@ -101,27 +101,20 @@ fun Standardbegrunnelse.triggesForPeriode(
 }
 
 private fun barnDødeForrigePeriode(tilkjenteYtelserForrigePeriode: List<AndelTilkjentYtelse>, minimertePersoner: List<MinimertPerson>): Boolean {
-    try {
-        if (tilkjenteYtelserForrigePeriode.isNotEmpty()) {
-            val fom =
-                tilkjenteYtelserForrigePeriode.minOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadFom }
-            val tom =
-                tilkjenteYtelserForrigePeriode.maxOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadTom }
-            return minimertePersoner.any { minimertPerson ->
-                val erDød = minimertPerson.erDød
-                if (erDød) {
-                    val fomFørDødsfall = fom <= minimertPerson.dødsfallsdato!!.toYearMonth()
-                    val tomEtterDødsfall = tom >= minimertPerson.dødsfallsdato.toYearMonth()
-                    return erDød && fomFørDødsfall && tomEtterDødsfall
-                }
-                return false
-            }
+    if (tilkjenteYtelserForrigePeriode.isNotEmpty()) {
+        val fom =
+            tilkjenteYtelserForrigePeriode.minOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadFom }
+        val tom =
+            tilkjenteYtelserForrigePeriode.maxOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadTom }
+        return minimertePersoner.filter { minimertPerson ->
+            minimertPerson.erDød
+        }.any { minimertPerson ->
+            val fomFørDødsfall = fom <= minimertPerson.dødsfallsdato!!.toYearMonth()
+            val tomEtterDødsfall = tom >= minimertPerson.dødsfallsdato.toYearMonth()
+            fomFørDødsfall && tomEtterDødsfall
         }
-        return false
-    } catch (e: NoSuchElementException) {
-        logger.info(e.message)
-        return false
     }
+    return false
 }
 
 private fun erEndretTriggerErOppfylt(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
@@ -103,7 +103,7 @@ fun Standardbegrunnelse.triggesForPeriode(
 fun dødeBarnForrigePeriode(
     ytelserForrigePeriode: List<AndelTilkjentYtelse>,
     barnIBehandling: List<MinimertPerson>
-): List<MinimertPerson> {
+): List<String> {
     return barnIBehandling.filter { barn ->
         val ytelserForrigePeriodeForBarn = ytelserForrigePeriode.filter {
             it.aktør.aktivFødselsnummer() == barn.aktivPersonIdent
@@ -119,7 +119,7 @@ fun dødeBarnForrigePeriode(
             barnDødeForrigePeriode = fomFørDødsfall && tomEtterDødsfall
         }
         barnDødeForrigePeriode
-    }
+    }.map { it.aktivPersonIdent }
 }
 
 private fun erEndretTriggerErOppfylt(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
@@ -104,25 +104,22 @@ fun dødeBarnForrigePeriode(
     ytelserForrigePeriode: List<AndelTilkjentYtelse>,
     barnIBehandling: List<MinimertPerson>
 ): List<MinimertPerson> {
-    if (ytelserForrigePeriode.isNotEmpty()) {
-        return barnIBehandling.filter { barn ->
-            val ytelserForrigePeriodeForBarn = ytelserForrigePeriode.filter {
-                it.aktør.aktivFødselsnummer() == barn.aktivPersonIdent
-            }
-            var barnDødeForrigePeriode = false
-            if (barn.erDød() && ytelserForrigePeriodeForBarn.isNotEmpty()) {
-                val fom =
-                    ytelserForrigePeriodeForBarn.minOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadFom }
-                val tom =
-                    ytelserForrigePeriodeForBarn.maxOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadTom }
-                val fomFørDødsfall = fom <= barn.dødsfallsdato!!.toYearMonth()
-                val tomEtterDødsfall = tom >= barn.dødsfallsdato.toYearMonth()
-                barnDødeForrigePeriode = fomFørDødsfall && tomEtterDødsfall
-            }
-            barnDødeForrigePeriode
+    return barnIBehandling.filter { barn ->
+        val ytelserForrigePeriodeForBarn = ytelserForrigePeriode.filter {
+            it.aktør.aktivFødselsnummer() == barn.aktivPersonIdent
         }
+        var barnDødeForrigePeriode = false
+        if (barn.erDød() && ytelserForrigePeriodeForBarn.isNotEmpty()) {
+            val fom =
+                ytelserForrigePeriodeForBarn.minOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadFom }
+            val tom =
+                ytelserForrigePeriodeForBarn.maxOf { andelTilkjentYtelse: AndelTilkjentYtelse -> andelTilkjentYtelse.stønadTom }
+            val fomFørDødsfall = fom <= barn.dødsfallsdato!!.toYearMonth()
+            val tomEtterDødsfall = tom >= barn.dødsfallsdato.toYearMonth()
+            barnDødeForrigePeriode = fomFørDødsfall && tomEtterDødsfall
+        }
+        barnDødeForrigePeriode
     }
-    return emptyList()
 }
 
 private fun erEndretTriggerErOppfylt(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/TriggesAv.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/TriggesAv.kt
@@ -28,6 +28,7 @@ data class TriggesAv(
     val småbarnstillegg: Boolean = false,
     val gjelderFørstePeriode: Boolean = false,
     val gjelderFraInnvilgelsestidspunkt: Boolean = false,
+    val barnDød: Boolean = false
 ) {
     fun erEndret() = endringsaarsaker.isNotEmpty()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/MinimertPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/MinimertPerson.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene
 
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
@@ -12,9 +13,11 @@ class MinimertPerson(
     val fødselsdato: LocalDate,
     val aktørId: String,
     val aktivPersonIdent: String,
-    val erDød: Boolean,
     val dødsfallsdato: LocalDate?
 ) {
+    val erDød = {
+        dødsfallsdato != null
+    }
     fun hentSeksårsdag(): LocalDate = fødselsdato.plusYears(6)
 
     fun tilMinimertRestPerson() = MinimertRestPerson(
@@ -25,13 +28,15 @@ class MinimertPerson(
 }
 
 fun PersonopplysningGrunnlag.tilMinimertePersoner(): List<MinimertPerson> =
-    this.søkerOgBarn.map {
+    this.søkerOgBarn.tilMinimertePersoner()
+
+fun List<Person>.tilMinimertePersoner(): List<MinimertPerson> =
+    this.map {
         MinimertPerson(
             it.type,
             it.fødselsdato,
             it.aktør.aktørId,
             it.aktør.aktivFødselsnummer(),
-            it.erDød(),
             it.dødsfall?.dødsfallDato
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/MinimertPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/MinimertPerson.kt
@@ -12,6 +12,8 @@ class MinimertPerson(
     val fødselsdato: LocalDate,
     val aktørId: String,
     val aktivPersonIdent: String,
+    val erDød: Boolean,
+    val dødsfallsdato: LocalDate?
 ) {
     fun hentSeksårsdag(): LocalDate = fødselsdato.plusYears(6)
 
@@ -28,7 +30,9 @@ fun PersonopplysningGrunnlag.tilMinimertePersoner(): List<MinimertPerson> =
             it.type,
             it.fødselsdato,
             it.aktør.aktørId,
-            it.aktør.aktivFødselsnummer()
+            it.aktør.aktivFødselsnummer(),
+            it.erDød(),
+            it.dødsfall?.dødsfallDato
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
@@ -262,7 +262,7 @@ fun hentGyldigeStandardbegrunnelserForVedtaksperiode(
         andelerTilkjentYtelse,
         utvidetVedtaksperiodeMedBegrunnelser
     ),
-    ytelserForrigeMåned = andelerTilkjentYtelse.filter { ytelseErFraForrigeMåned(it, utvidetVedtaksperiodeMedBegrunnelser) }
+    ytelserForrigePerioder = andelerTilkjentYtelse.filter { ytelseErFraForrigePeriode(it, utvidetVedtaksperiodeMedBegrunnelser) }
 )
 
 fun hentGyldigeEØSBegrunnelserForPeriode(
@@ -302,7 +302,7 @@ fun hentGyldigeBegrunnelserForVedtaksperiodeMinimert(
     minimerteEndredeUtbetalingAndeler: List<MinimertEndretAndel>,
     erFørsteVedtaksperiodePåFagsak: Boolean,
     ytelserForSøkerForrigeMåned: List<YtelseType>,
-    ytelserForrigeMåned: List<AndelTilkjentYtelse>
+    ytelserForrigePerioder: List<AndelTilkjentYtelse>
 ): List<Standardbegrunnelse> {
     val tillateBegrunnelserForVedtakstype = Standardbegrunnelse.values()
         .filter {
@@ -329,7 +329,7 @@ fun hentGyldigeBegrunnelserForVedtaksperiodeMinimert(
             minimerteEndredeUtbetalingAndeler,
             erFørsteVedtaksperiodePåFagsak,
             ytelserForSøkerForrigeMåned,
-            ytelserForrigeMåned
+            ytelserForrigePerioder
         )
         else -> {
             velgUtbetalingsbegrunnelser(
@@ -342,7 +342,7 @@ fun hentGyldigeBegrunnelserForVedtaksperiodeMinimert(
                 minimerteEndredeUtbetalingAndeler,
                 erFørsteVedtaksperiodePåFagsak,
                 ytelserForSøkerForrigeMåned,
-                ytelserForrigeMåned
+                ytelserForrigePerioder
             )
         }
     }
@@ -358,7 +358,7 @@ private fun velgRedusertBegrunnelser(
     minimerteEndredeUtbetalingAndeler: List<MinimertEndretAndel>,
     erFørsteVedtaksperiodePåFagsak: Boolean,
     ytelserForSøkerForrigeMåned: List<YtelseType>,
-    ytelserForrigeMåned: List<AndelTilkjentYtelse>
+    ytelserForrigePeriode: List<AndelTilkjentYtelse>
 ): List<Standardbegrunnelse> {
     val redusertBegrunnelser = tillateBegrunnelserForVedtakstype.filter {
         it.tilSanityBegrunnelse(sanityBegrunnelser)?.tilTriggesAv()?.gjelderFraInnvilgelsestidspunkt ?: false
@@ -374,7 +374,7 @@ private fun velgRedusertBegrunnelser(
             minimerteEndredeUtbetalingAndeler,
             erFørsteVedtaksperiodePåFagsak,
             ytelserForSøkerForrigeMåned,
-            ytelserForrigeMåned
+            ytelserForrigePeriode
         )
         return redusertBegrunnelser + utbetalingsbegrunnelser
     }
@@ -391,7 +391,7 @@ private fun velgUtbetalingsbegrunnelser(
     minimerteEndredeUtbetalingAndeler: List<MinimertEndretAndel>,
     erFørsteVedtaksperiodePåFagsak: Boolean,
     ytelserForSøkerForrigeMåned: List<YtelseType>,
-    ytelserForrigeMåned: List<AndelTilkjentYtelse>
+    ytelserForrigePeriode: List<AndelTilkjentYtelse>
 ): List<Standardbegrunnelse> {
     val standardbegrunnelser: MutableSet<Standardbegrunnelse> =
         tillateBegrunnelserForVedtakstype
@@ -407,7 +407,7 @@ private fun velgUtbetalingsbegrunnelser(
                         sanityBegrunnelser = sanityBegrunnelser,
                         erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
                         ytelserForSøkerForrigeMåned = ytelserForSøkerForrigeMåned,
-                        ytelserForrigeMåned = ytelserForrigeMåned
+                        ytelserForrigePeriode = ytelserForrigePeriode
                     )
                 ) {
                     acc.add(standardBegrunnelse)
@@ -433,7 +433,7 @@ fun hentYtelserForSøkerForrigeMåned(
     utvidetVedtaksperiodeMedBegrunnelser: UtvidetVedtaksperiodeMedBegrunnelser
 ) = andelerTilkjentYtelse.filter {
     it.type.erKnyttetTilSøker() &&
-        ytelseErFraForrigeMåned(it, utvidetVedtaksperiodeMedBegrunnelser)
+        ytelseErFraForrigePeriode(it, utvidetVedtaksperiodeMedBegrunnelser)
 }.map { it.type }
 
-fun ytelseErFraForrigeMåned(ytelse: AndelTilkjentYtelse, utvidetVedtaksperiodeMedBegrunnelser: UtvidetVedtaksperiodeMedBegrunnelser) = ytelse.stønadTom.sisteDagIInneværendeMåned().erDagenFør(utvidetVedtaksperiodeMedBegrunnelser.fom)
+fun ytelseErFraForrigePeriode(ytelse: AndelTilkjentYtelse, utvidetVedtaksperiodeMedBegrunnelser: UtvidetVedtaksperiodeMedBegrunnelser) = ytelse.stønadTom.sisteDagIInneværendeMåned().erDagenFør(utvidetVedtaksperiodeMedBegrunnelser.fom)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.lagVertikaleSegmenter
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertEndretAndel
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertRestPersonResultat
@@ -300,7 +299,7 @@ fun hentGyldigeBegrunnelserForVedtaksperiodeMinimert(
     aktørIderMedUtbetaling: List<String>,
     minimerteEndredeUtbetalingAndeler: List<MinimertEndretAndel>,
     erFørsteVedtaksperiodePåFagsak: Boolean,
-    ytelserForSøkerForrigeMåned: List<YtelseType>
+    ytelserForSøkerForrigeMåned: List<AndelTilkjentYtelse>
 ): List<Standardbegrunnelse> {
     val tillateBegrunnelserForVedtakstype = Standardbegrunnelse.values()
         .filter {
@@ -353,7 +352,7 @@ private fun velgRedusertBegrunnelser(
     aktørIderMedUtbetaling: List<String>,
     minimerteEndredeUtbetalingAndeler: List<MinimertEndretAndel>,
     erFørsteVedtaksperiodePåFagsak: Boolean,
-    ytelserForSøkerForrigeMåned: List<YtelseType>,
+    ytelserForSøkerForrigeMåned: List<AndelTilkjentYtelse>,
 ): List<Standardbegrunnelse> {
     val redusertBegrunnelser = tillateBegrunnelserForVedtakstype.filter {
         it.tilSanityBegrunnelse(sanityBegrunnelser)?.tilTriggesAv()?.gjelderFraInnvilgelsestidspunkt ?: false
@@ -384,7 +383,7 @@ private fun velgUtbetalingsbegrunnelser(
     aktørIderMedUtbetaling: List<String>,
     minimerteEndredeUtbetalingAndeler: List<MinimertEndretAndel>,
     erFørsteVedtaksperiodePåFagsak: Boolean,
-    ytelserForSøkerForrigeMåned: List<YtelseType>,
+    ytelserForSøkerForrigeMåned: List<AndelTilkjentYtelse>,
 ): List<Standardbegrunnelse> {
     val standardbegrunnelser: MutableSet<Standardbegrunnelse> =
         tillateBegrunnelserForVedtakstype
@@ -427,4 +426,4 @@ fun hentYtelserForSøkerForrigeMåned(
     it.type.erKnyttetTilSøker() &&
         it.stønadTom.sisteDagIInneværendeMåned()
             .erDagenFør(utvidetVedtaksperiodeMedBegrunnelser.fom)
-}.map { it.type }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -53,7 +53,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagSe
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.bostedsadresse.GrMatrikkeladresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.domene.PersonIdent
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.sivilstand.GrSivilstand
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.GrStatsborgerskap
 import no.nav.familie.ba.sak.kjerne.personident.Aktør

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -43,6 +43,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Dødsfall
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
@@ -52,6 +53,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagSe
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.bostedsadresse.GrMatrikkeladresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.domene.PersonIdent
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.sivilstand.GrSivilstand
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.GrStatsborgerskap
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -993,14 +995,16 @@ fun lagPerson(
     type: PersonType = PersonType.SØKER,
     personopplysningGrunnlag: PersonopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 0),
     fødselsdato: LocalDate = LocalDate.now().minusYears(19),
-    kjønn: Kjønn = Kjønn.KVINNE
+    kjønn: Kjønn = Kjønn.KVINNE,
+    dødsfall: Dødsfall? = null
 ) = Person(
     aktør = aktør,
     type = type,
     personopplysningGrunnlag = personopplysningGrunnlag,
     fødselsdato = fødselsdato,
     navn = type.name,
-    kjønn = kjønn
+    kjønn = kjønn,
+    dødsfall = dødsfall
 )
 
 fun lagRestSanityBegrunnelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -514,7 +514,6 @@ class ClientMocks {
                     )
                 ),
                 kjønn = Kjønn.MANN,
-                dødsfall = DødsfallData(true, "2022-06-25"),
                 navn = "Gutten Barnesen"
             ),
             barnFnr[1] to PersonInfo(
@@ -569,7 +568,6 @@ fun mockHentPersoninfoForMedIdenter(
         fødselsdato = LocalDate.of(2018, 5, 1),
         kjønn = Kjønn.KVINNE,
         navn = "Barn Barnesen",
-        dødsfall = DødsfallData(true, "2022-06-25"),
         sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8)))
     )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonExcep
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.VergeResponse
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.DødsfallData
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjonMaskert
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
@@ -28,7 +27,6 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutoma
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandlingAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandlingFnr
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.Personident
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
@@ -515,7 +513,6 @@ class ClientMocks {
                     )
                 ),
                 kjønn = Kjønn.MANN,
-                dødsfall = DødsfallData(true, "2022-06-25"),
                 navn = "Gutten Barnesen"
             ),
             barnFnr[1] to PersonInfo(
@@ -528,7 +525,6 @@ class ClientMocks {
                     )
                 ),
                 kjønn = Kjønn.KVINNE,
-                dødsfall = DødsfallData(true, "2022-04-25"),
                 navn = "Jenta Barnesen",
                 adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.FORTROLIG
             ),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -569,7 +569,7 @@ fun mockHentPersoninfoForMedIdenter(
         fødselsdato = LocalDate.of(2018, 5, 1),
         kjønn = Kjønn.KVINNE,
         navn = "Barn Barnesen",
-        dødsfall = DødsfallData(true, "25.06.2022"),
+        dødsfall = DødsfallData(true, "2022-06-25"),
         sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8)))
     )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonExcep
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.VergeResponse
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.DødsfallData
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjonMaskert
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
@@ -513,6 +514,7 @@ class ClientMocks {
                     )
                 ),
                 kjønn = Kjønn.MANN,
+                dødsfall = DødsfallData(true, "2022-06-25"),
                 navn = "Gutten Barnesen"
             ),
             barnFnr[1] to PersonInfo(
@@ -567,6 +569,7 @@ fun mockHentPersoninfoForMedIdenter(
         fødselsdato = LocalDate.of(2018, 5, 1),
         kjønn = Kjønn.KVINNE,
         navn = "Barn Barnesen",
+        dødsfall = DødsfallData(true, "25.06.2022"),
         sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8)))
     )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonExcep
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.VergeResponse
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.DødsfallData
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjonMaskert
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
@@ -27,6 +28,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutoma
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandlingAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandlingFnr
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.Personident
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
@@ -513,6 +515,7 @@ class ClientMocks {
                     )
                 ),
                 kjønn = Kjønn.MANN,
+                dødsfall = DødsfallData(true, "2022-06-25"),
                 navn = "Gutten Barnesen"
             ),
             barnFnr[1] to PersonInfo(
@@ -525,6 +528,7 @@ class ClientMocks {
                     )
                 ),
                 kjønn = Kjønn.KVINNE,
+                dødsfall = DødsfallData(true, "2022-04-25"),
                 navn = "Jenta Barnesen",
                 adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.FORTROLIG
             ),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonExcep
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.VergeResponse
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.DødsfallData
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjonMaskert
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/behandling/kjørRevurdering.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/behandling/kjørRevurdering.kt
@@ -36,6 +36,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilUtvidetVedta
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.erFørsteVedtaksperiodePåFagsak
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.hentGyldigeBegrunnelserForVedtaksperiodeMinimert
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.hentYtelserForSøkerForrigeMåned
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.ytelseErFraForrigeMåned
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.task.DistribuerDokumentDTO
@@ -377,7 +378,8 @@ fun leggTilAlleGyldigeBegrunnelserPåVedtaksperiodeIBehandling(
         ytelserForSøkerForrigeMåned = hentYtelserForSøkerForrigeMåned(
             andelerTilkjentYtelse,
             utvidetVedtaksperiodeMedBegrunnelser
-        )
+        ),
+        ytelserForrigeMåned = andelerTilkjentYtelse.filter { ytelseErFraForrigeMåned(it, utvidetVedtaksperiodeMedBegrunnelser) }
     )
 
     vedtaksperiodeService.oppdaterVedtaksperiodeMedStandardbegrunnelser(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/behandling/kjørRevurdering.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/behandling/kjørRevurdering.kt
@@ -36,7 +36,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilUtvidetVedta
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.erFørsteVedtaksperiodePåFagsak
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.hentGyldigeBegrunnelserForVedtaksperiodeMinimert
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.hentYtelserForSøkerForrigeMåned
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.ytelseErFraForrigeMåned
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.ytelseErFraForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.task.DistribuerDokumentDTO
@@ -379,7 +379,7 @@ fun leggTilAlleGyldigeBegrunnelserPåVedtaksperiodeIBehandling(
             andelerTilkjentYtelse,
             utvidetVedtaksperiodeMedBegrunnelser
         ),
-        ytelserForrigeMåned = andelerTilkjentYtelse.filter { ytelseErFraForrigeMåned(it, utvidetVedtaksperiodeMedBegrunnelser) }
+        ytelserForrigePerioder = andelerTilkjentYtelse.filter { ytelseErFraForrigePeriode(it, utvidetVedtaksperiodeMedBegrunnelser) }
     )
 
     vedtaksperiodeService.oppdaterVedtaksperiodeMedStandardbegrunnelser(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/brev/MinimertPerson.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/brev/MinimertPerson.kt
@@ -11,9 +11,13 @@ fun lagMinimertPerson(
     fødselsdato: LocalDate = LocalDate.now().minusYears(if (type == PersonType.BARN) 2 else 30),
     aktivPersonIdent: String = randomFnr(),
     aktørId: String = randomAktørId(aktivPersonIdent).aktørId,
+    erDød: Boolean = false,
+    dødsfallsdato: LocalDate? = null
 ) = MinimertPerson(
     type = type,
     fødselsdato = fødselsdato,
     aktivPersonIdent = aktivPersonIdent,
-    aktørId = aktørId
+    aktørId = aktørId,
+    erDød = erDød,
+    dødsfallsdato = dødsfallsdato
 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/brev/MinimertPerson.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/brev/MinimertPerson.kt
@@ -11,13 +11,11 @@ fun lagMinimertPerson(
     fødselsdato: LocalDate = LocalDate.now().minusYears(if (type == PersonType.BARN) 2 else 30),
     aktivPersonIdent: String = randomFnr(),
     aktørId: String = randomAktørId(aktivPersonIdent).aktørId,
-    erDød: Boolean = false,
     dødsfallsdato: LocalDate? = null
 ) = MinimertPerson(
     type = type,
     fødselsdato = fødselsdato,
     aktivPersonIdent = aktivPersonIdent,
     aktørId = aktørId,
-    erDød = erDød,
     dødsfallsdato = dødsfallsdato
 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevBegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevBegrunnelseTest.kt
@@ -41,6 +41,7 @@ class BrevBegrunnelseTest {
                     minimerteEndredeUtbetalingAndeler = brevBegrunnelserTestConfig.hentEndretUtbetalingAndeler(),
                     erFørsteVedtaksperiodePåFagsak = brevBegrunnelserTestConfig.erFørsteVedtaksperiodePåFagsak,
                     ytelserForSøkerForrigeMåned = brevBegrunnelserTestConfig.ytelserForSøkerForrigeMåned,
+                    ytelserForrigeMåned = emptyList()
                 )
             } catch (e: Exception) {
                 testReporter.publishEntry(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevBegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevBegrunnelseTest.kt
@@ -41,7 +41,7 @@ class BrevBegrunnelseTest {
                     minimerteEndredeUtbetalingAndeler = brevBegrunnelserTestConfig.hentEndretUtbetalingAndeler(),
                     erFørsteVedtaksperiodePåFagsak = brevBegrunnelserTestConfig.erFørsteVedtaksperiodePåFagsak,
                     ytelserForSøkerForrigeMåned = brevBegrunnelserTestConfig.ytelserForSøkerForrigeMåned,
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePerioder = emptyList()
                 )
             } catch (e: Exception) {
                 testReporter.publishEntry(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.SøkersAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagKompetanse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.dødeBarnForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -111,7 +112,6 @@ private fun lagBrevperiodeData(fom: LocalDate?, tom: LocalDate?, type: Vedtakspe
         uregistrerteBarn = emptyList(),
         minimerteKompetanserForPeriode = emptyList(),
         minimerteKompetanserSomStopperRettFørPeriode = emptyList(),
-        ytelserForrigePeriode = emptyList(),
-        barnIBehandling = emptyList()
+        dødeBarnForrigePeriode = emptyList()
     )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
@@ -110,6 +110,7 @@ private fun lagBrevperiodeData(fom: LocalDate?, tom: LocalDate?, type: Vedtakspe
         ),
         uregistrerteBarn = emptyList(),
         minimerteKompetanserForPeriode = emptyList(),
-        minimerteKompetanserSomStopperRettFørPeriode = emptyList()
+        minimerteKompetanserSomStopperRettFørPeriode = emptyList(),
+        barnIBehandling = emptyList()
     )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
@@ -111,6 +111,7 @@ private fun lagBrevperiodeData(fom: LocalDate?, tom: LocalDate?, type: Vedtakspe
         uregistrerteBarn = emptyList(),
         minimerteKompetanserForPeriode = emptyList(),
         minimerteKompetanserSomStopperRettFørPeriode = emptyList(),
+        ytelserForrigePeriode = emptyList(),
         barnIBehandling = emptyList()
     )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
@@ -86,6 +86,7 @@ class BrevperiodeTest {
                             behandlingsresultatPersonTestConfig.personerPåBehandling
                         )
                     } ?: emptyList(),
+                    ytelserForrigePeriode = emptyList(),
                     barnIBehandling = emptyList()
                 ).genererBrevPeriode()
             } catch (e: Exception) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
@@ -85,7 +85,8 @@ class BrevperiodeTest {
                         it.tilMinimertKompetanse(
                             behandlingsresultatPersonTestConfig.personerPåBehandling
                         )
-                    } ?: emptyList()
+                    } ?: emptyList(),
+                    barnIBehandling = emptyList()
                 ).genererBrevPeriode()
             } catch (e: Exception) {
                 testReporter.publishEntry(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
@@ -86,8 +86,7 @@ class BrevperiodeTest {
                             behandlingsresultatPersonTestConfig.personerPåBehandling
                         )
                     } ?: emptyList(),
-                    ytelserForrigePeriode = emptyList(),
-                    barnIBehandling = emptyList()
+                    dødeBarnForrigePeriode = emptyList()
                 ).genererBrevPeriode()
             } catch (e: Exception) {
                 testReporter.publishEntry(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
@@ -23,7 +24,7 @@ data class BrevBegrunnelserTestConfig(
     val vedtaksperiodetype: Vedtaksperiodetype,
 
     // Brukes for å se om det er en reduksjon i småbarnstillegg eller utvidet
-    val ytelserForSøkerForrigeMåned: List<YtelseType>,
+    val ytelserForSøkerForrigeMåned: List<AndelTilkjentYtelse>,
 
     val ytelserForBarnOgSøkerIPeriode: List<YtelseType>,
     val erFørsteVedtaksperiodePåFagsak: Boolean,
@@ -53,12 +54,16 @@ data class BrevbegrunnelserTestPerson(
     val overstyrteVilkårresultater: List<MinimertVilkårResultat>,
     val andreVurderinger: List<MinimertAnnenVurdering>,
     val endredeUtbetalinger: List<EndretUtbetalingAndelPåPerson>,
+    val erDød: Boolean = false,
+    val dødsfalldato: LocalDate? = null
 ) {
     fun tilMinimertPerson() = MinimertPerson(
         aktivPersonIdent = this.personIdent,
         aktørId = this.aktørId,
         type = this.type,
         fødselsdato = this.fødselsdato,
+        erDød = this.erDød,
+        dødsfallsdato = this.dødsfalldato
     )
 
     fun tilMinimerteEndredeUtbetalingAndeler() =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
@@ -24,7 +24,7 @@ data class BrevBegrunnelserTestConfig(
     val vedtaksperiodetype: Vedtaksperiodetype,
 
     // Brukes for å se om det er en reduksjon i småbarnstillegg eller utvidet
-    val ytelserForSøkerForrigeMåned: List<AndelTilkjentYtelse>,
+    val ytelserForSøkerForrigeMåned: List<YtelseType>,
 
     val ytelserForBarnOgSøkerIPeriode: List<YtelseType>,
     val erFørsteVedtaksperiodePåFagsak: Boolean,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
@@ -61,7 +61,6 @@ data class BrevbegrunnelserTestPerson(
         aktørId = this.aktørId,
         type = this.type,
         fødselsdato = this.fødselsdato,
-        erDød = this.erDød,
         dødsfallsdato = this.dødsfalldato
     )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 import no.nav.familie.ba.sak.common.randomAktørId
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -435,7 +435,7 @@ internal class StandardbegrunnelseTest {
         )
         assertEquals(
             barn1Fnr,
-            dødeBarnForrigePeriode[0].aktivPersonIdent
+            dødeBarnForrigePeriode[0]
         )
 
         ytelserForrigePeriode = listOf(
@@ -449,7 +449,7 @@ internal class StandardbegrunnelseTest {
         )
         assertEquals(
             barn2Fnr,
-            dødeBarnForrigePeriode[0].aktivPersonIdent
+            dødeBarnForrigePeriode[0]
         )
 
         // Barn1 og Barn2 dør i samme måned
@@ -471,7 +471,7 @@ internal class StandardbegrunnelseTest {
             dødeBarnForrigePeriode.size
         )
         assertTrue(
-            dødeBarnForrigePeriode.containsAll(barnIBehandling)
+            dødeBarnForrigePeriode.containsAll(barnIBehandling.map { it.aktivPersonIdent })
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -12,8 +12,6 @@ import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.dataGenerator.brev.lagMinimertPerson
 import no.nav.familie.ba.sak.integrasjoner.sanity.hentBegrunnelser
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertEndretUtbetalingAndel

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.dataGenerator.brev.lagMinimertPerson
 import no.nav.familie.ba.sak.integrasjoner.sanity.hentBegrunnelser
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertEndretUtbetalingAndel
@@ -65,6 +66,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -82,6 +84,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -99,6 +102,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -122,6 +126,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -145,6 +150,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -168,6 +174,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -187,6 +194,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -206,6 +214,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -239,6 +248,7 @@ internal class StandardbegrunnelseTest {
                     ).map { it.tilMinimertEndretUtbetalingAndel() },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -272,6 +282,7 @@ internal class StandardbegrunnelseTest {
                     ).map { it.tilMinimertEndretUtbetalingAndel() },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = emptyList()
                 )
         )
     }
@@ -332,7 +343,7 @@ internal class StandardbegrunnelseTest {
 
         val reduksjonBarnDødBegrunnelse = listOf(SanityBegrunnelse(apiNavn = "reduksjonBarnDod", navnISystem = "barnDød", ovrigeTriggere = listOf(ØvrigTrigger.BARN_DØD)))
 
-        val ytelserForSøkerForrigePeriode = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(LocalDate.now().minusMonths(1).year, LocalDate.now().minusMonths(1).month), tom = YearMonth.of(LocalDate.now().year, LocalDate.now().month)))
+        val ytelserForrigeMåned = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(LocalDate.now().minusMonths(1).year, LocalDate.now().minusMonths(1).month), tom = YearMonth.of(LocalDate.now().year, LocalDate.now().month)))
 
         assertTrue(
             Standardbegrunnelse.REDUKSJON_BARN_DØD
@@ -344,7 +355,8 @@ internal class StandardbegrunnelseTest {
                     minimertePersoner = personopplysningGrunnlag.tilMinimertePersoner(),
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
-                    ytelserForSøkerForrigeMåned = ytelserForSøkerForrigePeriode,
+                    ytelserForSøkerForrigeMåned = emptyList(),
+                    ytelserForrigeMåned = ytelserForrigeMåned
                 )
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -64,7 +64,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -82,7 +82,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -100,7 +100,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -124,7 +124,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -148,7 +148,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -172,7 +172,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -192,7 +192,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -212,7 +212,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -246,7 +246,7 @@ internal class StandardbegrunnelseTest {
                     ).map { it.tilMinimertEndretUtbetalingAndel() },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -280,7 +280,7 @@ internal class StandardbegrunnelseTest {
                     ).map { it.tilMinimertEndretUtbetalingAndel() },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = emptyList()
+                    ytelserForrigePeriode = emptyList()
                 )
         )
     }
@@ -353,7 +353,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = ytelserForrigeMåned
+                    ytelserForrigePeriode = ytelserForrigeMåned
                 )
         )
     }
@@ -379,7 +379,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = ytelserForrigeMåned
+                    ytelserForrigePeriode = ytelserForrigeMåned
                 )
         )
     }
@@ -405,7 +405,7 @@ internal class StandardbegrunnelseTest {
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
-                    ytelserForrigeMåned = ytelserForrigeMåned
+                    ytelserForrigePeriode = ytelserForrigeMåned
                 )
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -21,6 +21,8 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.domene.PersonIdent
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.personident.Personident
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.tilMinimertVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.tilMinimertePersoner
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
@@ -335,13 +337,14 @@ internal class StandardbegrunnelseTest {
 
     @Test
     fun `Dersom dødsfalldato ligger i forrige ytelse-periode skal begrunnelsen begrunnelser med trigger BARN_DØD trigges`() {
-        val dødtBarn = lagPerson(personIdent = PersonIdent("12345678910"), type = PersonType.BARN)
+        val fnr = "12345678910"
+        val dødtBarn = lagPerson(personIdent = PersonIdent(fnr), type = PersonType.BARN)
         dødtBarn.dødsfall = lagDødsfall(dødtBarn, dødsfallDatoFraPdl = LocalDate.now().minusMonths(1).withDayOfMonth(15).toString(), dødsfallAdresseFraPdl = null)
         val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, dødtBarn)
 
         val reduksjonBarnDødBegrunnelse = listOf(SanityBegrunnelse(apiNavn = "reduksjonBarnDod", navnISystem = "barnDød", ovrigeTriggere = listOf(ØvrigTrigger.BARN_DØD)))
 
-        val ytelserForrigeMåned = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(LocalDate.now().minusMonths(1).year, LocalDate.now().minusMonths(1).month), tom = YearMonth.of(LocalDate.now().year, LocalDate.now().month)))
+        val ytelserForrigeMåned = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(LocalDate.now().minusMonths(1).year, LocalDate.now().minusMonths(1).month), tom = YearMonth.of(LocalDate.now().year, LocalDate.now().month), aktør = Aktør(fnr + "00").also { it.personidenter.add(Personident(fnr, it)) }))
 
         assertTrue(
             Standardbegrunnelse.REDUKSJON_BARN_DØD
@@ -360,14 +363,15 @@ internal class StandardbegrunnelseTest {
 
     @Test
     fun `Dersom dødsfalldato ligger etter en ytelse-periode skal ikke begrunnelser med trigger BARN_DØD trigges`() {
-        val dødtBarn = lagPerson(personIdent = PersonIdent("12345678910"), type = PersonType.BARN)
+        val fnr = "12345678910"
+        val dødtBarn = lagPerson(personIdent = PersonIdent(fnr), type = PersonType.BARN)
         val dødsfallDato = LocalDate.now().minusMonths(1).withDayOfMonth(15)
         dødtBarn.dødsfall = lagDødsfall(dødtBarn, dødsfallDatoFraPdl = dødsfallDato.toString(), dødsfallAdresseFraPdl = null)
         val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, dødtBarn)
 
         val reduksjonBarnDødBegrunnelse = listOf(SanityBegrunnelse(apiNavn = "reduksjonBarnDod", navnISystem = "barnDød", ovrigeTriggere = listOf(ØvrigTrigger.BARN_DØD)))
 
-        val ytelserForrigeMåned = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(dødsfallDato.minusMonths(5).year, dødsfallDato.minusMonths(5).month), tom = YearMonth.of(dødsfallDato.minusMonths(1).year, dødsfallDato.minusMonths(1).month)))
+        val ytelserForrigeMåned = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(dødsfallDato.minusMonths(5).year, dødsfallDato.minusMonths(5).month), tom = YearMonth.of(dødsfallDato.minusMonths(1).year, dødsfallDato.minusMonths(1).month), aktør = Aktør(fnr + "00").also { it.personidenter.add(Personident(fnr, it)) }))
 
         assertFalse(
             Standardbegrunnelse.REDUKSJON_BARN_DØD
@@ -386,14 +390,15 @@ internal class StandardbegrunnelseTest {
 
     @Test
     fun `Dersom dødsfalldato ligger før en ytelse-periode skal ikke begrunnelser med trigger BARN_DØD trigges`() {
-        val dødtBarn = lagPerson(personIdent = PersonIdent("12345678910"), type = PersonType.BARN)
+        val fnr = "12345678910"
+        val dødtBarn = lagPerson(personIdent = PersonIdent(fnr), type = PersonType.BARN)
         val dødsfallDato = LocalDate.now().minusMonths(1).withDayOfMonth(15)
         dødtBarn.dødsfall = lagDødsfall(dødtBarn, dødsfallDatoFraPdl = dødsfallDato.toString(), dødsfallAdresseFraPdl = null)
         val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, dødtBarn)
 
         val reduksjonBarnDødBegrunnelse = listOf(SanityBegrunnelse(apiNavn = "reduksjonBarnDod", navnISystem = "barnDød", ovrigeTriggere = listOf(ØvrigTrigger.BARN_DØD)))
 
-        val ytelserForrigeMåned = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(dødsfallDato.plusMonths(5).year, dødsfallDato.plusMonths(5).month), tom = YearMonth.of(dødsfallDato.plusMonths(6).year, dødsfallDato.plusMonths(6).month)))
+        val ytelserForrigeMåned = listOf(lagAndelTilkjentYtelse(fom = YearMonth.of(dødsfallDato.plusMonths(5).year, dødsfallDato.plusMonths(5).month), tom = YearMonth.of(dødsfallDato.plusMonths(6).year, dødsfallDato.plusMonths(6).month), aktør = Aktør(fnr + "00").also { it.personidenter.add(Personident(fnr, it)) }))
 
         assertFalse(
             Standardbegrunnelse.REDUKSJON_BARN_DØD
@@ -407,6 +412,66 @@ internal class StandardbegrunnelseTest {
                     ytelserForSøkerForrigeMåned = emptyList(),
                     ytelserForrigePeriode = ytelserForrigeMåned
                 )
+        )
+    }
+
+    @Test
+    fun `dødeBarnForrigePeriode() skal returnere barn som døde i forrige periode og som er tilknyttet ytelsen`() {
+        val barn1Fnr = "12345678910"
+        val barn2Fnr = "12345678911"
+
+        // Barn1 dør før Barn2.
+        var dødsfallDatoBarn1 = LocalDate.of(2022, 5, 12)
+        var dødsfallDatoBarn2 = LocalDate.of(2022, 7, 2)
+        var barnIBehandling = listOf(lagMinimertPerson(dødsfallsdato = dødsfallDatoBarn1, aktivPersonIdent = barn1Fnr), lagMinimertPerson(dødsfallsdato = dødsfallDatoBarn2, aktivPersonIdent = barn2Fnr))
+        var ytelserForrigePeriode = listOf(
+            lagAndelTilkjentYtelse(fom = YearMonth.of(dødsfallDatoBarn1.minusMonths(1).year, dødsfallDatoBarn1.minusMonths(1).month), tom = YearMonth.of(dødsfallDatoBarn1.year, dødsfallDatoBarn1.month), aktør = Aktør(barn1Fnr + "00").also { it.personidenter.add(Personident(barn1Fnr, it)) }),
+        )
+
+        var dødeBarnForrigePeriode = dødeBarnForrigePeriode(ytelserForrigePeriode, barnIBehandling)
+        assertEquals(
+            1,
+            dødeBarnForrigePeriode.size
+        )
+        assertEquals(
+            barn1Fnr,
+            dødeBarnForrigePeriode[0].aktivPersonIdent
+        )
+
+        ytelserForrigePeriode = listOf(
+            lagAndelTilkjentYtelse(fom = YearMonth.of(dødsfallDatoBarn1.minusMonths(1).year, dødsfallDatoBarn1.minusMonths(1).month), tom = YearMonth.of(dødsfallDatoBarn2.year, dødsfallDatoBarn2.month), aktør = Aktør(barn2Fnr + "00").also { it.personidenter.add(Personident(barn2Fnr, it)) }),
+        )
+
+        dødeBarnForrigePeriode = dødeBarnForrigePeriode(ytelserForrigePeriode, barnIBehandling)
+        assertEquals(
+            1,
+            dødeBarnForrigePeriode.size
+        )
+        assertEquals(
+            barn2Fnr,
+            dødeBarnForrigePeriode[0].aktivPersonIdent
+        )
+
+        // Barn1 og Barn2 dør i samme måned
+        dødsfallDatoBarn1 = LocalDate.of(2022, 5, 12)
+        dødsfallDatoBarn2 = LocalDate.of(2022, 5, 2)
+
+        barnIBehandling = listOf(lagMinimertPerson(dødsfallsdato = dødsfallDatoBarn1, aktivPersonIdent = barn1Fnr), lagMinimertPerson(dødsfallsdato = dødsfallDatoBarn2, aktivPersonIdent = barn2Fnr))
+
+        ytelserForrigePeriode = listOf(
+            lagAndelTilkjentYtelse(fom = YearMonth.of(dødsfallDatoBarn1.minusMonths(1).year, dødsfallDatoBarn1.minusMonths(1).month), tom = YearMonth.of(dødsfallDatoBarn1.year, dødsfallDatoBarn1.month), aktør = Aktør(barn1Fnr + "00").also { it.personidenter.add(Personident(barn1Fnr, it)) }),
+            lagAndelTilkjentYtelse(
+                fom = YearMonth.of(dødsfallDatoBarn2.minusMonths(1).year, dødsfallDatoBarn2.minusMonths(1).month), tom = YearMonth.of(dødsfallDatoBarn2.year, dødsfallDatoBarn2.month), aktør = Aktør(barn2Fnr + "00").also { it.personidenter.add(Personident(barn2Fnr, it)) }
+            )
+        )
+
+        dødeBarnForrigePeriode = dødeBarnForrigePeriode(ytelserForrigePeriode, barnIBehandling)
+        assertEquals(
+            2,
+            dødeBarnForrigePeriode.size
+        )
+        assertTrue(
+            dødeBarnForrigePeriode.containsAll(barnIBehandling)
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -54,6 +54,7 @@ class VedtaksperiodeServiceUtilsTest {
             identerMedUtbetalingPåPeriode = identerMedUtbetaling,
             erFørsteVedtaksperiodePåFagsak = false,
             minimerteUtbetalingsperiodeDetaljer = listOf(),
+            ytelserForrigePeriode = emptyList(),
             barnIBehandling = emptyList()
         )
 
@@ -107,6 +108,7 @@ class VedtaksperiodeServiceUtilsTest {
             identerMedUtbetalingPåPeriode = identerMedUtbetaling,
             erFørsteVedtaksperiodePåFagsak = false,
             minimerteUtbetalingsperiodeDetaljer = listOf(),
+            ytelserForrigePeriode = emptyList(),
             barnIBehandling = emptyList()
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnels
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.dødeBarnForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.periodeErOppyltForYtelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilMinimertPerson
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -54,8 +55,7 @@ class VedtaksperiodeServiceUtilsTest {
             identerMedUtbetalingPåPeriode = identerMedUtbetaling,
             erFørsteVedtaksperiodePåFagsak = false,
             minimerteUtbetalingsperiodeDetaljer = listOf(),
-            ytelserForrigePeriode = emptyList(),
-            barnIBehandling = emptyList()
+            dødeBarnForrigePeriode = emptyList()
         )
 
         Assertions.assertEquals(
@@ -108,8 +108,7 @@ class VedtaksperiodeServiceUtilsTest {
             identerMedUtbetalingPåPeriode = identerMedUtbetaling,
             erFørsteVedtaksperiodePåFagsak = false,
             minimerteUtbetalingsperiodeDetaljer = listOf(),
-            ytelserForrigePeriode = emptyList(),
-            barnIBehandling = emptyList()
+            dødeBarnForrigePeriode = emptyList()
         )
 
         Assertions.assertEquals(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 
 import no.nav.familie.ba.sak.common.NullablePeriode
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.common.lagPerson
@@ -22,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.YearMonth
 
 class VedtaksperiodeServiceUtilsTest {
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 
 import no.nav.familie.ba.sak.common.NullablePeriode
-import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.common.lagPerson
@@ -23,7 +22,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.YearMonth
 
 class VedtaksperiodeServiceUtilsTest {
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -53,7 +53,8 @@ class VedtaksperiodeServiceUtilsTest {
             ),
             identerMedUtbetalingPåPeriode = identerMedUtbetaling,
             erFørsteVedtaksperiodePåFagsak = false,
-            minimerteUtbetalingsperiodeDetaljer = listOf()
+            minimerteUtbetalingsperiodeDetaljer = listOf(),
+            barnIBehandling = emptyList()
         )
 
         Assertions.assertEquals(
@@ -105,7 +106,8 @@ class VedtaksperiodeServiceUtilsTest {
             ),
             identerMedUtbetalingPåPeriode = identerMedUtbetaling,
             erFørsteVedtaksperiodePåFagsak = false,
-            minimerteUtbetalingsperiodeDetaljer = listOf()
+            minimerteUtbetalingsperiodeDetaljer = listOf(),
+            barnIBehandling = emptyList()
         )
 
         Assertions.assertEquals(


### PR DESCRIPTION
Avhengig av [endring](https://github.com/navikt/familie-sanity-brev/pull/236) i `familie-sanity-brev`

Lenke til Favro: [TEA-8911](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8911)

### 💰 Hva skal gjøres, og hvorfor?
Begrunnelsestekster knyttet til reduksjon eller opphør når et barn dør, dukket ikke opp som et valg i behandling med dødsfall dersom "Delt bosted" var valgt som utdypende vurdering i vilkårsvurderingen.

Logikken for om dødsfall-begrunnelser skulle dukke opp, var knyttet til at saksbehandler hadde satt en tom-dato på vilkåret "Bor med søker" og valgt den utdypende vurderingen "Vurdering annet grunnlag". Dersom "Delt bosted" var valgt i tillegg eller istedenfor som utdypende vurdering, "overkjørte" begrunnelsesregelen for delt bosted regelen for dødsfall.

For å løse dette har jeg lagt til en ny trigger for dødsfall-begrunnelser, som kun bryr seg om dødsdato og ikke om "tom"-dato er satt på et bestemt vilkår. Altså skal dødsfall-begrunnelser dukke opp som valg dersom barnet døde i forrige ytelsesperiode. Vil kun være relevant ved reduksjon eller opphør.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.