### PR TITLE
Fjern fremtidige posteringer testcase

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
@@ -555,7 +555,6 @@ class SimuleringUtilTest {
         val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(vedtakSimuleringMottakere, true)
 
         simuleringsperioder
-            .dropLast(1) // Siste måned er ikke utbetalt enda
             .forEach {
                 assertThat(it.korrigertResultat.abs()).isLessThanOrEqualTo(BigDecimal.ONE)
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
@@ -53,8 +53,7 @@ class SimuleringUtilTest {
         betalingType: BetalingType = if (beløp >= 0) BetalingType.DEBIT else BetalingType.KREDIT,
         posteringType: PosteringType = PosteringType.YTELSE,
         forfallsdato: LocalDate = LocalDate.now().minusMonths(1),
-        utenInntrekk: Boolean = false,
-        erFeilkonto: Boolean? = null
+        utenInntrekk: Boolean = false
     ) = ØkonomiSimuleringPostering(
         økonomiSimuleringMottaker = økonomiSimuleringMottaker,
         fagOmrådeKode = fagOmrådeKode,
@@ -587,14 +586,12 @@ class SimuleringUtilTest {
             mockVedtakSimuleringPostering(
                 beløp = 46,
                 posteringType = PosteringType.FEILUTBETALING,
-                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_INFOTRYGD,
-                erFeilkonto = false
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_INFOTRYGD
             ),
             mockVedtakSimuleringPostering(
                 beløp = -46,
                 posteringType = PosteringType.MOTP,
-                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_INFOTRYGD,
-                erFeilkonto = false
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_INFOTRYGD
             ),
 
             mockVedtakSimuleringPostering(

--- a/src/test/resources/kjerne.simulering/simulering_med_manuell_postering.json
+++ b/src/test/resources/kjerne.simulering/simulering_med_manuell_postering.json
@@ -921,23 +921,6 @@
           "endret_av": "T126296",
           "endret_tid": "2023-01-06 09:55:37.633",
           "versjon": 0
-        },
-        {
-          "id": 5661768,
-          "fk_okonomi_simulering_mottaker_id": 1228768,
-          "fagOmrådeKode": "BARNETRYGD",
-          "fom": "2023-01-01",
-          "tom": "2023-01-31",
-          "betalingType": "DEBIT",
-          "beløp": 305,
-          "posteringType": "YTELSE",
-          "forfallsdato": "2023-01-31",
-          "utenInntrekk": false,
-          "opprettet_av": "T126296",
-          "opprettet_tid": "2023-01-06 09:55:37.633",
-          "endret_av": "T126296",
-          "endret_tid": "2023-01-06 09:55:37.633",
-          "versjon": 0
         }
       ]
     }

--- a/src/test/resources/kjerne.simulering/simulering_med_mottrekk.json
+++ b/src/test/resources/kjerne.simulering/simulering_med_mottrekk.json
@@ -1129,23 +1129,6 @@
           "endretAv": "V142809",
           "endretTid": "2023-01-06 13:11:12.551",
           "versjon": 0
-        },
-        {
-          "id": 5670692,
-          "fk_okonomi_simulering_mottaker_id": 1229110,
-          "fagOmrådeKode": "BARNETRYGD",
-          "fom": "2023-01-01",
-          "tom": "2023-01-31",
-          "betalingType": "DEBIT",
-          "beløp": 658,
-          "posteringType": "YTELSE",
-          "forfallsdato": "2023-01-31",
-          "uten_inntrekk": false,
-          "opprettetAv": "V142809",
-          "opprettetTid": "2023-01-06 13:11:12.551",
-          "endretAv": "V142809",
-          "endretTid": "2023-01-06 13:11:12.551",
-          "versjon": 0
         }
       ]
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har et testcase med en "fremtidig" debit-postering ikke som ikke har en tilsvarende kredit-postering. Siden vi har passert januar er den ikke lenger fremtidig, og den gir feil. Fjerner derfor posteringer for januar 2023 i to tester



### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
