### PR TITLE
Tea-9681: Trur ikkje vi treng meir enn sjølve jar-fila når vi skal køyre docker-bygget, så da er det unødvendig å bygge inn mykje meir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+!target/familie-ba-sak.jar


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
No køyrer vi docker build på heile mappa vi køyrer frå. Med dockerignore sørger vi for at docker berre kopierer inn akkurat dei filene vi bryr oss om. Sia vi køyrer maven-bygg først, og bygger ein fat-jar, er det nok berre denne jar-fila vi faktisk treng å ha med inn.

Favro: [Tea-9681](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9681)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er det andre filer som må med? Har ikkje sett teikn til det, men kan jo vera noko godt gøymt

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
