### PR TITLE
Ny implementasjon av differanseberegning av søkers ytelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.config
 
 class FeatureToggleConfig {
     companion object {
-        const val KAN_DIFFERANSEBEREGNE_SØKERS_YTELSER = "familie-ba-sak.differanseberegn-sokers-ytelser"
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"
         const val SKATTEETATEN_API_EKTE_DATA = "familie-ba-sak.skatteetaten-api-ekte-data-i-respons"
         const val IKKE_STOPP_MIGRERINGSBEHANDLING = "familie-ba-sak.ikke.stopp.migeringsbehandling"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -66,8 +66,23 @@ private fun AndelTilkjentYtelse.utenDifferanseberegning(): AndelTilkjentYtelse {
     )
 }
 
+/**
+ * Gjør et forsøk på fjerne differanseberegning på andelen, samtidig som tidligere, funksjonelle splitter bevares
+ * Det kan være en funksjonell grunn til at en splitt finnes, selv om nabo-andelene ellers like, f.eks
+ * endring i overgangsstønad, som ikke fører til endring i småbarnstillegget. Splitten er nødvendig for riktige vedtaksperioder
+ * Splitten opprettholdes når fom og tom er satt på andelen og er forskjellig fra fom og tom på nabo-andelen. Det vil gjelde søkers ytelser
+ * Ved å sette fom og tom til <null> på alle andeler som har differanseberegning, vil naboer slås sammen hvis de ellers er like
+ * Det er en potensiell bug her: Det er en mulighet for at en funksjonell splitt i andeler
+ * sammenfaller med splitt pga differanseberegning, og blir fjernet
+ * Det beste hadde vært om andelene IKKE inneholdt splitter av denne typen, men at ekstra splitter ble utledet der de trengs
+ */
 fun <T : Tidsenhet> Tidslinje<AndelTilkjentYtelse, T>.utenDifferanseberegning() =
-    mapIkkeNull { it.utenDifferanseberegning() }
+    mapIkkeNull {
+        when {
+            it.differanseberegnetPeriodebeløp != null -> it.medPeriode(null, null)
+            else -> it
+        }
+    }.mapIkkeNull { it.utenDifferanseberegning() }
 
 fun Tidslinje<AndelTilkjentYtelse, Måned>.oppdaterDifferanseberegning(
     differanseberegnetBeløpTidslinje: Tidslinje<BigDecimal, Måned>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -85,9 +85,9 @@ fun <T : Tidsenhet> Tidslinje<AndelTilkjentYtelse, T>.utenDifferanseberegning() 
     }.mapIkkeNull { it.utenDifferanseberegning() }
 
 fun Tidslinje<AndelTilkjentYtelse, Måned>.oppdaterDifferanseberegning(
-    differanseberegnetBeløpTidslinje: Tidslinje<BigDecimal, Måned>
+    utenlandskBeløpINorskeKronerTidslinje: Tidslinje<BigDecimal, Måned>
 ): Tidslinje<AndelTilkjentYtelse, Måned> {
-    return this.kombinerMed(differanseberegnetBeløpTidslinje) { andel, differanseberegning ->
-        andel.oppdaterDifferanseberegning(differanseberegning)
+    return this.kombinerMed(utenlandskBeløpINorskeKronerTidslinje) { andel, utenlandskBeløpINorskeKroner ->
+        andel.oppdaterDifferanseberegning(utenlandskBeløpINorskeKroner)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -70,9 +70,9 @@ fun <T : Tidsenhet> Tidslinje<AndelTilkjentYtelse, T>.utenDifferanseberegning() 
     mapIkkeNull { it.utenDifferanseberegning() }
 
 fun Tidslinje<AndelTilkjentYtelse, Måned>.oppdaterDifferanseberegning(
-    differanseberegnetBeløpTidslinje: Tidslinje<Int, Måned>
+    differanseberegnetBeløpTidslinje: Tidslinje<BigDecimal, Måned>
 ): Tidslinje<AndelTilkjentYtelse, Måned> {
     return this.kombinerMed(differanseberegnetBeløpTidslinje) { andel, differanseberegning ->
-        andel.oppdaterDifferanseberegning(differanseberegning?.toBigDecimal())
+        andel.oppdaterDifferanseberegning(differanseberegning)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -104,7 +104,7 @@ class TilpassDifferanseberegningSøkersYtelserService(
     private val featureToggleService: FeatureToggleService
 ) : BarnasDifferanseberegningEndretAbonnent {
     override fun barnasDifferanseberegningEndret(tilkjentYtelse: TilkjentYtelse) {
-        if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_DIFFERANSEBEREGNE_SØKERS_YTELSER, false)) {
+        if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_BEHANDLE_UTVIDET_EØS_SEKUNDÆRLAND, false)) {
             val oppdaterteAndeler = tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 persongrunnlagService.hentBarna(tilkjentYtelse.behandling.id),
                 kompetanseRepository.finnFraBehandlingId(tilkjentYtelse.behandling.id)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -3,114 +3,154 @@ package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.common.tilfeldigPerson
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.SMÅBARNSTILLEGG
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.UTVIDET_BARNETRYGD
-import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ba.sak.kjerne.eøs.util.TilkjentYtelseBuilder
 import no.nav.familie.ba.sak.kjerne.eøs.util.barn
-import no.nav.familie.ba.sak.kjerne.eøs.util.der
-import no.nav.familie.ba.sak.kjerne.eøs.util.fom
 import no.nav.familie.ba.sak.kjerne.eøs.util.født
-import no.nav.familie.ba.sak.kjerne.eøs.util.har
-import no.nav.familie.ba.sak.kjerne.eøs.util.i
-import no.nav.familie.ba.sak.kjerne.eøs.util.minus
-import no.nav.familie.ba.sak.kjerne.eøs.util.og
-import no.nav.familie.ba.sak.kjerne.eøs.util.tom
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.aug
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.KompetanseBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.okt
-import no.nav.familie.ba.sak.kjerne.tidslinje.util.sep
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class DifferanseberegningSøkersYtelserTest {
 
-    private val Int.kr get() = this
-    private val Int.PLN get() = this * 2
-
     @Test
-    fun `skal håndtere to barn og utvidet barnetrygd og småbarnstillegg, der det ene barnet har underskudd etter differanseberegning`() {
+    fun `skal håndtere tre barn og utvidet barnetrygd og småbarnstillegg, der alle barna har underskudd i differanseberegning`() {
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
-        val barn1 = barn født 13.jan(2017)
-        val barn2 = barn født 15.jun(2020)
+        val barn1 = barn født 13.des(2016)
+        val barn2 = barn født 15.des(2017)
+        val barn3 = barn født 9.des(2018)
+        val barna = listOf(barn1, barn2, barn3)
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
-            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
-            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
-            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
-            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+        val kompetanser = KompetanseBuilder(jan(2017))
+            //              |1 stk <3 år|2 stk <3 år|3 stk <3 år|2 stk <3 år|1 stk <3 år|
+            //              |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .medKompetanse("PPPPPPSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSPPPSSS", barn1)
+            .medKompetanse("            SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSPPPPPPSSSSSSSSSSSSSSSSSSSSSSSS>", barn2)
+            .medKompetanse("                        SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS>", barn3)
+            .byggKompetanser()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            //           |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .medUtvidet("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .medSmåbarn("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$") { 1000 }
+            .medOrdinær("      $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", 100, { 1000 }, { -700 }) { 0 }
+            .medOrdinær("                                                   $$$") { 1000 }
+            .medOrdinær("                                                      $$$", 100, { 1000 }, { -700 }) { 0 }
+            .forPersoner(barn2)
+            .medOrdinær("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", 100, { 1000 }, { -700 }) { 0 }
+            .medOrdinær("                                          $$$$$$") { 1000 }
+            .medOrdinær("                                                $$$>", 100, { 1000 }, { -700 }) { 0 }
+            .forPersoner(barn3)
+            .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>", 100, { 1000 }, { -700 }) { 0 }
+            .bygg()
 
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1, barn2))
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
 
-        val forventet = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
-            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
-            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038)) og
-            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2019)) og
-            (søker har 1054.kr minus 1054.kr i UTVIDET_BARNETRYGD fom aug(2019) tom jun(2020)) og
-            (søker har 1054.kr minus 527.kr i UTVIDET_BARNETRYGD fom jul(2020) tom jul(2024)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom jul(2019)) og
-            (søker har 660.kr minus 392.kr i SMÅBARNSTILLEGG fom aug(2019) tom des(2019)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023))
+        val forventet = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            //           |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .medUtvidet("$$$$$$") { 1000 }
+            .medUtvidet("      $$$$$$", { 1000 }, { 300 }) { 300 }
+            .medUtvidet("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medUtvidet("                                          $$$$$$") { 1000 }
+            .medUtvidet("                                                $$$", { 1000 }, { 0 }) { 0 }
+            .medUtvidet("                                                   $$$") { 1000 }
+            .medUtvidet("                                                      $$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medSmåbarn("$$$$$$$$$$$$") { 1000 }
+            .medSmåbarn("            $$$$$$$$$$$$", { 1000 }, { 600 }) { 600 }
+            .medSmåbarn("                        $$$$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medSmåbarn("                                    $$$$$$", { 1000 }, { 267 }) { 267 }
+            .medSmåbarn("                                          $$$$$$") { 1000 }
+            .medSmåbarn("                                                $$$", { 1000 }, { 633 }) { 633 }
+            .medSmåbarn("                                                   $$$", { 1000 }, { 300 }) { 300 }
+            .medSmåbarn("                                                      $$$", { 1000 }, { 633 }) { 633 }
+            .medSmåbarn("                                                         $$$", { 1000 }, { 800 }) { 800 }
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$") { 1000 }
+            .medOrdinær("      $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", 100, { 1000 }, { -700 }) { 0 }
+            .medOrdinær("                                                   $$$") { 1000 }
+            .medOrdinær("                                                      $$$", 100, { 1000 }, { -700 }) { 0 }
+            .forPersoner(barn2)
+            .medOrdinær("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", 100, { 1000 }, { -700 }) { 0 }
+            .medOrdinær("                                          $$$$$$") { 1000 }
+            .medOrdinær("                                                $$$>", 100, { 1000 }, { -700 }) { 0 }
+            .forPersoner(barn3)
+            .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>", 100, { 1000 }, { -700 }) { 0 }
+            .bygg()
 
-        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+        assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
-    fun `differanseberegnet ordinær barnetrygd uten at søker har ytelser, skal gi uendrete andeler for barne`() {
-        val barn1 = barn født 13.jan(2017)
-        val barn2 = barn født 15.jun(2020)
+    fun `differanseberegnet ordinær barnetrygd uten at søker har ytelser, skal gi uendrete andeler for barna`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.des(2016)
+        val barn2 = barn født 15.des(2017)
+        val barna = listOf(barn1, barn2)
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
-            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
-            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+        val kompetanser = KompetanseBuilder(jan(2017))
+            //              |1 stk <3 år|2 stk <3 år|3 stk <3 år|2 stk <3 år|1 stk <3 år|
+            //              |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .medKompetanse("PPPPPPSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSPPPSSS", barn1)
+            .medKompetanse("            SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSPPPPPPSSSSSSSSSSSSSSSSSSSSSSSS>", barn2)
+            .byggKompetanser()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            //           |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$") { 1000 }
+            .medOrdinær("      $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", 100, { 1000 }, { -700 }) { 0 }
+            .medOrdinær("                                                   $$$") { 1000 }
+            .medOrdinær("                                                      $$$", 100, { 1000 }, { -700 }) { 0 }
+            .forPersoner(barn2)
+            .medOrdinær("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", 100, { 1000 }, { -700 }) { 0 }
+            .medOrdinær("                                          $$$$$$") { 1000 }
+            .medOrdinær("                                                $$$>", 100, { 1000 }, { -700 }) { 0 }
+            .bygg()
 
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1, barn2))
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
 
-        val forventet = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1054.kr og 1250.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2022)) og
-            (barn1 har 1054.kr og 1325.PLN i ORDINÆR_BARNETRYGD fom aug(2022) tom jul(2024)) og
-            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
-
-        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+        assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `Ingen differranseberegning skal gi uendrete andeler`() {
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
-        val barn1 = barn født 13.jan(2017)
-        val barn2 = barn født 15.jun(2020)
+        val barn1 = barn født 13.des(2016)
+        val barn2 = barn født 15.des(2017)
+        val barna = listOf(barn1, barn2)
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
-            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
-            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024)) og
-            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
+        val kompetanser = emptyList<Kompetanse>()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            //           |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .medUtvidet("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .medSmåbarn("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .forPersoner(barn2)
+            .medOrdinær("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
+            .bygg()
 
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1, barn2))
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
 
-        val forventet = lagInitiellTilkjentYtelse(behandling) der
-            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
-            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024)) og
-            (barn2 har 1054.kr i ORDINÆR_BARNETRYGD fom jul(2020) tom mai(2038))
-
-        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+        assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
@@ -118,82 +158,221 @@ class DifferanseberegningSøkersYtelserTest {
         val tilkjentYtelse = lagInitiellTilkjentYtelse()
 
         val nyeAndeler = tilkjentYtelse.andelerTilkjentYtelse
-            .differanseberegnSøkersYtelser(emptyList())
+            .differanseberegnSøkersYtelser(emptyList(), emptyList())
 
-        assertEqualsUnordered(emptyList(), nyeAndeler)
+        assertEquals(emptyList<AndelTilkjentYtelse>(), nyeAndeler)
     }
 
     @Test
-    fun `Søkers andel som har hatt differanseberegning, men ikke skal ha det lenger, skal fjerne differanseberegningen`() {
+    fun `Søkers andel som har hatt differanseberegning, men ikke skal ha det lenger, skal fjerne differanseberegningen og slå sammen perioder som med sikkerhet kan slås sammen`() {
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
-        val barn1 = barn født 13.jan(2017)
+        val barn1 = barn født 13.des(2016)
+        val barn2 = barn født 15.des(2017)
+        val barn3 = barn født 9.des(2018)
+        val barna = listOf(barn1, barn2, barn3)
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
-            (søker har 1054.kr og 30.PLN i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
-            (søker har 660.kr og 40.PLN i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023)) og
-            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024))
+        val kompetanser = emptyList<Kompetanse>()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            //           |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .medUtvidet("$$$$$$") { 1000 }
+            .medUtvidet("      $$$$$$", { 1000 }, { 300 }) { 300 }
+            .medUtvidet("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medUtvidet("                                          $$$$$$") { 1000 }
+            .medUtvidet("                                                $$$", { 1000 }, { 0 }) { 0 }
+            .medUtvidet("                                                   $$$") { 1000 }
+            .medUtvidet("                                                      $$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medSmåbarn("$$$$$$$$$$$$") { 1000 }
+            .medSmåbarn("            $$$$$$$$$$$$", { 1000 }, { 600 }) { 600 }
+            .medSmåbarn("                        $$$$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medSmåbarn("                                    $$$$$$", { 1000 }, { 267 }) { 267 }
+            .medSmåbarn("                                          $$$$$$") { 1000 }
+            .medSmåbarn("                                                $$$", { 1000 }, { 633 }) { 633 }
+            .medSmåbarn("                                                   $$$") { 1000 }
+            .medSmåbarn("                                                      $$$", { 1000 }, { 633 }) { 633 }
+            .medSmåbarn("                                                         $$$", { 1000 }, { 800 }) { 800 }
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .forPersoner(barn2)
+            .medOrdinær("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
+            .forPersoner(barn3)
+            .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
+            .bygg()
 
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1))
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
 
-        val forventet = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2024)) og
-            (søker har 1054.kr i UTVIDET_BARNETRYGD fom jun(2018) tom jul(2024)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom jul(2020) tom mai(2023))
+        // Dette er litt trist. Men selv om andelene er identiske, kan de ikke slås sammen fordi
+        // de er til forveksling like som andeler som har en funksjonell årsak til å være splittet
+        // Påfølgende andeler som begge har differanseberegning, KAN slås sammen
+        val forventet = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            //           |01-17      |01-18      |01-19      |01-20      |01-21      |01-22
+            .medUtvidet("$$$$$$") { 1000 }
+            .medUtvidet("      $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .medUtvidet("                                          $$$$$$") { 1000 }
+            .medUtvidet("                                                $$$") { 1000 }
+            .medUtvidet("                                                   $$$") { 1000 }
+            .medUtvidet("                                                      $$$$$$$$$$") { 1000 }
+            .medSmåbarn("$$$$$$$$$$$$") { 1000 }
+            .medSmåbarn("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .medSmåbarn("                                          $$$$$$") { 1000 }
+            .medSmåbarn("                                                $$$") { 1000 }
+            .medSmåbarn("                                                   $$$") { 1000 }
+            .medSmåbarn("                                                      $$$$$$") { 1000 }
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .forPersoner(barn2)
+            .medOrdinær("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
+            .forPersoner(barn3)
+            .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
+            .bygg()
 
-        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+        assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `Søkers andel som har differanseberegning, men underskuddet reduseres, skal få oppdatert differanseberegningen`() {
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
-        val barn1 = barn født 13.jan(2017)
+        val barn1 = barn født 13.des(2016)
+        val barna = listOf(barn1)
         val behandling = lagBehandling()
 
-        // Satsene er ikke riktige, men enklere å jobbe med
-        // 1 PLN = 2 kr
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1000.kr og 900.PLN i ORDINÆR_BARNETRYGD fom mai(2017) tom jul(2024)) og
-            (søker har 1000.kr minus 1000.kr i UTVIDET_BARNETRYGD fom jun(2017) tom jul(2021)) og
-            (søker har 600.kr minus 400.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019))
+        val kompetanser = KompetanseBuilder(jan(2017))
+            .medKompetanse("S>", barn1)
+            .byggKompetanser()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medSmåbarn("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", { 1000 }, { 300 }) { 300 }
+            .forPersoner(barn1)
+            .medOrdinær("$>", 100, { 1000 }, { -650 }) { 0 }
+            .bygg()
 
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1))
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
 
-        val forventet = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1000.kr og 900.PLN i ORDINÆR_BARNETRYGD fom mai(2017) tom jul(2024)) og
-            (søker har 1000.kr minus 400.PLN i UTVIDET_BARNETRYGD fom jun(2017) tom jul(2021)) og
-            (søker har 600.kr i SMÅBARNSTILLEGG fom aug(2018) tom des(2019))
+        val forventet = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", { 1000 }, { 350 }) { 350 }
+            .medSmåbarn("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .forPersoner(barn1)
+            .medOrdinær("$>", 100, { 1000 }, { -650 }) { 0 }
+            .bygg()
 
-        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+        assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `Skal tåle perioder der underskuddet på differanseberegning er større enn alle tilkjente ytelser`() {
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
-        val barn1 = barn født 13.jan(2019)
+        val barn1 = barn født 13.des(2016)
+        val barna = listOf(barn1)
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1054.kr og 1500.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2020)) og
-            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2020) tom jul(2025)) og
-            (søker har 1054.kr i UTVIDET_BARNETRYGD fom sep(2019) tom jul(2024)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom okt(2019) tom des(2021))
+        val kompetanser = KompetanseBuilder(jan(2017))
+            .medKompetanse("S>", barn1)
+            .byggKompetanser()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .medSmåbarn("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$") { 1000 }
+            .forPersoner(barn1)
+            .medOrdinær("$>", 100, { 1000 }, { -2650 }) { 0 }
+            .bygg()
 
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(listOf(barn1))
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
 
-        val forventet = lagInitiellTilkjentYtelse(behandling) der
-            (barn1 har 1054.kr og 1500.PLN i ORDINÆR_BARNETRYGD fom aug(2019) tom jul(2020)) og
-            (barn1 har 1054.kr i ORDINÆR_BARNETRYGD fom aug(2020) tom jul(2025)) og
-            (søker har 1054.kr minus 1054.kr i UTVIDET_BARNETRYGD fom sep(2019) tom jul(2020)) og
-            (søker har 1054.kr i UTVIDET_BARNETRYGD fom aug(2020) tom jul(2024)) og
-            (søker har 660.kr minus 660.kr i SMÅBARNSTILLEGG fom okt(2019) tom jul(2020)) og
-            (søker har 660.kr i SMÅBARNSTILLEGG fom aug(2020) tom des(2021))
+        val forventet = TilkjentYtelseBuilder(jan(2017), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .medSmåbarn("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", { 1000 }, { 0 }) { 0 }
+            .forPersoner(barn1)
+            .medOrdinær("$>", 100, { 1000 }, { -2650 }) { 0 }
+            .bygg()
 
-        assertEqualsUnordered(forventet.andelerTilkjentYtelse, nyeAndeler)
+        assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
+    }
+
+    @Test
+    fun `skal illustrere avrundingssproblematikk, der søker tjener`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.des(2016)
+        val barn2 = barn født 15.des(2017)
+        val barn3 = barn født 9.des(2018)
+        val barna = listOf(barn1, barn2, barn3)
+        val behandling = lagBehandling()
+
+        val kompetanser = KompetanseBuilder(jul(2020))
+            .medKompetanse("SSSSSS", barn1, barn2, barn3)
+            .byggKompetanser()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jul(2020), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$") { 1054 }
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { -400 }) { 0 }
+            .forPersoner(barn2, barn3)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
+            .bygg()
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+
+        val forventet = TilkjentYtelseBuilder(jul(2020), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$", { 1054 }, { 703 }) { 703 } // Egentlig 702,67
+            .forPersoner(barn1)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { -400 }) { 0 }
+            .forPersoner(barn2, barn3)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
+            .bygg()
+
+        assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
+    }
+
+    @Test
+    fun `skal illustrere avrundingssproblematikk, der søker taper`() {
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn1 = barn født 13.des(2016)
+        val barn2 = barn født 15.des(2017)
+        val barn3 = barn født 9.des(2018)
+        val barna = listOf(barn1, barn2, barn3)
+        val behandling = lagBehandling()
+
+        val kompetanser = KompetanseBuilder(jul(2020))
+            .medKompetanse("SSSSSS", barn1, barn2, barn3)
+            .byggKompetanser()
+
+        val tilkjentYtelse = TilkjentYtelseBuilder(jul(2020), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$") { 1054 }
+            .forPersoner(barn1, barn2)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { -400 }) { 0 }
+            .forPersoner(barn3)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
+            .bygg()
+
+        val nyeAndeler =
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+
+        val forventet = TilkjentYtelseBuilder(jul(2020), behandling)
+            .forPersoner(søker)
+            .medUtvidet("$$$$$$", { 1054 }, { 351 }) { 351 } // Egentlig 351,33
+            .forPersoner(barn1, barn2)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { -400 }) { 0 }
+            .forPersoner(barn3)
+            .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
+            .bygg()
+
+        assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 }
+
+private fun Collection<AndelTilkjentYtelse>.sortert() =
+    this.sortedWith(compareBy({ it.aktør.aktørId }, { it.type }, { it.stønadFom }))


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det var en mangel i forrige implementasjon: Kravet er at søkers ytelser først differanseberegnes i perioder der alle andeler tilkjente ytelser  for relevante barn er differanseberegnet, dvs kompetansen er vurdert til at Norge er sekundærland. 

Jeg løser (delvis) tre andre svakheter:
* Splitter i andeler forårsaket av differanseberegning ble ikke slått sammen hvis differanseberegning på barna ble fjernet. Det er delvis løst her
* Hvis søkers ytelse deles på et antall barn som ikke gir heltallsresultat, kan differanseberegningen bli flere kroner feil. Også delvis løst med overgang til BigDecimal. Avvik kan fortsatt forekomme, men det blir sjeldnere. 
* Fjernet en funksjonsbryter som bare var en duplikat

_Kan leses commit for commit, men funker nok også å se alt under ett._ 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
* De to siste fiksene, dvs avrunding og overdreven splitting.
* Løsningen med abonnenter for å injisere avhengigheter
* Ny-gammel måte å skrive tester på, som nok henger sammen med det neste punktet; 
* Sende inn kompetanser er kanskje unødvendig fordi jeg kan vel sjekke om samtlige andeler har differanseberegning i stedet?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
