### PR TITLE
Fjerner bruken av funksjonsbryteren KAN_BEHANDLE_EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -102,7 +102,6 @@ class FeatureToggleConfig(
     companion object {
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"
         const val SKATTEETATEN_API_EKTE_DATA = "familie-ba-sak.skatteetaten-api-ekte-data-i-respons"
-        const val KAN_BEHANDLE_EØS = "familie-ba-sak.behandling.eos"
         const val IKKE_STOPP_MIGRERINGSBEHANDLING = "familie-ba-sak.ikke.stopp.migeringsbehandling"
         const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
         const val TEKNISK_ENDRING = "familie-ba-sak.behandling.teknisk-endring"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.behandling
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
@@ -12,7 +11,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.BehandlingstemaSe
 import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.bestemKategoriVedOpprettelse
 import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.bestemUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingMigreringsinfo
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingMigreringsinfoRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
@@ -98,8 +96,6 @@ class BehandlingService(
                 )
             )
 
-            sjekkEøsToggleOgThrowHvisBrudd(kategori)
-
             val behandling = Behandling(
                 fagsak = fagsak,
                 opprettetÅrsak = nyBehandling.behandlingÅrsak,
@@ -157,17 +153,6 @@ class BehandlingService(
         val behandling = behandlingRepository.finnBehandling(behandlingId)
         behandling.overstyrtEndringstidspunkt = null
         behandlingHentOgPersisterService.lagreEllerOppdater(behandling, false)
-    }
-
-    private fun sjekkEøsToggleOgThrowHvisBrudd(
-        kategori: BehandlingKategori
-    ) {
-        if (kategori == BehandlingKategori.EØS && !featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            throw FunksjonellFeil(
-                melding = "EØS er ikke påskrudd",
-                frontendFeilmelding = "Det er ikke støtte for å behandle EØS søknad."
-            )
-        }
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.behandling
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
@@ -61,7 +60,6 @@ class BehandlingService(
     private val infotrygdService: InfotrygdService,
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val personidentService: PersonidentService,
-    private val featureToggleService: FeatureToggleService,
     private val taskRepository: TaskRepositoryWrapper,
     private val vilkårsvurderingService: VilkårsvurderingService
 ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.VergeInfo
@@ -90,16 +89,11 @@ class UtvidetBehandlingService(
 
         val endringstidspunkt = endringstidspunktService.finnEndringstidpunkForBehandling(behandlingId)
 
-        val kanBehandleEøs = featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)
+        val kompetanser: Collection<Kompetanse> = kompetanseRepository.finnFraBehandlingId(behandlingId)
 
-        val kompetanser: Collection<Kompetanse> =
-            if (kanBehandleEøs) kompetanseRepository.finnFraBehandlingId(behandlingId) else emptyList()
+        val valutakurser = valutakursRepository.finnFraBehandlingId(behandlingId)
 
-        val valutakurser =
-            if (kanBehandleEøs) valutakursRepository.finnFraBehandlingId(behandlingId) else emptyList()
-
-        val utenlandskePeriodebeløp =
-            if (kanBehandleEøs) utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId) else emptyList()
+        val utenlandskePeriodebeløp = utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId)
 
         val endreteUtbetalingerMedAndeler = andelerTilkjentYtelseOgEndreteUtbetalingerService
             .finnEndreteUtbetalingerMedAndelerIHenholdTilVilkårsvurdering(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.VergeInfo
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestArbeidsfordelingPåBehandling
@@ -62,7 +61,6 @@ class UtvidetBehandlingService(
     private val endringstidspunktService: EndringstidspunktService,
     private val valutakursRepository: ValutakursRepository,
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
-    private val featureToggleService: FeatureToggleService,
     private val korrigertEtterbetalingService: KorrigertEtterbetalingService,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
 ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.behandling.behandlingstema
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -24,8 +23,7 @@ class BehandlingstemaService(
     private val loggService: LoggService,
     private val oppgaveService: OppgaveService,
     private val vilkårsvurderingTidslinjeService: VilkårsvurderingTidslinjeService,
-    private val vilkårsvurderingRepository: VilkårsvurderingRepository,
-    private val featureToggleService: FeatureToggleService
+    private val vilkårsvurderingRepository: VilkårsvurderingRepository
 ) {
 
     fun oppdaterBehandlingstema(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -4,12 +4,9 @@ import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import org.springframework.stereotype.Service
@@ -18,10 +15,7 @@ import java.time.LocalDate
 @Service
 class EndringstidspunktService(
     private val behandlingRepository: BehandlingRepository,
-    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val kompetanseRepository: PeriodeOgBarnSkjemaRepository<Kompetanse>,
-    private val featureToggleService: FeatureToggleService,
-    private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
 ) {
     fun finnEndringstidpunkForBehandling(behandlingId: Long): LocalDate {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
@@ -42,16 +41,13 @@ class EndringstidspunktService(
             forrigeAndelerTilkjentYtelse = forrigeAndelerTilkjentYtelse
         ) ?: TIDENES_ENDE
 
+        val kompetansePerioder = kompetanseRepository.finnFraBehandlingId(nyBehandling.id)
+        val forrigeKompetansePerioder = kompetanseRepository.finnFraBehandlingId(sistIverksatteBehandling.id)
+        val førsteEndringstidspunkt = kompetansePerioder.finnFørsteEndringstidspunkt(forrigeKompetansePerioder)
+
         val førsteEndringstidspunktIKompetansePerioder =
-            if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-                val kompetansePerioder = kompetanseRepository.finnFraBehandlingId(nyBehandling.id)
-                val forrigeKompetansePerioder = kompetanseRepository.finnFraBehandlingId(sistIverksatteBehandling.id)
-                val førsteEndringstidspunkt = kompetansePerioder.finnFørsteEndringstidspunkt(forrigeKompetansePerioder)
-                if (førsteEndringstidspunkt != TIDENES_ENDE.toYearMonth()) {
-                    førsteEndringstidspunkt.førsteDagIInneværendeMåned()
-                } else {
-                    TIDENES_ENDE
-                }
+            if (førsteEndringstidspunkt != TIDENES_ENDE.toYearMonth()) {
+                førsteEndringstidspunkt.førsteDagIInneværendeMåned()
             } else {
                 TIDENES_ENDE
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.common.convertDataClassToJson
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
@@ -83,8 +82,7 @@ class BrevPeriodeService(
             kompetanseService.hentKompetanser(behandlingId = behandlingId)
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
-        val sanityEØSBegrunnelser =
-            if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) sanityService.hentSanityEØSBegrunnelser() else emptyList()
+        val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
 
         val restBehandlingsgrunnlagForBrev = hentRestBehandlingsgrunnlagForBrev(
             vilkårsvurdering = vilkårsvurdering,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.common.convertDataClassToJson
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
@@ -10,7 +9,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.tilMinimertUregisrertBarn
 import no.nav.familie.ba.sak.kjerne.beregning.Beløpsdifferanse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.beregning.hentPerioderMedEndringerFra
 import no.nav.familie.ba.sak.kjerne.brev.domene.BrevperiodeData
@@ -18,7 +16,6 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.RestBehandlingsgrunnlagForBrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertKompetanse
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertVedtaksperiode
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
@@ -45,15 +42,12 @@ import org.springframework.stereotype.Service
 class BrevPeriodeService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val persongrunnlagService: PersongrunnlagService,
-    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val vedtaksperiodeHentOgPersisterService: VedtaksperiodeHentOgPersisterService,
     private val sanityService: SanityService,
     private val søknadGrunnlagService: SøknadGrunnlagService,
     private val vilkårsvurderingService: VilkårsvurderingService,
-    private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
     private val personidentService: PersonidentService,
     private val kompetanseService: KompetanseService,
-    private val featureToggleService: FeatureToggleService,
     private val integrasjonClient: IntegrasjonClient,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
 ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -144,6 +144,5 @@ internal fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
 }
 
 fun FeatureToggleService.kanHåndtereEøsUtenomPrimærland() =
-    this.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS) &&
-        this.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS_SEKUNDERLAND) &&
+    this.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS_SEKUNDERLAND) &&
         this.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS_TO_PRIMERLAND)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
@@ -44,10 +44,6 @@ class KompetanseController(
         @PathVariable behandlingId: Long,
         @RequestBody restKompetanse: RestKompetanse
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build()
-        }
-
         val barnAktører = restKompetanse.barnIdenter.map { personidentService.hentAktør(it) }
         val kompetanse = restKompetanse.tilKompetanse(barnAktører = barnAktører)
 
@@ -66,10 +62,6 @@ class KompetanseController(
         @PathVariable kompetanseId: Long,
         @RequestBody restKompetanse: RestKompetanse
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build()
-        }
-
         val barnAktører = restKompetanse.barnIdenter.map { personidentService.hentAktør(it) }
         val kompetanse = restKompetanse.tilKompetanse(barnAktører = barnAktører)
 
@@ -87,10 +79,6 @@ class KompetanseController(
         @PathVariable behandlingId: Long,
         @PathVariable kompetanseId: Long
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build()
-        }
-
         kompetanseService.slettKompetanse(kompetanseId)
 
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
@@ -139,10 +127,19 @@ class KompetanseController(
     }
 
     private fun validerUtvidedEøsOgSekundærland(kompetanse: Kompetanse, behandlingId: Long) {
-        if (kompetanse.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND && !featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND)) {
-            val utvidetEllerSmåbarnstillegg = tilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId).any { andelTilkjentYtelse -> andelTilkjentYtelse.erSøkersAndel() }
+        if (kompetanse.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND && !featureToggleService.isEnabled(
+                FeatureToggleConfig.KAN_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND
+            )
+        ) {
+            val utvidetEllerSmåbarnstillegg =
+                tilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId)
+                    .any { andelTilkjentYtelse -> andelTilkjentYtelse.erSøkersAndel() }
             if (utvidetEllerSmåbarnstillegg) {
-                throw FunksjonellFeil("Støtter foreløpig ikke utvidet barnetrygd og/eller småbarnstillegg i kombinasjon med sekundærland.", "Søker har utvidet barnetrygd og/eller småbarnstillegg. Dette er ikke støttet i sekundærlandssaker enda. Ta kontakt med Team Familie", HttpStatus.BAD_REQUEST)
+                throw FunksjonellFeil(
+                    "Støtter foreløpig ikke utvidet barnetrygd og/eller småbarnstillegg i kombinasjon med sekundærland.",
+                    "Søker har utvidet barnetrygd og/eller småbarnstillegg. Dette er ikke støttet i sekundærlandssaker enda. Ta kontakt med Team Familie",
+                    HttpStatus.BAD_REQUEST
+                )
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpController.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
 
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.tilUtenlandskPeriodebeløp
@@ -25,7 +24,6 @@ import javax.validation.Valid
 @ProtectedWithClaims(issuer = "azuread")
 @Validated
 class UtenlandskPeriodebeløpController(
-    private val featureToggleService: FeatureToggleService,
     private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService,
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
     private val personidentService: PersonidentService,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpController.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
@@ -10,7 +9,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -39,15 +37,12 @@ class UtenlandskPeriodebeløpController(
         @Valid @RequestBody
         restUtenlandskPeriodebeløp: RestUtenlandskPeriodebeløp
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build()
-        }
-
         val barnAktører = restUtenlandskPeriodebeløp.barnIdenter.map { personidentService.hentAktør(it) }
 
         val eksisterendeUtenlandskPeriodeBeløp = utenlandskPeriodebeløpRepository.getById(restUtenlandskPeriodebeløp.id)
 
-        val utenlandskPeriodebeløp = restUtenlandskPeriodebeløp.tilUtenlandskPeriodebeløp(barnAktører, eksisterendeUtenlandskPeriodeBeløp)
+        val utenlandskPeriodebeløp =
+            restUtenlandskPeriodebeløp.tilUtenlandskPeriodebeløp(barnAktører, eksisterendeUtenlandskPeriodeBeløp)
 
         utenlandskPeriodebeløpService
             .oppdaterUtenlandskPeriodebeløp(BehandlingId(behandlingId), utenlandskPeriodebeløp)
@@ -60,10 +55,6 @@ class UtenlandskPeriodebeløpController(
         @PathVariable behandlingId: Long,
         @PathVariable utenlandskPeriodebeløpId: Long
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build()
-        }
-
         utenlandskPeriodebeløpService.slettUtenlandskPeriodebeløp(utenlandskPeriodebeløpId)
 
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -44,13 +44,11 @@ class VilkårsvurderingSteg(
             )
         }
 
-        if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            vilkårService.hentVilkårsvurdering(behandling.id)?.apply {
-                validerIkkeBlandetRegelverk(
-                    personopplysningGrunnlag = personopplysningGrunnlag,
-                    vilkårsvurdering = this
-                )
-            }
+        vilkårService.hentVilkårsvurdering(behandling.id)?.apply {
+            validerIkkeBlandetRegelverk(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = this
+            )
         }
     }
 
@@ -97,9 +95,7 @@ class VilkårsvurderingSteg(
         tilbakestillBehandlingService.tilbakestillDataTilVilkårsvurderingssteg(behandling)
         beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
 
-        if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS)) {
-            tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
-        }
+        tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
 
         behandlingstemaService.oppdaterBehandlingstema(
             behandling = behandlingHentOgPersisterService.hent(behandlingId = behandling.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/EøsSkjemaerForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/EøsSkjemaerForNyBehandlingService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
@@ -17,7 +16,7 @@ class EøsSkjemaerForNyBehandlingService(
 ) {
 
     fun kopierEøsSkjemaer(behandlingId: BehandlingId, forrigeBehandlingSomErVedtattId: BehandlingId?) {
-        if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS) && forrigeBehandlingSomErVedtattId != null) {
+        if (forrigeBehandlingSomErVedtattId != null) {
             kompetanseService.kopierOgErstattKompetanser(
                 fraBehandlingId = forrigeBehandlingSomErVedtattId,
                 tilBehandlingId = behandlingId

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.UtbetalingsperiodeMedBegrunnelser
 
 import hentPerioderMedUtbetaling
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KAN_BEHANDLE_EØS
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -58,16 +57,11 @@ class UtbetalingsperiodeMedBegrunnelserService(
                 reduksjonsperioder = perioderMedReduksjonFraSistIverksatteBehandling
             )
 
-        return if (featureToggleService.isEnabled(KAN_BEHANDLE_EØS)) {
-            val kompetanser = kompetanseRepository.finnFraBehandlingId(vedtak.behandling.id)
-
-            splittUtbetalingsperioderPåKompetanser(
-                utbetalingsperioder = utbetalingsperioderMedReduksjon,
-                kompetanser = kompetanser.toList()
-            )
-        } else {
-            utbetalingsperioderMedReduksjon
-        }
+        val kompetanser = kompetanseRepository.finnFraBehandlingId(vedtak.behandling.id)
+        return splittUtbetalingsperioderPåKompetanser(
+            utbetalingsperioder = utbetalingsperioderMedReduksjon,
+            kompetanser = kompetanser.toList()
+        )
     }
 
     fun hentReduksjonsperioderFraInnvilgelsesTidspunkt(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.ekstern.restDomene.RestGenererVedtaksperioderForOverstyrtEndringstidspunkt
@@ -448,7 +447,6 @@ class VedtaksperiodeService(
                     andelerTilkjentYtelse = andelerTilkjentYtelse,
                     sanityEØSBegrunnelser = sanityEØSBegrunnelser,
                     kompetanserIPeriode = kompetanserIPeriode,
-                    kanBehandleEØS = featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS),
                     kompetanserSomStopperRettFørPeriode = kompetanserSomStopperRettFørPeriode
                 )
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
@@ -201,7 +201,6 @@ fun hentGyldigeBegrunnelserForPeriode(
     aktørIderMedUtbetaling: List<String>,
     endretUtbetalingAndeler: List<EndretUtbetalingAndel>,
     andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-    kanBehandleEØS: Boolean,
     sanityEØSBegrunnelser: List<SanityEØSBegrunnelse>,
     kompetanserIPeriode: List<Kompetanse>,
     kompetanserSomStopperRettFørPeriode: List<Kompetanse>
@@ -215,15 +214,12 @@ fun hentGyldigeBegrunnelserForPeriode(
         endretUtbetalingAndeler = endretUtbetalingAndeler,
         andelerTilkjentYtelse = andelerTilkjentYtelse
     )
-    val eøsBegrunnelser = if (kanBehandleEØS) {
+    val eøsBegrunnelser =
         hentGyldigeEØSBegrunnelserForPeriode(
             sanityEØSBegrunnelser = sanityEØSBegrunnelser,
             kompetanserIPeriode = kompetanserIPeriode,
             kompetanserSomStopperRettFørPeriode = kompetanserSomStopperRettFørPeriode
         )
-    } else {
-        emptyList()
-    }
 
     return standardbegrunnelser + eøsBegrunnelser
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestNyttVilkår
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
@@ -21,7 +20,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingUtils.mut
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingUtils.muterPersonResultatPost
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingUtils.muterPersonVilkårResultaterPut
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
@@ -55,15 +53,6 @@ class VilkårService(
         vilkårId: Long,
         restPersonResultat: RestPersonResultat
     ): List<RestPersonResultat> {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS) &&
-            restPersonResultat.vilkårResultater.any { it.vurderesEtter == Regelverk.EØS_FORORDNINGEN }
-        ) {
-            throw Feil(
-                message = "EØS er ikke togglet på",
-                frontendFeilmelding = "Funksjonalitet for EØS er ikke lansert."
-            )
-        }
-
         val vilkårsvurdering = hentVilkårsvurderingThrows(behandlingId)
 
         val restVilkårResultat = restPersonResultat.vilkårResultater.singleOrNull { it.id == vilkårId }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
@@ -50,7 +49,6 @@ class LagreMigreringsdatoTest {
     val infotrygdService = mockk<InfotrygdService>()
     val vedtaksperiodeService = mockk<VedtaksperiodeService>()
     val personidentService = mockk<PersonidentService>()
-    val featureToggleService = mockk<FeatureToggleService>()
     val taskRepository = mockk<TaskRepositoryWrapper>()
     val behandlingMigreringsinfoRepository = mockk<BehandlingMigreringsinfoRepository>()
     val vilkårsvurderingService = mockk<VilkårsvurderingService>()
@@ -70,7 +68,6 @@ class LagreMigreringsdatoTest {
         infotrygdService,
         vedtaksperiodeService,
         personidentService,
-        featureToggleService,
         taskRepository,
         vilkårsvurderingService
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -41,7 +40,6 @@ class BehandlingstemaServiceTest {
     private val oppgaveService = mockk<OppgaveService>()
     private val tidslinjeService = mockk<VilkårsvurderingTidslinjeService>()
     private val vilkårsvurderingRepository = mockk<VilkårsvurderingRepository>()
-    private val featureToggleService = mockk<FeatureToggleService>()
 
     val behandlingstemaService = BehandlingstemaService(
         behandlingHentOgPersisterService = behandlingHentOgPersisterService,
@@ -49,15 +47,13 @@ class BehandlingstemaServiceTest {
         loggService = loggService,
         oppgaveService = oppgaveService,
         vilkårsvurderingTidslinjeService = tidslinjeService,
-        vilkårsvurderingRepository = vilkårsvurderingRepository,
-        featureToggleService = featureToggleService
+        vilkårsvurderingRepository = vilkårsvurderingRepository
     )
     val defaultFagsak = defaultFagsak()
     val defaultBehandling = lagBehandling(defaultFagsak)
 
     @BeforeAll
     fun init() {
-        every { featureToggleService.isEnabled(any()) } returns true
         every { behandlingHentOgPersisterService.hentAktivOgÅpenForFagsak(defaultFagsak.id) } returns defaultBehandling
     }
 
@@ -171,12 +167,6 @@ class BehandlingstemaServiceTest {
         val underkategori = behandlingstemaService.hentUnderkategoriFraInneværendeBehandling(defaultFagsak.id)
 
         assertEquals(BehandlingUnderkategori.ORDINÆR, underkategori)
-    }
-
-    @Test
-    fun `skal hente løpende kategori til NASJONAL når toggelen er av`() {
-        every { featureToggleService.isEnabled(any()) } returns false
-        assertEquals(BehandlingKategori.NASJONAL, behandlingstemaService.hentLøpendeKategori(defaultFagsak.id))
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.tilfeldigPerson
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -135,7 +134,6 @@ class VilkårsvurderingStegTest {
 
         every { vilkårService.hentVilkårsvurdering(behandling.id) } returns vilkårsvurdering
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
-        every { featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS) } returns true
 
         assertDoesNotThrow { vilkårsvurderingSteg.preValiderSteg(behandling, null) }
     }
@@ -162,7 +160,6 @@ class VilkårsvurderingStegTest {
 
         every { vilkårService.hentVilkårsvurdering(behandling.id) } returns vilkårsvurdering
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
-        every { featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_EØS) } returns true
 
         val exception = assertThrows<RuntimeException> { vilkårsvurderingSteg.preValiderSteg(behandling, null) }
         assertEquals(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
@@ -103,9 +102,6 @@ class VedtakServiceTest(
     private val infotrygdService: InfotrygdService,
 
     @Autowired
-    private val featureToggleService: FeatureToggleService,
-
-    @Autowired
     private val beregningService: BeregningService,
 
     @Autowired
@@ -152,7 +148,6 @@ class VedtakServiceTest(
             infotrygdService,
             vedtaksperiodeService,
             personidentService,
-            featureToggleService,
             taskRepository,
             vilkårsvurderingService
         )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
@@ -20,8 +19,12 @@ import javax.validation.ConstraintViolationException
 @ContextConfiguration(classes = [TestConfig::class, UtenlandskPeriodebeløpController::class, ValidationAutoConfiguration::class])
 class UtenlandskPeriodebeløpControllerTest {
 
-    @Autowired
-    lateinit var utenlandskPeriodebeløpController: UtenlandskPeriodebeløpController
+    val utenlandskPeriodebeløpController = UtenlandskPeriodebeløpController(
+        utenlandskPeriodebeløpService = mockk(relaxed = true),
+        utenlandskPeriodebeløpRepository = mockk(relaxed = true),
+        personidentService = mockk(relaxed = true),
+        utvidetBehandlingService = mockk(relaxed = true)
+    )
 
     @Test
     fun `Skal kaste feil dersom validering av input feiler`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
 
-import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
@@ -23,17 +21,21 @@ import javax.validation.ConstraintViolationException
 class UtenlandskPeriodebeløpControllerTest {
 
     @Autowired
-    lateinit var featureToggleService: FeatureToggleService
-
-    @Autowired
     lateinit var utenlandskPeriodebeløpController: UtenlandskPeriodebeløpController
 
     @Test
     fun `Skal kaste feil dersom validering av input feiler`() {
-        val exception = assertThrows<ConstraintViolationException> { utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(1, RestUtenlandskPeriodebeløp(1, null, null, emptyList(), beløp = (-1.0).toBigDecimal(), null, null, null)) }
+        val exception = assertThrows<ConstraintViolationException> {
+            utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(
+                1,
+                RestUtenlandskPeriodebeløp(1, null, null, emptyList(), beløp = (-1.0).toBigDecimal(), null, null, null)
+            )
+        }
 
         val forventedeFelterMedFeil = listOf("beløp")
-        val faktiskeFelterMedFeil = exception.constraintViolations.map { constraintViolation -> constraintViolation.propertyPath.toString().split(".").last() }
+        val faktiskeFelterMedFeil = exception.constraintViolations.map { constraintViolation ->
+            constraintViolation.propertyPath.toString().split(".").last()
+        }
 
         assertEqualsUnordered(forventedeFelterMedFeil, faktiskeFelterMedFeil)
 
@@ -42,19 +44,16 @@ class UtenlandskPeriodebeløpControllerTest {
 
     @Test
     fun `Skal ikke kaste feil dersom validering av input går bra`() {
-        // Stopper videre prosessering etter at validering er gjennomført
-        every { featureToggleService.isEnabled(any()) }.returns(false)
+        val response = utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(
+            1,
+            RestUtenlandskPeriodebeløp(1, null, null, emptyList(), beløp = 1.0.toBigDecimal(), null, null, null)
+        )
 
-        val response = utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(1, RestUtenlandskPeriodebeløp(1, null, null, emptyList(), beløp = 1.0.toBigDecimal(), null, null, null))
-
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.statusCode)
+        assertEquals(HttpStatus.OK, response.statusCode)
     }
 }
 
 class TestConfig {
-
-    @Bean
-    fun featureToggleService(): FeatureToggleService = mockk()
 
     @Bean
     fun utenlandskPeriodebeløpService(): UtenlandskPeriodebeløpService = mockk()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner funksjonsbryteren  KAN_BEHANDLE_EØS fordi den nå skal gjøres tilgjengelig for alle

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ endringen eer dekke av testene

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
