### PR TITLE
Fjerner avhengighet til SatsService.hentGyldigSats og skriver om til tidslinjer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -124,3 +124,22 @@ fun Tidslinje<AndelTilkjentYtelseForTidslinje, Måned>.tilAndelerTilkjentYtelse(
                 stønadTom = it.tilOgMed.tilYearMonth()
             )
         }
+
+/**
+ * Lager tidslinje med AndelTilkjentYtelseForTidslinje-objekter, som derfor er "trygg" mtp DB-endringer
+ * Ivaretar fom og tom i objektene, slik at ellers like andeler ikke blir slått sammen
+ */
+fun Iterable<AndelTilkjentYtelse>.tilTryggTidslinjeForSøkersYtelse(ytelseType: YtelseType) = this
+    .filter { it.erSøkersAndel() }
+    .filter { it.type == ytelseType }
+    .let {
+        tidslinje {
+            it.map {
+                Periode(
+                    it.stønadFom.tilTidspunkt(),
+                    it.stønadTom.tilTidspunkt(),
+                    it.tilpassTilTidslinjeOgBevarFomOgTom()
+                )
+            }
+        }
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.erTilogMed3ÅrTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
@@ -14,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import java.math.BigDecimal
 import java.time.YearMonth
 
 fun Iterable<AndelTilkjentYtelse>.tilSeparateTidslinjerForBarna(): Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>> {
@@ -74,3 +76,51 @@ fun Map<Aktør, Tidslinje<AndelTilkjentYtelse, Måned>>.kunAndelerTilOgMed3År(b
     // For hvert barn kombiner andel-tidslinjen med 3-års-tidslinjen. Resultatet er andelene når barna er inntil 3 år
     return this.joinIkkeNull(barnasErInntil3ÅrTidslinjer) { andel, _ -> andel }
 }
+
+data class AndelTilkjentYtelseForTidslinje(
+    val aktør: Aktør,
+    val beløp: Int,
+    val sats: Int,
+    val ytelseType: YtelseType,
+    val prosent: BigDecimal,
+    val stønadFom: YearMonth? = null,
+    val stønadTom: YearMonth? = null,
+    val nasjonaltPeriodebeløp: Int = beløp,
+    val differanseberegnetPeriodebeløp: Int? = null
+)
+
+fun AndelTilkjentYtelse.tilpassTilTidslinje() =
+    AndelTilkjentYtelseForTidslinje(
+        aktør = this.aktør,
+        beløp = this.kalkulertUtbetalingsbeløp,
+        ytelseType = this.type,
+        sats = this.sats,
+        prosent = this.prosent,
+        nasjonaltPeriodebeløp = this.nasjonaltPeriodebeløp ?: this.kalkulertUtbetalingsbeløp,
+        differanseberegnetPeriodebeløp = this.differanseberegnetPeriodebeløp
+    )
+
+fun AndelTilkjentYtelse.tilpassTilTidslinjeOgBevarFomOgTom() =
+    tilpassTilTidslinje().copy(
+        stønadFom = this.stønadFom,
+        stønadTom = this.stønadTom
+    )
+
+fun Tidslinje<AndelTilkjentYtelseForTidslinje, Måned>.tilAndelerTilkjentYtelse(tilkjentYtelse: TilkjentYtelse) =
+    perioder()
+        .filter { it.innhold != null }
+        .map {
+            AndelTilkjentYtelse(
+                behandlingId = tilkjentYtelse.behandling.id,
+                tilkjentYtelse = tilkjentYtelse,
+                aktør = it.innhold!!.aktør,
+                type = it.innhold.ytelseType,
+                kalkulertUtbetalingsbeløp = it.innhold.beløp,
+                nasjonaltPeriodebeløp = it.innhold.nasjonaltPeriodebeløp,
+                differanseberegnetPeriodebeløp = it.innhold.differanseberegnetPeriodebeløp,
+                sats = it.innhold.sats,
+                prosent = it.innhold.prosent,
+                stønadFom = it.fraOgMed.tilYearMonth(),
+                stønadTom = it.tilOgMed.tilYearMonth()
+            )
+        }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
+package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.erTilogMed3ÅrTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
@@ -68,6 +68,7 @@ object SatsService {
         .filter { it.gyldigFom == startDato }
         .filter { it.gyldigFom != LocalDate.MIN }
 
+    @Deprecated("Denne brukes nå bare av tester, og skal fjernes")
     fun hentGyldigSatsFor(
         satstype: SatsType,
         stønadFraOgMed: YearMonth,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGenerator.kt
@@ -1,8 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.Utils.avrundetHeltallAvProsent
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønadTidslinje
@@ -12,8 +11,8 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import java.time.LocalDate
 
 data class SmåbarnstilleggBarnetrygdGenerator(
@@ -57,35 +56,21 @@ data class SmåbarnstilleggBarnetrygdGenerator(
     private fun Tidslinje<SmåbarnstilleggPeriode, Måned>.lagSmåbarnstilleggAndeler(
         søkerAktør: Aktør
     ): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
-        return this.perioder().map {
-            val stønadFom = it.fraOgMed.tilYearMonth()
-            val stønadTom = it.tilOgMed.tilYearMonth()
+        return this.kombinerUtenNullMed(satstypeTidslinje(SatsType.SMA)) { småbarnstilleggPeriode, sats ->
+            val prosentIPeriode = småbarnstilleggPeriode.prosent
+            val beløpIPeriode = sats.avrundetHeltallAvProsent(prosent = prosentIPeriode)
 
-            val ordinærSatsForPeriode = SatsService.hentGyldigSatsFor(
-                satstype = SatsType.SMA,
-                stønadFraOgMed = stønadFom,
-                stønadTilOgMed = stønadTom
-            ).singleOrNull()?.sats
-                ?: throw Feil("Skal finnes én ordinær sats for gitt segment oppdelt basert på andeler")
-
-            val prosentIPeriode = it.innhold?.prosent ?: throw Feil("Skal finnes prosent for gitt periode")
-
-            val beløpIPeriode = ordinærSatsForPeriode.avrundetHeltallAvProsent(prosent = prosentIPeriode)
-
-            val andelTilkjentYtelse = AndelTilkjentYtelse(
-                behandlingId = behandlingId,
-                tilkjentYtelse = tilkjentYtelse,
+            AndelTilkjentYtelseForTidslinje(
                 aktør = søkerAktør,
-                stønadFom = stønadFom,
-                stønadTom = stønadTom,
-                kalkulertUtbetalingsbeløp = beløpIPeriode,
-                nasjonaltPeriodebeløp = beløpIPeriode,
-                type = YtelseType.SMÅBARNSTILLEGG,
-                sats = ordinærSatsForPeriode,
+                // Tar vare på overgangsstøandperiodene
+                stønadFom = småbarnstilleggPeriode.overgangsstønadPeriode.fomDato.toYearMonth(),
+                stønadTom = småbarnstilleggPeriode.overgangsstønadPeriode.tomDato.toYearMonth(),
+                beløp = beløpIPeriode,
+                ytelseType = YtelseType.SMÅBARNSTILLEGG,
+                sats = sats,
                 prosent = prosentIPeriode
             )
-
-            AndelTilkjentYtelseMedEndreteUtbetalinger.utenEndringer(andelTilkjentYtelse)
-        }
+        }.tilAndelerTilkjentYtelse(tilkjentYtelse)
+            .map { AndelTilkjentYtelseMedEndreteUtbetalinger.utenEndringer(it) }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseRepositoryUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseRepositoryUtil.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.ba.sak.kjerne.beregning
+
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.erIPraksisLik
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.inneholderIPraksis
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
+
+/**
+ * En litt risikabel funksjon, som benytter "funksjonell likhet" for å sjekke etter endringer på andel tilkjent ytelse
+ */
+fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
+    tilkjentYtelse: TilkjentYtelse,
+    oppdaterteAndeler: Collection<AndelTilkjentYtelse>
+): TilkjentYtelse {
+    if (tilkjentYtelse.andelerTilkjentYtelse.erIPraksisLik(oppdaterteAndeler)) {
+        return tilkjentYtelse
+    }
+
+    // Her er det viktig å beholde de originale andelene, som styres av JPA og har alt av innhold
+    val skalBeholdes = tilkjentYtelse.andelerTilkjentYtelse
+        .filter { oppdaterteAndeler.inneholderIPraksis(it) }
+
+    val skalLeggesTil = oppdaterteAndeler
+        .filter { !tilkjentYtelse.andelerTilkjentYtelse.inneholderIPraksis(it) }
+
+    // Forsikring: Sjekk at det ikke oppstår eller forsvinner andeler når de sjekkes for likhet
+    if (oppdaterteAndeler.size != (skalBeholdes.size + skalLeggesTil.size)) {
+        throw IllegalStateException("Avvik mellom antall innsendte andeler og kalkulerte endringer")
+    }
+
+    tilkjentYtelse.andelerTilkjentYtelse.clear()
+    tilkjentYtelse.andelerTilkjentYtelse.addAll(skalBeholdes + skalLeggesTil)
+
+    // Ekstra forsikring: Bygger tidslinjene på nytt for å sjekke at det ikke er introdusert duplikater
+    // Krasjer med Exception hvis det forekommer perioder per aktør og ytelsetype som overlapper
+    // Bør fjernes hvis det ikke forekommer feil
+    tilkjentYtelse.andelerTilkjentYtelse.sjekkForDuplikater()
+
+    return this.saveAndFlush(tilkjentYtelse)
+}
+
+@Deprecated("Brukes som sikkerhetsnett for å sjekke at det ikke oppstår duplikater. Burde være unødvendig")
+private fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
+    try {
+        // Det skal ikke være overlapp i andeler for en gitt ytelsestype og aktør
+        this.groupBy { it.aktør.aktørId + it.type }
+            .mapValues { (_, andeler) -> tidslinje { andeler.map { it.tilPeriode() } } }
+            .values.forEach { it.perioder() }
+    } catch (throwable: Throwable) {
+        throw IllegalStateException(
+            "Endring av andeler tilkjent ytelse i differanseberegning holder på å introdusere duplikater",
+            throwable
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -1,62 +1,48 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.Utils.avrundetHeltallAvProsent
-import no.nav.familie.ba.sak.common.erBack2BackIMånedsskifte
-import no.nav.familie.ba.sak.common.forrigeMåned
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.førsteDagINesteMåned
-import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.sisteDagIMåned
-import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMedKunVerdi
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullOgIkkeTom
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import no.nav.fpsak.tidsserie.LocalDateSegment
-import no.nav.fpsak.tidsserie.LocalDateTimeline
-import no.nav.fpsak.tidsserie.StandardCombinators
-import java.math.BigDecimal
-import java.time.LocalDate
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilForskjøvetTidslinjeForOppfyltVilkår
 
 data class UtvidetBarnetrygdGenerator(
     val behandlingId: Long,
     val tilkjentYtelse: TilkjentYtelse
 ) {
-
     fun lagUtvidetBarnetrygdAndeler(
         utvidetVilkår: List<VilkårResultat>,
-        andelerBarna: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
-    ): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
+        andelerBarna: List<AndelTilkjentYtelse>
+    ): List<AndelTilkjentYtelse> {
         if (utvidetVilkår.isEmpty() || andelerBarna.isEmpty()) return emptyList()
 
         val søkerAktør = utvidetVilkår.first().personResultat?.aktør ?: error("Vilkår mangler PersonResultat")
 
-        val datoSegmenter = utvidetVilkår
-            .filter { it.resultat == Resultat.OPPFYLT }
-            .map {
-                it.tilDatoSegment(utvidetVilkår = utvidetVilkår)
-            }
+        val utvidetVilkårTidslinje = utvidetVilkår.tilForskjøvetTidslinjeForOppfyltVilkår(Vilkår.UTVIDET_BARNETRYGD)
 
-        val utvidaTidslinje = LocalDateTimeline(datoSegmenter)
+        val størsteProsentTidslinje = andelerBarna
+            .tilSeparateTidslinjerForBarna().values
+            .kombinerUtenNullOgIkkeTom { andeler -> andeler.maxOf { it.prosent } }
 
-        val barnasTidslinje =
-            utledTidslinjeForBarna(andelerBarna)
-
-        val sammenslåttTidslinje = kombinerTidslinjer(utvidaTidslinje, barnasTidslinje)
-
-        val utvidetAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger> = sammenslåttTidslinje.toSegments()
-            .filter { segment -> segment.value.any { it.rolle == PersonType.BARN } && segment.value.any { it.rolle == PersonType.SØKER } }
-            .flatMap { segment ->
-                lagAndelerForSegmentBasertPåSatsperioder(segment, søkerAktør)
-            }
+        val utvidetAndeler = utvidetVilkårTidslinje.kombinerMedKunVerdi(
+            størsteProsentTidslinje,
+            satstypeTidslinje(SatsType.UTVIDET_BARNETRYGD)
+        ) { vilkår, prosent, sats ->
+            val nasjonaltPeriodebeløp = sats.avrundetHeltallAvProsent(prosent)
+            AndelTilkjentYtelseForTidslinje(
+                aktør = søkerAktør,
+                beløp = nasjonaltPeriodebeløp,
+                ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                sats = sats,
+                prosent = prosent
+            )
+        }.tilAndelerTilkjentYtelse(tilkjentYtelse)
 
         if (utvidetAndeler.isEmpty()) {
             throw FunksjonellFeil(
@@ -66,171 +52,5 @@ data class UtvidetBarnetrygdGenerator(
         }
 
         return utvidetAndeler
-    }
-
-    private fun lagAndelerForSegmentBasertPåSatsperioder(
-        segment: LocalDateSegment<List<PeriodeData>>,
-        søkerAktør: Aktør
-    ): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
-        val utvideteSatserForPeriode = SatsService.hentGyldigSatsFor(
-            satstype = SatsType.UTVIDET_BARNETRYGD,
-            stønadFraOgMed = segment.fom.toYearMonth(),
-            stønadTilOgMed = segment.tom.toYearMonth()
-        )
-
-        if (utvideteSatserForPeriode.isEmpty()) {
-            error("Finner ikke utvidet sats for periode fom=${segment.fom}, tom=${segment.tom}")
-        }
-
-        val prosentForPeriode =
-            segment.value.maxByOrNull { data -> data.prosent }?.prosent
-                ?: error("Finner ikke prosent for periode fom=${segment.fom}, tom=${segment.tom}")
-
-        return utvideteSatserForPeriode.map { satsperiode ->
-            val nasjonaltPeriodebeløp = satsperiode.sats.avrundetHeltallAvProsent(prosentForPeriode)
-            val andelTilkjentYtelse = AndelTilkjentYtelse(
-                behandlingId = behandlingId,
-                tilkjentYtelse = tilkjentYtelse,
-                aktør = søkerAktør,
-                stønadFom = satsperiode.fraOgMed,
-                stønadTom = satsperiode.tilOgMed,
-                kalkulertUtbetalingsbeløp = nasjonaltPeriodebeløp,
-                nasjonaltPeriodebeløp = nasjonaltPeriodebeløp,
-                type = YtelseType.UTVIDET_BARNETRYGD,
-                sats = satsperiode.sats,
-                prosent = prosentForPeriode
-            )
-
-            AndelTilkjentYtelseMedEndreteUtbetalinger.utenEndringer(andelTilkjentYtelse)
-        }
-    }
-
-    data class PeriodeData(val rolle: PersonType, val prosent: BigDecimal = BigDecimal.ZERO)
-
-    private fun utledTidslinjeForBarna(andelerBarna: List<AndelTilkjentYtelseMedEndreteUtbetalinger>): LocalDateTimeline<List<PeriodeData>> {
-        val barnasTidslinjer = andelerBarna
-            .groupBy { it.aktør }
-            .map { lagTidslinjeForBarn(identMedAndeler = it) }
-
-        val sammenlagtTidslinjeForBarna = barnasTidslinjer.reduce { sammenlagt, neste ->
-            (kombinerTidslinjer(sammenlagt, neste))
-        }
-
-        val barnasSegmenterSlåttSammenHvisLikProsent =
-            slåSammenEtterfølgendeSegmenterMedLikProsent(sammenlagtTidslinjeForBarna)
-
-        return LocalDateTimeline(barnasSegmenterSlåttSammenHvisLikProsent)
-    }
-
-    private fun lagTidslinjeForBarn(identMedAndeler: Map.Entry<Aktør, List<AndelTilkjentYtelseMedEndreteUtbetalinger>>) =
-        LocalDateTimeline(
-            identMedAndeler.value.map {
-                lagSegmentMedPeriodeData(
-                    fom = it.stønadFom.førsteDagIInneværendeMåned(),
-                    tom = it.stønadTom.sisteDagIInneværendeMåned(),
-                    prosentForPeriode = it.prosent,
-                    personType = PersonType.BARN
-                )
-            }
-        )
-
-    private fun slåSammenEtterfølgendeSegmenterMedLikProsent(sammenlagtTidslinjeForBarna: LocalDateTimeline<List<PeriodeData>>): List<LocalDateSegment<List<PeriodeData>>> {
-        return sammenlagtTidslinjeForBarna.toSegments()
-            .fold(listOf<LocalDateSegment<List<PeriodeData>>>()) { sammenslåttePerioder, nestePeriode ->
-                val sistePeriodeSomErSammenslått = sammenslåttePerioder.lastOrNull()
-                val segmenterErEtterfølgendeOgHarSammeProsent =
-                    sistePeriodeSomErSammenslått?.tom?.toYearMonth() == nestePeriode.fom.forrigeMåned() &&
-                        sistePeriodeSomErSammenslått.value.maxOf { it.prosent } == nestePeriode.value.maxOf { it.prosent }
-
-                if (sistePeriodeSomErSammenslått != null && segmenterErEtterfølgendeOgHarSammeProsent) {
-                    val prosentForPeriode = sistePeriodeSomErSammenslått.value.maxOf { it.prosent }
-                    sammenslåttePerioder.dropLast(1) + lagSegmentMedPeriodeData(
-                        fom = sistePeriodeSomErSammenslått.fom,
-                        tom = nestePeriode.tom,
-                        prosentForPeriode = prosentForPeriode,
-                        personType = PersonType.BARN
-                    )
-                } else {
-                    sammenslåttePerioder + lagSegmentMedPeriodeData(
-                        fom = nestePeriode.fom,
-                        tom = nestePeriode.tom,
-                        prosentForPeriode = nestePeriode.value.maxOf { it.prosent },
-                        personType = PersonType.BARN
-                    )
-                }
-            }
-    }
-
-    private fun lagSegmentMedPeriodeData(
-        fom: LocalDate,
-        tom: LocalDate,
-        prosentForPeriode: BigDecimal,
-        personType: PersonType
-    ) = LocalDateSegment(
-        fom,
-        tom,
-        listOf(
-            PeriodeData(
-                rolle = personType,
-                prosent = prosentForPeriode
-            )
-        )
-    )
-
-    private fun kombinerTidslinjer(
-        sammenlagtTidslinje: LocalDateTimeline<List<PeriodeData>>,
-        tidslinje: LocalDateTimeline<List<PeriodeData>>
-    ): LocalDateTimeline<List<PeriodeData>> {
-        val sammenlagt =
-            sammenlagtTidslinje.combine(
-                tidslinje,
-                StandardCombinators::bothValues,
-                LocalDateTimeline.JoinStyle.CROSS_JOIN
-            ) as LocalDateTimeline<List<List<PeriodeData>>>
-
-        return LocalDateTimeline(
-            sammenlagt.toSegments().map {
-                LocalDateSegment(it.fom, it.tom, it.value.flatten())
-            }
-        )
-    }
-}
-
-fun VilkårResultat.tilDatoSegment(
-    utvidetVilkår: List<VilkårResultat>
-): LocalDateSegment<List<UtvidetBarnetrygdGenerator.PeriodeData>> {
-    if (this.periodeFom == null) throw Feil("Fom må være satt på søkers periode ved utvidet barnetrygd")
-    val fraOgMedDato = this.periodeFom!!.førsteDagINesteMåned()
-    val tilOgMedDato = finnTilOgMedDato(tilOgMed = this.periodeTom, vilkårResultater = utvidetVilkår)
-    if (tilOgMedDato.toYearMonth() == fraOgMedDato.toYearMonth()
-        .minusMonths(1)
-    ) {
-        throw FunksjonellFeil("Du kan ikke legge inn fom. og tom. innenfor samme kalendermåned. Gå til utvidet barnetrygd vilkåret for å endre.")
-    }
-    return LocalDateSegment(
-        fraOgMedDato,
-        tilOgMedDato,
-        listOf(UtvidetBarnetrygdGenerator.PeriodeData(rolle = PersonType.SØKER))
-    )
-}
-
-fun finnTilOgMedDato(
-    tilOgMed: LocalDate?,
-    vilkårResultater: List<VilkårResultat>
-): LocalDate {
-    // LocalDateTimeline krasjer i isTimelineOutsideInterval funksjonen dersom vi sender med TIDENES_ENDE,
-    // så bruker tidenes ende minus én dag.
-    if (tilOgMed == null) return TIDENES_ENDE.minusDays(1)
-    val skalVidereføresEnMndEkstra = vilkårResultater.any { vilkårResultat ->
-        erBack2BackIMånedsskifte(
-            tilOgMed = tilOgMed,
-            fraOgMed = vilkårResultat.periodeFom
-        )
-    }
-
-    return if (skalVidereføresEnMndEkstra) {
-        tilOgMed.plusMonths(1).sisteDagIMåned()
-    } else {
-        tilOgMed.sisteDagIMåned()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -3,6 +3,11 @@ package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 import minsteAvHver
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.beregning.kunAndelerTilOgMed3År
+import no.nav.familie.ba.sak.kjerne.beregning.tilAndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilAndelerTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilSeparateTidslinjerForBarna
+import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinjeForSøkersYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilKronerPerValutaenhet
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilMånedligValutabeløp
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.times

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 import no.nav.familie.ba.sak.common.del
 import no.nav.familie.ba.sak.common.multipliser
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.medPeriode
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -1,12 +1,9 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseEndretAbonnent
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
-import no.nav.familie.ba.sak.kjerne.beregning.tilPeriode
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.erIPraksisLik
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.inneholderIPraksis
+import no.nav.familie.ba.sak.kjerne.beregning.oppdaterTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEndringAbonnent
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
@@ -14,7 +11,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -107,55 +103,5 @@ class TilpassDifferanseberegningSøkersYtelserService(
             kompetanser = kompetanseRepository.finnFraBehandlingId(tilkjentYtelse.behandling.id)
         )
         tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
-    }
-}
-
-/**
- * En litt risikabel funksjon, som benytter "funksjonell likhet" for å sjekke etter endringer
- * på andel tilkjent ytelse
- */
-fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
-    tilkjentYtelse: TilkjentYtelse,
-    oppdaterteAndeler: Collection<AndelTilkjentYtelse>
-): TilkjentYtelse {
-    if (tilkjentYtelse.andelerTilkjentYtelse.erIPraksisLik(oppdaterteAndeler)) {
-        return tilkjentYtelse
-    }
-
-    // Her er det viktig å beholde de originale andelene, som styres av JPA og har alt av innhold
-    val skalBeholdes = tilkjentYtelse.andelerTilkjentYtelse
-        .filter { oppdaterteAndeler.inneholderIPraksis(it) }
-
-    val skalLeggesTil = oppdaterteAndeler
-        .filter { !tilkjentYtelse.andelerTilkjentYtelse.inneholderIPraksis(it) }
-
-    // Forsikring: Sjekk at det ikke oppstår eller forsvinner andeler når de sjekkes for likhet
-    if (oppdaterteAndeler.size != (skalBeholdes.size + skalLeggesTil.size)) {
-        throw IllegalStateException("Avvik mellom antall innsendte andeler og kalkulerte endringer")
-    }
-
-    tilkjentYtelse.andelerTilkjentYtelse.clear()
-    tilkjentYtelse.andelerTilkjentYtelse.addAll(skalBeholdes + skalLeggesTil)
-
-    // Ekstra forsikring: Bygger tidslinjene på nytt for å sjekke at det ikke er introdusert duplikater
-    // Krasjer med Exception hvis det forekommer perioder per aktør og ytelsetype som overlapper
-    // Bør fjernes hvis det ikke forekommer feil
-    tilkjentYtelse.andelerTilkjentYtelse.sjekkForDuplikater()
-
-    return this.saveAndFlush(tilkjentYtelse)
-}
-
-@Deprecated("Brukes som sikkerhetsnett for å sjekke at det ikke oppstår duplikater. Burde være unødvendig")
-internal fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
-    try {
-        // Det skal ikke være overlapp i andeler for en gitt ytelsestype og aktør
-        this.groupBy { it.aktør.aktørId + it.type }
-            .mapValues { (_, andeler) -> tidslinje { andeler.map { it.tilPeriode() } } }
-            .values.forEach { it.perioder() }
-    } catch (throwable: Throwable) {
-        throw IllegalStateException(
-            "Endring av andeler tilkjent ytelse i differanseberegning holder på å introdusere duplikater",
-            throwable
-        )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseEndretAbonnent
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.tilPeriode
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.erIPraksisLik
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.inneholderIPraksis
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstilleggkorrigering/SmåbarnstilleggKorrigeringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstilleggkorrigering/SmåbarnstilleggKorrigeringService.kt
@@ -1,22 +1,23 @@
 package no.nav.familie.ba.sak.kjerne.småbarnstilleggkorrigering
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.opprettBooleanTidslinje
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
-import no.nav.familie.ba.sak.kjerne.beregning.SatsService
+import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseForTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.beregning.oppdaterTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.satstypeTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.tilAndelerTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilTryggTidslinjeForSøkersYtelse
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.harIkkeOverlappMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.harOverlappMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.time.YearMonth
@@ -25,101 +26,66 @@ import javax.transaction.Transactional
 @Service
 class SmåbarnstilleggKorrigeringService(
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
-    private val loggService: LoggService,
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
+    private val loggService: LoggService
 ) {
-
     @Transactional
-    fun leggTilSmåbarnstilleggPåBehandling(årMåned: YearMonth, behandling: Behandling): AndelTilkjentYtelse {
+    fun leggTilSmåbarnstilleggPåBehandling(årMåned: YearMonth, behandling: Behandling): List<AndelTilkjentYtelse> {
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandlingId = behandling.id)
         val andelTilkjentYtelser = tilkjentYtelse.andelerTilkjentYtelse
 
-        val andelerMedEndringer = andelerTilkjentYtelseOgEndreteUtbetalingerService
-            .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
+        val småbarnstilleggTidslinje = andelTilkjentYtelser.tilTryggTidslinjeForSøkersYtelse(YtelseType.SMÅBARNSTILLEGG)
+        val skalOpprettesTidslinje = opprettBooleanTidslinje(årMåned, årMåned)
 
-        val overlappendePeriodeFinnes = finnOverlappendeSmåbarnstilleggPeriode(andelerMedEndringer, årMåned)
-
-        if (overlappendePeriodeFinnes != null) {
+        if (småbarnstilleggTidslinje.harOverlappMed(skalOpprettesTidslinje)) {
             throw FunksjonellFeil("Det er ikke mulig å legge til småbarnstillegg for ${årMåned.tilMånedÅr()} fordi det allerede finnes småbarnstillegg for denne perioden")
         }
 
-        val nySmåbarnstillegg = opprettNyttSmåbarnstillegg(behandling, tilkjentYtelse, årMåned, årMåned)
+        val nyeSmåbarnstillegg = skalOpprettesTidslinje
+            .kombinerUtenNullMed(satstypeTidslinje(SatsType.SMA)) { _, sats ->
+                AndelTilkjentYtelseForTidslinje(
+                    aktør = behandling.fagsak.aktør,
+                    ytelseType = YtelseType.SMÅBARNSTILLEGG,
+                    prosent = BigDecimal(100),
+                    sats = sats,
+                    beløp = sats
+                )
+            }.tilAndelerTilkjentYtelse(tilkjentYtelse)
 
-        andelTilkjentYtelser.add(nySmåbarnstillegg)
+        andelTilkjentYtelser.addAll(nyeSmåbarnstillegg)
 
         loggService.opprettSmåbarnstilleggLogg(behandling, "Småbarnstillegg for ${årMåned.tilMånedÅr()} lagt til")
 
-        return nySmåbarnstillegg
+        return nyeSmåbarnstillegg
     }
 
     @Transactional
     fun fjernSmåbarnstilleggPåBehandling(årMåned: YearMonth, behandling: Behandling): List<AndelTilkjentYtelse> {
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandlingId = behandling.id)
-        val andelTilkjentYtelser = tilkjentYtelse.andelerTilkjentYtelse
 
-        val andelerMedEndringer = andelerTilkjentYtelseOgEndreteUtbetalingerService
-            .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
+        val småbarnstilleggTidslinje = tilkjentYtelse.andelerTilkjentYtelse
+            .tilTryggTidslinjeForSøkersYtelse(YtelseType.SMÅBARNSTILLEGG)
+        val skalFjernesTidslinje = opprettBooleanTidslinje(årMåned, årMåned)
 
-        val småBarnstilleggSomHarOverlappendePeriode =
-            finnOverlappendeSmåbarnstilleggPeriode(andelerMedEndringer, årMåned)
-                ?: throw FunksjonellFeil("Det er ikke mulig å fjerne småbarnstillegg for ${årMåned.tilMånedÅr()} fordi det ikke finnes småbarnstillegg for denne perioden")
-
-        val eksisterendeSmåBarnstilleggTidslinje =
-            AndelTilkjentYtelseTidslinje(listOf(småBarnstilleggSomHarOverlappendePeriode))
-        val filtrerBortSingelMånedTidslinje = opprettBooleanTidslinje(årMåned, årMåned)
-
-        val perioderUtenOverlapp =
-            eksisterendeSmåBarnstilleggTidslinje
-                .filtrerMed(filtrerBortSingelMånedTidslinje).perioder()
-                .filter { it.innhold == null }
-
-        val nyOppsplittetSmåbarnstillegg = perioderUtenOverlapp.map {
-            opprettNyttSmåbarnstillegg(
-                behandling,
-                tilkjentYtelse,
-                it.fraOgMed.tilYearMonth(),
-                it.tilOgMed.tilYearMonth()
-            )
+        if (småbarnstilleggTidslinje.harIkkeOverlappMed(skalFjernesTidslinje)) {
+            throw FunksjonellFeil("Det er ikke mulig å fjerne småbarnstillegg for ${årMåned.tilMånedÅr()} fordi det ikke finnes småbarnstillegg for denne perioden")
         }
 
-        andelTilkjentYtelser.remove(småBarnstilleggSomHarOverlappendePeriode.andel)
-        andelTilkjentYtelser.addAll(nyOppsplittetSmåbarnstillegg)
+        val nyeSmåbarnstilleggAndeler =
+            småbarnstilleggTidslinje.kombinerMed(skalFjernesTidslinje) { andel, skalFjernes ->
+                when (skalFjernes) {
+                    true -> null
+                    else -> andel
+                }
+            }.tilAndelerTilkjentYtelse(tilkjentYtelse)
+
+        val andelerTilkjentYtelserUtenomSmåbarnstillegg = tilkjentYtelse.andelerTilkjentYtelse
+            .filter { it.type != YtelseType.SMÅBARNSTILLEGG }
+
+        val oppdaterteAndeler = andelerTilkjentYtelserUtenomSmåbarnstillegg + nyeSmåbarnstilleggAndeler
+        tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
 
         loggService.opprettSmåbarnstilleggLogg(behandling, "Småbarnstillegg for ${årMåned.tilMånedÅr()} fjernet")
 
-        return nyOppsplittetSmåbarnstillegg
-    }
-
-    private fun opprettNyttSmåbarnstillegg(
-        behandling: Behandling,
-        tilkjentYtelse: TilkjentYtelse,
-        stønadFom: YearMonth,
-        stønadTom: YearMonth
-    ): AndelTilkjentYtelse {
-        val ordinærSatsForPeriode = SatsService.hentGyldigSatsFor(
-            satstype = SatsType.SMA,
-            stønadFraOgMed = stønadFom,
-            stønadTilOgMed = stønadTom
-        ).singleOrNull()?.sats ?: error("Skal finnes én ordinær sats for gitt segment oppdelt basert på andeler")
-
-        return AndelTilkjentYtelse(
-            behandlingId = behandling.id,
-            tilkjentYtelse = tilkjentYtelse,
-            aktør = behandling.fagsak.aktør,
-            stønadFom = stønadFom,
-            stønadTom = stønadTom,
-            type = YtelseType.SMÅBARNSTILLEGG,
-            prosent = BigDecimal(100),
-            sats = ordinærSatsForPeriode,
-            nasjonaltPeriodebeløp = ordinærSatsForPeriode,
-            kalkulertUtbetalingsbeløp = ordinærSatsForPeriode
-        )
-    }
-
-    private fun finnOverlappendeSmåbarnstilleggPeriode(
-        andelTilkjentYtelser: Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        årMåned: YearMonth
-    ) = andelTilkjentYtelser.firstOrNull {
-        it.erSmåbarnstillegg() && it.overlapperPeriode(MånedPeriode(årMåned, årMåned))
+        return nyeSmåbarnstilleggAndeler
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
@@ -166,3 +166,9 @@ fun <A, B, C, R, T : Tidsenhet> Tidslinje<A, T>.kombinerMedKunVerdi(
         else -> Innhold.utenInnhold()
     }
 }
+
+fun <V, H, T : Tidsenhet> Tidslinje<V, T>.harOverlappMed(tidslinje: Tidslinje<H, T>) =
+    this.kombinerUtenNullMed(tidslinje) { v, h -> true }.erIkkeTom()
+
+fun <V, H, T : Tidsenhet> Tidslinje<V, T>.harIkkeOverlappMed(tidslinje: Tidslinje<H, T>) =
+    !this.harOverlappMed(tidslinje)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeKombinator.kt
@@ -150,3 +150,19 @@ fun <A, B, C, R, T : Tidsenhet> Tidslinje<A, T>.kombinerMed(
         tidslinjeC.innholdForTidspunkt(tidspunkt).innhold
     ).tilInnhold()
 }
+
+fun <A, B, C, R, T : Tidsenhet> Tidslinje<A, T>.kombinerMedKunVerdi(
+    tidslinjeB: Tidslinje<B, T>,
+    tidslinjeC: Tidslinje<C, T>,
+    kombinator: (A, B, C) -> R?
+): Tidslinje<R, T> = tidsrom(this, tidslinjeB, tidslinjeC).tidslinjeFraTidspunkt { tidspunkt ->
+    val innholdA = this.innholdForTidspunkt(tidspunkt)
+    val innholdB = tidslinjeB.innholdForTidspunkt(tidspunkt)
+    val innholdC = tidslinjeC.innholdForTidspunkt(tidspunkt)
+
+    when {
+        innholdA.harVerdi && innholdB.harVerdi && innholdC.harVerdi ->
+            kombinator(innholdA.verdi, innholdB.verdi, innholdC.verdi).tilVerdi()
+        else -> Innhold.utenInnhold()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TomTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TomTidslinje.kt
@@ -7,3 +7,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 class TomTidslinje<I, T : Tidsenhet> : Tidslinje<I, T>() {
     override fun lagPerioder(): Collection<Periode<I, T>> = emptyList()
 }
+
+fun <I, T : Tidsenhet> Tidslinje<I, T>.erTom() = this == TomTidslinje<I, T>()
+fun <I, T : Tidsenhet> Tidslinje<I, T>.erIkkeTom() = !this.erTom()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
@@ -1,10 +1,10 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
-import io.mockk.mockk
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.common.nesteMåned
@@ -287,7 +287,7 @@ class SmåbarnstilleggUtilsTest {
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
                 behandlingId = 1L,
-                tilkjentYtelse = mockk()
+                tilkjentYtelse = lagInitiellTilkjentYtelse()
             ),
             nyePerioderMedFullOvergangsstønad = listOf(
                 InternPeriodeOvergangsstønad(
@@ -330,7 +330,7 @@ class SmåbarnstilleggUtilsTest {
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
                 behandlingId = 1L,
-                tilkjentYtelse = mockk()
+                tilkjentYtelse = lagInitiellTilkjentYtelse()
             ),
             nyePerioderMedFullOvergangsstønad = listOf(
                 InternPeriodeOvergangsstønad(
@@ -376,7 +376,7 @@ class SmåbarnstilleggUtilsTest {
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
                 behandlingId = 1L,
-                tilkjentYtelse = mockk()
+                tilkjentYtelse = lagInitiellTilkjentYtelse()
             ),
             nyePerioderMedFullOvergangsstønad = listOf(
                 InternPeriodeOvergangsstønad(
@@ -441,7 +441,7 @@ class SmåbarnstilleggUtilsTest {
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
                 behandlingId = 1L,
-                tilkjentYtelse = mockk()
+                tilkjentYtelse = lagInitiellTilkjentYtelse()
             ),
             nyePerioderMedFullOvergangsstønad = listOf(
                 InternPeriodeOvergangsstønad(
@@ -492,7 +492,7 @@ class SmåbarnstilleggUtilsTest {
         val påvirkerFagsak = vedtakOmOvergangsstønadPåvirkerFagsak(
             småbarnstilleggBarnetrygdGenerator = SmåbarnstilleggBarnetrygdGenerator(
                 behandlingId = 1L,
-                tilkjentYtelse = mockk()
+                tilkjentYtelse = lagInitiellTilkjentYtelse()
             ),
             nyePerioderMedFullOvergangsstønad = listOf(
                 InternPeriodeOvergangsstønad(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
+import hentPerioderMedUtbetaling
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.nesteMåned
@@ -13,6 +15,7 @@ import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
@@ -29,7 +32,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -449,7 +451,7 @@ internal class UtvidetBarnetrygdTest {
     }
 
     @Test
-    fun `Utvidet andel blir splittet opp på endring i utvidet vilkåret`() {
+    fun `Utvidet andel blir IKKE splittet opp på endring i utvidet vilkåret ved back-to-back, men utbetalingsperiodene blir det`() {
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =
@@ -521,24 +523,39 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             behandling = behandling
-        )
-            .andelerTilkjentYtelse.toList().sortedBy { it.type }
+        ).andelerTilkjentYtelse.toList().sortedBy { it.type }
 
-        assertEquals(3, andeler.size)
+        val vedtaksperioderMedBegrunnelser = hentPerioderMedUtbetaling(
+            andelerTilkjentYtelse = andeler.map { AndelTilkjentYtelseMedEndreteUtbetalinger.utenEndringer(it) },
+            vedtak = lagVedtak(behandling),
+            personResultater = vilkårsvurdering.personResultater,
+            personerIPersongrunnlag = personopplysningGrunnlag.personer.toList()
+        )
+
+        // Én  andel for barnet og én andel for utvidet barnetrygd. Utvidet-andelen splittes IKKE
+        assertEquals(2, andeler.size)
 
         val andelBarn = andeler[0]
-        val andelUtvidet1 = andeler[1]
-        val andelUtvidet2 = andeler[2]
+        val andelUtvidet = andeler[1]
 
         assertEquals(barnOppfylt.ident, andelBarn.aktør.aktivFødselsnummer())
-        assertEquals(barnOppfylt.tom.toYearMonth(), andelBarn.stønadTom)
+        assertEquals(YearMonth.of(2019, 5), andelBarn.stønadFom)
+        assertEquals(YearMonth.of(2020, 10), andelBarn.stønadTom)
 
-        assertEquals(søkerOrdinær.ident, andelUtvidet1.aktør.aktivFødselsnummer())
-        assertEquals(søkerOrdinær.ident, andelUtvidet2.aktør.aktivFødselsnummer())
-        assertEquals(søkerOrdinær.fom.plusMonths(1).toYearMonth(), andelUtvidet1.stønadFom)
-        assertEquals(b2bFom.plusMonths(1).toYearMonth(), andelUtvidet2.stønadFom)
-        assertEquals(b2bTom.toYearMonth().plusMonths(1), andelUtvidet1.stønadTom) // Legger på 1mnd pga back2back
-        assertEquals(søkerOrdinær.tom.toYearMonth(), andelUtvidet2.stønadTom)
+        assertEquals(søkerOrdinær.ident, andelUtvidet.aktør.aktivFødselsnummer())
+        assertEquals(YearMonth.of(2019, 5), andelUtvidet.stønadFom)
+        assertEquals(YearMonth.of(2020, 10), andelUtvidet.stønadTom)
+
+        // Én periode frem til og med 2020-02, og én fra og med 2020-03, der vilkåret er splittet
+        assertEquals(2, vedtaksperioderMedBegrunnelser.size)
+
+        val vedtaksperiode1 = vedtaksperioderMedBegrunnelser[0]
+        val vedtaksperiode2 = vedtaksperioderMedBegrunnelser[1]
+
+        assertEquals(LocalDate.of(2019, 5, 1), vedtaksperiode1.fom)
+        assertEquals(LocalDate.of(2020, 2, 29), vedtaksperiode1.tom)
+        assertEquals(LocalDate.of(2020, 3, 1), vedtaksperiode2.fom)
+        assertEquals(LocalDate.of(2020, 10, 31), vedtaksperiode2.tom)
     }
 
     @Test
@@ -874,43 +891,6 @@ internal class UtvidetBarnetrygdTest {
     }
 
     @Test
-    fun `Skal kaste feil hvis fom og tom er satt i samme måned`() {
-        val utvidetVilkårResultat = lagVilkårResultat(
-            vilkår = Vilkår.UTVIDET_BARNETRYGD,
-            fom = YearMonth.of(2022, 2),
-            tom = YearMonth.of(2022, 2)
-        )
-
-        assertThrows<FunksjonellFeil> {
-            utvidetVilkårResultat.tilDatoSegment(
-                utvidetVilkår = listOf(utvidetVilkårResultat)
-            )
-        }
-    }
-
-    @Test
-    fun `Skal ikke kaste feil hvis fom og tom er i samme måned, men tom er siste dag i mnd og nytt utvidet-vilkår starter første dag i neste mnd`() {
-        val utvidetVilkårResultat = lagVilkårResultat(
-            vilkårType = Vilkår.UTVIDET_BARNETRYGD,
-            periodeFom = LocalDate.of(2022, 2, 1),
-            periodeTom = LocalDate.of(2022, 2, 28)
-        )
-
-        assertDoesNotThrow {
-            utvidetVilkårResultat.tilDatoSegment(
-                utvidetVilkår = listOf(
-                    utvidetVilkårResultat,
-                    lagVilkårResultat(
-                        vilkårType = Vilkår.UTVIDET_BARNETRYGD,
-                        periodeFom = LocalDate.of(2022, 3, 1),
-                        periodeTom = null
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
     fun `Skal kaste feil hvis utvidet-andeler ikke overlapper med noen av barnas andeler`() {
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
@@ -931,7 +911,7 @@ internal class UtvidetBarnetrygdTest {
         )
 
         val barnasAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = YearMonth.of(2021, 10),
                 tom = YearMonth.of(2022, 2),
                 person = tilfeldigPerson(personType = PersonType.BARN),
@@ -939,7 +919,7 @@ internal class UtvidetBarnetrygdTest {
                 ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
                 tilkjentYtelse = tilkjentYtelse
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = YearMonth.of(2021, 10),
                 tom = YearMonth.of(2022, 1),
                 person = tilfeldigPerson(personType = PersonType.BARN),
@@ -981,7 +961,7 @@ internal class UtvidetBarnetrygdTest {
         )
 
         val barnasAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = YearMonth.of(2015, 10),
                 tom = YearMonth.of(2022, 2),
                 person = tilfeldigPerson(personType = PersonType.BARN),
@@ -997,12 +977,12 @@ internal class UtvidetBarnetrygdTest {
         ).lagUtvidetBarnetrygdAndeler(
             utvidetVilkår = listOf(utvidetVilkår),
             andelerBarna = barnasAndeler
-        )
+        ).sortedBy { it.stønadFom }
 
         assertEquals(2, utvidetAndeler.size)
 
-        val andelEtterSatsendring = utvidetAndeler[0]
-        val andelFørSatsendring = utvidetAndeler[1]
+        val andelFørSatsendring = utvidetAndeler[0]
+        val andelEtterSatsendring = utvidetAndeler[1]
 
         val datoForSatsendring = SatsService.hentDatoForSatsendring(
             satstype = SatsType.UTVIDET_BARNETRYGD,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.oppdaterTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.util.TilkjentYtelseBuilder
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilInneværendeMåned

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/TilkjentYtelseBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/TilkjentYtelseBuilder.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.satstypeTidslinje
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.tilAndelerTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
`SatsService.hentGyldigSats` tillater ikke å finne satsen for en periode i fremtiden. Det kan skape trøbbel, og virker som en unødvendig begrensning. I stedet bruker jeg `satstypeTidslinje` og skriver generelt om til å bruke tidslinjer mer.

_Les gjerne commit for commit_

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Fikler (som vanlig) med TilkjentYtelse.andelerTilkjentYtelse, som historisk sett ikke er lurt. Oppførselen er litt endret mtp hvilke andeler som fjernes og legges til. Men det _bør_ gå bra 🤞 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ koden allerede hadde tester. Har justert dem litt til å stemme overens med ny virkelighet, men de bør være funksjonelt like.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
