### PR TITLE
Gjør om landkode alpha3 til alpha2 for statistikk for utenlandsk adresse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.neovisionaries</groupId>
+            <artifactId>nv-i18n</artifactId>
+            <version>1.29</version>
+        </dependency>
 
         <dependency>
             <groupId>com.papertrailapp</groupId>

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -166,7 +166,7 @@ class SaksstatistikkService(
         return if (person.bostedsadresser.isNotEmpty()) {
             "NO"
         } else {
-            personopplysningerService.hentLandkodeUtenlandskBostedsadresse(
+            personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(
                 person.aktør
             )
         }
@@ -178,7 +178,9 @@ class SaksstatistikkService(
         return if (personInfo.bostedsadresser.isNotEmpty()) {
             "NO"
         } else {
-            personopplysningerService.hentLandkodeUtenlandskBostedsadresse(aktør)
+            personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(
+                aktør
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
@@ -206,7 +206,7 @@ class StønadsstatistikkService(
     } else if (personopplysningerService.hentPersoninfoEnkel(person.aktør).bostedsadresser.isNotEmpty()) {
         "NO"
     } else {
-        val landKode = personopplysningerService.hentLandkodeUtenlandskBostedsadresse(person.aktør)
+        val landKode = personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(person.aktør)
 
         if (landKode == PersonopplysningerService.UKJENT_LANDKODE) {
             logger.info("Sender landkode ukjent til DVH")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -142,7 +142,7 @@ class ClientMocks {
         }
 
         every {
-            mockPersonopplysningerService.hentLandkodeUtenlandskBostedsadresse(any())
+            mockPersonopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(any())
         } returns "NO"
 
         val ukjentId = "43125678910"
@@ -288,7 +288,7 @@ class ClientMocks {
             } returns VergeResponse(false)
 
             every {
-                mockPersonopplysningerService.hentLandkodeUtenlandskBostedsadresse(any())
+                mockPersonopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(any())
             } returns "NO"
 
             val idSlotForHentPersoninfo = slot<Aktør>()
@@ -423,6 +423,7 @@ class ClientMocks {
                             )
                         )
                     )
+
                     mockBarnAutomatiskBehandlingFnr -> personInfo.getValue(id)
                     mockBarnAutomatiskBehandling2Fnr -> personInfo.getValue(id)
                     mockSøkerAutomatiskBehandlingFnr -> personInfo.getValue(id)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -379,7 +379,7 @@ internal class SaksstatistikkServiceTest(
                 1
             )
         )
-        every { personopplysningerService.hentLandkodeUtenlandskBostedsadresse(tilAktør("12345678910")) } returns "SE"
+        every { personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(tilAktør("12345678910")) } returns "SE"
 
         every { behandlingHentOgPersisterService.hentAktivForFagsak(any()) } returns null
 
@@ -400,7 +400,7 @@ internal class SaksstatistikkServiceTest(
             Fagsak(status = FagsakStatus.OPPRETTET, aktør = randomAktørId)
         }
         every { personidentService.hentAktør(any()) } returns randomAktørId
-        every { personopplysningerService.hentLandkodeUtenlandskBostedsadresse(any()) } returns "SE"
+        every { personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(any()) } returns "SE"
 
         every { persongrunnlagService.hentAktiv(any()) } returns lagTestPersonopplysningGrunnlag(
             1,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
@@ -143,7 +143,7 @@ internal class StønadsstatistikkServiceTest(
         every { kompetanseService.hentKompetanser(any()) } returns kompetanseperioder
         every { persongrunnlagService.hentAktivThrows(any()) } returns personopplysningGrunnlag
         every { vedtakService.hentAktivForBehandling(any()) } returns vedtak
-        every { personopplysningerService.hentLandkodeUtenlandskBostedsadresse(any()) } returns "DK"
+        every { personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(any()) } returns "DK"
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(any()) } returns
             andelerTilkjentYtelse
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerServiceTest.kt
@@ -121,20 +121,20 @@ internal class PersonopplysningerServiceTest(
 
     @Test
     fun `hentLandkodeUtenlandskAdresse() skal returnere landkode `() {
-        val landkode = personopplysningerService.hentLandkodeUtenlandskBostedsadresse(tilAktør(ID_MOR))
-        assertThat(landkode).isEqualTo("DK")
+        val landkode = personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(tilAktør(ID_MOR))
+        assertThat(landkode).isEqualTo("GB")
     }
 
     @Test
     fun `hentLandkodeUtenlandskAdresse() skal returnere ZZ hvis ingen landkode `() {
-        val landkode = personopplysningerService.hentLandkodeUtenlandskBostedsadresse(tilAktør(ID_BARN_1))
+        val landkode = personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(tilAktør(ID_BARN_1))
         assertThat(landkode).isEqualTo("ZZ")
     }
 
     @Test
     fun `hentLandkodeUtenlandskAdresse() skal returnere ZZ hvis ingen bostedsadresse `() {
         val landkode =
-            personopplysningerService.hentLandkodeUtenlandskBostedsadresse(tilAktør(ID_MOR_MED_TOM_BOSTEDSADRESSE))
+            personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(tilAktør(ID_MOR_MED_TOM_BOSTEDSADRESSE))
         assertThat(landkode).isEqualTo("ZZ")
     }
 

--- a/src/test/resources/pdl/PdlIntegrasjon/utenlandskAdresseResponse.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/utenlandskAdresseResponse.json
@@ -1,16 +1,14 @@
 {
   "data": {
-
     "person": {
-
       "bostedsadresse": [
         {
           "utenlandskAdresse": {
-            "adressenavnNummer" : "Widbrook Way",
-            "postkode" : "SL68YA",
-            "bySted" : "Maidenhead",
-            "regionDistriktOmraade" : "Berkshire",
-            "landkode" : "DK"
+            "adressenavnNummer": "Widbrook Way",
+            "postkode": "SL68YA",
+            "bySted": "Maidenhead",
+            "regionDistriktOmraade": "Berkshire",
+            "landkode": "GBR"
           }
         }
       ]


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
PDL sin landkode er alpha3, mens man kontrakten til statistikk er alpha2. Nå som man migrerer over EØS så fikk vi valideringsfeil i ba-statistikk om at landkode var for lang.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
