### PR TITLE
Håndter forsatt opphørt som resultat på omregningsbehandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -195,7 +195,8 @@ data class Behandling(
 
     fun skalRettFraBehandlingsresultatTilIverksetting(): Boolean {
         return when {
-            skalBehandlesAutomatisk && erOmregning() && resultat == Behandlingsresultat.FORTSATT_INNVILGET -> true
+            skalBehandlesAutomatisk && erOmregning() &&
+                resultat in listOf(Behandlingsresultat.FORTSATT_INNVILGET, Behandlingsresultat.FORTSATT_OPPHØRT) -> true
             skalBehandlesAutomatisk && erMigrering() && resultat == Behandlingsresultat.INNVILGET -> true
             skalBehandlesAutomatisk && erFødselshendelse() && resultat == Behandlingsresultat.INNVILGET -> true
             skalBehandlesAutomatisk && erSatsendring() && resultat == Behandlingsresultat.ENDRET_UTBETALING -> true

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Autobrev6og18ÅrFortsattOpphørtTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Autobrev6og18ÅrFortsattOpphørtTest.kt
@@ -1,0 +1,169 @@
+package no.nav.familie.ba.sak.kjerne.verdikjedetester
+
+import no.nav.familie.ba.sak.common.lagSøknadDTO
+import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
+import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedStandardbegrunnelser
+import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
+import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
+import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.Autobrev6og18ÅrService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
+import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
+import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenarioPerson
+import no.nav.familie.ba.sak.task.dto.Autobrev6og18ÅrDTO
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import java.time.LocalDate
+import java.time.YearMonth
+
+class Autobrev6og18ÅrFortsattOpphørtTest(
+    @Autowired private val fagsakService: FagsakService,
+    @Autowired private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    @Autowired private val vedtakService: VedtakService,
+    @Autowired private val stegService: StegService,
+    @Autowired private val autobrev6og18ÅrService: Autobrev6og18ÅrService,
+) : AbstractVerdikjedetest() {
+
+    @Test
+    fun `Skal støtte fortsatt opphørt som resultat`() {
+        val scenario = mockServerKlient().lagScenario(
+            RestScenario(
+                søker = RestScenarioPerson(fødselsdato = "1996-11-12", fornavn = "Mor", etternavn = "Søker"),
+                barna = listOf(
+                    RestScenarioPerson(
+                        fødselsdato = LocalDate.now().minusYears(18).toString(),
+                        fornavn = "AttenåringEn",
+                        etternavn = "Barnesen",
+                        bostedsadresser = emptyList()
+                    ),
+                    RestScenarioPerson(
+                        fødselsdato = LocalDate.now().minusYears(18).plusMonths(1).toString(),
+                        fornavn = "AttenåringTo",
+                        etternavn = "Barnesen",
+                        bostedsadresser = emptyList()
+                    )
+                )
+            )
+        )
+
+        val fagsakId = familieBaSakKlient().opprettFagsak(søkersIdent = scenario.søker.ident!!).data?.id!!
+        familieBaSakKlient().opprettBehandling(søkersIdent = scenario.søker.ident)
+
+        val restFagsakEtterOpprettelse = familieBaSakKlient().hentFagsak(fagsakId = fagsakId)
+
+        val aktivBehandling = hentAktivBehandling(restFagsak = restFagsakEtterOpprettelse.data!!)
+        val restRegistrerSøknad =
+            RestRegistrerSøknad(
+                søknad = lagSøknadDTO(
+                    søkerIdent = scenario.søker.ident,
+                    barnasIdenter = scenario.barna.map { it.ident!! }
+                ),
+                bekreftEndringerViaFrontend = false
+            )
+        val restUtvidetBehandling: Ressurs<RestUtvidetBehandling> =
+            familieBaSakKlient().registrererSøknad(
+                behandlingId = aktivBehandling.behandlingId,
+                restRegistrerSøknad = restRegistrerSøknad
+            )
+
+        // Godkjenner alle vilkår på førstegangsbehandling.
+        restUtvidetBehandling.data!!.personResultater.forEach { restPersonResultat ->
+            restPersonResultat.vilkårResultater.filter { it.resultat == Resultat.IKKE_VURDERT }.forEach {
+
+                familieBaSakKlient().putVilkår(
+                    behandlingId = restUtvidetBehandling.data!!.behandlingId,
+                    vilkårId = it.id,
+                    restPersonResultat = RestPersonResultat(
+                        personIdent = restPersonResultat.personIdent,
+                        vilkårResultater = listOf(
+                            it.copy(
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = LocalDate.now().minusMonths(2)
+                            )
+                        )
+                    )
+                )
+            }
+        }
+
+        familieBaSakKlient().validerVilkårsvurdering(
+            behandlingId = restUtvidetBehandling.data!!.behandlingId
+        )
+
+        val restUtvidetBehandlingEtterBehandlingsresultat =
+            familieBaSakKlient().behandlingsresultatStegOgGåVidereTilNesteSteg(
+                behandlingId = restUtvidetBehandling.data!!.behandlingId
+            )
+
+        val restUtvidetBehandlingEtterVurderTilbakekreving =
+            familieBaSakKlient().lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                restUtvidetBehandlingEtterBehandlingsresultat.data!!.behandlingId,
+                RestTilbakekreving(Tilbakekrevingsvalg.IGNORER_TILBAKEKREVING, begrunnelse = "begrunnelse")
+            )
+
+        val førsteVedtaksperiodeId =
+            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.vedtak!!.vedtaksperioderMedBegrunnelser.sortedBy { it.fom }
+                .first()
+        familieBaSakKlient().oppdaterVedtaksperiodeMedStandardbegrunnelser(
+            vedtaksperiodeId = førsteVedtaksperiodeId.id,
+            restPutVedtaksperiodeMedStandardbegrunnelser = RestPutVedtaksperiodeMedStandardbegrunnelser(
+                standardbegrunnelser = listOf(
+                    Standardbegrunnelse.INNVILGET_BOR_HOS_SØKER.name
+                )
+            )
+        )
+
+        val restUtvidetBehandlingEtterSendTilBeslutter =
+            familieBaSakKlient().sendTilBeslutter(behandlingId = restUtvidetBehandlingEtterVurderTilbakekreving.data!!.behandlingId)
+
+        familieBaSakKlient().iverksettVedtak(
+            behandlingId = restUtvidetBehandlingEtterSendTilBeslutter.data!!.behandlingId,
+            restBeslutningPåVedtak = RestBeslutningPåVedtak(
+                Beslutning.GODKJENT
+            ),
+            beslutterHeaders = HttpHeaders().apply {
+                setBearerAuth(
+                    token(
+                        mapOf(
+                            "groups" to listOf("SAKSBEHANDLER", "BESLUTTER"),
+                            "azp" to "azp-test",
+                            "name" to "Mock McMockface Beslutter",
+                            "NAVident" to "Z0000"
+                        )
+                    )
+                )
+            }
+        )
+
+        håndterIverksettingAvBehandling(
+            behandlingEtterVurdering = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = fagsakId)!!,
+            søkerFnr = scenario.søker.ident,
+            fagsakService = fagsakService,
+            vedtakService = vedtakService,
+            stegService = stegService
+        )
+
+        autobrev6og18ÅrService.opprettOmregningsoppgaveForBarnIBrytingsalder(
+            autobrev6og18ÅrDTO = Autobrev6og18ÅrDTO(
+                fagsakId = fagsakId,
+                alder = 18,
+                årMåned = YearMonth.now()
+            )
+        )
+
+        val behandlinger = behandlingHentOgPersisterService.hentBehandlinger(fagsakId)
+
+        Assertions.assertEquals(2, behandlinger.size)
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9136

Får feilen "Håndtering av stegtype 'BEHANDLINGSRESULTAT' feilet på behandling" ved omregningsbehandling (autobrev 6 og 18 år) når ytelsen opphører samme/neste måned, selv om dette er gjort i tidligere behandlinger. Dette er fordi resultatet blir fortsatt opphørt og ikke fortsatt innvilget. Legger derfor til fortsatt opphørt som gyldig resultat for å sende en omregningsbehandling rett fra behandlingresultat til iverksetting.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er litt usikker på om dette løser oppgaven, men tror det!

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
