### PR TITLE
Behandlingsresultat: endre måten vi henter ut endret utbetaling andel for aty

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -168,8 +168,8 @@ object BehandlingsresultatUtils {
 
         val finnesPersonMedEndretKompetanse = allePersonerMedKompetanser.any { aktør ->
             erEndringIKompetanseForPerson(
-                nåværendeKompetanser = nåværendeKompetanser.filter { it.barnAktører.contains(aktør) },
-                forrigeKompetanser = forrigeKompetanser.filter { it.barnAktører.contains(aktør) }
+                nåværendeKompetanserForPerson = nåværendeKompetanser.filter { it.barnAktører.contains(aktør) },
+                forrigeKompetanserForPerson = forrigeKompetanser.filter { it.barnAktører.contains(aktør) }
             )
         }
 
@@ -177,11 +177,11 @@ object BehandlingsresultatUtils {
     }
 
     private fun erEndringIKompetanseForPerson(
-        nåværendeKompetanser: List<Kompetanse>,
-        forrigeKompetanser: List<Kompetanse>
+        nåværendeKompetanserForPerson: List<Kompetanse>,
+        forrigeKompetanserForPerson: List<Kompetanse>
     ): Boolean {
-        val nåværendeTidslinje = nåværendeKompetanser.tilTidslinje()
-        val forrigeTidslinje = forrigeKompetanser.tilTidslinje()
+        val nåværendeTidslinje = nåværendeKompetanserForPerson.tilTidslinje()
+        val forrigeTidslinje = forrigeKompetanserForPerson.tilTidslinje()
 
         val endringerTidslinje = nåværendeTidslinje.kombinerUtenNullMed(forrigeTidslinje) { nåværende, forrige ->
             (
@@ -205,8 +205,8 @@ object BehandlingsresultatUtils {
 
         val finnesPersonerMedEndretEndretUtbetalingAndel = allePersoner.any { aktør ->
             erEndringIEndretUtbetalingAndelPerPerson(
-                nåværendeEndretAndeler = nåværendeEndretAndeler.filter { it.person?.aktør == aktør },
-                forrigeEndretAndeler = forrigeEndretAndeler.filter { it.person?.aktør == aktør }
+                nåværendeEndretAndelerForPerson = nåværendeEndretAndeler.filter { it.person?.aktør == aktør },
+                forrigeEndretAndelerForPerson = forrigeEndretAndeler.filter { it.person?.aktør == aktør }
             )
         }
 
@@ -214,11 +214,11 @@ object BehandlingsresultatUtils {
     }
 
     private fun erEndringIEndretUtbetalingAndelPerPerson(
-        nåværendeEndretAndeler: List<EndretUtbetalingAndel>,
-        forrigeEndretAndeler: List<EndretUtbetalingAndel>
+        nåværendeEndretAndelerForPerson: List<EndretUtbetalingAndel>,
+        forrigeEndretAndelerForPerson: List<EndretUtbetalingAndel>
     ): Boolean {
-        val nåværendeTidslinje = EndretUtbetalingAndelTidslinje(nåværendeEndretAndeler)
-        val forrigeTidslinje = EndretUtbetalingAndelTidslinje(forrigeEndretAndeler)
+        val nåværendeTidslinje = EndretUtbetalingAndelTidslinje(nåværendeEndretAndelerForPerson)
+        val forrigeTidslinje = EndretUtbetalingAndelTidslinje(forrigeEndretAndelerForPerson)
 
         val endringerTidslinje = nåværendeTidslinje.kombinerUtenNullMed(forrigeTidslinje) { nåværende, forrige ->
             (

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.EndretUtbetalingAndelTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
@@ -107,8 +107,8 @@ object BehandlingsresultatUtils {
         forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
         nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
     ): List<Søknadsresultat> {
-        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndeler)
-        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndeler)
+        val forrigeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(forrigeAndeler)
+        val nåværendeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(nåværendeAndeler)
 
         val resultatTidslinje = nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
             val forrigeBeløp = forrige?.kalkulertUtbetalingsbeløp
@@ -350,8 +350,8 @@ object BehandlingsresultatUtils {
         opphørstidspunkt: YearMonth,
         erFremstiltKravForPerson: Boolean
     ): Boolean {
-        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndeler)
-        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndeler)
+        val nåværendeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(nåværendeAndeler)
+        val forrigeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(forrigeAndeler)
 
         val endringIBeløpTidslinje = nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
             val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp ?: 0

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -95,8 +95,8 @@ object BehandlingsresultatUtils {
     ): List<Søknadsresultat> {
         val alleSøknadsresultater = personerFremstiltKravFor.flatMap { aktør ->
             utledSøknadResultatFraAndelerTilkjentYtelsePerPerson(
-                forrigeAndeler = forrigeAndeler.filter { it.aktør == aktør },
-                nåværendeAndeler = nåværendeAndeler.filter { it.aktør == aktør }
+                forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
+                nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør }
             )
         }
 
@@ -104,11 +104,11 @@ object BehandlingsresultatUtils {
     }
 
     private fun utledSøknadResultatFraAndelerTilkjentYtelsePerPerson(
-        forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
+        forrigeAndelerForPerson: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        nåværendeAndelerForPerson: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
     ): List<Søknadsresultat> {
-        val forrigeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(forrigeAndeler)
-        val nåværendeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(nåværendeAndeler)
+        val forrigeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(forrigeAndelerForPerson)
+        val nåværendeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(nåværendeAndelerForPerson)
 
         val resultatTidslinje = nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
             val forrigeBeløp = forrige?.kalkulertUtbetalingsbeløp

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -619,8 +619,8 @@ private fun Set<YtelsePersonResultat>.matcherAltOgHarBådeEndretOgOpphørtResult
 }
 
 fun hentOpphørsresultatPåBehandling(
-    nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-    forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
+    nåværendeAndeler: List<AndelTilkjentYtelse>,
+    forrigeAndeler: List<AndelTilkjentYtelse>
 ): Opphørsresultat {
     val nåværendeBehandlingOpphørsdato = nåværendeAndeler.maxOf { it.stønadTom }
     val forrigeBehandlingOpphørsdato = forrigeAndeler.maxOf { it.stønadTom }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.EndretUtbetalingAndelTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -288,8 +287,8 @@ object BehandlingsresultatUtils {
     }
 
     internal fun utledEndringsresultat(
-        nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
+        forrigeAndeler: List<AndelTilkjentYtelse>,
         personerFremstiltKravFor: List<Aktør>,
         nåværendeKompetanser: List<Kompetanse>,
         forrigeKompetanser: List<Kompetanse>,
@@ -332,8 +331,8 @@ object BehandlingsresultatUtils {
 
     // NB: For personer fremstilt krav for tar vi ikke hensyn til alle endringer i beløp i denne funksjonen
     internal fun erEndringIBeløp(
-        nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
+        forrigeAndeler: List<AndelTilkjentYtelse>,
         personerFremstiltKravFor: List<Aktør>
     ): Boolean {
         val allePersonerMedAndeler = (nåværendeAndeler.map { it.aktør } + forrigeAndeler.map { it.aktør }).distinct()
@@ -353,13 +352,13 @@ object BehandlingsresultatUtils {
 
     // Kun interessert i endringer i beløp FØR opphørstidspunkt
     private fun erEndringIBeløpForPerson(
-        nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
+        forrigeAndeler: List<AndelTilkjentYtelse>,
         opphørstidspunkt: YearMonth,
         erFremstiltKravForPerson: Boolean
     ): Boolean {
-        val nåværendeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(nåværendeAndeler)
-        val forrigeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(forrigeAndeler)
+        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndeler)
+        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndeler)
 
         val endringIBeløpTidslinje = nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
             val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp ?: 0

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -10,7 +10,9 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.EndretUtbetalingAndelTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
@@ -39,8 +41,8 @@ import java.time.YearMonth
 object BehandlingsresultatUtils {
 
     private fun utledResultatPåSøknad(
-        forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        forrigeAndeler: List<AndelTilkjentYtelse>,
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
         nåværendePersonResultater: Set<PersonResultat>,
         personerFremstiltKravFor: List<Aktør>,
         endretUtbetalingAndeler: List<EndretUtbetalingAndel>
@@ -91,8 +93,8 @@ object BehandlingsresultatUtils {
             }
 
     internal fun utledSøknadResultatFraAndelerTilkjentYtelse(
-        forrigeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        nåværendeAndeler: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        forrigeAndeler: List<AndelTilkjentYtelse>,
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
         personerFremstiltKravFor: List<Aktør>,
         endretUtbetalingAndeler: List<EndretUtbetalingAndel>
     ): List<Søknadsresultat> {
@@ -108,12 +110,12 @@ object BehandlingsresultatUtils {
     }
 
     private fun utledSøknadResultatFraAndelerTilkjentYtelsePerPerson(
-        forrigeAndelerForPerson: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-        nåværendeAndelerForPerson: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        forrigeAndelerForPerson: List<AndelTilkjentYtelse>,
+        nåværendeAndelerForPerson: List<AndelTilkjentYtelse>,
         endretUtbetalingAndelerForPerson: List<EndretUtbetalingAndel>
     ): List<Søknadsresultat> {
-        val forrigeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(forrigeAndelerForPerson)
-        val nåværendeTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(nåværendeAndelerForPerson)
+        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndelerForPerson)
+        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndelerForPerson)
         val endretUtbetalingTidslinje = EndretUtbetalingAndelTidslinje(endretUtbetalingAndelerForPerson)
 
         val resultatTidslinje = nåværendeTidslinje.kombinerMed(forrigeTidslinje, endretUtbetalingTidslinje) { nåværende, forrige, endretUtbetalingAndel ->
@@ -127,7 +129,7 @@ object BehandlingsresultatUtils {
                     val endringsperiodeÅrsak = endretUtbetalingAndel?.årsak
 
                     when {
-                        nåværende.andel.differanseberegnetPeriodebeløp != null -> Søknadsresultat.INNVILGET
+                        nåværende.differanseberegnetPeriodebeløp != null -> Søknadsresultat.INNVILGET
                         endringsperiodeÅrsak == Årsak.DELT_BOSTED -> Søknadsresultat.INNVILGET
                         (endringsperiodeÅrsak == Årsak.ALLEREDE_UTBETALT) ||
                             (endringsperiodeÅrsak == Årsak.ENDRE_MOTTAKER) ||

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 
-class AndelTilkjentYtelseTidslinje(
+class AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(
     private val andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
 ) : Tidslinje<AndelTilkjentYtelseMedEndreteUtbetalinger, Måned>() {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
@@ -1,0 +1,22 @@
+package no.nav.familie.ba.sak.kjerne.beregning
+
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
+
+class AndelTilkjentYtelseTidslinje(
+    private val andelerTilkjentYtelse: List<AndelTilkjentYtelse>
+) : Tidslinje<AndelTilkjentYtelse, Måned>() {
+
+    override fun lagPerioder(): List<Periode<AndelTilkjentYtelse, Måned>> {
+        return andelerTilkjentYtelse.map {
+            Periode(
+                fraOgMed = it.stønadFom.tilTidspunkt(),
+                tilOgMed = it.stønadTom.tilTidspunkt(),
+                innhold = it
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGenerator.kt
@@ -36,7 +36,7 @@ data class SmåbarnstilleggBarnetrygdGenerator(
         val perioderMedFullOvergangsstønadTidslinje =
             InternPeriodeOvergangsstønadTidslinje(perioderMedFullOvergangsstønad)
 
-        val utvidetBarnetrygdTidslinje = AndelTilkjentYtelseTidslinje(andelerTilkjentYtelse = utvidetAndeler)
+        val utvidetBarnetrygdTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(andelerTilkjentYtelse = utvidetAndeler)
 
         val barnSomGirRettTilSmåbarnstilleggTidslinje = lagTidslinjeForPerioderMedBarnSomGirRettTilSmåbarnstillegg(
             barnasAndeler = barnasAndeler,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
@@ -191,7 +191,7 @@ fun lagTidslinjeForPerioderMedBarnSomGirRettTilSmåbarnstillegg(
     barnasAktørerOgFødselsdatoer: List<Pair<Aktør, LocalDate>>
 ): Tidslinje<BarnSinRettTilSmåbarnstillegg, Måned> {
     val barnasAndelerTidslinjer =
-        barnasAndeler.groupBy { it.aktør }.mapValues { AndelTilkjentYtelseTidslinje(it.value) }
+        barnasAndeler.groupBy { it.aktør }.mapValues { AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(it.value) }
 
     val barnasAndelerUnder3ÅrTidslinje = barnasAndelerTidslinjer.map { (barnAktør, barnTidslinje) ->
         val barnetsFødselsdato = barnasAktørerOgFødselsdatoer.find { it.first == barnAktør }?.second
@@ -213,7 +213,7 @@ data class SmåbarnstilleggPeriode(
 
 fun kombinerAlleTidslinjerTilProsentTidslinje(
     perioderMedFullOvergangsstønadTidslinje: InternPeriodeOvergangsstønadTidslinje,
-    utvidetBarnetrygdTidslinje: AndelTilkjentYtelseTidslinje,
+    utvidetBarnetrygdTidslinje: AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje,
     barnSomGirRettTilSmåbarnstilleggTidslinje: Tidslinje<BarnSinRettTilSmåbarnstillegg, Måned>
 ): Tidslinje<SmåbarnstilleggPeriode, Måned> {
     return perioderMedFullOvergangsstønadTidslinje

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.common.YearMonthConverter
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.hentPerioderMedEndringerFra
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -312,9 +312,9 @@ fun List<AndelTilkjentYtelse>?.hentTidslinje() =
         } ?: emptyList()
     )
 
-fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilTidslinjerPerPersonOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseTidslinje> =
+fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilTidslinjerPerPersonOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
-        AndelTilkjentYtelseTidslinje(
+        AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(
             andelerTilkjentYtelsePåPerson
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstilleggkorrigering/SmåbarnstilleggKorrigeringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstilleggkorrigering/SmåbarnstilleggKorrigeringService.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.opprettBooleanTidslinje
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
@@ -65,7 +65,7 @@ class SmåbarnstilleggKorrigeringService(
                 ?: throw FunksjonellFeil("Det er ikke mulig å fjerne småbarnstillegg for ${årMåned.tilMånedÅr()} fordi det ikke finnes småbarnstillegg for denne perioden")
 
         val eksisterendeSmåBarnstilleggTidslinje =
-            AndelTilkjentYtelseTidslinje(listOf(småBarnstilleggSomHarOverlappendePeriode))
+            AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(listOf(småBarnstilleggSomHarOverlappendePeriode))
         val filtrerBortSingelMånedTidslinje = opprettBooleanTidslinje(årMåned, årMåned)
 
         val perioderUtenOverlapp =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -7,7 +7,7 @@ import io.mockk.mockkStatic
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.common.lagPerson
@@ -69,7 +69,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -77,7 +77,7 @@ class BehandlingsresultatUtilsTest {
             )
         )
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mai22,
                 beløp = 1054,
@@ -100,13 +100,13 @@ class BehandlingsresultatUtilsTest {
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -114,13 +114,13 @@ class BehandlingsresultatUtilsTest {
             )
         )
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mai22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -143,13 +143,13 @@ class BehandlingsresultatUtilsTest {
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -157,19 +157,19 @@ class BehandlingsresultatUtilsTest {
             )
         )
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mai22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = mai22.plusMonths(1),
                 tom = aug22,
                 beløp = 527,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -192,13 +192,13 @@ class BehandlingsresultatUtilsTest {
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -206,13 +206,13 @@ class BehandlingsresultatUtilsTest {
             )
         )
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = des22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -235,13 +235,13 @@ class BehandlingsresultatUtilsTest {
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -249,13 +249,13 @@ class BehandlingsresultatUtilsTest {
             )
         )
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = des22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -278,13 +278,13 @@ class BehandlingsresultatUtilsTest {
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -292,19 +292,19 @@ class BehandlingsresultatUtilsTest {
             )
         )
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mai22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = mai22.plusMonths(1),
                 tom = aug22,
                 beløp = 527,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -630,13 +630,13 @@ class BehandlingsresultatUtilsTest {
         every { YearMonth.now() } returns YearMonth.of(2022, 4)
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mai22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mai22,
                 beløp = 1054,
@@ -645,13 +645,13 @@ class BehandlingsresultatUtilsTest {
         )
 
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mai22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -673,13 +673,13 @@ class BehandlingsresultatUtilsTest {
         every { YearMonth.now() } returns YearMonth.of(2022, 4)
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -688,13 +688,13 @@ class BehandlingsresultatUtilsTest {
         )
 
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = feb22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = feb22,
                 beløp = 1054,
@@ -717,13 +717,13 @@ class BehandlingsresultatUtilsTest {
         every { YearMonth.now() } returns apr22
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mar22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mar22,
                 beløp = 1054,
@@ -732,13 +732,13 @@ class BehandlingsresultatUtilsTest {
         )
 
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = feb22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = feb22,
                 beløp = 1054,
@@ -761,13 +761,13 @@ class BehandlingsresultatUtilsTest {
         every { YearMonth.now() } returns apr22
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mar22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mar22,
                 beløp = 1054,
@@ -776,13 +776,13 @@ class BehandlingsresultatUtilsTest {
         )
 
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mar22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = mar22,
                 beløp = 1054,
@@ -1027,7 +1027,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1037,7 +1037,8 @@ class BehandlingsresultatUtilsTest {
         val søknadsResultat = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = listOf(forrigeAndel),
             nåværendeAndeler = listOf(forrigeAndel.copy()),
-            personerFremstiltKravFor = emptyList()
+            personerFremstiltKravFor = emptyList(),
+            endretUtbetalingAndeler = emptyList()
         )
 
         assertThat(søknadsResultat, Is(emptyList()))
@@ -1048,7 +1049,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1058,7 +1059,8 @@ class BehandlingsresultatUtilsTest {
         val søknadsResultat = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = listOf(forrigeAndel),
             nåværendeAndeler = listOf(forrigeAndel.copy()),
-            personerFremstiltKravFor = listOf(barn1Aktør)
+            personerFremstiltKravFor = listOf(barn1Aktør),
+            endretUtbetalingAndeler = emptyList()
         )
 
         assertThat(søknadsResultat.size, Is(1))
@@ -1070,7 +1072,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 0,
@@ -1080,13 +1082,10 @@ class BehandlingsresultatUtilsTest {
         val søknadsResultat = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = listOf(forrigeAndel),
             nåværendeAndeler = listOf(
-                forrigeAndel.copy(
-                    andelTilkjentYtelse = forrigeAndel.andel.copy(
-                        kalkulertUtbetalingsbeløp = 1054
-                    )
-                )
+                forrigeAndel.copy(kalkulertUtbetalingsbeløp = 1054)
             ),
-            personerFremstiltKravFor = listOf(barn1Aktør)
+            personerFremstiltKravFor = listOf(barn1Aktør),
+            endretUtbetalingAndeler = emptyList()
         )
 
         assertThat(søknadsResultat.size, Is(1))
@@ -1098,7 +1097,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1108,13 +1107,10 @@ class BehandlingsresultatUtilsTest {
         val søknadsResultat = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = listOf(forrigeAndel),
             nåværendeAndeler = listOf(
-                forrigeAndel.copy(
-                    andelTilkjentYtelse = forrigeAndel.andel.copy(
-                        kalkulertUtbetalingsbeløp = 0
-                    )
-                )
+                forrigeAndel.copy(kalkulertUtbetalingsbeløp = 0)
             ),
-            personerFremstiltKravFor = listOf(barn1Aktør)
+            personerFremstiltKravFor = listOf(barn1Aktør),
+            endretUtbetalingAndeler = emptyList()
         )
 
         assertThat(søknadsResultat.size, Is(1))
@@ -1127,7 +1123,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = barn1Person.aktør
 
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1146,16 +1142,10 @@ class BehandlingsresultatUtilsTest {
         val søknadsResultat = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = listOf(forrigeAndel),
             nåværendeAndeler = listOf(
-                forrigeAndel.copy(
-                    andelTilkjentYtelse = forrigeAndel.andel.copy(
-                        kalkulertUtbetalingsbeløp = 0,
-                        endretUtbetalingAndeler = mutableListOf(
-                            endretUtbetalingAndel
-                        )
-                    )
-                )
+                forrigeAndel.copy(kalkulertUtbetalingsbeløp = 0)
             ),
-            personerFremstiltKravFor = listOf(barn1Aktør)
+            personerFremstiltKravFor = listOf(barn1Aktør),
+            endretUtbetalingAndeler = listOf(endretUtbetalingAndel)
         )
 
         assertThat(søknadsResultat.size, Is(1))
@@ -1171,7 +1161,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = barn1Person.aktør
 
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1190,16 +1180,10 @@ class BehandlingsresultatUtilsTest {
         val søknadsResultat = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = listOf(forrigeAndel),
             nåværendeAndeler = listOf(
-                forrigeAndel.copy(
-                    andelTilkjentYtelse = forrigeAndel.andel.copy(
-                        kalkulertUtbetalingsbeløp = 0,
-                        endretUtbetalingAndeler = mutableListOf(
-                            endretUtbetalingAndel
-                        )
-                    )
-                )
+                forrigeAndel.copy(kalkulertUtbetalingsbeløp = 0)
             ),
-            personerFremstiltKravFor = listOf(barn1Aktør)
+            personerFremstiltKravFor = listOf(barn1Aktør),
+            endretUtbetalingAndeler = listOf(endretUtbetalingAndel)
         )
 
         assertThat(søknadsResultat.size, Is(1))
@@ -1212,7 +1196,7 @@ class BehandlingsresultatUtilsTest {
         val barn1Aktør = barn1Person.aktør
 
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1223,13 +1207,12 @@ class BehandlingsresultatUtilsTest {
             forrigeAndeler = listOf(forrigeAndel),
             nåværendeAndeler = listOf(
                 forrigeAndel.copy(
-                    andelTilkjentYtelse = forrigeAndel.andel.copy(
-                        kalkulertUtbetalingsbeløp = 0,
-                        differanseberegnetPeriodebeløp = 0
-                    )
+                    kalkulertUtbetalingsbeløp = 0,
+                    differanseberegnetPeriodebeløp = 0
                 )
             ),
-            personerFremstiltKravFor = listOf(barn1Aktør)
+            personerFremstiltKravFor = listOf(barn1Aktør),
+            endretUtbetalingAndeler = emptyList()
         )
 
         assertThat(søknadsResultat.size, Is(1))
@@ -1243,13 +1226,13 @@ class BehandlingsresultatUtilsTest {
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
                 aktør = barn1Aktør
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1257,23 +1240,13 @@ class BehandlingsresultatUtilsTest {
             )
         )
         val nåværendeAndeler = listOf(
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 0,
                 aktør = barn1Aktør,
-                endretUtbetalingAndeler = listOf(
-                    lagEndretUtbetalingAndel(
-                        person = barn1Person,
-                        fom = jan22,
-                        tom = aug22,
-                        prosent = BigDecimal(100),
-                        behandlingId = 123L,
-                        årsak = Årsak.ALLEREDE_UTBETALT
-                    )
-                )
             ),
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1060,
@@ -1281,10 +1254,20 @@ class BehandlingsresultatUtilsTest {
             )
         )
 
+        val endretUtbetalingAndel = lagEndretUtbetalingAndel(
+            person = barn1Person,
+            fom = jan22,
+            tom = aug22,
+            prosent = BigDecimal(100),
+            behandlingId = 123L,
+            årsak = Årsak.ALLEREDE_UTBETALT
+        )
+
         val søknadsResultat = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = forrigeAndeler,
             nåværendeAndeler = nåværendeAndeler,
-            personerFremstiltKravFor = listOf(barn1Aktør, barn2Aktør)
+            personerFremstiltKravFor = listOf(barn1Aktør, barn2Aktør),
+            endretUtbetalingAndeler = listOf(endretUtbetalingAndel)
         )
 
         assertThat(søknadsResultat.size, Is(2))
@@ -1619,7 +1602,7 @@ class BehandlingsresultatUtilsTest {
     @Test
     fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i beløp`() {
         val forrigeAndel =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+            lagAndelTilkjentYtelse(
                 fom = jan22,
                 tom = aug22,
                 beløp = 1054,
@@ -1628,7 +1611,7 @@ class BehandlingsresultatUtilsTest {
 
         val endringsresultat = utledEndringsresultat(
             forrigeAndeler = listOf(forrigeAndel),
-            nåværendeAndeler = listOf(forrigeAndel.copy(andelTilkjentYtelse = forrigeAndel.andel.copy(kalkulertUtbetalingsbeløp = 40))),
+            nåværendeAndeler = listOf(forrigeAndel.copy(kalkulertUtbetalingsbeløp = 40)),
             personerFremstiltKravFor = emptyList(),
             forrigeKompetanser = emptyList(),
             nåværendeKompetanser = emptyList(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -1244,7 +1244,7 @@ class BehandlingsresultatUtilsTest {
                 fom = jan22,
                 tom = aug22,
                 beløp = 0,
-                aktør = barn1Aktør,
+                aktør = barn1Aktør
             ),
             lagAndelTilkjentYtelse(
                 fom = jan22,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
@@ -199,7 +199,7 @@ class SmåbarnstilleggUtilsTest {
 
         val kombinertTidslinje = kombinerAlleTidslinjerTilProsentTidslinje(
             perioderMedFullOvergangsstønadTidslinje = InternPeriodeOvergangsstønadTidslinje(overgangsstønadPerioder),
-            utvidetBarnetrygdTidslinje = AndelTilkjentYtelseTidslinje(utvidetAndeler),
+            utvidetBarnetrygdTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(utvidetAndeler),
             barnSomGirRettTilSmåbarnstilleggTidslinje = barnsSomGirRettTilSmåbarnstilleggTidslinje
         )
 
@@ -258,7 +258,7 @@ class SmåbarnstilleggUtilsTest {
 
         val kombinertTidslinje = kombinerAlleTidslinjerTilProsentTidslinje(
             perioderMedFullOvergangsstønadTidslinje = InternPeriodeOvergangsstønadTidslinje(overgangsstønadPerioder),
-            utvidetBarnetrygdTidslinje = AndelTilkjentYtelseTidslinje(utvidetAndeler),
+            utvidetBarnetrygdTidslinje = AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(utvidetAndeler),
             barnSomGirRettTilSmåbarnstilleggTidslinje = barnsSomGirRettTilSmåbarnstilleggTidslinje
         )
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Gjør to ting:
- Endrer måten vi henter ut endret utbetaling andel for en gitt måned. Før var vi avhengig av listen med endringer som lå på andelen, men nå lager vi heller en endretUtbetalingAndelTidslinje som vi kombinerer sammen med de to Aty-tidslinjene
- Bruker AndelTilkjentYtelse direkte i stedet for å få gjennom wrapper-klassen AndelTilkjentYtelseMedEndreteUtbetalinger

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Endrer ikke på logikken så eksisterende tester burde fortsatt kjøre grønt 💚

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
