### PR TITLE
Tea-8868: Unngår å gruppere saman bor med søker-vilkår til samme tidslinje

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærEtter
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 
 class VilkårsvurderingTidslinjer(
@@ -29,7 +30,7 @@ class VilkårsvurderingTidslinjer(
 
     private val vilkårsresultaterTidslinjeMap = aktørTilPersonResultater
         .entries.associate { (aktør, personResultat) ->
-            aktør to personResultat.vilkårResultater.groupBy { it.vilkårType }
+            aktør to personResultat.vilkårResultater.groupBy { if (it.vilkårType != Vilkår.BOR_MED_SØKER) it.vilkårType else it.id }
                 .map { it.value.tilVilkårRegelverkResultatTidslinje() }
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjerTest.kt
@@ -1,0 +1,148 @@
+package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
+
+import no.nav.familie.ba.sak.common.defaultFagsak
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPersonResultaterForSøkerOgToBarn
+import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.config.tilAktør
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+internal class VilkårsvurderingTidslinjerTest {
+
+    @Test
+    fun `kan ha to overlappende perioder hvis det er bor med søker-vilkåret`() {
+        val søkerFnr = randomFnr()
+        val barnFnr = randomFnr()
+        val barn2Fnr = randomFnr()
+        val barnaFnr = listOf(barnFnr, barn2Fnr)
+
+        val defaultBehandling = lagBehandling(defaultFagsak())
+        val vilkårsvurdering = Vilkårsvurdering(
+            behandling = defaultBehandling
+        ).also {
+            it.personResultater = lagPersonResultaterForSøkerOgToBarn(
+                it,
+                tilAktør(søkerFnr),
+                tilAktør(barnFnr),
+                tilAktør(barn2Fnr),
+                LocalDate.now().minusMonths(3),
+                LocalDate.now().minusMonths(2)
+            )
+        }
+        vilkårsvurdering.personResultater.filter { it.aktør.aktivFødselsnummer() == barnFnr }.forEach {
+            it.vilkårResultater.add(
+                lagVilkårResultat(
+                    id = 500,
+                    personResultat = it,
+                    vilkårType = Vilkår.BOR_MED_SØKER,
+                    behandlingId = defaultBehandling.id,
+                    periodeTom = null,
+                    resultat = Resultat.OPPFYLT
+                )
+            )
+            it.vilkårResultater.add(
+                lagVilkårResultat(
+                    id = 1000,
+                    personResultat = it,
+                    vilkårType = Vilkår.BOR_MED_SØKER,
+                    behandlingId = defaultBehandling.id,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_OPPFYLT
+                )
+            )
+        }
+
+        assertDoesNotThrow {
+            VilkårsvurderingTidslinjer(
+                vilkårsvurdering = vilkårsvurdering,
+                personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(defaultBehandling.id, søkerFnr, barnaFnr)
+            )
+        }
+    }
+
+    @Test
+    fun `kan ikke ha to overlappende perioder hvis det er bosatt i riket-vilkåret`() {
+        val søkerFnr = randomFnr()
+        val barnFnr = randomFnr()
+        val barn2Fnr = randomFnr()
+        val barnaFnr = listOf(barnFnr, barn2Fnr)
+
+        val defaultBehandling = lagBehandling(defaultFagsak())
+        val vilkårsvurdering = Vilkårsvurdering(
+            behandling = defaultBehandling
+        ).also {
+            it.personResultater = lagPersonResultaterForSøkerOgToBarn(
+                it,
+                tilAktør(søkerFnr),
+                tilAktør(barnFnr),
+                tilAktør(barn2Fnr),
+                LocalDate.now().minusMonths(3),
+                LocalDate.now().minusMonths(2)
+            )
+        }
+        vilkårsvurdering.personResultater.filter { it.aktør.aktivFødselsnummer() == barnFnr }.forEach {
+            it.vilkårResultater.add(
+                lagVilkårResultat(
+                    id = 500,
+                    personResultat = it,
+                    vilkårType = Vilkår.BOSATT_I_RIKET,
+                    behandlingId = defaultBehandling.id,
+                    periodeTom = null,
+                    resultat = Resultat.OPPFYLT
+                )
+            )
+            it.vilkårResultater.add(
+                lagVilkårResultat(
+                    id = 1000,
+                    personResultat = it,
+                    vilkårType = Vilkår.BOSATT_I_RIKET,
+                    behandlingId = defaultBehandling.id,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_OPPFYLT
+                )
+            )
+        }
+
+        assertThrows<Tidslinje.Companion.TidslinjeFeilException> {
+            VilkårsvurderingTidslinjer(
+                vilkårsvurdering = vilkårsvurdering,
+                personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(defaultBehandling.id, søkerFnr, barnaFnr)
+            )
+        }
+    }
+
+    private fun lagVilkårResultat(
+        id: Long = 0,
+        personResultat: PersonResultat? = null,
+        vilkårType: Vilkår = Vilkår.BOSATT_I_RIKET,
+        resultat: Resultat = Resultat.OPPFYLT,
+        periodeFom: LocalDate? = LocalDate.of(2009, 12, 24),
+        periodeTom: LocalDate? = LocalDate.of(2010, 1, 31),
+        begrunnelse: String = "",
+        behandlingId: Long = lagBehandling().id,
+        utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = emptyList()
+    ) = VilkårResultat(
+        id = id,
+        personResultat = personResultat,
+        vilkårType = vilkårType,
+        resultat = resultat,
+        periodeFom = periodeFom,
+        periodeTom = periodeTom,
+        begrunnelse = begrunnelse,
+        behandlingId = behandlingId,
+        utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger
+    )
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
For vilkåret bor med søker skal vi tillate at periodar overlappar. Det typiske eksempelet her er at du søker for delt bosted, men foreldra bur saman, så vi avslår det, og innvilger heller fullt. Da skal delt bosted-vilkåret vera avslått, gjerne med udefinert fom og tom, medan fullt-vilkåret skal vera innvilga.

Favro:

- https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8868
- https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9253

Det er mogleg denne PR-en ikkje løyser alle problema, men det her må uansett gjerast. Tenkjer å leite etter moglege andre ting som må oppdaterast i preprod etter denne er merga.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
