### PR TITLE
Feature/differanseberegning søkers ytelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/FeatureToggleConfig.kt
@@ -100,6 +100,7 @@ class FeatureToggleConfig(
     }
 
     companion object {
+        const val KAN_DIFFERANSEBEREGNE_SØKERS_YTELSER = "familie-ba-sak.differanseberegn-sokers-ytelser"
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"
         const val SKATTEETATEN_API_EKTE_DATA = "familie-ba-sak.skatteetaten-api-ekte-data-i-respons"
         const val IKKE_STOPP_MIGRERINGSBEHANDLING = "familie-ba-sak.ikke.stopp.migeringsbehandling"
@@ -110,7 +111,8 @@ class FeatureToggleConfig(
             "familie-ba-sak.endringer.validering.migeringsbehandling"
         const val NY_MÅTE_Å_GENERERE_ANDELER_TILKJENT_YTELSE = "familie-ba-sak.behandling.generer-andeler-med-ny-metode"
         const val NY_MÅTE_Å_SPLITTE_VEDTAKSPERIODER = "familie-ba-sak.behandling.ny-metode-for-splitt-vedtaksperioder"
-        const val SJEKK_OM_UTVIDET_ER_ENDRET_BEHANDLINGSRESULTAT = "familie-ba-sak.behandling.behandlingsresultat-utvidet-endret"
+        const val SJEKK_OM_UTVIDET_ER_ENDRET_BEHANDLINGSRESULTAT =
+            "familie-ba-sak.behandling.behandlingsresultat-utvidet-endret"
         const val NY_MÅTE_Å_GENERERE_ATY_BARNA = "familie-ba-sak.behandling.ny-metode-generer-aty-barna"
 
         const val KAN_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND = "familie-ba-sak.behandling.utvidet-eos-sekunderland"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -50,3 +51,15 @@ fun AndelTilkjentYtelse.medPeriode(fraOgMed: YearMonth?, tilOgMed: YearMonth?) =
         stønadFom = fraOgMed ?: MIN_MÅNED,
         stønadTom = tilOgMed ?: MAX_MÅNED
     ).also { versjon = this.versjon }
+
+/**
+ * Ivaretar fom og tom, slik at eventuelle splitter blir med videre.
+ */
+fun Iterable<AndelTilkjentYtelse>.tilTidslinjeForSøkersYtelse(ytelseType: YtelseType) = this
+    .filter { it.erSøkersAndel() }
+    .filter { it.type == ytelseType }
+    .let {
+        tidslinje {
+            it.map { Periode(it.stønadFom.tilTidspunkt(), it.stønadTom.tilTidspunkt(), it) }
+        }
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -1,13 +1,28 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
+import no.nav.familie.ba.sak.common.erTilogMed3ÅrTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilKronerPerValutaenhet
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilMånedligValutabeløp
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.times
 import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.join
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.joinIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerKunVerdiMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullOgIkkeTom
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapIkkeNull
 
 /**
  * ADVARSEL: Muterer TilkjentYtelse
@@ -37,28 +52,131 @@ fun beregnDifferanse(
     val barnasAndeler = barnasDifferanseberegneteAndelTilkjentYtelseTidslinjer.tilAndelerTilkjentYtelse()
     val søkersAndeler = andelerTilkjentYtelse.filter { it.erSøkersAndel() }
 
-    validarSøkersYtelserMotEventueltNegativeAndelerForBarna(søkersAndeler, barnasAndeler)
-
     return søkersAndeler + barnasAndeler
 }
 
-private fun validarSøkersYtelserMotEventueltNegativeAndelerForBarna(
-    søkersAndelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-    barnasAndelerTilkjentYtelse: List<AndelTilkjentYtelse>
-) {
-    val barnasSumNegativeDifferansebeløp = barnasAndelerTilkjentYtelse
-        .map { minOf(it.differanseberegnetPeriodebeløp ?: 0, 0) }
-        .sum()
+/**
+ * ADVARSEL: Muterer TilkjentYtelse
+ * Differanseberegner søkers ytelser, dvs utvidet barnetrygd og småbarnstillegg
+ * Forutsetningen er at barnas andeler allerede er differanseberegnet
+ * Funksjonen returnerer det nye settet av andeler tilkjent ytelse, inklusive barnas
+ */
+fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
+    barna: List<Person>
+): List<AndelTilkjentYtelse> {
+    val utvidetBarnetrygdTidslinje = this.tilTidslinjeForSøkersYtelse(YtelseType.UTVIDET_BARNETRYGD)
+    val småbarnstilleggTidslinje = this.tilTidslinjeForSøkersYtelse(YtelseType.SMÅBARNSTILLEGG)
+    val barnasAndelerTidslinjer = this.tilSeparateTidslinjerForBarna()
 
-    val søkersSumUtbetalingsbeløp = søkersAndelerTilkjentYtelse
-        .map { it.kalkulertUtbetalingsbeløp }
-        .sum()
+    // Lag tidslinjer for hvert barn som inneholder underskuddet fra differanseberegningen på ordinær barnetrygd.
+    // Resultatet er tidslinjer med underskuddet som positivt beløp der det inntreffer
+    val barnasUnderskuddPåDifferanseberegningTidslinjer =
+        barnasAndelerTidslinjer.tilUnderskuddPåDifferanseberegningen()
 
-    if (barnasSumNegativeDifferansebeløp < 0 && søkersSumUtbetalingsbeløp > 0) {
-        TODO(
-            "Søker har småbarnstillegg og/elleer utvidet barnetrygd, " +
-                "samtidig som ett eller flere barn har endt med negative utbetalingsbeløp etter differanseberegning. " +
-                "Det er ikke støttet ennå"
-        )
+    // Vi finner hvor mye hvert barn skal ha som andel av utvidet barnetrygd på hvert tidspunkt.
+    // Det tilsvarer utvidet barnetrygd på et gitt tidspunkt delt på antall barn som har ytelse på det tidspunktet
+    val barnasDelAvUtvidetBarnetrygdTidslinjer =
+        utvidetBarnetrygdTidslinje.fordelForholdsmessigPåBarnasAndeler(barnasAndelerTidslinjer)
+
+    // Vi finner det minste av barnets underskudd og del av utvidet barnetrygd
+    // og summerer resultatet for alle barna
+    val reduksjonUtvidetBarnetrygdTidslinje = minsteAvHver(
+        barnasDelAvUtvidetBarnetrygdTidslinjer,
+        barnasUnderskuddPåDifferanseberegningTidslinjer
+    ).sum()
+
+    // Til slutt oppdaterer vi differanseberegningen på utvidet barnetrygd med reduksjonen
+    val differanseberegnetUtvidetBarnetrygdTidslinje =
+        utvidetBarnetrygdTidslinje.oppdaterDifferanseberegning(reduksjonUtvidetBarnetrygdTidslinje)
+
+    // For hvert barn finner vi ut hvor mye underskudd som gjenstår etter at delen av utvidet barnetrygd er trukket fra
+    val barnasGjenståendeUnderskuddTidslinjer = barnasUnderskuddPåDifferanseberegningTidslinjer
+        .minus(barnasDelAvUtvidetBarnetrygdTidslinjer)
+        .filtrerHverKunVerdi { it > 0 }
+
+    // For hvert barn kombiner andel-tidslinjen med 3-års-tidslinjen. Resultatet er andelene når barna er inntil 3 år
+    val barnasAndelerInntil3ÅrTidslinjer = barnasAndelerTidslinjer.kunAndelerTilOgMed3År(barna)
+
+    // Vi finner hvor mye hvert barn skal ha som andel av småbarnstillegget på hvert tidspunkt.
+    // Det tilsvarer småbarnstillegget på et gitt tidspunkt delt på antall barn under 3 år som har ytelse på det tidspunktet
+    val barnasDelAvSmåbarnstilleggetTidslinjer =
+        småbarnstilleggTidslinje.fordelForholdsmessigPåBarnasAndeler(barnasAndelerInntil3ÅrTidslinjer)
+
+    // Vi finner det minste av barnets underskudd og del av småbarnstillegget
+    // og summerer resultatet for alle barna
+    val reduksjonSmåbarnstilleggTidslinje = minsteAvHver(
+        barnasDelAvSmåbarnstilleggetTidslinjer,
+        barnasGjenståendeUnderskuddTidslinjer
+    ).sum()
+
+    // Til slutt oppdaterer vi differanseberegningen på småbarnstillegget med reduksjonen
+    val differanseberegnetSmåbarnstilleggTidslinje =
+        småbarnstilleggTidslinje.oppdaterDifferanseberegning(reduksjonSmåbarnstilleggTidslinje)
+
+    return this.filter { !it.erSøkersAndel() } +
+        differanseberegnetUtvidetBarnetrygdTidslinje.tilAndelTilkjentYtelse() +
+        differanseberegnetSmåbarnstilleggTidslinje.tilAndelTilkjentYtelse()
+}
+
+fun Tidslinje<AndelTilkjentYtelse, Måned>.fordelForholdsmessigPåBarnasAndeler(
+    barnasAndeler: Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>>
+): Map<Aktør, Tidslinje<Int, Måned>> {
+    val antallAktørerMedYtelseTidslinje =
+        barnasAndeler.values.kombinerUtenNullOgIkkeTom { it.count() }
+
+    val ytelsePerBarnTidslinje =
+        this.kombinerUtenNullMed(antallAktørerMedYtelseTidslinje) { andel, antall ->
+            andel.kalkulertUtbetalingsbeløp / antall
+        }
+
+    return barnasAndeler.kombinerKunVerdiMed(ytelsePerBarnTidslinje) { _, ytelsePerBarn -> ytelsePerBarn }
+}
+
+fun Tidslinje<AndelTilkjentYtelse, Måned>.oppdaterDifferanseberegning(
+    differanseberegnetBeløpTidslinje: Tidslinje<Int, Måned>
+): Tidslinje<AndelTilkjentYtelse, Måned> {
+    return this.kombinerMed(differanseberegnetBeløpTidslinje) { andel, differanseberegning ->
+        when {
+            andel != null && differanseberegning != null && differanseberegning > 0 ->
+                andel.oppdaterDifferanseberegning(differanseberegning.toBigDecimal())
+            else -> andel
+        }
     }
 }
+
+fun Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>>.tilUnderskuddPåDifferanseberegningen() =
+    mapValues { (_, tidslinje) ->
+        tidslinje
+            .mapIkkeNull { innhold -> innhold.differanseberegnetPeriodebeløp }
+            .mapIkkeNull { maxOf(-it, 0) }
+            .filtrer { it != null && it > 0 }
+    }
+
+fun Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>>.kunAndelerTilOgMed3År(barna: List<Person>):
+    Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>> {
+    val barnasErInntil3ÅrTidslinjer = barna.associate { it.aktør to erTilogMed3ÅrTidslinje(it.fødselsdato) }
+
+    // For hvert barn kombiner andel-tidslinjen med 3-års-tidslinjen. Resultatet er andelene når barna er inntil 3 år
+    return this.joinIkkeNull(barnasErInntil3ÅrTidslinjer) { andel, _ -> andel }
+}
+
+fun <K, I : Comparable<I>, T : Tidsenhet> minsteAvHver(
+    aTidslinjer: Map<K, Tidslinje<I, T>>,
+    bTidslinjer: Map<K, Tidslinje<I, T>>
+) = aTidslinjer.joinIkkeNull(bTidslinjer) { a, b -> minOf(a, b) }
+
+fun <K, T : Tidsenhet> Map<K, Tidslinje<Int, T>>.minus(
+    bTidslinjer: Map<K, Tidslinje<Int, T>>
+) = this.join(bTidslinjer) { a, b ->
+    when {
+        a != null && b != null -> a - b
+        else -> a
+    }
+}
+
+fun <K, I, T : Tidsenhet> Map<K, Tidslinje<I, T>>.filtrerHverKunVerdi(
+    filter: (I) -> Boolean
+) = mapValues { (_, tidslinje) -> tidslinje.filtrer { if (it != null) filter(it) else false } }
+
+fun Map<Aktør, Tidslinje<Int, Måned>>.sum() =
+    values.kombinerUtenNullOgIkkeTom { it.sum() }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeFraTidspunkt.kt
@@ -47,7 +47,7 @@ data class Innholdsresultat<I>(
     val verdi
         get() = innhold!!
 
-    fun <R> mapInnhold(mapper: (I?) -> R?): R? = if (this.harInnhold) mapper(verdi) else null
+    fun <R> mapInnhold(mapper: (I?) -> R?): R? = if (this.harInnhold) mapper(innhold) else null
     fun <R> mapVerdi(mapper: (I) -> R): R? = if (this.harVerdi) mapper(verdi) else null
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeJoin.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeJoin.kt
@@ -33,10 +33,80 @@ fun <K, V, H, R, T : Tidsenhet> Map<K, Tidslinje<V, T>>.leftJoin(
     }
 }
 
+/**
+ * Extension-metode for å kombinere to nøkkel-verdi-map'er der verdiene er tidslinjer
+ * Nøkkelen må være av samme type, K, tidslinjene må være i samme tidsenhet (T)
+ * Innholdet i tidslinjene i map'en på venstre side må alle være av typen V
+ * Innholdet i tidslinjene i map'en på høyre side må alle være av typen H
+ * Kombinator-funksjonen kalles med verdiene av fra venstre og høyre tidslinje for samme nøkkel og tidspunkt.
+ * <null> blir sendt som verdier hvis venstre, høyre eller begge tidslinjer mangler verdi for et tidspunkt
+ * Resultatet er en ny map der nøklene er av type K, og tidslinjene har innhold av typen (nullable) R.
+ * Bare nøkler som finnes i begge map'ene vil finnes i den resulterende map'en
+ */
+fun <K, V, H, R, T : Tidsenhet> Map<K, Tidslinje<V, T>>.join(
+    høyreTidslinjer: Map<K, Tidslinje<H, T>>,
+    kombinator: (V?, H?) -> R?
+): Map<K, Tidslinje<R, T>> {
+    val venstreTidslinjer = this
+    val alleNøkler = venstreTidslinjer.keys.intersect(høyreTidslinjer.keys)
+
+    return alleNøkler.associateWith { nøkkel ->
+        val venstreTidslinje = venstreTidslinjer.getOrDefault(nøkkel, TomTidslinje())
+        val høyreTidslinje = høyreTidslinjer.getOrDefault(nøkkel, TomTidslinje())
+
+        venstreTidslinje.kombinerMed(høyreTidslinje, kombinator)
+    }
+}
+
+/**
+ * Extension-metode for å kombinere to nøkkel-verdi-map'er der verdiene er tidslinjer
+ * Nøkkelen må være av samme type, K, tidslinjene må være i samme tidsenhet (T)
+ * Innholdet i tidslinjene i map'en på venstre side må alle være av typen V
+ * Innholdet i tidslinjene i map'en på høyre side må alle være av typen H
+ * Kombinator-funksjonen kalles med verdiene av fra venstre og høyre tidslinje for samme nøkkel og tidspunkt.
+ * Kombinator-funksjonen blir IKKE kalt Hvis venstre, høyre eller begge tidslinjer mangler verdi for et tidspunkt
+ * Resultatet er en ny map der nøklene er av type K, og tidslinjene har innhold av typen (nullable) R.
+ * Bare nøkler som finnes i begge map'ene vil finnes i den resulterende map'en
+ */
+fun <K, V, H, R, T : Tidsenhet> Map<K, Tidslinje<V, T>>.joinIkkeNull(
+    høyreTidslinjer: Map<K, Tidslinje<H, T>>,
+    kombinator: (V, H) -> R?
+): Map<K, Tidslinje<R, T>> {
+    val venstreTidslinjer = this
+    val alleNøkler = venstreTidslinjer.keys.intersect(høyreTidslinjer.keys)
+
+    return alleNøkler.associateWith { nøkkel ->
+        val venstreTidslinje = venstreTidslinjer.getOrDefault(nøkkel, TomTidslinje())
+        val høyreTidslinje = høyreTidslinjer.getOrDefault(nøkkel, TomTidslinje())
+
+        venstreTidslinje.kombinerUtenNullMed(høyreTidslinje, kombinator)
+    }
+}
+
 // TODO: Strengt tatt ikke en leftJoin. Er bare en vanlig kombinerMed, og bruken bør erstattes med det
 fun <V, H, R, T : Tidsenhet> Tidslinje<V, T>.leftJoin(
     høyreTidslinje: Tidslinje<H, T>,
     kombinator: (V, H?) -> R?
 ): Tidslinje<R, T> = this.kombinerMed(høyreTidslinje) { venstre, høyre ->
     venstre?.let { kombinator(venstre, høyre) }
+}
+
+/**
+ * Extension-metode for å kombinere en nøkkel-verdi-map'er der verdiene er tidslinjer, med en enkelt tidslinje
+ * Innholdet i tidslinjene i map'en på venstre side må alle være av typen V
+ * Innholdet i tidslinjen på høyre side er av typen H
+ * Kombinator-funksjonen kalles for hvert tidspunkt med med verdien for det tidspunktet fra høyre tidslinje og
+ * vedien fra den enkelte av venstre tidslinjer etter tur.
+ * Kombinator-funksjonen blir IKKE kalt Hvis venstre, høyre eller begge tidslinjer mangler verdi for et tidspunkt
+ * Resultatet er en ny map der nøklene er av type K, og tidslinjene har innhold av typen (nullable) R.
+ */
+fun <K, V, H, R, T : Tidsenhet> Map<K, Tidslinje<V, T>>.kombinerKunVerdiMed(
+    høyreTidslinje: Tidslinje<H, T>,
+    kombinator: (V, H) -> R?
+): Map<K, Tidslinje<R, T>> {
+    val venstreTidslinjer = this
+
+    return venstreTidslinjer.mapValues { (_, venstreTidslinje) ->
+        venstreTidslinje.kombinerUtenNullMed(høyreTidslinje, kombinator)
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
@@ -1,86 +1,101 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom
 
 /**
  * Extension-metode for å kombinere to tidslinjer
- * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
- * fra minste fraOgMed til største tilOgMed fra begge tidslinjene
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
+ * fra minste fraOgMed() til største tilOgMed() fra begge tidslinjene
  * Tidsenhet (T) må være av samme type
  * Hver av tidslinjene kan ha ulik innholdstype, hhv V og H
  * Kombintor-funksjonen tar inn (nullable) av V og H og returnerer (nullable) R
+ * Kombinator-funksjonen blir ikke kalt hvis begge tidslinjene mangler innhold for tidspunktet
+ * Hvis kombinator-funksjonen returner <null>, antas det at tidslinjen ikke skal ha verdi for tidspunktet
  * Resultatet er en tidslinje med tidsenhet T og innhold R
  */
 fun <V, H, R, T : Tidsenhet> Tidslinje<V, T>.kombinerMed(
     høyreTidslinje: Tidslinje<H, T>,
     kombinator: (V?, H?) -> R?
-): Tidslinje<R, T> {
-    val venstreTidslinje = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(venstreTidslinje, høyreTidslinje) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? =
-            kombinator(
-                venstreTidslinje.innholdForTidspunkt(tidspunkt),
-                høyreTidslinje.innholdForTidspunkt(tidspunkt)
-            )
+): Tidslinje<R, T> = tidsrom(this, høyreTidslinje).tidslinjeFraTidspunkt { tidspunkt ->
+    val venstre = this.innholdsresultatForTidspunkt(tidspunkt)
+    val høyre = høyreTidslinje.innholdsresultatForTidspunkt(tidspunkt)
+
+    when {
+        !(venstre.harInnhold || høyre.harInnhold) -> Innholdsresultat.utenInnhold()
+        else -> kombinator(venstre.innhold, høyre.innhold).tilInnhold()
     }
 }
 
 /**
- * Extension-metode for å kombinere to tidslinjer
- * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
+ * Extension-metode for å kombinere to tidslinjer der begge har verdi
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
  * fra minste fraOgMed til største tilOgMed fra begge tidslinjene
  * Tidsenhet (T) må være av samme type
  * Hver av tidslinjene kan ha ulik innholdstype, hhv V og H
- * Hvis innholdet V eller H er null returneres null
+ * Hvis innholdet V eller H mangler innhold, så vil ikke resulterende tidslinje få innhold for det tidspunktet
  * Kombintor-funksjonen tar ellers V og H og returnerer (nullable) R
+ * Hvis kombinator-funksjonen returner <null>, antas det at tidslinjen ikke skal ha verdi for tidspunktet
  * Resultatet er en tidslinje med tidsenhet T og innhold R
  */
 fun <V, H, R, T : Tidsenhet> Tidslinje<V, T>.kombinerUtenNullMed(
     høyreTidslinje: Tidslinje<H, T>,
     kombinator: (V, H) -> R?
-): Tidslinje<R, T> {
-    val venstreTidslinje = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(venstreTidslinje, høyreTidslinje) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? {
-            val venstre = venstreTidslinje.innholdForTidspunkt(tidspunkt)
-            val høyre = høyreTidslinje.innholdForTidspunkt(tidspunkt)
+): Tidslinje<R, T> = tidsrom(this, høyreTidslinje).tidslinjeFraTidspunkt { tidspunkt ->
+    val venstre = this.innholdsresultatForTidspunkt(tidspunkt)
+    val høyre = høyreTidslinje.innholdsresultatForTidspunkt(tidspunkt)
 
-            return when {
-                venstre == null || høyre == null -> null
-                else -> kombinator(venstre, høyre)
-            }
-        }
+    when {
+        venstre.harVerdi && høyre.harVerdi -> kombinator(venstre.verdi, høyre.verdi).tilVerdi()
+        else -> Innholdsresultat.utenInnhold()
     }
 }
 
 /**
  * Extension-metode for å kombinere liste av tidslinjer
- * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
- * fra minste fraOgMed til største fraOgMed() fra alle tidslinjene
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
+ * fra minste <fraOgMed()> til største <tilOgMed()> fra alle tidslinjene
  * Innhold (I) og tidsenhet (T) må være av samme type
  * Kombintor-funksjonen tar inn Iterable<I> og returner (nullable) R
  * Null-verdier fjernes før de sendes til kombinator-funksjonen, som betyr at en tom iterator kan bli sendt
- * Resultatet er en tidslnije med tidsenhet T og innhold R
+ * Hvis reesultatet fra kombinatoren er null, tolkes det som at det ikke skal være innhold
+ * Resultatet er en tidslinje med tidsenhet T og innhold R
  */
 fun <I, R, T : Tidsenhet> Collection<Tidslinje<I, T>>.kombinerUtenNull(
     listeKombinator: (Iterable<I>) -> R?
-): Tidslinje<R, T> {
-    if (this.isEmpty()) return tidslinje { emptyList() }
-    val tidslinjer = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(tidslinjer) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? =
-            listeKombinator(tidslinjer.map { it.innholdForTidspunkt(tidspunkt) }.filterNotNull())
-    }
+) = tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+    this.map { it.innholdsresultatForTidspunkt(tidspunkt) }
+        .filter { it.harVerdi }
+        .map { it.verdi }
+        .let(listeKombinator).tilVerdi()
 }
 
 /**
  * Extension-metode for å kombinere liste av tidslinjer
- * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
- * fra minste fraOgMed til største fraOgMed() fra alle tidslinjene
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
+ * fra minste <fraOgMed()> til største <tilOgMed()> fra alle tidslinjene
+ * Innhold (I) og tidsenhet (T) må være av samme type
+ * Kombintor-funksjonen tar inn Iterable<I> og returner (nullable) R
+ * Null-verdier fjernes, og listen av verdier sendes til kombinator-funksjonen bare hvis den inneholder verdier
+ * Hvis reesultatet fra kombinatoren er null, tolkes det som at det ikke skal være innhold
+ * Resultatet er en tidslinje med tidsenhet T og innhold R
+ */
+fun <I, R, T : Tidsenhet> Collection<Tidslinje<I, T>>.kombinerUtenNullOgIkkeTom(
+    listeKombinator: (Iterable<I>) -> R?
+) = tidsrom().tidslinjeFraTidspunkt { tidspunkt ->
+    this.map { it.innholdsresultatForTidspunkt(tidspunkt) }
+        .filter { it.harVerdi }
+        .map { it.verdi }
+        .takeIf { it.isNotEmpty() }
+        ?.let(listeKombinator).tilVerdi()
+}
+
+/**
+ * Extension-metode for å kombinere liste av tidslinjer
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
+ * fra minste <fraOgMed()> til største <tilOgMed()> fra alle tidslinjene
  * Innhold (I) og tidsenhet (T) må være av samme type
  * Kombintor-funksjonen tar inn Iterable<I> og returner (nullable) R
  * Resultatet er en tidslinje med tidsenhet T og innhold R
@@ -97,8 +112,8 @@ fun <I, R, T : Tidsenhet> Collection<Tidslinje<I, T>>.kombiner(
 
 /**
  * Extension-metode for å kombinere to tidslinjer
- * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
- * fra minste fraOgMed til største tilOgMed fra begge tidslinjene
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
+ * fra minste <fraOgMed()> til største <tilOgMed()> fra begge tidslinjene
  * Tidsenhet (T) må være av samme type
  * Hver av tidslinjene kan ha ulik innholdstype, hhv V og H
  * Kombintor-funksjonen tar inn tidspunktet og (nullable) av V og H og returnerer (nullable) R
@@ -107,22 +122,18 @@ fun <I, R, T : Tidsenhet> Collection<Tidslinje<I, T>>.kombiner(
 fun <V, H, R, T : Tidsenhet> Tidslinje<V, T>.tidspunktKombinerMed(
     høyreTidslinje: Tidslinje<H, T>,
     kombinator: (Tidspunkt<T>, V?, H?) -> R?
-): Tidslinje<R, T> {
-    val venstreTidslinje = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(venstreTidslinje, høyreTidslinje) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? =
-            kombinator(
-                tidspunkt,
-                venstreTidslinje.innholdForTidspunkt(tidspunkt),
-                høyreTidslinje.innholdForTidspunkt(tidspunkt)
-            )
-    }
+) = tidsrom(this, høyreTidslinje).tidslinjeFraTidspunkt { tidspunkt ->
+    kombinator(
+        tidspunkt,
+        this.innholdsresultatForTidspunkt(tidspunkt).innhold,
+        høyreTidslinje.innholdsresultatForTidspunkt(tidspunkt).innhold
+    ).tilInnhold()
 }
 
 /**
  * Extension-metode for å kombinere tre tidslinjer
- * Kombinasjonen baserer seg på TidslinjeSomStykkerOppTiden, som itererer gjennom alle tidspunktene
- * fra minste fraOgMed til største fraOgMed() fra alle tidslinjene
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
+ * fra minste <fraOgMed()> til største <tilOgMed()> fra alle tidslinjene
  * Tidsenhet (T) må være av samme type
  * Hver av tidslinjene kan ha ulik innholdstype, hhv A, B og C
  * Kombintor-funksjonen tar inn (nullable) av A, B og C og returner (nullable) R
@@ -132,14 +143,10 @@ fun <A, B, C, R, T : Tidsenhet> Tidslinje<A, T>.kombinerMed(
     tidslinjeB: Tidslinje<B, T>,
     tidslinjeC: Tidslinje<C, T>,
     kombinator: (A?, B?, C?) -> R?
-): Tidslinje<R, T> {
-    val tidslinjeA = this
-    return object : TidslinjeSomStykkerOppTiden<R, T>(tidslinjeA, tidslinjeB, tidslinjeC) {
-        override fun finnInnholdForTidspunkt(tidspunkt: Tidspunkt<T>): R? =
-            kombinator(
-                tidslinjeA.innholdForTidspunkt(tidspunkt),
-                tidslinjeB.innholdForTidspunkt(tidspunkt),
-                tidslinjeC.innholdForTidspunkt(tidspunkt)
-            )
-    }
+) = tidsrom(this, tidslinjeB, tidslinjeC).tidslinjeFraTidspunkt { tidspunkt ->
+    kombinator(
+        this.innholdsresultatForTidspunkt(tidspunkt).innhold,
+        tidslinjeB.innholdsresultatForTidspunkt(tidspunkt).innhold,
+        tidslinjeC.innholdsresultatForTidspunkt(tidspunkt).innhold
+    ).tilInnhold()
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
@@ -38,6 +38,8 @@ fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): Collection<Tidspunkt<T>
     else -> (fraOgMed()!!..tilOgMed()!!).toList()
 }
 
+fun <T : Tidsenhet> tidsrom(vararg tidslinjer: Tidslinje<*, T>) = tidslinjer.toList().tidsrom()
+
 private fun <T : Tidsenhet> Iterable<Tidspunkt<T>>.størsteEllerNull() =
     this.reduceOrNull { acc, neste -> størsteAv(acc, neste) }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -1,0 +1,123 @@
+package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.SMÅBARNSTILLEGG
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.UTVIDET_BARNETRYGD
+import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
+import no.nav.familie.ba.sak.kjerne.eøs.util.barn
+import no.nav.familie.ba.sak.kjerne.eøs.util.der
+import no.nav.familie.ba.sak.kjerne.eøs.util.fom
+import no.nav.familie.ba.sak.kjerne.eøs.util.født
+import no.nav.familie.ba.sak.kjerne.eøs.util.har
+import no.nav.familie.ba.sak.kjerne.eøs.util.i
+import no.nav.familie.ba.sak.kjerne.eøs.util.minus
+import no.nav.familie.ba.sak.kjerne.eøs.util.og
+import no.nav.familie.ba.sak.kjerne.eøs.util.tom
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.aug
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
+import org.junit.jupiter.api.Test
+
+class DifferanseberegningSøkersYtelserTest {
+
+    private val Int.kr get() = this
+    private val Int.PLN get() = this * 2
+
+    @Test
+    fun `skal håndtere to barn og utvidet barnetrygd og småbarnstillegg, der det ene barnet har underskudd etter differanseberegning`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.jan(2017)
+        val barn2 = barn født 15.jun(2020)
+        val behandling = lagBehandling()
+
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
+            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
+            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
+            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
+            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1, barn2))
+
+        val forventet = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
+            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
+            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038)) og
+            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2019)) og
+            (søker har 1054.kr minus 1054.kr i UTVIDET_BARNETRYGD fom aug(2019) tom jun(2020)) og
+            (søker har 1054.kr minus 527.kr i UTVIDET_BARNETRYGD fom jul(2020) tom jul(2024)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom jul(2019)) og
+            (søker har 660.kr minus 392.kr i SMÅBARNSTILLEGG fom aug(2019) tom des(2019)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023))
+
+        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+    }
+
+    @Test
+    fun `differanseberegnet ordinær barnetrygd uten at søker har ytelser, skal gi uendrete andeler for barne`() {
+        val barn1 = barn født 13.jan(2017)
+        val barn2 = barn født 15.jun(2020)
+        val behandling = lagBehandling()
+
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
+            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
+            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1, barn2))
+
+        val forventet = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
+            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
+            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+
+        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+    }
+
+    @Test
+    fun `Ingen differranseberegning skal gi uendrete andeler`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.jan(2017)
+        val barn2 = barn født 15.jun(2020)
+        val behandling = lagBehandling()
+
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
+            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
+            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024)) og
+            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1, barn2))
+
+        val forventet = lagInitiellTilkjentYtelse(behandling) der
+            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
+            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024)) og
+            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+
+        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+    }
+
+    @Test
+    fun `Tom tilkjent ytelse og ingen barn skal ikke gi feil`() {
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+
+        val nyeAndeler = tilkjentYtelse.andelerTilkjentYtelse
+            .differanseberegnSøkersYtelser(emptyList())
+
+        assertEqualsUnordered(emptyList(), nyeAndeler)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/TilkjentYtelseDsl.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/TilkjentYtelseDsl.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ba.sak.kjerne.eøs.util
+
+import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import java.math.BigDecimal
+import java.time.YearMonth
+
+/**
+ * Enkel DSL for å bygge TilkjentYtelse. Eksempel på bruk er:
+ *
+ * val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
+ *     (søker har 1054 i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
+ *     (søker har 660 i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
+ *     (søker har 660 i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
+ *     (barn1 har 1054 i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
+ *     (barn1 har 1054 i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
+ *     (barn2 har 1054 i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+ *
+ *     Utenlandsk beløp som gir differanseberegning kan introduseres med <og> eller <minus>, f.eks:
+ *     (barn1 har 1054 og 756 i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022))
+ *     (barn1 har 1054 minus 756 i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022))
+ */
+infix fun TilkjentYtelse.der(andelTilkjentYtelse: AndelTilkjentYtelse): TilkjentYtelse {
+    this.andelerTilkjentYtelse.add(
+        andelTilkjentYtelse.copy(
+            tilkjentYtelse = this,
+            behandlingId = this.behandling.id
+        )
+    )
+    return this
+}
+
+infix fun TilkjentYtelse.og(andelTilkjentYtelse: AndelTilkjentYtelse) = this.der(andelTilkjentYtelse)
+
+infix fun Person.har(sats: Int) = AndelTilkjentYtelse(
+    aktør = this.aktør,
+    sats = sats,
+    kalkulertUtbetalingsbeløp = sats,
+    behandlingId = 0,
+    tilkjentYtelse = lagInitiellTilkjentYtelse(),
+    stønadFom = YearMonth.now(),
+    stønadTom = YearMonth.now(),
+    type = YtelseType.ORDINÆR_BARNETRYGD,
+    prosent = BigDecimal.valueOf(100),
+    nasjonaltPeriodebeløp = sats
+)
+
+infix fun AndelTilkjentYtelse.fom(tidspunkt: Tidspunkt<Måned>) = this.copy(stønadFom = tidspunkt.tilYearMonth())
+infix fun AndelTilkjentYtelse.tom(tidspunkt: Tidspunkt<Måned>) = this.copy(stønadTom = tidspunkt.tilYearMonth())
+infix fun AndelTilkjentYtelse.i(ytelseType: YtelseType) = this.copy(type = ytelseType)
+infix fun AndelTilkjentYtelse.og(utenlandskBeløp: Int) = this.copy(
+    differanseberegnetPeriodebeløp = sats - utenlandskBeløp,
+    kalkulertUtbetalingsbeløp = maxOf(sats - utenlandskBeløp, 0)
+)
+
+infix fun AndelTilkjentYtelse.minus(utenlandskBeløp: Int) = this.og(utenlandskBeløp)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Hvis differanseberegningen av barns ordinære barnetrygd blir negativ, så skal resten kunne komme til fratrekk i utvidet barnetrygd og eventuelt småbarnstillegg. Logikken er beskrevet i [dette Favro-kortet](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8958).

*Bør leses commit for commit*

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Det er en del dupliseing i selve logikken. Landet på å la det bli sånn fordi det opplevdes som hakket lettere å lese, synes jeg.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
