### PR TITLE
Bug: EØS-migreringer skaper problemer pga tomme kompetanser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -268,6 +268,8 @@ data class Behandling(
 
     fun erManuellMigrering() = erManuellMigreringForEndreMigreringsdato() || erHelmanuellMigrering()
 
+    fun erEøsMigrering() = opprettetÅrsak == BehandlingÅrsak.MIGRERING && kategori == BehandlingKategori.EØS
+
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 
     fun erTekniskBehandling() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_OPPHØR || erTekniskEndring()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -268,7 +268,7 @@ data class Behandling(
 
     fun erManuellMigrering() = erManuellMigreringForEndreMigreringsdato() || erHelmanuellMigrering()
 
-    fun erEøsMigrering() = opprettetÅrsak == BehandlingÅrsak.MIGRERING && kategori == BehandlingKategori.EØS
+    fun erAutomatiskEøsMigrering() = erMigrering() && opprettetÅrsak == BehandlingÅrsak.MIGRERING && kategori == BehandlingKategori.EØS
 
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -79,7 +79,9 @@ class BrevPeriodeService(
             .filter {
                 if (forrigeBehandling?.erEøsMigrering() == true && inneværendeBehandling.skalBehandlesAutomatisk) {
                     it.erFelterSatt()
-                } else true
+                } else {
+                    true
+                }
             }
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -72,7 +72,7 @@ class BrevPeriodeService(
             søknadGrunnlagService.hentAktiv(behandlingId = behandlingId.id)?.hentUregistrerteBarn()
                 ?: emptyList()
 
-        val kompetanser = kompetanseService.hentKompetanser(behandlingId = behandlingId)
+        val kompetanser = kompetanseService.hentKompetanser(behandlingId = behandlingId).filter { it.erFelterSatt() }
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
         val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
@@ -92,7 +92,7 @@ class BrevPeriodeService(
                 andelerTilkjentYtelse = andelerMedEndringer,
                 uregistrerteBarn = uregistrerteBarn,
                 skalLogge = skalLogge,
-                kompetanser = kompetanser.toList(),
+                kompetanser = kompetanser,
                 sanityBegrunnelser = sanityBegrunnelser,
                 sanityEØSBegrunnelser = sanityEØSBegrunnelser
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -77,7 +77,7 @@ class BrevPeriodeService(
 
         val kompetanser = kompetanseService.hentKompetanser(behandlingId = behandlingId)
             .filter {
-                if (forrigeBehandling?.erEøsMigrering() == true && inneværendeBehandling.skalBehandlesAutomatisk) {
+                if (forrigeBehandling?.erAutomatiskEøsMigrering() == true && inneværendeBehandling.skalBehandlesAutomatisk) {
                     it.erFelterSatt()
                 } else {
                     true

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -72,7 +72,15 @@ class BrevPeriodeService(
             søknadGrunnlagService.hentAktiv(behandlingId = behandlingId.id)?.hentUregistrerteBarn()
                 ?: emptyList()
 
-        val kompetanser = kompetanseService.hentKompetanser(behandlingId = behandlingId).filter { it.erFelterSatt() }
+        val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksattFraBehandlingsId(behandlingId = behandlingId.id)
+        val inneværendeBehandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId.id)
+
+        val kompetanser = kompetanseService.hentKompetanser(behandlingId = behandlingId)
+            .filter {
+                if (forrigeBehandling?.erEøsMigrering() == true && inneværendeBehandling.skalBehandlesAutomatisk) {
+                    it.erFelterSatt()
+                } else true
+            }
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
         val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
@@ -92,7 +100,7 @@ class BrevPeriodeService(
                 andelerTilkjentYtelse = andelerMedEndringer,
                 uregistrerteBarn = uregistrerteBarn,
                 skalLogge = skalLogge,
-                kompetanser = kompetanser,
+                kompetanser = kompetanser.toList(),
                 sanityBegrunnelser = sanityBegrunnelser,
                 sanityEØSBegrunnelser = sanityEØSBegrunnelser
             )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10696

Kun ta med kompetanser som er utfylte når brev skal genereres ved automatiske behandlinger, og forrige behandling var en EØS-migrering. Grunnen til dette er fordi ved automatiske EØS-migreringer så blir kompetansen tom. Dette skaper problemer i autobrev-behandlinger fordi man drar med seg den tomme kompetansen, som det blir kastet feil for (se bilde av feil under).

Problemet ble opprinnelig prøvd løst her: https://github.com/navikt/familie-ba-sak/pull/3129, men måtte reverteres her: https://github.com/navikt/familie-ba-sak/pull/3136.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei ikke egentlig.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Koster mye og gir minimalt med verdi.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

<img width="1762" alt="image" src="https://user-images.githubusercontent.com/25459913/207671983-e7413650-e443-4728-b5a2-4492d15933aa.png">
