### PR TITLE
Filtrerer bort tom kompetanse ved migrering primærland ved autobrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.tilMinimertUregisrertBarn
 import no.nav.familie.ba.sak.kjerne.beregning.Beløpsdifferanse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
@@ -19,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
@@ -72,8 +75,18 @@ class BrevPeriodeService(
             søknadGrunnlagService.hentAktiv(behandlingId = behandlingId.id)?.hentUregistrerteBarn()
                 ?: emptyList()
 
+        val forrigeBehandlingSomErIverksatt = behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(
+            behandlingHentOgPersisterService.hent(behandlingId.id)
+        )
+
         val kompetanser =
-            kompetanseService.hentKompetanser(behandlingId = behandlingId)
+            if (forrigeBehandlingSomErIverksatt?.kategori == BehandlingKategori.EØS && forrigeBehandlingSomErIverksatt.opprettetÅrsak == BehandlingÅrsak.MIGRERING) {
+                // filtrerer bort kompetanser for migreringer av primærlandsaker
+                kompetanseService.hentKompetanser(behandlingId = behandlingId)
+                    .filter { it.resultat == KompetanseResultat.NORGE_ER_PRIMÆRLAND && !it.erFelterSatt() }
+            } else {
+                kompetanseService.hentKompetanser(behandlingId = behandlingId)
+            }
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
         val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -93,15 +93,17 @@ data class Kompetanse(
         )
 
     fun validerFelterErSatt() {
-        if (søkersAktivitet == null ||
-            annenForeldersAktivitet == null ||
-            barnetsBostedsland == null ||
-            resultat == null ||
-            barnAktører.isEmpty()
+        if (erFelterSatt()
         ) {
             throw Feil("Kompetanse mangler verdier")
         }
     }
+
+    fun erFelterSatt() = søkersAktivitet == null ||
+        annenForeldersAktivitet == null ||
+        barnetsBostedsland == null ||
+        resultat == null ||
+        barnAktører.isEmpty()
 
     companion object {
         val NULL = Kompetanse(null, null, emptySet())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Autobrev opphør 6 og 18 feiler for migrerte sakers av eøs primærland fordi komeptanseskjemaet er opprettet uten verdier. Filtrerer bort disse ved oppretting av brevperioder
![Screenshot 2022-12-05 at 15 04 42](https://user-images.githubusercontent.com/1121978/205666311-94612d5a-28f5-44c2-afc7-7f8f031b859e.png)


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Testet i preprod med sak:
https://barnetrygd.dev.intern.nav.no/fagsak/200008723/saksoversikt

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
