### PR TITLE
Sql for å rydde opp TEA-9712 for utvidet barnetrygd med vurder_etter ikke null

### DIFF
--- a/src/main/resources/db/migration/V226__vurderes_etter_null_for_utvidet.sql
+++ b/src/main/resources/db/migration/V226__vurderes_etter_null_for_utvidet.sql
@@ -1,0 +1,3 @@
+update vilkar_resultat
+set vurderes_etter = null
+where vilkar = 'UTVIDET_BARNETRYGD';


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9712

I en kommentar så sier Eivind at man skal kjøre denne sql for å oppdatere gamle saker slik at det står "null" i vurderes_etter for UTVIDET_BARNETRYGD

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
@EAamli 
Kjørte
select count(*) from vilkar_resultat where vilkar='UTVIDET_BARNETRYGD' AND vurderes_etter is not null;
Som ga 159526 i prod og 1194 i preprod. Stemmer dettte? Synes det er rart at jeg fikk så mange i preprod når du hadde alt kjørt det der

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
