### PR TITLE
Tilbakestiller status på behandling til UTREDES ved omgjøring til manuell behandling for småbarnstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakBehandlingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -36,6 +37,7 @@ class AutovedtakSmåbarnstilleggService(
     private val fagsakService: FagsakService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val vedtakService: VedtakService,
+    private val behandlingService: BehandlingService,
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val småbarnstilleggService: SmåbarnstilleggService,
     private val taskService: TaskService,
@@ -111,6 +113,11 @@ class AutovedtakSmåbarnstilleggService(
             begrunnAutovedtakForSmåbarnstillegg(behandlingEtterBehandlingsresultat)
         } catch (e: VedtaksperiodefinnerSmåbarnstilleggFeil) {
             logger.warn(e.message, e)
+
+            behandlingService.oppdaterStatusPåBehandling(
+                behandlingEtterBehandlingsresultat.id,
+                BehandlingStatus.UTREDES
+            )
             return kanIkkeBehandleAutomatisk(
                 behandling = behandlingEtterBehandlingsresultat,
                 metric = antallVedtakOmOvergangsstønadTilManuellBehandling[TilManuellBehandlingÅrsak.KLARER_IKKE_BEGRUNNE]!!,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
@@ -114,12 +114,12 @@ class AutovedtakSmåbarnstilleggService(
         } catch (e: VedtaksperiodefinnerSmåbarnstilleggFeil) {
             logger.warn(e.message, e)
 
-            behandlingService.oppdaterStatusPåBehandling(
+            val behandlingSomSkalManueltBehandles = behandlingService.oppdaterStatusPåBehandling(
                 behandlingEtterBehandlingsresultat.id,
                 BehandlingStatus.UTREDES
             )
             return kanIkkeBehandleAutomatisk(
-                behandling = behandlingEtterBehandlingsresultat,
+                behandling = behandlingSomSkalManueltBehandles,
                 metric = antallVedtakOmOvergangsstønadTilManuellBehandling[TilManuellBehandlingÅrsak.KLARER_IKKE_BEGRUNNE]!!,
                 meldingIOppgave = "Småbarnstillegg: klarer ikke bestemme vedtaksperiode som skal begrunnes, må behandles manuelt"
             )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til denne feilen: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10669
Retter opp årsaken til at feilen i saken over har oppstått. Årsaken til feilen er at autovedtak for småbarnstillegg setter status til "iverksetter vedtak" på slutten av behandlingsresultat-steget. Når man da skal begrunne vedtaket etterpå, og dette feiler av en eller annen grunn, så er fortsatt status "iverksetter vedtak" når behandligen blir gjort om til manuell. Her tilbakestiller jeg status til "utredes" om behandlingen blir omgjort til manuell behandling. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Syns måten det er løst på med å sette status = "iverksetter vedtak" i behandlingsresultat-steget virker litt rart, og jeg kunne gjerne tenke meg å skrive om dette. Men det blir en større omskriving, fordi det kan ha flere side-effekter.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
tenker at det er unødvendig, men lov til å være uenig!

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
