### PR TITLE
henter større bolker med behandlinger i konsistensavstemming, og heller bruker chunked for å sikre data størrelsen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
@@ -13,7 +13,6 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
@@ -106,7 +105,7 @@ class AvstemmingService(
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun opprettKonsistensavstemmingDataTask(
         avstemmingsdato: LocalDateTime,
-        relevanteBehandlinger: Page<BigInteger>,
+        relevanteBehandlinger: List<BigInteger>,
         batchId: Long,
         transaksjonsId: UUID,
         chunkNr: Int
@@ -114,7 +113,7 @@ class AvstemmingService(
         val perioderTilAvstemming =
             hentDataForKonsistensavstemming(
                 avstemmingsdato,
-                relevanteBehandlinger.content.map { it.toLong() }
+                relevanteBehandlinger.map { it.toLong() }
             )
         val batch = batchRepository.getById(batchId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
@@ -108,13 +108,6 @@ class TestVerktøyController(
         }
     }
 
-    @PostMapping(path = ["/test-konsistenavstemming"])
-    @Unprotected
-    fun testKonsistensavstemmingLogikk(): ResponseEntity<Ressurs<String>> {
-        konsistensavstemMotOppdragStartTask.dryRunKonsistensavstemming()
-        return ResponseEntity.ok(Ressurs.success("OK"))
-    }
-
     @PostMapping(path = ["/test-konsistenavstemming/{size}"])
     @Unprotected
     fun testKonsistensavstemmingLogikkNy(@PathVariable size: Int): ResponseEntity<Ressurs<String>> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
@@ -30,16 +30,22 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
         avstemmingService.nullstillDataChunk()
         avstemmingService.sendKonsistensavstemmingStart(konsistensavstemmingTask.avstemmingdato, transaksjonsId)
 
-        var relevanteBehandlinger = avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
+        var relevanteBehandlinger =
+            avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(Pageable.ofSize(ANTALL_BEHANDLINGER))
 
-        for (chunkNr in 1..relevanteBehandlinger.totalPages) {
-            avstemmingService.opprettKonsistensavstemmingDataTask(
-                konsistensavstemmingTask.avstemmingdato,
-                relevanteBehandlinger,
-                konsistensavstemmingTask.batchId,
-                transaksjonsId,
-                chunkNr
-            )
+        var chunkNr = 1
+        for (pageNumber in 1..relevanteBehandlinger.totalPages) {
+            relevanteBehandlinger.content.chunked(AvstemmingService.KONSISTENSAVSTEMMING_DATA_CHUNK_STORLEK)
+                .forEach { oppstykketRelaterterteBehandlinger ->
+                    avstemmingService.opprettKonsistensavstemmingDataTask(
+                        konsistensavstemmingTask.avstemmingdato,
+                        oppstykketRelaterterteBehandlinger,
+                        konsistensavstemmingTask.batchId,
+                        transaksjonsId,
+                        chunkNr
+                    )
+                    chunkNr = chunkNr.inc()
+                }
             relevanteBehandlinger =
                 avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(relevanteBehandlinger.nextPageable())
         }
@@ -49,21 +55,6 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
             transaksjonsId,
             konsistensavstemmingTask.avstemmingdato
         )
-    }
-
-    fun dryRunKonsistensavstemming() {
-        logger.info("Start: hent behandlinger klar for konsistensavstemming ${LocalDateTime.now()}")
-        var relevanteBehandlinger = avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
-
-        val behandlinger = mutableListOf<BigInteger>()
-        for (chunkNr in 1..40) {
-            logger.info("Chunk $chunkNr: hent behandlinger klar for konsistensavstemming ${LocalDateTime.now()}")
-            behandlinger.addAll(relevanteBehandlinger.content)
-            relevanteBehandlinger =
-                avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(relevanteBehandlinger.nextPageable())
-        }
-        logger.info("Slutt: hent behandlinger klar for konsistensavstemming ${LocalDateTime.now()}")
-        logger.info("behandlinger: $behandlinger")
     }
 
     fun dryRunKonsistensavstemmingOmskriving(size: Int) {
@@ -91,6 +82,7 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
 
     companion object {
         const val TASK_STEP_TYPE = "konsistensavstemMotOppdragStart"
+        const val ANTALL_BEHANDLINGER = 10000
         private val logger = LoggerFactory.getLogger(KonsistensavstemMotOppdragStartTask::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
@@ -36,10 +36,10 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
         var chunkNr = 1
         for (pageNumber in 1..relevanteBehandlinger.totalPages) {
             relevanteBehandlinger.content.chunked(AvstemmingService.KONSISTENSAVSTEMMING_DATA_CHUNK_STORLEK)
-                .forEach { oppstykketRelaterterteBehandlinger ->
+                .forEach { oppstykketRelevanteBehandlinger ->
                     avstemmingService.opprettKonsistensavstemmingDataTask(
                         konsistensavstemmingTask.avstemmingdato,
-                        oppstykketRelaterterteBehandlinger,
+                        oppstykketRelevanteBehandlinger,
                         konsistensavstemmingTask.batchId,
                         transaksjonsId,
                         chunkNr

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import junit.framework.Assert.assertEquals
@@ -10,6 +11,9 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.task.KonsistensavstemMotOppdragAvsluttTask
 import no.nav.familie.ba.sak.task.KonsistensavstemMotOppdragDataTask
+import no.nav.familie.ba.sak.task.KonsistensavstemMotOppdragStartTask
+import no.nav.familie.ba.sak.task.dto.KonsistensavstemmingStartTaskDTO
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.junit.jupiter.api.BeforeEach
@@ -42,12 +46,15 @@ class AvstemmingServiceTest {
     val batchId = 1000000L
     val avstemmingsdato = LocalDateTime.now()
     val transaksjonsId = UUID.randomUUID()
+    val konsistensavstemmingStartTaskDTO = KonsistensavstemmingStartTaskDTO(batchId, avstemmingsdato)
+
+    lateinit var task: KonsistensavstemMotOppdragStartTask
 
     @BeforeEach
     fun setUp() {
         val behandlingId = BigInteger.ONE
         val page = mockk<Page<BigInteger>>()
-        val pageable = Pageable.ofSize(AvstemmingService.KONSISTENSAVSTEMMING_DATA_CHUNK_STORLEK)
+        val pageable = Pageable.ofSize(KonsistensavstemMotOppdragStartTask.ANTALL_BEHANDLINGER)
         every { behandlingHentOgPersisterService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(pageable) } returns page
         every { page.totalPages } returns 1
         every { page.content } returns listOf(behandlingId)
@@ -74,6 +81,10 @@ class AvstemmingServiceTest {
         )
         val aktivFødselsnummere = mapOf(behandlingId.toLong() to "test")
         every { behandlingHentOgPersisterService.hentAktivtFødselsnummerForBehandlinger(any()) } returns aktivFødselsnummere
+        val uuidMock = mockkStatic(UUID::class)
+        every { UUID.randomUUID() } returns transaksjonsId
+
+        task = KonsistensavstemMotOppdragStartTask(avstemmingService)
     }
 
     @Test
@@ -85,10 +96,11 @@ class AvstemmingServiceTest {
             )
         } returns ""
 
-        konsistensavstemOppdragStart(
-            batchId = batchId,
-            avstemmingsdato = avstemmingsdato,
-            transaksjonsId = transaksjonsId
+        task.doTask(
+            Task(
+                payload = objectMapper.writeValueAsString(konsistensavstemmingStartTaskDTO),
+                type = KonsistensavstemMotOppdragStartTask.TASK_STEP_TYPE
+            )
         )
 
         val taskSlots = mutableListOf<Task>()
@@ -148,28 +160,5 @@ class AvstemmingServiceTest {
         assertEquals(1, dataChunkSlot.captured.chunkNr)
         assertEquals(transaksjonsId, dataChunkSlot.captured.transaksjonsId)
         assertEquals(true, dataChunkSlot.captured.erSendt)
-    }
-
-    private fun konsistensavstemOppdragStart(batchId: Long, avstemmingsdato: LocalDateTime, transaksjonsId: UUID) {
-        avstemmingService.nullstillDataChunk()
-
-        avstemmingService.sendKonsistensavstemmingStart(avstemmingsdato, transaksjonsId)
-
-        var relevanteBehandlinger =
-            avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
-
-        for (chunkNr in 1..relevanteBehandlinger.totalPages) {
-            avstemmingService.opprettKonsistensavstemmingDataTask(
-                avstemmingsdato,
-                relevanteBehandlinger,
-                batchId,
-                transaksjonsId,
-                chunkNr
-            )
-            relevanteBehandlinger =
-                avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(relevanteBehandlinger.nextPageable())
-        }
-
-        avstemmingService.opprettKonsistensavstemmingAvsluttTask(batchId, transaksjonsId, avstemmingsdato)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTaskTest.kt
@@ -1,9 +1,8 @@
 package no.nav.familie.ba.sak.task
 
 import io.mockk.every
-import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AvstemmingService
 import no.nav.familie.ba.sak.task.dto.KonsistensavstemmingStartTaskDTO
@@ -31,15 +30,16 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
         val task = Task(payload = payload, type = KonsistensavstemMotOppdragStartTask.TASK_STEP_TYPE)
         val startTask = KonsistensavstemMotOppdragStartTask(avstemmingService)
 
-        every { avstemmingService.nullstillDataChunk() } just runs
-        every { avstemmingService.sendKonsistensavstemmingStart(avstemmingdato, any()) } just runs
+        justRun { avstemmingService.nullstillDataChunk() }
+        justRun { avstemmingService.sendKonsistensavstemmingStart(avstemmingdato, any()) }
         val page = mockk<Page<BigInteger>>()
         val pageable = mockk<Pageable>()
         val nrOfPages = 3
         every { page.totalPages } returns nrOfPages
         every { page.nextPageable() } returns pageable
+        every { page.content } returns listOf(BigInteger.valueOf(42))
         every { avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(any()) } returns page
-        every {
+        justRun {
             avstemmingService.opprettKonsistensavstemmingDataTask(
                 avstemmingdato,
                 any(),
@@ -47,8 +47,8 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
                 any(),
                 any()
             )
-        } just runs
-        every { avstemmingService.opprettKonsistensavstemmingAvsluttTask(batchId, any(), avstemmingdato) } just runs
+        }
+        justRun { avstemmingService.opprettKonsistensavstemmingAvsluttTask(batchId, any(), avstemmingdato) }
         startTask.doTask(task)
 
         verify(exactly = 1) { avstemmingService.nullstillDataChunk() }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Optimalisering av konsistensavstemming start tasken
I stedet for å hente 500 per query, så henter man nå 10000 av gangen, og heller chunker ved bruk av kode.

Hvor den gamle brukte 3 minutter på 20000 behandlinger, så brukte den nye måten 11 sekunder

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
