### PR TITLE
Fjerner overflødige felter, navn og adresse, fra Verge

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestRegistrerInstitusjonOgVerge.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestRegistrerInstitusjonOgVerge.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.institusjon.Institusjon
 import no.nav.familie.ba.sak.kjerne.verge.Verge
 
-data class VergeInfo(val navn: String?, val adresse: String?, val ident: String)
+data class VergeInfo(val ident: String)
 
 data class InstitusjonInfo(val orgNummer: String, val eksternTssNummer: String)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -146,7 +146,7 @@ class UtvidetBehandlingService(
             migreringsdato = behandlingService.hentMigreringsdatoIBehandling(behandlingId = behandlingId),
             valutakurser = valutakurser.map { it.tilRestValutakurs() },
             utenlandskePeriodebeløp = utenlandskePeriodebeløp.map { it.tilRestUtenlandskPeriodebeløp() },
-            verge = behandling.verge?.let { VergeInfo(it.navn, it.adresse, it.ident) },
+            verge = behandling.verge?.let { VergeInfo(it.ident) },
             korrigertEtterbetaling = korrigertEtterbetalingService.finnAktivtKorrigeringPåBehandling(behandlingId)
                 ?.tilRestKorrigertEtterbetaling()
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/verge/Verge.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/verge/Verge.kt
@@ -23,12 +23,6 @@ data class Verge(
     @SequenceGenerator(name = "verge_seq_generator", sequenceName = "verge_seq", allocationSize = 50)
     val id: Long = 0,
 
-    @Column(name = "navn", updatable = true, length = 100)
-    var navn: String = "",
-
-    @Column(name = "adresse", updatable = true, length = 500)
-    var adresse: String = "",
-
     @Column(name = "ident", updatable = true, length = 20)
     var ident: String,
 

--- a/src/main/resources/db/migration/V221__drop_verge_navn_adresse_og_unique_index_verge_ident.sql
+++ b/src/main/resources/db/migration/V221__drop_verge_navn_adresse_og_unique_index_verge_ident.sql
@@ -1,0 +1,4 @@
+DROP INDEX uidx_verge_navn;
+DROP INDEX uidx_verge_ident;
+ALTER TABLE verge DROP COLUMN navn;
+Alter TABLE verge DROP COLUMN adresse;

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerInstitusjonOgVergeStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerInstitusjonOgVergeStegTest.kt
@@ -68,7 +68,7 @@ class RegistrerInstitusjonOgVergeStegTest {
         every { fagsakRepositoryMock.finnFagsak(any()) } returns behandling.fagsak
         every { fagsakRepositoryMock.save(capture(fagsakSlot)) } returns behandling.fagsak
         every { vergeRepositoryMock.findByBehandling(any()) } returns null
-        every { vergeRepositoryMock.save(capture(vergeSlot)) } returns Verge(1L, "", "", "", behandling)
+        every { vergeRepositoryMock.save(capture(vergeSlot)) } returns Verge(1L, "", behandling)
         every { loggServiceMock.opprettRegistrerVergeLogg(any()) } just runs
         every { loggServiceMock.opprettRegistrerInstitusjonLogg(any()) } just runs
         every { loggServiceMock.lagre(any()) } returns Logg(
@@ -81,8 +81,6 @@ class RegistrerInstitusjonOgVergeStegTest {
         every { behandlingHentOgPersisterServiceMock.hent(any()) } returns behandling
         val restRegistrerInstitusjonOgVerge = RestRegistrerInstitusjonOgVerge(
             vergeInfo = VergeInfo(
-                "verge navn",
-                "verge adresse",
                 "12345678910"
             ),
             institusjonInfo = InstitusjonInfo("12345", "cool tsr")
@@ -109,7 +107,7 @@ class RegistrerInstitusjonOgVergeStegTest {
         every { fagsakRepositoryMock.finnFagsak(any()) } returns behandling.fagsak
         every { fagsakRepositoryMock.save(any()) } returns behandling.fagsak
         every { vergeRepositoryMock.findByBehandling(any()) } returns null
-        every { vergeRepositoryMock.save(any()) } returns Verge(1L, "", "", "", behandling)
+        every { vergeRepositoryMock.save(any()) } returns Verge(1L, "", behandling)
         every { loggServiceMock.opprettRegistrerVergeLogg(any()) } just runs
         every { loggServiceMock.opprettRegistrerInstitusjonLogg(any()) } just runs
         every { loggServiceMock.lagre(any()) } returns Logg(
@@ -121,11 +119,7 @@ class RegistrerInstitusjonOgVergeStegTest {
         )
         every { behandlingHentOgPersisterServiceMock.hent(any()) } returns behandling
         val restRegistrerInstitusjonOgVerge = RestRegistrerInstitusjonOgVerge(
-            vergeInfo = VergeInfo(
-                "verge navn",
-                "verge adresse",
-                "12345678910"
-            ),
+            vergeInfo = VergeInfo("12345678910"),
             institusjonInfo = InstitusjonInfo("12345", "cool tsr")
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/verge/VergeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/verge/VergeServiceTest.kt
@@ -18,14 +18,12 @@ class VergeServiceTest {
         val behandling = lagBehandling()
         val vergeSlot = slot<Verge>()
         every { vergeRepositoryMock.findByBehandling(any()) } returns null
-        every { vergeRepositoryMock.save(capture(vergeSlot)) } returns Verge(1L, "", "", "", behandling)
+        every { vergeRepositoryMock.save(capture(vergeSlot)) } returns Verge(1L, "", behandling)
         val vergeService = VergeService(vergeRepositoryMock)
-        val verge = Verge(1L, "verge 1", "adresse 1", "12345678910", behandling)
+        val verge = Verge(1L, "12345678910", behandling)
         vergeService.OppdaterVergeForBehandling(behandling, verge)
         val vergeCaptured = vergeSlot.captured
         assertThat(vergeCaptured.id).isEqualTo(verge.id)
-        assertThat(vergeCaptured.navn).isEqualTo(verge.navn)
-        assertThat(vergeCaptured.adresse).isEqualTo(verge.adresse)
         assertThat(vergeCaptured.ident).isEqualTo(verge.ident)
         assertThat(vergeCaptured.behandling.id).isEqualTo(behandling.id)
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Navn og adresse kan fjernes fra verge da det er overflødig informasjon som ikke trengs videre ved distribusjon av brev via Dokdist-API. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
