### PR TITLE
Tea-8538: Tar bort standard-parametre for TriggesAv-objektet, desse er unødvendige og kan potensielt gi feil ved at vi ikkje hugsar å overstyre der det trengs

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/TriggesAv.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/TriggesAv.kt
@@ -12,23 +12,23 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import java.math.BigDecimal
 
 data class TriggesAv(
-    val vilkår: Set<Vilkår> = emptySet(),
-    val personTyper: Set<PersonType> = setOf(PersonType.BARN, PersonType.SØKER),
-    val personerManglerOpplysninger: Boolean = false,
-    val satsendring: Boolean = false,
-    val barnMedSeksårsdag: Boolean = false,
-    val vurderingAnnetGrunnlag: Boolean = false,
-    val medlemskap: Boolean = false,
-    val deltbosted: Boolean = false,
-    val deltBostedSkalIkkeDeles: Boolean = false,
-    val valgbar: Boolean = true,
-    val endringsaarsaker: Set<Årsak> = emptySet(),
-    val etterEndretUtbetaling: Boolean = false,
-    val endretUtbetalingSkalUtbetales: EndretUtbetalingsperiodeDeltBostedTriggere = EndretUtbetalingsperiodeDeltBostedTriggere.UTBETALING_IKKE_RELEVANT,
-    val småbarnstillegg: Boolean = false,
-    val gjelderFørstePeriode: Boolean = false,
-    val gjelderFraInnvilgelsestidspunkt: Boolean = false,
-    val barnDød: Boolean = false
+    val vilkår: Set<Vilkår>,
+    val personTyper: Set<PersonType>,
+    val personerManglerOpplysninger: Boolean,
+    val satsendring: Boolean,
+    val barnMedSeksårsdag: Boolean,
+    val vurderingAnnetGrunnlag: Boolean,
+    val medlemskap: Boolean,
+    val deltbosted: Boolean,
+    val deltBostedSkalIkkeDeles: Boolean,
+    val valgbar: Boolean,
+    val endringsaarsaker: Set<Årsak>,
+    val etterEndretUtbetaling: Boolean,
+    val endretUtbetalingSkalUtbetales: EndretUtbetalingsperiodeDeltBostedTriggere,
+    val småbarnstillegg: Boolean,
+    val gjelderFørstePeriode: Boolean,
+    val gjelderFraInnvilgelsestidspunkt: Boolean,
+    val barnDød: Boolean
 ) {
     fun erEndret() = endringsaarsaker.isNotEmpty()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1122,6 +1122,10 @@ fun lagTriggesAv(
     etterEndretUtbetaling = etterEndretUtbetaling,
     endretUtbetalingSkalUtbetales = endretUtbetalingSkalUtbetales,
     småbarnstillegg = småbarnstillegg,
+    barnDød = false,
+    deltBostedSkalIkkeDeles = false,
+    gjelderFraInnvilgelsestidspunkt = false,
+    gjelderFørstePeriode = false
 )
 
 fun oppfyltVilkår(vilkår: Vilkår, regelverk: Regelverk? = null) =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/UtgjørendePersonerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/UtgjørendePersonerTest.kt
@@ -8,8 +8,10 @@ import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertPersonResultat
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonerForAlleUtgjørendeVilkår
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
@@ -137,10 +139,10 @@ class UtgjørendePersonerTest {
                 tom = LocalDate.of(2010, 6, 1)
             ),
             oppdatertBegrunnelseType = VedtakBegrunnelseType.INNVILGET,
-            triggesAv = TriggesAv(setOf(Vilkår.LOVLIG_OPPHOLD)),
+            triggesAv = lagTriggesAv(Vilkår.LOVLIG_OPPHOLD),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
-            erFørsteVedtaksperiodePåFagsak = false,
+            erFørsteVedtaksperiodePåFagsak = false
 
         )
 
@@ -157,10 +159,10 @@ class UtgjørendePersonerTest {
                 tom = LocalDate.of(2010, 6, 1)
             ),
             oppdatertBegrunnelseType = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.vedtakBegrunnelseType,
-            triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
+            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
-            erFørsteVedtaksperiodePåFagsak = false,
+            erFørsteVedtaksperiodePåFagsak = false
         )
 
         assertEquals(1, personerMedUtgjørendeVilkårBosattIRiket.size)
@@ -232,10 +234,10 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = Standardbegrunnelse.REDUKSJON_BOSATT_I_RIKTET.vedtakBegrunnelseType,
-            triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
+            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
-            erFørsteVedtaksperiodePåFagsak = false,
+            erFørsteVedtaksperiodePåFagsak = false
 
         )
 
@@ -252,10 +254,10 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = Standardbegrunnelse.OPPHØR_UTVANDRET.vedtakBegrunnelseType,
-            triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
+            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
-            erFørsteVedtaksperiodePåFagsak = false,
+            erFørsteVedtaksperiodePåFagsak = false
 
         )
 
@@ -280,7 +282,7 @@ class UtgjørendePersonerTest {
             lagTestPersonopplysningGrunnlag(
                 behandling.id,
                 søkerFnr,
-                listOf(barn1Fnr, barn2Fnr),
+                listOf(barn1Fnr, barn2Fnr)
             )
 
         val vilkårsvurdering = Vilkårsvurdering(
@@ -323,11 +325,10 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = VedtakBegrunnelseType.INNVILGET,
-            triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), medlemskap = true),
+            triggesAv = lagTriggesAv(vilkår = Vilkår.BOSATT_I_RIKET, medlemskap = true),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
-            erFørsteVedtaksperiodePåFagsak = false,
-
+            erFørsteVedtaksperiodePåFagsak = false
         )
 
         val personerMedUtgjørendeVilkårBosattIRiket = hentPersonerForAlleUtgjørendeVilkår(
@@ -337,10 +338,10 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = VedtakBegrunnelseType.INNVILGET,
-            triggesAv = TriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
+            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
-            erFørsteVedtaksperiodePåFagsak = false,
+            erFørsteVedtaksperiodePåFagsak = false
 
         )
 
@@ -356,4 +357,24 @@ class UtgjørendePersonerTest {
             personerMedUtgjørendeVilkårBosattIRiket.first().personIdent
         )
     }
+
+    private fun lagTriggesAv(vilkår: Vilkår, medlemskap: Boolean = false) =
+        TriggesAv(
+            vilkår = setOf(vilkår),
+            medlemskap = medlemskap,
+            gjelderFørstePeriode = false,
+            gjelderFraInnvilgelsestidspunkt = false,
+            deltBostedSkalIkkeDeles = false,
+            barnDød = false,
+            barnMedSeksårsdag = false,
+            deltbosted = false,
+            personTyper = setOf(PersonType.BARN, PersonType.SØKER),
+            endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.UTBETALING_IKKE_RELEVANT,
+            endringsaarsaker = emptySet(),
+            personerManglerOpplysninger = false,
+            etterEndretUtbetaling = false,
+            satsendring = false, småbarnstillegg = false,
+            valgbar = false,
+            vurderingAnnetGrunnlag = false
+        )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/UtgjørendePersonerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/UtgjørendePersonerTest.kt
@@ -4,16 +4,14 @@ import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.lagTriggesAv
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertPersonResultat
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonerForAlleUtgjørendeVilkår
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilMinimertPerson
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -139,7 +137,7 @@ class UtgjørendePersonerTest {
                 tom = LocalDate.of(2010, 6, 1)
             ),
             oppdatertBegrunnelseType = VedtakBegrunnelseType.INNVILGET,
-            triggesAv = lagTriggesAv(Vilkår.LOVLIG_OPPHOLD),
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.LOVLIG_OPPHOLD)),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false
@@ -159,7 +157,7 @@ class UtgjørendePersonerTest {
                 tom = LocalDate.of(2010, 6, 1)
             ),
             oppdatertBegrunnelseType = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.vedtakBegrunnelseType,
-            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false
@@ -234,7 +232,7 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = Standardbegrunnelse.REDUKSJON_BOSATT_I_RIKTET.vedtakBegrunnelseType,
-            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false
@@ -254,7 +252,7 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = Standardbegrunnelse.OPPHØR_UTVANDRET.vedtakBegrunnelseType,
-            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false
@@ -325,7 +323,7 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = VedtakBegrunnelseType.INNVILGET,
-            triggesAv = lagTriggesAv(vilkår = Vilkår.BOSATT_I_RIKET, medlemskap = true),
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET), medlemskap = true),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false
@@ -338,7 +336,7 @@ class UtgjørendePersonerTest {
                 tom = TIDENES_ENDE
             ),
             oppdatertBegrunnelseType = VedtakBegrunnelseType.INNVILGET,
-            triggesAv = lagTriggesAv(Vilkår.BOSATT_I_RIKET),
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.BOSATT_I_RIKET)),
             aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false
@@ -357,24 +355,4 @@ class UtgjørendePersonerTest {
             personerMedUtgjørendeVilkårBosattIRiket.first().personIdent
         )
     }
-
-    private fun lagTriggesAv(vilkår: Vilkår, medlemskap: Boolean = false) =
-        TriggesAv(
-            vilkår = setOf(vilkår),
-            medlemskap = medlemskap,
-            gjelderFørstePeriode = false,
-            gjelderFraInnvilgelsestidspunkt = false,
-            deltBostedSkalIkkeDeles = false,
-            barnDød = false,
-            barnMedSeksårsdag = false,
-            deltbosted = false,
-            personTyper = setOf(PersonType.BARN, PersonType.SØKER),
-            endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.UTBETALING_IKKE_RELEVANT,
-            endringsaarsaker = emptySet(),
-            personerManglerOpplysninger = false,
-            etterEndretUtbetaling = false,
-            satsendring = false, småbarnstillegg = false,
-            valgbar = false,
-            vurderingAnnetGrunnlag = false
-        )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.lagTriggesAv
 import no.nav.familie.ba.sak.common.lagUtbetalingsperiodeDetalj
 import no.nav.familie.ba.sak.common.lagUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
@@ -293,7 +294,7 @@ internal class StandardbegrunnelseTest {
             lagEndretUtbetalingAndel(prosent = BigDecimal.ZERO, person = barn)
                 .tilMinimertEndretUtbetalingAndel()
                 .oppfyllerSkalUtbetalesTrigger(
-                    triggesAv = lagTriggesAv(EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES)
+                    triggesAv = lagTriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES)
                 )
         )
 
@@ -320,30 +321,10 @@ internal class StandardbegrunnelseTest {
             lagEndretUtbetalingAndel(prosent = BigDecimal.valueOf(100), person = barn)
                 .tilMinimertEndretUtbetalingAndel()
                 .oppfyllerSkalUtbetalesTrigger(
-                    triggesAv = lagTriggesAv(EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES)
+                    triggesAv = lagTriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES)
                 )
         )
     }
-
-    private fun lagTriggesAv(endretUtbetalingSkalUtbetales: EndretUtbetalingsperiodeDeltBostedTriggere) =
-        TriggesAv(
-            vilkår = emptySet(),
-            medlemskap = false,
-            gjelderFørstePeriode = false,
-            gjelderFraInnvilgelsestidspunkt = false,
-            deltBostedSkalIkkeDeles = false,
-            barnDød = false,
-            barnMedSeksårsdag = false,
-            deltbosted = false,
-            personTyper = setOf(PersonType.BARN, PersonType.SØKER),
-            endretUtbetalingSkalUtbetales = endretUtbetalingSkalUtbetales,
-            endringsaarsaker = emptySet(),
-            personerManglerOpplysninger = false,
-            etterEndretUtbetaling = false,
-            satsendring = false, småbarnstillegg = false,
-            valgbar = false,
-            vurderingAnnetGrunnlag = false
-        )
 
     @Test
     fun `Alle begrunnelser er unike`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -293,7 +293,7 @@ internal class StandardbegrunnelseTest {
             lagEndretUtbetalingAndel(prosent = BigDecimal.ZERO, person = barn)
                 .tilMinimertEndretUtbetalingAndel()
                 .oppfyllerSkalUtbetalesTrigger(
-                    triggesAv = TriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES),
+                    triggesAv = lagTriggesAv(EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES)
                 )
         )
 
@@ -301,7 +301,7 @@ internal class StandardbegrunnelseTest {
             lagEndretUtbetalingAndel(prosent = BigDecimal.valueOf(100), person = barn)
                 .tilMinimertEndretUtbetalingAndel()
                 .oppfyllerSkalUtbetalesTrigger(
-                    triggesAv = TriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_IKKE_UTBETALES),
+                    triggesAv = lagTriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_IKKE_UTBETALES)
                 )
         )
     }
@@ -312,7 +312,7 @@ internal class StandardbegrunnelseTest {
             lagEndretUtbetalingAndel(prosent = BigDecimal.ZERO, person = barn)
                 .tilMinimertEndretUtbetalingAndel()
                 .oppfyllerSkalUtbetalesTrigger(
-                    triggesAv = TriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_IKKE_UTBETALES),
+                    triggesAv = lagTriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_IKKE_UTBETALES)
                 )
         )
 
@@ -320,10 +320,30 @@ internal class StandardbegrunnelseTest {
             lagEndretUtbetalingAndel(prosent = BigDecimal.valueOf(100), person = barn)
                 .tilMinimertEndretUtbetalingAndel()
                 .oppfyllerSkalUtbetalesTrigger(
-                    triggesAv = TriggesAv(endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES),
+                    triggesAv = lagTriggesAv(EndretUtbetalingsperiodeDeltBostedTriggere.SKAL_UTBETALES)
                 )
         )
     }
+
+    private fun lagTriggesAv(endretUtbetalingSkalUtbetales: EndretUtbetalingsperiodeDeltBostedTriggere) =
+        TriggesAv(
+            vilkår = emptySet(),
+            medlemskap = false,
+            gjelderFørstePeriode = false,
+            gjelderFraInnvilgelsestidspunkt = false,
+            deltBostedSkalIkkeDeles = false,
+            barnDød = false,
+            barnMedSeksårsdag = false,
+            deltbosted = false,
+            personTyper = setOf(PersonType.BARN, PersonType.SØKER),
+            endretUtbetalingSkalUtbetales = endretUtbetalingSkalUtbetales,
+            endringsaarsaker = emptySet(),
+            personerManglerOpplysninger = false,
+            etterEndretUtbetaling = false,
+            satsendring = false, småbarnstillegg = false,
+            valgbar = false,
+            vurderingAnnetGrunnlag = false
+        )
 
     @Test
     fun `Alle begrunnelser er unike`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestBehandlingsgrunnlagForBrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertPersonResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertRestEndretUtbetalingAndel
@@ -16,7 +17,6 @@ import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnels
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.dødeBarnForrigePeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.periodeErOppyltForYtelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilMinimertPerson
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -34,7 +34,7 @@ class VedtaksperiodeServiceUtilsTest {
 
         val persongrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandling.id, personer = arrayOf(søker, barn))
-        val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD))
+        val triggesAv = lagTriggesAv()
         val vilkårsvurdering = lagVilkårsvurdering(
             søkerAktør = søker.aktør,
             behandling = behandling,
@@ -78,7 +78,7 @@ class VedtaksperiodeServiceUtilsTest {
 
         val persongrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandling.id, personer = arrayOf(søker, barn2))
-        val triggesAv = TriggesAv(vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD))
+        val triggesAv = lagTriggesAv()
         val vilkårsvurdering = lagVilkårsvurdering(
             søkerAktør = søker.aktør,
             behandling = behandling,
@@ -116,6 +116,26 @@ class VedtaksperiodeServiceUtilsTest {
             personidenterForBegrunnelse.toSet()
         )
     }
+
+    private fun lagTriggesAv() =
+        TriggesAv(
+            vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD),
+            medlemskap = false,
+            gjelderFørstePeriode = false,
+            gjelderFraInnvilgelsestidspunkt = false,
+            deltBostedSkalIkkeDeles = false,
+            barnDød = false,
+            barnMedSeksårsdag = false,
+            deltbosted = false,
+            personTyper = setOf(PersonType.BARN, PersonType.SØKER),
+            endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.UTBETALING_IKKE_RELEVANT,
+            endringsaarsaker = emptySet(),
+            personerManglerOpplysninger = false,
+            etterEndretUtbetaling = false,
+            satsendring = false, småbarnstillegg = false,
+            valgbar = false,
+            vurderingAnnetGrunnlag = false
+        )
 
     val ytelseTyperSmåbarnstillegg =
         setOf(YtelseType.SMÅBARNSTILLEGG, YtelseType.UTVIDET_BARNETRYGD, YtelseType.ORDINÆR_BARNETRYGD)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -5,17 +5,16 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.lagTriggesAv
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestBehandlingsgrunnlagForBrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertPersonResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertRestEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnelse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.periodeErOppyltForYtelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilMinimertPerson
@@ -34,7 +33,7 @@ class VedtaksperiodeServiceUtilsTest {
 
         val persongrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandling.id, personer = arrayOf(søker, barn))
-        val triggesAv = lagTriggesAv()
+        val triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD))
         val vilkårsvurdering = lagVilkårsvurdering(
             søkerAktør = søker.aktør,
             behandling = behandling,
@@ -78,7 +77,7 @@ class VedtaksperiodeServiceUtilsTest {
 
         val persongrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandling.id, personer = arrayOf(søker, barn2))
-        val triggesAv = lagTriggesAv()
+        val triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD))
         val vilkårsvurdering = lagVilkårsvurdering(
             søkerAktør = søker.aktør,
             behandling = behandling,
@@ -116,26 +115,6 @@ class VedtaksperiodeServiceUtilsTest {
             personidenterForBegrunnelse.toSet()
         )
     }
-
-    private fun lagTriggesAv() =
-        TriggesAv(
-            vilkår = setOf(Vilkår.UTVIDET_BARNETRYGD),
-            medlemskap = false,
-            gjelderFørstePeriode = false,
-            gjelderFraInnvilgelsestidspunkt = false,
-            deltBostedSkalIkkeDeles = false,
-            barnDød = false,
-            barnMedSeksårsdag = false,
-            deltbosted = false,
-            personTyper = setOf(PersonType.BARN, PersonType.SØKER),
-            endretUtbetalingSkalUtbetales = EndretUtbetalingsperiodeDeltBostedTriggere.UTBETALING_IKKE_RELEVANT,
-            endringsaarsaker = emptySet(),
-            personerManglerOpplysninger = false,
-            etterEndretUtbetaling = false,
-            satsendring = false, småbarnstillegg = false,
-            valgbar = false,
-            vurderingAnnetGrunnlag = false
-        )
 
     val ytelseTyperSmåbarnstillegg =
         setOf(YtelseType.SMÅBARNSTILLEGG, YtelseType.UTVIDET_BARNETRYGD, YtelseType.ORDINÆR_BARNETRYGD)


### PR DESCRIPTION
…a bort standard-parametra frå TriggesAv-objektet

### 💰 Hva skal gjøres, og hvorfor?
Tar bort standard-parametre som dels er unødvendige, dels ei mogleg feilkjelde.

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8538

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har oppdatert oppsettet i dei eksisterande

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
