### PR TITLE
En mulig workaround for autobrevVed6og18År-tasker med kjent feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakService.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.steg.TilbakestillBehandlingTilBehandlingsresultatService
+import no.nav.familie.ba.sak.kjerne.steg.VilkårsvurderingDTO
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -31,7 +32,8 @@ class AutovedtakService(
         aktør: Aktør,
         behandlingType: BehandlingType,
         behandlingÅrsak: BehandlingÅrsak,
-        fagsakId: Long
+        fagsakId: Long,
+        brukAlternativAtyMetodeForBarna: Boolean = false
     ): Behandling {
         val nyBehandling = stegService.håndterNyBehandling(
             NyBehandling(
@@ -43,7 +45,10 @@ class AutovedtakService(
             )
         )
 
-        val behandlingEtterBehandlingsresultat = stegService.håndterVilkårsvurdering(nyBehandling)
+        val behandlingEtterBehandlingsresultat = stegService.håndterVilkårsvurdering(
+            nyBehandling,
+            VilkårsvurderingDTO(brukAlternativAtyMetodeForBarna)
+        )
         return behandlingEtterBehandlingsresultat
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
@@ -85,7 +85,8 @@ class Autobrev6og18ÅrService(
                 standardbegrunnelse = AutobrevUtils.hentGjeldendeVedtakbegrunnelseReduksjonForAlder(
                     autobrev6og18ÅrDTO.alder
                 ),
-                fagsakId = behandling.fagsak.id
+                fagsakId = behandling.fagsak.id,
+                brukAlternativAtyBarnaMetode = autobrev6og18ÅrDTO.brukAlternativAtyMetodeForBarna
             )
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutovedtakBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutovedtakBrevService.kt
@@ -28,7 +28,8 @@ data class AutovedtakBrevBehandlingsdata(
     val aktør: Aktør,
     val behandlingsårsak: BehandlingÅrsak,
     val standardbegrunnelse: Standardbegrunnelse,
-    val fagsakId: Long
+    val fagsakId: Long,
+    val brukAlternativAtyBarnaMetode: Boolean = false
 )
 
 @Service
@@ -51,7 +52,8 @@ class AutovedtakBrevService(
                 aktør = behandlingsdata.aktør,
                 behandlingType = BehandlingType.REVURDERING,
                 behandlingÅrsak = behandlingsdata.behandlingsårsak,
-                fagsakId = behandlingsdata.fagsakId
+                fagsakId = behandlingsdata.fagsakId,
+                brukAlternativAtyMetodeForBarna = behandlingsdata.brukAlternativAtyBarnaMetode
             )
 
         vedtaksperiodeService.oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -160,7 +160,8 @@ class BeregningService(
     fun oppdaterBehandlingMedBeregning(
         behandling: Behandling,
         personopplysningGrunnlag: PersonopplysningGrunnlag,
-        nyEndretUtbetalingAndel: EndretUtbetalingAndel? = null
+        nyEndretUtbetalingAndel: EndretUtbetalingAndel? = null,
+        skalBrukeNyMåteÅGenerereAndelerForBarna: Boolean? = null
     ): TilkjentYtelse {
         val endreteUtbetalingAndeler = andelerTilkjentYtelseOgEndreteUtbetalingerService
             .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id).filter {
@@ -184,7 +185,8 @@ class BeregningService(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 behandling = behandling,
                 endretUtbetalingAndeler = endreteUtbetalingAndeler,
-                skalBrukeNyMåteÅGenerereAndelerForBarna = featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_GENERERE_ATY_BARNA)
+                skalBrukeNyMåteÅGenerereAndelerForBarna = skalBrukeNyMåteÅGenerereAndelerForBarna
+                    ?: featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_GENERERE_ATY_BARNA)
             ) { søkerAktør ->
                 småbarnstilleggService.hentOgLagrePerioderMedFullOvergangsstønad(
                     søkerAktør = søkerAktør,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -220,12 +220,15 @@ class StegService(
     }
 
     @Transactional
-    fun håndterVilkårsvurdering(behandling: Behandling): Behandling {
+    fun håndterVilkårsvurdering(
+        behandling: Behandling,
+        data: VilkårsvurderingDTO = VilkårsvurderingDTO()
+    ): Behandling {
         val behandlingSteg: VilkårsvurderingSteg =
             hentBehandlingSteg(StegType.VILKÅRSVURDERING) as VilkårsvurderingSteg
 
         val behandlingEtterVilkårsvurdering = håndterSteg(behandling, behandlingSteg) {
-            behandlingSteg.utførStegOgAngiNeste(behandling, "")
+            behandlingSteg.utførStegOgAngiNeste(behandling, data)
         }
 
         return if (behandlingEtterVilkårsvurdering.skalBehandlesAutomatisk) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SendAutobrev6og18ÅrTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SendAutobrev6og18ÅrTask.kt
@@ -2,14 +2,18 @@ package no.nav.familie.ba.sak.task
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.Autobrev6og18ÅrService
 import no.nav.familie.ba.sak.task.dto.Autobrev6og18ÅrDTO
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.RekjørSenereException
 import org.springframework.stereotype.Service
+import java.lang.RuntimeException
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 @TaskStepBeskrivelse(
@@ -20,7 +24,8 @@ import java.time.LocalDate
     settTilManuellOppfølgning = true
 )
 class SendAutobrev6og18ÅrTask(
-    private val autobrev6og18ÅrService: Autobrev6og18ÅrService
+    private val autobrev6og18ÅrService: Autobrev6og18ÅrService,
+    private val taskRepository: TaskRepositoryWrapper
 ) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
@@ -29,12 +34,42 @@ class SendAutobrev6og18ÅrTask(
         if (!LocalDate.now().toYearMonth().equals(autobrevDTO.årMåned)) {
             throw Feil("Task for autobrev må kjøres innenfor måneden det skal sjekkes mot.")
         }
+        try {
+            autobrev6og18ÅrService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevDTO)
+        } catch (e: RuntimeException) {
+            if (e.message == KJENT_FEIL_RELATERT_TIL_BARNAS_ATY && !autobrevDTO.brukAlternativAtyMetodeForBarna) {
+                forsøkPåNyttMedAlternativMetodeForBarnasAty(task, autobrevDTO)
+            } else {
+                throw e
+            }
+        }
+    }
 
-        autobrev6og18ÅrService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevDTO)
+    private fun forsøkPåNyttMedAlternativMetodeForBarnasAty(
+        task: Task,
+        autobrevDTO: Autobrev6og18ÅrDTO
+    ) {
+        taskRepository.save(
+            task.copy(
+                payload = objectMapper.writeValueAsString(
+                    Autobrev6og18ÅrDTO(
+                        fagsakId = autobrevDTO.fagsakId,
+                        alder = autobrevDTO.alder,
+                        årMåned = autobrevDTO.årMåned,
+                        brukAlternativAtyMetodeForBarna = true
+                    )
+                )
+            )
+        )
+        throw RekjørSenereException(
+            årsak = "Prøver igjen med bryteren ny-metode-genererer-aty-barna overstyrt som en workaround for kjent feil",
+            triggerTid = LocalDateTime.now().plusMinutes(1)
+        )
     }
 
     companion object {
-
         const val TASK_STEP_TYPE = "sendAutobrevVed6og18År"
+        const val KJENT_FEIL_RELATERT_TIL_BARNAS_ATY =
+            "Steg 'Journalfør vedtaksbrev' kan ikke settes på behandling i kombinasjon med status UTREDES"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/dto/Autobrev6og18ÅrDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/dto/Autobrev6og18ÅrDTO.kt
@@ -5,5 +5,6 @@ import java.time.YearMonth
 class Autobrev6og18ÅrDTO(
     val fagsakId: Long,
     val alder: Int,
-    val årMåned: YearMonth
+    val årMåned: YearMonth,
+    val brukAlternativAtyMetodeForBarna: Boolean = false
 )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9887)
Forsøkt meg på en workaround for autobrevVed6og18År-tasker som feiler pga. ulikt behandlingsresultat fra forrige behandling, relatert til toggelen ny-metode-generere-aty-barna, ved å la taskene kjøre på nytt med toggelen overstyrt.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Usikker på om dette er den rette måten å løse det på, eller om det bare forskyver på problemet

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
