### PR TITLE
Legger på mulighet til å forkorte til-og-med på EØS-skjemaer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/PeriodeOgBarnSkjema.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/PeriodeOgBarnSkjema.kt
@@ -61,8 +61,8 @@ fun <T : PeriodeOgBarnSkjema<T>> T.utenInnholdHeretter() =
 fun <T : PeriodeOgBarnSkjema<T>> T.medBarnaSomForsvinnerFra(skjema: T): T =
     this.kopier(barnAktører = skjema.barnAktører.minus(this.barnAktører))
 
-fun <T : PeriodeOgBarnSkjema<T>> T.periodeBlirLukketAv(skjema: T): Boolean =
-    this.tom == null && skjema.tom != null
+fun <T : PeriodeOgBarnSkjema<T>> T.tilOgMedBlirForkortetEllerLukketAv(skjema: T): Boolean =
+    skjema.tom != null && (this.tom == null || this.tom!! > skjema.tom)
 
 fun <T : PeriodeOgBarnSkjema<T>> T.erLikBortsettFraTilOgMed(skjema: T): Boolean =
     this.kopier(tom = skjema.tom) == skjema

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/PeriodeOgBarnSkjema.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/PeriodeOgBarnSkjema.kt
@@ -52,10 +52,10 @@ fun <T : PeriodeOgBarnSkjema<T>> T.utenBarn(): T =
 fun <T : PeriodeOgBarnSkjema<T>> T.utenPeriode(): T =
     this.kopier(fom = null, tom = null, barnAktører = this.barnAktører)
 
-fun <T : PeriodeOgBarnSkjema<T>> T.utenInnholdHeretter() =
+fun <T : PeriodeOgBarnSkjema<T>> T.utenInnholdTilOgMed(tom: YearMonth?) =
     this.kopier(
-        fom = tom?.plusMonths(1),
-        tom = null
+        fom = this.tom?.plusMonths(1),
+        tom = tom
     ).utenInnhold()
 
 fun <T : PeriodeOgBarnSkjema<T>> T.medBarnaSomForsvinnerFra(skjema: T): T =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/JusteringAvOppdatering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/JusteringAvOppdatering.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.erLikBortsettFraTilOgMed
 import no.nav.familie.ba.sak.kjerne.eøs.felles.harEkteDelmengdeAvBarna
 import no.nav.familie.ba.sak.kjerne.eøs.felles.medBarnaSomForsvinnerFra
 import no.nav.familie.ba.sak.kjerne.eøs.felles.tilOgMedBlirForkortetEllerLukketAv
-import no.nav.familie.ba.sak.kjerne.eøs.felles.utenInnholdHeretter
+import no.nav.familie.ba.sak.kjerne.eøs.felles.utenInnholdTilOgMed
 
 /**
  * Funksjon som inverterer en skjema-oppdatering,[this], som skal endre et sett av [gjeldendeSkjemaer]
@@ -17,11 +17,11 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.utenInnholdHeretter
  * 2a. Lukker periode på det gjeldende skjemaet, dvs til-og-med går fra <null> til en verdi, eller til-og-med er tidligere
  * 2b. og/eller reduserer antall barn
  * så skal det lages en ny oppdatering med blankt skjema for det som ligger "utenfor" [oppdatering], dvs har
- * 1. Perioden som starter måneden etter ny til-og-med-dato, og er åpen fremover (til-og-med er <null>)
+ * 1. Perioden som starter måneden etter ny til-og-med-dato, og frem frem til eksisterende til-og-med (kan være <null>)
  * 2. Barnet/barna som blir fjernet
  *
  * Problemet som skal løses er at skjemaer som kun varierer i periode eller barn, slås sammen fordi de ellers er like
- * Lukking av periode eller fjerning av barn vil føre til en umiddelbar sammenslåing og nulle ut oppdateringen
+ * Lukking/forkorting av periode eller fjerning av barn vil føre til en umiddelbar sammenslåing og nulle ut oppdateringen
  * Ved å lage den "motsatte" endringen med et tomt skjema "utenfor" det gjeldende skjemaet,
  * blir nettoeffekten at den ønskede oppdateringen oppstår, og et tomt skjema dekker området rundt
  *
@@ -47,11 +47,12 @@ fun <T : PeriodeOgBarnSkjemaEntitet<T>> T.somInversOppdateringEllersNull(gjelden
 
     return when {
         skjemaetDerTilOgMedForkortesOgBarnFjernes != null ->
-            oppdatering.medBarnaSomForsvinnerFra(skjemaetDerTilOgMedForkortesOgBarnFjernes).utenInnholdHeretter()
+            oppdatering.medBarnaSomForsvinnerFra(skjemaetDerTilOgMedForkortesOgBarnFjernes)
+                .utenInnholdTilOgMed(skjemaetDerTilOgMedForkortesOgBarnFjernes.tom)
         skjemaetDerBarnFjernes != null ->
             oppdatering.medBarnaSomForsvinnerFra(skjemaetDerBarnFjernes).utenInnhold()
         skjemaetDerTilOgMedForkortes != null ->
-            oppdatering.utenInnholdHeretter()
+            oppdatering.utenInnholdTilOgMed(skjemaetDerTilOgMedForkortes.tom)
         else -> null
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/JusteringAvOppdatering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/JusteringAvOppdatering.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.erLikBortsettFraBarnOgTilOgMed
 import no.nav.familie.ba.sak.kjerne.eøs.felles.erLikBortsettFraTilOgMed
 import no.nav.familie.ba.sak.kjerne.eøs.felles.harEkteDelmengdeAvBarna
 import no.nav.familie.ba.sak.kjerne.eøs.felles.medBarnaSomForsvinnerFra
-import no.nav.familie.ba.sak.kjerne.eøs.felles.periodeBlirLukketAv
+import no.nav.familie.ba.sak.kjerne.eøs.felles.tilOgMedBlirForkortetEllerLukketAv
 import no.nav.familie.ba.sak.kjerne.eøs.felles.utenInnholdHeretter
 
 /**
@@ -14,7 +14,8 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.utenInnholdHeretter
  *
  * I tilfellet der oppdateringen:
  * 1. Gjelder ett gjeldende skjema
- * 2. Lukker periode på det gjeldende skjemaet, dvs til-og-med går fra <null> til en verdi, og/eller reduserer antall barn
+ * 2a. Lukker periode på det gjeldende skjemaet, dvs til-og-med går fra <null> til en verdi, eller til-og-med er tidligere
+ * 2b. og/eller reduserer antall barn
  * så skal det lages en ny oppdatering med blankt skjema for det som ligger "utenfor" [oppdatering], dvs har
  * 1. Perioden som starter måneden etter ny til-og-med-dato, og er åpen fremover (til-og-med er <null>)
  * 2. Barnet/barna som blir fjernet
@@ -28,8 +29,8 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.utenInnholdHeretter
 fun <T : PeriodeOgBarnSkjemaEntitet<T>> T.somInversOppdateringEllersNull(gjeldendeSkjemaer: Collection<T>): T? {
     val oppdatering = this
 
-    val skjemaetDerPeriodeLukkes = gjeldendeSkjemaer.filter { gjeldende ->
-        gjeldende.periodeBlirLukketAv(oppdatering) &&
+    val skjemaetDerTilOgMedForkortes = gjeldendeSkjemaer.filter { gjeldende ->
+        gjeldende.tilOgMedBlirForkortetEllerLukketAv(oppdatering) &&
             gjeldende.erLikBortsettFraTilOgMed(oppdatering)
     }.singleOrNull()
 
@@ -38,18 +39,18 @@ fun <T : PeriodeOgBarnSkjemaEntitet<T>> T.somInversOppdateringEllersNull(gjelden
             gjeldende.erLikBortsettFraBarn(oppdatering)
     }.singleOrNull()
 
-    val skjemaetDerPeriodeLukkesOgBarnFjernes = gjeldendeSkjemaer.filter { gjeldende ->
-        gjeldende.periodeBlirLukketAv(oppdatering) &&
+    val skjemaetDerTilOgMedForkortesOgBarnFjernes = gjeldendeSkjemaer.filter { gjeldende ->
+        gjeldende.tilOgMedBlirForkortetEllerLukketAv(oppdatering) &&
             oppdatering.harEkteDelmengdeAvBarna(gjeldende) &&
             gjeldende.erLikBortsettFraBarnOgTilOgMed(oppdatering)
     }.singleOrNull()
 
     return when {
-        skjemaetDerPeriodeLukkesOgBarnFjernes != null ->
-            oppdatering.medBarnaSomForsvinnerFra(skjemaetDerPeriodeLukkesOgBarnFjernes).utenInnholdHeretter()
+        skjemaetDerTilOgMedForkortesOgBarnFjernes != null ->
+            oppdatering.medBarnaSomForsvinnerFra(skjemaetDerTilOgMedForkortesOgBarnFjernes).utenInnholdHeretter()
         skjemaetDerBarnFjernes != null ->
             oppdatering.medBarnaSomForsvinnerFra(skjemaetDerBarnFjernes).utenInnhold()
-        skjemaetDerPeriodeLukkes != null ->
+        skjemaetDerTilOgMedForkortes != null ->
             oppdatering.utenInnholdHeretter()
         else -> null
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -172,6 +172,31 @@ internal class KompetanseServiceTest {
     }
 
     @Test
+    fun `skal kunne forkorte til-og-med ved å sende inn identisk skjema med tidligere til-og-med-dato`() {
+        val behandlingId = BehandlingId(10L)
+        val barn1 = tilfeldigPerson(personType = PersonType.BARN)
+        val barn2 = tilfeldigPerson(personType = PersonType.BARN)
+        val barn3 = tilfeldigPerson(personType = PersonType.BARN)
+
+        // Kompetanse med sekundærland for tre barn med til-og-med-dato
+        KompetanseBuilder(jan(2020), behandlingId)
+            .medKompetanse("SSSSSSS", barn1, barn2, barn3)
+            .lagreTil(mockKompetanseRepository)
+
+        // Endrer kun til-og-med dato til tidligere tidspunkt
+        val oppdatertKompetanse = kompetanse(jan(2020), "SSS", barn1, barn2, barn3)
+        kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
+
+        // Forventer tomt skjema fra oppdatert dato og fremover til orignal til-og-med
+        val forventedeKompetanser = KompetanseBuilder(jan(2020), behandlingId)
+            .medKompetanse("SSS----", barn1, barn2, barn3)
+            .byggKompetanser()
+
+        val faktiskeKompetanser = kompetanseService.hentKompetanser(behandlingId)
+        assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
+    }
+
+    @Test
     fun `skal opprette tomt skjema for barn som fjernes fra ellers uendret skjema`() {
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Legger på mulighet for å forkorte til-og-med, ref [denne](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9728) 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
