### PR TITLE
Fjernet default verdi for vurderesEtter for utvidet barnetrygd vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/Vilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/Vilkår.kt
@@ -92,14 +92,15 @@ enum class Vilkår(
 
     fun defaultRegelverk(behandlingKategori: BehandlingKategori): Regelverk? {
         return when (this) {
-            BOR_MED_SØKER, BOSATT_I_RIKET, LOVLIG_OPPHOLD, UTVIDET_BARNETRYGD -> {
+            BOR_MED_SØKER, BOSATT_I_RIKET, LOVLIG_OPPHOLD -> {
                 if (behandlingKategori == BehandlingKategori.EØS) {
                     Regelverk.EØS_FORORDNINGEN
                 } else {
                     Regelverk.NASJONALE_REGLER
                 }
             }
-            UNDER_18_ÅR, GIFT_PARTNERSKAP -> null
+
+            UTVIDET_BARNETRYGD, UNDER_18_ÅR, GIFT_PARTNERSKAP -> null
         }
     }
 
@@ -112,17 +113,21 @@ enum class Vilkår(
             UNDER_18_ÅR -> VurderBarnErUnder18(
                 alder = person.hentAlder()
             )
+
             BOR_MED_SØKER -> VurderBarnErBosattMedSøker(
                 søkerAdresser = person.personopplysningGrunnlag.søker.bostedsadresser,
                 barnAdresser = person.bostedsadresser
             )
+
             GIFT_PARTNERSKAP -> VurderBarnErUgift(
                 sivilstander = person.sivilstander
             )
+
             BOSATT_I_RIKET -> VurderPersonErBosattIRiket(
                 adresser = person.bostedsadresser,
                 vurderFra = vurderFra
             )
+
             LOVLIG_OPPHOLD -> if (person.type == BARN) {
                 VurderBarnHarLovligOpphold(
                     aktør = person.aktør
@@ -146,6 +151,7 @@ enum class Vilkår(
                     opphold = person.opphold
                 )
             }
+
             UTVIDET_BARNETRYGD -> throw Feil("Ikke støtte for å automatisk vurdere vilkåret ${this.beskrivelse}")
         }
 


### PR DESCRIPTION
Lenke til Favro: [TEA-9712](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9712)

### 💰 Hva skal gjøres, og hvorfor?
Vilkår av typen `UTVIDET_BARNETRYGD` har fått feltet `vurderesEtter` satt til `NASJONALE_REGLER` dersom behandlingskategori er "Nasjonal" og `EØS_FORORDNINGEN` dersom kategori er "EØS". Problemet oppstår i revurderingen dersom man skal behandle i henhold til annet regelverk enn i førstegangsbehandlingen. Saksbehandler får regelverks-mismatch da det ikke går an å sette `vurderesEtter` på vilkåret `UTVIDET_BARNETRYGD` i frontend. 

Løsningen er å alltid sette `vurderesEtter` til null for `UTVIDET_BARNETRYGD`, slik det allerede er gjort for `UNDER_18_ÅR` og `GIFT_PARNTERSKAP`.

Eivind nullstiller `vurderesEtter` for `UTVIDET_BARNETRYGD`  i databasen for alle eksisterende behandlinger.
