### PR TITLE
Bedre logging når vi får feil med flere personer som får overgangsstønad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -44,7 +44,7 @@ class SmåbarnstilleggService(
             .map { it.tilInternPeriodeOvergangsstønad() }
             .slåSammenTidligerePerioder()
             .splitFramtidigePerioderFraForrigeBehandling(
-                gamleOvergangsstønadPerioder = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId)
+                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId)
             )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -44,7 +44,8 @@ class SmåbarnstilleggService(
             .map { it.tilInternPeriodeOvergangsstønad() }
             .slåSammenTidligerePerioder()
             .splitFramtidigePerioderFraForrigeBehandling(
-                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId)
+                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId),
+                secureLogger = secureLogger
             )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -44,8 +44,7 @@ class SmåbarnstilleggService(
             .map { it.tilInternPeriodeOvergangsstønad() }
             .slåSammenTidligerePerioder()
             .splitFramtidigePerioderFraForrigeBehandling(
-                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId),
-                secureLogger = secureLogger
+                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId)
             )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -54,13 +54,13 @@ fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandl
     overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>,
     secureLogger: Logger
 ): List<InternPeriodeOvergangsstønad> {
-    val personerMedOvergangsstønad = (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }
+    val personerMedOvergangsstønadIForrigeOgInneværendeBehandling = (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }
     val erOvergangsstønadForMerEnnEnPerson =
-        personerMedOvergangsstønad.toSet().size > 1
+        personerMedOvergangsstønadIForrigeOgInneværendeBehandling.toSet().size > 1
     if (erOvergangsstønadForMerEnnEnPerson) {
         secureLogger.info(
             "Fant overgangsstønad for mer enn 1 person." +
-                "Personer: $personerMedOvergangsstønad" +
+                "Personer: $personerMedOvergangsstønadIForrigeOgInneværendeBehandling" +
                 "Perioder i inneværende behandling: $this" +
                 "Perioder fra forrige behandling: $overgangsstønadPerioderFraForrigeBehandling"
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -7,7 +7,10 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
+
+val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
 data class InternPeriodeOvergangsstønad(
     val personIdent: String,
@@ -51,8 +54,7 @@ fun List<InternPeriodeOvergangsstønad>.slåSammenSammenhengendePerioder(): List
  *
  ***/
 fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandling(
-    overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>,
-    secureLogger: Logger
+    overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>
 ): List<InternPeriodeOvergangsstønad> {
     val personerMedOvergangsstønadIForrigeOgInneværendeBehandling = (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }
     val erOvergangsstønadForMerEnnEnPerson =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -50,10 +50,10 @@ fun List<InternPeriodeOvergangsstønad>.slåSammenSammenhengendePerioder(): List
  *
  ***/
 fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandling(
-    gamleOvergangsstønadPerioder: List<InternPeriodeOvergangsstønad>
+    overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>
 ): List<InternPeriodeOvergangsstønad> {
     val erOvergangsstønadForMerEnnEnPerson =
-        (this + gamleOvergangsstønadPerioder).map { it.personIdent }.toSet().size > 1
+        (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }.toSet().size > 1
     if (erOvergangsstønadForMerEnnEnPerson)
         throw Feil("Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn en person.")
 
@@ -61,7 +61,7 @@ fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandl
     val framtidigePerioder = this.minus(tidligerePerioder)
     val nyeOvergangsstønadTidslinje = InternPeriodeOvergangsstønadTidslinje(framtidigePerioder)
 
-    val gammelOvergangsstønadTidslinje = InternPeriodeOvergangsstønadTidslinje(gamleOvergangsstønadPerioder)
+    val gammelOvergangsstønadTidslinje = InternPeriodeOvergangsstønadTidslinje(overgangsstønadPerioderFraForrigeBehandling)
 
     val oppsplittedeFramtigigePerioder = gammelOvergangsstønadTidslinje
         .kombinerMed(nyeOvergangsstønadTidslinje) { gammelOvergangsstønadPeriode, nyOvergangsstønadPeriode ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -61,9 +61,9 @@ fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandl
         personerMedOvergangsstønadIForrigeOgInneværendeBehandling.toSet().size > 1
     if (erOvergangsstønadForMerEnnEnPerson) {
         secureLogger.info(
-            "Fant overgangsstønad for mer enn 1 person." +
-                "Personer: $personerMedOvergangsstønadIForrigeOgInneværendeBehandling" +
-                "Perioder i inneværende behandling: $this" +
+            "Fant overgangsstønad for mer enn 1 person. \n" +
+                "Personer: $personerMedOvergangsstønadIForrigeOgInneværendeBehandling \n" +
+                "Perioder i inneværende behandling: $this \n" +
                 "Perioder fra forrige behandling: $overgangsstønadPerioderFraForrigeBehandling"
         )
         throw Feil("Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn en person.")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har en sendAutobrevVed6og18År task som feiler pga "Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn en person.". Siden vi ikke har lagt på så mye logging er det vanskelig å vite hvilke perioder og hvilke personer den har funnet. Legger derfor på bedre logging slik at vi enklere kan debugge.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Kun debug

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
