### PR TITLE
Eksponerer tilbakestillBehandlingTilBehandlingsresultatService

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelController.kt
@@ -114,4 +114,23 @@ class EndretUtbetalingAndelController(
             )
         )
     }
+
+    @PostMapping(path = ["/{behandlingId}/tilbakestill"])
+    fun tilbakestillBehandlingTilBehandlingsresultat(
+        @PathVariable behandlingId: Long
+    ): ResponseEntity<Ressurs<String>> {
+        tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.UPDATE)
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "Opprett endretutbetalingandel"
+        )
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+
+        tilbakestillBehandlingTilBehandlingsresultatService
+            .tilbakestillBehandlingTilBehandlingsresultat(behandlingId = behandling.id)
+
+        return ResponseEntity.ok(
+            Ressurs.success("OK")
+        )
+    }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Trenger å manuelt kjøre tilbakestillBehandlingTilBehandlingsresultat på en sak uten utvidetBehandlingService                   .lagRestUtvidetBehandling(behandlingId = behandling.id) kalles for en saken rett etterpå for å rette opp en sak manuelt
