### PR TITLE
[Bug] Filtrer bort perioder som ikke er oppfylt når vi skal lage splitt i vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
@@ -193,7 +193,7 @@ fun Set<PersonResultat>.tilTidslinjeForSplitt(personerIPersongrunnlag: List<Pers
 }
 
 fun PersonResultat.tilTidslinjeForSplittForPerson(fødselsdato: LocalDate, personType: PersonType): Tidslinje<List<VilkårResultat>, Måned> {
-    val tidslinjer = this.vilkårResultater.tilForskjøvetTidslinjerForHvertVilkår(fødselsdato)
+    val tidslinjer = this.vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(fødselsdato)
 
     return tidslinjer.kombiner { alleVilkårOppfyltEllerNull(vilkårResultater = it, personType = personType) }.filtrerIkkeNull().slåSammenLike()
 }
@@ -202,9 +202,9 @@ fun PersonResultat.tilTidslinjeForSplittForPerson(fødselsdato: LocalDate, perso
  * Extention-funksjon som tar inn et sett med vilkårResultater og returnerer en forskjøvet måned-basert tidslinje for hvert vilkår
  * Se readme-fil for utdypende forklaring av logikken for hvert vilkår
  * */
-fun Set<VilkårResultat>.tilForskjøvetTidslinjerForHvertVilkår(fødselsdato: LocalDate): List<Tidslinje<VilkårResultat, Måned>> {
+fun Set<VilkårResultat>.tilForskjøvetTidslinjerForHvertOppfylteVilkår(fødselsdato: LocalDate): List<Tidslinje<VilkårResultat, Måned>> {
     return this.groupBy { it.vilkårType }.map { (vilkår, vilkårResultater) ->
-        val tidslinje = vilkårResultater.tilTidslinje()
+        val tidslinje = vilkårResultater.filter { it.erOppfylt() }.tilTidslinje()
             .tilMånedFraMånedsskifteIkkeNull { innholdSisteDagForrigeMåned, innholdFørsteDagDenneMåned ->
                 when {
                     !innholdSisteDagForrigeMåned.erOppfylt() || !innholdFørsteDagDenneMåned.erOppfylt() -> null

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/PersonResultatTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/PersonResultatTest.kt
@@ -25,7 +25,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvu
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.beskjærPå18År
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilForskjøvetTidslinjerForHvertVilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilForskjøvetTidslinjerForHvertOppfylteVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilFørskjøvetVilkårResultatTidslinjeMap
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilTidslinjeForSplitt
 import org.junit.jupiter.api.Assertions
@@ -393,7 +393,7 @@ class PersonResultatTest {
             maksTom = barnets18årsdag
         )
 
-        val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertVilkår(barnets18årsdag.minusYears(18))
+        val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
         Assertions.assertEquals(5, tidslinjer.size)
 
@@ -445,7 +445,7 @@ class PersonResultatTest {
             maksTom = barnets18årsdag
         )
 
-        val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertVilkår(barnets18årsdag.minusYears(18))
+        val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
         Assertions.assertEquals(5, tidslinjer.size)
 
@@ -496,7 +496,7 @@ class PersonResultatTest {
             maksTom = barnets18årsdag
         )
 
-        val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertVilkår(barnets18årsdag.minusYears(18))
+        val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
         Assertions.assertEquals(5, tidslinjer.size)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10422

Filtrer bort perioder som ikke er oppfylt. Avslåtte perioder er ikke relevant i scenariene hvor funksjonen brukes. Endrer også navn på funksjon for å tydeliggjøre

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
