### PR TITLE
Fjerner ubrukt felt fra utvidet behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
@@ -44,6 +44,5 @@ data class RestUtvidetBehandling(
     val verge: VergeInfo?,
     val korrigertEtterbetaling: RestKorrigertEtterbetaling?,
     val korrigertVedtak: RestKorrigertVedtak?,
-    val feilutbetaltValuta: List<RestFeilutbetaltValuta>,
-    val trekkILøpendeUtbetaling: List<RestFeilutbetaltValuta>
+    val feilutbetaltValuta: List<RestFeilutbetaltValuta>
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -153,8 +153,7 @@ class UtvidetBehandlingService(
                 ?.tilRestKorrigertEtterbetaling(),
             korrigertVedtak = korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(behandlingId)
                 ?.tilRestKorrigertVedtak(),
-            feilutbetaltValuta = feilutbetaltValuta,
-            trekkILøpendeUtbetaling = feilutbetaltValuta
+            feilutbetaltValuta = feilutbetaltValuta
         )
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Jobbet med å overføre feilutbetaltValuta logikken fra ba-sak til ks-sak.
Oppdaget trekkILøpendeUtbetaling som senere ble renamet til feilutbetaltValuta, men ikke fjernet fra behandlingresponsen enda. Frontend bruker heller ikke feltet, så tenkte det er greit å bli kvitt det nå.
