### PR TITLE
Teknisk/tislinje fra tidspunkt og forbedrede map funksjoner

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
@@ -1,0 +1,71 @@
+package no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon
+
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.TidspunktClosedRange
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
+
+fun <T : Tidsenhet> Tidslinje<*, T>.tidsrom(): TidspunktClosedRange<T> = fraOgMed()..tilOgMed()
+
+fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): TidspunktClosedRange<T> = fraOgMed()..tilOgMed()
+
+fun <T : Tidsenhet, I> TidspunktClosedRange<T>.tidslinjeFraTidspunkt(
+    tidspunktMapper: (Tidspunkt<T>) -> Innholdsresultat<I>
+): Tidslinje<I, T> = tidslinje {
+    map { tidspunkt -> TidspunktMedInnholdsresultat(tidspunkt, tidspunktMapper(tidspunkt)) }
+        .filter { it.harInnhold }
+        .fold(emptyList()) { perioder, tidspunktMedInnholdsresultat ->
+            val sistePeriode = perioder.lastOrNull()
+            when {
+                sistePeriode != null && sistePeriode.kanUtvidesMed(tidspunktMedInnholdsresultat) ->
+                    perioder.replaceLast(sistePeriode.utvidMed(tidspunktMedInnholdsresultat))
+                else -> perioder + tidspunktMedInnholdsresultat.tilPeriode()
+            }
+        }
+}
+
+data class Innholdsresultat<I>(
+    val innhold: I?,
+    val harInnhold: Boolean = true
+) {
+    companion object {
+        fun <I> utenInnhold() = Innholdsresultat<I>(null, false)
+    }
+}
+
+fun <I, T : Tidsenhet> Tidslinje<I, T>.innholdsresultatForTidspunkt(tidspunkt: Tidspunkt<T>): Innholdsresultat<I> =
+    perioder().innholdsresultatForTidspunkt(tidspunkt)
+
+fun <I, T : Tidsenhet> Collection<Periode<I, T>>.innholdsresultatForTidspunkt(
+    tidspunkt: Tidspunkt<T>
+): Innholdsresultat<I> {
+    val periode = this.firstOrNull { it.fraOgMed <= tidspunkt && it.tilOgMed >= tidspunkt }
+    return when (periode) {
+        null -> Innholdsresultat.utenInnhold()
+        else -> Innholdsresultat(periode.innhold, true)
+    }
+}
+
+private data class TidspunktMedInnholdsresultat<I, T : Tidsenhet>(
+    val tidspunkt: Tidspunkt<T>,
+    val innholdsresultat: Innholdsresultat<I>
+) {
+    val harInnhold get() = innholdsresultat.harInnhold
+    val innhold get() = innholdsresultat.innhold
+}
+
+private fun <I, T : Tidsenhet> Periode<I, T>.kanUtvidesMed(tidspunktMedInnholdsresultat: TidspunktMedInnholdsresultat<I, T>) =
+    tidspunktMedInnholdsresultat.harInnhold &&
+        this.innhold == tidspunktMedInnholdsresultat.innhold &&
+        this.tilOgMed.erRettFør(tidspunktMedInnholdsresultat.tidspunkt.somEndelig())
+
+private fun <I, T : Tidsenhet> Periode<I, T>.utvidMed(tidspunktMedInnholdsresultat: TidspunktMedInnholdsresultat<I, T>): Periode<I, T> =
+    this.copy(tilOgMed = tidspunktMedInnholdsresultat.tidspunkt)
+
+private fun <I, T : Tidsenhet> TidspunktMedInnholdsresultat<I, T>.tilPeriode() =
+    Periode(this.tidspunkt.somFraOgMed(), this.tidspunkt.somTilOgMed(), this.innhold)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
@@ -38,7 +38,17 @@ data class Innholdsresultat<I>(
     companion object {
         fun <I> utenInnhold() = Innholdsresultat<I>(null, false)
     }
+
+    val harVerdi
+        get() = harInnhold && innhold != null
+
+    val verdi
+        get() = innhold!!
+
+    fun <R> mapVerdi(mapper: (I) -> R): R? = if (this.harVerdi) mapper(verdi) else null
 }
+
+fun <I> I.tilInnhold() = Innholdsresultat(this)
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.innholdsresultatForTidspunkt(tidspunkt: Tidspunkt<T>): Innholdsresultat<I> =
     perioder().innholdsresultatForTidspunkt(tidspunkt)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
@@ -46,12 +46,15 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.innholdsresultatForTidspunkt(tidspunkt: T
 fun <I, T : Tidsenhet> Collection<Periode<I, T>>.innholdsresultatForTidspunkt(
     tidspunkt: Tidspunkt<T>
 ): Innholdsresultat<I> {
-    val periode = this.firstOrNull { it.fraOgMed <= tidspunkt && it.tilOgMed >= tidspunkt }
+    val periode = this.firstOrNull { it.omfatter(tidspunkt) }
     return when (periode) {
         null -> Innholdsresultat.utenInnhold()
         else -> Innholdsresultat(periode.innhold, true)
     }
 }
+
+private fun <I, T : Tidsenhet> Periode<I, T>.omfatter(tidspunkt: Tidspunkt<T>) =
+    this.fraOgMed <= tidspunkt && this.tilOgMed >= tidspunkt
 
 private data class TidspunktMedInnholdsresultat<I, T : Tidsenhet>(
     val tidspunkt: Tidspunkt<T>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
@@ -33,6 +33,8 @@ data class Innholdsresultat<I>(
     val innhold: I?,
     val harInnhold: Boolean = true
 ) {
+    constructor(innhold: I?) : this(innhold, true)
+
     companion object {
         fun <I> utenInnhold() = Innholdsresultat<I>(null, false)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeSomStykkerOppTiden.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeSomStykkerOppTiden.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 
+@Deprecated("Bruk funksjonen tidlinjeFraTidspunkt i stedet")
 abstract class TidslinjeSomStykkerOppTiden<I, T : Tidsenhet>(
     avhengigheter: Collection<Tidslinje<*, T>>
 ) : TidslinjeMedAvhengigheter<I, T>(avhengigheter) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
@@ -1,36 +1,35 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TidslinjeSomStykkerOppTiden
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdForTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.Innholdsresultat
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdsresultatForTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tidslinjeFraTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tidsrom
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
 
 /**
  * Extension-metode for å map'e innhold fra en type og verdi til en annen
  * Hvis det nå oppstår tilgrensende perioder med samme innhold, slås de sammen
  */
-fun <I, T : Tidsenhet, R> Tidslinje<I, T>.map(mapper: (I?) -> R?): Tidslinje<R, T> {
-    val tidslinje = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(listOf(tidslinje)) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>) =
-            mapper(tidslinje.innholdForTidspunkt(tidspunkt))
+fun <I, T : Tidsenhet, R> Tidslinje<I, T>.map(mapper: (I?) -> R?): Tidslinje<R, T> =
+    tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+        val innholdsresultat = this.innholdsresultatForTidspunkt(tidspunkt)
+        when (innholdsresultat.harInnhold) {
+            false -> Innholdsresultat(null, false)
+            else -> Innholdsresultat<R>(mapper(innholdsresultat.innhold))
+        }
     }
-}
 
 /**
  * Extension-metode for å map'e innhold som ikke er <null> fra en type og verdi til en annen
  * Hvis det nå oppstår tilgrensende perioder med samme innhold, slås de sammen
  */
-fun <I, T : Tidsenhet, R> Tidslinje<I, T>.mapNotNull(mapper: (I) -> R?): Tidslinje<R, T> {
-    val tidslinje = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(listOf(tidslinje)) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? {
-            val innhold = tidslinje.innholdForTidspunkt(tidspunkt)
-            return when (innhold) {
-                null -> null
-                else -> mapper(innhold)
-            }
+fun <I, T : Tidsenhet, R> Tidslinje<I, T>.mapIkkeNull(mapper: (I) -> R?): Tidslinje<R, T> =
+    tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+        val innholdsresultat = this.innholdsresultatForTidspunkt(tidspunkt)
+        when (innholdsresultat.harInnhold) {
+            false -> Innholdsresultat.utenInnhold()
+            innholdsresultat.innhold == null -> Innholdsresultat.utenInnhold()
+            else -> Innholdsresultat(mapper(innholdsresultat.innhold!!))
         }
     }
-}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
@@ -15,7 +15,7 @@ fun <I, T : Tidsenhet, R> Tidslinje<I, T>.map(mapper: (I?) -> R?): Tidslinje<R, 
     tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
         val innholdsresultat = this.innholdsresultatForTidspunkt(tidspunkt)
         when (innholdsresultat.harInnhold) {
-            false -> Innholdsresultat(null, false)
+            false -> Innholdsresultat.utenInnhold()
             else -> Innholdsresultat<R>(mapper(innholdsresultat.innhold))
         }
     }
@@ -28,8 +28,7 @@ fun <I, T : Tidsenhet, R> Tidslinje<I, T>.mapIkkeNull(mapper: (I) -> R?): Tidsli
     tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
         val innholdsresultat = this.innholdsresultatForTidspunkt(tidspunkt)
         when (innholdsresultat.harInnhold) {
-            false -> Innholdsresultat.utenInnhold()
-            innholdsresultat.innhold == null -> Innholdsresultat.utenInnhold()
-            else -> Innholdsresultat(mapper(innholdsresultat.innhold!!))
+            false, (innholdsresultat.innhold == null) -> Innholdsresultat.utenInnhold()
+            else -> Innholdsresultat<R>(mapper(innholdsresultat.innhold!!))
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilDagEllerFørsteDagIPerioden
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilDagEllerSisteDagIPerioden
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapNotNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapIkkeNull
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
@@ -59,7 +59,7 @@ data class VilkårsvurderingBuilder<T : Tidsenhet>(
 
         fun medVilkår(tidslinje: Tidslinje<VilkårRegelverkResultat, T>): PersonResultatBuilder<T> {
             vilkårsresultatTidslinjer.add(
-                tidslinje.mapNotNull { UtdypendeVilkårRegelverkResultat(it.vilkår, it.resultat, it.regelverk) }
+                tidslinje.mapIkkeNull { UtdypendeVilkårRegelverkResultat(it.vilkår, it.resultat, it.regelverk) }
             )
             return this
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidslinjeFraTidspunktTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidslinjeFraTidspunktTest.kt
@@ -1,0 +1,66 @@
+package no.nav.familie.ba.sak.kjerne.tidslinje
+
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.Innholdsresultat
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdsresultatForTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tidslinjeFraTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tidsrom
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.okt
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.sep
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TidslinjeFraTidspunktTest {
+    val tidslinje = tidslinje {
+        listOf(
+            Periode(mar(2018), mar(2018), null),
+            Periode(mai(2018), mai(2018), "A"),
+            Periode(jun(2018), sep(2018), "B"),
+            Periode(des(2018), feb(2019), "C"),
+            Periode(apr(2019), jul(2019), null),
+            Periode(sep(2019), jan(2020), "D"),
+            Periode(feb(2020), okt(2020), null),
+            Periode(nov(2020), feb(2021), "e"),
+            Periode(apr(2021), apr(2021), null)
+        )
+    }
+
+    @Test
+    fun `skal gjenskape underliggende tidslinje dersom innholdet returneres uendret `() {
+        val resultat = tidslinje.tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+            tidslinje.innholdsresultatForTidspunkt(tidspunkt)
+        }
+
+        assertEquals(tidslinje, resultat)
+    }
+
+    @Test
+    fun `skal skape sammenhengende tidslinje i samme tidsrom hvis alt innhold er identisk`() {
+        val resultat = tidslinje.tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+            Innholdsresultat("A")
+        }
+
+        val forventet = tidslinje { listOf(Periode(mar(2018), apr(2021), "A")) }
+
+        assertEquals(forventet, resultat)
+    }
+
+    @Test
+    fun `skal skape tom tidslinje dersom alt innhold mangler`() {
+        val resultat = tidslinje.tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+            Innholdsresultat.utenInnhold<String>()
+        }
+
+        assertEquals(TomTidslinje<String, Måned>(), resultat)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinjeTest.kt
@@ -2,10 +2,15 @@ package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.Innholdsresultat
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdsresultatForTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.aug
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
@@ -13,6 +18,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.okt
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.sep
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -64,5 +70,14 @@ internal class MapTidslinjeTest {
         assertEquals(forventet, faktisk)
         assertEquals(jan(2020), faktisk.fraOgMed())
         assertEquals(okt(2021), faktisk.tilOgMed())
+
+        (
+            (aug(2019)..des(2019))
+                .plus(apr(2020)..jun(2020))
+                .plus(sep(2020)..feb(2021))
+                .plus(nov(2021)..mai(2022))
+            ).forEach {
+            assertEquals(Innholdsresultat.utenInnhold<String>(), faktisk.innholdsresultatForTidspunkt(it))
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinjeTest.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
+
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
+import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.aug
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.okt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class MapTidslinjeTest {
+
+    val tidslinje = tidslinje {
+        listOf(
+            Periode(aug(2019), nov(2019), null),
+            Periode(jan(2020), mar(2020), "A"),
+            Periode(apr(2020), jun(2020), null),
+            Periode(jul(2020), aug(2020), "B"),
+            Periode(mar(2021), okt(2021), "C"),
+            Periode(jan(2022), mai(2022), null)
+        )
+    }
+
+    @Test
+    fun `skal mappe innhold og ivareta null`() {
+        val faktisk = tidslinje.map { it?.lowercase() }
+
+        val forventet = tidslinje {
+            listOf(
+                Periode(aug(2019), nov(2019), null),
+                Periode(jan(2020), mar(2020), "a"),
+                Periode(apr(2020), jun(2020), null),
+                Periode(jul(2020), aug(2020), "b"),
+                Periode(mar(2021), okt(2021), "c"),
+                Periode(jan(2022), mai(2022), null)
+            )
+        }
+
+        assertEquals(forventet, faktisk)
+        assertEquals(aug(2019), faktisk.fraOgMed())
+        assertEquals(mai(2022), faktisk.tilOgMed())
+    }
+
+    @Test
+    fun `skal mappe innhold og fjerne null`() {
+        val faktisk = tidslinje.mapIkkeNull { it.lowercase() }
+
+        val forventet = tidslinje {
+            listOf(
+                Periode(jan(2020), mar(2020), "a"),
+                Periode(jul(2020), aug(2020), "b"),
+                Periode(mar(2021), okt(2021), "c")
+            )
+        }
+
+        assertEquals(forventet, faktisk)
+        assertEquals(jan(2020), faktisk.fraOgMed())
+        assertEquals(okt(2021), faktisk.tilOgMed())
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
`TidslinjeSomStykkerOppTiden` vil kunne introdusere flere/lengre perioder med null-verdier enn underliggende tidslinje har. Det er unødvendig og forvirrende. Legger til `tidslinjeFraTidspunkt` som løser problemet og gir en mer funksjonell implementasjon. 

Endrringen innfører et skille mellom tidslinje-innhold som finnes men er null – og de rinnholdet ikke finnes i det hele tatt. Til nå har begge blitt representert av null. Det er tilsvarende som for lister, der [1,null,3,null,5] er noe annet enn [1,3,5]. 

Det bør lages et par PRer til etter denne:
* Endre navn på `map` til `mappInnhold` og `mapIkkeNull` til `mapInnholdIkkeNull`
* Fjerne bruken av `TidslinjeSomStykkerOppTiden` og erstatte med `tidslinjeFraTidspunkt`

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
