### PR TITLE
Konsistensavstemming manuell oppfølging

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
@@ -133,6 +133,22 @@ class AvstemmingService(
         dataChunkRepository.save(DataChunk(batch = batch, transaksjonsId = transaksjonsId, chunkNr = chunkNr))
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+    fun opprettKonsistensavstemmingDataTaskDryrun(
+        avstemmingsdato: LocalDateTime,
+        relevanteBehandlinger: List<BigInteger>,
+        transaksjonsId: UUID,
+        chunkNr: Int
+    ) {
+        val perioderTilAvstemming =
+            hentDataForKonsistensavstemming(
+                avstemmingsdato,
+                relevanteBehandlinger.map { it.toLong() }
+            )
+
+        logger.info("[dryRun-konsinstenavstemming] Oppretter konsisensavstemmingstasker for transaksjonsId $transaksjonsId og chunk $chunkNr med ${perioderTilAvstemming.size} løpende saker")
+    }
+
     private fun hentDataForKonsistensavstemming(
         avstemmingstidspunkt: LocalDateTime,
         relevanteBehandlinger: List<Long>

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTask.kt
@@ -28,8 +28,11 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
             objectMapper.readValue(task.payload, KonsistensavstemmingStartTaskDTO::class.java)
         val transaksjonsId = UUID.randomUUID()
 
+        val avstemmingsDato = LocalDateTime.now()
+        logger.info("Konsistensavstemming ble initielt trigget ${konsistensavstemmingTask.avstemmingdato}, men bruker $avstemmingsDato som avstemmingsdato")
+
         avstemmingService.nullstillDataChunk()
-        avstemmingService.sendKonsistensavstemmingStart(konsistensavstemmingTask.avstemmingdato, transaksjonsId)
+        avstemmingService.sendKonsistensavstemmingStart(avstemmingsDato, transaksjonsId)
 
         var relevanteBehandlinger =
             avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(Pageable.ofSize(ANTALL_BEHANDLINGER))
@@ -39,7 +42,7 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
             relevanteBehandlinger.content.chunked(AvstemmingService.KONSISTENSAVSTEMMING_DATA_CHUNK_STORLEK)
                 .forEach { oppstykketRelevanteBehandlinger ->
                     avstemmingService.opprettKonsistensavstemmingDataTask(
-                        konsistensavstemmingTask.avstemmingdato,
+                        avstemmingsDato,
                         oppstykketRelevanteBehandlinger,
                         konsistensavstemmingTask.batchId,
                         transaksjonsId,
@@ -54,7 +57,7 @@ class KonsistensavstemMotOppdragStartTask(val avstemmingService: AvstemmingServi
         avstemmingService.opprettKonsistensavstemmingAvsluttTask(
             konsistensavstemmingTask.batchId,
             transaksjonsId,
-            konsistensavstemmingTask.avstemmingdato
+            avstemmingsDato
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingServiceTest.kt
@@ -16,6 +16,8 @@ import no.nav.familie.ba.sak.task.dto.KonsistensavstemmingStartTaskDTO
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.Page
@@ -24,6 +26,7 @@ import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class AvstemmingServiceTest {
@@ -89,9 +92,10 @@ class AvstemmingServiceTest {
 
     @Test
     fun `Verifiser at konsistensavstemOppdragStart oppretter data- og avslutt task og sender start melding`() {
+        val avstemmingsdatoSlot = slot<LocalDateTime>()
         every {
             økonomiKlient.konsistensavstemOppdragStart(
-                avstemmingsdato,
+                capture(avstemmingsdatoSlot),
                 transaksjonsId
             )
         } returns ""
@@ -111,7 +115,7 @@ class AvstemmingServiceTest {
 
         verify(exactly = 1) {
             økonomiKlient.konsistensavstemOppdragStart(
-                avstemmingsdato = avstemmingsdato,
+                avstemmingsdato = avstemmingsdatoSlot.captured,
                 transaksjonsId = transaksjonsId
             )
         }
@@ -121,6 +125,8 @@ class AvstemmingServiceTest {
 
         assertEquals(KonsistensavstemMotOppdragDataTask.TASK_STEP_TYPE, taskSlots[0].type)
         assertEquals(KonsistensavstemMotOppdragAvsluttTask.TASK_STEP_TYPE, taskSlots[1].type)
+
+        Assertions.assertThat(avstemmingsdatoSlot.captured).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTaskTest.kt
@@ -31,7 +31,7 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
         val startTask = KonsistensavstemMotOppdragStartTask(avstemmingService)
 
         justRun { avstemmingService.nullstillDataChunk() }
-        justRun { avstemmingService.sendKonsistensavstemmingStart(avstemmingdato, any()) }
+        justRun { avstemmingService.sendKonsistensavstemmingStart(any(), any()) }
         val page = mockk<Page<BigInteger>>()
         val pageable = mockk<Pageable>()
         val nrOfPages = 3
@@ -41,21 +41,21 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
         every { avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(any()) } returns page
         justRun {
             avstemmingService.opprettKonsistensavstemmingDataTask(
-                avstemmingdato,
+                any(),
                 any(),
                 batchId,
                 any(),
                 any()
             )
         }
-        justRun { avstemmingService.opprettKonsistensavstemmingAvsluttTask(batchId, any(), avstemmingdato) }
+        justRun { avstemmingService.opprettKonsistensavstemmingAvsluttTask(batchId, any(), any()) }
         startTask.doTask(task)
 
         verify(exactly = 1) { avstemmingService.nullstillDataChunk() }
-        verify(exactly = 1) { avstemmingService.sendKonsistensavstemmingStart(avstemmingdato, any()) }
+        verify(exactly = 1) { avstemmingService.sendKonsistensavstemmingStart(any(), any()) }
         verify(exactly = nrOfPages) {
             avstemmingService.opprettKonsistensavstemmingDataTask(
-                avstemmingdato,
+                any(),
                 any(),
                 batchId,
                 any(),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- Konsistensavstemming task kjøres kun 1 gang og settes til manuell oppfølging hvis feil
- Bruker dagens dato som avstemmingsdato slik at den kan rekjøres ved feil
- dryRun gjør litt mere nå

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
