### PR TITLE
Persongrunnlag på institusjon- og enslig mindreårig saker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -14,6 +14,9 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.BARN_ENSLIG_MINDREÅRIG
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.INSTITUSJON
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.NORMAL
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.arbeidsforhold.ArbeidsforholdService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.opphold.GrOpphold
@@ -189,7 +192,10 @@ class PersongrunnlagService(
             aktør = aktør,
             personopplysningGrunnlag = personopplysningGrunnlag,
             målform = målform,
-            personType = PersonType.SØKER,
+            personType = when (behandling.fagsak.type) {
+                NORMAL -> PersonType.SØKER
+                BARN_ENSLIG_MINDREÅRIG, INSTITUSJON -> PersonType.BARN
+            },
             enkelPersonInfo = enkelPersonInfo,
             hentArbeidsforhold = behandling.skalBehandlesAutomatisk
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlag.kt
@@ -53,6 +53,8 @@ data class PersonopplysningGrunnlag(
 
     val søker: Person
         get() = personer.singleOrNull { it.type == PersonType.SØKER }
+            // Vil returnere barnet på EM-saker, som da i prinsippet også er søkeren. Vil også returnere barnet på inst. saker
+            ?: personer.singleOrNull()?.takeIf { it.type == PersonType.BARN }
             ?: error("Persongrunnlag mangler søker eller det finnes flere personer i grunnlaget med type=SØKER")
 
     val annenForelder: Person?

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
@@ -137,7 +137,8 @@ class PersonResultat(
         return nyttPersonResultat
     }
 
-    fun erSøkersResultater() = vilkårResultater.none { it.vilkårType == Vilkår.UNDER_18_ÅR } || vilkårsvurdering.behandling.fagsak.type != FagsakType.NORMAL
+    fun erSøkersResultater() = vilkårResultater.none { it.vilkårType == Vilkår.UNDER_18_ÅR } ||
+        vilkårsvurdering.behandling.fagsak.type in listOf(FagsakType.BARN_ENSLIG_MINDREÅRIG, FagsakType.INSTITUSJON)
 
     fun erDeltBosted(segmentFom: LocalDate): Boolean =
         vilkårResultater

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.erUnder18ÅrVilkårTidslinje
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.isSameOrBefore
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
@@ -136,7 +137,7 @@ class PersonResultat(
         return nyttPersonResultat
     }
 
-    fun erSøkersResultater() = vilkårResultater.none { it.vilkårType == Vilkår.UNDER_18_ÅR }
+    fun erSøkersResultater() = vilkårResultater.none { it.vilkårType == Vilkår.UNDER_18_ÅR } || vilkårsvurdering.behandling.fagsak.type != FagsakType.NORMAL
 
     fun erDeltBosted(segmentFom: LocalDate): Boolean =
         vilkårResultater

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
@@ -269,7 +269,9 @@ class VilkårVurderingTest(
 
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 4)
         val barn = genererPerson(PersonType.BARN, personopplysningGrunnlag, søkerAddress, Kjønn.MANN)
+        val feilregistrertSøker = genererPerson(PersonType.BARN, personopplysningGrunnlag, søkerAddress, Kjønn.KVINNE)
         personopplysningGrunnlag.personer.add(barn)
+        personopplysningGrunnlag.personer.add(feilregistrertSøker)
 
         assertThrows(IllegalStateException::class.java) {
             Vilkår.BOR_MED_SØKER.vurderVilkår(barn, LocalDate.now()).resultat

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.randomFnr
 import org.junit.jupiter.api.Assertions
@@ -38,5 +39,12 @@ class PersongrunnlagTest {
 
         val nye = persongrunnlagService.finnNyeBarn(forrigeBehandling = forrigeBehandling, behandling = behandling)
         Assertions.assertEquals(nyttbarn, nye.singleOrNull()!!.aktør.aktivFødselsnummer())
+    }
+
+    @Test
+    fun `Returnerer barnet som "søker" når grunnlag kun består av ett barn (enslig mindreårig eller institusjonsbarn)`() {
+        val barnet = lagPerson(type = PersonType.BARN)
+        val persongrunnlag = lagTestPersonopplysningGrunnlag(1L, barnet)
+        Assertions.assertEquals(barnet, persongrunnlag.søker)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9625

Noe må gjøres med hva som lagres i persongrunnlaget på institusjon/enslig_mindreårig-saker for at vilkårene på barnet skal dukke opp under vilkårsvurderingen i frontend. Default oppførsel er å lagre hovedaktøren på saken som SØKER, som blir feil når det dreier seg om et barn, siden det er denne persontypen som da blir gjeldene, og man får ikke sett vilkårene som gjelder for barn. Har gjort følgende:

- Legger til "aktør" som BARN istedenfor SØKER ved opprettelse av  personopplysningGrunnlag på institusjon/enslig_mindreårig-saker.
- Returnerer barnet når "persongrunnlag.søker" kalles på en institusjon/enslig_mindreårig-sak istedenfor å kaste feil, siden det er barnet som da er aktøren man er ute etter.
- Utvider funksjonen validerYtelsePersoner med en mer fornuftig validering når det gjelder enslig mindreårig eller institusjon etter samtale med Eivind om det.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er det trygt å anta fagsaktype institusjon eller enslig_mindreårig dersom persongrunnlag kun inneholder ett barn?
Det forenkler en hel del i hvert fall, og siden alle flyter ser ut til å benytte funksjonen hentOgLagreSøkerOgBarnINyttGrunnlag, klarer jeg ikke se det er en tilstand som kan oppstå ellers...

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
