### PR TITLE
Valider migreringsdato også når tidligere migreringsdato ikke er lagret ned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -318,13 +318,13 @@ class BehandlingService(
         migreringsdato: LocalDate,
         erEndreMigreringsdatoBehandling: Boolean
     ) {
+        val datoLagringAvMigreringsdatoBleInnført = LocalDate.of(2022, 2, 14)
+
         val nyMigreringsdatoErSenereEnnForrigeMigreringsdato = forrigeMigreringsdato != null &&
             migreringsdato.toYearMonth().isSameOrAfter(forrigeMigreringsdato)
 
         val nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed =
-            forrigeMigreringsdato == null && migreringsdato.toYearMonth().isSameOrAfter(
-                YearMonth.of(2022, 2)
-            )
+            forrigeMigreringsdato == null && migreringsdato.isSameOrAfter(datoLagringAvMigreringsdatoBleInnført)
 
         if (erEndreMigreringsdatoBehandling &&
             (nyMigreringsdatoErSenereEnnForrigeMigreringsdato || nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -302,9 +302,15 @@ class BehandlingService(
                         )
                     }
 
-        if (behandling.erManuellMigreringForEndreMigreringsdato() &&
-            forrigeMigreringsdato != null &&
+        val nyMigreringsdatoErSenereEnnForrigeMigreringsdato = forrigeMigreringsdato != null &&
             migreringsdato.toYearMonth().isSameOrAfter(forrigeMigreringsdato)
+
+        val nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed = forrigeMigreringsdato == null && migreringsdato.toYearMonth().isSameOrAfter(
+            YearMonth.of(2022, 2)
+        )
+
+        if (behandling.erManuellMigreringForEndreMigreringsdato() &&
+            (nyMigreringsdatoErSenereEnnForrigeMigreringsdato || nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed)
         ) {
             throw FunksjonellFeil("Migreringsdatoen du har lagt inn er lik eller senere enn eksisterende migreringsdato. Du må velge en tidligere migreringsdato for å fortsette.")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -302,22 +302,35 @@ class BehandlingService(
                         )
                     }
 
-        val nyMigreringsdatoErSenereEnnForrigeMigreringsdato = forrigeMigreringsdato != null &&
-            migreringsdato.toYearMonth().isSameOrAfter(forrigeMigreringsdato)
-
-        val nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed = forrigeMigreringsdato == null && migreringsdato.toYearMonth().isSameOrAfter(
-            YearMonth.of(2022, 2)
+        validerMigreringdato(
+            forrigeMigreringsdato = forrigeMigreringsdato,
+            migreringsdato = migreringsdato,
+            erEndreMigreringsdatoBehandling = behandling.erManuellMigreringForEndreMigreringsdato()
         )
-
-        if (behandling.erManuellMigreringForEndreMigreringsdato() &&
-            (nyMigreringsdatoErSenereEnnForrigeMigreringsdato || nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed)
-        ) {
-            throw FunksjonellFeil("Migreringsdatoen du har lagt inn er lik eller senere enn eksisterende migreringsdato. Du må velge en tidligere migreringsdato for å fortsette.")
-        }
 
         val behandlingMigreringsinfo =
             BehandlingMigreringsinfo(behandling = behandling, migreringsdato = migreringsdato)
         behandlingMigreringsinfoRepository.save(behandlingMigreringsinfo)
+    }
+
+    private fun validerMigreringdato(
+        forrigeMigreringsdato: YearMonth?,
+        migreringsdato: LocalDate,
+        erEndreMigreringsdatoBehandling: Boolean
+    ) {
+        val nyMigreringsdatoErSenereEnnForrigeMigreringsdato = forrigeMigreringsdato != null &&
+            migreringsdato.toYearMonth().isSameOrAfter(forrigeMigreringsdato)
+
+        val nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed =
+            forrigeMigreringsdato == null && migreringsdato.toYearMonth().isSameOrAfter(
+                YearMonth.of(2022, 2)
+            )
+
+        if (erEndreMigreringsdatoBehandling &&
+            (nyMigreringsdatoErSenereEnnForrigeMigreringsdato || nyMigreringsdatoErSenereEnnMuligMigreringdatoNårForrigeMigreringsdatoIkkeErLagretNed)
+        ) {
+            throw FunksjonellFeil("Migreringsdatoen du har lagt inn er lik eller senere enn eksisterende migreringsdato. Du må velge en tidligere migreringsdato for å fortsette.")
+        }
     }
 
     fun hentMigreringsdatoIBehandling(behandlingId: Long): LocalDate? {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
@@ -154,27 +154,4 @@ class LagreMigreringsdatoTest {
             feil.melding
         )
     }
-
-    @Test
-    fun `Lagre tidligere migreringstidspunkt skal ikke kaste feil dersom forrige behandling ikke er migreringsbehandling`() {
-        every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(any()) } returns null
-        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns
-            lagBehandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING).also {
-                it.status = BehandlingStatus.AVSLUTTET
-                it.resultat = Behandlingsresultat.INNVILGET
-            }
-        every { vilkårsvurderingService.hentTidligsteVilkårsvurderingKnyttetTilMigrering(any()) } returns YearMonth.now()
-
-        every { behandlingMigreringsinfoRepository.save(any()) } returns mockk()
-
-        assertDoesNotThrow {
-            behandlingService.lagreNedMigreringsdato(
-                migreringsdato = LocalDate.now(),
-                behandling = lagBehandling(
-                    behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                    årsak = BehandlingÅrsak.ENDRE_MIGRERINGSDATO
-                )
-            )
-        }
-    }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9556

Lagring av migreringsdato ble innført i midten av februar, og migreringer som skjedde før den tid ble opprettet uten å ha lagret ned migreringsdato. Hvis en saksbehandler nå skal opprette en endre migreringsdato behandling på disse sakene så er det ingen validering som sjekker at den nye datoen er senere enn eksisterende dato. Det er dette jeg prøver å løse i denne PRen.

Jeg legger til validering som kaster en feil hvis tidligere migreringsdato ikke er lagret ned, og den nye migreringsdatoen er februar 22 eller senere.  

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Liker ikke helt å ha en hardkodet verdi (feb 22) i koden, men må nesten det i dette tilfellet? 🤷 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Føler ikke det gir nok verdi

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
