### PR TITLE
Fikser bug som bruker verdien 0 hvis det kommer fra simulering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -298,8 +298,9 @@ class BrevService(
         val korrigertEtterbetaling =
             korrigertEtterbetalingService.finnAktivtKorrigeringPåBehandling(vedtak.behandling.id)
 
-        return korrigertEtterbetaling?.beløp?.let { Utils.formaterBeløp(it) } ?: simuleringService.hentEtterbetaling(vedtak.behandling.id
-        ).takeIf { it >= BigDecimal.ZERO }?.run { Utils.formaterBeløp(this.toInt()) }
+        return korrigertEtterbetaling?.beløp?.let { Utils.formaterBeløp(it) } ?: simuleringService.hentEtterbetaling(
+            vedtak.behandling.id
+        ).takeIf { it > BigDecimal.ZERO }?.run { Utils.formaterBeløp(this.toInt()) }
     }
 
     private fun erFeilutbetalingPåBehandling(behandlingId: Long): Boolean =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -134,6 +134,7 @@ class BrevService(
                 vedtakFellesfelter = vedtakFellesfelter,
                 informasjonOmAarligKontroll = vedtaksperiodeService.skalHaÅrligKontroll(vedtak)
             )
+
             Brevmal.VEDTAK_FORTSATT_INNVILGET_INSTITUSJON -> ForsattInnvilget(
                 mal = Brevmal.VEDTAK_FORTSATT_INNVILGET_INSTITUSJON,
                 vedtakFellesfelter = vedtakFellesfelter
@@ -294,11 +295,11 @@ class BrevService(
         hentEtterbetalingsbeløp(vedtak)?.let { EtterbetalingInstitusjon(it) }
 
     private fun hentEtterbetalingsbeløp(vedtak: Vedtak): String? {
-        val etterbetalingsBeløp =
-            korrigertEtterbetalingService.finnAktivtKorrigeringPåBehandling(vedtak.behandling.id)?.beløp?.toBigDecimal()
-                ?: simuleringService.hentEtterbetaling(vedtak.behandling.id)
+        val korrigertEtterbetaling =
+            korrigertEtterbetalingService.finnAktivtKorrigeringPåBehandling(vedtak.behandling.id)
 
-        return etterbetalingsBeløp.takeIf { it >= BigDecimal.ZERO }?.run { Utils.formaterBeløp(this.toInt()) }
+        return korrigertEtterbetaling?.beløp?.let { Utils.formaterBeløp(it) } ?: simuleringService.hentEtterbetaling(vedtak.behandling.id
+        ).takeIf { it >= BigDecimal.ZERO }?.run { Utils.formaterBeløp(this.toInt()) }
     }
 
     private fun erFeilutbetalingPåBehandling(behandlingId: Long): Boolean =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Liten bugfix. Vi ønsker ikke å bruke verdien 0 hvis det kommer fra simulering, bare hvis det kommer fra korrigert etterbetaling.
