### PR TITLE
Behandlingsresultat/endring i kompetanse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -9,14 +9,54 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilTidslinje
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.fpsak.tidsserie.LocalDateSegment
 import no.nav.fpsak.tidsserie.LocalDateTimeline
 import no.nav.fpsak.tidsserie.StandardCombinators
 
 object BehandlingsresultatUtils {
+
+    internal fun erEndringIKompetanse(
+        nåværendeKompetanser: List<Kompetanse>,
+        forrigeKompetanser: List<Kompetanse>
+    ): Boolean {
+        val allePersonerMedKompetanser = (nåværendeKompetanser.flatMap { it.barnAktører } + forrigeKompetanser.flatMap { it.barnAktører }).distinct()
+
+        val finnesPersonMedEndretKompetanse = allePersonerMedKompetanser.any { aktør ->
+            erEndringIKompetanseForPerson(
+                nåværendeKompetanser = nåværendeKompetanser.filter { it.barnAktører.contains(aktør) },
+                forrigeKompetanser = forrigeKompetanser.filter { it.barnAktører.contains(aktør) }
+            )
+        }
+
+        return finnesPersonMedEndretKompetanse
+    }
+
+    private fun erEndringIKompetanseForPerson(
+        nåværendeKompetanser: List<Kompetanse>,
+        forrigeKompetanser: List<Kompetanse>
+    ): Boolean {
+        val nåværendeTidslinje = nåværendeKompetanser.tilTidslinje()
+        val forrigeTidslinje = forrigeKompetanser.tilTidslinje()
+
+        val endringerTidslinje = nåværendeTidslinje.kombinerUtenNullMed(forrigeTidslinje) { nåværende, forrige ->
+            (
+                nåværende.søkersAktivitet != forrige.søkersAktivitet ||
+                    nåværende.søkersAktivitetsland != forrige.søkersAktivitetsland ||
+                    nåværende.annenForeldersAktivitet != forrige.annenForeldersAktivitet ||
+                    nåværende.annenForeldersAktivitetsland != forrige.annenForeldersAktivitetsland ||
+                    nåværende.barnetsBostedsland != forrige.barnetsBostedsland ||
+                    nåværende.resultat != forrige.resultat
+                )
+        }
+
+        return endringerTidslinje.perioder().any { it.innhold == true }
+    }
 
     private fun ikkeStøttetFeil(behandlingsresultater: MutableSet<YtelsePersonResultat>) =
         Feil(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -217,6 +217,136 @@ class BehandlingsresultatUtilsTest {
     }
 
     @Test
+    fun `Endring i kompetanse - skal returnere true når søkers aktivitet endrer seg`() {
+        val forrigeBehandling = lagBehandling()
+        val nåværendeBehandling = lagBehandling()
+        val forrigeKompetanse =
+            lagKompetanse(
+                behandlingId = forrigeBehandling.id,
+                barnAktører = setOf(barn1Aktør),
+                barnetsBostedsland = "NO",
+                søkersAktivitet = SøkersAktivitet.ARBEIDER,
+                søkersAktivitetsland = "NO",
+                annenForeldersAktivitet = AnnenForeldersAktivitet.INAKTIV,
+                annenForeldersAktivitetsland = "PO",
+                kompetanseResultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
+                fom = YearMonth.now().minusMonths(6),
+                tom = null
+            )
+
+        val endring = BehandlingsresultatUtils.erEndringIKompetanse(
+            nåværendeKompetanser = listOf(forrigeKompetanse.copy(søkersAktivitet = SøkersAktivitet.ARBEIDER_PÅ_NORSK_SOKKEL).apply { behandlingId = nåværendeBehandling.id }),
+            forrigeKompetanser = listOf(forrigeKompetanse)
+        )
+
+        assertEquals(true, endring)
+    }
+
+    @Test
+    fun `Endring i kompetanse - skal returnere true når annen forelders aktivitetsland endrer seg`() {
+        val forrigeBehandling = lagBehandling()
+        val nåværendeBehandling = lagBehandling()
+        val forrigeKompetanse =
+            lagKompetanse(
+                behandlingId = forrigeBehandling.id,
+                barnAktører = setOf(barn1Aktør),
+                barnetsBostedsland = "NO",
+                søkersAktivitet = SøkersAktivitet.ARBEIDER,
+                søkersAktivitetsland = "NO",
+                annenForeldersAktivitet = AnnenForeldersAktivitet.INAKTIV,
+                annenForeldersAktivitetsland = "PO",
+                kompetanseResultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
+                fom = YearMonth.now().minusMonths(6),
+                tom = null
+            )
+
+        val endring = BehandlingsresultatUtils.erEndringIKompetanse(
+            nåværendeKompetanser = listOf(forrigeKompetanse.copy(annenForeldersAktivitetsland = "DK").apply { behandlingId = nåværendeBehandling.id }),
+            forrigeKompetanser = listOf(forrigeKompetanse)
+        )
+
+        assertEquals(true, endring)
+    }
+
+    @Test
+    fun `Endring i kompetanse - skal returnere true når annen forelders aktivitet endrer seg`() {
+        val forrigeBehandling = lagBehandling()
+        val nåværendeBehandling = lagBehandling()
+        val forrigeKompetanse =
+            lagKompetanse(
+                behandlingId = forrigeBehandling.id,
+                barnAktører = setOf(barn1Aktør),
+                barnetsBostedsland = "NO",
+                søkersAktivitet = SøkersAktivitet.ARBEIDER,
+                søkersAktivitetsland = "NO",
+                annenForeldersAktivitet = AnnenForeldersAktivitet.INAKTIV,
+                annenForeldersAktivitetsland = "PO",
+                kompetanseResultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
+                fom = YearMonth.now().minusMonths(6),
+                tom = null
+            )
+
+        val endring = BehandlingsresultatUtils.erEndringIKompetanse(
+            nåværendeKompetanser = listOf(forrigeKompetanse.copy(annenForeldersAktivitet = AnnenForeldersAktivitet.FORSIKRET_I_BOSTEDSLAND).apply { behandlingId = nåværendeBehandling.id }),
+            forrigeKompetanser = listOf(forrigeKompetanse)
+        )
+
+        assertEquals(true, endring)
+    }
+
+    @Test
+    fun `Endring i kompetanse - skal returnere true når barnets bostedsland endrer seg`() {
+        val forrigeBehandling = lagBehandling()
+        val nåværendeBehandling = lagBehandling()
+        val forrigeKompetanse =
+            lagKompetanse(
+                behandlingId = forrigeBehandling.id,
+                barnAktører = setOf(barn1Aktør),
+                barnetsBostedsland = "NO",
+                søkersAktivitet = SøkersAktivitet.ARBEIDER,
+                søkersAktivitetsland = "NO",
+                annenForeldersAktivitet = AnnenForeldersAktivitet.INAKTIV,
+                annenForeldersAktivitetsland = "PO",
+                kompetanseResultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
+                fom = YearMonth.now().minusMonths(6),
+                tom = null
+            )
+
+        val endring = BehandlingsresultatUtils.erEndringIKompetanse(
+            nåværendeKompetanser = listOf(forrigeKompetanse.copy(barnetsBostedsland = "DK").apply { behandlingId = nåværendeBehandling.id }),
+            forrigeKompetanser = listOf(forrigeKompetanse)
+        )
+
+        assertEquals(true, endring)
+    }
+
+    @Test
+    fun `Endring i kompetanse - skal returnere true når resultat på kompetansen endrer seg`() {
+        val forrigeBehandling = lagBehandling()
+        val nåværendeBehandling = lagBehandling()
+        val forrigeKompetanse =
+            lagKompetanse(
+                behandlingId = forrigeBehandling.id,
+                barnAktører = setOf(barn1Aktør),
+                barnetsBostedsland = "NO",
+                søkersAktivitet = SøkersAktivitet.ARBEIDER,
+                søkersAktivitetsland = "NO",
+                annenForeldersAktivitet = AnnenForeldersAktivitet.INAKTIV,
+                annenForeldersAktivitetsland = "PO",
+                kompetanseResultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
+                fom = YearMonth.now().minusMonths(6),
+                tom = null
+            )
+
+        val endring = BehandlingsresultatUtils.erEndringIKompetanse(
+            nåværendeKompetanser = listOf(forrigeKompetanse.copy(resultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND).apply { behandlingId = nåværendeBehandling.id }),
+            forrigeKompetanser = listOf(forrigeKompetanse)
+        )
+
+        assertEquals(true, endring)
+    }
+
+    @Test
     fun `Endring i kompetanse - skal returnere false når det kun blir lagt på en ekstra kompetanseperiode`() {
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Lager metode som detekterer om det har vært endring i kompetanse.

Ønsker for hvert barn å se om det har vært en endring i kompetanse. Tingene vi må se på er:
- Barnets bostedsland
- Søkers aktivitetsland
- Søkers aktivitet
- Annen forelders aktivitetsland
- Annen forelders aktivitet
- Resultat (primærland/sekundærland)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Måten jeg har løst det på nå tar ikke hensyn til eventuelle splitter som skulle oppstå (så lenge innholdet på hver side av splitten er likt). Jeg tror ikke slike splitter er ønsket å ta med uansett, men greit å høre med Eivind.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
