### PR TITLE
Filtrer ut Endre migreringsdato-behandlinger ved offset-retting

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -177,12 +177,14 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
         """
             select distinct b.id from Behandling b
             where b.resultat not in (:ugyldigeResultater)
+                and b.opprettetÅrsak not in (:ugyldigeÅrsaker)
                 and b.status = 'AVSLUTTET'
                 and b.endretTidspunkt >= :startDato
         """
     )
     fun finnBehandlingerOpprettetEtterDatoForOffsetFeil(
         ugyldigeResultater: List<Behandlingsresultat>,
+        ugyldigeÅrsaker: List<BehandlingÅrsak> = listOf(BehandlingÅrsak.ENDRE_MIGRERINGSDATO),
         startDato: LocalDateTime
     ): List<Long>
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Andeler i endre migreringsdato behandlinger skal få ny offset, selv om de er like som i forrige behandling. Må derfor filtrere de ut så vi ikke oppdaterer feil på flere behandlinger.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
