### PR TITLE
Lager en wrapper-klasse for andel tilkjent ytelse som brukes ved generering av utbetalingsoppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/OffsetOppdatering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/OffsetOppdatering.kt
@@ -1,9 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi
 
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-
 data class OffsetOppdatering(
-    val beståendeAndelSomSkalHaOppdatertOffset: AndelTilkjentYtelse,
+    val beståendeAndelSomSkalHaOppdatertOffset: AndelTilkjentYtelseForUtbetalingsoppdrag,
     val periodeOffset: Long?,
     val forrigePeriodeOffset: Long?,
     val kildeBehandlingId: Long?
@@ -13,6 +11,7 @@ data class OffsetOppdatering(
         beståendeAndelSomSkalHaOppdatertOffset.forrigePeriodeOffset = forrigePeriodeOffset
         beståendeAndelSomSkalHaOppdatertOffset.kildeBehandlingId = kildeBehandlingId
     }
+
     fun erGyldigOppdatering() =
         beståendeAndelSomSkalHaOppdatertOffset.periodeOffset != periodeOffset ||
             beståendeAndelSomSkalHaOppdatertOffset.forrigePeriodeOffset != forrigePeriodeOffset ||

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsperiodeMal.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsperiodeMal.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
@@ -37,7 +36,7 @@ data class UtbetalingsperiodeMal(
      * @return Periode til utbetalingsoppdrag
      */
     fun lagPeriodeFraAndel(
-        andel: AndelTilkjentYtelse,
+        andel: AndelTilkjentYtelseForUtbetalingsoppdrag,
         periodeIdOffset: Int,
         forrigePeriodeIdOffset: Int?,
         opphørKjedeFom: YearMonth? = null

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtils.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi
 
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import java.time.YearMonth
 
@@ -14,12 +13,12 @@ object ØkonomiUtils {
      * @param[andelerForInndeling] andeler som skal sorteres i grupper for kjeding
      * @return ident med kjedegruppe.
      */
-    fun kjedeinndelteAndeler(andelerForInndeling: List<AndelTilkjentYtelse>): Map<String, List<AndelTilkjentYtelse>> {
+    fun kjedeinndelteAndeler(andelerForInndeling: List<AndelTilkjentYtelseForUtbetalingsoppdrag>): Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> {
         val (personMedSmåbarnstilleggAndeler, personerMedAndeler) =
             andelerForInndeling.partition { it.type == YtelseType.SMÅBARNSTILLEGG }.toList().map {
                 it.groupBy { andel -> andel.aktør.aktivFødselsnummer() }
             }
-        val andelerForKjeding = mutableMapOf<String, List<AndelTilkjentYtelse>>()
+        val andelerForKjeding = mutableMapOf<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>()
         andelerForKjeding.putAll(personerMedAndeler)
 
         if (personMedSmåbarnstilleggAndeler.size > 1) {
@@ -42,9 +41,9 @@ object ØkonomiUtils {
      * @return map med personident og siste bestående andel. Bestående andel=null dersom alle opphøres eller ny person.
      */
     fun sisteBeståendeAndelPerKjede(
-        forrigeKjeder: Map<String, List<AndelTilkjentYtelse>>,
-        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelse>>
-    ): Map<String, AndelTilkjentYtelse?> {
+        forrigeKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>,
+        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>
+    ): Map<String, AndelTilkjentYtelseForUtbetalingsoppdrag?> {
         val allePersoner = forrigeKjeder.keys.union(oppdaterteKjeder.keys)
         return allePersoner.associateWith { kjedeIdentifikator ->
             beståendeAndelerIKjede(
@@ -64,15 +63,15 @@ object ØkonomiUtils {
      * @return map med personident og andel=null som markerer at alle andeler skal opphøres.
      */
     fun sisteAndelPerKjede(
-        forrigeKjeder: Map<String, List<AndelTilkjentYtelse>>,
-        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelse>>
-    ): Map<String, AndelTilkjentYtelse?> =
+        forrigeKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>,
+        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>
+    ): Map<String, AndelTilkjentYtelseForUtbetalingsoppdrag?> =
         forrigeKjeder.keys.union(oppdaterteKjeder.keys).associateWith { null }
 
     private fun beståendeAndelerIKjede(
-        forrigeKjede: List<AndelTilkjentYtelse>?,
-        oppdatertKjede: List<AndelTilkjentYtelse>?
-    ): List<AndelTilkjentYtelse>? {
+        forrigeKjede: List<AndelTilkjentYtelseForUtbetalingsoppdrag>?,
+        oppdatertKjede: List<AndelTilkjentYtelseForUtbetalingsoppdrag>?
+    ): List<AndelTilkjentYtelseForUtbetalingsoppdrag>? {
         val forrige = forrigeKjede?.toSet() ?: emptySet()
         val oppdatert = oppdatertKjede?.toSet() ?: emptySet()
         val førsteEndring = forrige.disjunkteAndeler(oppdatert).minByOrNull { it.stønadFom }?.stønadFom
@@ -92,9 +91,9 @@ object ØkonomiUtils {
      * @return map med personident og oppdaterte kjeder
      */
     fun oppdaterBeståendeAndelerMedOffset(
-        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelse>>,
-        forrigeKjeder: Map<String, List<AndelTilkjentYtelse>>
-    ): Map<String, List<AndelTilkjentYtelse>> {
+        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>,
+        forrigeKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>
+    ): Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> {
         oppdaterteKjeder
             .filter { forrigeKjeder.containsKey(it.key) }
             .forEach { (kjedeIdentifikator, oppdatertKjede) ->
@@ -122,8 +121,8 @@ object ØkonomiUtils {
      * @return liste over oppdateringer som skal utføres
      */
     fun finnBeståendeAndelerMedOffsetSomMåOppdateres(
-        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelse>>,
-        forrigeKjeder: Map<String, List<AndelTilkjentYtelse>>
+        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>,
+        forrigeKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>
     ): List<OffsetOppdatering> = oppdaterteKjeder
         .filter { forrigeKjeder.containsKey(it.key) }
         .flatMap { (kjedeIdentifikator, oppdatertKjede) ->
@@ -154,9 +153,9 @@ object ØkonomiUtils {
      * @return andeler som må bygges fordelt på kjeder
      */
     fun andelerTilOpprettelse(
-        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelse>>,
-        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelse?>
-    ): List<List<AndelTilkjentYtelse>> =
+        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>,
+        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelseForUtbetalingsoppdrag?>
+    ): List<List<AndelTilkjentYtelseForUtbetalingsoppdrag>> =
         oppdaterteKjeder.map { (kjedeIdentifikator, oppdatertKjedeTilstand) ->
             if (sisteBeståendeAndelIHverKjede[kjedeIdentifikator] != null) {
                 oppdatertKjedeTilstand.filter { it.stønadFom.isAfter(sisteBeståendeAndelIHverKjede[kjedeIdentifikator]!!.stønadTom) }
@@ -174,10 +173,10 @@ object ØkonomiUtils {
      * @return map av siste andel og opphørsdato fra kjeder med opphør
      */
     fun andelerTilOpphørMedDato(
-        forrigeKjeder: Map<String, List<AndelTilkjentYtelse>>,
-        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelse?>,
+        forrigeKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>,
+        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelseForUtbetalingsoppdrag?>,
         endretMigreringsDato: YearMonth? = null
-    ): List<Pair<AndelTilkjentYtelse, YearMonth>> =
+    ): List<Pair<AndelTilkjentYtelseForUtbetalingsoppdrag, YearMonth>> =
         forrigeKjeder
             .mapValues { (person, forrigeAndeler) ->
                 forrigeAndeler.filter {
@@ -194,7 +193,7 @@ object ØkonomiUtils {
                     )
             }
 
-    fun gjeldendeForrigeOffsetForKjede(andelerFraForrigeBehandling: Map<String, List<AndelTilkjentYtelse>>): Map<String, Int> =
+    fun gjeldendeForrigeOffsetForKjede(andelerFraForrigeBehandling: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>>): Map<String, Int> =
         andelerFraForrigeBehandling.map { (personIdent, forrigeKjede) ->
             personIdent to (
                 forrigeKjede.filter { it.kalkulertUtbetalingsbeløp > 0 }
@@ -205,13 +204,13 @@ object ØkonomiUtils {
 
     private fun altIKjedeOpphøres(
         kjedeidentifikator: String,
-        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelse?>
+        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelseForUtbetalingsoppdrag?>
     ): Boolean = sisteBeståendeAndelIHverKjede[kjedeidentifikator] == null
 
     private fun andelOpphøres(
         kjedeidentifikator: String,
-        andel: AndelTilkjentYtelse,
-        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelse?>
+        andel: AndelTilkjentYtelseForUtbetalingsoppdrag,
+        sisteBeståendeAndelIHverKjede: Map<String, AndelTilkjentYtelseForUtbetalingsoppdrag?>
     ): Boolean = andel.stønadFom > sisteBeståendeAndelIHverKjede[kjedeidentifikator]!!.stønadTom
 
     const val SMÅBARNSTILLEGG_SUFFIX = "_SMÅBARNSTILLEGG"
@@ -221,24 +220,24 @@ object ØkonomiUtils {
  * Merk at det søkes snitt på visse attributter (erTilsvarendeForUtbetaling)
  * og man kun returnerer objekter fra receiver (ikke other)
  */
-private fun Set<AndelTilkjentYtelse>.snittAndeler(other: Set<AndelTilkjentYtelse>): Set<AndelTilkjentYtelse> {
+private fun Set<AndelTilkjentYtelseForUtbetalingsoppdrag>.snittAndeler(other: Set<AndelTilkjentYtelseForUtbetalingsoppdrag>): Set<AndelTilkjentYtelseForUtbetalingsoppdrag> {
     val andelerKunIDenne = this.subtractAndeler(other)
     return this.subtractAndeler(andelerKunIDenne)
 }
 
-private fun Set<AndelTilkjentYtelse>.disjunkteAndeler(other: Set<AndelTilkjentYtelse>): Set<AndelTilkjentYtelse> {
+private fun Set<AndelTilkjentYtelseForUtbetalingsoppdrag>.disjunkteAndeler(other: Set<AndelTilkjentYtelseForUtbetalingsoppdrag>): Set<AndelTilkjentYtelseForUtbetalingsoppdrag> {
     val andelerKunIDenne = this.subtractAndeler(other)
     val andelerKunIAnnen = other.subtractAndeler(this)
     return andelerKunIDenne.union(andelerKunIAnnen)
 }
 
-private fun Set<AndelTilkjentYtelse>.subtractAndeler(other: Set<AndelTilkjentYtelse>): Set<AndelTilkjentYtelse> {
+private fun Set<AndelTilkjentYtelseForUtbetalingsoppdrag>.subtractAndeler(other: Set<AndelTilkjentYtelseForUtbetalingsoppdrag>): Set<AndelTilkjentYtelseForUtbetalingsoppdrag> {
     return this.filter { a ->
         other.none { b -> a.erTilsvarendeForUtbetaling(b) }
     }.toSet()
 }
 
-private fun AndelTilkjentYtelse.erTilsvarendeForUtbetaling(other: AndelTilkjentYtelse): Boolean {
+private fun AndelTilkjentYtelseForUtbetalingsoppdrag.erTilsvarendeForUtbetaling(other: AndelTilkjentYtelseForUtbetalingsoppdrag): Boolean {
     return (
         this.aktør == other.aktør &&
             this.stønadFom == other.stønadFom &&

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdragFactory
+import no.nav.familie.ba.sak.integrasjoner.økonomi.pakkInnForUtbetaling
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils
@@ -264,11 +266,16 @@ class BeregningService(
             } ?: emptyList()
     }
 
-    fun hentSisteOffsetPerIdent(fagsakId: Long): Map<String, Int> {
+    fun hentSisteOffsetPerIdent(
+        fagsakId: Long,
+        andelTilkjentYtelseForUtbetalingsoppdragFactory: AndelTilkjentYtelseForUtbetalingsoppdragFactory
+    ): Map<String, Int> {
         val alleAndelerTilkjentYtelserIverksattMotØkonomi =
             hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId)
                 .flatMap { it.andelerTilkjentYtelse }
                 .filter { it.erAndelSomSkalSendesTilOppdrag() }
+                .pakkInnForUtbetaling(andelTilkjentYtelseForUtbetalingsoppdragFactory)
+
         val alleTideligereKjederIverksattMotØkonomi =
             ØkonomiUtils.kjedeinndelteAndeler(alleAndelerTilkjentYtelserIverksattMotØkonomi)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -165,16 +165,6 @@ data class AndelTilkjentYtelse(
             "forrigePeriodeOffset = $forrigePeriodeOffset, kildeBehandlingId = $kildeBehandlingId, nasjonaltPeriodebeløp = $nasjonaltPeriodebeløp, differanseberegnetBeløp = $differanseberegnetPeriodebeløp)"
     }
 
-    fun erTilsvarendeForUtbetaling(other: AndelTilkjentYtelse): Boolean {
-        return (
-            this.aktør == other.aktør &&
-                this.stønadFom == other.stønadFom &&
-                this.stønadTom == other.stønadTom &&
-                this.kalkulertUtbetalingsbeløp == other.kalkulertUtbetalingsbeløp &&
-                this.type == other.type
-            )
-    }
-
     fun overlapperMed(andelFraAnnenBehandling: AndelTilkjentYtelse): Boolean {
         return this.type == andelFraAnnenBehandling.type &&
             this.overlapperPeriode(andelFraAnnenBehandling.periode)
@@ -237,30 +227,6 @@ data class AndelTilkjentYtelse(
             .filter { vilkårResultat ->
                 regelverkavhenigeVilkår().any { it == vilkårResultat.vilkårType }
             }
-
-    companion object {
-
-        /**
-         * Merk at det søkes snitt på visse attributter (erTilsvarendeForUtbetaling)
-         * og man kun returnerer objekter fra receiver (ikke other)
-         */
-        fun Set<AndelTilkjentYtelse>.snittAndeler(other: Set<AndelTilkjentYtelse>): Set<AndelTilkjentYtelse> {
-            val andelerKunIDenne = this.subtractAndeler(other)
-            return this.subtractAndeler(andelerKunIDenne)
-        }
-
-        fun Set<AndelTilkjentYtelse>.disjunkteAndeler(other: Set<AndelTilkjentYtelse>): Set<AndelTilkjentYtelse> {
-            val andelerKunIDenne = this.subtractAndeler(other)
-            val andelerKunIAnnen = other.subtractAndeler(this)
-            return andelerKunIDenne.union(andelerKunIAnnen)
-        }
-
-        private fun Set<AndelTilkjentYtelse>.subtractAndeler(other: Set<AndelTilkjentYtelse>): Set<AndelTilkjentYtelse> {
-            return this.filter { a ->
-                other.none { b -> a.erTilsvarendeForUtbetaling(b) }
-            }.toSet()
-        }
-    }
 }
 
 fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp(): List<AndelTilkjentYtelse> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForSimuleringFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.UtbetalingsoppdragService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiKlient
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
@@ -60,12 +61,14 @@ class SimuleringService(
         val utbetalingsoppdrag = økonomiService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             vedtak = vedtak,
             saksbehandlerId = SikkerhetContext.hentSaksbehandler().take(8),
+            andelTilkjentYtelseForUtbetalingsoppdragFactory = AndelTilkjentYtelseForSimuleringFactory(),
             erSimulering = true
         )
         if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_GENERERE_UTBETALINGSOPPDRAG_NY)) {
             val tilkjentYtelse = utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
                 vedtak = vedtak,
                 saksbehandlerId = SikkerhetContext.hentSaksbehandler().take(8),
+                andelTilkjentYtelseForUtbetalingsoppdragFactory = AndelTilkjentYtelseForSimuleringFactory(),
                 erSimulering = true
             )
             val gammelUtbetalingsoppdragIString = objectMapper.writeValueAsString(utbetalingsoppdrag)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/IverksettMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/IverksettMotOppdrag.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForIverksettingFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.UtbetalingsoppdragService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -64,13 +65,15 @@ class IverksettMotOppdrag(
         if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_GENERERE_UTBETALINGSOPPDRAG_NY)) {
             val tilkjentYtelse = utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
                 vedtak = vedtakService.hent(data.vedtaksId),
-                saksbehandlerId = data.saksbehandlerId
+                saksbehandlerId = data.saksbehandlerId,
+                andelTilkjentYtelseForUtbetalingsoppdragFactory = AndelTilkjentYtelseForIverksettingFactory()
             )
             secureLogger.info("Generert utbetalingsoppdrag under iverksettelse på ny måte=${tilkjentYtelse.utbetalingsoppdrag}")
         } else {
             val utbetalingsoppdrag = økonomiService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
                 vedtak = vedtakService.hent(data.vedtaksId),
-                saksbehandlerId = data.saksbehandlerId
+                saksbehandlerId = data.saksbehandlerId,
+                andelTilkjentYtelseForUtbetalingsoppdragFactory = AndelTilkjentYtelseForIverksettingFactory()
             )
             val gammelUtbetalingsoppdrag = objectMapper.writeValueAsString(utbetalingsoppdrag)
             secureLogger.info("Generert utbetalingsoppdrag under iverksettelse på gamle måte=$gammelUtbetalingsoppdrag")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.verify
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.sisteDagIMåned
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForIverksettingFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiKlient
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
@@ -55,23 +56,6 @@ internal class UtbetalingsoppdragServiceTest {
         every {
             service.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
                 any(),
-                any()
-            )
-        } returns lagTilkjentYtelse(utbetalingsoppdrag)
-        val vedtak = mockk<Vedtak> {
-            every { behandling } returns mockk {
-                every { id } returns 1L
-            }
-        }
-        service.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(vedtak, "")
-        verify { økonomiKlient wasNot Called }
-    }
-
-    @Test
-    fun `skal sende til oppdrag hvis det fins utbetalingsperioder`() {
-        val utbetalingsoppdrag = lagUtbetalingsoppdrag(listOf(lagUtbetalingsperiode()))
-        every {
-            service.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
                 any(),
                 any()
             )
@@ -81,7 +65,34 @@ internal class UtbetalingsoppdragServiceTest {
                 every { id } returns 1L
             }
         }
-        service.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(vedtak, "")
+        service.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
+            vedtak,
+            "",
+            AndelTilkjentYtelseForIverksettingFactory()
+        )
+        verify { økonomiKlient wasNot Called }
+    }
+
+    @Test
+    fun `skal sende til oppdrag hvis det fins utbetalingsperioder`() {
+        val utbetalingsoppdrag = lagUtbetalingsoppdrag(listOf(lagUtbetalingsperiode()))
+        every {
+            service.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                any(),
+                any(),
+                any()
+            )
+        } returns lagTilkjentYtelse(utbetalingsoppdrag)
+        val vedtak = mockk<Vedtak> {
+            every { behandling } returns mockk {
+                every { id } returns 1L
+            }
+        }
+        service.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
+            vedtak,
+            "",
+            AndelTilkjentYtelseForIverksettingFactory()
+        )
         verify { økonomiKlient.iverksettOppdrag(utbetalingsoppdrag) }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
@@ -97,7 +97,11 @@ class ØkonomiIntegrasjonTest(
         beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
 
         assertDoesNotThrow {
-            økonomiService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(vedtak, "ansvarligSaksbehandler")
+            økonomiService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
+                vedtak,
+                "ansvarligSaksbehandler",
+                AndelTilkjentYtelseForIverksettingFactory()
+            )
         }
     }
 
@@ -137,7 +141,11 @@ class ØkonomiIntegrasjonTest(
 
         beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
 
-        økonomiService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(vedtak, "ansvarligSaksbehandler")
+        økonomiService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
+            vedtak,
+            "ansvarligSaksbehandler",
+            AndelTilkjentYtelseForIverksettingFactory()
+        )
         behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.AVSLUTTET)
 
         fagsak.status = FagsakStatus.LØPENDE

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtilsTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.andelerTilOppr
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.kjedeinndelteAndeler
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.oppdaterBeståendeAndelerMedOffset
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.sisteBeståendeAndelPerKjede
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.SMÅBARNSTILLEGG
@@ -41,7 +42,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person
                 )
-            )
+            ).forIverksetting()
         )
 
         assertEquals(2, kjederBehandling.size)
@@ -82,7 +83,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person2
                 )
-            )
+            ).forIverksetting()
         )
         val kjederBehandling2 = kjedeinndelteAndeler(
             listOf(
@@ -114,7 +115,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person2
                 )
-            )
+            ).forIverksetting()
         )
 
         val sisteBeståendePerKjede =
@@ -143,7 +144,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person
                 )
-            )
+            ).forIverksetting()
         )
         val kjederBehandling2 = kjedeinndelteAndeler(
             listOf(
@@ -161,7 +162,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person
                 )
-            )
+            ).forIverksetting()
         )
 
         val sisteBeståendePerKjede =
@@ -188,7 +189,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person
                 )
-            )
+            ).forIverksetting()
         )
 
         val sisteBeståendePerKjede =
@@ -216,7 +217,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person
                 )
-            )
+            ).forIverksetting()
         )
 
         val sisteBeståendePerKjede =
@@ -257,7 +258,7 @@ internal class ØkonomiUtilsTest {
                     person = person,
                     aktør = person.aktør
                 )
-            )
+            ).forIverksetting()
         )
         val kjederBehandling2 = kjedeinndelteAndeler(
             listOf(
@@ -285,7 +286,7 @@ internal class ØkonomiUtilsTest {
                     person = person,
                     aktør = person.aktør
                 )
-            )
+            ).forIverksetting()
         )
 
         val sisteBeståendePerKjede =
@@ -341,7 +342,7 @@ internal class ØkonomiUtilsTest {
                     person = førsteBarn,
                     aktør = førsteBarn.aktør
                 )
-            )
+            ).forIverksetting()
         )
         val kjederBehandling2 = kjedeinndelteAndeler(
             listOf(
@@ -369,7 +370,7 @@ internal class ØkonomiUtilsTest {
                     person = andreBarn,
                     aktør = andreBarn.aktør
                 )
-            )
+            ).forIverksetting()
         )
 
         val sisteBeståendePerKjede =
@@ -411,7 +412,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person
                 )
-            )
+            ).forIverksetting()
         )
         val kjederBehandling2 = kjedeinndelteAndeler(
             listOf(
@@ -436,7 +437,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person
                 )
-            )
+            ).forIverksetting()
         )
 
         val sisteBeståendePerKjede =
@@ -485,7 +486,7 @@ internal class ØkonomiUtilsTest {
                     forrigeperiodeIdOffset = 2,
                     person = person2
                 )
-            )
+            ).forIverksetting()
         )
         val kjederBehandling2 = kjedeinndelteAndeler(
             listOf(
@@ -503,7 +504,7 @@ internal class ØkonomiUtilsTest {
                     1054,
                     person = person2
                 )
-            )
+            ).forIverksetting()
         )
 
         val oppdaterte =
@@ -549,7 +550,7 @@ internal class ØkonomiUtilsTest {
                 behandling = forrigeBehandling
             )
 
-        )
+        ).forIverksetting()
 
         val andelerIDenneBehandlingen = listOf(
             lagAndelTilkjentYtelse(
@@ -592,7 +593,7 @@ internal class ØkonomiUtilsTest {
                 forrigeperiodeIdOffset = 2,
                 behandling = behandling
             )
-        )
+        ).forIverksetting()
 
         val oppdateringer = ØkonomiUtils.finnBeståendeAndelerMedOffsetSomMåOppdateres(
             forrigeKjeder = kjedeinndelteAndeler(andelerIForrigeBehandling),
@@ -645,7 +646,7 @@ internal class ØkonomiUtilsTest {
                 kildeBehandlingId = forrigeBehandling.id
             )
 
-        )
+        ).forIverksetting()
 
         val andelerIDenneBehandlingen = listOf(
             lagAndelTilkjentYtelse(
@@ -692,7 +693,7 @@ internal class ØkonomiUtilsTest {
                 behandling = behandling,
                 kildeBehandlingId = behandling.id
             )
-        )
+        ).forIverksetting()
 
         val oppdateringer = ØkonomiUtils.finnBeståendeAndelerMedOffsetSomMåOppdateres(
             forrigeKjeder = kjedeinndelteAndeler(andelerIForrigeBehandling),
@@ -733,7 +734,7 @@ internal class ØkonomiUtilsTest {
                 behandling = forrigeBehandling
             )
 
-        )
+        ).forIverksetting()
 
         val andelerIDenneBehandlingen = listOf(
             lagAndelTilkjentYtelse(
@@ -766,7 +767,7 @@ internal class ØkonomiUtilsTest {
                 forrigeperiodeIdOffset = null,
                 behandling = behandling
             )
-        )
+        ).forIverksetting()
 
         val oppdateringer = ØkonomiUtils.finnBeståendeAndelerMedOffsetSomMåOppdateres(
             forrigeKjeder = kjedeinndelteAndeler(andelerIForrigeBehandling),
@@ -845,7 +846,7 @@ internal class ØkonomiUtilsTest {
                 forrigeperiodeIdOffset = 0,
                 behandling = forrigeBehandling
             )
-        )
+        ).forIverksetting()
 
         val andelerIDenneBehandlingen = listOf(
             lagAndelTilkjentYtelse(
@@ -888,7 +889,7 @@ internal class ØkonomiUtilsTest {
                 forrigeperiodeIdOffset = null,
                 behandling = behandling
             )
-        )
+        ).forIverksetting()
 
         val oppdateringer = ØkonomiUtils.finnBeståendeAndelerMedOffsetSomMåOppdateres(
             forrigeKjeder = kjedeinndelteAndeler(andelerIForrigeBehandling),
@@ -931,3 +932,6 @@ internal class ØkonomiUtilsTest {
         assertEquals(forrigeBehandling.id, andreOrdinæreOppdatering.kildeBehandlingId)
     }
 }
+
+fun Collection<AndelTilkjentYtelse>.forIverksetting() =
+    AndelTilkjentYtelseForIverksettingFactory().pakkInnForUtbetaling(this)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/NyUtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/NyUtbetalingsoppdragGeneratorTest.kt
@@ -123,8 +123,8 @@ class NyUtbetalingsoppdragGeneratorTest(
             lagVedtakMedTilkjentYtelse(
                 vedtak = vedtak,
                 tilkjentYtelse = tilkjentYtelse
-            )
-
+            ),
+            AndelTilkjentYtelseForIverksettingFactory()
         )
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse.utbetalingsoppdrag)
         assertEquals(Utbetalingsoppdrag.KodeEndring.NY, utbetalingsoppdrag.kodeEndring)
@@ -212,11 +212,12 @@ class NyUtbetalingsoppdragGeneratorTest(
                 tilkjentYtelse = lagInitiellTilkjentYtelse(behandling),
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerTilkjentYtelse
+                        andelerTilkjentYtelse.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = 0
             ),
+            AndelTilkjentYtelseForIverksettingFactory(),
             forrigeTilkjentYtelse = forrigeTilkjentYtelse
         )
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse.utbetalingsoppdrag)
@@ -301,7 +302,8 @@ class NyUtbetalingsoppdragGeneratorTest(
             lagVedtakMedTilkjentYtelse(
                 vedtak = vedtak,
                 tilkjentYtelse = tilkjentYtelse
-            )
+            ),
+            AndelTilkjentYtelseForIverksettingFactory()
         )
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
         val tilkjentYtelse2 = lagInitiellTilkjentYtelse(behandling2)
@@ -349,12 +351,13 @@ class NyUtbetalingsoppdragGeneratorTest(
                 vedtak = vedtak2,
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = sisteOffsetPåFagsak,
                 tilkjentYtelse = tilkjentYtelse2
             ),
+            AndelTilkjentYtelseForIverksettingFactory(),
             forrigeTilkjentYtelse = oppdatertTilkjentYtelse
         )
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse2.utbetalingsoppdrag)
@@ -441,7 +444,8 @@ class NyUtbetalingsoppdragGeneratorTest(
             lagVedtakMedTilkjentYtelse(
                 vedtak = vedtak,
                 tilkjentYtelse = tilkjentYtelse
-            )
+            ),
+            AndelTilkjentYtelseForIverksettingFactory()
         )
 
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
@@ -481,12 +485,13 @@ class NyUtbetalingsoppdragGeneratorTest(
                 vedtak = vedtak2,
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = sisteOffsetPåFagsak,
                 tilkjentYtelse = tilkjentYtelse2
             ),
+            AndelTilkjentYtelseForIverksettingFactory(),
             forrigeTilkjentYtelse = oppdatertTilkjentYtelse
         )
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse2.utbetalingsoppdrag)
@@ -567,7 +572,8 @@ class NyUtbetalingsoppdragGeneratorTest(
             lagVedtakMedTilkjentYtelse(
                 vedtak = vedtak,
                 tilkjentYtelse = tilkjentYtelse
-            )
+            ),
+            AndelTilkjentYtelseForIverksettingFactory()
         )
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse.utbetalingsoppdrag)
         assertEquals(Utbetalingsoppdrag.KodeEndring.NY, utbetalingsoppdrag.kodeEndring)
@@ -634,7 +640,8 @@ class NyUtbetalingsoppdragGeneratorTest(
                     vedtak = vedtak,
                     erSimulering = true,
                     tilkjentYtelse = tilkjentYtelse
-                )
+                ),
+                AndelTilkjentYtelseForIverksettingFactory()
             )
         }
         assertEquals("Finnes flere personer med småbarnstillegg", exception.message)
@@ -694,7 +701,8 @@ class NyUtbetalingsoppdragGeneratorTest(
             lagVedtakMedTilkjentYtelse(
                 vedtak = vedtak,
                 tilkjentYtelse = tilkjentYtelse
-            )
+            ),
+            AndelTilkjentYtelseForIverksettingFactory()
         )
 
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
@@ -744,12 +752,13 @@ class NyUtbetalingsoppdragGeneratorTest(
                 erSimulering = true,
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = sisteOffsetPåFagsak,
                 tilkjentYtelse = tilkjentYtelse2
             ),
+            AndelTilkjentYtelseForIverksettingFactory(),
             forrigeTilkjentYtelse = oppdatertTilkjentYtelse
         )
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse2.utbetalingsoppdrag)
@@ -833,7 +842,8 @@ class NyUtbetalingsoppdragGeneratorTest(
             lagVedtakMedTilkjentYtelse(
                 vedtak = vedtak,
                 tilkjentYtelse = tilkjentYtelse
-            )
+            ),
+            AndelTilkjentYtelseForIverksettingFactory()
         )
         oppdatertTilkjentYtelse.andelerTilkjentYtelse.forEach { it.tilkjentYtelse = oppdatertTilkjentYtelse }
         beregningService.lagreTilkjentYtelseMedOppdaterteAndeler(oppdatertTilkjentYtelse)
@@ -856,10 +866,11 @@ class NyUtbetalingsoppdragGeneratorTest(
                 sisteOffsetPåFagsak = 0,
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 )
             ),
+            AndelTilkjentYtelseForIverksettingFactory(),
             forrigeTilkjentYtelse = oppdatertTilkjentYtelse
         )
 
@@ -923,7 +934,11 @@ class NyUtbetalingsoppdragGeneratorTest(
         førsteTilkjentYtelse.utbetalingsoppdrag = "utbetalingsoppdrg"
         tilkjentYtelseRepository.saveAndFlush(førsteTilkjentYtelse)
 
-        utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(førsteVedtak, "Z123")
+        utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+            førsteVedtak,
+            "Z123",
+            AndelTilkjentYtelseForIverksettingFactory()
+        )
         førsteBehandling.status = BehandlingStatus.AVSLUTTET
         førsteBehandling.leggTilBehandlingStegTilstand(StegType.BEHANDLING_AVSLUTTET)
         behandlingService.lagre(førsteBehandling)
@@ -963,7 +978,11 @@ class NyUtbetalingsoppdragGeneratorTest(
         tilkjentYtelseRepository.saveAndFlush(andreTilkjentYtelse)
 
         val tilkjentYtelse =
-            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(andreVedtak, "Z123")
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                andreVedtak,
+                "Z123",
+                AndelTilkjentYtelseForIverksettingFactory()
+            )
         val utbetalingsoppdrag =
             objectMapper.readValue(tilkjentYtelse.utbetalingsoppdrag, Utbetalingsoppdrag::class.java)
         assertEquals(Utbetalingsoppdrag.KodeEndring.ENDR, utbetalingsoppdrag.kodeEndring)
@@ -1006,8 +1025,8 @@ class NyUtbetalingsoppdragGeneratorTest(
             lagVedtakMedTilkjentYtelse(
                 vedtak = vedtak,
                 tilkjentYtelse = tilkjentYtelse
-            )
-
+            ),
+            AndelTilkjentYtelseForIverksettingFactory()
         )
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse.utbetalingsoppdrag)
         assertEquals(Utbetalingsoppdrag.KodeEndring.NY, utbetalingsoppdrag.kodeEndring)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragIntegrasjonTest.kt
@@ -118,7 +118,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak,
                 true,
                 oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerTilkjentYtelse
+                    andelerTilkjentYtelse.forIverksetting()
                 )
             )
 
@@ -203,11 +203,11 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak = vedtak,
                 erFørsteBehandlingPåFagsak = false,
                 forrigeKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerTilkjentYtelse
+                    andelerTilkjentYtelse.forIverksetting()
                 ),
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerTilkjentYtelse
+                        andelerTilkjentYtelse.forIverksetting()
                     )
                 )
             )
@@ -295,7 +295,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             vedtak,
             true,
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerFørstegangsbehandling
+                andelerFørstegangsbehandling.forIverksetting()
             )
         )
 
@@ -346,16 +346,16 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak2,
                 false,
                 forrigeKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerFørstegangsbehandling
+                    andelerFørstegangsbehandling.forIverksetting()
                 ),
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = sisteOffsetPåFagsak,
                 oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerRevurdering
+                    andelerRevurdering.forIverksetting()
                 )
             )
 
@@ -443,7 +443,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             vedtak,
             true,
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerFørstegangsbehandling
+                andelerFørstegangsbehandling.forIverksetting()
             )
         )
 
@@ -485,16 +485,16 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak2,
                 false,
                 forrigeKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerFørstegangsbehandling
+                    andelerFørstegangsbehandling.forIverksetting()
                 ),
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = sisteOffsetPåFagsak,
                 oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerRevurdering
+                    andelerRevurdering.forIverksetting()
                 )
             )
 
@@ -572,7 +572,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             vedtak,
             true,
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerTilkjentYtelse
+                andelerTilkjentYtelse.forIverksetting()
             )
         )
 
@@ -624,7 +624,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak,
                 true,
                 oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerTilkjentYtelse
+                    andelerTilkjentYtelse.forIverksetting()
                 )
             )
         }
@@ -687,7 +687,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             vedtak,
             true,
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerFørstegangsbehandling
+                andelerFørstegangsbehandling.forIverksetting()
             )
         )
 
@@ -738,16 +738,16 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak2,
                 false,
                 forrigeKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerFørstegangsbehandling
+                    andelerFørstegangsbehandling.forIverksetting()
                 ),
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = sisteOffsetPåFagsak,
                 oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerRevurdering
+                    andelerRevurdering.forIverksetting()
                 ),
                 erSimulering = true
             )
@@ -856,7 +856,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             vedtak,
             true,
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerFørstegangsbehandling
+                andelerFørstegangsbehandling.forIverksetting()
             )
         )
 
@@ -908,16 +908,16 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak2,
                 false,
                 forrigeKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerFørstegangsbehandling
+                    andelerFørstegangsbehandling.forIverksetting()
                 ),
                 sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                     ØkonomiUtils.kjedeinndelteAndeler(
-                        andelerFørstegangsbehandling
+                        andelerFørstegangsbehandling.forIverksetting()
                     )
                 ),
                 sisteOffsetPåFagsak = sisteOffsetPåFagsak,
                 oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerRevurdering
+                    andelerRevurdering.forIverksetting()
                 ),
                 erSimulering = true
             )
@@ -1043,15 +1043,15 @@ class UtbetalingsoppdragIntegrasjonTest(
             false,
             sisteOffsetPåFagsak = 1,
             forrigeKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerAndregangsbehandling
+                andelerAndregangsbehandling.forIverksetting()
             ),
             sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
                 ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerFørstegangsbehandling + andelerAndregangsbehandling
+                    (andelerFørstegangsbehandling + andelerAndregangsbehandling).forIverksetting()
                 )
             ),
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerRevurderingsbehandling
+                andelerRevurderingsbehandling.forIverksetting()
             )
         )
 
@@ -1093,7 +1093,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             vedtak,
             true,
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerFørstegangsbehandling
+                andelerFørstegangsbehandling.forIverksetting()
             )
         )
 
@@ -1115,7 +1115,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             vedtak,
             false,
             oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                andelerRevurdering
+                andelerRevurdering.forIverksetting()
             )
         )
 
@@ -1177,7 +1177,11 @@ class UtbetalingsoppdragIntegrasjonTest(
         førsteTilkjentYtelse.utbetalingsoppdrag = "utbetalingsoppdrg"
         tilkjentYtelseRepository.saveAndFlush(førsteTilkjentYtelse)
 
-        økonomiService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(førsteVedtak, "Z123")
+        økonomiService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+            førsteVedtak,
+            "Z123",
+            AndelTilkjentYtelseForIverksettingFactory()
+        )
         førsteBehandling.status = BehandlingStatus.AVSLUTTET
         førsteBehandling.leggTilBehandlingStegTilstand(StegType.BEHANDLING_AVSLUTTET)
         behandlingService.lagre(førsteBehandling)
@@ -1216,7 +1220,11 @@ class UtbetalingsoppdragIntegrasjonTest(
         andreTilkjentYtelse.andelerTilkjentYtelse.addAll(andreAndelerTilkjentYtelse)
         tilkjentYtelseRepository.saveAndFlush(andreTilkjentYtelse)
 
-        val utbetalingsoppdrag = økonomiService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(andreVedtak, "Z123")
+        val utbetalingsoppdrag = økonomiService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+            andreVedtak,
+            "Z123",
+            AndelTilkjentYtelseForIverksettingFactory()
+        )
         assertEquals(Utbetalingsoppdrag.KodeEndring.ENDR, utbetalingsoppdrag.kodeEndring)
         assertEquals(3, utbetalingsoppdrag.utbetalingsperiode.size)
         assertEquals(true, utbetalingsoppdrag.utbetalingsperiode.first().erEndringPåEksisterendePeriode)
@@ -1259,7 +1267,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 vedtak,
                 true,
                 oppdaterteKjeder = ØkonomiUtils.kjedeinndelteAndeler(
-                    andelerTilkjentYtelse
+                    andelerTilkjentYtelse.forIverksetting()
                 )
             )
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har i dag en knyttet til generering av utbetalingsoppdrag. Ved simulering skal ikke andelene oppdateres med periodeOffset, men det skjer uansett pga at andelene hentes ut i en transaksjon under JPA, og offset-verdiene endres på andel entitetene

Jeg forsøker med dette å lage to ulike wrappere rundt andelene som brukes i generering av utbetalingsoppdrag. Hvis det er simulering, vil wrapper-implementasjonen ikke oppdatere offset-verdiene på andel-entitetene. 

Målet vare å gjøre så lite endringer som mulig. Det har ikke lykkes helt.

_Greiest å lese commit for commit_

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ det ikke skal introdusere funksjonelle endrringer

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
