### PR TITLE
Kaste feil hvis man får fortsatt innvilget på endre migreringsdato-behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
@@ -91,6 +91,13 @@ class BehandlingsresultatSteg(
             )
         }
 
+        if (behandlingMedOppdatertBehandlingsresultat.erManuellMigreringForEndreMigreringsdato() && behandlingMedOppdatertBehandlingsresultat.resultat == Behandlingsresultat.FORTSATT_INNVILGET) {
+            throw FunksjonellFeil(
+                "Fortsatt innvilget er et ugyldig behandlingsresultat når du skal endre migreringsdato. " +
+                    "Henlegg behandlingen. Når du starter en ny endre migreringsdato behandling, må du velge en dato som er tidligere enn gjeldene dato for migrering."
+            )
+        }
+
         if (behandlingMedOppdatertBehandlingsresultat.erBehandlingMedVedtaksbrevutsending()) {
             behandlingService.nullstillEndringstidspunkt(behandling.id)
             vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9379

Det skal ikke være mulig å få fortsatt innvilget på endre migreringsdato behandlinger. Legger derfor til en validering, slik at det blir kastet feil om dette skulle skje.

Feilmeldingen er godkjent av fag.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tror ikke det gir mening her

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
