### PR TITLE
Bruker GitHub Actions sin innebygde mekanisme for å avbryte pågåande jobbar heller enn å bruke tredjeparten vi bruker no

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,7 +7,7 @@ env:
   IMAGE: ghcr.io/navikt/familie-ba-sak:${{ github.sha }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -5,17 +5,12 @@ on:
 
 env:
   IMAGE: ghcr.io/navikt/familie-ba-sak:${{ github.sha }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  avslutt-andre-workflows-samme-branch:
-    name: Avslutt andre workflows på samme branch
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
   ktlint:
     name: Ktlint
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
GitHub har no støtte for å avbryte samtidig pågåande bygg for samme grein, som vi kan ta i bruk heller enn å bruke eit tredjepartsbibliotek for det.

Det kjens både tryggare frå eit vedlikehaldsperspektiv og frå eit tryggleiksperspektiv

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9791)


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
