### PR TITLE
Fjerne duplikate begrunnelser fra forhåndsvisning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -101,7 +101,7 @@ class VedtaksperiodeMedBegrunnelserController(
     }
 
     @GetMapping("/brevbegrunnelser/{vedtaksperiodeId}")
-    fun genererBrevBegrunnelserForPeriode(@PathVariable vedtaksperiodeId: Long): ResponseEntity<Ressurs<List<String>>> {
+    fun genererBrevBegrunnelserForPeriode(@PathVariable vedtaksperiodeId: Long): ResponseEntity<Ressurs<Set<String>>> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.VEILEDER,
             handling = "hente genererte begrunnelser"
@@ -116,7 +116,7 @@ class VedtaksperiodeMedBegrunnelserController(
             }
         }
 
-        return ResponseEntity.ok(Ressurs.Companion.success(begrunnelser))
+        return ResponseEntity.ok(Ressurs.Companion.success(begrunnelser.toSet()))
     }
 
     /*


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Gjør om listen med begrunnelser fra liste til sett for å fjerne identiske begrunnelser.
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10271

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Denne endringen påvirker kun forhåndsvisningen av begrunnelsene. For å fjerne duplikater i brevet er det gjort egen endring i familie-brev. Se egen PR ().

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### Bilder
| Før | Etter    | 
| :---:   | :---: | 
| <img width="798" alt="image" src="https://user-images.githubusercontent.com/46678893/204303891-208fc154-b92f-49d5-8d3f-3bfee467b08b.png"> | <img width="687" alt="image" src="https://user-images.githubusercontent.com/46678893/204304092-08c22242-425c-4c4b-96cd-ee998484d402.png">   | 
