### PR TITLE
fix: oppdater enhet for behandlig tar i bruk nytt endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/FagsystemsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/FagsystemsbehandlingService.kt
@@ -47,7 +47,7 @@ class FagsystemsbehandlingService(
     ): HentFagsystemsbehandlingRespons {
         val behandlingId = behandling.id
         val persongrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandlingId)
-        val arbeidsfordeling = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId)
+        val arbeidsfordeling = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId)
         val aktivVedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId)
 
         val faktainfo = Faktainfo(

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
@@ -234,6 +234,23 @@ class IntegrasjonClient(
         }
     }
 
+    fun tilordneEnhetForOppgave(oppgaveId: Long, nyEnhet: String): OppgaveResponse {
+        val baseUri = URI.create("$integrasjonUri/oppgave/$oppgaveId/enhet/$nyEnhet")
+        val uri = UriComponentsBuilder.fromUri(baseUri).queryParam("fjernMappeFraOppgave", true).build()
+            .toUri() // fjerner alltid mappe fra Barnetrygd siden hver enhet sin mappestruktur
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "oppgave",
+            uri = uri,
+            formål = "Bytt enhet"
+        ) {
+            patchForEntity(
+                uri,
+                HttpHeaders().medContentTypeJsonUTF8()
+            )
+        }
+    }
+
     fun finnOppgaveMedId(oppgaveId: Long): Oppgave {
         val uri = URI.create("$integrasjonUri/oppgave/$oppgaveId")
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -140,7 +140,7 @@ class OppgaveService(
         }
     }
 
-    fun endretTilordnetEnhetPåOppgaverForBehandling(behandling: Behandling, nyEnhet: String) {
+    fun endreTilordnetEnhetPåOppgaverForBehandling(behandling: Behandling, nyEnhet: String) {
         hentOppgaverSomIkkeErFerdigstilt(behandling).forEach { dbOppgave ->
             val oppgave = hentOppgave(dbOppgave.gsakId.toLong())
             logger.info("Oppdaterer enhet fra ${oppgave.tildeltEnhetsnr} til $nyEnhet på oppgave ${oppgave.id}")

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -140,6 +140,14 @@ class OppgaveService(
         }
     }
 
+    fun endretTilordnetEnhetPåOppgaverForBehandling(behandling: Behandling, nyEnhet: String) {
+        hentOppgaverSomIkkeErFerdigstilt(behandling).forEach { dbOppgave ->
+            val oppgave = hentOppgave(dbOppgave.gsakId.toLong())
+            logger.info("Oppdaterer enhet fra ${oppgave.tildeltEnhetsnr} til $nyEnhet på oppgave ${oppgave.id}")
+            integrasjonClient.tilordneEnhetForOppgave(oppgaveId = oppgave.id!!, nyEnhet = nyEnhet)
+        }
+    }
+
     fun fordelOppgave(oppgaveId: Long, saksbehandler: String, overstyrFordeling: Boolean = false): String {
         if (!overstyrFordeling) {
             val oppgave = integrasjonClient.finnOppgaveMedId(oppgaveId)
@@ -200,8 +208,10 @@ class OppgaveService(
             when {
                 gammelOppgave.id == null ->
                     logger.warn("Finner ikke oppgave ${dbOppgave.gsakId} ved oppdatering av frist")
+
                 gammelOppgave.fristFerdigstillelse == null ->
                     logger.warn("Oppgave ${dbOppgave.gsakId} har ingen oppgavefrist ved oppdatering av frist")
+
                 oppgaveErAvsluttet -> {}
                 else -> {
                     val nyFrist = LocalDate.parse(gammelOppgave.fristFerdigstillelse!!).plus(forlengelse)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -160,7 +160,7 @@ class ArbeidsfordelingService(
                 begrunnelse = begrunnelse
             )
 
-            oppgaveService.endretTilordnetEnhetPåOppgaverForBehandling(
+            oppgaveService.endreTilordnetEnhetPåOppgaverForBehandling(
                 behandling,
                 oppdatertArbeidsfordelingPåBehandling.behandlendeEnhetId
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublis
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ArbeidsfordelingService(
@@ -29,6 +30,7 @@ class ArbeidsfordelingService(
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher
 ) {
 
+    @Transactional
     fun manueltOppdaterBehandlendeEnhet(behandling: Behandling, endreBehandlendeEnhet: RestEndreBehandlendeEnhet) {
         val aktivArbeidsfordelingPåBehandling =
             arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id)
@@ -91,6 +93,7 @@ class ArbeidsfordelingService(
                             )
                         )
                     }
+
                     else -> {
                         if (!aktivArbeidsfordelingPåBehandling.manueltOverstyrt &&
                             (aktivArbeidsfordelingPåBehandling.behandlendeEnhetId != arbeidsfordelingsenhet.enhetId)
@@ -157,14 +160,14 @@ class ArbeidsfordelingService(
                 begrunnelse = begrunnelse
             )
 
-            oppgaveService.patchOppgaverForBehandling(behandling) {
-                logger.info("Oppdaterer enhet fra ${it.tildeltEnhetsnr} til ${oppdatertArbeidsfordelingPåBehandling.behandlendeEnhetId} på oppgave ${it.id}")
-                it.copy(tildeltEnhetsnr = oppdatertArbeidsfordelingPåBehandling.behandlendeEnhetId)
-            }
+            oppgaveService.endretTilordnetEnhetPåOppgaverForBehandling(
+                behandling,
+                oppdatertArbeidsfordelingPåBehandling.behandlendeEnhetId
+            )
         }
     }
 
-    fun hentAbeidsfordelingPåBehandling(behandlingId: Long): ArbeidsfordelingPåBehandling {
+    fun hentArbeidsfordelingPåBehandling(behandlingId: Long): ArbeidsfordelingPåBehandling {
         return arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandlingId)
             ?: error("Finner ikke tilknyttet arbeidsfordeling på behandling med id $behandlingId")
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -72,7 +72,7 @@ class UtvidetBehandlingService(
         val personopplysningGrunnlag = persongrunnlagService.hentAktiv(behandlingId = behandling.id)
         val personer = personopplysningGrunnlag?.søkerOgBarn
 
-        val arbeidsfordeling = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+        val arbeidsfordeling = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
 
         val vedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandling.id)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -291,7 +291,7 @@ class BrevService(
             behandling = vedtak.behandling,
             totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(vedtak.behandling.id)
         )
-        val enhet = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(vedtak.behandling.id).behandlendeEnhetNavn
+        val enhet = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(vedtak.behandling.id).behandlendeEnhetNavn
         return GrunnlagOgSignaturData(
             grunnlag = personopplysningGrunnlag,
             saksbehandler = saksbehandler,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -77,7 +77,7 @@ fun ManueltBrevRequest.byggMottakerdata(
         persongrunnlagService.hentPersonerPåBehandling(listOf(ident), behandling).singleOrNull()
             ?: error("Fant flere eller ingen personer med angitt personident på behandling $behandling")
     }
-    val enhet = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandling.id).run {
+    val enhet = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandling.id).run {
         Enhet(enhetId = behandlendeEnhetId, enhetNavn = behandlendeEnhetNavn)
     }
     return when {
@@ -89,6 +89,7 @@ fun ManueltBrevRequest.byggMottakerdata(
                     override val navn = hentPerson(fødselsnummer).navn
                 }
             )
+
         else -> hentPerson(mottakerIdent).let { mottakerPerson ->
             this.copy(
                 enhet = enhet,
@@ -130,6 +131,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
                 )
             )
         )
+
     Brevmal.INNHENTE_OPPLYSNINGER,
     Brevmal.INNHENTE_OPPLYSNINGER_INSTITUSJON ->
         InnhenteOpplysningerBrev(
@@ -145,6 +147,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
                 )
             )
         )
+
     Brevmal.HENLEGGE_TRUKKET_SØKNAD ->
         HenleggeTrukketSøknadBrev(
             data = HenleggeTrukketSøknadData(
@@ -155,6 +158,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
                 )
             )
         )
+
     Brevmal.VARSEL_OM_REVURDERING ->
         VarselbrevMedÅrsaker(
             mal = Brevmal.VARSEL_OM_REVURDERING,
@@ -163,6 +167,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
             varselÅrsaker = this.multiselectVerdier,
             enhet = this.enhetNavn()
         )
+
     Brevmal.VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14 ->
         VarselOmRevurderingDeltBostedParagraf14Brev(
             data = VarselOmRevurderingDeltBostedParagraf14Data(
@@ -174,6 +179,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
                 )
             )
         )
+
     Brevmal.VARSEL_OM_REVURDERING_SAMBOER ->
         if (this.datoAvtale == null) {
             throw FunksjonellFeil(
@@ -224,7 +230,10 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
             fodselsnummer = this.vedrørende?.fødselsnummer ?: mottakerIdent,
             enhetNavn = this.enhetNavn(),
             årsaker = this.multiselectVerdier,
-            antallUkerSvarfrist = this.antallUkerSvarfrist ?: throw Feil(message = "Antall uker svarfrist er ikke satt", frontendFeilmelding = "Antall uker svarfrist er ikke satt"),
+            antallUkerSvarfrist = this.antallUkerSvarfrist ?: throw Feil(
+                message = "Antall uker svarfrist er ikke satt",
+                frontendFeilmelding = "Antall uker svarfrist er ikke satt"
+            ),
             organisasjonsnummer = if (erTilInstitusjon) mottakerIdent else null,
             gjelder = this.vedrørende?.navn
         )
@@ -236,6 +245,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
             enhet = this.enhetNavn(),
             mal = Brevmal.INFORMASJONSBREV_FØDSEL_MINDREÅRIG
         )
+
     Brevmal.INFORMASJONSBREV_FØDSEL_UMYNDIG,
     Brevmal.INFORMASJONSBREV_FØDSEL_VERGEMÅL ->
         EnkeltInformasjonsbrev(
@@ -244,6 +254,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
             enhet = this.enhetNavn(),
             mal = Brevmal.INFORMASJONSBREV_FØDSEL_VERGEMÅL
         )
+
     Brevmal.INFORMASJONSBREV_FØDSEL_GENERELL ->
         EnkeltInformasjonsbrev(
             navn = this.mottakerNavn,
@@ -251,6 +262,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
             enhet = this.enhetNavn(),
             mal = Brevmal.INFORMASJONSBREV_FØDSEL_GENERELL
         )
+
     Brevmal.INFORMASJONSBREV_KAN_SØKE ->
         InformasjonsbrevKanSøke(
             navn = this.mottakerNavn,
@@ -258,6 +270,7 @@ fun ManueltBrevRequest.tilBrev(hentLandkoder: (() -> Map<String, String>)) = whe
             enhet = this.enhetNavn(),
             dokumentliste = this.multiselectVerdier
         )
+
     Brevmal.VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED ->
         VarselbrevMedÅrsakerOgBarn(
             mal = Brevmal.VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/JournalførVedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/JournalførVedtaksbrev.kt
@@ -58,7 +58,7 @@ class JournalførVedtaksbrev(
         }
 
         val behanlendeEnhet =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id).behandlendeEnhetId
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id).behandlendeEnhetId
 
         val mottaker = if (fagsak.type == FagsakType.INSTITUSJON) {
             mutableListOf(MottakerInfo(fagsak.institusjon!!.orgNummer, BrukerIdType.ORGNR, false))

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
@@ -99,7 +99,7 @@ class TilbakekrevingService(
             )
 
         val persongrunnlag = persongrunnlagService.hentAktivThrows(behandlingId)
-        val arbeidsfordeling = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId)
+        val arbeidsfordeling = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId)
         val institusjon = hentInstitusjon(vedtak.behandling.fagsak)
         val verge = hentVerge(vedtak.behandling.verge?.ident)
 
@@ -135,7 +135,7 @@ class TilbakekrevingService(
     fun lagOpprettTilbakekrevingRequest(behandling: Behandling): OpprettTilbakekrevingRequest {
         val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id)
 
-        val enhet = arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandling.id)
+        val enhet = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandling.id)
 
         val aktivtVedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandling.id)
             ?: throw Feil("Fant ikke aktivt vedtak på behandling ${behandling.id}")

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -58,11 +58,12 @@ class SaksstatistikkService(
             BehandlingÅrsak.SØKNAD -> {
                 behandlingSøknadsinfoService.hentSøknadMottattDato(behandlingId) ?: behandling.opprettetTidspunkt
             }
+
             else -> behandling.opprettetTidspunkt
         }
 
         val behandlendeEnhetsKode =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId).behandlendeEnhetId
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId).behandlendeEnhetId
         val ansvarligEnhetKode = arbeidsfordelingService.hentArbeidsfordelingsenhet(behandling).enhetId
 
         val aktivtVedtak = vedtakService.hentAktivForBehandling(behandlingId)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
@@ -108,6 +108,9 @@ class IntegrasjonClientMock {
             every { mockIntegrasjonClient.patchOppgave(any()) } returns
                 OppgaveResponse(12345678L)
 
+            every { mockIntegrasjonClient.tilordneEnhetForOppgave(any(), any()) } returns
+                OppgaveResponse(12345678L)
+
             every { mockIntegrasjonClient.fordelOppgave(any(), any()) } returns
                 OppgaveResponse(12345678L)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumerTest.kt
@@ -83,7 +83,7 @@ internal class HentFagsystemsbehandlingRequestConsumerTest {
             tilfeldigPerson(personType = PersonType.BARN),
             tilfeldigPerson(personType = PersonType.SØKER)
         )
-        every { arbeidsfordelingService.hentAbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
+        every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
             behandlendeEnhetId = "4820",
             behandlendeEnhetNavn = "Nav",
             behandlingId = behandling.id

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -90,7 +90,7 @@ class OppgaveServiceTest {
         } returns null
         every { personidentService.hentAktør(any()) } returns Aktør(AKTØR_ID_FAGSAK)
 
-        every { arbeidsfordelingService.hentAbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
+        every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
             behandlingId = 1,
             behandlendeEnhetId = ENHETSNUMMER,
             behandlendeEnhetNavn = "enhet"

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -134,7 +134,7 @@ internal class SaksstatistikkServiceTest(
     fun init() {
         MockKAnnotations.init()
 
-        every { arbeidsfordelingService.hentAbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
+        every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
             behandlendeEnhetId = "4820",
             behandlendeEnhetNavn = "Nav",
             behandlingId = 1
@@ -491,14 +491,18 @@ internal class SaksstatistikkServiceTest(
                     "/schema/behandling-schema.json"
                 )
             } catch (e: Exception) {
-                throw IllegalStateException("Skjema til saksstatistikk validerer ikke etter endringer blant enum-verdier. Sjekk feilmelding og oppdater enten enum til å passe skjema eller skjema til å passe enum.", e)
+                throw IllegalStateException(
+                    "Skjema til saksstatistikk validerer ikke etter endringer blant enum-verdier. Sjekk feilmelding og oppdater enten enum til å passe skjema eller skjema til å passe enum.",
+                    e
+                )
             }
         }
     }
 
     @Test
     fun `Enum-verdier brukt i sakDvh skal validere mot json schema`() {
-        val deltagere = PersonType.values().map { personType -> AktørDVH(randomAktør().aktørId.toLong(), personType.name) }
+        val deltagere =
+            PersonType.values().map { personType -> AktørDVH(randomAktør().aktørId.toLong(), personType.name) }
 
         FagsakStatus.values().forEach {
             val sakDvh = SakDVH(
@@ -520,7 +524,10 @@ internal class SaksstatistikkServiceTest(
                     "/schema/sak-schema.json"
                 )
             } catch (e: Exception) {
-                throw IllegalStateException("Skjema til saksstatistikk validerer ikke etter endringer blant enum-verdier. Sjekk feilmelding og oppdater enten enum til å passe skjema eller skjema til å passe enum.", e)
+                throw IllegalStateException(
+                    "Skjema til saksstatistikk validerer ikke etter endringer blant enum-verdier. Sjekk feilmelding og oppdater enten enum til å passe skjema eller skjema til å passe enum.",
+                    e
+                )
             }
         }
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
@@ -189,7 +189,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandling =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
 
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandling.behandlendeEnhetId)
     }
@@ -203,7 +203,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandling =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandling.behandlendeEnhetId)
 
         stegService.håndterSøknad(
@@ -218,7 +218,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandlingEtterSøknadsregistrering =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandlingEtterSøknadsregistrering.behandlendeEnhetId)
     }
 
@@ -231,7 +231,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandling =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandling.behandlendeEnhetId)
 
         stegService.håndterSøknad(
@@ -246,7 +246,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandlingEtterSøknadsregistrering =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(FORTROLIG_ENHET, arbeidsfordelingPåBehandlingEtterSøknadsregistrering.behandlendeEnhetId)
     }
 
@@ -259,7 +259,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandling =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandling.behandlendeEnhetId)
 
         stegService.håndterSøknad(
@@ -274,7 +274,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandlingEtterSøknadsregistreringUtenDiskresjonskode =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(
             IKKE_FORTROLIG_ENHET,
             arbeidsfordelingPåBehandlingEtterSøknadsregistreringUtenDiskresjonskode.behandlendeEnhetId
@@ -295,7 +295,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandlingEtterSøknadsregistreringMedDiskresjonskode =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(
             FORTROLIG_ENHET,
             arbeidsfordelingPåBehandlingEtterSøknadsregistreringMedDiskresjonskode.behandlendeEnhetId
@@ -311,7 +311,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandling =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandling.behandlendeEnhetId)
 
         arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(
@@ -334,7 +334,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandlingEtterSøknadsregistrering =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(MANUELT_OVERSTYRT_ENHET, arbeidsfordelingPåBehandlingEtterSøknadsregistrering.behandlendeEnhetId)
     }
 
@@ -347,7 +347,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         val arbeidsfordelingPåBehandling =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandling.behandlendeEnhetId)
 
         oppgaveService.opprettOppgave(behandling.id, Oppgavetype.BehandleSak, now())
@@ -364,11 +364,11 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         verify(exactly = 1) {
-            oppgaveService.patchOppgave(any())
+            integrasjonClient.tilordneEnhetForOppgave(any(), any())
         }
 
         val arbeidsfordelingPåBehandlingEtterSøknadsregistreringUtenDiskresjonskode =
-            arbeidsfordelingService.hentAbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(
             FORTROLIG_ENHET,
             arbeidsfordelingPåBehandlingEtterSøknadsregistreringUtenDiskresjonskode.behandlendeEnhetId


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- Fikser feil ved at man ikke kan bytte enhet hvis man har mappe satt, siden den nye mappen ikke har tilgang til mappen.
- Fikser også feil om at endringen ikke ble rullet tilbake ved feil, men i stedet ble commit i ba-sak basen, slik at det ble usynk mellom ba og oppgave, og at man ikke sendte saksstatistikkmelding.
- Skrivefeil på hentArbeidsfordelingPåBehandling

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Testet ok i preprod

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
