### PR TITLE
Postgres kjem med gjennom spring-boot-starter. Vi tar dermed ein risiko for manglande kompabilitet ved at vi sjølv spesifiserer postgres-versjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ved å fjerne eksplisitt versjonering av postgres-avhengnaden vil vi bruke den som kjem frå Spring Boot-starteren, og dermed er vi sikre på at versjonane er kompatible.

Merk at denne endringa gjer det enda eit hakk viktigare at vi regelmessig oppgraderer Spring Boot.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
