### PR TITLE
TEA-9340 2 nye varselbrev for årleg kontroll EØS-saker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>1.20221024145007_b6fe7d6</prosessering.version>
         <felles.version>1.20221006150009_46021ed</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20220609214258_f30c3ce</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>2.0_20221027151559_d8da825</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20221102104015_575df8b</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20220923123433_db565d1</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -126,7 +126,7 @@ class DokumentService(
         erForhåndsvisning: Boolean = false
     ): ByteArray {
         Result.runCatching {
-            val brev: Brev = manueltBrevRequest.tilBrev()
+            val brev: Brev = manueltBrevRequest.tilBrev(integrasjonClient.hentLandkoderISO2())
             return brevKlient.genererBrev(
                 målform = manueltBrevRequest.mottakerMålform.tilSanityFormat(),
                 brev = brev

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -126,7 +126,7 @@ class DokumentService(
         erForhåndsvisning: Boolean = false
     ): ByteArray {
         Result.runCatching {
-            val brev: Brev = manueltBrevRequest.tilBrev(integrasjonClient.hentLandkoderISO2())
+            val brev: Brev = manueltBrevRequest.tilBrev { integrasjonClient.hentLandkoderISO2() }
             return brevKlient.genererBrev(
                 målform = manueltBrevRequest.mottakerMålform.tilSanityFormat(),
                 brev = brev

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -112,7 +112,7 @@ fun ManueltBrevRequest.leggTilEnhet(arbeidsfordelingService: ArbeidsfordelingSer
     )
 }
 
-fun ManueltBrevRequest.tilBrev(landkoderISO2: Map<String, String>) = when (this.brevmal) {
+fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = when (this.brevmal) {
     Brevmal.INFORMASJONSBREV_DELT_BOSTED ->
         InformasjonsbrevDeltBostedBrev(
             data = InformasjonsbrevDeltBostedData(
@@ -283,7 +283,7 @@ fun ManueltBrevRequest.tilBrev(landkoderISO2: Map<String, String>) = when (this.
             navn = this.mottakerNavn,
             fødselsnummer = this.mottakerIdent,
             enhet = this.enhetNavn(),
-            mottakerlandSed = tilLandNavn(landkoderISO2, this.mottakerlandSED())
+            mottakerlandSed = tilLandNavn(hentLandkoder(), this.mottakerlandSED())
         )
 
     Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER ->
@@ -292,7 +292,7 @@ fun ManueltBrevRequest.tilBrev(landkoderISO2: Map<String, String>) = when (this.
             navn = this.mottakerNavn,
             fødselsnummer = this.mottakerIdent,
             enhet = this.enhetNavn(),
-            mottakerlandSed = tilLandNavn(landkoderISO2, this.mottakerlandSED()),
+            mottakerlandSed = tilLandNavn(hentLandkoder(), this.mottakerlandSED()),
             dokumentliste = this.multiselectVerdier
         )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
@@ -50,6 +50,16 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
         "varselOmRevurderingFraNasjonalTilEOS",
         "Varsel om revurdering fra nasjonal til EØS"
     ),
+    VARSEL_OM_ÅRLIG_REVURDERING_EØS(
+        false,
+        "varselOmAarligRevurderingEos",
+        "Varsel om årlig revurdering EØS"
+    ),
+    VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER(
+        false,
+        "varselOmAarligRevurderingEosMedInnhentingAvOpplysninger",
+        "Varsel om årlig revurdering EØS med innhenting av opplysninger"
+    ),
 
     SVARTIDSBREV(false, "svartidsbrev", "Svartidsbrev"),
     SVARTIDSBREV_INSTITUSJON(false, "svartidsbrevInstitusjon", "Svartidsbrev institusjon"),
@@ -109,7 +119,9 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
             VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14,
             VARSEL_OM_REVURDERING_SAMBOER,
             VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED,
-            VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS -> true
+            VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS,
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS,
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER -> true
 
             INFORMASJONSBREV_DELT_BOSTED,
             HENLEGGE_TRUKKET_SØKNAD,
@@ -162,6 +174,8 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
             INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED -> Dokumenttype.BARNETRYGD_INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED
             VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED -> Dokumenttype.BARNETRYGD_VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED
             VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS -> Dokumenttype.BARNETRYGD_VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS -> Dokumenttype.BARNETRYGD_VARSEL_OM_ÅRLIG_REVURDERING_EØS
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER -> Dokumenttype.BARNETRYGD_VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER
             INFORMASJONSBREV_KAN_SØKE_EØS -> Dokumenttype.BARNETRYGD_INFORMASJONSBREV_KAN_SØKE_EØS
             INNHENTE_OPPLYSNINGER_INSTITUSJON -> Dokumenttype.BARNETRYGD_INNHENTE_OPPLYSNINGER_INSTITUSJON
             SVARTIDSBREV_INSTITUSJON -> Dokumenttype.BARNETRYGD_SVARTIDSBREV_INSTITUSJON
@@ -198,6 +212,8 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
             VARSEL_OM_REVURDERING_SAMBOER -> Distribusjonstype.ANNET
             VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED -> Distribusjonstype.VIKTIG
             VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS -> Distribusjonstype.VIKTIG
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS -> Distribusjonstype.VIKTIG
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER -> Distribusjonstype.VIKTIG
             SVARTIDSBREV, SVARTIDSBREV_INSTITUSJON -> Distribusjonstype.ANNET
             FORLENGET_SVARTIDSBREV, FORLENGET_SVARTIDSBREV_INSTITUSJON -> Distribusjonstype.ANNET
             INFORMASJONSBREV_FØDSEL_MINDREÅRIG -> Distribusjonstype.ANNET
@@ -247,7 +263,9 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
             VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED,
             SVARTIDSBREV,
             SVARTIDSBREV_INSTITUSJON,
-            FORLENGET_SVARTIDSBREV_INSTITUSJON -> true
+            FORLENGET_SVARTIDSBREV_INSTITUSJON,
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS,
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER -> true
 
             else -> false
         }
@@ -273,6 +291,9 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
                 manuellFrist
                     ?: throw Feil("Ventefrist var ikke satt for $this")
 
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS,
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER -> 30 * 2
+
             else -> throw Feil("Ventefrist ikke definert for brevtype $this")
         }
 
@@ -288,7 +309,9 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
             VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED,
             SVARTIDSBREV,
             SVARTIDSBREV_INSTITUSJON,
-            FORLENGET_SVARTIDSBREV_INSTITUSJON -> SettPåVentÅrsak.AVVENTER_DOKUMENTASJON
+            FORLENGET_SVARTIDSBREV_INSTITUSJON,
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS,
+            VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER -> SettPåVentÅrsak.AVVENTER_DOKUMENTASJON
 
             else -> throw Feil("Venteårsak ikke definert for brevtype $this")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VarselbrevÅrlegKontrollEØS.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VarselbrevÅrlegKontrollEØS.kt
@@ -1,0 +1,61 @@
+package no.nav.familie.ba.sak.kjerne.brev.domene.maler
+
+import no.nav.familie.ba.sak.common.tilDagMånedÅr
+import java.time.LocalDate
+
+data class VarselbrevÅrlegKontrollEøs(
+    override val mal: Brevmal,
+    override val data: VarselbrevÅrlegKontrollEøsData
+) : Brev {
+
+    constructor(
+        mal: Brevmal,
+        navn: String,
+        fødselsnummer: String,
+        enhet: String,
+        mottakerlandSed: String,
+        dokumentliste: List<String> = emptyList()
+    ) : this(
+        mal = mal,
+        data = VarselbrevÅrlegKontrollEøsData(
+            delmalData = VarselbrevÅrlegKontrollEøsData.DelmalData(signatur = SignaturDelmal(enhet = enhet)),
+            flettefelter = VarselbrevÅrlegKontrollEøsData.Flettefelter(
+                navn = navn,
+                fodselsnummer = fødselsnummer,
+                mottakerlandSed = mottakerlandSed,
+                dokumentliste = dokumentliste
+            )
+        )
+    )
+}
+
+data class VarselbrevÅrlegKontrollEøsData(
+    override val delmalData: DelmalData,
+    override val flettefelter: Flettefelter
+) : BrevData {
+
+    data class Flettefelter(
+        override val navn: Flettefelt,
+        override val fodselsnummer: Flettefelt,
+        override val brevOpprettetDato: Flettefelt = flettefelt(LocalDate.now().tilDagMånedÅr()),
+        val mottakerlandSed: Flettefelt,
+        val dokumentliste: Flettefelt
+    ) : FlettefelterForDokument {
+
+        constructor(
+            navn: String,
+            fodselsnummer: String,
+            mottakerlandSed: String,
+            dokumentliste: List<String>
+        ) : this(
+            navn = flettefelt(navn),
+            fodselsnummer = flettefelt(fodselsnummer),
+            mottakerlandSed = flettefelt(mottakerlandSed),
+            dokumentliste = flettefelt(dokumentliste)
+        )
+    }
+
+    data class DelmalData(
+        val signatur: SignaturDelmal
+    )
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevTypeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevTypeTest.kt
@@ -24,17 +24,30 @@ class BrevTypeTest {
         Brevmal.FORLENGET_SVARTIDSBREV_INSTITUSJON
     )
 
-    private val førerIkkeTilAvventingAvDokumentasjon = Brevmal.values().filter { it !in førerTilAvventerDokumentasjon }
+    private val eøsDokumentMedAvventerDokumentasjon = listOf(
+        Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS,
+        Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER
+    )
+
+    private val førerIkkeTilAvventingAvDokumentasjon = Brevmal.values()
+        .filter {
+            it !in førerTilAvventerDokumentasjon && it !in eøsDokumentMedAvventerDokumentasjon
+        }
 
     @Test
     fun `Skal si om behandling settes på vent`() {
-        val setterIkkeBehandlingPåVent = Brevmal.values().filter { !førerTilAvventerDokumentasjon.contains(it) }
+        val setterIkkeBehandlingPåVent = Brevmal.values()
+            .filter { !førerTilAvventerDokumentasjon.contains(it) && it !in eøsDokumentMedAvventerDokumentasjon }
 
         setterIkkeBehandlingPåVent.forEach {
             Assertions.assertFalse(it.setterBehandlingPåVent())
         }
 
         førerTilAvventerDokumentasjon.forEach {
+            Assertions.assertTrue(it.setterBehandlingPåVent())
+        }
+
+        eøsDokumentMedAvventerDokumentasjon.forEach {
             Assertions.assertTrue(it.setterBehandlingPåVent())
         }
 
@@ -60,6 +73,14 @@ class BrevTypeTest {
     @Test
     fun `Skal gi riktig ventefrist eøs`() {
         Assertions.assertEquals(90L, Brevmal.SVARTIDSBREV.ventefristDager(behandlingKategori = BehandlingKategori.EØS))
+        Assertions.assertEquals(
+            60L,
+            Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS.ventefristDager(behandlingKategori = BehandlingKategori.EØS)
+        )
+        Assertions.assertEquals(
+            60L,
+            Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER.ventefristDager(behandlingKategori = BehandlingKategori.EØS)
+        )
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
@@ -20,7 +20,7 @@ class ManueltBrevRequestTest {
 
     @Test
     fun `Forlenget svartidsbrev request skal gi forlenget svartid brevmal med riktig data`() {
-        val brev = baseRequest.copy(Brevmal.FORLENGET_SVARTIDSBREV).tilBrev(emptyMap())
+        val brev = baseRequest.copy(Brevmal.FORLENGET_SVARTIDSBREV).tilBrev { emptyMap() }
 
         assertThat(brev::class).isEqualTo(ForlengetSvartidsbrev::class)
         brev as ForlengetSvartidsbrev
@@ -42,7 +42,7 @@ class ManueltBrevRequestTest {
                 navn = "testnavn"
             )
         )
-            .tilBrev(emptyMap())
+            .tilBrev { emptyMap() }
 
         assertThat(brev::class).isEqualTo(ForlengetSvartidsbrev::class)
         brev as ForlengetSvartidsbrev
@@ -72,13 +72,13 @@ class ManueltBrevRequestTest {
                 navn = "navn tilhørende $fnr"
             )
         )
-        brevRequestTilPerson.tilBrev(emptyMap()).data.apply {
+        brevRequestTilPerson.tilBrev { emptyMap() }.data.apply {
             assertThat(flettefelter.fodselsnummer).containsExactly(brevRequestTilPerson.mottakerIdent)
             assertThat(flettefelter.navn).containsExactly(brevRequestTilPerson.mottakerNavn)
             assertThat(flettefelter.organisasjonsnummer).isNull()
             assertThat(flettefelter.gjelder).isNull()
         }
-        brevRequestTilInstitusjon.tilBrev(emptyMap()).data.apply {
+        brevRequestTilInstitusjon.tilBrev { emptyMap() }.data.apply {
             assertThat(flettefelter.organisasjonsnummer).containsExactly(brevRequestTilInstitusjon.mottakerIdent)
             assertThat(flettefelter.fodselsnummer).containsExactly(brevRequestTilInstitusjon.vedrørende?.fødselsnummer)
             assertThat(flettefelter.navn).containsExactly(brevRequestTilPerson.mottakerNavn)
@@ -89,7 +89,7 @@ class ManueltBrevRequestTest {
     @Test
     fun `Varsel årleg kontroll eøs request skal gi varsel årleg kontroll eøs brevmal med riktig data`() {
         val brev = baseRequest.copy(brevmal = Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS, mottakerlandSed = "SE")
-            .tilBrev(mapOf(Pair("SE", "Sverige")))
+            .tilBrev { mapOf(Pair("SE", "Sverige")) }
 
         assertThat(brev::class).isEqualTo(VarselbrevÅrlegKontrollEøs::class)
         brev as VarselbrevÅrlegKontrollEøs
@@ -108,7 +108,7 @@ class ManueltBrevRequestTest {
             mottakerlandSed = "SE",
             multiselectVerdier = dokumentliste
         )
-            .tilBrev(mapOf(Pair("SE", "Sverige")))
+            .tilBrev { mapOf(Pair("SE", "Sverige")) }
 
         assertThat(brev::class).isEqualTo(VarselbrevÅrlegKontrollEøs::class)
         brev as VarselbrevÅrlegKontrollEøs

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.ForlengetSvartidsbrev
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.VarselbrevÅrlegKontrollEøs
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -19,7 +20,7 @@ class ManueltBrevRequestTest {
 
     @Test
     fun `Forlenget svartidsbrev request skal gi forlenget svartid brevmal med riktig data`() {
-        val brev = baseRequest.copy(Brevmal.FORLENGET_SVARTIDSBREV).tilBrev()
+        val brev = baseRequest.copy(Brevmal.FORLENGET_SVARTIDSBREV).tilBrev(emptyMap())
 
         assertThat(brev::class).isEqualTo(ForlengetSvartidsbrev::class)
         brev as ForlengetSvartidsbrev
@@ -41,7 +42,7 @@ class ManueltBrevRequestTest {
                 navn = "testnavn"
             )
         )
-            .tilBrev()
+            .tilBrev(emptyMap())
 
         assertThat(brev::class).isEqualTo(ForlengetSvartidsbrev::class)
         brev as ForlengetSvartidsbrev
@@ -71,18 +72,53 @@ class ManueltBrevRequestTest {
                 navn = "navn tilhørende $fnr"
             )
         )
-        brevRequestTilPerson.tilBrev().data.apply {
+        brevRequestTilPerson.tilBrev(emptyMap()).data.apply {
             assertThat(flettefelter.fodselsnummer).containsExactly(brevRequestTilPerson.mottakerIdent)
             assertThat(flettefelter.navn).containsExactly(brevRequestTilPerson.mottakerNavn)
             assertThat(flettefelter.organisasjonsnummer).isNull()
             assertThat(flettefelter.gjelder).isNull()
         }
-        brevRequestTilInstitusjon.tilBrev().data.apply {
+        brevRequestTilInstitusjon.tilBrev(emptyMap()).data.apply {
             assertThat(flettefelter.organisasjonsnummer).containsExactly(brevRequestTilInstitusjon.mottakerIdent)
             assertThat(flettefelter.fodselsnummer).containsExactly(brevRequestTilInstitusjon.vedrørende?.fødselsnummer)
             assertThat(flettefelter.navn).containsExactly(brevRequestTilPerson.mottakerNavn)
             assertThat(flettefelter.gjelder).containsExactly(brevRequestTilInstitusjon.vedrørende?.navn)
         }
+    }
+
+    @Test
+    fun `Varsel årleg kontroll eøs request skal gi varsel årleg kontroll eøs brevmal med riktig data`() {
+        val brev = baseRequest.copy(brevmal = Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS, mottakerlandSed = "SE")
+            .tilBrev(mapOf(Pair("SE", "Sverige")))
+
+        assertThat(brev::class).isEqualTo(VarselbrevÅrlegKontrollEøs::class)
+        brev as VarselbrevÅrlegKontrollEøs
+
+        assertThat(brev.mal).isEqualTo(Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS)
+
+        assertThat(brev.data.flettefelter.mottakerlandSed!!.single()).isEqualTo("Sverige")
+        assertThat(brev.data.flettefelter.dokumentliste!!.isEmpty()).isTrue
+    }
+
+    @Test
+    fun `Varsel årleg kontroll eøs med innhenting av opplysninger request skal gi varsel årleg kontroll eøs brevmal med riktig data`() {
+        val dokumentliste = listOf("Dokument 1", "Dokument 2")
+        val brev = baseRequest.copy(
+            brevmal = Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER,
+            mottakerlandSed = "SE",
+            multiselectVerdier = dokumentliste
+        )
+            .tilBrev(mapOf(Pair("SE", "Sverige")))
+
+        assertThat(brev::class).isEqualTo(VarselbrevÅrlegKontrollEøs::class)
+        brev as VarselbrevÅrlegKontrollEøs
+
+        assertThat(brev.mal).isEqualTo(Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER)
+
+        assertThat(brev.data.flettefelter.mottakerlandSed!!.single()).isEqualTo("Sverige")
+        assertThat(brev.data.flettefelter.dokumentliste!!.isEmpty()).isFalse
+        println(brev.data.flettefelter.dokumentliste)
+        assertThat(brev.data.flettefelter.dokumentliste).containsAll(dokumentliste)
     }
 
     class PersonITest(override val fødselsnummer: String, override val navn: String) : Person


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Lagt til støtte for 2 nye varselbrev i forbindelse med revurdering årleg kontroll av EØS-saker. Begge breva bruker nytt flettefelt mottakerlandSED, og eine brevet skal ha med liste over dokumenter.
Begge breva fører til at behandling skal settes på vent.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9340

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
