### PR TITLE
Bugfix/manglende kopiering av vilkårsvurdering ved manglende opplysninger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpost
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpostType
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.JournalføringRepository
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
@@ -63,7 +64,8 @@ class DokumentService(
     private val settPåVentService: SettPåVentService,
     private val utgåendeJournalføringService: UtgåendeJournalføringService,
     private val fagsakRepository: FagsakRepository,
-    private val organisasjonService: OrganisasjonService
+    private val organisasjonService: OrganisasjonService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService
 ) {
 
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -253,7 +255,12 @@ class DokumentService(
 
     private fun leggTilOpplysningspliktIVilkårsvurdering(behandling: Behandling) {
         val vilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandling.id)
-            ?: vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false)
+            ?: vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(
+                behandling = behandling,
+                bekreftEndringerViaFrontend = false,
+                forrigeBehandlingSomErVedtatt = behandlingHentOgPersisterService
+                    .hentForrigeBehandlingSomErVedtatt(behandling)
+            )
         vilkårsvurdering.personResultater.single { it.erSøkersResultater() }
             .leggTilBlankAnnenVurdering(AnnenVurderingType.OPPLYSNINGSPLIKT)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -112,7 +112,7 @@ class VilkårsvurderingForNyBehandlingService(
     fun initierVilkårsvurderingForBehandling(
         behandling: Behandling,
         bekreftEndringerViaFrontend: Boolean,
-        forrigeBehandlingSomErVedtatt: Behandling? = null
+        forrigeBehandlingSomErVedtatt: Behandling?
     ): Vilkårsvurdering {
         val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandling.id)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -210,13 +210,19 @@ internal class DokumentServiceEnhetstest {
             assertThat(personResultat.andreVurderinger).extracting("type")
                 .containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
             verify(exactly = 0) {
-                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any())
+                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any(), null)
             }
 
             // Scenario uten eksisterende vilkårsvurdering
             personResultat.setAndreVurderinger(emptySet()) // nullstiller andreVurderinger
             every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns null
-            every { vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(any(), any()) } returns
+            every {
+                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(
+                    any(),
+                    any(),
+                    null
+                )
+            } returns
                 vilkårsvurdering
 
             sendBrev(brevmal, behandling)
@@ -224,7 +230,7 @@ internal class DokumentServiceEnhetstest {
             assertThat(personResultat.andreVurderinger).extracting("type")
                 .containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
             verify(exactly = 1) {
-                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any())
+                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any(), null)
             }
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -61,7 +61,8 @@ internal class DokumentServiceEnhetstest {
             settPåVentService = mockk(relaxed = true),
             utgåendeJournalføringService = utgåendeJournalføringService,
             fagsakRepository = fagsakRepository,
-            organisasjonService = organisasjonService
+            organisasjonService = organisasjonService,
+            behandlingHentOgPersisterService = mockk(relaxed = true)
         )
     )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpost
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.JournalføringRepository
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.brev.DokumentService.Companion.alleredeDistribuertMelding
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
@@ -44,11 +45,11 @@ internal class DokumentServiceEnhetstest {
     val journalføringRepository = mockk<JournalføringRepository>(relaxed = true)
     val fagsakRepository = mockk<FagsakRepository>(relaxed = true)
     val organisasjonService = mockk<OrganisasjonService>(relaxed = true)
+    val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>(relaxed = true)
 
     private val dokumentService: DokumentService = spyk(
         DokumentService(
             integrasjonClient = integrasjonClient,
-
             loggService = mockk(relaxed = true),
             persongrunnlagService = mockk(relaxed = true),
             journalføringRepository = journalføringRepository,
@@ -62,7 +63,7 @@ internal class DokumentServiceEnhetstest {
             utgåendeJournalføringService = utgåendeJournalføringService,
             fagsakRepository = fagsakRepository,
             organisasjonService = organisasjonService,
-            behandlingHentOgPersisterService = mockk(relaxed = true)
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService
         )
     )
 
@@ -192,7 +193,86 @@ internal class DokumentServiceEnhetstest {
     }
 
     @Test
-    fun `sendManueltBrev skal legge til opplysningspliktvilkåret, om så ved å initiere vilkårsvurdering først`() {
+    fun `sendManueltBrev skal legge til opplysningspliktvilkåret når gjeldende og forrige vilkårsvurdering mangler`() {
+        val brevSomFørerTilOpplysningsplikt = Brevmal.values().filter { it.førerTilOpplysningsplikt() }
+
+        brevSomFørerTilOpplysningsplikt.forEach { brevmal ->
+            val behandling = lagBehandling()
+            val vilkårsvurdering = lagVilkårsvurdering(lagPerson().aktør, behandling, Resultat.IKKE_VURDERT)
+            val personResultat = vilkårsvurdering.personResultater.find { it.erSøkersResultater() }!!
+
+            // Scenario uten eksisterende vilkårsvurdering
+            every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns null
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling) } returns null
+            every {
+                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(
+                    any(),
+                    any(),
+                    null
+                )
+            } returns
+                vilkårsvurdering
+
+            every { journalføringRepository.save(any()) } returns
+                DbJournalpost(behandling = behandling, journalpostId = "id")
+
+            sendBrev(brevmal, behandling)
+
+            assertThat(personResultat.andreVurderinger).extracting("type")
+                .containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
+            verify(exactly = 1) {
+                behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+            }
+            verify(exactly = 1) {
+                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any(), null)
+            }
+        }
+    }
+
+    @Test
+    fun `sendManueltBrev skal legge til opplysningspliktvilkåret når gjeldende vilkårsvurdering mangler, men forrige finnes`() {
+        val brevSomFørerTilOpplysningsplikt = Brevmal.values().filter { it.førerTilOpplysningsplikt() }
+
+        brevSomFørerTilOpplysningsplikt.forEach { brevmal ->
+            val behandling = lagBehandling()
+            val forrigeVedtatteBehandling = lagBehandling()
+            val vilkårsvurdering = lagVilkårsvurdering(lagPerson().aktør, behandling, Resultat.IKKE_VURDERT)
+            val personResultat = vilkårsvurdering.personResultater.find { it.erSøkersResultater() }!!
+
+            // Scenario uten eksisterende vilkårsvurdering
+            every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns null
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling) } returns forrigeVedtatteBehandling
+            every {
+                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(
+                    any(),
+                    any(),
+                    forrigeVedtatteBehandling
+                )
+            } returns
+                vilkårsvurdering
+
+            every { journalføringRepository.save(any()) } returns
+                DbJournalpost(behandling = behandling, journalpostId = "id")
+
+            sendBrev(brevmal, behandling)
+
+            assertThat(personResultat.andreVurderinger).extracting("type")
+                .containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
+            verify(exactly = 1) {
+                behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+            }
+            verify(exactly = 1) {
+                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(
+                    behandling,
+                    any(),
+                    forrigeVedtatteBehandling
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `sendManueltBrev skal legge til opplysningspliktvilkåret når vilkårsvurderingen finnes`() {
         val brevSomFørerTilOpplysningsplikt = Brevmal.values().filter { it.førerTilOpplysningsplikt() }
 
         brevSomFørerTilOpplysningsplikt.forEach { brevmal ->
@@ -210,26 +290,6 @@ internal class DokumentServiceEnhetstest {
             assertThat(personResultat.andreVurderinger).extracting("type")
                 .containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
             verify(exactly = 0) {
-                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any(), null)
-            }
-
-            // Scenario uten eksisterende vilkårsvurdering
-            personResultat.setAndreVurderinger(emptySet()) // nullstiller andreVurderinger
-            every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns null
-            every {
-                vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(
-                    any(),
-                    any(),
-                    null
-                )
-            } returns
-                vilkårsvurdering
-
-            sendBrev(brevmal, behandling)
-
-            assertThat(personResultat.andreVurderinger).extracting("type")
-                .containsExactly(AnnenVurderingType.OPPLYSNINGSPLIKT)
-            verify(exactly = 1) {
                 vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any(), null)
             }
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
@@ -110,7 +110,7 @@ class VilkårVurderingTest(
         personopplysningGrunnlagRepository.save(personopplysningGrunnlag)
 
         val vilkårsvurdering =
-            vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false)
+            vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false, null)
 
         val forventetAntallVurderteVilkår =
             Vilkår.hentVilkårFor(PersonType.BARN).size +

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -687,7 +687,7 @@ class VilkårServiceTest(
             barnAktør = personidentService.hentOgLagreAktørIder(listOf(barnFnr), true)
         )
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
-        vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false)
+        vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false, null)
         val exception = assertThrows<RuntimeException> {
             vilkårService.postVilkår(
                 behandling.id,
@@ -727,7 +727,7 @@ class VilkårServiceTest(
         )
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
         val vilkårsvurdering =
-            vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false)
+            vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false, null)
         assertEquals(
             1,
             vilkårsvurdering.personResultater.find { it.erSøkersResultater() }?.vilkårResultater?.filter { it.vilkårType == Vilkår.UTVIDET_BARNETRYGD }?.size
@@ -851,7 +851,7 @@ class VilkårServiceTest(
             barnAktør = personidentService.hentOgLagreAktørIder(listOf(barnFnr), true)
         )
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
-        vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false)
+        vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false, null)
 
         val exception = assertThrows<RuntimeException> {
             vilkårService.deleteVilkår(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Hvis saksbehandler revurderer pga av søknad og sender ut et brev i registrer-søknad-steget, så er ikke vilkårsvurderingen opprettet ennå. Hvis brevet utløser opplysningsplikt, vil vilkårsvurderingen opprettes. Denne fiksen sørger for at vilkårsvurderingen fra eventuell vedtatt behandling blir kopiert. Fjerner null-default-verdien på forrige-behandling-parameteren, slik at fremtidige utviklere må ta stilling til den. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
