### PR TITLE
Legger til id'ene til endringsperioder i hashcode og equals på andel tilkjent ytelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -116,10 +116,14 @@ data class AndelTilkjentYtelse(
 
     @Column(name = "differanseberegnet_periodebelop")
     val differanseberegnetPeriodebeløp: Int? = null
+
 ) : BaseEntitet() {
 
     val periode
         get() = MånedPeriode(stønadFom, stønadTom)
+
+    fun endretUtbetalingAndelIder() =
+        (endretUtbetalingAndeler as MutableList<EndretUtbetalingAndel>?)?.map { it.id as Long? }?.filterNotNull()
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {
@@ -136,7 +140,8 @@ data class AndelTilkjentYtelse(
             Objects.equals(stønadTom, annen.stønadTom) &&
             Objects.equals(aktør, annen.aktør) &&
             Objects.equals(nasjonaltPeriodebeløp, annen.nasjonaltPeriodebeløp) &&
-            Objects.equals(differanseberegnetPeriodebeløp, annen.differanseberegnetPeriodebeløp)
+            Objects.equals(differanseberegnetPeriodebeløp, annen.differanseberegnetPeriodebeløp) &&
+            Objects.equals(endretUtbetalingAndelIder(), annen.endretUtbetalingAndelIder())
     }
 
     override fun hashCode(): Int {
@@ -149,7 +154,8 @@ data class AndelTilkjentYtelse(
             stønadTom,
             aktør,
             nasjonaltPeriodebeløp,
-            differanseberegnetPeriodebeløp
+            differanseberegnetPeriodebeløp,
+            endretUtbetalingAndelIder()
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.util.DeltBostedBuilder
@@ -70,7 +71,7 @@ class TilkjentYtelseDifferanseberegningTest {
         assertEquals(8, tilkjentYtelse.andelerTilkjentYtelse.size)
         assertEqualsUnordered(
             forventetTilkjentYtelseMedDelt.andelerTilkjentYtelse,
-            tilkjentYtelse.andelerTilkjentYtelse
+            tilkjentYtelse.andelerTilkjentYtelse.utenEndringer() // Equals tar hensyn til endringsperioder. Fjerner dem
         )
 
         val utenlandskePeriodebeløp = UtenlandskPeriodebeløpBuilder(startMåned, behandlingId)
@@ -97,7 +98,7 @@ class TilkjentYtelseDifferanseberegningTest {
         assertEquals(14, andelerMedDifferanse.size)
         assertEqualsUnordered(
             forventetTilkjentYtelseMedDiff.andelerTilkjentYtelse,
-            andelerMedDifferanse
+            andelerMedDifferanse.utenEndringer() // Equals tar hensyn til endringsperioder. Fjerner dem
         )
     }
 
@@ -155,7 +156,7 @@ class TilkjentYtelseDifferanseberegningTest {
         assertEquals(6, andelerMedDiff.size)
         assertEqualsUnordered(
             forventetTilkjentYtelseMedDiff.andelerTilkjentYtelse,
-            andelerMedDiff
+            andelerMedDiff.utenEndringer() // Equals tar hensyn til endringsperioder. Fjerner dem
         )
 
         val blanktUtenlandskPeridebeløp = UtenlandskPeriodebeløpBuilder(startMåned, behandlingId)
@@ -180,4 +181,7 @@ class TilkjentYtelseDifferanseberegningTest {
             andelerMedDiffIgjen
         )
     }
+
+    fun Collection<AndelTilkjentYtelse>.utenEndringer() =
+        this.map { it.copy(endretUtbetalingAndeler = mutableListOf()) }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi får trøbbel tilknyttet EØS fordi det ikke tas hensyn til endringsperioder i vurderingen om to andeler tilkjent ytelse er like. Forsøker å quickfix'e det med å legge inn id'ene til endringene i hashcode og equals i AndelTilkjentYtelse

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Vet jo at dette er litt dirty. Bør løses ordentlig med å frikoble andeler og endringer

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ de eksisterende testene _burde_ sjekke dette

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
