### PR TITLE
Fix: Feil barn hentes inn i begrunnelse ved opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Opphørsperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Opphørsperiode.kt
@@ -35,7 +35,7 @@ fun mapTilOpphørsperioder(
     val utbetalingsperioder =
         mapTilUtbetalingsperioder(personopplysningGrunnlag, andelerTilkjentYtelse)
 
-    val alleOpphørsperioder = if (forrigeUtbetalingsperioder.isNotEmpty() && utbetalingsperioder.isEmpty()) {
+    return if (forrigeUtbetalingsperioder.isNotEmpty() && utbetalingsperioder.isEmpty()) {
         listOf(
             Opphørsperiode(
                 periodeFom = forrigeUtbetalingsperioder.minOf { it.periodeFom },
@@ -56,8 +56,6 @@ fun mapTilOpphørsperioder(
             ).flatten()
         }.sortedBy { it.periodeFom }
     }
-
-    return slåSammenOpphørsperioder(alleOpphørsperioder)
 }
 
 fun slåSammenOpphørsperioder(alleOpphørsperioder: List<Opphørsperiode>): List<Opphørsperiode> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -508,7 +508,7 @@ class VedtaksperiodeService(
         )
     }
 
-    fun hentOpphørsperioder(behandling: Behandling, endringstidspunkt: LocalDate? = null): List<Opphørsperiode> {
+    fun hentOpphørsperioder(behandling: Behandling, endringstidspunkt: LocalDate = TIDENES_MORGEN): List<Opphørsperiode> {
         if (behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET) return emptyList()
 
         val iverksatteBehandlinger =
@@ -546,7 +546,7 @@ class VedtaksperiodeService(
             andelerTilkjentYtelse = andelerTilkjentYtelse
         )
         val (perioderFørEndringstidspunkt, fraEndringstidspunktOgUtover) =
-            alleOpphørsperioder.partition { it.periodeFom.isBefore(endringstidspunkt ?: TIDENES_MORGEN) }
+            alleOpphørsperioder.partition { it.periodeFom.isBefore(endringstidspunkt) }
 
         return perioderFørEndringstidspunkt + slåSammenOpphørsperioder(fraEndringstidspunktOgUtover)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -281,8 +281,14 @@ class VedtaksperiodeService(
         gjelderFortsattInnvilget: Boolean = false,
         manueltOverstyrtEndringstidspunkt: LocalDate? = null
     ): List<VedtaksperiodeMedBegrunnelser> {
+        val endringstidspunkt = manueltOverstyrtEndringstidspunkt
+            ?: if (!gjelderFortsattInnvilget) {
+                endringstidspunktService.finnEndringstidpunkForBehandling(behandlingId = vedtak.behandling.id)
+            } else {
+                TIDENES_MORGEN
+            }
         val opphørsperioder =
-            hentOpphørsperioder(vedtak.behandling).map { it.tilVedtaksperiodeMedBegrunnelse(vedtak) }
+            hentOpphørsperioder(vedtak.behandling, endringstidspunkt).map { it.tilVedtaksperiodeMedBegrunnelse(vedtak) }
 
         val utbetalingsperioder =
             utbetalingsperiodeMedBegrunnelserService.hentUtbetalingsperioder(vedtak, opphørsperioder)
@@ -291,25 +297,14 @@ class VedtaksperiodeService(
 
         return filtrerUtPerioderBasertPåEndringstidspunkt(
             vedtaksperioderMedBegrunnelser = (utbetalingsperioder + opphørsperioder),
-            behandlingId = vedtak.behandling.id,
-            gjelderFortsattInnvilget = gjelderFortsattInnvilget,
-            manueltOverstyrtEndringstidspunkt = manueltOverstyrtEndringstidspunkt
+            endringstidspunkt = endringstidspunkt
         ) + avslagsperioder
     }
 
     fun filtrerUtPerioderBasertPåEndringstidspunkt(
         vedtaksperioderMedBegrunnelser: List<VedtaksperiodeMedBegrunnelser>,
-        behandlingId: Long,
-        gjelderFortsattInnvilget: Boolean = false,
-        manueltOverstyrtEndringstidspunkt: LocalDate? = null
+        endringstidspunkt: LocalDate
     ): List<VedtaksperiodeMedBegrunnelser> {
-        val endringstidspunkt = manueltOverstyrtEndringstidspunkt
-            ?: if (!gjelderFortsattInnvilget) {
-                endringstidspunktService.finnEndringstidpunkForBehandling(behandlingId = behandlingId)
-            } else {
-                TIDENES_MORGEN
-            }
-
         return vedtaksperioderMedBegrunnelser.filter { (it.tom ?: TIDENES_ENDE).isSameOrAfter(endringstidspunkt) }
     }
 
@@ -508,7 +503,7 @@ class VedtaksperiodeService(
         )
     }
 
-    fun hentOpphørsperioder(behandling: Behandling): List<Opphørsperiode> {
+    fun hentOpphørsperioder(behandling: Behandling, endringstidspunkt: LocalDate? = null): List<Opphørsperiode> {
         if (behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET) return emptyList()
 
         val iverksatteBehandlinger =
@@ -539,12 +534,16 @@ class VedtaksperiodeService(
         val andelerTilkjentYtelse = andelerTilkjentYtelseOgEndreteUtbetalingerService
             .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
 
-        return mapTilOpphørsperioder(
+        val alleOpphørsperioder = mapTilOpphørsperioder(
             forrigePersonopplysningGrunnlag = forrigePersonopplysningGrunnlag,
             forrigeAndelerTilkjentYtelse = forrigeAndelerMedEndringer,
             personopplysningGrunnlag = personopplysningGrunnlag,
             andelerTilkjentYtelse = andelerTilkjentYtelse
         )
+        val (perioderFørEndringstidspunkt, fraEndringstidspunktOgUtover) =
+            alleOpphørsperioder.partition { it.periodeFom.isBefore(endringstidspunkt ?: TIDENES_MORGEN) }
+
+        return perioderFørEndringstidspunkt + slåSammenOpphørsperioder(fraEndringstidspunktOgUtover)
     }
 
     private fun hentAvslagsperioderMedBegrunnelser(vedtak: Vedtak): List<VedtaksperiodeMedBegrunnelser> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/OpphørsperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/OpphørsperiodeTest.kt
@@ -205,7 +205,7 @@ class OpphørsperiodeTest {
             andelerTilkjentYtelse = listOf(andelBarn1),
             personopplysningGrunnlag = personopplysningGrunnlag,
             forrigePersonopplysningGrunnlag = personopplysningGrunnlag
-        )
+        ).run (::slåSammenOpphørsperioder)
 
         assertEquals(1, opphørsperioder.size)
         assertEquals(reduksjonFom.nesteMåned(), opphørsperioder[0].periodeFom.toYearMonth())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/OpphørsperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/OpphørsperiodeTest.kt
@@ -205,7 +205,7 @@ class OpphørsperiodeTest {
             andelerTilkjentYtelse = listOf(andelBarn1),
             personopplysningGrunnlag = personopplysningGrunnlag,
             forrigePersonopplysningGrunnlag = personopplysningGrunnlag
-        ).run (::slåSammenOpphørsperioder)
+        ).run(::slåSammenOpphørsperioder)
 
         assertEquals(1, opphørsperioder.size)
         assertEquals(reduksjonFom.nesteMåned(), opphørsperioder[0].periodeFom.toYearMonth())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
@@ -1,0 +1,109 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ba.sak.common.lagVedtak
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
+import no.nav.familie.ba.sak.kjerne.beregning.EndringstidspunktService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.steg.StegType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import java.time.LocalDate
+import java.time.YearMonth
+
+class VedtaksperiodeServiceEnhetstest {
+
+    private val behandlingRepository: BehandlingRepository = mockk()
+    private val persongrunnlagService: PersongrunnlagService = mockk()
+    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService = mockk()
+    private val endringstidspunktService: EndringstidspunktService = mockk()
+
+    private val VedtaksperiodeService = VedtaksperiodeService(
+        behandlingRepository = behandlingRepository,
+        personidentService = mockk(),
+        persongrunnlagService = persongrunnlagService,
+        andelTilkjentYtelseRepository = mockk(),
+        vedtaksperiodeHentOgPersisterService = mockk(),
+        vedtakRepository = mockk(),
+        vilkårsvurderingRepository = mockk(relaxed = true),
+        sanityService = mockk(),
+        søknadGrunnlagService = mockk(relaxed = true),
+        endretUtbetalingAndelRepository = mockk(),
+        endringstidspunktService = endringstidspunktService,
+        featureToggleService = mockk(),
+        utbetalingsperiodeMedBegrunnelserService = mockk(relaxed = true),
+        kompetanseRepository = mockk(),
+        andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+    )
+
+    private val person = lagPerson()
+    private val forrigeBehandling = lagBehandling().also {
+        it.behandlingStegTilstand.add(BehandlingStegTilstand(0, it, StegType.BEHANDLING_AVSLUTTET))
+    }
+    private val behandling = lagBehandling(fagsak = forrigeBehandling.fagsak)
+    private val vedtak = lagVedtak(behandling)
+
+    private val endringstidspunkt = LocalDate.of(2022, 11, 1)
+    private val ytelseOpphørtFørEndringstidspunkt = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        fom = YearMonth.from(endringstidspunkt).minusMonths(3),
+        tom = YearMonth.from(endringstidspunkt).minusMonths(2),
+        person = person
+    )
+    private val ytelseOpphørtSammeMåned = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        fom = YearMonth.from(endringstidspunkt),
+        tom = YearMonth.from(endringstidspunkt).plusYears(18),
+        person = person
+    )
+
+    @BeforeEach
+    fun init() {
+        every { behandlingRepository.finnIverksatteBehandlinger(any()) } returns listOf(behandling, forrigeBehandling)
+        every { endringstidspunktService.finnEndringstidpunkForBehandling(vedtak.behandling.id) } returns endringstidspunkt
+        every { persongrunnlagService.hentAktiv(any()) } returns
+                lagTestPersonopplysningGrunnlag(vedtak.behandling.id, person)
+        every {
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(forrigeBehandling.id)
+        } returns listOf(ytelseOpphørtSammeMåned)
+
+        every {
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
+        } returns listOf(ytelseOpphørtFørEndringstidspunkt)
+    }
+
+    @Test
+    fun `genererVedtaksperioderMedBegrunnelser skal slå sammen opphørsperioder fra og med endringstidspunkt`() {
+        val returnerteVedtaksperioderNårUtledetEndringstidspunktErLikSisteOpphørFom = VedtaksperiodeService
+            .genererVedtaksperioderMedBegrunnelser(vedtak)
+            .filter { it.type == Vedtaksperiodetype.OPPHØR }
+
+        val førsteOpphørFomDato =
+            returnerteVedtaksperioderNårUtledetEndringstidspunktErLikSisteOpphørFom.minOf { it.fom!! }
+        val senesteOpphørTomDato =
+            returnerteVedtaksperioderNårUtledetEndringstidspunktErLikSisteOpphørFom.sortedBy { it.tom ?: TIDENES_ENDE }.last().tom
+
+        val returnerteVedtaksperioderNårOverstyrtEndringstidspunktErFørsteOpphørFom = VedtaksperiodeService
+            .genererVedtaksperioderMedBegrunnelser(vedtak, manueltOverstyrtEndringstidspunkt = førsteOpphørFomDato)
+            .filter { it.type == Vedtaksperiodetype.OPPHØR }
+        val returnerteVedtaksperioderNårOverstyrtEndringstidspunktErFørFørsteOpphør = VedtaksperiodeService
+            .genererVedtaksperioderMedBegrunnelser(vedtak, manueltOverstyrtEndringstidspunkt = førsteOpphørFomDato.minusMonths(1))
+            .filter { it.type == Vedtaksperiodetype.OPPHØR }
+
+        assertThat(returnerteVedtaksperioderNårUtledetEndringstidspunktErLikSisteOpphørFom).hasSize(2).last()
+            .hasFieldOrPropertyWithValue("fom", endringstidspunkt)
+        assertThat(returnerteVedtaksperioderNårOverstyrtEndringstidspunktErFørFørsteOpphør).hasSize(1).first()
+            .hasFieldOrPropertyWithValue("fom", førsteOpphørFomDato)
+            .hasFieldOrPropertyWithValue("tom", senesteOpphørTomDato)
+        assertThat(returnerteVedtaksperioderNårOverstyrtEndringstidspunktErFørFørsteOpphør)
+            .isEqualTo(returnerteVedtaksperioderNårOverstyrtEndringstidspunktErFørsteOpphørFom)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
@@ -17,7 +17,6 @@ import no.nav.familie.ba.sak.kjerne.steg.StegType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -43,7 +42,7 @@ class VedtaksperiodeServiceEnhetstest {
         featureToggleService = mockk(),
         utbetalingsperiodeMedBegrunnelserService = mockk(relaxed = true),
         kompetanseRepository = mockk(),
-        andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+        andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService
     )
 
     private val person = lagPerson()
@@ -70,7 +69,7 @@ class VedtaksperiodeServiceEnhetstest {
         every { behandlingRepository.finnIverksatteBehandlinger(any()) } returns listOf(behandling, forrigeBehandling)
         every { endringstidspunktService.finnEndringstidpunkForBehandling(vedtak.behandling.id) } returns endringstidspunkt
         every { persongrunnlagService.hentAktiv(any()) } returns
-                lagTestPersonopplysningGrunnlag(vedtak.behandling.id, person)
+            lagTestPersonopplysningGrunnlag(vedtak.behandling.id, person)
         every {
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(forrigeBehandling.id)
         } returns listOf(ytelseOpphørtSammeMåned)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -558,7 +558,6 @@ class VedtaksperiodeServiceTest(
     @Test
     fun `generere vedtaksperioder basert på manuelt overstyrt endringstidspunkt`() {
         val vedtak = lagVedtak()
-        val behandlingId = vedtak.behandling.id
         val avslagsperioder = listOf(
             lagVedtaksperiodeMedBegrunnelser(
                 vedtak,
@@ -582,10 +581,8 @@ class VedtaksperiodeServiceTest(
             )
         )
         val vedtaksperioder = vedtaksperiodeService.filtrerUtPerioderBasertPåEndringstidspunkt(
-            behandlingId = behandlingId,
             vedtaksperioderMedBegrunnelser = utbetalingsperioder,
-            gjelderFortsattInnvilget = false,
-            manueltOverstyrtEndringstidspunkt = LocalDate.of(2021, 3, 1)
+            endringstidspunkt = LocalDate.of(2021, 3, 1)
         ) + avslagsperioder
 
         assertNotNull(vedtaksperioder)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9895](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9895)

Ekskluderer perioder datert før endringstidspunktet fra sammenslåingen av opphørsperioder, da perioder fra tidligere vedtak uten en fastsatt tom-dato dekket over nye, siden de regnes som gjeldende til ubestemt tid, og det førte til feil begrunnelse for opphør i vedtaksbrevet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
