### PR TITLE
Legg til "erFeilkonto" på ØkonomiSimuleringPostering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>1.20230109093555_e5eaa65</prosessering.version>
         <felles.version>1.20230116145510_2afcc20</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>2.0_20230110150447_4edded8</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20230126101531_7e94a8f</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20221123134052_8bdd6c8</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
@@ -272,5 +272,6 @@ fun SimulertPostering.tilVedtakSimuleringPostering(økonomiSimuleringMottaker: �
         posteringType = this.posteringType,
         forfallsdato = this.forfallsdato,
         utenInntrekk = this.utenInntrekk,
-        økonomiSimuleringMottaker = økonomiSimuleringMottaker
+        økonomiSimuleringMottaker = økonomiSimuleringMottaker,
+        erFeilkonto = this.erFeilkonto
     )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/ØkonomiSimuleringPostering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/ØkonomiSimuleringPostering.kt
@@ -70,7 +70,7 @@ data class ØkonomiSimuleringPostering(
     @Column(name = "uten_inntrekk", nullable = false)
     val utenInntrekk: Boolean,
 
-    @Column(name = "er_feilkonto", nullable = false)
+    @Column(name = "er_feilkonto", nullable = true)
     val erFeilkonto: Boolean?
 ) : BaseEntitet() {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/ØkonomiSimuleringPostering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/ØkonomiSimuleringPostering.kt
@@ -68,7 +68,10 @@ data class ØkonomiSimuleringPostering(
     val forfallsdato: LocalDate,
 
     @Column(name = "uten_inntrekk", nullable = false)
-    val utenInntrekk: Boolean
+    val utenInntrekk: Boolean,
+
+    @Column(name = "er_feilkonto", nullable = false)
+    val erFeilkonto: Boolean?
 ) : BaseEntitet() {
 
     override fun hashCode() = id.hashCode()

--- a/src/main/resources/db/migration/V235__okonomi_simulering_mottaker_legg_til_er_feilutbetaling.sql
+++ b/src/main/resources/db/migration/V235__okonomi_simulering_mottaker_legg_til_er_feilutbetaling.sql
@@ -1,0 +1,2 @@
+ALTER TABLE okonomi_simulering_postering
+    ADD er_feilkonto BOOLEAN;

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ØkonomiTestConfig.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ØkonomiTestConfig.kt
@@ -57,7 +57,8 @@ val simulertPosteringMock = listOf(
         beløp = 50.0.toBigDecimal(),
         posteringType = PosteringType.YTELSE,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -67,7 +68,8 @@ val simulertPosteringMock = listOf(
         beløp = 1004.0.toBigDecimal(),
         posteringType = PosteringType.YTELSE,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -77,7 +79,8 @@ val simulertPosteringMock = listOf(
         beløp = 50.0.toBigDecimal(),
         posteringType = PosteringType.FEILUTBETALING,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -87,7 +90,8 @@ val simulertPosteringMock = listOf(
         beløp = (-50.0).toBigDecimal(),
         posteringType = PosteringType.MOTP,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -97,7 +101,8 @@ val simulertPosteringMock = listOf(
         beløp = (-1054.0).toBigDecimal(),
         posteringType = PosteringType.YTELSE,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -107,7 +112,8 @@ val simulertPosteringMock = listOf(
         beløp = 50.0.toBigDecimal(),
         posteringType = PosteringType.YTELSE,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -117,7 +123,8 @@ val simulertPosteringMock = listOf(
         beløp = 1004.0.toBigDecimal(),
         posteringType = PosteringType.YTELSE,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -127,7 +134,8 @@ val simulertPosteringMock = listOf(
         beløp = 50.0.toBigDecimal(),
         posteringType = PosteringType.FEILUTBETALING,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -137,7 +145,8 @@ val simulertPosteringMock = listOf(
         beløp = (-50.0).toBigDecimal(),
         posteringType = PosteringType.MOTP,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -147,7 +156,8 @@ val simulertPosteringMock = listOf(
         beløp = (-1054.0).toBigDecimal(),
         posteringType = PosteringType.YTELSE,
         forfallsdato = LocalDate.parse("2021-02-23"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     ),
     SimulertPostering(
         fagOmrådeKode = FagOmrådeKode.BARNETRYGD,
@@ -157,7 +167,8 @@ val simulertPosteringMock = listOf(
         beløp = 1054.0.toBigDecimal(),
         posteringType = PosteringType.YTELSE,
         forfallsdato = LocalDate.parse("2024-05-10"),
-        utenInntrekk = false
+        utenInntrekk = false,
+        erFeilkonto = null
     )
 )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
@@ -63,7 +63,8 @@ class SimuleringUtilTest {
         beløp = beløp.toBigDecimal(),
         posteringType = posteringType,
         forfallsdato = forfallsdato,
-        utenInntrekk = utenInntrekk
+        utenInntrekk = utenInntrekk,
+        erFeilkonto = null
     )
 
     fun mockVedtakSimuleringPosteringer(
@@ -83,7 +84,8 @@ class SimuleringUtilTest {
             beløp = beløp.toBigDecimal(),
             posteringType = posteringstype,
             forfallsdato = måned.plusMonths(index.toLong()).atEndOfMonth(),
-            utenInntrekk = false
+            utenInntrekk = false,
+            erFeilkonto = null
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
@@ -364,6 +364,7 @@ class VurderTilbakekrevingStegTest {
         beløp = beløp.toBigDecimal(),
         posteringType = posteringType,
         forfallsdato = forfallsdato,
-        utenInntrekk = utenInntrekk
+        utenInntrekk = utenInntrekk,
+        erFeilkonto = null
     )
 }


### PR DESCRIPTION
Legger til felt som lar oss skille på om en feilutbetaling er reel eller ikke. Dersom nøs har laget en manuell postering etter at betalingen har gått ut fra venteregisteret(eller noe i den duren, jeg er ikke helt stødig på når det skjer) får vi feilutbetaling tilsvarende den manuelle posteringen. 

Siden den de feilutbetalingene ikke er reelle ønsker vi å se bort fra dem. Vi har en antagelse om at "erFeilkonto" er false når feilutbetalingene ikke er reelle, og at vi dermed kan se bort fra dem