### PR TITLE
Tea-9533: Databaseskript for å finne ut kor vi har brukt samme periodeoffset i samme behandling, som er ei kjelde til feil vi ser no

### DIFF
--- a/src/main/resources/db/manuelle/FinnAndelerMedSammeOffset.sql
+++ b/src/main/resources/db/manuelle/FinnAndelerMedSammeOffset.sql
@@ -1,4 +1,4 @@
-select aty.periode_offset, b.id, count(1) from andel_tilkjent_ytelse aty
+select aty.periode_offset, b.id as "Behandlingsid", b.opprettet_tid as "Behandling opprettet", count(1) from andel_tilkjent_ytelse aty
                                                    inner join behandling b on b.id = aty.fk_behandling_id
-group by (b.id, aty.periode_offset)
+group by (b.id, aty.periode_offset, b.opprettet_tid)
 having count(aty.periode_offset) > 1;

--- a/src/main/resources/db/manuelle/FinnAndelerMedSammeOffset.sql
+++ b/src/main/resources/db/manuelle/FinnAndelerMedSammeOffset.sql
@@ -1,0 +1,4 @@
+select aty.periode_offset, b.id, count(1) from andel_tilkjent_ytelse aty
+                                                   inner join behandling b on b.id = aty.fk_behandling_id
+group by (b.id, aty.periode_offset)
+having count(aty.periode_offset) > 1;


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9533 oppdaga vi at vi har feil som skuldast at to periodar har fått samme offsets innad i samme behandling. Denne offseten er den vi bruker vidare mot økonomi som referanse, så når vi da seinare prøver å referere tilbake, får vi anten ikkje-deterministisk framferd eller teknisk feil.

I denne spørringa hentar vi ut kor det gjeld, for å få oversikt over omfanget. Dette er tenkt å køyrast manuelt ved behov.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Kun manuell SQL-select. Ligg i ei mappe som ikkje blir plukka opp av Flyway.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
