### PR TITLE
Tea-8707: Gjera så flytting av resultat for vilkårsvurdering gjer mindre mutering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
@@ -82,7 +83,10 @@ object VilkårsvurderingResultatFlytter {
     ) {
         // Fyll inn den initierte med person fra aktiv
         val personsVilkårAktivt = oppdaterEksisterendePerson(
-            personFraInit = personFraInit,
+            personFraInit = PersonFraInitRequest(
+                aktør = personFraInit.aktør,
+                vilkårResultater = personFraInit.vilkårResultater
+            ),
             kopieringSkjerFraForrigeBehandling = kopieringSkjerFraForrigeBehandling,
             personTilOppdatert = personTilOppdatert,
             forrigeBehandlingVilkårsvurdering = forrigeBehandlingVilkårsvurdering,
@@ -98,7 +102,7 @@ object VilkårsvurderingResultatFlytter {
     }
 
     private fun oppdaterEksisterendePerson(
-        personFraInit: PersonResultat,
+        personFraInit: PersonFraInitRequest,
         kopieringSkjerFraForrigeBehandling: Boolean,
         personTilOppdatert: PersonResultat,
         forrigeBehandlingVilkårsvurdering: Vilkårsvurdering?,
@@ -169,4 +173,5 @@ object VilkårsvurderingResultatFlytter {
             this
         }
     }
+    private data class PersonFraInitRequest(val aktør: Aktør, val vilkårResultater: Set<VilkårResultat>)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
@@ -136,10 +136,12 @@ object VilkårsvurderingResultatFlytter {
             }
         }
 
-        // Hvis forrige behandling inneholdt utvidet-vilkåret eller underkategorien er utvidet skal
-        // utvidet-vilkåret kopieres med videre uansett nåværende underkategori
-        if (personsVilkårOppdatert.none { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.UTVIDET_BARNETRYGD } &&
-            (eksistererUtvidetVilkårPåForrigeBehandling(personResultaterFraForrigeBehandling, personFraInit) || løpendeUnderkategori == BehandlingUnderkategori.UTVIDET)
+        if (forrigeBehandlingInneholdtUtvidetVilkåretEllerUnderkategorienErUtvidet(
+                personsVilkårOppdatert,
+                personResultaterFraForrigeBehandling,
+                personFraInit,
+                løpendeUnderkategori
+            )
         ) {
             val utvidetVilkår =
                 personenSomFinnesVilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.UTVIDET_BARNETRYGD }
@@ -153,6 +155,21 @@ object VilkårsvurderingResultatFlytter {
         personTilOppdatert.setSortedVilkårResultater(personsVilkårOppdatert.toSet())
         return personsVilkårAktivt
     }
+
+    // Hvis forrige behandling inneholdt utvidet-vilkåret eller underkategorien er utvidet skal
+    // utvidet-vilkåret kopieres med videre uansett nåværende underkategori
+    private fun forrigeBehandlingInneholdtUtvidetVilkåretEllerUnderkategorienErUtvidet(
+        personsVilkårOppdatert: MutableSet<VilkårResultat>,
+        personResultaterFraForrigeBehandling: Set<PersonResultat>?,
+        personFraInit: PersonFraInitRequest,
+        løpendeUnderkategori: BehandlingUnderkategori?
+    ) = personsVilkårOppdatert.none { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.UTVIDET_BARNETRYGD } &&
+        (
+            eksistererUtvidetVilkårPåForrigeBehandling(
+                personResultaterFraForrigeBehandling,
+                personFraInit
+            ) || løpendeUnderkategori == BehandlingUnderkategori.UTVIDET
+            )
 
     private fun eksistererUtvidetVilkårPåForrigeBehandling(
         personResultaterFraForrigeBehandling: Set<PersonResultat>?,
@@ -174,5 +191,6 @@ object VilkårsvurderingResultatFlytter {
             this
         }
     }
+
     private data class PersonFraInitRequest(val aktør: Aktør, val vilkårResultater: Set<VilkårResultat>)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
@@ -59,13 +59,15 @@ object VilkårsvurderingResultatFlytter {
                     personenSomFinnesVilkårResultater = personenSomFinnes.vilkårResultater,
                     personResultaterFraForrigeBehandling = forrigeBehandlingVilkårsvurdering?.personResultater
                 )
+                vilkårResultatet = vilkårSomSkalOppdateresPåEksisterendePerson.personsVilkårOppdatert
+
                 // Fjern person fra aktivt dersom alle vilkår er fjernet, ellers oppdater
                 if (vilkårSomSkalOppdateresPåEksisterendePerson.personsVilkårAktivt.isEmpty()) {
                     personResultaterAktivt.remove(personenSomFinnes)
                 } else {
+                    // Mutering skjer herifrå og ut
                     personenSomFinnes.setSortedVilkårResultater(vilkårSomSkalOppdateresPåEksisterendePerson.personsVilkårAktivt.toSet())
                 }
-                vilkårResultatet = vilkårSomSkalOppdateresPåEksisterendePerson.personsVilkårOppdatert
             }
             personResultaterOppdatert.add(
                 PersonResultat(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
@@ -143,13 +143,11 @@ object VilkårsvurderingResultatFlytter {
         ) {
             val utvidetVilkår =
                 personenSomFinnesVilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.UTVIDET_BARNETRYGD }
-            if (utvidetVilkår.isNotEmpty()) {
-                personsVilkårOppdatert.addAll(
-                    utvidetVilkår.filtrerVilkårÅKopiere(kopieringSkjerFraForrigeBehandling = kopieringSkjerFraForrigeBehandling)
-                        .map { it.kopierMedParent(personTilOppdatert) }
-                )
-                personsVilkårAktivt.removeAll(utvidetVilkår)
-            }
+            personsVilkårOppdatert.addAll(
+                utvidetVilkår.filtrerVilkårÅKopiere(kopieringSkjerFraForrigeBehandling = kopieringSkjerFraForrigeBehandling)
+                    .map { it.kopierMedParent(personTilOppdatert) }
+            )
+            personsVilkårAktivt.removeAll(utvidetVilkår)
         }
 
         personTilOppdatert.setSortedVilkårResultater(personsVilkårOppdatert.toSet())

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
@@ -1,0 +1,153 @@
+package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
+
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import java.time.Period
+
+object VilkårsvurderingResultatFlytter {
+
+    /**
+     * Dersom personer i initieltResultat har vurderte vilkår i aktivtResultat vil disse flyttes til initieltResultat
+     * (altså vil tilsvarende vilkår overskrives i initieltResultat og slettes fra aktivtResultat).
+     *
+     * @param initiellVilkårsvurdering - Vilkårsvurdering med vilkår basert på siste behandlignsgrunnlag. Skal bli neste aktive.
+     * @param aktivVilkårsvurdering -  Vilkårsvurdering med vilkår basert på forrige behandlingsgrunnlag
+     * @param forrigeBehandlingVilkårsvurdering - Vilkårsvurdering fra forrige behandling (om den eksisterer).
+     *                                            Brukes for å sjekke om utvidet-vilkåret skal kopieres med videre.
+     * @param løpendeUnderkategori - Den løpende underkategorien for fagsaken. Brukes for å sjekke om utvidet-vilkåret skal kopieres med videre.
+     * @return oppdaterte versjoner av initieltResultat og aktivtResultat:
+     * initieltResultat (neste aktivt) med vilkår som skal benyttes videre
+     * aktivtResultat med hvilke vilkår som ikke skal benyttes videre
+     */
+    fun flyttResultaterTilInitielt(
+        initiellVilkårsvurdering: Vilkårsvurdering,
+        aktivVilkårsvurdering: Vilkårsvurdering,
+        forrigeBehandlingVilkårsvurdering: Vilkårsvurdering? = null,
+        løpendeUnderkategori: BehandlingUnderkategori? = null
+    ): Pair<Vilkårsvurdering, Vilkårsvurdering> {
+        // OBS!! MÅ jobbe på kopier av vilkårsvurderingen her for å ikke oppdatere databasen
+        // Viktig at det er vår egen implementasjon av kopier som brukes, da kotlin sin copy-funksjon er en shallow copy
+        val initiellVilkårsvurderingKopi = initiellVilkårsvurdering.kopier()
+        val aktivVilkårsvurderingKopi = aktivVilkårsvurdering.kopier()
+
+        // Identifiserer hvilke vilkår som skal legges til og hvilke som kan fjernes
+        val personResultaterAktivt = aktivVilkårsvurderingKopi.personResultater.toMutableSet()
+        val personResultaterOppdatert = mutableSetOf<PersonResultat>()
+        initiellVilkårsvurderingKopi.personResultater.forEach { personFraInit ->
+            val personTilOppdatert = PersonResultat(
+                vilkårsvurdering = initiellVilkårsvurderingKopi,
+                aktør = personFraInit.aktør
+            )
+            val personenSomFinnes = personResultaterAktivt.firstOrNull { it.aktør == personFraInit.aktør }
+
+            if (personenSomFinnes == null) {
+                // Legg til ny person
+                personTilOppdatert.setSortedVilkårResultater(
+                    personFraInit.vilkårResultater.map { it.kopierMedParent(personTilOppdatert) }
+                        .toSet()
+                )
+            } else {
+                // Fyll inn den initierte med person fra aktiv
+                oppdaterEksisterendePerson(
+                    personenSomFinnes = personenSomFinnes,
+                    personFraInit = personFraInit,
+                    kopieringSkjerFraForrigeBehandling = initiellVilkårsvurderingKopi.behandling.id != aktivVilkårsvurderingKopi.behandling.id,
+                    personTilOppdatert = personTilOppdatert,
+                    forrigeBehandlingVilkårsvurdering = forrigeBehandlingVilkårsvurdering,
+                    løpendeUnderkategori = løpendeUnderkategori,
+                    personResultaterAktivt = personResultaterAktivt
+                )
+            }
+            personResultaterOppdatert.add(personTilOppdatert)
+        }
+
+        aktivVilkårsvurderingKopi.personResultater = personResultaterAktivt
+        initiellVilkårsvurderingKopi.personResultater = personResultaterOppdatert
+
+        return Pair(initiellVilkårsvurderingKopi, aktivVilkårsvurderingKopi)
+    }
+
+    private fun oppdaterEksisterendePerson(
+        personenSomFinnes: PersonResultat,
+        personFraInit: PersonResultat,
+        kopieringSkjerFraForrigeBehandling: Boolean,
+        personTilOppdatert: PersonResultat,
+        forrigeBehandlingVilkårsvurdering: Vilkårsvurdering?,
+        løpendeUnderkategori: BehandlingUnderkategori?,
+        personResultaterAktivt: MutableSet<PersonResultat>
+    ) {
+        val personsVilkårAktivt = personenSomFinnes.vilkårResultater.toMutableSet()
+        val personsVilkårOppdatert = mutableSetOf<VilkårResultat>()
+        personFraInit.vilkårResultater.forEach { vilkårFraInit ->
+            val vilkårSomFinnes =
+                personenSomFinnes.vilkårResultater.filter { it.vilkårType == vilkårFraInit.vilkårType }
+
+            val vilkårSomSkalKopieresOver = vilkårSomFinnes.filtrerVilkårÅKopiere(
+                kopieringSkjerFraForrigeBehandling = kopieringSkjerFraForrigeBehandling
+            )
+            val vilkårSomSkalFjernesFraAktivt = vilkårSomFinnes - vilkårSomSkalKopieresOver
+            personsVilkårAktivt.removeAll(vilkårSomSkalFjernesFraAktivt)
+
+            if (vilkårSomSkalKopieresOver.isEmpty()) {
+                // Legg til nytt vilkår på person
+                personsVilkårOppdatert.add(vilkårFraInit.kopierMedParent(personTilOppdatert))
+            } else {
+                /*  Vilkår er vurdert på person - flytt fra aktivt og overskriv initierte
+                            ikke oppfylte eller ikke vurdert perioder skal ikke kopieres om minst en oppfylt
+                            periode eksisterer. */
+
+                personsVilkårOppdatert.addAll(
+                    vilkårSomSkalKopieresOver.map { it.kopierMedParent(personTilOppdatert) }
+                )
+                personsVilkårAktivt.removeAll(vilkårSomSkalKopieresOver)
+            }
+        }
+        val eksistererUtvidetVilkårPåForrigeBehandling =
+            forrigeBehandlingVilkårsvurdering?.personResultater
+                ?.firstOrNull { it.aktør == personFraInit.aktør }
+                ?.vilkårResultater
+                ?.any {
+                    it.vilkårType == Vilkår.UTVIDET_BARNETRYGD &&
+                        it.resultat == Resultat.OPPFYLT &&
+                        // forrige behandling har minst et måned ubetalt utvidet barnetrygd
+                        it.differanseIPeriode().toTotalMonths() >= Period.ofMonths(1).months
+                } ?: false
+
+        // Hvis forrige behandling inneholdt utvidet-vilkåret eller underkategorien er utvidet skal
+        // utvidet-vilkåret kopieres med videre uansett nåværende underkategori
+        if (personsVilkårOppdatert.none { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.UTVIDET_BARNETRYGD } &&
+            (eksistererUtvidetVilkårPåForrigeBehandling || løpendeUnderkategori == BehandlingUnderkategori.UTVIDET)
+        ) {
+            val utvidetVilkår =
+                personenSomFinnes.vilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.UTVIDET_BARNETRYGD }
+            if (utvidetVilkår.isNotEmpty()) {
+                personsVilkårOppdatert.addAll(
+                    utvidetVilkår.filtrerVilkårÅKopiere(kopieringSkjerFraForrigeBehandling = kopieringSkjerFraForrigeBehandling)
+                        .map { it.kopierMedParent(personTilOppdatert) }
+                )
+                personsVilkårAktivt.removeAll(utvidetVilkår)
+            }
+        }
+
+        personTilOppdatert.setSortedVilkårResultater(personsVilkårOppdatert.toSet())
+
+        // Fjern person fra aktivt dersom alle vilkår er fjernet, ellers oppdater
+        if (personsVilkårAktivt.isEmpty()) {
+            personResultaterAktivt.remove(personenSomFinnes)
+        } else {
+            personenSomFinnes.setSortedVilkårResultater(personsVilkårAktivt.toSet())
+        }
+    }
+
+    private fun List<VilkårResultat>.filtrerVilkårÅKopiere(kopieringSkjerFraForrigeBehandling: Boolean): List<VilkårResultat> {
+        return if (kopieringSkjerFraForrigeBehandling) {
+            this.filter { it.resultat == Resultat.OPPFYLT }
+        } else {
+            this
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
@@ -82,7 +82,7 @@ object VilkårsvurderingResultatFlytter {
         personResultaterAktivt: MutableSet<PersonResultat>
     ) {
         // Fyll inn den initierte med person fra aktiv
-        val personsVilkårAktivt = oppdaterEksisterendePerson(
+        val vilkårSomSkalOppdateresPåEksisterendePerson = finnVilkårSomSkalOppdateresPåEksisterendePerson(
             personFraInit = PersonFraInitRequest(
                 aktør = personFraInit.aktør,
                 vilkårResultater = personFraInit.vilkårResultater
@@ -94,7 +94,7 @@ object VilkårsvurderingResultatFlytter {
         )
 
         personTilOppdatert.setSortedVilkårResultater(
-            personsVilkårAktivt.personsVilkårOppdatert.map {
+            vilkårSomSkalOppdateresPåEksisterendePerson.personsVilkårOppdatert.map {
                 it.kopierMedParent(
                     personTilOppdatert
                 )
@@ -102,14 +102,14 @@ object VilkårsvurderingResultatFlytter {
         )
 
         // Fjern person fra aktivt dersom alle vilkår er fjernet, ellers oppdater
-        if (personsVilkårAktivt.personsVilkårAktivt.isEmpty()) {
+        if (vilkårSomSkalOppdateresPåEksisterendePerson.personsVilkårAktivt.isEmpty()) {
             personResultaterAktivt.remove(personenSomFinnes)
         } else {
-            personenSomFinnes.setSortedVilkårResultater(personsVilkårAktivt.personsVilkårAktivt.toSet())
+            personenSomFinnes.setSortedVilkårResultater(vilkårSomSkalOppdateresPåEksisterendePerson.personsVilkårAktivt.toSet())
         }
     }
 
-    private fun oppdaterEksisterendePerson(
+    private fun finnVilkårSomSkalOppdateresPåEksisterendePerson(
         personFraInit: PersonFraInitRequest,
         kopieringSkjerFraForrigeBehandling: Boolean,
         løpendeUnderkategori: BehandlingUnderkategori?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingResultatFlytter.kt
@@ -82,12 +82,12 @@ object VilkårsvurderingResultatFlytter {
     ) {
         // Fyll inn den initierte med person fra aktiv
         val personsVilkårAktivt = oppdaterEksisterendePerson(
-            personenSomFinnes = personenSomFinnes,
             personFraInit = personFraInit,
             kopieringSkjerFraForrigeBehandling = kopieringSkjerFraForrigeBehandling,
             personTilOppdatert = personTilOppdatert,
             forrigeBehandlingVilkårsvurdering = forrigeBehandlingVilkårsvurdering,
-            løpendeUnderkategori = løpendeUnderkategori
+            løpendeUnderkategori = løpendeUnderkategori,
+            personenSomFinnesVilkårResultater = personenSomFinnes.vilkårResultater
         )
         // Fjern person fra aktivt dersom alle vilkår er fjernet, ellers oppdater
         if (personsVilkårAktivt.isEmpty()) {
@@ -98,14 +98,13 @@ object VilkårsvurderingResultatFlytter {
     }
 
     private fun oppdaterEksisterendePerson(
-        personenSomFinnes: PersonResultat,
         personFraInit: PersonResultat,
         kopieringSkjerFraForrigeBehandling: Boolean,
         personTilOppdatert: PersonResultat,
         forrigeBehandlingVilkårsvurdering: Vilkårsvurdering?,
-        løpendeUnderkategori: BehandlingUnderkategori?
+        løpendeUnderkategori: BehandlingUnderkategori?,
+        personenSomFinnesVilkårResultater: Set<VilkårResultat>
     ): Set<VilkårResultat> {
-        val personenSomFinnesVilkårResultater = personenSomFinnes.vilkårResultater
         val personsVilkårAktivt = personenSomFinnesVilkårResultater.toMutableSet()
         val personsVilkårOppdatert = mutableSetOf<VilkårResultat>()
         personFraInit.vilkårResultater.forEach { vilkårFraInit ->


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
VilkårsvurderingUtils::flyttResultaterTilInitielt gjer ei heil masse mutering i mange retningar. Det gjer at det er vanskeleg å halde styr på kva som skjer og krevjande å følgje flyten.

Det gjeld også i tilhøyrande hjelpemetode, som eg med denne har skrive om til å ikkje mutere på eksisterande objekt.

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8707

I denne PR-en samlar eg muteringa til sist i metoden,


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Det kjens enno ikkje eilt bra

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
