### PR TITLE
Svitsjer et par tislinjeomformere til å bruke tidslinjeFraTidspunkt og benytter anledningen til å forenkle

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
@@ -5,16 +5,18 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tid.TidspunktClosedRange
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.rangeTo
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
 
-fun <T : Tidsenhet> Tidslinje<*, T>.tidsrom(): TidspunktClosedRange<T> = fraOgMed()..tilOgMed()
+fun <T : Tidsenhet> Tidslinje<*, T>.tidsrom(): Iterable<Tidspunkt<T>> = fraOgMed()..tilOgMed()
 
-fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): TidspunktClosedRange<T> = fraOgMed()..tilOgMed()
+fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): Iterable<Tidspunkt<T>> = when {
+    this.toList().isEmpty() -> emptyList()
+    else -> fraOgMed()..tilOgMed()
+}
 
-fun <T : Tidsenhet, I> TidspunktClosedRange<T>.tidslinjeFraTidspunkt(
+fun <T : Tidsenhet, I> Iterable<Tidspunkt<T>>.tidslinjeFraTidspunkt(
     tidspunktMapper: (Tidspunkt<T>) -> Innholdsresultat<I>
 ): Tidslinje<I, T> = tidslinje {
     map { tidspunkt -> TidspunktMedInnholdsresultat(tidspunkt, tidspunktMapper(tidspunkt)) }
@@ -29,9 +31,15 @@ fun <T : Tidsenhet, I> TidspunktClosedRange<T>.tidslinjeFraTidspunkt(
         }
 }
 
+/**
+ * Innholdsresultat har tre tilstander
+ * - uten innhold               -> harInnhold = false, harVerdi = false
+ * - innhold som er null        -> harInnhold = true,  harVerdi = false
+ * - innhold som ikke er null   -> harInnhold = true,  harVerdi = true
+ */
 data class Innholdsresultat<I>(
     val innhold: I?,
-    val harInnhold: Boolean = true
+    internal val harInnhold: Boolean = true
 ) {
     constructor(innhold: I?) : this(innhold, true)
 
@@ -45,10 +53,12 @@ data class Innholdsresultat<I>(
     val verdi
         get() = innhold!!
 
+    fun <R> mapInnhold(mapper: (I?) -> R?): R? = if (this.harInnhold) mapper(verdi) else null
     fun <R> mapVerdi(mapper: (I) -> R): R? = if (this.harVerdi) mapper(verdi) else null
 }
 
-fun <I> I.tilInnhold() = Innholdsresultat(this)
+fun <I> I?.tilInnhold() = Innholdsresultat(this)
+fun <I> I?.tilVerdi() = this?.let { Innholdsresultat<I>(it) } ?: Innholdsresultat.utenInnhold()
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.innholdsresultatForTidspunkt(tidspunkt: Tidspunkt<T>): Innholdsresultat<I> =
     perioder().innholdsresultatForTidspunkt(tidspunkt)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
@@ -85,14 +85,13 @@ fun <I, R, T : Tidsenhet> Collection<Tidslinje<I, T>>.kombinerUtenNull(
  * Resultatet er en tidslinje med tidsenhet T og innhold R
  */
 fun <I, R, T : Tidsenhet> Collection<Tidslinje<I, T>>.kombiner(
-    listeKombinator: (Iterable<I?>) -> R?
-): Tidslinje<R, T> {
-    if (this.isEmpty()) return tidslinje { emptyList() }
-    val tidslinjer = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(tidslinjer) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? =
-            listeKombinator(tidslinjer.map { it.innholdForTidspunkt(tidspunkt) })
-    }
+    listeKombinator: (Iterable<I>) -> R?
+) = tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+    this.map { it.innholdsresultatForTidspunkt(tidspunkt) }
+        .filter { it.harVerdi }
+        .map { it.verdi }
+        .let { listeKombinator(it) }
+        .tilVerdi()
 }
 
 /**

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/EndreTid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/EndreTid.kt
@@ -3,11 +3,10 @@ package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.Innholdsresultat.Companion.utenInnhold
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdForTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdsresultatForTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tidslinjeFraTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tilInnhold
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.tilVerdi
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Tidsenhet
@@ -79,9 +78,7 @@ fun <I, R> Tidslinje<I, Dag>.tilMånedFraMånedsskifteIkkeNull(
     val innholdSisteDagForrigeMåned = innholdsresultatForTidspunkt(måned.forrige().tilSisteDagIMåneden())
     val innholdFørsteDagDenneMåned = innholdsresultatForTidspunkt(måned.tilFørsteDagIMåneden())
 
-    innholdSisteDagForrigeMåned
-        .mapVerdi { s -> innholdFørsteDagDenneMåned.mapVerdi { mapper(s, it) } }
-        ?.let { it.tilInnhold() } ?: utenInnhold()
+    innholdSisteDagForrigeMåned.mapVerdi { s -> innholdFørsteDagDenneMåned.mapVerdi { mapper(s, it) } }.tilVerdi()
 }
 
 /**

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinjeTest.kt
@@ -1,9 +1,15 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
 
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
+import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tid.Uendelighet
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.tilCharTidslinje
 import org.junit.Assert.assertEquals
@@ -91,15 +97,16 @@ internal class BeskjæreTidslinjeTest {
     }
 
     @Test
-    fun `skal beskjære uendelig fremtid slik at den kortest mulig`() {
+    fun `skal beskjære uendelig fremtid slik at den blir kortest mulig`() {
         val hovedlinje = "aaaaaa>".tilCharTidslinje(des(1993))
         val beskjæring = "bbb>".tilCharTidslinje(feb(2002))
 
         val faktisk = hovedlinje.beskjærEtter(beskjæring)
-        val forventet = "aaa>".tilCharTidslinje(feb(2002))
+        val forventet = tidslinje { listOf(Periode(feb(2002), feb(2002).somUendeligLengeTil(), 'a')) }
 
         assertEquals(forventet, faktisk)
         assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+        assertEquals(Uendelighet.FREMTID, faktisk.tilOgMed().uendelighet)
     }
 
     @Test
@@ -108,10 +115,11 @@ internal class BeskjæreTidslinjeTest {
         val beskjæring = "<bbb".tilCharTidslinje(feb(2002))
 
         val faktisk = hovedlinje.beskjærEtter(beskjæring)
-        val forventet = "<aaa".tilCharTidslinje(feb(2002))
+        val forventet = tidslinje { listOf(Periode(mai(2002).somUendeligLengeSiden(), mai(2002), 'a')) }
 
         assertEquals(forventet, faktisk)
         assertEquals(forventet.somEndelig(), faktisk.somEndelig())
+        assertEquals(Uendelighet.FORTID, faktisk.fraOgMed().uendelighet)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
`TidslinjeSomStykkerOppTiden` er foreldet og denne PRen fjerrner bruken et par steder. Beskjæring av tidslinjer blir da litt enklere og riktigere, og et par tester må endres til å reflektere det. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ dette er dekket av tester fra før

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
