### PR TITLE
Bugfix feil regelverk ved månedsskifte

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MapTidslinje.kt
@@ -17,3 +17,20 @@ fun <I, T : Tidsenhet, R> Tidslinje<I, T>.map(mapper: (I?) -> R?): Tidslinje<R, 
             mapper(tidslinje.innholdForTidspunkt(tidspunkt))
     }
 }
+
+/**
+ * Extension-metode for å map'e innhold som ikke er <null> fra en type og verdi til en annen
+ * Hvis det nå oppstår tilgrensende perioder med samme innhold, slås de sammen
+ */
+fun <I, T : Tidsenhet, R> Tidslinje<I, T>.mapNotNull(mapper: (I) -> R?): Tidslinje<R, T> {
+    val tidslinje = this
+    return object : TidslinjeSomStykkerOppTiden<R, T>(listOf(tidslinje)) {
+        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? {
+            val innhold = tidslinje.innholdForTidspunkt(tidspunkt)
+            return when (innhold) {
+                null -> null
+                else -> mapper(innhold)
+            }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseUtils
+import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårRegelverkResultat
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjer
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
@@ -13,8 +14,9 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilFørsteDagIMåneden
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilSisteDagIMåneden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilDagEllerFørsteDagIPerioden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilDagEllerSisteDagIPerioden
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapNotNull
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
@@ -55,6 +57,13 @@ data class VilkårsvurderingBuilder<T : Tidsenhet>(
             return this
         }
 
+        fun medVilkår(tidslinje: Tidslinje<VilkårRegelverkResultat, T>): PersonResultatBuilder<T> {
+            vilkårsresultatTidslinjer.add(
+                tidslinje.mapNotNull { UtdypendeVilkårRegelverkResultat(it.vilkår, it.resultat, it.regelverk) }
+            )
+            return this
+        }
+
         fun forPerson(person: Person, startTidspunkt: Tidspunkt<T>): PersonResultatBuilder<T> {
             return byggPerson().forPerson(person, startTidspunkt)
         }
@@ -90,8 +99,8 @@ internal fun <T : Tidsenhet> Periode<UtdypendeVilkårRegelverkResultat, T>.tilVi
             vilkårType = this.innhold?.vilkår!!,
             resultat = this.innhold?.resultat!!,
             vurderesEtter = this.innhold?.regelverk,
-            periodeFom = this.fraOgMed.tilFørsteDagIMåneden().tilLocalDateEllerNull(),
-            periodeTom = this.tilOgMed.tilSisteDagIMåneden().tilLocalDateEllerNull(),
+            periodeFom = this.fraOgMed.tilDagEllerFørsteDagIPerioden().tilLocalDateEllerNull(),
+            periodeTom = this.tilOgMed.tilDagEllerSisteDagIPerioden().tilLocalDateEllerNull(),
             begrunnelse = "",
             behandlingId = personResultat.vilkårsvurdering.behandling.id,
             utdypendeVilkårsvurderinger = this.innhold?.utdypendeVilkårsvurderinger ?: emptyList()
@@ -101,6 +110,9 @@ internal fun <T : Tidsenhet> Periode<UtdypendeVilkårRegelverkResultat, T>.tilVi
 
 fun <T : Tidsenhet> VilkårsvurderingBuilder<T>.byggVilkårsvurderingTidslinjer() =
     VilkårsvurderingTidslinjer(this.byggVilkårsvurdering(), this.byggPersonopplysningGrunnlag())
+
+fun <T : Tidsenhet> VilkårsvurderingBuilder.PersonResultatBuilder<T>.byggVilkårsvurderingTidslinjer() =
+    this.byggPerson().byggVilkårsvurderingTidslinjer()
 
 fun <T : Tidsenhet> VilkårsvurderingBuilder<T>.byggTilkjentYtelse() =
     TilkjentYtelseUtils.beregnTilkjentYtelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
@@ -2,20 +2,40 @@ package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.oppfyltVilkår
 import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.tilpassKompetanserTilRegelverk
+import no.nav.familie.ba.sak.kjerne.eøs.util.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.konkatenerTidslinjer
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.ogSenere
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.VilkårsvurderingBuilder
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.byggVilkårsvurderingTidslinjer
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.tilRegelverkResultatTidslinje
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk.EØS_FORORDNINGEN
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk.NASJONALE_REGLER
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOR_MED_SØKER
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOSATT_I_RIKET
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.GIFT_PARTNERSKAP
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.LOVLIG_OPPHOLD
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.UNDER_18_ÅR
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import java.time.YearMonth
 
 internal class TidslinjerTest {
 
@@ -31,28 +51,28 @@ internal class TidslinjerTest {
 
         val vilkårsvurderingBygger = VilkårsvurderingBuilder<Måned>(behandling)
             .forPerson(søker, startMåned)
-            .medVilkår("EEEEEEEENNEEEEEEEEEEE", Vilkår.BOSATT_I_RIKET)
-            .medVilkår("EEEEEEEENNEEEEEEEEEEE", Vilkår.LOVLIG_OPPHOLD)
+            .medVilkår("EEEEEEEENNEEEEEEEEEEE", BOSATT_I_RIKET)
+            .medVilkår("EEEEEEEENNEEEEEEEEEEE", LOVLIG_OPPHOLD)
             .byggPerson()
-        val søkerResult = " EEEEEEEENNEEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
+        val søkerResult = " EEEEEEENNEEEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         vilkårsvurderingBygger.forPerson(barn1, startMåned)
-            .medVilkår("++++++++++++++++     ", Vilkår.UNDER_18_ÅR)
-            .medVilkår("   EEE NNNN  EEEE+++ ", Vilkår.BOSATT_I_RIKET)
-            .medVilkår("     EEENNEEEEEEEEE  ", Vilkår.LOVLIG_OPPHOLD)
-            .medVilkår("NNNNNNNNNNEEEEEEEEEEE", Vilkår.BOR_MED_SØKER)
-            .medVilkår("+++++++++++++++++++++", Vilkår.GIFT_PARTNERSKAP)
+            .medVilkår("++++++++++++++++     ", UNDER_18_ÅR)
+            .medVilkår("   EEE NNNN  EEEE+++ ", BOSATT_I_RIKET)
+            .medVilkår("     EEENNEEEEEEEEE  ", LOVLIG_OPPHOLD)
+            .medVilkår("NNNNNNNNNNEEEEEEEEEEE", BOR_MED_SØKER)
+            .medVilkår("+++++++++++++++++++++", GIFT_PARTNERSKAP)
             .byggPerson()
-        val barn1Result = " ???????!NN???EE?????".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
+        val barn1Result = " ???????NN!???EE?????".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         vilkårsvurderingBygger.forPerson(barn2, startMåned)
-            .medVilkår("+++++++++>", Vilkår.UNDER_18_ÅR)
-            .medVilkår(" EEEE++EE>", Vilkår.BOSATT_I_RIKET)
-            .medVilkår("EEEEEEEEE>", Vilkår.LOVLIG_OPPHOLD)
-            .medVilkår("EEEENNEEE>", Vilkår.BOR_MED_SØKER)
-            .medVilkår("+++++++++>", Vilkår.GIFT_PARTNERSKAP)
+            .medVilkår("+++++++++>", UNDER_18_ÅR)
+            .medVilkår(" EEEE++EE>", BOSATT_I_RIKET)
+            .medVilkår("EEEEEEEEE>", LOVLIG_OPPHOLD)
+            .medVilkår("EEEENNEEE>", BOR_MED_SØKER)
+            .medVilkår("+++++++++>", GIFT_PARTNERSKAP)
             .byggPerson()
-        val barn2Result = " ?EEE!!EE!!EEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
+        val barn2Result = " ?EE!!!E!!EEEEEEEEEEE".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(
             vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
@@ -75,19 +95,19 @@ internal class TidslinjerTest {
 
         val vilkårsvurderingBygger = VilkårsvurderingBuilder<Måned>(behandling)
             .forPerson(søker, startMåned)
-            .medVilkår("EEEEEEEEEEEEENNNNNNNN", Vilkår.BOSATT_I_RIKET)
-            .medVilkår("EEEEEEEEEEEEENNNNNNNN", Vilkår.LOVLIG_OPPHOLD)
+            .medVilkår("EEEEEEEEEEEEENNNNNNNN", BOSATT_I_RIKET)
+            .medVilkår("EEEEEEEEEEEEENNNNNNNN", LOVLIG_OPPHOLD)
             .byggPerson()
-        val søkerResult = " EEEEEEEEEEEEENNNNNNN".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
+        val søkerResult = " EEEEEEEEEEEENNNNNNNN".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         vilkårsvurderingBygger.forPerson(barn1, startMåned)
-            .medVilkår("++++++++++++++++     ", Vilkår.UNDER_18_ÅR)
-            .medVilkår("   EEEENNNNEEEEEEEE ", Vilkår.BOSATT_I_RIKET)
-            .medVilkår("     EEENNEEEEEEEEE  ", Vilkår.LOVLIG_OPPHOLD)
-            .medVilkår("NNNNNNNNNNEEEEEEEEEEE", Vilkår.BOR_MED_SØKER)
-            .medVilkår("+++++++++++++++++++++", Vilkår.GIFT_PARTNERSKAP)
+            .medVilkår("++++++++++++++++     ", UNDER_18_ÅR)
+            .medVilkår("   EEEENNNNEEEEEEEE ", BOSATT_I_RIKET)
+            .medVilkår("     EEENNEEEEEEEEE  ", LOVLIG_OPPHOLD)
+            .medVilkår("NNNNNNNNNNEEEEEEEEEEE", BOR_MED_SØKER)
+            .medVilkår("+++++++++++++++++++++", GIFT_PARTNERSKAP)
             .byggPerson()
-        val barn1Result = " ?????!!!!!!EE!!?????".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
+        val barn1Result = " ?????!!!!!EE!!!?????".tilRegelverkResultatTidslinje(startMåned).filtrerIkkeNull()
 
         val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(
             vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
@@ -107,14 +127,14 @@ internal class TidslinjerTest {
 
         val vilkårsvurderingBygger = VilkårsvurderingBuilder<Måned>(behandling)
             .forPerson(søker, jan(2020))
-            .medVilkår("+>", Vilkår.BOSATT_I_RIKET)
-            .medVilkår("+>", Vilkår.LOVLIG_OPPHOLD)
+            .medVilkår("+>", BOSATT_I_RIKET)
+            .medVilkår("+>", LOVLIG_OPPHOLD)
             .forPerson(barn1, jan(2020))
-            .medVilkår("+>", Vilkår.UNDER_18_ÅR)
-            .medVilkår("+>", Vilkår.BOSATT_I_RIKET)
-            .medVilkår("+>", Vilkår.LOVLIG_OPPHOLD)
-            .medVilkår("+>", Vilkår.BOR_MED_SØKER)
-            .medVilkår("+>", Vilkår.GIFT_PARTNERSKAP)
+            .medVilkår("+>", UNDER_18_ÅR)
+            .medVilkår("+>", BOSATT_I_RIKET)
+            .medVilkår("+>", LOVLIG_OPPHOLD)
+            .medVilkår("+>", BOR_MED_SØKER)
+            .medVilkår("+>", GIFT_PARTNERSKAP)
             .byggPerson()
 
         val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(
@@ -128,4 +148,202 @@ internal class TidslinjerTest {
                 .perioder().maxOf { it.tilOgMed.tilYearMonth() }
         )
     }
+
+    @Test
+    fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS i månedsskiftet`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019).tilLocalDate())
+
+        val vilkårsvurderingTidslinjer = VilkårsvurderingBuilder<Dag>()
+            .forPerson(søker, 30.apr(2020))
+            .medVilkår("NE", BOSATT_I_RIKET, LOVLIG_OPPHOLD)
+            .forPerson(barn1, 30.apr(2020))
+            .medVilkår("++", UNDER_18_ÅR, GIFT_PARTNERSKAP)
+            .medVilkår("NE", BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER)
+            .byggVilkårsvurderingTidslinjer()
+
+        val barn1Result = "E".tilRegelverkResultatTidslinje(mai(2020))
+
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
+    }
+
+    @Test
+    fun `Sjekk overgang fra oppfylt EØS til oppfylt nasjonalt i månedsskiftet`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019).tilLocalDate())
+
+        val vilkårsvurderingTidslinjer = VilkårsvurderingBuilder<Dag>()
+            .forPerson(søker, 30.apr(2020))
+            .medVilkår("EN", BOSATT_I_RIKET, LOVLIG_OPPHOLD)
+            .forPerson(barn1, 30.apr(2020))
+            .medVilkår("++", UNDER_18_ÅR, GIFT_PARTNERSKAP)
+            .medVilkår("EN", BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER)
+            .byggVilkårsvurderingTidslinjer()
+
+        val barn1Result = "N".tilRegelverkResultatTidslinje(mai(2020))
+
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
+    }
+
+    @Test
+    fun `Sjekk overgang fra oppfylt EØS til oppfylt blandet i månedsskiftet`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019).tilLocalDate())
+
+        val vilkårsvurderingTidslinjer = VilkårsvurderingBuilder<Dag>()
+            .forPerson(søker, 30.apr(2020))
+            .medVilkår("EE", BOSATT_I_RIKET, LOVLIG_OPPHOLD)
+            .forPerson(barn1, 30.apr(2020))
+            .medVilkår("++", UNDER_18_ÅR, GIFT_PARTNERSKAP)
+            .medVilkår("EE", BOSATT_I_RIKET)
+            .medVilkår("EE", LOVLIG_OPPHOLD)
+            .medVilkår("EN", BOR_MED_SØKER)
+            .byggVilkårsvurderingTidslinjer()
+
+        val barn1Result = "!".tilRegelverkResultatTidslinje(mai(2020))
+
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
+    }
+
+    @Test
+    fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS dagen før siste dag i måneden`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019).tilLocalDate())
+
+        val giftPartnerskap =
+            (26.jan(2020)..30.nov(2021)).tilTidslinje { oppfyltVilkår(GIFT_PARTNERSKAP) }
+        val under18 =
+            (26.jan(2020)..30.nov(2021)).tilTidslinje { oppfyltVilkår(UNDER_18_ÅR) }
+        val bosattBarnOgSøker = konkatenerTidslinjer(
+            (26.jan(2020)..29.apr(2021)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) },
+            (30.apr(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) }
+        )
+        val lovligOppholdBarnOgSøker = konkatenerTidslinjer(
+            (26.jan(2020)..29.apr(2021)).tilTidslinje { oppfyltVilkår(LOVLIG_OPPHOLD, NASJONALE_REGLER) },
+            (30.apr(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(LOVLIG_OPPHOLD, EØS_FORORDNINGEN) }
+        )
+        val borMedSøker = konkatenerTidslinjer(
+            (26.jan(2020)..29.apr(2021)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, NASJONALE_REGLER) },
+            (30.apr(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, EØS_FORORDNINGEN) }
+        )
+
+        val barnaRegelverkTidslinjer = VilkårsvurderingBuilder<Dag>()
+            .forPerson(søker, 26.jan(2020))
+            .medVilkår(bosattBarnOgSøker)
+            .medVilkår(lovligOppholdBarnOgSøker)
+            .forPerson(barn, 26.jan(2020))
+            .medVilkår(bosattBarnOgSøker)
+            .medVilkår(lovligOppholdBarnOgSøker)
+            .medVilkår(giftPartnerskap)
+            .medVilkår(under18)
+            .medVilkår(borMedSøker)
+            .byggVilkårsvurderingTidslinjer()
+            .barnasRegelverkResultatTidslinjer()
+
+        val kompetanser = tilpassKompetanserTilRegelverk(
+            emptyList(),
+            barnaRegelverkTidslinjer
+        )
+
+        assertEquals(1, kompetanser.size)
+        assertEquals(YearMonth.of(2021, 5), kompetanser.first().fom)
+        assertEquals(YearMonth.of(2021, 11), kompetanser.first().tom)
+    }
+
+    @Test
+    fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS dagen andre dag i måneden`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019).tilLocalDate())
+
+        val giftPartnerskap =
+            (26.jan(2020)..30.nov(2021)).tilTidslinje { oppfyltVilkår(GIFT_PARTNERSKAP) }
+        val under18 =
+            (26.jan(2020)..30.nov(2021)).tilTidslinje { oppfyltVilkår(UNDER_18_ÅR) }
+        val bosattBarnOgSøker = konkatenerTidslinjer(
+            (26.jan(2020)..1.mai(2021)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) },
+            (2.mai(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) }
+        )
+        val lovligOppholdBarnOgSøker = konkatenerTidslinjer(
+            (26.jan(2020)..1.mai(2021)).tilTidslinje { oppfyltVilkår(LOVLIG_OPPHOLD, NASJONALE_REGLER) },
+            (2.mai(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(LOVLIG_OPPHOLD, EØS_FORORDNINGEN) }
+        )
+        val borMedSøker = konkatenerTidslinjer(
+            (26.jan(2020)..1.mai(2021)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, NASJONALE_REGLER) },
+            (2.mai(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, EØS_FORORDNINGEN) }
+        )
+
+        val barnaRegelverkTidslinjer = VilkårsvurderingBuilder<Dag>()
+            .forPerson(søker, 26.jan(2020))
+            .medVilkår(bosattBarnOgSøker)
+            .medVilkår(lovligOppholdBarnOgSøker)
+            .forPerson(barn, 26.jan(2020))
+            .medVilkår(bosattBarnOgSøker)
+            .medVilkår(lovligOppholdBarnOgSøker)
+            .medVilkår(giftPartnerskap)
+            .medVilkår(under18)
+            .medVilkår(borMedSøker)
+            .byggVilkårsvurderingTidslinjer()
+            .barnasRegelverkResultatTidslinjer()
+
+        val kompetanser = tilpassKompetanserTilRegelverk(
+            emptyList(),
+            barnaRegelverkTidslinjer
+        )
+
+        val forventetRegelverkResultat =
+            "NNNNNNNNNNNNNNNNEEEEEE".tilRegelverkResultatTidslinje(feb(2020))
+
+        assertEquals(forventetRegelverkResultat, barnaRegelverkTidslinjer[barn.aktør])
+        assertEquals(1, kompetanser.size)
+        assertEquals(YearMonth.of(2021, 6), kompetanser.first().fom)
+        assertEquals(YearMonth.of(2021, 11), kompetanser.first().tom)
+    }
+
+    @Test
+    fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS dagen før siste dag i måneden, der siste periode er uendelig`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019).tilLocalDate())
+
+        val giftPartnerskap =
+            26.jan(2020).ogSenere().tilTidslinje { oppfyltVilkår(GIFT_PARTNERSKAP) }
+        val under18 =
+            26.jan(2020).ogSenere().tilTidslinje { oppfyltVilkår(UNDER_18_ÅR) }
+        val bosattBarnOgSøker = konkatenerTidslinjer(
+            (26.jan(2020)..29.apr(2021)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) },
+            30.apr(2021).ogSenere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) }
+        )
+        val lovligOppholdBarnOgSøker = konkatenerTidslinjer(
+            (26.jan(2020)..29.apr(2021)).tilTidslinje { oppfyltVilkår(LOVLIG_OPPHOLD, NASJONALE_REGLER) },
+            30.apr(2021).ogSenere().tilTidslinje { oppfyltVilkår(LOVLIG_OPPHOLD, EØS_FORORDNINGEN) }
+        )
+        val borMedSøker = konkatenerTidslinjer(
+            (26.jan(2020)..29.apr(2021)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, NASJONALE_REGLER) },
+            30.apr(2021).ogSenere().tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, EØS_FORORDNINGEN) }
+        )
+
+        val barnaRegelverkTidslinjer = VilkårsvurderingBuilder<Dag>()
+            .forPerson(søker, 26.jan(2020))
+            .medVilkår(bosattBarnOgSøker)
+            .medVilkår(lovligOppholdBarnOgSøker)
+            .forPerson(barn, 26.jan(2020))
+            .medVilkår(bosattBarnOgSøker)
+            .medVilkår(lovligOppholdBarnOgSøker)
+            .medVilkår(giftPartnerskap)
+            .medVilkår(under18)
+            .medVilkår(borMedSøker)
+            .byggVilkårsvurderingTidslinjer()
+            .barnasRegelverkResultatTidslinjer()
+
+        val kompetanser = tilpassKompetanserTilRegelverk(
+            emptyList(),
+            barnaRegelverkTidslinjer
+        )
+
+        assertEquals(1, kompetanser.size)
+        assertEquals(YearMonth.of(2021, 5), kompetanser.first().fom)
+        assertNull(kompetanser.first().tom)
+    }
 }
+
+fun VilkårsvurderingTidslinjer.barnasRegelverkResultatTidslinjer() = this.barnasTidslinjer()
+    .mapValues { (_, barnetsTidslinjer) -> barnetsTidslinjer.regelverkResultatTidslinje }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinjeTest.kt
@@ -7,13 +7,14 @@ import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.eøs.util.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.konkatenerTidslinjer
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.ogSenere
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.ogTidligere
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.aug
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
@@ -109,13 +110,13 @@ class VilkårsresultatMånedTidslinjeTest {
     @Test
     fun `Hvis regelverk byttes i månedskiftet, skal det være kontinuerlig oppfylt vilkår`() {
         val dagvilkårtidslinje = konkatenerTidslinjer(
-            (26.jan(2020)..31.mar(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
-            (1.apr(2020)..30.nov(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) }
+            31.mar(2020).ogTidligere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
+            1.apr(2020).ogSenere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) }
         )
 
         val forventetMånedstidslinje = konkatenerTidslinjer(
-            (feb(2020)..apr(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
-            (mai(2020)..nov(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) }
+            mar(2020).ogTidligere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
+            apr(2020).ogSenere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) }
         )
 
         val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
@@ -125,12 +126,28 @@ class VilkårsresultatMånedTidslinjeTest {
     @Test
     fun `Hvis det byttes fra oppfylt til ikke oppfylt i månedskiftet, skal kun gi oppfylt til og med denne måneden`() {
         val dagvilkårtidslinje = konkatenerTidslinjer(
-            (26.jan(2020)..31.mar(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
-            (1.apr(2020)..30.nov(2020)).tilTidslinje { ikkeOppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) }
+            31.mar(2020).ogTidligere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) },
+            1.apr(2020).ogSenere().tilTidslinje { ikkeOppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) }
         )
 
         val forventetMånedstidslinje = konkatenerTidslinjer(
-            (feb(2020)..mar(2020)).tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) }
+            mar(2020).ogTidligere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) }
+        )
+
+        val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+        assertEquals(forventetMånedstidslinje, faktiskMånedstidslinje)
+    }
+
+    @Test
+    fun `Hvis regelverk byttes dagen før månedskiftet, skal det være kontinuerlig oppfylt vilkår`() {
+        val dagvilkårtidslinje = konkatenerTidslinjer(
+            29.apr(2020).ogTidligere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) },
+            30.apr(2020).ogSenere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) }
+        )
+
+        val forventetMånedstidslinje = konkatenerTidslinjer(
+            apr(2020).ogTidligere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER) },
+            mai(2020).ogSenere().tilTidslinje { oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN) }
         )
 
         val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidspunktClosedRangeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidspunktClosedRangeTest.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje
 
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.ogSenere
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.ogTidligere
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 import org.junit.jupiter.api.Assertions
@@ -28,5 +31,25 @@ class TidspunktClosedRangeTest {
         Assertions.assertEquals(305, tidsrom.count())
         Assertions.assertEquals(fom, tidsrom.first())
         Assertions.assertEquals(tom, tidsrom.last())
+    }
+
+    @Test
+    fun `test tidsrom med uendelig fremtid fra et tidspunkt`() {
+        val fom = YearMonth.of(2020, 1).tilTidspunkt()
+        val tidsrom = fom.ogSenere()
+
+        Assertions.assertEquals(1, tidsrom.count())
+        Assertions.assertEquals(fom.somUendeligLengeTil(), tidsrom.first())
+        Assertions.assertEquals(fom.somUendeligLengeTil(), tidsrom.last())
+    }
+
+    @Test
+    fun `test tidsrom med uendelig fortid fra et tidspunkt`() {
+        val tom = YearMonth.of(2020, 1).tilTidspunkt()
+        val tidsrom = tom.ogTidligere()
+
+        Assertions.assertEquals(1, tidsrom.count())
+        Assertions.assertEquals(tom.somUendeligLengeSiden(), tidsrom.first())
+        Assertions.assertEquals(tom.somUendeligLengeSiden(), tidsrom.last())
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/eksperimentelt/TidspunktClosedRangeUtvidelser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/eksperimentelt/TidspunktClosedRangeUtvidelser.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt
+
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
+
+fun <T : Tidsenhet> Tidspunkt<T>.ogSenere() = this.somUendeligLengeTil().rangeTo(this.somUendeligLengeTil())
+fun <T : Tidsenhet> Tidspunkt<T>.ogTidligere() = this.somUendeligLengeSiden().rangeTo(this.somUendeligLengeSiden())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Gjeldende tolkning er at regelverket som skal benyttes er det som gjaldt forrige måned. Det stemmer _ikke_; det er regelverket som gjelder for _inneværende_ måned som skal benyttes. 

Regelverket ved månedsskifte ble også feil hvis tom-datoen var null, dvs uendelig. Fkser det ved å sjekke tidsrommet én måned før og etter hhv fom og ttom

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
