### PR TITLE
Fjerner vilkårsresultater som er IKKE_OPPFYLT ifm beregning av EØS-perioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinje.kt
@@ -1,17 +1,24 @@
 package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerSenereEnn
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.DagTidspunkt.Companion.tilTidspunktEllerTidligereEnn
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 
-fun Iterable<VilkårResultat>.tilVilkårRegelverkResultatTidslinje(): Tidslinje<VilkårRegelverkResultat, Dag> {
-    val vilkårResultater = this
-    return object : Tidslinje<VilkårRegelverkResultat, Dag>() {
-        override fun lagPerioder() = vilkårResultater.map { it.tilPeriode() }
-    }
+/**
+ * Lager tidslinje av VilkårRegelverkResultat for ett vilkår og én aktør
+ * For beregning er vi strengt tatt bare interessert i oppfylte vilkår, og her fjernes alle andre vilkårsresultater
+ * Antakelsen er at IKKE_OPPFYLT i ALLE tilfeller kan ignoreres for beregning, og evt bare brukes for info i brev
+ * Løser problemet med BOR_MED_SØKER-vilkår som kan være oppfylt mens undervilkåret DELT_BOSTED ikke er oppfylt.
+ * Ikke oppfylt DELT_BOSTED er løst funksjonelt ved at BOR_MED_SØKER settes til IKKE_OPPFYLT med fom og tom lik null.
+ * fom og tom lik null tolkes som fra uendelig lenge siden til uendelig lenge til, som ville skapt overlapp med oppfylt vilkår
+ * Overlapp er ikke støttet av tidsliner, og ville gitt exception
+ */
+fun Iterable<VilkårResultat>.tilVilkårRegelverkResultatTidslinje() = tidslinje {
+    this.filter { it.erOppfylt() }
+        .map { it.tilPeriode() }
 }
 
 fun VilkårResultat.tilPeriode(): Periode<VilkårRegelverkResultat, Dag> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -13,7 +13,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærEtter
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 
 class VilkårsvurderingTidslinjer(
@@ -30,7 +29,7 @@ class VilkårsvurderingTidslinjer(
 
     private val vilkårsresultaterTidslinjeMap = aktørTilPersonResultater
         .entries.associate { (aktør, personResultat) ->
-            aktør to personResultat.vilkårResultater.groupBy { if (it.vilkårType != Vilkår.BOR_MED_SØKER) it.vilkårType else it.id }
+            aktør to personResultat.vilkårResultater.groupBy { it.vilkårType }
                 .map { it.value.tilVilkårRegelverkResultatTidslinje() }
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
@@ -176,6 +176,8 @@ class VilkårResultat(
         else -> Period.ZERO
     }
 
+    fun erOppfylt() = this.resultat == Resultat.OPPFYLT
+
     companion object {
 
         val VilkårResultatComparator = compareBy<VilkårResultat>({ it.periodeFom }, { it.resultat }, { it.vilkårType })

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjerTest.kt
@@ -21,7 +21,7 @@ import java.time.LocalDate
 internal class VilkårsvurderingTidslinjerTest {
 
     @Test
-    fun `kan ha to overlappende perioder hvis det er bor med søker-vilkåret`() {
+    fun `et vilkår kan ha overlappende vilkårsresultater hvis bare ett er oppfylt`() {
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val barn2Fnr = randomFnr()
@@ -40,25 +40,17 @@ internal class VilkårsvurderingTidslinjerTest {
                 LocalDate.now().minusMonths(2)
             )
         }
+
+        // Legg på et overlappende vilkårsresultat som IKKE er oppfylt
         vilkårsvurdering.personResultater.filter { it.aktør.aktivFødselsnummer() == barnFnr }.forEach {
-            it.vilkårResultater.add(
-                lagVilkårResultat(
-                    id = 500,
-                    personResultat = it,
-                    vilkårType = Vilkår.BOR_MED_SØKER,
-                    behandlingId = defaultBehandling.id,
-                    periodeTom = null,
-                    resultat = Resultat.OPPFYLT
-                )
-            )
             it.vilkårResultater.add(
                 lagVilkårResultat(
                     id = 1000,
                     personResultat = it,
                     vilkårType = Vilkår.BOR_MED_SØKER,
                     behandlingId = defaultBehandling.id,
-                    periodeFom = null,
-                    periodeTom = null,
+                    periodeFom = null, // uendelig lenge siden
+                    periodeTom = null, // uendelig lenge til
                     resultat = Resultat.IKKE_OPPFYLT
                 )
             )
@@ -73,7 +65,7 @@ internal class VilkårsvurderingTidslinjerTest {
     }
 
     @Test
-    fun `kan ikke ha to overlappende perioder hvis det er bosatt i riket-vilkåret`() {
+    fun `kan ikke ha to overlappende vilkårsresultater hvis begge er oppfylt`() {
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val barn2Fnr = randomFnr()
@@ -92,6 +84,8 @@ internal class VilkårsvurderingTidslinjerTest {
                 LocalDate.now().minusMonths(2)
             )
         }
+
+        // Legg på et overlappende vilkårsresultat som ER oppfylt
         vilkårsvurdering.personResultater.filter { it.aktør.aktivFødselsnummer() == barnFnr }.forEach {
             it.vilkårResultater.add(
                 lagVilkårResultat(
@@ -101,17 +95,6 @@ internal class VilkårsvurderingTidslinjerTest {
                     behandlingId = defaultBehandling.id,
                     periodeTom = null,
                     resultat = Resultat.OPPFYLT
-                )
-            )
-            it.vilkårResultater.add(
-                lagVilkårResultat(
-                    id = 1000,
-                    personResultat = it,
-                    vilkårType = Vilkår.BOSATT_I_RIKET,
-                    behandlingId = defaultBehandling.id,
-                    periodeFom = null,
-                    periodeTom = null,
-                    resultat = Resultat.IKKE_OPPFYLT
                 )
             )
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Får dann og vann TidslinjeException fordi det er funksjonelt mulig å legge inn IKKE_OPPFYLTE vilkårresultater som overlapper med OPPFYLT vilkårrsresultat for samme vilkår og aktør. BOR_MED_SØKER er et sånt tilfelle, der vilkåret som sådan er OPPFYLT, mens undervilkåret DELT_BOSTED ikke er oppfylt. Saksbehandler oppretter da to vilkårsresultater for BOR_MED_SØKER for et barn, ett OPPFYLT og ett IKKE_OPPFYLT. Antakelsen er at IKKE_OPPFYLTE vilkår av denne typen kan ignoreres i beregning fordi de bare skal brukes i brev-generering. Det er OPPFYLTE vilkår som sammenstilles til EØS-perioder, og fravær av perioder oppfører seg likt som perioder som er IKKE_OPPFYLT.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Tusenkronersspørsmålet er om antakelsen holder. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ testene fantes. Måtte justere dem, da

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
