### PR TITLE
Setter ned antall autoretry til 1 ved GET fra nginx

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: teamfamilie
   labels:
     team: teamfamilie
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: '1'
 spec:
   envFrom:
     - secret: familie-ba-sak

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: teamfamilie
   labels:
     team: teamfamilie
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: '1'
 
 spec:
   envFrom:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Nginx har automatisk retry for GET kall som tar tid. Vi har skatteetaten-api som kan ta lengre tid enn retryintervallet på 1 minutt. Så for å unngå at nginx spammer oss med tunge kall, så settes denne parameteren.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
Testet i miljø
