### PR TITLE
Legger til samme logikk for "innhente opplysninger"-brevet tilpasset institusjon som ellers

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -189,10 +189,9 @@ class DokumentService(
             )
         }
 
-        if ((
-            manueltBrevRequest.brevmal == Brevmal.INNHENTE_OPPLYSNINGER ||
-                manueltBrevRequest.brevmal == Brevmal.VARSEL_OM_REVURDERING
-            ) && behandling != null
+        if (
+            behandling != null &&
+            manueltBrevRequest.brevmal.førerTilOpplysningsplikt()
         ) {
             leggTilOpplysningspliktIVilkårsvurdering(behandling)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
@@ -202,10 +202,20 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
             AUTOVEDTAK_NYFØDT_BARN_FRA_FØR -> Distribusjonstype.VEDTAK
         }
 
+    fun førerTilOpplysningsplikt(): Boolean =
+        when (this) {
+            INNHENTE_OPPLYSNINGER,
+            INNHENTE_OPPLYSNINGER_INSTITUSJON,
+            VARSEL_OM_REVURDERING -> true
+
+            else -> false
+        }
+
     fun setterBehandlingPåVent(): Boolean =
         when (this) {
             FORLENGET_SVARTIDSBREV,
             INNHENTE_OPPLYSNINGER,
+            INNHENTE_OPPLYSNINGER_INSTITUSJON,
             VARSEL_OM_REVURDERING,
             VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14,
             INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED,
@@ -221,6 +231,7 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
     fun ventefristDager(manuellFrist: Long? = null, behandlingKategori: BehandlingKategori?): Long =
         when (this) {
             INNHENTE_OPPLYSNINGER,
+            INNHENTE_OPPLYSNINGER_INSTITUSJON,
             VARSEL_OM_REVURDERING,
             VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14,
             INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED,
@@ -245,6 +256,7 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
         when (this) {
             FORLENGET_SVARTIDSBREV,
             INNHENTE_OPPLYSNINGER,
+            INNHENTE_OPPLYSNINGER_INSTITUSJON,
             VARSEL_OM_REVURDERING,
             VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14,
             INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevTypeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevTypeTest.kt
@@ -12,6 +12,7 @@ class BrevTypeTest {
 
     private val førerTilAvventerDokumentasjon = listOf(
         Brevmal.INNHENTE_OPPLYSNINGER,
+        Brevmal.INNHENTE_OPPLYSNINGER_INSTITUSJON,
         Brevmal.VARSEL_OM_REVURDERING,
         Brevmal.VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14,
         Brevmal.INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10069

- logikk for å sette behandlingen på vent og trigge opplysningspliktvilkåret etter brevet er sendt.
- venteårsak
- ventefristDager

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
