### PR TITLE
Tea-6031: Fjerner dirtiescontext på alle tester som skal fungere etter man begynte å cleare mocks

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -83,7 +82,6 @@ import java.time.format.DateTimeFormatter
     "mock-rest-template-config"
 )
 @Tag("integration")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MigreringServiceTest(
     @Autowired
     private val databaseCleanupService: DatabaseCleanupService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
@@ -35,12 +35,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 import java.time.LocalDate.now
 
-// Todo. Bruker every. Dette endrer funksjonalliteten for alle klasser.
-// TODO kan kanskje fjerne dirties
-@DirtiesContext
 class ArbeidsfordelingIntegrationTest(
 
     @Autowired

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutomatiskVilkårsvurderingIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutomatiskVilkårsvurderingIntegrasjonTest.kt
@@ -22,12 +22,8 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 import java.time.LocalDate
 
-// Todo. Bruker every. Dette endrer funksjonalliteten for alle klasser.
-// TODO kan kanskje fjerne dirties
-@DirtiesContext
 class AutomatiskVilkårsvurderingIntegrasjonTest(
     @Autowired val stegService: StegService,
     @Autowired val mockPersonopplysningerService: PersonopplysningerService,
@@ -51,7 +47,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(barnFnr)) } returns mockBarnAutomatiskBehandling
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
-        val behandlingFørVilkår = stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+        val behandlingFørVilkår =
+            stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)
@@ -67,7 +64,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(barnFnr)) } returns mockBarnGift
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
-        val behandlingFørVilkår = stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+        val behandlingFørVilkår =
+            stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)
@@ -92,7 +90,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(søkerFnr)) } returns søker
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
-        val behandlingFørVilkår = stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+        val behandlingFørVilkår =
+            stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)
@@ -136,7 +135,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(søkerFnr)) } returns søker
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
-        val behandlingFørVilkår = stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+        val behandlingFørVilkår =
+            stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
@@ -66,12 +66,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 import java.time.LocalDate
 import java.time.YearMonth
 
-// Todo. Bruker every. Dette endrer funksjonalliteten for alle klasser.
-@DirtiesContext
 class BehandlingIntegrationTest(
     @Autowired
     private val behandlingRepository: BehandlingRepository,
@@ -659,10 +656,12 @@ class BehandlingIntegrationTest(
                     assertEquals(barn1Postnummer, matrikkeladresse.postnummer)
                     assertEquals(barn1Tilleggsnavn, matrikkeladresse.tilleggsnavn)
                 }
+
                 barn2Fnr -> {
                     val ukjentBosted = it.bostedsadresser.sisteAdresse() as GrUkjentBosted
                     assertEquals(barn2BostedKommune, ukjentBosted.bostedskommune)
                 }
+
                 else -> {
                     throw RuntimeException("Ujent barn fnr")
                 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
@@ -36,11 +36,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
-import org.springframework.test.annotation.DirtiesContext
 import java.time.LocalDate
 import java.time.YearMonth
 
-@DirtiesContext
 class AutobrevSmåbarnstilleggOpphørTest(
     @Autowired private val fagsakService: FagsakService,
     @Autowired private val fagsakRepository: FagsakRepository,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -67,12 +67,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
-import org.springframework.test.annotation.DirtiesContext
 import java.time.LocalDate
 import java.time.YearMonth
 
-// Todo. Bruker every. Dette endrer funksjonalliteten for alle klasser.
-@DirtiesContext
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class BehandleSmåbarnstilleggTest(
     @Autowired private val fagsakService: FagsakService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
@@ -25,12 +25,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 import java.time.LocalDate
 import java.time.YearMonth
 
-// Todo. Bruker every. Dette endrer funksjonalliteten for alle klasser.
-@DirtiesContext
 class BehandlingSatsendringTest(
     @Autowired private val mockLocalDateService: LocalDateService,
     @Autowired private val behandleFødselshendelseTask: BehandleFødselshendelseTask,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelTest.kt
@@ -18,12 +18,10 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
-@DirtiesContext
 class EndretUtbetalingAndelTest(
     @Autowired private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     @Autowired private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 class FerdigstillBehandlingTaskTest : AbstractSpringIntegrationTest() {
 
     @Autowired


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det ble tidligere påstått i kommentarene at @DirtiesContext måtte bli brukt fordi `every` ble brukt som `endret funksjonalliteten for alle klasser.`. Jeg så dog at man uansett unmocker og setter opp mockene på nytt for hver test, så jeg forsøkte å fjerne @DirtiesContext og det har vist seg til å fungere.

Vi får uansett ikke så mye gevinst på dette, da spring context'n må settes opp på nytt for mange av våre tester. (mest gevinst på verdikjedetest?)
Dette er pågrunn av at mange av testene kjører med forskjellig antall @ActiveProfiles (burde sees på i en annen sak)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Litt usikker på hvor stabilt dette er. Har tidligere fått beskjed om at det testene sporadisk feiler hvis man ikke har DirtiesContext, men jeg har ikke opplevd dette.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [X] Ja
- [ ] Nei
