### PR TITLE
Skriver om til å utnytte kompilatoren til å tvinge frem håndtering når BehandlingUnderkategori-enum'en får ny konstant

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.ekstern.restDomene
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.steg.StegType
@@ -20,7 +19,7 @@ data class RestUtvidetBehandling(
     val skalBehandlesAutomatisk: Boolean,
     val type: BehandlingType,
     val kategori: BehandlingKategori,
-    val underkategori: BehandlingUnderkategori,
+    val underkategori: BehandlingUnderkategoriDTO,
     val årsak: BehandlingÅrsak,
     val opprettetTidspunkt: LocalDateTime,
     val endretAv: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVisningBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVisningBehandling.kt
@@ -13,7 +13,7 @@ class RestVisningBehandling(
     val behandlingId: Long,
     val opprettetTidspunkt: LocalDateTime,
     val kategori: BehandlingKategori,
-    val underkategori: BehandlingUnderkategori,
+    val underkategori: BehandlingUnderkategoriDTO,
     val aktiv: Boolean,
     val årsak: BehandlingÅrsak?,
     val type: BehandlingType,
@@ -26,7 +26,7 @@ fun Behandling.tilRestVisningBehandling(vedtaksdato: LocalDateTime?) = RestVisni
     behandlingId = this.id,
     opprettetTidspunkt = this.opprettetTidspunkt,
     kategori = this.kategori,
-    underkategori = this.underkategori,
+    underkategori = this.underkategori.tilDto(),
     aktiv = this.aktiv,
     årsak = this.opprettetÅrsak,
     type = this.type,
@@ -34,3 +34,18 @@ fun Behandling.tilRestVisningBehandling(vedtaksdato: LocalDateTime?) = RestVisni
     resultat = this.resultat,
     vedtaksdato = vedtaksdato
 )
+
+enum class BehandlingUnderkategoriDTO {
+    ORDINÆR,
+    UTVIDET
+}
+
+fun BehandlingUnderkategoriDTO.tilDomene() = when (this) {
+    BehandlingUnderkategoriDTO.ORDINÆR -> BehandlingUnderkategori.ORDINÆR
+    BehandlingUnderkategoriDTO.UTVIDET -> BehandlingUnderkategori.UTVIDET
+}
+
+fun BehandlingUnderkategori.tilDto() = when (this) {
+    BehandlingUnderkategori.ORDINÆR -> BehandlingUnderkategoriDTO.ORDINÆR
+    BehandlingUnderkategori.UTVIDET -> BehandlingUnderkategoriDTO.UTVIDET
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/SøknadDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/SøknadDTO.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.kontrakter.felles.objectMapper
 import java.time.LocalDate
@@ -11,7 +10,7 @@ data class RestRegistrerSøknad(
 )
 
 data class SøknadDTO(
-    val underkategori: BehandlingUnderkategori,
+    val underkategori: BehandlingUnderkategoriDTO,
     val søkerMedOpplysninger: SøkerMedOpplysninger,
     val barnaMedOpplysninger: List<BarnMedOpplysninger>,
     val endringAvOpplysningerBegrunnelse: String

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.kontrakter.felles.Tema
@@ -78,7 +79,10 @@ class OppgaveService(
                 fristFerdigstillelse = fristForFerdigstillelse,
                 beskrivelse = lagOppgaveTekst(fagsakId, beskrivelse),
                 enhetsnummer = arbeidsfordelingsenhet?.behandlendeEnhetId,
-                behandlingstema = behandling.underkategori.tilOppgaveBehandlingTema().value,
+                behandlingstema = when (behandling.underkategori) {
+                    BehandlingUnderkategori.ORDINÆR -> behandling.underkategori.tilOppgaveBehandlingTema().value
+                    BehandlingUnderkategori.UTVIDET -> behandling.underkategori.tilOppgaveBehandlingTema().value
+                },
                 behandlingstype = behandling.kategori.tilOppgavebehandlingType().value,
                 tilordnetRessurs = tilordnetNavIdent
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.VergeInfo
+import no.nav.familie.ba.sak.ekstern.restDomene.tilDto
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestArbeidsfordelingPåBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestBehandlingStegTilstand
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestFødselshendelsefiltreringResultat
@@ -105,7 +106,7 @@ class UtvidetBehandlingService(
             skalBehandlesAutomatisk = behandling.skalBehandlesAutomatisk,
             type = behandling.type,
             kategori = behandling.kategori,
-            underkategori = behandling.underkategori,
+            underkategori = behandling.underkategori.tilDto(),
             årsak = behandling.opprettetÅrsak,
             opprettetTidspunkt = behandling.opprettetTidspunkt,
             endretAv = behandling.endretAv,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaService.kt
@@ -63,9 +63,13 @@ class BehandlingstemaService(
 
             behandlingHentOgPersisterService.lagreEllerOppdater(behandling).also { lagretBehandling ->
                 oppgaveService.patchOppgaverForBehandling(lagretBehandling) {
-                    if (it.behandlingstema != lagretBehandling.underkategori.tilOppgaveBehandlingTema().value || it.behandlingstype != lagretBehandling.kategori.tilOppgavebehandlingType().value) {
+                    val lagretUnderkategori = lagretBehandling.underkategori
+                    if (it.behandlingstema != lagretUnderkategori.tilOppgaveBehandlingTema().value || it.behandlingstype != lagretBehandling.kategori.tilOppgavebehandlingType().value) {
                         it.copy(
-                            behandlingstema = lagretBehandling.underkategori.tilOppgaveBehandlingTema().value,
+                            behandlingstema = when (lagretUnderkategori) {
+                                BehandlingUnderkategori.ORDINÆR -> lagretUnderkategori.tilOppgaveBehandlingTema().value
+                                BehandlingUnderkategori.UTVIDET -> lagretUnderkategori.tilOppgaveBehandlingTema().value
+                            },
                             behandlingstype = lagretBehandling.kategori.tilOppgavebehandlingType().value
                         )
                     } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -283,7 +283,7 @@ data class Behandling(
 
     fun hentYtelseTypeTilVilkår(): YtelseType = when (underkategori) {
         BehandlingUnderkategori.UTVIDET -> YtelseType.UTVIDET_BARNETRYGD
-        else -> YtelseType.ORDINÆR_BARNETRYGD
+        BehandlingUnderkategori.ORDINÆR -> YtelseType.ORDINÆR_BARNETRYGD
     }
 
     fun harUtførtSteg(steg: StegType) =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -3,10 +3,10 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.convertDataClassToJson
+import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -158,12 +158,12 @@ class BehandlingsresultatService(
             ?.map { personidentService.hentAktør(it.ident) }
             ?: emptyList()
 
-        val utvidetBarnetrygdSøker =
-            if (søknadDTO?.underkategori == BehandlingUnderkategori.UTVIDET) {
-                listOf(behandling.fagsak.aktør)
-            } else {
-                emptyList()
+        val utvidetBarnetrygdSøker = søknadDTO?.let {
+            when (it.underkategori) {
+                BehandlingUnderkategoriDTO.UTVIDET -> listOf(behandling.fagsak.aktør)
+                BehandlingUnderkategoriDTO.ORDINÆR -> emptyList()
             }
+        } ?: emptyList()
 
         val nyeBarn = persongrunnlagService.finnNyeBarn(forrigeBehandling = forrigeBehandling, behandling = behandling)
             .map { it.aktør }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -147,7 +147,10 @@ class BeregningService(
             barnMedUtbetalingSomIkkeBlittEndretISisteBehandling.intersect(nyeBarnISisteBehandling)
 
         return behandling.resultat == Behandlingsresultat.INNVILGET_OG_OPPHØRT &&
-            behandling.underkategori == BehandlingUnderkategori.ORDINÆR &&
+            when (behandling.underkategori) {
+                BehandlingUnderkategori.ORDINÆR -> true
+                BehandlingUnderkategori.UTVIDET -> false
+            } &&
             behandling.erSøknad() &&
             nyeBarnMedUtebtalingSomIkkeErEndret.isEmpty()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -433,12 +433,16 @@ object TilkjentYtelseUtils {
         underkategori: BehandlingUnderkategori,
         personType: PersonType
     ): YtelseType {
-        return if (personType == PersonType.SØKER && underkategori == BehandlingUnderkategori.UTVIDET) {
-            YtelseType.UTVIDET_BARNETRYGD
-        } else if (personType == PersonType.BARN) {
-            YtelseType.ORDINÆR_BARNETRYGD
-        } else {
-            throw Feil("Ikke støttet. Klarte ikke utlede YtelseType for underkategori $underkategori og persontype $personType.")
+        return when (underkategori) {
+            BehandlingUnderkategori.UTVIDET -> when (personType) {
+                PersonType.SØKER -> YtelseType.UTVIDET_BARNETRYGD
+                PersonType.BARN -> YtelseType.ORDINÆR_BARNETRYGD
+                PersonType.ANNENPART -> throw Feil("Utvidet barnetrygd kan ikke værre knyttet til Annen part")
+            }
+            BehandlingUnderkategori.ORDINÆR -> when (personType) {
+                PersonType.BARN -> YtelseType.ORDINÆR_BARNETRYGD
+                PersonType.SØKER, PersonType.ANNENPART -> throw Feil("Ordinær barnetrygd kan bare være knyttet til barn")
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
 import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
+import no.nav.familie.ba.sak.ekstern.restDomene.tilDomene
 import no.nav.familie.ba.sak.ekstern.restDomene.writeValueAsString
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.BehandlingstemaService
@@ -32,10 +33,10 @@ class RegistrereSøknad(
         val søknadDTO: SøknadDTO = data.søknad
         val innsendtSøknad = søknadDTO.writeValueAsString()
 
-        if (behandling.underkategori != søknadDTO.underkategori) {
+        if (behandling.underkategori != søknadDTO.underkategori.tilDomene()) {
             behandlingstemaService.oppdaterBehandlingstema(
                 behandling = behandlingHentOgPersisterService.hent(behandlingId = behandling.id),
-                overstyrtUnderkategori = søknadDTO.underkategori
+                overstyrtUnderkategori = søknadDTO.underkategori.tilDomene()
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
@@ -111,13 +111,15 @@ data class VilkårsvurderingForNyBehandlingUtils(
             val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = person.aktør)
 
             // NB Dette må gjøres om når vi skal begynne å migrere EØS-saker
-            val ytelseType = if (person.type == PersonType.SØKER) {
-                when (vilkårsvurdering.behandling.underkategori) {
+            val ytelseType = when (person.type) {
+                PersonType.SØKER -> when (vilkårsvurdering.behandling.underkategori) {
                     BehandlingUnderkategori.UTVIDET -> YtelseType.UTVIDET_BARNETRYGD
                     BehandlingUnderkategori.ORDINÆR -> YtelseType.ORDINÆR_BARNETRYGD
                 }
-            } else {
-                YtelseType.ORDINÆR_BARNETRYGD
+                PersonType.BARN, PersonType.ANNENPART -> when (vilkårsvurdering.behandling.underkategori) {
+                    BehandlingUnderkategori.UTVIDET -> YtelseType.ORDINÆR_BARNETRYGD // Er ikke dette en feilsituasjon? Ref TilkjentYtelseUtils.finnYtelseType
+                    BehandlingUnderkategori.ORDINÆR -> YtelseType.ORDINÆR_BARNETRYGD
+                }
             }
 
             val vilkårTyperForPerson = Vilkår.hentVilkårFor(person.type, ytelseType = ytelseType)

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -79,7 +80,10 @@ class SaksstatistikkService(
             sakId = behandling.fagsak.id.toString(),
             behandlingType = behandling.type.name,
             behandlingStatus = behandling.status.name,
-            behandlingKategori = behandling.underkategori.name, // Gjøres pga. tilpasning til DVH-modell
+            behandlingKategori = when (behandling.underkategori) { // Gjøres pga. tilpasning til DVH-modell
+                BehandlingUnderkategori.ORDINÆR -> behandling.underkategori.name
+                BehandlingUnderkategori.UTVIDET -> behandling.underkategori.name
+            },
             behandlingUnderkategori = when (behandling.fagsak.type) { // <-'
                 NORMAL -> null
                 BARN_ENSLIG_MINDREÅRIG -> ENSLIG_MINDREÅRIG_KODE

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.beregning.beregnUtbetalingsperioderUtenKlassifisering
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -71,7 +72,10 @@ class StønadsstatistikkService(
             personV2 = hentSøkerV2(behandlingId),
             ensligForsørger = utledEnsligForsørger(behandlingId), // TODO implementere støtte for dette
             kategoriV2 = KategoriV2.valueOf(behandling.kategori.name),
-            underkategoriV2 = UnderkategoriV2.valueOf(behandling.underkategori.name),
+            underkategoriV2 = when (behandling.underkategori) {
+                BehandlingUnderkategori.ORDINÆR -> UnderkategoriV2.valueOf(behandling.underkategori.name)
+                BehandlingUnderkategori.UTVIDET -> UnderkategoriV2.valueOf(behandling.underkategori.name)
+            },
             behandlingTypeV2 = BehandlingTypeV2.valueOf(behandling.type.name),
             utbetalingsperioderV2 = hentUtbetalingsperioderV2(behandlingId),
             funksjonellId = UUID.randomUUID().toString(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.ekstern.restDomene.SøkerMedOpplysninger
 import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.VergeInfo
+import no.nav.familie.ba.sak.ekstern.restDomene.tilDto
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestPerson
 import no.nav.familie.ba.sak.integrasjoner.økonomi.sats
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -450,7 +451,7 @@ fun lagSøknadDTO(
     underkategori: BehandlingUnderkategori = BehandlingUnderkategori.ORDINÆR
 ): SøknadDTO {
     return SøknadDTO(
-        underkategori = underkategori,
+        underkategori = underkategori.tilDto(),
         søkerMedOpplysninger = SøkerMedOpplysninger(
             ident = søkerIdent
         ),
@@ -664,7 +665,10 @@ fun kjørStegprosessForFGB(
     )
 
     if (verge != null) {
-        stegService.håndterRegistrerVerge(behandling, RestRegistrerInstitusjonOgVerge(vergeInfo = verge, institusjonInfo = null))
+        stegService.håndterRegistrerVerge(
+            behandling,
+            RestRegistrerInstitusjonOgVerge(vergeInfo = verge, institusjonInfo = null)
+        )
     }
 
     val behandlingEtterPersongrunnlagSteg = stegService.håndterSøknad(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
+import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
 import no.nav.familie.ba.sak.ekstern.restDomene.SøkerMedOpplysninger
 import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
@@ -146,7 +147,7 @@ class SøknadGrunnlagTest(
         val søkerAktør = personidentService.hentAktør(søkerIdent)
 
         val søknadDTO = SøknadDTO(
-            underkategori = BehandlingUnderkategori.ORDINÆR,
+            underkategori = BehandlingUnderkategoriDTO.ORDINÆR,
             søkerMedOpplysninger = SøkerMedOpplysninger(
                 ident = søkerIdent
             ),
@@ -227,7 +228,7 @@ class SøknadGrunnlagTest(
             behandling = behandlingEtterVilkårsvurderingSteg,
             restRegistrerSøknad = RestRegistrerSøknad(
                 søknad = SøknadDTO(
-                    underkategori = BehandlingUnderkategori.ORDINÆR,
+                    underkategori = BehandlingUnderkategoriDTO.ORDINÆR,
                     søkerMedOpplysninger = SøkerMedOpplysninger(
                         ident = søkerFnr
                     ),
@@ -277,7 +278,7 @@ class SøknadGrunnlagTest(
             behandling = behandlingEtterVilkårsvurderingSteg,
             restRegistrerSøknad = RestRegistrerSøknad(
                 søknad = SøknadDTO(
-                    underkategori = BehandlingUnderkategori.ORDINÆR,
+                    underkategori = BehandlingUnderkategoriDTO.ORDINÆR,
                     søkerMedOpplysninger = SøkerMedOpplysninger(
                         ident = søkerFnr
                     ),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -17,11 +17,11 @@ import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
+import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
 import no.nav.familie.ba.sak.ekstern.restDomene.SøkerMedOpplysninger
 import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -119,7 +119,7 @@ class VedtaksperiodeServiceTest(
             behandling = behandling,
             restRegistrerSøknad = RestRegistrerSøknad(
                 søknad = SøknadDTO(
-                    underkategori = BehandlingUnderkategori.ORDINÆR,
+                    underkategori = BehandlingUnderkategoriDTO.ORDINÆR,
                     søkerMedOpplysninger = SøkerMedOpplysninger(
                         ident = søkerFnr
                     ),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.verdikjedetester
 import io.mockk.every
 import no.nav.familie.ba.sak.common.lagSøknadDTO
 import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.NavnOgIdent
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedStandardbegrunnelser
@@ -250,7 +251,7 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
 
         val aktivBehandling = hentAktivBehandling(restFagsak = restFagsakEtterJournalføring.data!!)
 
-        assertEquals(BehandlingUnderkategori.UTVIDET, aktivBehandling.underkategori)
+        assertEquals(BehandlingUnderkategoriDTO.UTVIDET, aktivBehandling.underkategori)
 
         val restRegistrerSøknad =
             RestRegistrerSøknad(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Så at en ny konstant ("Institusjon") i BehandlingUnderkategori ikke førte til kompileringsfeil, enda den brukes i mange integrasjonspunkter. Denne PRen tar i bruk `when` uten else for å tvinge frem håndtering alle steder. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Overgangen til YtelseType gjør vi på to forskjellige måter. 
- VilkårsvurderingForNyBehandlingUtils.lagPersonResultaterForMigreringsbehandling
- TilkjentYtelseUtils.finnYtelseType

I tillegg innføres en DTO-type for kommunikasjon med frontend, for å fange opp endringer der også. Usikker på om det er nødvendig/ønskelig

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ det _burde_ værre sjekket av andre tester. 

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [] Nei
