### PR TITLE
Forsøker å sette nginx proxy timeout verdier til 3 minutter

### DIFF
--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -7,6 +7,8 @@ metadata:
     team: teamfamilie
   annotations:
     nginx.ingress.kubernetes.io/proxy-next-upstream-tries: '1'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "180"
 
 spec:
   envFrom:


### PR DESCRIPTION
da POST-request til api/oppgave/hent-frister-for-apne-utvidet-barnetrygd-behandlinger også ble brutt etter 1 minutt på lik linje med GET