### PR TITLE
Legger inn extension-funksjon for å mappe dager ved månedsskiftet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinje.kt
@@ -1,25 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
-import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdForTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilForrigeMåned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilFørsteDagIMåneden
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilNesteMåned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.tilSisteDagIMåneden
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilPeriodeMedInnhold
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilPeriodeUtenInnhold
-
-fun Tidslinje<VilkårRegelverkResultat, Dag>.tilMånedsbasertTidslinjeForVilkårRegelverkResultat() = this
-    .tilMånedEtterVilkårsregler { it.erOppfylt() }
-    .slåSammenLike()
-    .filtrerIkkeNull()
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.tilMånedFraMånedsskifteIkkeNull
 
 /**
  * Extension-funksjon som konverterer en dag-basert tidslinje til en måned-basert tidslinje med VilkårRegelverkResultat
@@ -36,15 +19,7 @@ fun Tidslinje<VilkårRegelverkResultat, Dag>.tilMånedsbasertTidslinjeForVilkår
  * Ikke oppfylt | Oppfylt EØS   -> <Tomt>
  * Ikke oppfylt | Oppfylt Nasj  -> <Tomt>
  */
-fun <I> Tidslinje<I, Dag>.tilMånedEtterVilkårsregler(erOppfylt: (I?) -> Boolean) = tidslinje {
-    (fraOgMed().tilForrigeMåned()..tilOgMed().tilNesteMåned()).map { måned ->
-        val innholdSisteDagForrigeMåned = innholdForTidspunkt(måned.forrige().tilSisteDagIMåneden())
-        val innholdFørsteDagDenneMåned = innholdForTidspunkt(måned.tilFørsteDagIMåneden())
-
-        if (erOppfylt(innholdSisteDagForrigeMåned) && erOppfylt(innholdFørsteDagDenneMåned)) {
-            måned.tilPeriodeMedInnhold(innholdFørsteDagDenneMåned)
-        } else {
-            måned.tilPeriodeUtenInnhold()
-        }
+fun Tidslinje<VilkårRegelverkResultat, Dag>.tilMånedsbasertTidslinjeForVilkårRegelverkResultat() = this
+    .tilMånedFraMånedsskifteIkkeNull { sisteDagForrigeMåned, førsteDagDenneMåned ->
+        if (sisteDagForrigeMåned.erOppfylt() && førsteDagDenneMåned.erOppfylt()) førsteDagDenneMåned else null
     }
-}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MånedFraMånedsskifteTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/MånedFraMånedsskifteTest.kt
@@ -1,0 +1,75 @@
+package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
+
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.tilCharTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class MånedFraMånedsskifteTest {
+
+    @Test
+    fun `skal gi tom tidslinje hvis alle dager er inni én måned`() {
+        val daglinje = "aaaaaa".tilCharTidslinje(7.des(2021))
+        val månedtidsline = daglinje
+            .tilMånedFraMånedsskifteIkkeNull { verdiSisteDagForrigeMåned, verdiFørsteDagDenneMåned -> 'b' }
+
+        assertEquals(TomTidslinje<Char, Måned>(), månedtidsline)
+    }
+
+    @Test
+    fun `skal gi én måned ved ett månedsskifte`() {
+        val daglinje = "abcdefg".tilCharTidslinje(28.nov(2021))
+        val månedtidsline = daglinje
+            .tilMånedFraMånedsskifteIkkeNull { verdiSisteDagForrigeMåned, verdiFørsteDagDenneMåned ->
+                verdiFørsteDagDenneMåned
+            }
+
+        assertEquals("d".tilCharTidslinje(des(2021)), månedtidsline)
+    }
+
+    @Test
+    fun `skal gi to måneder ved to månedsskifter`() {
+        val daglinje = "abcdefghijklmnopqrstuvwxyzæøå0123456789".tilCharTidslinje(28.nov(2021))
+        val månedtidsline = daglinje
+            .tilMånedFraMånedsskifteIkkeNull { verdiSisteDagForrigeMåned, verdiFørsteDagDenneMåned ->
+                verdiSisteDagForrigeMåned
+            }
+
+        assertEquals("c4".tilCharTidslinje(des(2021)), månedtidsline)
+    }
+
+    @Test
+    fun `skal gi tom tidslinje hvis månedsskiftet mangler verdi på begge sider`() {
+        val daglinje = "abcdefghijklmnopqrstuvwxyzæøå0123456789".tilCharTidslinje(28.nov(2021))
+            .mapIkkeNull {
+                when (it) {
+                    'c', 'd', '4', '5' -> null // 30/11, 1/12, 31/12 og 1/1 mangler verdi
+                    else -> it
+                }
+            }
+
+        val månedtidsline = daglinje
+            .tilMånedFraMånedsskifteIkkeNull { verdiSisteDagForrigeMåned, verdiFørsteDagDenneMåned -> 'A' }
+
+        assertEquals(TomTidslinje<Char, Måned>(), månedtidsline)
+    }
+
+    @Test
+    fun `skal gi tom tidslinje hvis månedsskiftet mangler verdi på begge én av sidene`() {
+        val daglinje = "abcdefghijklmnopqrstuvwxyzæøå0123456789".tilCharTidslinje(28.nov(2021))
+            .mapIkkeNull {
+                when (it) {
+                    'c', '5' -> null // 30/11 og 1/1 mangler verdi
+                    else -> it
+                }
+            }
+
+        val månedtidsline = daglinje
+            .tilMånedFraMånedsskifteIkkeNull { verdiSisteDagForrigeMåned, verdiFørsteDagDenneMåned -> 'A' }
+
+        assertEquals(TomTidslinje<Char, Måned>(), månedtidsline)
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Legger til en ny tidslinje-funksjon som lar en generere en månedstidslinje fra siste dag i forrige måned og første dag i inneværende måned, og tar den i bruk for å generere vilkårsresultat-tidslinjer. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
