### PR TITLE
Utvider tiden på konsistensavstemming avslutttask fra 45min til 2.5timer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragAvsluttTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragAvsluttTask.kt
@@ -19,7 +19,7 @@ import java.time.LocalDateTime
 @TaskStepBeskrivelse(
     taskStepType = KonsistensavstemMotOppdragAvsluttTask.TASK_STEP_TYPE,
     beskrivelse = "Avslutt Konsistensavstemming mot oppdrag",
-    maxAntallFeil = 3
+    maxAntallFeil = 10 // 2.5 time bør være nok tid for å att alle datataskene har kjørt
 )
 class KonsistensavstemMotOppdragAvsluttTask(
     val avstemmingService: AvstemmingService,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Etter optimalisering av løypa, så blir 3 retries litt knapt, siden den må vente på noen tusen tasker skal kjøre ferdig før den blir grønn. Hver retry er 15 min. Utvidet antall retries slik at tasken har 2.5t å kjøre ferdig på.
