### PR TITLE
Endre valideringen av personidenter med OS-perioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -166,9 +166,9 @@ class BeregningService(
                 vilkårsvurdering = vilkårsvurdering,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 behandling = behandling
-            ) { aktørId ->
+            ) { søkerAktør ->
                 småbarnstilleggService.hentOgLagrePerioderMedFullOvergangsstønad(
-                    aktør = aktørId,
+                    søkerAktør = søkerAktør,
                     behandlingId = behandling.id
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -44,12 +44,12 @@ class SmåbarnstilleggService(
             .map { it.tilInternPeriodeOvergangsstønad() }
             .slåSammenTidligerePerioder()
             .splitFramtidigePerioderFraForrigeBehandling(
-                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId),
+                overgangsstønadPerioderFraForrigeBehandling = hentPerioderMedOvergangsstønadFraForrigeIverksatteBehandling(behandlingId),
                 søkerAktør = aktør
             )
     }
 
-    private fun hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId: Long): List<InternPeriodeOvergangsstønad> {
+    private fun hentPerioderMedOvergangsstønadFraForrigeIverksatteBehandling(behandlingId: Long): List<InternPeriodeOvergangsstønad> {
         val forrigeIverksatteBehandling =
             behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksattFraBehandlingsId(behandlingId = behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -29,9 +29,9 @@ class SmåbarnstilleggService(
         aktør: Aktør,
         behandlingId: Long
     ): List<InternPeriodeOvergangsstønad> {
-        val periodeOvergangsstønad = hentPerioderMedFullOvergangsstønad(aktør)
+        val periodeOvergangsstønad = hentPerioderMedFullOvergangsstønad(aktør = aktør)
 
-        periodeOvergangsstønadGrunnlagRepository.deleteByBehandlingId(behandlingId)
+        periodeOvergangsstønadGrunnlagRepository.deleteByBehandlingId(behandlingId = behandlingId)
         periodeOvergangsstønadGrunnlagRepository.saveAll(
             periodeOvergangsstønad.map {
                 it.tilPeriodeOvergangsstønadGrunnlag(
@@ -44,7 +44,8 @@ class SmåbarnstilleggService(
             .map { it.tilInternPeriodeOvergangsstønad() }
             .slåSammenTidligerePerioder()
             .splitFramtidigePerioderFraForrigeBehandling(
-                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId)
+                overgangsstønadPerioderFraForrigeBehandling = hentPerioderOvergangsønadFraForrigeIverksatteBehandling(behandlingId),
+                søkerAktør = aktør
             )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -26,16 +26,16 @@ class SmåbarnstilleggService(
 ) {
 
     fun hentOgLagrePerioderMedFullOvergangsstønad(
-        aktør: Aktør,
+        søkerAktør: Aktør,
         behandlingId: Long
     ): List<InternPeriodeOvergangsstønad> {
-        val periodeOvergangsstønad = hentPerioderMedFullOvergangsstønad(aktør = aktør)
+        val periodeOvergangsstønad = hentPerioderMedFullOvergangsstønad(aktør = søkerAktør)
 
         periodeOvergangsstønadGrunnlagRepository.deleteByBehandlingId(behandlingId = behandlingId)
         periodeOvergangsstønadGrunnlagRepository.saveAll(
             periodeOvergangsstønad.map {
                 it.tilPeriodeOvergangsstønadGrunnlag(
-                    behandlingId, aktør
+                    behandlingId = behandlingId, aktør = søkerAktør
                 )
             }
         )
@@ -45,7 +45,7 @@ class SmåbarnstilleggService(
             .slåSammenTidligerePerioder()
             .splitFramtidigePerioderFraForrigeBehandling(
                 overgangsstønadPerioderFraForrigeBehandling = hentPerioderMedOvergangsstønadFraForrigeIverksatteBehandling(behandlingId),
-                søkerAktør = aktør
+                søkerAktør = søkerAktør
             )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -69,7 +69,7 @@ fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandl
                 "Perioder i inneværende behandling: $this \n" +
                 "Perioder fra forrige behandling: $overgangsstønadPerioderFraForrigeBehandling"
         )
-        throw Feil("Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn 1 person.")
+        throw Feil("Antar overgangsstønad for kun søker, men fant overgangsstønad for andre personer enn søker.")
     }
 
     val tidligerePerioder = this.filter { it.tomDato.isSameOrBefore(LocalDate.now()) }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.forrigeMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
 import org.slf4j.Logger
@@ -54,19 +55,21 @@ fun List<InternPeriodeOvergangsstønad>.slåSammenSammenhengendePerioder(): List
  *
  ***/
 fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandling(
-    overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>
+    overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>,
+    søkerAktør: Aktør
 ): List<InternPeriodeOvergangsstønad> {
-    val personerMedOvergangsstønadIForrigeOgInneværendeBehandling = (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }.toSet()
-    val erOvergangsstønadForMerEnnEnPerson =
-        personerMedOvergangsstønadIForrigeOgInneværendeBehandling.size > 1
-    if (erOvergangsstønadForMerEnnEnPerson) {
+    val personidenterMedOvergangsstønadIForrigeOgInneværendeBehandling = (this + overgangsstønadPerioderFraForrigeBehandling).map { it.personIdent }.toSet()
+    val allePersonidenterErTilknyttetSøker =
+        personidenterMedOvergangsstønadIForrigeOgInneværendeBehandling.all { personident -> søkerAktør.personidenter.map { it.fødselsnummer }.contains(personident) }
+
+    if (!allePersonidenterErTilknyttetSøker) {
         secureLogger.info(
-            "Fant overgangsstønad for mer enn 1 person. \n" +
-                "Personer: $personerMedOvergangsstønadIForrigeOgInneværendeBehandling \n" +
+            "Fant overgangsstønad for andre personer enn søker. \n" +
+                "Personer: $personidenterMedOvergangsstønadIForrigeOgInneværendeBehandling \n" +
                 "Perioder i inneværende behandling: $this \n" +
                 "Perioder fra forrige behandling: $overgangsstønadPerioderFraForrigeBehandling"
         )
-        throw Feil("Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn en person.")
+        throw Feil("Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn 1 person.")
     }
 
     val tidligerePerioder = this.filter { it.tomDato.isSameOrBefore(LocalDate.now()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -109,7 +109,7 @@ fun randomFnr(): String = fødselsnummerGenerator.foedselsnummer().asString
 fun randomPersonident(aktør: Aktør, fnr: String = randomFnr()): Personident =
     Personident(fødselsnummer = fnr, aktør = aktør)
 
-fun randomAktørId(fnr: String = randomFnr()): Aktør =
+fun randomAktør(fnr: String = randomFnr()): Aktør =
     Aktør(Random.nextLong(1000_000_000_000, 31_121_299_99999).toString()).also {
         it.personidenter.add(
             randomPersonident(it, fnr)
@@ -179,7 +179,7 @@ fun tilfeldigPerson(
     fødselsdato: LocalDate = LocalDate.now(),
     personType: PersonType = PersonType.BARN,
     kjønn: Kjønn = Kjønn.MANN,
-    aktør: Aktør = randomAktørId(),
+    aktør: Aktør = randomAktør(),
 ) =
     Person(
         id = nestePersonId(),
@@ -196,7 +196,7 @@ fun tilfeldigSøker(
     fødselsdato: LocalDate = LocalDate.now(),
     personType: PersonType = PersonType.SØKER,
     kjønn: Kjønn = Kjønn.MANN,
-    aktør: Aktør = randomAktørId(),
+    aktør: Aktør = randomAktør(),
 ) =
     Person(
         id = nestePersonId(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
@@ -91,7 +91,7 @@ internal class TidTest {
 
     @Test
     fun `skal bestemme om periode er etterfølgende periode`() {
-        val personAktørId = randomAktørId()
+        val personAktørId = randomAktør()
         val behandling = lagBehandling()
         val resultat: Resultat = mockk()
         val vilkår: Vilkår = mockk(relaxed = true)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/brev/MinimertPerson.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/brev/MinimertPerson.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.dataGenerator.brev
 
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.MinimertPerson
@@ -10,7 +10,7 @@ fun lagMinimertPerson(
     type: PersonType = PersonType.BARN,
     fødselsdato: LocalDate = LocalDate.now().minusYears(if (type == PersonType.BARN) 2 else 30),
     aktivPersonIdent: String = randomFnr(),
-    aktørId: String = randomAktørId(aktivPersonIdent).aktørId,
+    aktørId: String = randomAktør(aktivPersonIdent).aktørId,
     dødsfallsdato: LocalDate? = null
 ) = MinimertPerson(
     type = type,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/endretUtbetaling/MinimertEndretUtbetaling.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/endretUtbetaling/MinimertEndretUtbetaling.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.dataGenerator.endretUtbetaling
 
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertEndretAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
@@ -8,7 +8,7 @@ import java.math.BigDecimal
 import java.time.YearMonth
 
 fun lagMinimertEndretUtbetalingAndel(
-    aktørId: String = randomAktørId(randomFnr()).aktørId,
+    aktørId: String = randomAktør(randomFnr()).aktørId,
     fom: YearMonth? = YearMonth.now(),
     tom: YearMonth? = YearMonth.now(),
     årsak: Årsak? = Årsak.DELT_BOSTED,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/Datagenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/Datagenerator.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner
 
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.DEFAULT_JOURNALFØRENDE_ENHET
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Sakstype
 import no.nav.familie.ba.sak.task.dto.FAGSYSTEM
@@ -96,7 +96,7 @@ fun lagTestOppgaveDTO(
 ): Oppgave {
     return Oppgave(
         id = oppgaveId,
-        aktoerId = randomAktørId().aktørId,
+        aktoerId = randomAktør().aktørId,
         identer = listOf(OppgaveIdentV2("11111111111", IdentGruppe.FOLKEREGISTERIDENT)),
         journalpostId = "1234",
         tildeltEnhetsnr = tildeltEnhetsnr,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
@@ -18,7 +18,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import no.nav.familie.ba.sak.common.MDCOperations
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVedtak
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTestDev
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
@@ -449,7 +449,7 @@ class IntergrasjonTjenesteTest : AbstractSpringIntegrationTestDev() {
     @Test
     @Tag("integration")
     fun `skal opprette skyggesak for Sak`() {
-        val aktørId = randomAktørId()
+        val aktørId = randomAktør()
 
         wireMockServer.stubFor(post("/api/skyggesak/v1").willReturn(okJson(objectMapper.writeValueAsString(success(null)))))
 
@@ -475,7 +475,7 @@ class IntergrasjonTjenesteTest : AbstractSpringIntegrationTestDev() {
     @Test
     @Tag("integration")
     fun `skal kaste integrasjonsfeil ved oppretting av skyggesak`() {
-        val aktørId = randomAktørId()
+        val aktørId = randomAktør()
 
         wireMockServer.stubFor(post("/api/skyggesak/v1").willReturn(status(500)))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
@@ -124,7 +124,7 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
     private fun andelPåTilkjentYtelse(
         tilkjentYtelse: TilkjentYtelse,
         periodeOffset: Long,
-        aktør: Aktør = randomAktørId()
+        aktør: Aktør = randomAktør()
     ) = AndelTilkjentYtelse(
         aktør = aktør,
         behandlingId = tilkjentYtelse.behandling.id,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.defaultFagsak
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.AutovedtakFødselshendelseService
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevService
@@ -36,7 +36,7 @@ class AutobrevStegServiceTest {
 
     @Test
     fun `Skal stoppe autovedtak og opprette oppgave ved åpen behandling som utredes`() {
-        val aktør = randomAktørId()
+        val aktør = randomAktør()
         val fagsak = defaultFagsak(aktør)
         val behandling = lagBehandling(fagsak).also {
             it.status = BehandlingStatus.UTREDES
@@ -57,7 +57,7 @@ class AutobrevStegServiceTest {
 
     @Test
     fun `Skal stoppe autovedtak og opprette oppgave ved åpen behandling med status Fatter vedtak`() {
-        val aktør = randomAktørId()
+        val aktør = randomAktør()
         val fagsak = defaultFagsak(aktør)
         val behandling = lagBehandling(fagsak).also {
             it.status = BehandlingStatus.FATTER_VEDTAK
@@ -78,7 +78,7 @@ class AutobrevStegServiceTest {
 
     @Test
     fun `Skal stoppe autovedtak ved å kaste feil ved åpen behandling som iverksettes`() {
-        val aktør = randomAktørId()
+        val aktør = randomAktør()
         val fagsak = defaultFagsak(aktør)
         val behandling = lagBehandling(fagsak).also {
             it.status = BehandlingStatus.IVERKSETTER_VEDTAK

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FlerlingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FlerlingUtilsTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse
 
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
@@ -253,8 +253,8 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal lage oppgave fordi barnet i hendelse ikke behandles på åpen behandling`() {
-        val barn = randomAktørId()
-        val barn2 = randomAktørId()
+        val barn = randomAktør()
+        val barn2 = randomAktør()
 
         assertFalse(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(
@@ -266,8 +266,8 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal ignorere hendelse fordi barnet i hendelse behandles på åpen behandling`() {
-        val barn = randomAktørId()
-        val barn2 = randomAktørId()
+        val barn = randomAktør()
+        val barn2 = randomAktør()
 
         assertTrue(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(
@@ -279,9 +279,9 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal ignorere hendelse fordi barna i hendelse behandles på åpen behandling`() {
-        val barn = randomAktørId()
-        val barn2 = randomAktørId()
-        val barn3 = randomAktørId()
+        val barn = randomAktør()
+        val barn2 = randomAktør()
+        val barn3 = randomAktør()
 
         assertTrue(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(
@@ -293,9 +293,9 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal lage oppgave fordi kun 1 av barna i hendelse behandles på åpen behandling`() {
-        val barn = randomAktørId()
-        val barn2 = randomAktørId()
-        val barn3 = randomAktørId()
+        val barn = randomAktør()
+        val barn2 = randomAktør()
+        val barn3 = randomAktør()
 
         assertFalse(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.DatoIntervallEntitet
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
@@ -147,7 +147,7 @@ class VilkårVurderingTest(
     ): Person {
         val fnr = randomFnr()
         return Person(
-            aktør = randomAktørId(fnr),
+            aktør = randomAktør(fnr),
             type = type,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fødselsdato = LocalDate.of(1991, 1, 1),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelForFlereBarnTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelForFlereBarnTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ba.sak.common.LocalDateService
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.VergeResponse
@@ -41,9 +41,9 @@ import java.time.LocalDate
 
 class FiltreringsregelForFlereBarnTest {
 
-    val barnAktør0 = randomAktørId()
-    val barnAktør1 = randomAktørId()
-    val gyldigAktør = randomAktørId()
+    val barnAktør0 = randomAktør()
+    val barnAktør1 = randomAktør()
+    val gyldigAktør = randomAktør()
 
     val personopplysningGrunnlagRepositoryMock = mockk<PersonopplysningGrunnlagRepository>()
     val personopplysningerServiceMock = mockk<PersonopplysningerService>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregler
 
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.tilfeldigSøker
@@ -16,7 +16,7 @@ import java.time.LocalDate
 
 internal class FiltreringsregelTest {
 
-    private val gyldigAktørId = randomAktørId()
+    private val gyldigAktørId = randomAktør()
 
     @Test
     fun `Regelevaluering skal resultere i Ja`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVedtak
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
@@ -305,7 +305,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
     ) = PeriodeOvergangsstønadGrunnlag(
         id = 1,
         behandlingId = 1,
-        aktør = randomAktørId(),
+        aktør = randomAktør(),
         fom = fom,
         tom = tom,
         datakilde = PeriodeOvergangsstønad.Datakilde.EF

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingUtilsTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils.validerBehandlingIkkeSendtTilEksterneTjenester
 import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.bestemKategoriVedOpprettelse
 import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.bestemUnderkategori
@@ -126,7 +126,7 @@ class BehandlingUtilsTest {
 
     @Test
     fun `Skal returnere utvidet hvis det eksisterer en løpende utvidet-sak`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
 
         val behandling = lagBehandling()
 
@@ -158,7 +158,7 @@ class BehandlingUtilsTest {
 
     @Test
     fun `Skal returnere ordinær hvis det eksisterer en utvidet-sak som er avsluttet`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
 
         val behandling = lagBehandling()
 
@@ -190,7 +190,7 @@ class BehandlingUtilsTest {
 
     @Test
     fun `Skal returnere ordinær hvis det eksisterer en løpende ordinær-sak`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
 
         val behandling = lagBehandling()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.lagPersonResultaterForSøkerOgToBarn
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.tilAktør
@@ -63,7 +63,7 @@ class BehandlingstemaServiceTest {
 
     @Test
     fun `Skal utlede EØS dersom minst ett vilkår i har blitt behandlet i inneværende behandling`() {
-        val barn = randomAktørId()
+        val barn = randomAktør()
         val vilkårsvurdering = Vilkårsvurdering(
             behandling = defaultBehandling,
         )
@@ -93,7 +93,7 @@ class BehandlingstemaServiceTest {
 
     @Test
     fun `Skal utlede NASJONAL dersom EØS vilkåret ble behandlet i annen behandling`() {
-        val barn = randomAktørId()
+        val barn = randomAktør()
         val vilkårsvurdering = Vilkårsvurdering(
             behandling = defaultBehandling,
         )
@@ -150,7 +150,7 @@ class BehandlingstemaServiceTest {
 
     @Test
     fun `Skal utlede ORDINÆR dersom UTVIDET vilkåret ble behandlet i annen behandling`() {
-        val barn = randomAktørId()
+        val barn = randomAktør()
         val vilkårsvurdering = Vilkårsvurdering(
             behandling = defaultBehandling,
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatMedKravTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatMedKravTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.inneværendeMåned
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -18,8 +18,8 @@ class BehandlingsresultatMedKravTest {
 
     val søker = tilfeldigPerson()
 
-    private val barn1Aktør = randomAktørId()
-    private val barn2Aktør = randomAktørId()
+    private val barn1Aktør = randomAktør()
+    private val barn2Aktør = randomAktør()
     private val defaultYtelseSluttForLøpende = inneværendeMåned().plusMonths(1)
     private val defaultYtelseSluttForAvslått = TIDENES_MORGEN.toYearMonth()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtenKravTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtenKravTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.inneværendeMåned
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test
 class BehandlingsresultatUtenKravTest {
 
     val søker = tilfeldigPerson()
-    private val barn1Aktør = randomAktørId()
-    private val barn2Aktør = randomAktørId()
+    private val barn1Aktør = randomAktør()
+    private val barn2Aktør = randomAktør()
 
     /**
      * Tester for caser hvor krav ikke er framstilt av søker.

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -18,7 +18,7 @@ class BehandlingsresultatUtilsTest {
 
     val søker = tilfeldigPerson()
 
-    private val barn1Aktør = randomAktørId()
+    private val barn1Aktør = randomAktør()
 
     @Test
     fun `Skal kaste feil dersom det finnes uvurderte ytelsepersoner`() {
@@ -172,7 +172,7 @@ private fun lagYtelsePerson(
     val ytelseType = YtelseType.ORDINÆR_BARNETRYGD
     val kravOpprinnelse = listOf(KravOpprinnelse.TIDLIGERE, KravOpprinnelse.INNEVÆRENDE)
     return YtelsePerson(
-        aktør = randomAktørId(),
+        aktør = randomAktør(),
         ytelseType = ytelseType,
         kravOpprinnelse = kravOpprinnelse,
         resultater = setOf(resultat),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/InternPeriodeOvergangsstønadTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/InternPeriodeOvergangsstønadTest.kt
@@ -1,12 +1,18 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.common.randomPersonident
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.slåSammenSammenhengendePerioder
+import no.nav.familie.ba.sak.kjerne.beregning.domene.splitFramtidigePerioderFraForrigeBehandling
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 
 class InternPeriodeOvergangsstønadTest {
@@ -46,5 +52,67 @@ class InternPeriodeOvergangsstønadTest {
         ).slåSammenSammenhengendePerioder()
 
         assertEquals(2, sammenslåttePerioder.size)
+    }
+
+    @Test
+    fun `Skal kaste feil hvis OS-perioder hører til to forskjellige personer`() {
+        val aktør1 = randomAktør(fnr = "12345678910")
+        val aktør2 = randomAktør(fnr = "23456789101")
+
+        val gamlePerioder = listOf(
+            InternPeriodeOvergangsstønad(
+                fomDato = LocalDate.now().minusYears(3).førsteDagIInneværendeMåned(),
+                tomDato = LocalDate.now().minusMonths(5).sisteDagIMåned(),
+                personIdent = aktør1.aktivFødselsnummer()
+            ),
+            InternPeriodeOvergangsstønad(
+                fomDato = LocalDate.now().minusMonths(4).førsteDagIInneværendeMåned(),
+                tomDato = LocalDate.now().minusMonths(1).sisteDagIMåned(),
+                personIdent = aktør1.aktivFødselsnummer()
+            )
+        )
+
+        val nyePerioder = listOf(
+            InternPeriodeOvergangsstønad(
+                fomDato = LocalDate.now().minusYears(3).førsteDagIInneværendeMåned(),
+                tomDato = LocalDate.now().minusMonths(1).sisteDagIMåned(),
+                personIdent = aktør2.aktivFødselsnummer()
+            )
+        )
+
+        assertThrows<Feil> { nyePerioder.splitFramtidigePerioderFraForrigeBehandling(overgangsstønadPerioderFraForrigeBehandling = gamlePerioder, søkerAktør = aktør2) }
+    }
+    @Test
+    fun `Skal ikke kaste feil hvis OS-perioder har forskjellige personidenter, men er knyttet til samme aktør`() {
+        val ident1 = "12345678910"
+        val ident2 = "23456789101"
+        val aktør = randomAktør(fnr = ident1).also {
+            it.personidenter.add(
+                randomPersonident(it, ident2)
+            )
+        }
+
+        val gamlePerioder = listOf(
+            InternPeriodeOvergangsstønad(
+                fomDato = LocalDate.now().minusYears(3).førsteDagIInneværendeMåned(),
+                tomDato = LocalDate.now().minusMonths(5).sisteDagIMåned(),
+                personIdent = ident1
+            ),
+            InternPeriodeOvergangsstønad(
+                fomDato = LocalDate.now().minusMonths(4).førsteDagIInneværendeMåned(),
+                tomDato = LocalDate.now().minusMonths(1).sisteDagIMåned(),
+                personIdent = ident1
+            )
+        )
+
+        val nyePerioder = listOf(
+            InternPeriodeOvergangsstønad(
+                fomDato = LocalDate.now().minusYears(3).førsteDagIInneværendeMåned(),
+                tomDato = LocalDate.now().minusMonths(1).sisteDagIMåned(),
+                personIdent = ident2
+            )
+        )
+
+        assertDoesNotThrow { nyePerioder.splitFramtidigePerioderFraForrigeBehandling(overgangsstønadPerioderFraForrigeBehandling = gamlePerioder, søkerAktør = aktør) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.common.nesteMåned
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.tilfeldigPerson
@@ -31,7 +31,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal generere periode med rett til småbarnstillegg for 1 barn`() {
-        val aktør = randomAktørId()
+        val aktør = randomAktør()
 
         val småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
             behandlingId = 1L,
@@ -99,8 +99,8 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal generere periode med rett til småbarnstillegg for 2 barn hvor kun 1 får utbetalinger`() {
-        val barnUnder3År = randomAktørId()
-        val barnOver3År = randomAktørId()
+        val barnUnder3År = randomAktør()
+        val barnOver3År = randomAktør()
 
         val småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
             behandlingId = 1L,
@@ -178,8 +178,8 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal svare false om at nye perioder med full OS påvirker behandling`() {
-        val personIdent = randomAktørId()
-        val barnIdent = randomAktørId()
+        val personIdent = randomAktør()
+        val barnIdent = randomAktør()
 
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
@@ -224,8 +224,8 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal svare false om at nye perioder med full OS påvirker behandling ved flere perioder`() {
-        val personIdent = randomAktørId()
-        val barnIdent = randomAktørId()
+        val personIdent = randomAktør()
+        val barnIdent = randomAktør()
 
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
@@ -289,8 +289,8 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `skal ikke behandle vedtak om overgangsstønad når vedtaket ikke fører til endring i utbetaling`() {
-        val personIdent = randomAktørId()
-        val barnIdent = randomAktørId()
+        val personIdent = randomAktør()
+        val barnIdent = randomAktør()
 
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
@@ -340,8 +340,8 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `skal behandle vedtak om overgangsstønad når vedtaket fører til endring i utbetaling`() {
-        val personIdent = randomAktørId()
-        val barnIdent = randomAktørId()
+        val personIdent = randomAktør()
+        val barnIdent = randomAktør()
 
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.nesteMåned
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
@@ -903,7 +903,7 @@ internal class UtvidetBarnetrygdTest {
     fun `Skal kaste feil hvis utvidet-andeler ikke overlapper med noen av barnas andeler`() {
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
-        val søkerAktør = randomAktørId()
+        val søkerAktør = randomAktør()
 
         val utvidetVilkår = lagVilkårResultat(vilkårType = Vilkår.UTVIDET_BARNETRYGD, periodeFom = LocalDate.of(2018, 2, 1), periodeTom = LocalDate.of(2019, 2, 28), personResultat = PersonResultat(aktør = søkerAktør, vilkårsvurdering = lagVilkårsvurdering(søkerAktør = søkerAktør, behandling = behandling, resultat = Resultat.OPPFYLT)))
 
@@ -941,7 +941,7 @@ internal class UtvidetBarnetrygdTest {
     fun `Skal dele opp utvidet-segment ved endring i sats`() {
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
-        val søkerAktør = randomAktørId()
+        val søkerAktør = randomAktør()
 
         val utvidetVilkår = lagVilkårResultat(vilkårType = Vilkår.UTVIDET_BARNETRYGD, periodeFom = LocalDate.of(2016, 2, 1), periodeTom = LocalDate.of(2022, 2, 28), personResultat = PersonResultat(aktør = søkerAktør, vilkårsvurdering = lagVilkårsvurdering(søkerAktør = søkerAktør, behandling = behandling, resultat = Resultat.OPPFYLT)))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelserTestKlasser.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.brev.domene
 
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
@@ -47,7 +47,7 @@ data class BrevBegrunnelserTestConfig(
 
 data class BrevbegrunnelserTestPerson(
     val personIdent: String = randomFnr(),
-    val aktørId: String = randomAktørId(personIdent).aktørId,
+    val aktørId: String = randomAktør(personIdent).aktørId,
     val type: PersonType,
     val fødselsdato: LocalDate,
     val overstyrteVilkårresultater: List<MinimertVilkårResultat>,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagPersonResultat
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -373,7 +373,7 @@ class EndretUtbetalingAndelValideringTest {
             personResultatForPerson,
             lagPersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
-                aktør = randomAktørId(),
+                aktør = randomAktør(),
                 resultat = Resultat.OPPFYLT,
                 personType = PersonType.BARN,
                 periodeFom = fom.minusMonths(3),
@@ -451,7 +451,7 @@ class EndretUtbetalingAndelValideringTest {
             personResultatForPerson,
             lagPersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
-                aktør = randomAktørId(),
+                aktør = randomAktør(),
                 resultat = Resultat.OPPFYLT,
                 personType = PersonType.BARN,
                 periodeFom = fom1.minusMonths(3),
@@ -536,7 +536,7 @@ class EndretUtbetalingAndelValideringTest {
             personResultatForPerson,
             lagPersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
-                aktør = randomAktørId(),
+                aktør = randomAktør(),
                 resultat = Resultat.OPPFYLT,
                 personType = PersonType.BARN,
                 periodeFom = fomBarn2,
@@ -615,7 +615,7 @@ class EndretUtbetalingAndelValideringTest {
             personResultatForPerson,
             lagPersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
-                aktør = randomAktørId(),
+                aktør = randomAktør(),
                 resultat = Resultat.OPPFYLT,
                 personType = PersonType.BARN,
                 periodeFom = fomBarn2,
@@ -649,7 +649,7 @@ class EndretUtbetalingAndelValideringTest {
             ),
             lagPersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
-                aktør = randomAktørId(),
+                aktør = randomAktør(),
                 periodeFom = LocalDate.now().minusMonths(4),
                 periodeTom = LocalDate.now(),
                 resultat = Resultat.OPPFYLT

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -70,7 +70,7 @@ class SendTilBeslutterTest {
     @Test
     fun `Sjekk validering som inneholder annen vurdering som ikke er vurdert`() {
         val vilkårsvurdering =
-            lagVilkårsvurdering(randomAktørId(), lagBehandling(), Resultat.IKKE_VURDERT)
+            lagVilkårsvurdering(randomAktør(), lagBehandling(), Resultat.IKKE_VURDERT)
 
         assertThrows<FunksjonellFeil> {
             vilkårsvurdering.validerAtAlleAnndreVurderingerErVurdert()
@@ -80,7 +80,7 @@ class SendTilBeslutterTest {
     @Test
     fun `Sjekk validering som inneholder annen vurdering hvor alle er vurdert`() {
         val vilkårsvurdering =
-            lagVilkårsvurdering(randomAktørId(), lagBehandling(), Resultat.IKKE_OPPFYLT)
+            lagVilkårsvurdering(randomAktør(), lagBehandling(), Resultat.IKKE_OPPFYLT)
 
         vilkårsvurdering.validerAtAlleAnndreVurderingerErVurdert()
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagPersonResultat
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
@@ -66,9 +66,9 @@ class VilkårsvurderingStegTest {
         årsak = BehandlingÅrsak.HELMANUELL_MIGRERING
     )
     val søkerPersonIdent = randomFnr()
-    val søkerAktørId = randomAktørId(søkerPersonIdent)
+    val søkerAktørId = randomAktør(søkerPersonIdent)
     val barnIdent = randomFnr()
-    val barnAktørId = randomAktørId(barnIdent)
+    val barnAktørId = randomAktør(barnIdent)
 
     @BeforeEach
     fun setup() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.FeatureToggleService
@@ -157,7 +157,7 @@ class VedtakServiceTest(
             vilkårsvurderingService,
         )
 
-        val personAktørId = randomAktørId()
+        val personAktørId = randomAktør()
 
         behandling = lagBehandling()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/AnnenVurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/AnnenVurderingServiceTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPersonResultat
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.ekstern.restDomene.RestAnnenVurdering
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.AnnenVurdering
@@ -31,7 +31,7 @@ class AnnenVurderingServiceTest {
 
         personResultat = lagPersonResultat(
             vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling()),
-            aktør = randomAktørId(),
+            aktør = randomAktør(),
             resultat = Resultat.OPPFYLT,
             periodeFom = LocalDate.of(2020, 1, 1),
             periodeTom = LocalDate.of(2020, 7, 1)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagVilkårResultat
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -27,7 +27,7 @@ class OppdaterVilkårsvurderingTest {
     @Test
     fun `Skal legge til nytt vilkår`() {
         val fnr1 = randomFnr()
-        val aktørId1 = randomAktørId()
+        val aktørId1 = randomAktør()
         val behandling = lagBehandling()
         val resA = lagVilkårsvurdering(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
         val resB = lagVilkårsvurderingResultatB(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
@@ -45,7 +45,7 @@ class OppdaterVilkårsvurderingTest {
     @Test
     fun `Skal fjerne vilkår`() {
         val fnr1 = randomFnr()
-        val aktørId1 = randomAktørId()
+        val aktørId1 = randomAktør()
         val behandling = lagBehandling()
         val resA = lagVilkårsvurderingResultatB(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
         val resB = lagVilkårsvurdering(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
@@ -65,8 +65,8 @@ class OppdaterVilkårsvurderingTest {
     fun `Skal legge til person på vilkårsvurdering`() {
         val fnr1 = randomFnr()
         val fnr2 = randomFnr()
-        val aktørId1 = randomAktørId()
-        val aktørId2 = randomAktørId()
+        val aktørId1 = randomAktør()
+        val aktørId2 = randomAktør()
         val behandling = lagBehandling()
         val resA = lagVilkårsvurdering(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
         val resB = lagVilkårsvurdering(
@@ -83,8 +83,8 @@ class OppdaterVilkårsvurderingTest {
     fun `Skal fjerne person på vilkårsvurdering`() {
         val fnr1 = randomFnr()
         val fnr2 = randomFnr()
-        val aktørId1 = randomAktørId()
-        val aktørId2 = randomAktørId()
+        val aktørId1 = randomAktør()
+        val aktørId2 = randomAktør()
         val behandling = lagBehandling()
         val resA = lagVilkårsvurdering(
             behandling = behandling,
@@ -125,7 +125,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal ha med tomt vilkår på person hvis vilkåret ble avslått forrige behandling`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
 
@@ -172,7 +172,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal ha med oppfylte perioder fra vilkår på person hvis vilkåret ble både avslått og innvilget forrige behandling`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
 
@@ -226,7 +226,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal beholde vilkår om utvidet barnetrygd når forrige behandling inneholdt utvidet-vilkåret, men inneværende behandling er ordinær`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
         val initUtenUtvidetVilkår =
@@ -254,7 +254,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal beholde vilkår om utvidet barnetrygd når det eksisterer løpende sak med utvidet, men inneværende behandling er ordinær`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
         val initUtenUtvidetVilkår =
@@ -281,7 +281,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal fjerne vilkår om utvidet barnetrygd når den inneværende behandlingen gjelder ordinær, og det ikke eksisterer løpende sak med utvidet, eller utvidet-vilkåret var på forrige behandling`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
         val initUtenUtvidetVilkår =
@@ -312,7 +312,7 @@ class OppdaterVilkårsvurderingTest {
     @Test
     fun `Skal kun kopiere over oppfylte utvidet-vilkår ved opprettelse av ny behandling, men slette alle fra aktiv`() {
         val søkerFnr = randomFnr()
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
 
@@ -361,7 +361,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal kopiere over alle utvidet-vilkår fra aktiv vilkårsvurdering hvis den aktive vilkårsvurderingen er fra den inneværende behandlingen`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
         val initUtenUtvidetVilkår =
@@ -409,7 +409,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal ikke legge til utvidet vilkåret hvis det kun eksisterer ikke-oppfylte perioder, men fortsatt slette fra aktiv`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/PeriodeMapperTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/PeriodeMapperTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.defaultFagsak
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -54,13 +54,13 @@ class PeriodeMapperTest {
             it.behandlingStegTilstand.add(BehandlingStegTilstand(0, it, FØRSTE_STEG))
         }
 
-        vilkårsvurdering = lagVilkårsvurdering(randomAktørId(), behandling, Resultat.IKKE_VURDERT)
+        vilkårsvurdering = lagVilkårsvurdering(randomAktør(), behandling, Resultat.IKKE_VURDERT)
     }
 
     @Test
     fun `Kombinert tidslinje returnerer rette rette vilkårsresultater for tidsintervaller`() {
         val personResultat =
-            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = randomAktørId())
+            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = randomAktør())
 
         val tidslinje1 = LocalDateTimeline(
             listOf(
@@ -225,7 +225,7 @@ class PeriodeMapperTest {
         // Periode med fom-dato medio mai og tom-dato medio juni skal bli hele mai og juni
 
         val personResultat =
-            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = randomAktørId())
+            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = randomAktør())
         personResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -252,7 +252,7 @@ class PeriodeMapperTest {
         val periodeTom18ÅrsVilkår = LocalDate.of(2038, 5, 15)
 
         val personResultat =
-            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = randomAktørId())
+            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = randomAktør())
         personResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårVurderingMatcherTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårVurderingMatcherTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
@@ -13,7 +13,7 @@ class VilkårVurderingMatcherTest {
 
     private val randomBehandling = lagBehandling()
     private val søkerFnr = randomFnr()
-    private val søkerAktørId = randomAktørId()
+    private val søkerAktørId = randomAktør()
 
     private fun likeVilkårResultater(a: VilkårResultat?, b: VilkårResultat?): Boolean =
         a?.vilkårType == b?.vilkårType &&

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingStegUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingStegUtilsTest.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.toPeriode
 import no.nav.familie.ba.sak.ekstern.restDomene.RestVilkårResultat
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -36,7 +36,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @BeforeEach
     fun init() {
-        val personAktørId = randomAktørId()
+        val personAktørId = randomAktør()
 
         behandling = lagBehandling()
 
@@ -312,7 +312,7 @@ class VilkårsvurderingStegUtilsTest {
     fun `Skal nullstille periode hvis det kun finnes en periode`() {
         val mockPersonResultat = PersonResultat(
             vilkårsvurdering = vilkårsvurdering,
-            aktør = randomAktørId(),
+            aktør = randomAktør(),
         )
 
         val mockVilkårResultat = VilkårResultat(
@@ -376,7 +376,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke bort ikke oppfylte perioder når det gjelder samme behandling`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
         val initiellVilkårvurdering =
@@ -405,7 +405,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke oppfylt om oppfylt finnes ved kopiering fra forrige behandling`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
         val behandling2 = lagBehandling()
 
@@ -432,7 +432,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke ikke oppfylt om oppfylt ikke finnes`() {
-        val søkerAktørId = randomAktørId()
+        val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
         val initiellVilkårsvurdering =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.ekstern.restDomene.RestVilkårResultat
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -18,13 +18,13 @@ import java.time.LocalDateTime
 class VilkårsvurderingUtilsTest {
 
     private val uvesentligVilkårsvurdering =
-        lagVilkårsvurdering(randomAktørId(), lagBehandling(), Resultat.IKKE_VURDERT)
+        lagVilkårsvurdering(randomAktør(), lagBehandling(), Resultat.IKKE_VURDERT)
 
     @Test
     fun `feil kastes når det finnes løpende oppfylt ved forsøk på å legge til avslag uten periode`() {
         val personResultat = PersonResultat(
             vilkårsvurdering = uvesentligVilkårsvurdering,
-            aktør = randomAktørId()
+            aktør = randomAktør()
         )
         val løpendeOppfylt = VilkårResultat(
             personResultat = personResultat,
@@ -62,7 +62,7 @@ class VilkårsvurderingUtilsTest {
     fun `feil kastes når det finnes avslag uten periode ved forsøk på å legge til løpende oppfylt`() {
         val personResultat = PersonResultat(
             vilkårsvurdering = uvesentligVilkårsvurdering,
-            aktør = randomAktørId()
+            aktør = randomAktør()
         )
         val avslagUtenPeriode = VilkårResultat(
             personResultat = personResultat,
@@ -100,7 +100,7 @@ class VilkårsvurderingUtilsTest {
     fun `skal ikke kaste feil hvis vilkåret er bor med søker`() {
         val personResultat = PersonResultat(
             vilkårsvurdering = uvesentligVilkårsvurdering,
-            aktør = randomAktørId()
+            aktør = randomAktør()
         )
         val løpendeOppfylt = VilkårResultat(
             personResultat = personResultat,
@@ -138,7 +138,7 @@ class VilkårsvurderingUtilsTest {
     fun `feil kastes ikke når når ingen periode er løpende`() {
         val personResultat = PersonResultat(
             vilkårsvurdering = uvesentligVilkårsvurdering,
-            aktør = randomAktørId()
+            aktør = randomAktør()
         )
         val avslagUtenPeriode = VilkårResultat(
             personResultat = personResultat,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.common.lagVedtaksperiodeMedBegrunnelser
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.tilfeldigSøker
 import no.nav.familie.ba.sak.config.FeatureToggleService
@@ -250,7 +250,7 @@ internal class SaksstatistikkServiceTest(
         every { persongrunnlagService.hentSøker(any()) } returns tilfeldigSøker()
         every { persongrunnlagService.hentBarna(any<Behandling>()) } returns listOf(
             tilfeldigPerson()
-                .copy(aktør = randomAktørId("01010000001"))
+                .copy(aktør = randomAktør("01010000001"))
         )
 
         every { vedtakService.hentAktivForBehandling(any()) } returns vedtak
@@ -375,7 +375,7 @@ internal class SaksstatistikkServiceTest(
 
     @Test
     fun `Skal mappe til sakDVH, aktører har SØKER og BARN`() {
-        val randomAktørId = randomAktørId()
+        val randomAktørId = randomAktør()
         every { fagsakService.hentPåFagsakId(any()) } answers {
             Fagsak(status = FagsakStatus.OPPRETTET, aktør = randomAktørId)
         }
@@ -480,7 +480,7 @@ internal class SaksstatistikkServiceTest(
 
     @Test
     fun `Enum-verdier brukt i sakDvh skal validere mot json schema`() {
-        val deltagere = PersonType.values().map { personType -> AktørDVH(randomAktørId().aktørId.toLong(), personType.name) }
+        val deltagere = PersonType.values().map { personType -> AktørDVH(randomAktør().aktørId.toLong(), personType.name) }
 
         FagsakStatus.values().forEach {
             val sakDvh = SakDVH(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.AbstractMockkSpringRunner
@@ -854,7 +854,7 @@ class MigreringServiceTest(
         every { mockkPersonidentService.hentOgLagreAktørIder(any(), false) } answers { callOriginal() }
 
         every { mockkPersonidentService.hentOgLagreAktør(any(), false) } returns
-            Aktør(randomAktørId().aktørId, personidenter = mutableSetOf())
+            Aktør(randomAktør().aktørId, personidenter = mutableSetOf())
 
         assertThatThrownBy {
             s.migrer(ident)
@@ -863,7 +863,7 @@ class MigreringServiceTest(
 
         // Verifiserer at feiltypen ikke er den samme når vi endrer til unike aktørId'er for barna
         every { mockkPersonidentService.hentOgLagreAktør(any(), false) } answers {
-            Aktør(randomAktørId().aktørId, personidenter = mutableSetOf())
+            Aktør(randomAktør().aktørId, personidenter = mutableSetOf())
         }
         assertThatThrownBy { s.migrer(ident) }
             .extracting("feiltype").isNotEqualTo(MigreringsfeilType.HISTORISK_IDENT_REGNET_SOM_EKSTRA_BARN_I_INFOTRYGD)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingUtplukkingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingUtplukkingIntegrationTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.nyRevurdering
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
@@ -266,7 +266,7 @@ class KonsistensavstemmingUtplukkingIntegrationTest : AbstractSpringIntegrationT
         tilkjentYtelse: TilkjentYtelse,
         kildeBehandlingId: Long,
         periodeOffset: Long,
-        aktør: Aktør = randomAktørId(),
+        aktør: Aktør = randomAktør(),
     ) = AndelTilkjentYtelse(
         behandlingId = tilkjentYtelse.behandling.id,
         tilkjentYtelse = tilkjentYtelse,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandslingsresultat/BehandlingsresultaterTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandslingsresultat/BehandlingsresultaterTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -26,7 +26,7 @@ class BehandlingsresultaterTest {
 
     @BeforeEach
     fun init() {
-        every { personidentService.hentAktør(any()) } answers { randomAktørId() }
+        every { personidentService.hentAktør(any()) } answers { randomAktør() }
     }
 
     @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.kompetanse
 
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
@@ -24,9 +24,9 @@ class KompetanseRepositoryTest(
 
     @Test
     fun `Skal lagre flere kompetanser med gjenbruk av flere aktører`() {
-        val søker = aktørIdRepository.save(randomAktørId())
-        val barn1 = aktørIdRepository.save(randomAktørId())
-        val barn2 = aktørIdRepository.save(randomAktørId())
+        val søker = aktørIdRepository.save(randomAktør())
+        val barn1 = aktørIdRepository.save(randomAktør())
+        val barn2 = aktørIdRepository.save(randomAktør())
 
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))
@@ -48,8 +48,8 @@ class KompetanseRepositoryTest(
 
     @Test
     fun `Skal lagre skjema-feltene`() {
-        val søker = aktørIdRepository.save(randomAktørId())
-        val barn1 = aktørIdRepository.save(randomAktørId())
+        val søker = aktørIdRepository.save(randomAktør())
+        val barn1 = aktørIdRepository.save(randomAktør())
 
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
 
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
@@ -24,9 +24,9 @@ class UtenlandskPeriodebeløpRepositoryTest(
 
     @Test
     fun `Skal lagre flere utenlandske periodebeløp med gjenbruk av flere aktører`() {
-        val søker = aktørIdRepository.save(randomAktørId())
-        val barn1 = aktørIdRepository.save(randomAktørId())
-        val barn2 = aktørIdRepository.save(randomAktørId())
+        val søker = aktørIdRepository.save(randomAktør())
+        val barn1 = aktørIdRepository.save(randomAktør())
+        val barn2 = aktørIdRepository.save(randomAktør())
 
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))
@@ -48,8 +48,8 @@ class UtenlandskPeriodebeløpRepositoryTest(
 
     @Test
     fun `Skal lagre skjema-feltene`() {
-        val søker = aktørIdRepository.save(randomAktørId())
-        val barn1 = aktørIdRepository.save(randomAktørId())
+        val søker = aktørIdRepository.save(randomAktør())
+        val barn1 = aktørIdRepository.save(randomAktør())
 
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
 
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagValutakurs
@@ -24,9 +24,9 @@ class ValutakursRepositoryTest(
 
     @Test
     fun `Skal lagre flere valutakurser med gjenbruk av flere aktører`() {
-        val søker = aktørIdRepository.save(randomAktørId())
-        val barn1 = aktørIdRepository.save(randomAktørId())
-        val barn2 = aktørIdRepository.save(randomAktørId())
+        val søker = aktørIdRepository.save(randomAktør())
+        val barn1 = aktørIdRepository.save(randomAktør())
+        val barn2 = aktørIdRepository.save(randomAktør())
 
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))
@@ -48,8 +48,8 @@ class ValutakursRepositoryTest(
 
     @Test
     fun `Skal lagre skjema-feltene`() {
-        val søker = aktørIdRepository.save(randomAktørId())
-        val barn1 = aktørIdRepository.save(randomAktørId())
+        val søker = aktørIdRepository.save(randomAktør())
+        val barn1 = aktørIdRepository.save(randomAktør())
 
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.fagsak
 
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
-import no.nav.familie.ba.sak.common.randomAktørId
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.ClientMocks
@@ -91,7 +91,7 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal opprette fagsak med aktørid`() {
-        val aktørId = randomAktørId()
+        val aktørId = randomAktør()
 
         val response =
             fagsakController.hentEllerOpprettFagsak(FagsakRequest(personIdent = null, aktørId = aktørId.aktørId))
@@ -135,7 +135,7 @@ class FagsakControllerTest(
     fun `Skal returnere eksisterende fagsak på person som allerede finnes med gammel ident`() {
         val fnr = randomFnr()
         val nyttFnr = randomFnr()
-        val aktørId = randomAktørId().aktørId
+        val aktørId = randomAktør().aktørId
 
         // Får ikke mockPersonopplysningerService til å virke riktig derfor oppdateres db direkte.
         val aktør = aktørIdRepository.save(Aktør(aktørId))
@@ -163,7 +163,7 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal returnere eksisterende fagsak på person som allerede finnes basert på aktørid`() {
-        val aktørId = randomAktørId()
+        val aktørId = randomAktør()
 
         val nyRestFagsak = fagsakController.hentEllerOpprettFagsak(
             FagsakRequest(personIdent = aktørId.aktivFødselsnummer(), aktørId = aktørId.aktørId)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til task som feiler med meldingen: "no.nav.familie.ba.sak.common.Feil: Antar overgangsstønad for kun søker, men fant overgangsstønad for mer enn en person."

Grunnen til at denne feilet er fordi søker har endret ident. I forrige behandling hentet vi perioder fra infotrygd (som var oppdatert), men nå har EF periodene på sin side (hvor identen ikke var oppdatert). Har snakket med EF om dette, og kommet frem til at det er enklest å endre valideringen fra vår side. Personidenten i periodene brukes ikke direkte til noe annet enn eventuell feilsøking når det skjer noe feil. Endrer derfor valideringen til å sjekke om personidentene vi finner er knyttet til andre aktører enn søker sin aktør, som er det vi i utgangspunktet er interessert i.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Ikke egentlig. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
