### PR TITLE
Tea-9063: Justert tekst ved angring av korrigert etterbetaling i loggene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
@@ -395,7 +395,7 @@ class LoggService(
 
         val tittel = if (korrigertEtterbetaling.aktiv) {
             "Etterbetaling i brev er korrigert"
-        } else "Etterbetaling i brev er fjernet"
+        } else "Korrigert etterbetaling er angret"
 
         lagre(
             Logg(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Justerer tekst som dukker opp i loggene når man angrer korrigert etterbetaling

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
