### PR TITLE
Logg hver person med overgangsstønad kun 1 gang

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -56,9 +56,9 @@ fun List<InternPeriodeOvergangsstønad>.slåSammenSammenhengendePerioder(): List
 fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandling(
     overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>
 ): List<InternPeriodeOvergangsstønad> {
-    val personerMedOvergangsstønadIForrigeOgInneværendeBehandling = (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }
+    val personerMedOvergangsstønadIForrigeOgInneværendeBehandling = (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }.toSet()
     val erOvergangsstønadForMerEnnEnPerson =
-        personerMedOvergangsstønadIForrigeOgInneværendeBehandling.toSet().size > 1
+        personerMedOvergangsstønadIForrigeOgInneværendeBehandling.size > 1
     if (erOvergangsstønadForMerEnnEnPerson) {
         secureLogger.info(
             "Fant overgangsstønad for mer enn 1 person. \n" +


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Etter å ha tatt i bruk loggingen jeg la på i går oppdaget jeg at hver person blir listet ut flere ganger. Dette er unødvendig. Endrer derfor til å bruke set også for det som logges.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bare logging

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
