### PR TITLE
Tea-9191: Viss vi har ytelsepersonresultat som både er endra utbetaling og endra ikkje utbetaling, så skal vi bruke resultat for endra utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -108,6 +108,7 @@ object BehandlingsresultatUtils {
             samledeResultater == setOf(YtelsePersonResultat.FORTSATT_OPPHØRT) -> Behandlingsresultat.FORTSATT_OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.ENDRET_UTBETALING) -> Behandlingsresultat.ENDRET_UTBETALING
             samledeResultater == setOf(YtelsePersonResultat.ENDRET_UTEN_UTBETALING) -> Behandlingsresultat.ENDRET_UTEN_UTBETALING
+            samledeResultater == setOf(YtelsePersonResultat.ENDRET_UTBETALING, YtelsePersonResultat.ENDRET_UTEN_UTBETALING) -> Behandlingsresultat.ENDRET_UTBETALING
             samledeResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(emptySet()) -> Behandlingsresultat.ENDRET_OG_OPPHØRT
             samledeResultater == setOf(YtelsePersonResultat.OPPHØRT, YtelsePersonResultat.FORTSATT_OPPHØRT) ||
                 samledeResultater == setOf(YtelsePersonResultat.OPPHØRT) -> Behandlingsresultat.OPPHØRT

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -145,6 +145,24 @@ class BehandlingsresultatUtilsTest {
             BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
         )
     }
+    @Test
+    fun `både ENDRET_UTBETALING og ENDRET_UTEN_UTBETALING som samlede resultater gir behandilngsresultat ENDRET_UTBETALING`() {
+        val personer = listOf(
+            lagYtelsePerson(
+                resultat = YtelsePersonResultat.ENDRET_UTBETALING,
+                ytelseSlutt = YearMonth.now().minusMonths(1)
+            ),
+            lagYtelsePerson(
+                resultat = YtelsePersonResultat.ENDRET_UTEN_UTBETALING,
+                ytelseSlutt = YearMonth.now()
+            )
+        )
+
+        assertEquals(
+            Behandlingsresultat.ENDRET_UTBETALING,
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersoner(personer)
+        )
+    }
 }
 
 private fun lagYtelsePerson(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -146,7 +146,7 @@ class BehandlingsresultatUtilsTest {
         )
     }
     @Test
-    fun `både ENDRET_UTBETALING og ENDRET_UTEN_UTBETALING som samlede resultater gir behandilngsresultat ENDRET_UTBETALING`() {
+    fun `både ENDRET_UTBETALING og ENDRET_UTEN_UTBETALING som samlede resultater gir behandlingsresultat ENDRET_UTBETALING`() {
         val personer = listOf(
             lagYtelsePerson(
                 resultat = YtelsePersonResultat.ENDRET_UTBETALING,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dette gir i dag feilmelding, ref https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9191 , men er et legitimt scenario.

Årsaken til at vi skiller på disse er at endring med utbetaling skal trigge iverksetting til økonomi, mens endring uten utbetaling ikke gjør dette. Siden det her er minst en endring som fører til endring i utbetaling så bør denne få presidens.

Her bør vi derfor sette resultatttypen til endra utbetaling.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Nei