### PR TITLE
Fikser visning av delmal 1 for årlig kontroll EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -69,7 +69,8 @@ class BrevService(
         return when (brevmal) {
             Brevmal.VEDTAK_FØRSTEGANGSVEDTAK -> Førstegangsvedtak(
                 vedtakFellesfelter = vedtakFellesfelter,
-                etterbetaling = hentEtterbetaling(vedtak)
+                etterbetaling = hentEtterbetaling(vedtak),
+                informasjonOmAarligKontroll = vedtaksperiodeService.skalHaÅrligKontroll(vedtak)
             )
 
             Brevmal.VEDTAK_FØRSTEGANGSVEDTAK_INSTITUSJON -> Førstegangsvedtak(
@@ -125,7 +126,10 @@ class BrevService(
                 vedtakFellesfelter = vedtakFellesfelter
             )
 
-            Brevmal.VEDTAK_FORTSATT_INNVILGET -> ForsattInnvilget(vedtakFellesfelter = vedtakFellesfelter)
+            Brevmal.VEDTAK_FORTSATT_INNVILGET -> ForsattInnvilget(
+                vedtakFellesfelter = vedtakFellesfelter,
+                informasjonOmAarligKontroll = vedtaksperiodeService.skalHaÅrligKontroll(vedtak)
+            )
             Brevmal.VEDTAK_FORTSATT_INNVILGET_INSTITUSJON -> ForsattInnvilget(
                 mal = Brevmal.VEDTAK_FORTSATT_INNVILGET_INSTITUSJON,
                 vedtakFellesfelter = vedtakFellesfelter

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
@@ -9,7 +9,8 @@ data class ForsattInnvilget(
 
     constructor(
         mal: Brevmal = Brevmal.VEDTAK_FORTSATT_INNVILGET,
-        vedtakFellesfelter: VedtakFellesfelter
+        vedtakFellesfelter: VedtakFellesfelter,
+        informasjonOmAarligKontroll: Boolean = false
     ) :
         this(
             mal = mal,
@@ -21,7 +22,8 @@ data class ForsattInnvilget(
                         beslutter = vedtakFellesfelter.beslutter
                     ),
                     hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
-                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData,
+                    informasjonOmAarligKontroll = informasjonOmAarligKontroll
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -43,6 +45,7 @@ data class ForsattInnvilgetData(
     data class Delmaler(
         val signaturVedtak: SignaturVedtak,
         val hjemmeltekst: Hjemmeltekst,
-        val korrigertVedtak: KorrigertVedtakData?
+        val korrigertVedtak: KorrigertVedtakData?,
+        val informasjonOmAarligKontroll: Boolean
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
@@ -11,7 +11,8 @@ data class Førstegangsvedtak(
         mal: Brevmal = Brevmal.VEDTAK_FØRSTEGANGSVEDTAK,
         vedtakFellesfelter: VedtakFellesfelter,
         etterbetaling: Etterbetaling? = null,
-        etterbetalingInstitusjon: EtterbetalingInstitusjon? = null
+        etterbetalingInstitusjon: EtterbetalingInstitusjon? = null,
+        informasjonOmAarligKontroll: Boolean = false
     ) :
         this(
             mal = mal,
@@ -25,7 +26,8 @@ data class Førstegangsvedtak(
                     etterbetaling = etterbetaling,
                     hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
                     etterbetalingInstitusjon = etterbetalingInstitusjon,
-                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData
+                    korrigertVedtak = vedtakFellesfelter.korrigertVedtakData,
+                    informasjonOmAarligKontroll = informasjonOmAarligKontroll
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     navn = vedtakFellesfelter.søkerNavn,
@@ -49,6 +51,7 @@ data class FørstegangsvedtakData(
         val etterbetaling: Etterbetaling?,
         val hjemmeltekst: Hjemmeltekst,
         val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
-        val korrigertVedtak: KorrigertVedtakData?
+        val korrigertVedtak: KorrigertVedtakData?,
+        val informasjonOmAarligKontroll: Boolean
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.NullablePeriode
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
+import no.nav.familie.ba.sak.common.erSenereEnnInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
@@ -635,7 +636,7 @@ class VedtaksperiodeService(
     }
 
     fun skalHaÅrligKontroll(vedtak: Vedtak) = vedtak.behandling.kategori == BehandlingKategori.EØS &&
-        hentPersisterteVedtaksperioder(vedtak).any { it.tom == null }
+        hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
 
     companion object {
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9732)
Legger til Informasjon om årlig kontroll som en mulig delmal for vedtaksbrevene Førstegangsvedtak og FortsattInnvilget, og utvider sjekken som trigger delmalen til å inkludere tom-dato blant vedtaksperiodene som ikke er utløpt, ved siden av tom-dato som er null.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
