### PR TITLE
Ikkje send autobrev opphør småbarnstillegg, når småbarnstillegget fortsatt er løpende neste måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -131,13 +131,15 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
             WHERE
                     b.id in :iverksatteLøpendeBehandlinger
                 AND NOT EXISTS (SELECT b2 from Behandling b2 where b2.fagsak.id = b.fagsak.id AND b2.status <> 'AVSLUTTET')
+                AND NOT EXISTS (SELECT aty2 from AndelTilkjentYtelse aty2 where aty2.behandlingId = b.id AND aty2.type = 'SMÅBARNSTILLEGG' AND aty.stønadFom = :innværendeMåned)
                 AND aty.type = 'SMÅBARNSTILLEGG'
                 AND aty.stønadTom = :stønadTom
         """
     )
     fun finnAlleFagsakerMedOpphørSmåbarnstilleggIMåned(
         iverksatteLøpendeBehandlinger: List<Long>,
-        stønadTom: YearMonth = YearMonth.now().minusMonths(1)
+        stønadTom: YearMonth = YearMonth.now().minusMonths(1),
+        innværendeMåned: YearMonth = YearMonth.now()
     ): List<Long>
 
     @Query(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
BA-sak har fått overført overgangsstønad med splitt i perioder, d.v.s. to perioder med full overgangsstønad ligger back to back, og det er ingen endring i utbetalt overgangsstønad.
Småbarnstillegget er difor innvilget for begge perioder, men ba-sak har alikavel sendt autobrev om opphør.
Fiksen skal hindre at autobrev om opphør av småbarnstillegg blir sendt ut, sidan ytelsen fortsatt er løpende.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
