### PR TITLE
Fjerner overstyrende tittel for LoggType.INSTITUSJON_REGISTRERT

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
@@ -77,12 +77,10 @@ class LoggService(
     }
 
     fun opprettRegistrerInstitusjonLogg(behandling: Behandling) {
-        val tittel = "institusjon ble registrert"
         lagre(
             Logg(
                 behandlingId = behandling.id,
                 type = LoggType.INSTITUSJON_REGISTRERT,
-                tittel = tittel,
                 rolle = SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
                     rolleConfig,
                     BehandlerRolle.SAKSBEHANDLER


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner overstyrende tittel med liten forbokstav. Korrekt tittel vil da settes fra Loggtype.visningsnavn istedet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Verifisert manuelt i frontend

Før:
![image](https://user-images.githubusercontent.com/47184872/196653097-3c05898d-4f4f-4c7e-b9ac-6d7391f35c96.png)

Nå:
![image](https://user-images.githubusercontent.com/47184872/196653233-e4f51b6a-c718-4acf-866f-39f7fc4da812.png)

