### PR TITLE
Bug/begrunnelser vises ikke

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -72,10 +72,6 @@ class BrevPeriodeService(
             søknadGrunnlagService.hentAktiv(behandlingId = behandlingId.id)?.hentUregistrerteBarn()
                 ?: emptyList()
 
-        val forrigeBehandlingSomErIverksatt = behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(
-            behandlingHentOgPersisterService.hent(behandlingId.id)
-        )
-
         val kompetanser = kompetanseService.hentKompetanser(behandlingId = behandlingId)
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -6,8 +6,6 @@ import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.tilMinimertUregisrertBarn
 import no.nav.familie.ba.sak.kjerne.beregning.Beløpsdifferanse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
@@ -21,7 +19,6 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
@@ -79,14 +76,7 @@ class BrevPeriodeService(
             behandlingHentOgPersisterService.hent(behandlingId.id)
         )
 
-        val kompetanser =
-            if (forrigeBehandlingSomErIverksatt?.kategori == BehandlingKategori.EØS && forrigeBehandlingSomErIverksatt.opprettetÅrsak == BehandlingÅrsak.MIGRERING) {
-                // filtrerer bort kompetanser for migreringer av primærlandsaker
-                kompetanseService.hentKompetanser(behandlingId = behandlingId)
-                    .filter { it.resultat == KompetanseResultat.NORGE_ER_PRIMÆRLAND && !it.erFelterSatt() }
-            } else {
-                kompetanseService.hentKompetanser(behandlingId = behandlingId)
-            }
+        val kompetanser = kompetanseService.hentKompetanser(behandlingId = behandlingId)
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
         val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -93,17 +93,17 @@ data class Kompetanse(
         )
 
     fun validerFelterErSatt() {
-        if (erFelterSatt()
+        if (!erFelterSatt()
         ) {
             throw Feil("Kompetanse mangler verdier")
         }
     }
 
-    fun erFelterSatt() = søkersAktivitet == null ||
-        annenForeldersAktivitet == null ||
-        barnetsBostedsland == null ||
-        resultat == null ||
-        barnAktører.isEmpty()
+    fun erFelterSatt() = søkersAktivitet != null &&
+        annenForeldersAktivitet != null &&
+        barnetsBostedsland != null &&
+        resultat != null &&
+        barnAktører.isNotEmpty()
 
     companion object {
         val NULL = Kompetanse(null, null, emptySet())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Retter en bug hvor begrunnelser knyttet til sekundærland blir valgt, men ikke dukker opp i brevet: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10673

Feilen ble introdusert i PRen lenket under hvor man filtrerer bort alle sekundærland-kompetanser hvis forrige behandling var EØS migrering: 
https://github.com/navikt/familie-ba-sak/pull/3129

Denne PRen reverterer PRen over + fikser en mismatch i navngivning på funksjon og den tilhørende boolske verdien

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei. Ønsker egentlig å teste at disse endringene løser problemet, men er ikke så lett å få testet fordi man trenger personer som kan automatisk migreres fra infotrygd.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️ 
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Vil få det ut fort, så ønsker ikke bruke tid på det. Tror det er vanskelig å skrive gode tester som dekker scenariet.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
