### PR TITLE
TEA-9441 Tea-9377 Oppdaterer sendManueltBrev i DokumentService

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/UtgåendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/UtgåendeJournalføringService.kt
@@ -23,16 +23,18 @@ class UtgåendeJournalføringService(
 ) {
 
     fun journalførManueltBrev(
-        fnr: String,
+        brukersId: String,
         fagsakId: String,
         journalførendeEnhet: String,
         brev: ByteArray,
         dokumenttype: Dokumenttype,
         førsteside: Førsteside?,
+        brukersType: BrukerIdType = BrukerIdType.FNR,
+        brukersNavn: String = "",
         tilVerge: Boolean = false
     ): String {
         return journalførDokument(
-            brukerId = fnr,
+            brukerId = brukersId,
             fagsakId = fagsakId,
             journalførendeEnhet = journalførendeEnhet,
             brev = listOf(
@@ -43,7 +45,9 @@ class UtgåendeJournalføringService(
                 )
             ),
             førsteside = førsteside,
-            tilVerge = tilVerge
+            brukersType = brukersType,
+            brukersNavn = brukersNavn,
+            tilVerge = tilVerge,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/UtgåendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/UtgåendeJournalføringService.kt
@@ -47,7 +47,7 @@ class UtgåendeJournalføringService(
             førsteside = førsteside,
             brukersType = brukersType,
             brukersNavn = brukersNavn,
-            tilVerge = tilVerge,
+            tilVerge = tilVerge
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -64,7 +64,9 @@ fun ManueltBrevRequest.byggMottakerdata(
     val mottakerPerson = if (!erTilInstitusjon) {
         persongrunnlagService.hentPersonerPåBehandling(listOf(this.mottakerIdent), behandling).singleOrNull()
             ?: error("Fant en eller ingen mottakere på behandling")
-    } else null
+    } else {
+        null
+    }
 
     val arbeidsfordelingPåBehandling = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandling.id)
     return this.copy(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
@@ -79,7 +79,7 @@ class PersonResultat(
         vilkårResultater.addAll(nyeVilkårResultater.toSortedSet(VilkårResultatComparator))
     }
 
-    private fun setAndreVurderinger(nyeAndreVurderinger: Set<AnnenVurdering>) {
+    fun setAndreVurderinger(nyeAndreVurderinger: Set<AnnenVurdering>) {
         andreVurderinger.clear()
         andreVurderinger.addAll(nyeAndreVurderinger)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -142,7 +142,7 @@ internal class DokumentServiceEnhetstest {
         personResultat.setAndreVurderinger(emptySet()) // nullstiller andreVurderinger
         every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns null
         every { vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(any(), any()) } returns
-                vilkårsvurdering
+            vilkårsvurdering
 
         sendBrevInnhenteOpplysninger(vilkårsvurdering.behandling)
 
@@ -163,6 +163,4 @@ internal class DokumentServiceEnhetstest {
             fagsakId = behandling.fagsak.id
         )
     }
-
-
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -4,18 +4,36 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
+import no.nav.familie.ba.sak.integrasjoner.journalføring.UtgåendeJournalføringService
+import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpost
+import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.JournalføringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.brev.DokumentService.Companion.alleredeDistribuertMelding
+import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.RestClientResponseException
 
 internal class DokumentServiceEnhetstest {
     val integrasjonClient = mockk<IntegrasjonClient>(relaxed = true)
+    val vilkårsvurderingService = mockk<VilkårsvurderingService>(relaxed = true)
+    val vilkårsvurderingForNyBehandlingService = mockk<VilkårsvurderingForNyBehandlingService>(relaxed = true)
+    val utgåendeJournalføringService = mockk<UtgåendeJournalføringService>(relaxed = true)
+    val journalføringRepository = mockk<JournalføringRepository>(relaxed = true)
 
     private val dokumentService: DokumentService = spyk(
         DokumentService(
@@ -23,15 +41,15 @@ internal class DokumentServiceEnhetstest {
 
             loggService = mockk(relaxed = true),
             persongrunnlagService = mockk(relaxed = true),
-            journalføringRepository = mockk(relaxed = true),
+            journalføringRepository = journalføringRepository,
             taskRepository = mockk(relaxed = true),
             brevKlient = mockk(relaxed = true),
             brevService = mockk(relaxed = true),
-            vilkårsvurderingService = mockk(relaxed = true),
-            vilkårsvurderingForNyBehandlingService = mockk(relaxed = true),
+            vilkårsvurderingService = vilkårsvurderingService,
+            vilkårsvurderingForNyBehandlingService = vilkårsvurderingForNyBehandlingService,
             rolleConfig = mockk(relaxed = true),
             settPåVentService = mockk(relaxed = true),
-            utgåendeJournalføringService = mockk(relaxed = true)
+            utgåendeJournalføringService = utgåendeJournalføringService
         )
     )
 
@@ -103,4 +121,48 @@ internal class DokumentServiceEnhetstest {
 
         verify { dokumentService.logger.warn(alleredeDistribuertMelding(journalpostId, behandlingId)) }
     }
+
+    @Test
+    fun `sendManueltBrev skal legge til opplysningspliktvilkåret, om så ved å initiere vilkårsvurdering først`() {
+        val vilkårsvurdering = lagVilkårsvurdering(lagPerson().aktør, lagBehandling(), Resultat.IKKE_VURDERT)
+        val personResultat = vilkårsvurdering.personResultater.find { it.erSøkersResultater() }!!
+
+        // Scenario med eksisterende vilkårsvurdering
+        every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns vilkårsvurdering
+        every { journalføringRepository.save(any()) } returns DbJournalpost(behandling = vilkårsvurdering.behandling, journalpostId = "id")
+
+        sendBrevInnhenteOpplysninger(vilkårsvurdering.behandling)
+
+        assertThat(personResultat.andreVurderinger).extracting("type").containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
+        verify(exactly = 0) {
+            vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(any(), any())
+        }
+
+        // Scenario uten eksisterende vilkårsvurdering
+        personResultat.setAndreVurderinger(emptySet()) // nullstiller andreVurderinger
+        every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns null
+        every { vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(any(), any()) } returns
+                vilkårsvurdering
+
+        sendBrevInnhenteOpplysninger(vilkårsvurdering.behandling)
+
+        assertThat(personResultat.andreVurderinger).extracting("type").containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
+        verify(exactly = 1) {
+            vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(any(), any())
+        }
+    }
+
+    private fun sendBrevInnhenteOpplysninger(behandling: Behandling) {
+        dokumentService.sendManueltBrev(
+            ManueltBrevRequest(
+                brevmal = Brevmal.INNHENTE_OPPLYSNINGER,
+                mottakerIdent = "123456789",
+                enhet = Enhet("enhet", "enhetNavn")
+            ),
+            behandling = behandling,
+            fagsakId = behandling.fagsak.id
+        )
+    }
+
+
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -28,6 +28,7 @@ internal class DokumentServiceEnhetstest {
             brevKlient = mockk(relaxed = true),
             brevService = mockk(relaxed = true),
             vilkårsvurderingService = mockk(relaxed = true),
+            vilkårsvurderingForNyBehandlingService = mockk(relaxed = true),
             rolleConfig = mockk(relaxed = true),
             settPåVentService = mockk(relaxed = true),
             utgåendeJournalføringService = mockk(relaxed = true)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Legger til støtte for institusjon som mottaker ved sending av brev via høyremenyen:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9441

Forsøker samtidig å løse problemet med at opplysningspliktvilkåret ikke alltid legges til etter utsending av brev:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9377
- Initierer vilkårsvurderingen for behandlingen hvis den ikke finnes
- Tar vare på andreVurderinger når vilkårsvurderingen oppdateres senere.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Problemet med opplysningspliktvilkåret som ikke vises, er at det blir forsøkt lagret på vilkårsvurderingen, som først blir opprettet når man kommer til det steget, vanligvis. Det ser likevel ut som det skal gå bra å initiere vilkårsvurderingen tidligere etter behov. Eller hva tenker dere?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
