### PR TITLE
Kast Feil hvis begrunnelse med apiNavn ikke finnes i listen med begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
@@ -72,10 +72,10 @@ data class BegrunnelseMedTriggere(
 fun Vedtaksbegrunnelse.tilBegrunnelseMedTriggere(
     sanityBegrunnelser: List<SanityBegrunnelse>
 ): BegrunnelseMedTriggere {
+    val sanityBegrunnelse = sanityBegrunnelser.firstOrNull { it.apiNavn == this.standardbegrunnelse.sanityApiNavn } ?: throw Feil("Finner ikke sanityBegrunnelse med apiNavn=${this.standardbegrunnelse.sanityApiNavn}")
     return BegrunnelseMedTriggere(
         standardbegrunnelse = this.standardbegrunnelse,
-        triggesAv = sanityBegrunnelser
-            .firstOrNull { it.apiNavn == this.standardbegrunnelse.sanityApiNavn }!!
+        triggesAv = sanityBegrunnelse
             .tilTriggesAv()
     )
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Kaster en Feil hvis man ikke finner en begrunnelse med gitt apiNavn. Dette er for å unngå nullpointers som dette:

![image](https://user-images.githubusercontent.com/25459913/208864834-35053462-13e3-4677-8a34-f5fca8c32f34.png)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Unødvendig imo

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
