### PR TITLE
Bugfix/korrekt opprydding i differanseberegning av søkers ytelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -64,8 +64,13 @@ fun beregnDifferanse(
 fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
     barna: List<Person>
 ): List<AndelTilkjentYtelse> {
+    // Ta bort eventuell eksisterende differanseberegning, slik at kalkulertUtbetalingsbeløp er nasjonal sats
     val utvidetBarnetrygdTidslinje = this.tilTidslinjeForSøkersYtelse(YtelseType.UTVIDET_BARNETRYGD)
+        .utenDifferanseberegning()
+
     val småbarnstilleggTidslinje = this.tilTidslinjeForSøkersYtelse(YtelseType.SMÅBARNSTILLEGG)
+        .utenDifferanseberegning()
+
     val barnasAndelerTidslinjer = this.tilSeparateTidslinjerForBarna()
 
     // Lag tidslinjer for hvert barn som inneholder underskuddet fra differanseberegningen på ordinær barnetrygd.

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.join
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.joinIkkeNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerKunVerdiMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullOgIkkeTom
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
@@ -135,14 +134,6 @@ fun Tidslinje<AndelTilkjentYtelse, Måned>.fordelForholdsmessigPåBarnasAndeler(
         }
 
     return barnasAndeler.kombinerKunVerdiMed(ytelsePerBarnTidslinje) { _, ytelsePerBarn -> ytelsePerBarn }
-}
-
-fun Tidslinje<AndelTilkjentYtelse, Måned>.oppdaterDifferanseberegning(
-    differanseberegnetBeløpTidslinje: Tidslinje<Int, Måned>
-): Tidslinje<AndelTilkjentYtelse, Måned> {
-    return this.kombinerMed(differanseberegnetBeløpTidslinje) { andel, differanseberegning ->
-        andel.oppdaterDifferanseberegning(differanseberegning?.toBigDecimal())
-    }
 }
 
 fun Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>>.tilUnderskuddPåDifferanseberegningen() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -136,11 +136,7 @@ fun Tidslinje<AndelTilkjentYtelse, Måned>.oppdaterDifferanseberegning(
     differanseberegnetBeløpTidslinje: Tidslinje<Int, Måned>
 ): Tidslinje<AndelTilkjentYtelse, Måned> {
     return this.kombinerMed(differanseberegnetBeløpTidslinje) { andel, differanseberegning ->
-        when {
-            andel != null && differanseberegning != null && differanseberegning > 0 ->
-                andel.oppdaterDifferanseberegning(differanseberegning.toBigDecimal())
-            else -> andel
-        }
+        andel.oppdaterDifferanseberegning(differanseberegning?.toBigDecimal())
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -5,6 +5,8 @@ import no.nav.familie.ba.sak.common.multipliser
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapIkkeNull
 import java.math.BigDecimal
@@ -66,3 +68,11 @@ private fun AndelTilkjentYtelse.utenDifferanseberegning(): AndelTilkjentYtelse {
 
 fun <T : Tidsenhet> Tidslinje<AndelTilkjentYtelse, T>.utenDifferanseberegning() =
     mapIkkeNull { it.utenDifferanseberegning() }
+
+fun Tidslinje<AndelTilkjentYtelse, Måned>.oppdaterDifferanseberegning(
+    differanseberegnetBeløpTidslinje: Tidslinje<Int, Måned>
+): Tidslinje<AndelTilkjentYtelse, Måned> {
+    return this.kombinerMed(differanseberegnetBeløpTidslinje) { andel, differanseberegning ->
+        andel.oppdaterDifferanseberegning(differanseberegning?.toBigDecimal())
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -4,6 +4,9 @@ import no.nav.familie.ba.sak.common.del
 import no.nav.familie.ba.sak.common.multipliser
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapIkkeNull
 import java.math.BigDecimal
 
 fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal): BigDecimal =
@@ -60,3 +63,6 @@ private fun AndelTilkjentYtelse.utenDifferanseberegning(): AndelTilkjentYtelse {
         differanseberegnetPeriodebeløp = null
     )
 }
+
+fun <T : Tidsenhet> Tidslinje<AndelTilkjentYtelse, T>.utenDifferanseberegning() =
+    mapIkkeNull { it.utenDifferanseberegning() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -148,6 +148,30 @@ class DifferanseberegningSøkersYtelserTest {
     }
 
     @Test
+    fun `Søkers andel som har differanseberegning, men underskuddet reduseres, skal få oppdatert differanseberegningen`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.jan(2017)
+        val behandling = lagBehandling()
+
+        // Satsene er ikke riktige, men enklere å jobbe med
+        // 1 PLN = 2 kr
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1000.kr og 900.PLN i ORDINÆR_BARNETRYGD fom mai(2017) tom jul(2024)) og
+            (søker har 1000.kr minus 1000.kr i UTVIDET_BARNETRYGD fom jun(2017) tom jul(2021)) og
+            (søker har 600.kr minus 400.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019))
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1))
+
+        val forventet = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1000.kr og 900.PLN i ORDINÆR_BARNETRYGD fom mai(2017) tom jul(2024)) og
+            (søker har 1000.kr minus 400.PLN i UTVIDET_BARNETRYGD fom jun(2017) tom jul(2021)) og
+            (søker har 600.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019))
+
+        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+    }
+
+    @Test
     fun `Skal tåle perioder der underskuddet på differanseberegning er større enn alle tilkjente ytelser`() {
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.jan(2019)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -23,6 +23,8 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.okt
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.sep
 import org.junit.jupiter.api.Test
 
 class DifferanseberegningSøkersYtelserTest {
@@ -119,5 +121,55 @@ class DifferanseberegningSøkersYtelserTest {
             .differanseberegnSøkersYtelser(emptyList())
 
         assertEqualsUnordered(emptyList(), nyeAndeler)
+    }
+
+    @Test
+    fun `Søkers andel som har hatt differanseberegning, men ikke skal ha det lenger, skal fjerne differanseberegningen`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.jan(2017)
+        val behandling = lagBehandling()
+
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
+            (søker har 1054.kr og 30.PLN i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
+            (søker har 660.kr og 40.PLN i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
+            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024))
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1))
+
+        val forventet = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024)) og
+            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023))
+
+        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+    }
+
+    @Test
+    fun `Skal tåle perioder der underskuddet på differanseberegning er større enn alle tilkjente ytelser`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.jan(2019)
+        val behandling = lagBehandling()
+
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1054.kr og 1500.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2020)) og
+            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2020) tom jul(2025)) og
+            (søker har 1054.kr i UTVIDET_BARNETRYGD fom sep(2019) tom jul(2024)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom okt(2019) tom des(2021))
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1))
+
+        val forventet = lagInitiellTilkjentYtelse(behandling) der
+            (barn1 har 1054.kr og 1500.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2020)) og
+            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2020) tom jul(2025)) og
+            (søker har 1054.kr minus 1054.kr i UTVIDET_BARNETRYGD fom sep(2019) tom jul(2020)) og
+            (søker har 1054.kr i UTVIDET_BARNETRYGD fom aug(2020) tom jul(2024)) og
+            (søker har 660.kr minus 660.kr i SMÅBARNSTILLEGG fom okt(2019) tom jul(2020)) og
+            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2020) tom des(2021))
+
+        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Hvis søkers ytelser allerede er differanseberegnet, kan det oppstå feil når vi skal beregne på nytt. Denne fiksen gjør to ting:
* Fjerner eventuelt eksisterende differanseberegning før beregning
* Gjennomfører differanseberegningen uansett

_Bør leses commit for commit_

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Endringen betyr at alle søkers ytelser vil gå gjennom denne koden og få nye andeler (ofte identiske med de som ble sendt inn) underveis, tilsvarende som for barnas ytelse. Det innebærer en større risiko enn forrige versjon (med feil).

Riskoen som introduseres skyldes at `TilkjentYtelse` er under kontroll av JPA, og at manipulering av andelene kan skape uheldige sideeffekter. _Kan_ jo ta en ny runde på om det er mulig å unngå å treffe denne koden hvis differanseberegning ikke er relevant. Utfordringen jeg har, er at vi må håndtere tilfellet der differanseberegning _var_ relevant, men ikke lenger er det. I praksis tror jeg det betyr at en god del av differanseberegningen må kjøres uansett. 

Denne koden introduserer egentlig ikke noe nytt, siden barnas andeler har gått gjennom det samme (altså at andeler legges til, fjernes og slås sammen) en god stund. Dermed burde risikoen være liten. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
