### PR TITLE
Tillatt migrering av saker med opphørsgrunn 0, men hvor opphørtFom er satt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -285,13 +285,20 @@ class MigreringService(
             kastOgTellMigreringsFeil(MigreringsfeilType.ÅPEN_SAK_INFOTRYGD)
         }
 
-        val ikkeOpphørteSaker = ferdigBehandledeSaker.sortedByDescending { it.iverksattdato }
+        var ikkeOpphørteSaker = ferdigBehandledeSaker.sortedByDescending { it.iverksattdato }
             .filter {
                 it.stønad != null && (it.stønad!!.opphørsgrunn == "0" || it.stønad!!.opphørsgrunn.isNullOrEmpty())
             }
 
         if (ikkeOpphørteSaker.size > 1) {
-            kastOgTellMigreringsFeil(MigreringsfeilType.FLERE_LØPENDE_SAKER_INFOTRYGD)
+            ikkeOpphørteSaker = ikkeOpphørteSaker.filter {
+                it.stønad!!.opphørtFom != null && it.stønad!!.opphørtFom == "000000"
+            }
+            if (ikkeOpphørteSaker.size > 1) {
+                kastOgTellMigreringsFeil(MigreringsfeilType.FLERE_LØPENDE_SAKER_INFOTRYGD)
+            }
+            logger.info("Filtrerte bort saker med opphørtFom satt men med opphørsgrunn 0")
+            secureLog.info("Filtrerte bort saker med opphørtFom satt men med opphørsgrunn 0 for ident=$personIdent")
         }
 
         if (ikkeOpphørteSaker.isEmpty()) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Endringer i flere løpende saker sjekken etter diskusjon med Tore

Har sett litt på dette. Problemet er nok at vi har hatt en feil i Infotrygd, hvor det IKKE er satt opphørsgrunn.
Spesielt i august 2020; det finnes 2.020 tilfeller hvor Opphørsdato (B20_OPPHOERT_VFOM) er satt, men ikke B20_OPPHORSGRUNN.
I tillegg har vi 12 andre slengere med samme problem.
 
I det konkrete eksemplet er det sak A07 du finner ekstra på grunn av dette. Både B20_OPPHOERT_VFOM og B20_OPPHOERT_IVER  inneholder ‘092020’, men B20_OPPHORSGRUNN er altså feilaktig 0.
 
Er det mulig for deg å endre testen, slik at du kun sjekker på B20_OPPHOERT_VFOM, IKKE på B20_OPPHORSGRUNN???
I så fall tror jeg mange flere kan migreres maskinelt uten problemer.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇