### PR TITLE
dropper fagsak.eier

### DIFF
--- a/src/main/resources/db/migration/V219__fjerner_fagsak_eier.sql
+++ b/src/main/resources/db/migration/V219__fjerner_fagsak_eier.sql
@@ -1,0 +1,3 @@
+alter table fagsak
+drop column eier;
+


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Siste del av fjerning av fagsak.eier

Ble gjort i 2 steg for å unngå å minste bakoverkompatibilitet under deploy.