### PR TITLE
Vi går tilbake til vanlig runners siden det finnes færre runners for 8 cores og det ga oss ikke gevinst

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   deploy-to-dev:
     name: Bygg app/image, push til github, deploy til dev-gcp
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   integrasjonstester:
     name: Kjører integrasjonstester
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
For ba-sak går vi tilbake til vanlig ubuntu-runner siden det ikke finnes mange runners for 8 cores samt at det ikke ga oss gevinst i integrasjonstestene. Vi lar det stå for ks foreløpig da ks har fått stor gevinst av å bytte.