### PR TITLE
Fiksar upålitelege testdata. Det å bruke derivasjonar frå dagens dato i sånne ting gjer at testar som hardkodar inn dato på eit eller anna tidspunkt vil feile,

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/mockserver/domene/RestScenarioPerson.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/mockserver/domene/RestScenarioPerson.kt
@@ -7,6 +7,7 @@ import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import java.time.LocalDate
+import java.time.Month
 import java.time.Period
 
 data class RestScenarioPerson(
@@ -47,8 +48,8 @@ val defaultBostedsadresseHistorikk = mutableListOf(
         )
     ),
     Bostedsadresse(
-        angittFlyttedato = LocalDate.now().minusYears(1),
-        gyldigTilOgMed = null,
+        angittFlyttedato = LocalDate.of(2018, Month.JANUARY, 1),
+        gyldigTilOgMed = LocalDate.now().minusDays(16),
         matrikkeladresse = Matrikkeladresse(
             matrikkelId = 123L,
             bruksenhetsnummer = "H301",


### PR DESCRIPTION
… i sånne ting gjer at testar som hardkodar inn dato på eit eller anna tidspunkt vil feile, og da kastar vi bort mykje ting på å feilsøke. Fristande å hardkode også til og med-dato, men usikker på om vi med det mistar noko, så tar kun fom-dato i denne runden

### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
