### PR TITLE
Vis bedre frontendfeilmelding hvis antall uker svarfrist ikke er satt ved svartidsbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -218,7 +218,7 @@ fun ManueltBrevRequest.tilBrev() = when (this.brevmal) {
             fodselsnummer = this.vedrørende?.fødselsnummer ?: mottakerIdent,
             enhetNavn = this.enhetNavn(),
             årsaker = this.multiselectVerdier,
-            antallUkerSvarfrist = this.antallUkerSvarfrist ?: throw Feil("Antall uker svarfrist er ikke satt"),
+            antallUkerSvarfrist = this.antallUkerSvarfrist ?: throw Feil(message = "Antall uker svarfrist er ikke satt", frontendFeilmelding = "Antall uker svarfrist er ikke satt"),
             organisasjonsnummer = if (erTilInstitusjon) mottakerIdent else null,
             gjelder = this.vedrørende?.navn
         )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Til nå har feilmeldingen frontend vært "En feil har oppstått" hvis man prøver å generere svartidsbrev uten å ha satt antall uker svarfrist. Jeg endrer så feilmeldingen "Antall uker svarfrist er ikke satt" blir vist frontend så saksbehandler kan se hva som er galt. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Avklart med Gunn.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det er bare teksten på en feilmelding

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei


Før:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/25459913/198096320-951f2c00-d9fb-496e-b3b6-61acc3698740.png">

Etter: 
<img width="392" alt="image" src="https://user-images.githubusercontent.com/25459913/198096364-17c26d57-b7b3-4ef0-ae0f-d88893249eca.png">
