### PR TITLE
Tea-7453: Rettar sortering av logghendingar, samt tekst og duplikate fnr i logginnslaget ved fleirlingar

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggRepository.kt
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface LoggRepository : JpaRepository<Logg, Long> {
-    @Query(value = "SELECT l FROM Logg l WHERE l.behandlingId = :behandlingId ORDER BY l.opprettetTidspunkt, l.id desc")
+    @Query(value = "SELECT l FROM Logg l WHERE l.behandlingId = :behandlingId ORDER BY l.opprettetTidspunkt desc, l.id desc")
     fun hentLoggForBehandling(behandlingId: Long): List<Logg>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
@@ -202,7 +202,7 @@ class LoggService(
                     rolleConfig,
                     BehandlerRolle.SAKSBEHANDLER
                 ),
-                tekst = "Gjelder ${fødselsdatoer(behandling)}"
+                tekst = "Gjelder barn ${fødselsdatoer(behandling)}"
             )
         )
     }
@@ -210,6 +210,7 @@ class LoggService(
     private fun fødselsdatoer(behandling: BehandlingLoggRequest) = Utils.slåSammen(
         behandling.barnasIdenter
             .filter { Identkonverterer.er11Siffer(it) }
+            .distinct()
             .map { FoedselsNr(it) }
             .map { it.foedselsdato }
             .map { it.tilKortString() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceTest.kt
@@ -88,7 +88,7 @@ class LoggServiceTest(
 
         val loggForBehandling = loggService.hentLoggForBehandling(behandlingId = behandling.id)
         assertEquals(2, loggForBehandling.size)
-        assertTrue(loggForBehandling.any { it.type == LoggType.LIVSHENDELSE && it.tekst == "Gjelder 01.08.22" })
+        assertTrue(loggForBehandling.any { it.type == LoggType.LIVSHENDELSE && it.tekst == "Gjelder barn 01.08.22" })
         assertTrue(loggForBehandling.any { it.type == LoggType.BEHANDLING_OPPRETTET })
         assertTrue(loggForBehandling.none { it.rolle != BehandlerRolle.SYSTEM })
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceTest.kt
@@ -179,7 +179,10 @@ class LoggServiceTest(
 
     @Test
     fun `Om to logginnslag blir oppretta i samme sekund skal vi sortere med den første først`() {
-        val behandlingId = 1L
+        val behandlingId = lagBehandling(
+            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            årsak = BehandlingÅrsak.SØKNAD
+        ).id
         val tidspunkt = LocalDateTime.now()
         val logg1 = loggService.lagre(
             Logg(
@@ -204,5 +207,43 @@ class LoggServiceTest(
 
         val logginnslag = loggService.hentLoggForBehandling(behandlingId)
         assertEquals(listOf(logg2.id, logg1.id), logginnslag.map { it.id })
+    }
+
+    @Test
+    fun `eldste logginnslag skal komme sist og nyaste først`() {
+        val behandlingId = lagBehandling(
+            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            årsak = BehandlingÅrsak.SØKNAD
+        ).id
+        val eldst = loggService.lagre(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.BEHANDLING_OPPRETTET,
+                tittel = "Førstegangbehandling opprettet",
+                rolle = BehandlerRolle.SAKSBEHANDLER,
+                tekst = ""
+            )
+        )
+        val mellomst = loggService.lagre(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.LIVSHENDELSE,
+                tittel = "Søknaden ble registrert",
+                rolle = BehandlerRolle.SAKSBEHANDLER,
+                tekst = ""
+            )
+        )
+        val nyast = loggService.lagre(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.LIVSHENDELSE,
+                tittel = "Vilkårsvurdering gjennomført",
+                rolle = BehandlerRolle.SAKSBEHANDLER,
+                tekst = ""
+            )
+        )
+
+        val logginnslag = loggService.hentLoggForBehandling(behandlingId)
+        assertEquals(listOf(nyast.id, mellomst.id, eldst.id), logginnslag.map { it.id })
     }
 }


### PR DESCRIPTION
Dagens lærdom er at ved sortering på fleire felt i Spring-SQL-Query må ein definere om det er stigande eller synkande for kvart felt.

Rettar også duplikate innslag og feil tekst.

### 💰 Hva skal gjøres, og hvorfor?

Dette er rettingar av feil frå førre PR på [Tea-7453](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7453), oppdaga under test. Logghendingane kom no i feil rekkjefølgje (skal vera nyaste øverst).

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
