### PR TITLE
Bugfix/tea 8868 Tillet overlappande periodar i validering for bor med søker-vilkåret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinje.kt
@@ -5,12 +5,15 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerSenereEnn
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerTidligereEnn
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 
 fun Iterable<VilkårResultat>.tilVilkårRegelverkResultatTidslinje(): Tidslinje<VilkårRegelverkResultat, Dag> {
     val vilkårResultater = this
     return object : Tidslinje<VilkårRegelverkResultat, Dag>() {
         override fun lagPerioder() = vilkårResultater.map { it.tilPeriode() }
+        override fun skalValidereMotOverlapp(): Boolean =
+            vilkårResultater.map { it.vilkårType }.any { Vilkår.BOR_MED_SØKER != it }
     }
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinjeKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinjeKtTest.kt
@@ -15,36 +15,28 @@ internal class VilkårsresultatDagTidslinjeKtTest {
     @Test
     fun `kan ha to overlappende perioder hvis det er bor med søker-vilkåret`() {
         val personAktørId = randomAktør()
-        val behandling = lagBehandling()
-        val vilkårsvurdering = lagVilkårsvurdering(personAktørId, behandling, Resultat.OPPFYLT)
-
         val personResultat = PersonResultat(
-            vilkårsvurdering = vilkårsvurdering,
+            vilkårsvurdering = lagVilkårsvurdering(personAktørId, lagBehandling(), Resultat.OPPFYLT),
             aktør = personAktørId
         )
 
         val vilkårResultat = setOf(
-            VilkårResultat(
-                personResultat = personResultat,
-                resultat = Resultat.OPPFYLT,
-                vilkårType = Vilkår.BOR_MED_SØKER,
-                periodeFom = LocalDate.of(2020, 3, 31),
-                periodeTom = null,
-                begrunnelse = "",
-                behandlingId = personResultat.vilkårsvurdering.behandling.id
-            ),
-            VilkårResultat(
-                personResultat = personResultat,
-                resultat = Resultat.IKKE_OPPFYLT,
-                vilkårType = Vilkår.BOR_MED_SØKER,
-                periodeFom = null,
-                periodeTom = null,
-                begrunnelse = "",
-                behandlingId = personResultat.vilkårsvurdering.behandling.id
-            )
+            lagVilkårResultat(personResultat, Resultat.OPPFYLT, fom = LocalDate.of(2020, 3, 31)),
+            lagVilkårResultat(personResultat, Resultat.IKKE_OPPFYLT, fom = null)
         )
 
         val tidslinje = vilkårResultat.tilVilkårRegelverkResultatTidslinje()
         tidslinje.perioder()
     }
+
+    private fun lagVilkårResultat(personResultat: PersonResultat, resultat: Resultat, fom: LocalDate?) =
+        VilkårResultat(
+            personResultat = personResultat,
+            resultat = resultat,
+            vilkårType = Vilkår.BOR_MED_SØKER,
+            periodeFom = fom,
+            periodeTom = null,
+            begrunnelse = "",
+            behandlingId = personResultat.vilkårsvurdering.behandling.id
+        )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinjeKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinjeKtTest.kt
@@ -1,0 +1,50 @@
+package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
+
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class VilkårsresultatDagTidslinjeKtTest {
+
+    @Test
+    fun `kan ha to overlappende perioder hvis det er bor med søker-vilkåret`() {
+        val personAktørId = randomAktør()
+        val behandling = lagBehandling()
+        val vilkårsvurdering = lagVilkårsvurdering(personAktørId, behandling, Resultat.OPPFYLT)
+
+        val personResultat = PersonResultat(
+            vilkårsvurdering = vilkårsvurdering,
+            aktør = personAktørId
+        )
+
+        val vilkårResultat = setOf(
+            VilkårResultat(
+                personResultat = personResultat,
+                resultat = Resultat.OPPFYLT,
+                vilkårType = Vilkår.BOR_MED_SØKER,
+                periodeFom = LocalDate.of(2020, 3, 31),
+                periodeTom = null,
+                begrunnelse = "",
+                behandlingId = personResultat.vilkårsvurdering.behandling.id
+            ),
+            VilkårResultat(
+                personResultat = personResultat,
+                resultat = Resultat.IKKE_OPPFYLT,
+                vilkårType = Vilkår.BOR_MED_SØKER,
+                periodeFom = null,
+                periodeTom = null,
+                begrunnelse = "",
+                behandlingId = personResultat.vilkårsvurdering.behandling.id
+            )
+        )
+
+        val tidslinje = vilkårResultat.tilVilkårRegelverkResultatTidslinje()
+        tidslinje.perioder()
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinjeKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinjeKtTest.kt
@@ -4,10 +4,13 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje.Companion.TidslinjeFeilException
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 
 internal class VilkårsresultatDagTidslinjeKtTest {
@@ -21,19 +24,36 @@ internal class VilkårsresultatDagTidslinjeKtTest {
         )
 
         val vilkårResultat = setOf(
-            lagVilkårResultat(personResultat, Resultat.OPPFYLT, fom = LocalDate.of(2020, 3, 31)),
-            lagVilkårResultat(personResultat, Resultat.IKKE_OPPFYLT, fom = null)
+            lagVilkårResultat(personResultat, Resultat.OPPFYLT, fom = LocalDate.of(2020, 3, 31), Vilkår.BOR_MED_SØKER),
+            lagVilkårResultat(personResultat, Resultat.IKKE_OPPFYLT, fom = null, Vilkår.BOR_MED_SØKER)
         )
 
         val tidslinje = vilkårResultat.tilVilkårRegelverkResultatTidslinje()
-        tidslinje.perioder()
+        assertDoesNotThrow { tidslinje.perioder() }
     }
 
-    private fun lagVilkårResultat(personResultat: PersonResultat, resultat: Resultat, fom: LocalDate?) =
+    @Test
+    fun `kan ikke ha to overlappende perioder hvis det er bosatt i riket-vilkåret`() {
+        val personAktørId = randomAktør()
+        val personResultat = PersonResultat(
+            vilkårsvurdering = lagVilkårsvurdering(personAktørId, lagBehandling(), Resultat.OPPFYLT),
+            aktør = personAktørId
+        )
+
+        val vilkårResultat = setOf(
+            lagVilkårResultat(personResultat, Resultat.OPPFYLT, fom = LocalDate.of(2020, 3, 31), Vilkår.BOSATT_I_RIKET),
+            lagVilkårResultat(personResultat, Resultat.IKKE_OPPFYLT, fom = null, Vilkår.BOSATT_I_RIKET)
+        )
+
+        val tidslinje = vilkårResultat.tilVilkårRegelverkResultatTidslinje()
+        assertThrows<TidslinjeFeilException> { tidslinje.perioder() }
+    }
+
+    private fun lagVilkårResultat(personResultat: PersonResultat, resultat: Resultat, fom: LocalDate?, vilkår: Vilkår) =
         VilkårResultat(
             personResultat = personResultat,
             resultat = resultat,
-            vilkårType = Vilkår.BOR_MED_SØKER,
+            vilkårType = vilkår,
             periodeFom = fom,
             periodeTom = null,
             begrunnelse = "",


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
For vilkåret _bor med søker_ skal vi tillate at periodar overlappar. Det typiske eksempelet her er at du søker for delt bosted, men foreldra bur saman, så vi avslår det, og innvilger heller fullt. Da skal delt bosted-vilkåret vera avslått, gjerne med udefinert fom og tom, medan fullt-vilkåret skal vera innvilga.

Favro:
- https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8868
- https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9253

Det er mogleg denne PR-en ikkje løyser alle problema, men det her må uansett gjerast. Tenkjer å leite etter moglege andre ting som må oppdaterast i preprod etter denne er merga.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Vurderte å heller enn flagg-metoden dele opp tidslinje sin valider-metode i fleire, og så overstyre den eine frå subklassa. Alternativt å trekkje ut valideringa her til ei eiga klasse, og så overstyre den. Men synes begge desse moglegheitene verka som meir styr enn den enkle løysinga her, utan nødvendigvis å tilføre så mykje.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
