### PR TITLE
Tea-4925: Setter t.o.m dato i vilkår til å være dødsdato dersom person er død + bugfix

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.common.maksimum
 import no.nav.familie.ba.sak.common.minimum
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
+import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -277,10 +278,17 @@ object TilkjentYtelseUtils {
 
         val oppfyltTom = if (skalVidereføresEnMånedEkstra) minsteTom.plusMonths(1) else minsteTom
 
-        val oppfyltTomKommerFra18ÅrsVilkår =
-            oppfyltTom == periodeResultatBarn.vilkårResultater.find {
-                it.vilkårType == Vilkår.UNDER_18_ÅR
-            }?.periodeTom
+        val periodeTomFra18Årsvilkår = periodeResultatBarn.vilkårResultater.find {
+            it.vilkårType == Vilkår.UNDER_18_ÅR
+        }?.periodeTom
+
+        val skalAvslutteMånedenFør =
+            if (person.dødsfall != null) {
+                person.dødsfall!!.dødsfallDato.withDayOfMonth(1) >= person.fødselsdato.til18ÅrsVilkårsdato()
+                    .withDayOfMonth(1)
+            } else {
+                oppfyltTom == periodeTomFra18Årsvilkår
+            }
 
         val (periodeUnder6År, periodeOver6år) = splittPeriodePå6Årsdag(
             person.hentSeksårsdag(),
@@ -304,7 +312,7 @@ object TilkjentYtelseUtils {
                 fraOgMed = periodeOver6år.fom
             ),
             stønadTilOgMed = settRiktigStønadTom(
-                skalAvsluttesMånedenFør = oppfyltTomKommerFra18ÅrsVilkår,
+                skalAvsluttesMånedenFør = skalAvslutteMånedenFør,
                 tilOgMed = periodeOver6år.tom
             ),
             maxSatsGyldigFraOgMed = SatsService.tilleggEndringJanuar2022,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -282,7 +282,7 @@ object TilkjentYtelseUtils {
             it.vilkårType == Vilkår.UNDER_18_ÅR
         }?.periodeTom
 
-        val skalAvslutteMånedenFør =
+        val skalAvsluttesMånedenFør =
             if (person.dødsfall != null) {
                 person.dødsfall!!.dødsfallDato.withDayOfMonth(1) >= person.fødselsdato.til18ÅrsVilkårsdato()
                     .withDayOfMonth(1)
@@ -312,7 +312,7 @@ object TilkjentYtelseUtils {
                 fraOgMed = periodeOver6år.fom
             ),
             stønadTilOgMed = settRiktigStønadTom(
-                skalAvsluttesMånedenFør = skalAvslutteMånedenFør,
+                skalAvsluttesMånedenFør = skalAvsluttesMånedenFør,
                 tilOgMed = periodeOver6år.tom
             ),
             maxSatsGyldigFraOgMed = SatsService.tilleggEndringJanuar2022,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -93,7 +94,7 @@ data class VilkårsvurderingForNyBehandlingUtils(
                 val fom = if (vilkår.gjelderAlltidFraBarnetsFødselsdato()) person.fødselsdato else null
 
                 val tom: LocalDate? =
-                    if (vilkår == Vilkår.UNDER_18_ÅR) person.fødselsdato.plusYears(18).minusDays(1) else null
+                    if (vilkår == Vilkår.UNDER_18_ÅR) person.fødselsdato.til18ÅrsVilkårsdato() else null
 
                 val begrunnelse = "Migrering"
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingMigreringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingMigreringUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
+import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
@@ -39,7 +40,7 @@ object VilkårsvurderingMigreringUtils {
             forrigeBehandlingsvilkårsvurdering, vilkår, person
         ).minWithOrNull(VilkårResultat.VilkårResultatComparator)?.periodeTom
         return when {
-            vilkår == Vilkår.UNDER_18_ÅR -> periodeFom.plusYears(18).minusDays(1)
+            vilkår == Vilkår.UNDER_18_ÅR -> periodeFom.til18ÅrsVilkårsdato()
             vilkår == Vilkår.GIFT_PARTNERSKAP -> null
             forrigeVilkårsPeriodeTom != null -> forrigeVilkårsPeriodeTom
             else -> null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -468,11 +468,13 @@ private fun utledResultatForGiftPartnerskap(person: Person) =
 private fun utledBegrunnelse(
     vilkår: Vilkår,
     person: Person
-) = when (vilkår) {
-    Vilkår.UNDER_18_ÅR -> "Vurdert og satt automatisk"
-    Vilkår.GIFT_PARTNERSKAP -> if (person.sivilstander.sisteSivilstand()?.type?.somForventetHosBarn() == false)
+) = when {
+    person.erDød() -> "Dødsfall"
+    vilkår == Vilkår.UNDER_18_ÅR -> "Vurdert og satt automatisk"
+    vilkår == Vilkår.GIFT_PARTNERSKAP -> if (person.sivilstander.sisteSivilstand()?.type?.somForventetHosBarn() == false) {
         "Vilkåret er forsøkt behandlet automatisk, men barnet er registrert som gift i " +
-            "folkeregisteret. Vurder hvilke konsekvenser dette skal ha for behandlingen" else ""
+            "folkeregisteret. Vurder hvilke konsekvenser dette skal ha for behandlingen"
+    } else ""
 
     else -> ""
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
@@ -2,7 +2,9 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import io.mockk.every
 import io.mockk.spyk
+import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.dato
+import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
 import no.nav.familie.ba.sak.common.årMnd
 import no.nav.familie.ba.sak.kjerne.beregning.domene.Sats
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
@@ -15,6 +17,33 @@ class SatsServiceTest {
     private val satsService = spyk(SatsService)
 
     private val MAX_GYLDIG_FRA_OG_MED = årMnd("2020-05")
+
+    @Test
+    fun `Barn som er under 6 år hele perioden får tillegg hele perioden`() {
+        val periode = Periode(LocalDate.of(2019, 1, 1), LocalDate.of(2022, 1, 1))
+        val seksårsdag = LocalDate.of(2023, 1, 1)
+
+        Assertions.assertEquals(periode, satsService.hentPeriodeTil6år(seksårsdag, periode.fom, periode.tom))
+    }
+
+    @Test
+    fun `Barn som fyller 6 år i løpet av perioden får tilleggsperiode før seksårsdag`() {
+        val periode = Periode(LocalDate.of(2019, 1, 1), LocalDate.of(2022, 1, 1))
+        val seksårsdag = LocalDate.of(2021, 1, 1)
+
+        Assertions.assertEquals(
+            Periode(periode.fom, seksårsdag.sisteDagIForrigeMåned()),
+            satsService.hentPeriodeTil6år(seksårsdag, periode.fom, periode.tom)
+        )
+    }
+
+    @Test
+    fun `Barn som er over 6 år hele perioden får ingen tillegsperiode`() {
+        val periode = Periode(LocalDate.of(2019, 1, 1), LocalDate.of(2022, 1, 1))
+        val seksårsdag = LocalDate.of(2018, 1, 1)
+
+        Assertions.assertEquals(null, satsService.hentPeriodeTil6år(seksårsdag, periode.fom, periode.tom))
+    }
 
     @Test
     fun `Skal bruke sats for satstype som er løpende`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.MånedPeriode
-import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.forrigeMåned
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
@@ -10,7 +9,6 @@ import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.nesteMåned
 import no.nav.familie.ba.sak.common.randomFnr
-import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -34,33 +32,6 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 internal class TilkjentYtelseUtilsTest {
-
-    @Test
-    fun `Barn som er under 6 år hele perioden får tillegg hele perioden`() {
-        val periode = Periode(LocalDate.of(2019, 1, 1), LocalDate.of(2022, 1, 1))
-        val seksårsdag = LocalDate.of(2023, 1, 1)
-
-        assertEquals(periode, SatsService.hentPeriodeTil6år(seksårsdag, periode.fom, periode.tom))
-    }
-
-    @Test
-    fun `Barn som fyller 6 år i løpet av perioden får tilleggsperiode før seksårsdag`() {
-        val periode = Periode(LocalDate.of(2019, 1, 1), LocalDate.of(2022, 1, 1))
-        val seksårsdag = LocalDate.of(2021, 1, 1)
-
-        assertEquals(
-            Periode(periode.fom, seksårsdag.sisteDagIForrigeMåned()),
-            SatsService.hentPeriodeTil6år(seksårsdag, periode.fom, periode.tom)
-        )
-    }
-
-    @Test
-    fun `Barn som er over 6 år hele perioden får ingen tillegsperiode`() {
-        val periode = Periode(LocalDate.of(2019, 1, 1), LocalDate.of(2022, 1, 1))
-        val seksårsdag = LocalDate.of(2018, 1, 1)
-
-        assertEquals(null, SatsService.hentPeriodeTil6år(seksårsdag, periode.fom, periode.tom))
-    }
 
     @Test
     fun `Barn som fyller 6 år i det vilkårene er oppfylt får andel måneden etter`() {
@@ -577,8 +548,8 @@ internal class TilkjentYtelseUtilsTest {
 
         vilkårsvurdering.personResultater =
             vilkårsvurdering.personResultater.filter { it.aktør != personResultat.aktør }.toSet() + setOf(
-            personResultat
-        )
+                personResultat
+            )
 
         return vilkårsvurdering
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
@@ -548,8 +548,8 @@ internal class TilkjentYtelseUtilsTest {
 
         vilkårsvurdering.personResultater =
             vilkårsvurdering.personResultater.filter { it.aktør != personResultat.aktør }.toSet() + setOf(
-                personResultat
-            )
+            personResultat
+        )
 
         return vilkårsvurdering
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingForNyBehandlingServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingForNyBehandlingServiceTest.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
 import no.nav.familie.ba.sak.dataGenerator.vilkårsvurdering.lagBarnVilkårResultat
@@ -159,7 +160,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         Assertions.assertTrue {
             barnVilkårResultat.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }.all {
                 it.periodeFom == barnetsFødselsdato &&
-                    it.periodeTom == barnetsFødselsdato.plusYears(18).minusDays(1)
+                    it.periodeTom == barnetsFødselsdato.til18ÅrsVilkårsdato()
             }
         }
 
@@ -323,7 +324,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         Assertions.assertTrue {
             barnVilkårResultat.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }.all {
                 it.periodeFom == barnetsFødselsdato &&
-                    it.periodeTom == barnetsFødselsdato.plusYears(18).minusDays(1)
+                    it.periodeTom == barnetsFødselsdato.til18ÅrsVilkårsdato()
             }
         }
         Assertions.assertTrue {
@@ -381,7 +382,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         Assertions.assertTrue {
             barnPersonResultat.vilkårResultater.any {
                 it.vilkårType == Vilkår.UNDER_18_ÅR &&
-                    it.periodeTom == barnetsFødselsdato.plusYears(18).minusDays(1) &&
+                    it.periodeTom == barnetsFødselsdato.til18ÅrsVilkårsdato() &&
                     it.periodeFom == barnetsFødselsdato
             }
         }
@@ -447,7 +448,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         Assertions.assertTrue {
             barnPersonResultat.vilkårResultater.any {
                 it.vilkårType == Vilkår.UNDER_18_ÅR &&
-                    it.periodeTom == barnetsFødselsdato.plusYears(18).minusDays(1) &&
+                    it.periodeTom == barnetsFødselsdato.til18ÅrsVilkårsdato() &&
                     it.periodeFom == barnetsFødselsdato
             }
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.common.vurderVilkårsvurderingTilInnvilget
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.ClientMocks
@@ -590,7 +591,7 @@ class VilkårServiceTest(
         assertTrue {
             barnVilkårResultat.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }.all {
                 it.periodeFom == barnetsFødselsdato &&
-                    it.periodeTom == barnetsFødselsdato.plusYears(18).minusDays(1)
+                    it.periodeTom == barnetsFødselsdato.til18ÅrsVilkårsdato()
             }
         }
         assertTrue {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Dersom barn er død ved opprettelse av behandling så vil t.o.m dato på alle vilkår være preutfylt med dødsfallsdatoen til barnet, og begrunnelsen blir satt til dødsfall.
Det er også fikset en bug slik at dersom t.o.m datoen i under18år vilkåret blir satt til før barnet har fylt 18, så vil man nå få betalt for inneværende måned.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4925

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [X] Ja
- [ ] Nei

Ønsker en muntlig gjennomgang dersom det kan være uante sideeffekter som kommer av disse endringene.

Før:

Etter:
