### PR TITLE
Tillat 0 som verdi i etterbetaling korrigering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -298,7 +298,7 @@ class BrevService(
             korrigertEtterbetalingService.finnAktivtKorrigeringPåBehandling(vedtak.behandling.id)?.beløp?.toBigDecimal()
                 ?: simuleringService.hentEtterbetaling(vedtak.behandling.id)
 
-        return etterbetalingsBeløp.takeIf { it > BigDecimal.ZERO }?.run { Utils.formaterBeløp(this.toInt()) }
+        return etterbetalingsBeløp.takeIf { it >= BigDecimal.ZERO }?.run { Utils.formaterBeløp(this.toInt()) }
     }
 
     private fun erFeilutbetalingPåBehandling(behandlingId: Long): Boolean =


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etterbetaling korrigering må også tillate verdi === 0 i tillegg til positive heltall.
Endringer må også gjøres i frontend. Se: https://github.com/navikt/familie-ba-sak-frontend/pull/2490

### 👀 Screen shots
Før:

https://user-images.githubusercontent.com/110383605/214021777-b2124a31-1976-4bd3-ba69-2e876a1e535e.mov


Etter:

https://user-images.githubusercontent.com/110383605/214021792-11302bdd-fab0-4046-8f4b-9bb87ff4f0c4.mov


