### PR TITLE
Ignorer offsetandeler som er null i validering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -55,7 +55,7 @@ class TilkjentYtelseValideringService(
     }
 
     private fun TilkjentYtelse.harAndelerTilkjentYtelseMedSammeOffset(): Boolean {
-        val periodeOffsetForAndeler = this.andelerTilkjentYtelse.map { it.periodeOffset }
+        val periodeOffsetForAndeler = this.andelerTilkjentYtelse.mapNotNull { it.periodeOffset }
 
         return periodeOffsetForAndeler.size != periodeOffsetForAndeler.distinct().size
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Valideringen er for streng og stopper behandlinger som ikke burde stoppes. 
