### PR TITLE
Tiltak for å unngå gateway time-out ved henting av behandlingsfrister…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
@@ -154,7 +154,7 @@ class OppgaveController(
         return ResponseEntity.ok(Ressurs.success(fagsakId, "Oppgaven $oppgaveId er lukket"))
     }
 
-    @GetMapping("/hent-frister-for-apne-utvidet-barnetrygd-behandlinger")
+    @PostMapping("/hent-frister-for-apne-utvidet-barnetrygd-behandlinger")
     fun hentFristerForÅpneUtvidetBarnetrygdBehandlinger(): ResponseEntity<Ressurs<String>> {
         val behandleSakOppgaveFrister = oppgaveService.hentFristerForÅpneUtvidetBarnetrygdBehandlinger()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -222,8 +222,7 @@ class OppgaveService(
     }
 
     fun hentFristerForÅpneUtvidetBarnetrygdBehandlinger(): String {
-        val åpneUtvidetBarnetrygdBehandlinger = behandlingRepository.finnÅpneBehandlinger(opprettetFør = LocalDateTime.now())
-            .filter { it.underkategori == BehandlingUnderkategori.UTVIDET }
+        val åpneUtvidetBarnetrygdBehandlinger = behandlingRepository.finnÅpneUtvidetBarnetrygdBehandlinger()
 
         val behandlingsfrister = åpneUtvidetBarnetrygdBehandlinger.map { behandling ->
             val behandleSakOppgave = try {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -132,6 +132,10 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Query("SELECT b FROM Behandling b JOIN b.fagsak f WHERE b.opprettetTidspunkt < :opprettetFør AND b.status <> 'AVSLUTTET' AND f.arkivert = false")
     fun finnÅpneBehandlinger(opprettetFør: LocalDateTime): List<Behandling>
 
+    @Lock(LockModeType.NONE)
+    @Query("SELECT b FROM Behandling b JOIN b.fagsak f WHERE b.status <> 'AVSLUTTET' AND b.underkategori = 'UTVIDET' AND f.arkivert = false")
+    fun finnÅpneUtvidetBarnetrygdBehandlinger(): List<Behandling>
+
     @Query("SELECT DISTINCT aty.behandlingId FROM AndelTilkjentYtelse aty WHERE aty.behandlingId in :iverksatteLøpende AND aty.sats = :gammelSats AND aty.kalkulertUtbetalingsbeløp > 0 AND aty.stønadTom >= :månedÅrForEndring")
     fun finnBehandlingerForSatsendring(
         iverksatteLøpende: List<Long>,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -197,10 +197,9 @@ class OppgaveServiceTest {
 
     @Test
     fun `hent oppgavefrister for åpne utvidtet barnetrygd behandlinger`() {
-        every { behandlingRepository.finnÅpneBehandlinger(any()) } returns listOf(
+        every { behandlingRepository.finnÅpneUtvidetBarnetrygdBehandlinger() } returns listOf(
             lagTestBehandling().copy(underkategori = BehandlingUnderkategori.UTVIDET, id = 1002602L),
-            lagTestBehandling().copy(underkategori = BehandlingUnderkategori.UTVIDET, id = 1002602L),
-            lagTestBehandling().copy(underkategori = BehandlingUnderkategori.ORDINÆR, id = 1002602L)
+            lagTestBehandling().copy(underkategori = BehandlingUnderkategori.UTVIDET, id = 1002602L)
         )
         every { oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(any(), any()) } returns lagTestOppgave()
 


### PR DESCRIPTION
… for åpne utvidet barnetrygd saker ([Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10716)):

- Filtrer på UTVIDET i SQL-spørringen istedenfor i koden
- Gjør endepunktet om til POST som gir time-out senere enn GET (3 min vs 1 min)