### PR TITLE
TEA-3821 Lagt inn støtte for ny delmal Korrigert vedtak med nytt flettefelt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -244,7 +244,8 @@ fun hentHjemmeltekst(
     minimerteVedtaksperioder: List<MinimertVedtaksperiode>,
     sanityBegrunnelser: List<SanityBegrunnelse>,
     opplysningspliktHjemlerSkalMedIBrev: Boolean = false,
-    målform: Målform
+    målform: Målform,
+    vedtakKorrigertHjemmelSkalMedIBrev: Boolean = false
 ): String {
     val sanityStandardbegrunnelser = minimerteVedtaksperioder.flatMap { vedtaksperiode ->
         vedtaksperiode.begrunnelser.mapNotNull { begrunnelse ->
@@ -266,14 +267,18 @@ fun hentHjemmeltekst(
             finnesVedtaksperiodeMedFritekst = minimerteVedtaksperioder.flatMap { it.fritekster }.isNotEmpty()
         )
 
+    val forvaltningsloverHjemler = hentForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev)
+
     val alleHjemlerForBegrunnelser = hentAlleTyperHjemler(
-        hjemlerSeparasjonsavtaleStorbritannia = sanityEøsBegrunnelser.flatMap { it.hjemlerSeperasjonsavtalenStorbritannina }.distinct(),
+        hjemlerSeparasjonsavtaleStorbritannia = sanityEøsBegrunnelser.flatMap { it.hjemlerSeperasjonsavtalenStorbritannina }
+            .distinct(),
         ordinæreHjemler = ordinæreHjemler.distinct(),
         hjemlerFraFolketrygdloven = (sanityStandardbegrunnelser.flatMap { it.hjemlerFolketrygdloven } + sanityEøsBegrunnelser.flatMap { it.hjemlerFolketrygdloven })
             .distinct(),
         hjemlerEØSForordningen883 = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen883 }.distinct(),
         hjemlerEØSForordningen987 = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen987 }.distinct(),
-        målform = målform
+        målform = målform,
+        hjemlerFraForvaltningsloven = forvaltningsloverHjemler
     )
 
     return slåSammenHjemlerAvUlikeTyper(alleHjemlerForBegrunnelser)
@@ -301,7 +306,8 @@ private fun hentAlleTyperHjemler(
     hjemlerFraFolketrygdloven: List<String>,
     hjemlerEØSForordningen883: List<String>,
     hjemlerEØSForordningen987: List<String>,
-    målform: Målform
+    målform: Målform,
+    hjemlerFraForvaltningsloven: List<String>
 ): List<String> {
     val alleHjemlerForBegrunnelser = mutableListOf<String>()
 
@@ -356,6 +362,18 @@ private fun hentAlleTyperHjemler(
     if (hjemlerEØSForordningen987.isNotEmpty()) {
         alleHjemlerForBegrunnelser.add("EØS-forordning 987/2009 artikkel ${Utils.slåSammen(hjemlerEØSForordningen987)}")
     }
+    if (hjemlerFraForvaltningsloven.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+            when (målform) {
+                Målform.NB -> "forvaltningsloven"
+                Målform.NN -> "forvaltningslova"
+            }
+            } ${
+            hjemlerTilHjemmeltekst(hjemler = hjemlerFraForvaltningsloven, lovForHjemmel = "forvaltningsloven")
+            }"
+        )
+    }
     return alleHjemlerForBegrunnelser
 }
 
@@ -383,3 +401,7 @@ fun hentVirkningstidspunkt(opphørsperioder: List<Opphørsperiode>, behandlingId
         ?.tilMånedÅr()
         ?: throw Feil("Fant ikke opphørdato ved generering av dødsfallbrev på behandling $behandlingId")
     )
+
+fun hentForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev: Boolean): List<String> {
+    return if (vedtakKorrigertHjemmelSkalMedIBrev) listOf("35") else emptyList()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Avslag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Avslag.kt
@@ -20,7 +20,8 @@ data class Avslag(
                         saksbehandler = vedtakFellesfelter.saksbehandler,
                         beslutter = vedtakFellesfelter.beslutter
                     ),
-                    hjemmeltekst = vedtakFellesfelter.hjemmeltekst
+                    hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -41,6 +42,7 @@ data class AvslagData(
 
     data class Delmaler(
         val signaturVedtak: SignaturVedtak,
-        val hjemmeltekst: Hjemmeltekst
+        val hjemmeltekst: Hjemmeltekst,
+        val korrigertVedtak: KorrigertVedtakData?
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/FellesDelmaler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/FellesDelmaler.kt
@@ -58,3 +58,12 @@ data class AutoUnderskrift(
         flettefelt(enhet)
     )
 }
+
+data class KorrigertVedtakData(
+    val datoKorrigertVedtak: Flettefelt
+) {
+
+    constructor(datoKorrigertVedtak: String) : this(
+        flettefelt(datoKorrigertVedtak)
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
@@ -20,7 +20,8 @@ data class ForsattInnvilget(
                         saksbehandler = vedtakFellesfelter.saksbehandler,
                         beslutter = vedtakFellesfelter.beslutter
                     ),
-                    hjemmeltekst = vedtakFellesfelter.hjemmeltekst
+                    hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -41,6 +42,7 @@ data class ForsattInnvilgetData(
 
     data class Delmaler(
         val signaturVedtak: SignaturVedtak,
-        val hjemmeltekst: Hjemmeltekst
+        val hjemmeltekst: Hjemmeltekst,
+        val korrigertVedtak: KorrigertVedtakData?
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
@@ -24,7 +24,8 @@ data class Førstegangsvedtak(
                     ),
                     etterbetaling = etterbetaling,
                     hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
-                    etterbetalingInstitusjon = etterbetalingInstitusjon
+                    etterbetalingInstitusjon = etterbetalingInstitusjon,
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -47,6 +48,7 @@ data class FørstegangsvedtakData(
         val signaturVedtak: SignaturVedtak,
         val etterbetaling: Etterbetaling?,
         val hjemmeltekst: Hjemmeltekst,
-        val etterbetalingInstitusjon: EtterbetalingInstitusjon?
+        val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
+        val korrigertVedtak: KorrigertVedtakData?
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/OpphørMedEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/OpphørMedEndring.kt
@@ -26,7 +26,8 @@ data class OpphørMedEndring(
                     hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
                     feilutbetaling = erFeilutbetalingPåBehandling,
                     etterbetaling = etterbetaling,
-                    etterbetalingInstitusjon = etterbetalingInstitusjon
+                    etterbetalingInstitusjon = etterbetalingInstitusjon,
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -49,6 +50,7 @@ data class OpphørMedEndringData(
         val feilutbetaling: Boolean,
         val hjemmeltekst: Hjemmeltekst,
         val etterbetaling: Etterbetaling?,
-        val etterbetalingInstitusjon: EtterbetalingInstitusjon?
+        val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
+        val korrigertVedtak: KorrigertVedtakData?
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Opphørt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Opphørt.kt
@@ -22,7 +22,8 @@ data class Opphørt(
                         beslutter = vedtakFellesfelter.beslutter
                     ),
                     hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
-                    feilutbetaling = erFeilutbetalingPåBehandling
+                    feilutbetaling = erFeilutbetalingPåBehandling,
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -44,6 +45,7 @@ data class OpphørtData(
     data class Delmaler(
         val signaturVedtak: SignaturVedtak,
         val feilutbetaling: Boolean,
-        val hjemmeltekst: Hjemmeltekst
+        val hjemmeltekst: Hjemmeltekst,
+        val korrigertVedtak: KorrigertVedtakData?
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
@@ -29,7 +29,8 @@ data class VedtakEndring(
                     klage = erKlage,
                     klageInstitusjon = erKlage,
                     feilutbetaling = erFeilutbetalingPåBehandling,
-                    etterbetalingInstitusjon = etterbetalingInstitusjon
+                    etterbetalingInstitusjon = etterbetalingInstitusjon,
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -55,6 +56,7 @@ data class EndringVedtakData(
         val hjemmeltekst: Hjemmeltekst,
         val klage: Boolean,
         val klageInstitusjon: Boolean,
-        val etterbetalingInstitusjon: EtterbetalingInstitusjon?
+        val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
+        val korrigertVedtak: KorrigertVedtakData?
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Vedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Vedtaksbrev.kt
@@ -43,5 +43,6 @@ data class VedtakFellesfelter(
     val søkerFødselsnummer: String,
     val perioder: List<BrevPeriode>,
     val organisasjonsnummer: String? = null,
-    val gjelder: String? = null
+    val gjelder: String? = null,
+    val korrigertVedtakData: KorrigertVedtakData? = null
 )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Lagt inn støtte for ny delmal Korrigert vedtak med nytt flettefelt i vedtaksbrev. Delmalen skal kunne brukes i alle versjoner av vedtaksbrav (ikkje autobrev), og teksten skal være utformet slik at same delmal også kan brukes for institusjon.

Favro-kort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3821

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
