### PR TITLE
Fikser konvertering av vilkårsresultat fra dagsnivå til månedsnivå

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/VilkårRegelverkResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/VilkårRegelverkResultat.kt
@@ -82,3 +82,5 @@ fun RegelverkResultat?.kombinerMed(resultat: RegelverkResultat?) = when (this) {
     IKKE_OPPFYLT -> IKKE_OPPFYLT
     IKKE_FULLT_VURDERT -> IKKE_FULLT_VURDERT
 }
+
+fun VilkårRegelverkResultat?.erOppfylt() = this?.resultat == Resultat.OPPFYLT

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/Periode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/Periode.kt
@@ -13,3 +13,7 @@ data class Periode<I, T : Tidsenhet>(
 
     override fun toString(): String = "$fraOgMed - $tilOgMed: $innhold"
 }
+
+fun <I, T : Tidsenhet> Tidspunkt<T>.tilPeriodeMedInnhold(innhold: I?) = Periode(this, this, innhold)
+
+fun <I, T : Tidsenhet> Tidspunkt<T>.tilPeriodeUtenInnhold() = tilPeriodeMedInnhold(null as I)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1256,3 +1256,9 @@ fun oppfyltVilkår(vilkår: Vilkår, regelverk: Regelverk? = null) =
             else -> RegelverkResultat.OPPFYLT_REGELVERK_IKKE_SATT
         }
     )
+
+fun ikkeOppfyltVilkår(vilkår: Vilkår, regelverk: Regelverk? = null) =
+    VilkårRegelverkResultat(
+        vilkår = vilkår,
+        regelverkResultat = RegelverkResultat.IKKE_OPPFYLT
+    )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -266,8 +266,8 @@ internal class KompetanseServiceTest {
             .byggPerson()
 
         val forventedeKompetanser = KompetanseBuilder(seksMånederSiden.neste(), behandlingId)
-            .medKompetanse("---", barn1, barn2) // Begge barna har 3 mnd EØS-regelverk før nå-tidspunktet
-            .medKompetanse("   ->", barn1) // Bare barn 1 har EØS-regelverk etter nå-tidspunktet
+            .medKompetanse("--", barn1, barn2) // Begge barna har 3 mnd EØS-regelverk før nå-tidspunktet
+            .medKompetanse("  ->", barn1) // Bare barn 1 har EØS-regelverk etter nå-tidspunktet
             .byggKompetanser()
 
         val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(
@@ -305,8 +305,8 @@ internal class KompetanseServiceTest {
             .medVilkår("+++++++++++", Vilkår.UNDER_18_ÅR, Vilkår.GIFT_PARTNERSKAP)
             .medVilkår("EEEEEEEEEEE", Vilkår.BOSATT_I_RIKET, Vilkår.LOVLIG_OPPHOLD, Vilkår.BOR_MED_SØKER)
             .forPerson(barn2, jan(2020))
-            .medVilkår("  +++", Vilkår.UNDER_18_ÅR, Vilkår.GIFT_PARTNERSKAP)
-            .medVilkår("  EEE", Vilkår.BOSATT_I_RIKET, Vilkår.LOVLIG_OPPHOLD, Vilkår.BOR_MED_SØKER)
+            .medVilkår("  ++++", Vilkår.UNDER_18_ÅR, Vilkår.GIFT_PARTNERSKAP)
+            .medVilkår("  EEEE", Vilkår.BOSATT_I_RIKET, Vilkår.LOVLIG_OPPHOLD, Vilkår.BOR_MED_SØKER)
             .forPerson(barn3, jan(2020))
             .medVilkår("+>", Vilkår.UNDER_18_ÅR, Vilkår.GIFT_PARTNERSKAP)
             .medVilkår("N>", Vilkår.BOSATT_I_RIKET, Vilkår.LOVLIG_OPPHOLD, Vilkår.BOR_MED_SØKER)
@@ -324,7 +324,7 @@ internal class KompetanseServiceTest {
         val faktiskeKompetanser = kompetanseService.hentKompetanser(behandlingId)
 
         val forventedeKompetanser = KompetanseBuilder(jan(2020), behandlingId)
-            .medKompetanse(" SP  SS-----", barn1)
+            .medKompetanse(" SP  SS----", barn1)
             .medKompetanse("     -", barn2)
             .medKompetanse("   PP ", barn1, barn2)
             .byggKompetanser()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.forskyv
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.VilkårsvurderingBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
@@ -34,7 +33,7 @@ internal class TidslinjerTest {
             .medVilkår("EEEEEEEENNEEEEEEEEEEE", Vilkår.BOSATT_I_RIKET)
             .medVilkår("EEEEEEEENNEEEEEEEEEEE", Vilkår.LOVLIG_OPPHOLD)
             .byggPerson()
-        val søkerResult = "EEEEEEEENNEEEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).forskyv(1)
+        val søkerResult = " EEEEEEEENNEEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         vilkårsvurderingBygger.forPerson(barn1, startMåned)
             .medVilkår("++++++++++++++++     ", Vilkår.UNDER_18_ÅR)
@@ -43,7 +42,7 @@ internal class TidslinjerTest {
             .medVilkår("NNNNNNNNNNEEEEEEEEEEE", Vilkår.BOR_MED_SØKER)
             .medVilkår("+++++++++++++++++++++", Vilkår.GIFT_PARTNERSKAP)
             .byggPerson()
-        val barn1Result = "?????!?!NN!??EEE?????".tilRegelverkResultatTidslinje(startMåned).forskyv(1)
+        val barn1Result = " ???????!NN???EE?????".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         vilkårsvurderingBygger.forPerson(barn2, startMåned)
             .medVilkår("+++++++++>", Vilkår.UNDER_18_ÅR)
@@ -52,7 +51,7 @@ internal class TidslinjerTest {
             .medVilkår("EEEENNEEE>", Vilkår.BOR_MED_SØKER)
             .medVilkår("+++++++++>", Vilkår.GIFT_PARTNERSKAP)
             .byggPerson()
-        val barn2Result = "?EEE!!!E!!EEEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).forskyv(1)
+        val barn2Result = " ?EEE!!EE!!EEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(
             vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
@@ -78,7 +77,7 @@ internal class TidslinjerTest {
             .medVilkår("EEEEEEEEEEEEENNNNNNNN", Vilkår.BOSATT_I_RIKET)
             .medVilkår("EEEEEEEEEEEEENNNNNNNN", Vilkår.LOVLIG_OPPHOLD)
             .byggPerson()
-        val søkerResult = "EEEEEEEEEEEEENNNNNNNN".tilRegelverkResultatTidslinje(startMåned).forskyv(1)
+        val søkerResult = " EEEEEEEEEEEEENNNNNNN".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         vilkårsvurderingBygger.forPerson(barn1, startMåned)
             .medVilkår("++++++++++++++++     ", Vilkår.UNDER_18_ÅR)
@@ -87,7 +86,7 @@ internal class TidslinjerTest {
             .medVilkår("NNNNNNNNNNEEEEEEEEEEE", Vilkår.BOR_MED_SØKER)
             .medVilkår("+++++++++++++++++++++", Vilkår.GIFT_PARTNERSKAP)
             .byggPerson()
-        val barn1Result = "?????!!!!!!EE!!!?????".tilRegelverkResultatTidslinje(startMåned).forskyv(1)
+        val barn1Result = " ?????!!!!!!EE!!?????".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(
             vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/RestTidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/RestTidslinjerTest.kt
@@ -47,11 +47,11 @@ internal class RestTidslinjerTest {
 
         // Stopper ved søkers siste til-og-med-dato fordi Regelverk er <null> etter det, som filtreres bort
         assertEquals(
-            28.feb(2022).tilLocalDate(),
+            31.jan(2022).tilLocalDate(),
             barnetsTidslinjer.regelverkTidslinje.last().tilOgMed
         )
         assertEquals(
-            28.feb(2022).tilLocalDate(),
+            31.jan(2022).tilLocalDate(),
             barnetsTidslinjer.oppfyllerEgneVilkårIKombinasjonMedSøkerTidslinje.last().tilOgMed
         )
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
EØS-perioder blir én måned for lange fordi eksisterende kode ikke sjekker om perioden avsluttes siste dag i måneden. Da skal EØS-perioden også stoppe den måneden. Dette endrer oppførselen til en del tester, som da må ha vært feil hele tiden. 

MERK at det er tilsvarende kode i `PersonResultat`. Det må sjekkes om ikke også den bør skrives om. Det blir i så fall en egen PR.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [] Nei
