### PR TITLE
Tea-9777: Rekkjefølgja på select i postgres er ikkje-deterministisk, så når vi assertert på første innslag, må vi sortere for at det skal bli rett

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -519,7 +519,7 @@ class BehandleSmåbarnstilleggTest(
 
         val småbarnstilleggAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(
             behandlingId = aktivBehandling.id
-        ).filter { it.erSmåbarnstillegg() }
+        ).filter { it.erSmåbarnstillegg() }.sortedBy { it.id }
 
         assertEquals(2, småbarnstilleggAndeler.size)
         assertEquals(fomDato.toYearMonth(), småbarnstilleggAndeler.first().stønadFom)


### PR DESCRIPTION
Ref [dokumentasjonen](https://www.postgresql.org/docs/current/queries-order.html)

### 💰 Hva skal gjøres, og hvorfor?
Stabiliserer test

Favro: [Tea-9777](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9777)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
