### PR TITLE
Putter validering av tomt utbetalingsoppdrag bak en funksjonsbryter, …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -100,6 +100,7 @@ class FeatureToggleConfig(
     }
 
     companion object {
+        const val UTBETALINGSOPPDRAG_UTEN_PERIODER_ER_OK = "familie-ba-sak.utbetalingsoppdrag.uten-perioder-er-ok"
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"
         const val SKATTEETATEN_API_EKTE_DATA = "familie-ba-sak.skatteetaten-api-ekte-data-i-respons"
         const val IKKE_STOPP_MIGRERINGSBEHANDLING = "familie-ba-sak.ikke.stopp.migeringsbehandling"

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragValidator.kt
@@ -10,11 +10,12 @@ import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 
 fun Utbetalingsoppdrag.valider(
     behandlingsresultat: Behandlingsresultat,
-    erEndreMigreringsdatoBehandling: Boolean = false
+    erEndreMigreringsdatoBehandling: Boolean = false,
+    erOkMedManglendeUtbetalingsperioder: Boolean = false
 ) {
     if (this.utbetalingsperiode.isNotEmpty() && behandlingsresultat == Behandlingsresultat.FORTSATT_INNVILGET && !erEndreMigreringsdatoBehandling) {
         throw FunksjonellFeil("Behandling har resultat fortsatt innvilget, men det finnes utbetalingsperioder som ifølge systemet skal endres. $KONTAKT_TEAMET_SUFFIX")
-    } else if (this.utbetalingsperiode.isEmpty()) {
+    } else if (this.utbetalingsperiode.isEmpty() && !erOkMedManglendeUtbetalingsperioder) {
         throw FunksjonellFeil(
             "Utbetalingsoppdraget inneholder ingen utbetalingsperioder " +
                 "og det er grunn til å tro at denne ikke bør simuleres eller iverksettes. $KONTAKT_TEAMET_SUFFIX"

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
@@ -181,7 +181,11 @@ class ØkonomiService(
                 } else {
                     it.valider(
                         behandlingsresultat = vedtak.behandling.resultat,
-                        erEndreMigreringsdatoBehandling = vedtak.behandling.opprettetÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO
+                        erEndreMigreringsdatoBehandling = vedtak.behandling.opprettetÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
+                        erOkMedManglendeUtbetalingsperioder = featureToggleService.isEnabled(
+                            FeatureToggleConfig.UTBETALINGSOPPDRAG_UTEN_PERIODER_ER_OK,
+                            false
+                        )
                     )
                 }
             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I dag stoppes behandlinger som fører til tomt utbetalingsoppdrag av en validering. Det _virker_ som valideringen er for defensiv; tilkjent ytelse _burde_ være riktig på dette tidspunktet, og tomme utbetalingsoppdrag blir ikke sendt til simulering eller oppdrag. Det skal være riktig oppførsel.

Løsningen er å putte valideringen bak en funksjonsbryter, slik at vi kan teste å kjøre uten. 

Funksjonsbryter: familie-ba-sak.utbetalingsoppdrag.uten-perioder-er-ok

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Krever en funksjonell vurdering av om hypotesen om at valideringen er unødvendig. Har snakket med Eivind, som skal teste litt.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ var nødvendig å _fjerne_ tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
