### PR TITLE
Sletter toggles for migrering som ikke er nødvendig lenger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -22,8 +22,6 @@ class FeatureToggleConfig {
         const val KAN_GENERERE_UTBETALINGSOPPDRAG_NY = "familie-ba-sak.generer.utbetalingsoppdrag.ny"
         const val KAN_GENERERE_UTBETALINGSOPPDRAG_NY_VALIDERING =
             "familie-ba-sak.generer.utbetalingsoppdrag.ny.validering"
-        const val KAN_MIGRERE_EØS_PRIMÆRLAND_ORDINÆR = "familie-ba-sak.migrer.or-eu"
-        const val KAN_MIGRERE_EØS_PRIMÆRLAND_UTVIDET = "familie-ba-sak.migrer.ut-eu"
 
         const val SKAL_KUNNE_KORRIGERE_VEDTAK = "familie-ba-sak.kunne-korrigere-vedtak"
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.domene.MigreringResponseDto
@@ -317,21 +316,11 @@ class MigreringService(
                 BehandlingUnderkategori.UTVIDET
             }
 
-            (
-                sak.valg == "OR" && sak.undervalg == "EU" && featureToggleService.isEnabled(
-                    FeatureToggleConfig.KAN_MIGRERE_EØS_PRIMÆRLAND_ORDINÆR,
-                    false
-                )
-                ) -> {
+            (sak.valg == "OR" && sak.undervalg == "EU") -> {
                 BehandlingUnderkategori.ORDINÆR
             }
 
-            (
-                sak.valg == "UT" && sak.undervalg == "EU" && featureToggleService.isEnabled(
-                    FeatureToggleConfig.KAN_MIGRERE_EØS_PRIMÆRLAND_UTVIDET,
-                    false
-                )
-                ) -> {
+            (sak.valg == "UT" && sak.undervalg == "EU") -> {
                 BehandlingUnderkategori.UTVIDET
             }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Rydde PR: Fjerner toggles for migrering som man ikke trenger lenger
