### PR TITLE
Revert sentry-logback tilbake til 5.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-logback</artifactId>
-            <version>6.3.1</version>
+            <version>5.7.4</version>
         </dependency>
 
         <!-- swagger -->


### PR DESCRIPTION
sentry-logback 6.3.1 brakk deploy. Reverter tilbake til 5.7.4