### PR TITLE
Inkludere institusjon-informasjon i responsen HentFagsystemsbehandlingRespons når ba-sak mottar ein HentFagsystemsbehandlingRequest

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/FagsystemsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/FagsystemsbehandlingService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
+import no.nav.familie.ba.sak.kjerne.tilbakekreving.hentTilbakekrevingInstitusjon
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.statistikk.producer.KafkaProducer
 import no.nav.familie.kontrakter.felles.tilbakekreving.Faktainfo
@@ -66,7 +67,8 @@ class FagsystemsbehandlingService(
             enhetId = arbeidsfordeling.behandlendeEnhetId,
             enhetsnavn = arbeidsfordeling.behandlendeEnhetNavn,
             revurderingsvedtaksdato = aktivVedtak.vedtaksdato!!.toLocalDate(),
-            faktainfo = faktainfo
+            faktainfo = faktainfo,
+            institusjon = hentTilbakekrevingInstitusjon(behandling.fagsak)
         )
 
         return HentFagsystemsbehandlingRespons(hentFagsystemsbehandling = hentFagsystemsbehandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
@@ -6,8 +6,6 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
-import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
@@ -23,7 +21,6 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingstype
 import no.nav.familie.kontrakter.felles.tilbakekreving.FeilutbetaltePerioderDto
 import no.nav.familie.kontrakter.felles.tilbakekreving.ForhåndsvisVarselbrevRequest
-import no.nav.familie.kontrakter.felles.tilbakekreving.Institusjon
 import no.nav.familie.kontrakter.felles.tilbakekreving.OpprettManueltTilbakekrevingRequest
 import no.nav.familie.kontrakter.felles.tilbakekreving.OpprettTilbakekrevingRequest
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
@@ -100,7 +97,7 @@ class TilbakekrevingService(
 
         val persongrunnlag = persongrunnlagService.hentAktivThrows(behandlingId)
         val arbeidsfordeling = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId)
-        val institusjon = hentInstitusjon(vedtak.behandling.fagsak)
+        val institusjon = hentTilbakekrevingInstitusjon(vedtak.behandling.fagsak)
         val verge = hentVerge(vedtak.behandling.verge?.ident)
 
         return tilbakekrevingKlient.hentForhåndsvisningVarselbrev(
@@ -150,7 +147,7 @@ class TilbakekrevingService(
         val tilbakekreving = tilbakekrevingRepository.findByBehandlingId(behandling.id)
             ?: throw Feil("Fant ikke tilbakekreving på behandling ${behandling.id}")
 
-        val institusjon = hentInstitusjon(behandling.fagsak)
+        val institusjon = hentTilbakekrevingInstitusjon(behandling.fagsak)
         val verge = hentVerge(behandling.verge?.ident)
 
         return OpprettTilbakekrevingRequest(
@@ -204,17 +201,6 @@ class TilbakekrevingService(
                 frontendFeilmelding = "Av tekniske årsaker så kan ikke behandling opprettes. Kontakt brukerstøtte for å rapportere feilen."
             )
         }
-    }
-
-    private fun hentInstitusjon(fagsak: Fagsak): Institusjon? {
-        var institusjon: Institusjon? = null
-        if (fagsak.type == FagsakType.INSTITUSJON) {
-            requireNotNull(
-                fagsak.institusjon
-            ) { "Fagsaktype er institusjon, men institusjon finnes ikke på fagsak: ${fagsak.id}" }
-            institusjon = Institusjon(organisasjonsnummer = fagsak.institusjon!!.orgNummer)
-        }
-        return institusjon
     }
 
     private fun hentVerge(vergeIdent: String?): Verge? {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtil.kt
@@ -5,11 +5,14 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.simulering.domene.SimuleringsPeriode
 import no.nav.familie.ba.sak.kjerne.simulering.domene.ØkonomiSimuleringMottaker
 import no.nav.familie.ba.sak.kjerne.simulering.vedtakSimuleringMottakereTilRestSimulering
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.domene.Tilbakekreving
 import no.nav.familie.kontrakter.felles.tilbakekreving.Faktainfo
+import no.nav.familie.kontrakter.felles.tilbakekreving.Institusjon
 import no.nav.familie.kontrakter.felles.tilbakekreving.Periode
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.kontrakter.felles.tilbakekreving.Varsel
@@ -34,7 +37,8 @@ fun validerVerdierPåRestTilbakekreving(restTilbakekreving: RestTilbakekreving?,
 fun slåsammenNærliggendeFeilutbtalingPerioder(simuleringsPerioder: List<SimuleringsPeriode>): List<Periode> {
     val perioder: MutableList<Periode> = mutableListOf()
 
-    val sortedSimuleringsPerioder = simuleringsPerioder.sortedBy { it.fom }.filter { it.feilutbetaling != BigDecimal.ZERO }
+    val sortedSimuleringsPerioder =
+        simuleringsPerioder.sortedBy { it.fom }.filter { it.feilutbetaling != BigDecimal.ZERO }
     var aktuellFom: LocalDate = sortedSimuleringsPerioder.first().fom
     var aktuellTom: LocalDate = sortedSimuleringsPerioder.first().tom
 
@@ -73,3 +77,14 @@ fun hentFaktainfoForTilbakekreving(behandling: Behandling, tilbakekreving: Tilba
         tilbakekrevingsvalg = tilbakekreving.valg,
         konsekvensForYtelser = emptySet()
     )
+
+fun hentTilbakekrevingInstitusjon(fagsak: Fagsak): Institusjon? {
+    var institusjon: Institusjon? = null
+    if (fagsak.type == FagsakType.INSTITUSJON) {
+        requireNotNull(
+            fagsak.institusjon
+        ) { "Fagsaktype er institusjon, men institusjon finnes ikke på fagsak: ${fagsak.id}" }
+        institusjon = Institusjon(organisasjonsnummer = fagsak.institusjon!!.orgNummer)
+    }
+    return institusjon
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dersom saksbehandler velger å opprette tilbakekrevingsbehandling manuelt (frå menyvalget  "Opprett behandling" med type "Tilbakekreving" i ba-sak) før denne oppgåven er gjort, så vil behandlingen opprettast som ein behandling på bruker og ikkje institusjon.

Dersom kravgrunnlaget, som vart opprettet når revurdering med feilutbetaling vart vedtatt, har ligget i "innboksen" i familie-tilbake i 8 veker, så blir kravgrunnlaget automatisk lest inn og tilbakekrevingsbehandling oppretta, og behandling vil bli opprettet feil, som beskrivet over.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
