### PR TITLE
Behandlingsresultat/bug andeler utvidet og smaabarnstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -77,19 +77,23 @@ object BehandlingsresultatEndringUtils {
         val opphørstidspunkt = nåværendeAndeler.utledOpphørsdatoForNåværendeBehandlingMedFallback(forrigeAndeler = forrigeAndeler) ?: return false // Returnerer false hvis verken forrige eller nåværende behandling har andeler
 
         val erEndringIBeløpForMinstEnPerson = allePersonerMedAndeler.any { aktør ->
-            erEndringIBeløpForPerson(
-                nåværendeAndeler = nåværendeAndeler.filter { it.aktør == aktør },
-                forrigeAndeler = forrigeAndeler.filter { it.aktør == aktør },
-                opphørstidspunkt = opphørstidspunkt,
-                erFremstiltKravForPerson = personerFremstiltKravFor.contains(aktør)
-            )
+            val ytelseTyperForPerson = (nåværendeAndeler.map { it.type } + forrigeAndeler.map { it.type }).distinct()
+
+            ytelseTyperForPerson.any { ytelseType ->
+                erEndringIBeløpForPersonOgType(
+                    nåværendeAndeler = nåværendeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
+                    forrigeAndeler = forrigeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
+                    opphørstidspunkt = opphørstidspunkt,
+                    erFremstiltKravForPerson = personerFremstiltKravFor.contains(aktør)
+                )
+            }
         }
 
         return erEndringIBeløpForMinstEnPerson
     }
 
     // Kun interessert i endringer i beløp FØR opphørstidspunkt
-    private fun erEndringIBeløpForPerson(
+    private fun erEndringIBeløpForPersonOgType(
         nåværendeAndeler: List<AndelTilkjentYtelse>,
         forrigeAndeler: List<AndelTilkjentYtelse>,
         opphørstidspunkt: YearMonth,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -67,17 +67,21 @@ object BehandlingsresultatSøknadUtils {
         endretUtbetalingAndeler: List<EndretUtbetalingAndel>
     ): List<Søknadsresultat> {
         val alleSøknadsresultater = personerFremstiltKravFor.flatMap { aktør ->
-            utledSøknadResultatFraAndelerTilkjentYtelsePerPerson(
-                forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
-                nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør },
-                endretUtbetalingAndelerForPerson = endretUtbetalingAndeler.filter { it.person?.aktør == aktør }
-            )
+            val ytelseTyper = (forrigeAndeler.map { it.type } + nåværendeAndeler.map { it.type }).distinct()
+
+            ytelseTyper.flatMap { ytelseType ->
+                utledSøknadResultatFraAndelerTilkjentYtelsePerPersonOgType(
+                    forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
+                    nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
+                    endretUtbetalingAndelerForPerson = endretUtbetalingAndeler.filter { it.person?.aktør == aktør }
+                )
+            }
         }
 
         return alleSøknadsresultater.distinct()
     }
 
-    private fun utledSøknadResultatFraAndelerTilkjentYtelsePerPerson(
+    private fun utledSøknadResultatFraAndelerTilkjentYtelsePerPersonOgType(
         forrigeAndelerForPerson: List<AndelTilkjentYtelse>,
         nåværendeAndelerForPerson: List<AndelTilkjentYtelse>,
         endretUtbetalingAndelerForPerson: List<EndretUtbetalingAndel>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.common.YearMonthConverter
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.hentPerioderMedEndringerFra
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -312,9 +312,9 @@ fun List<AndelTilkjentYtelse>?.hentTidslinje() =
         } ?: emptyList()
     )
 
-fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilTidslinjerPerPersonOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje> =
+fun List<AndelTilkjentYtelse>.tilTidslinjerPerPersonOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseTidslinje> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
-        AndelTilkjentYtelseMedEndreteUtbetalingerTidslinje(
+        AndelTilkjentYtelseTidslinje(
             andelerTilkjentYtelsePåPerson
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.UtbetalingsperiodeMed
 import hentPerioderMedUtbetaling
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -20,14 +21,14 @@ class UtbetalingsperiodeMedBegrunnelserService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val kompetanseRepository: KompetanseRepository,
     private val vilkårsvurderingService: VilkårsvurderingService,
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
+    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository
 ) {
     fun hentUtbetalingsperioder(
         vedtak: Vedtak,
         opphørsperioder: List<VedtaksperiodeMedBegrunnelser>
     ): List<VedtaksperiodeMedBegrunnelser> {
-        val andelerTilkjentYtelse = andelerTilkjentYtelseOgEndreteUtbetalingerService
-            .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(vedtak.behandling.id)
+        val andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtak.behandling.id)
 
         val vilkårsvurdering =
             vilkårsvurderingService.hentAktivForBehandlingThrows(behandlingId = vedtak.behandling.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -1,5 +1,4 @@
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -1,3 +1,4 @@
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -14,7 +15,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilTidslinjeForSplitt
 
 fun hentPerioderMedUtbetaling(
-    andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+    andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
     vedtak: Vedtak,
     personResultater: Set<PersonResultat>,
     personerIPersongrunnlag: List<Person>

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatEndri
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatEndringUtils.erEndringIKompetanse
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatEndringUtils.erEndringIVilkårvurderingForPerson
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatEndringUtils.utledEndringsresultat
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
@@ -454,6 +455,58 @@ class BehandlingsresultatEndringUtilsTest {
                 tom = aug22,
                 beløp = 527,
                 aktør = barn1Aktør
+            ),
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = aug22,
+                beløp = 1054,
+                aktør = barn2Aktør
+            )
+        )
+
+        val erEndringIBeløp = erEndringIBeløp(
+            nåværendeAndeler = nåværendeAndeler,
+            forrigeAndeler = forrigeAndeler,
+            personerFremstiltKravFor = listOf()
+        )
+
+        assertEquals(true, erEndringIBeløp)
+    }
+
+    @Test
+    fun `Endring i beløp - Skal returnere true hvis utvidet ikke er endret men småbarnstillegg kun er lagt på`() {
+        val søker = lagPerson(type = PersonType.SØKER).aktør
+        val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
+
+        val forrigeAndeler = listOf(
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = aug22,
+                beløp = 1054,
+                aktør = søker,
+                ytelseType = YtelseType.UTVIDET_BARNETRYGD
+            ),
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = aug22,
+                beløp = 1054,
+                aktør = barn2Aktør
+            )
+        )
+        val nåværendeAndeler = listOf(
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = aug22,
+                beløp = 1054,
+                aktør = søker,
+                ytelseType = YtelseType.UTVIDET_BARNETRYGD
+            ),
+            lagAndelTilkjentYtelse(
+                fom = mai22,
+                tom = aug22,
+                beløp = 630,
+                aktør = søker,
+                ytelseType = YtelseType.SMÅBARNSTILLEGG
             ),
             lagAndelTilkjentYtelse(
                 fom = jan22,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -526,7 +526,7 @@ internal class UtvidetBarnetrygdTest {
         ).andelerTilkjentYtelse.toList().sortedBy { it.type }
 
         val vedtaksperioderMedBegrunnelser = hentPerioderMedUtbetaling(
-            andelerTilkjentYtelse = andeler.map { AndelTilkjentYtelseMedEndreteUtbetalinger.utenEndringer(it) },
+            andelerTilkjentYtelse = andeler,
             vedtak = lagVedtak(behandling),
             personResultater = vilkårsvurdering.personResultater,
             personerIPersongrunnlag = personopplysningGrunnlag.personer.toList()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagPersonResultat
@@ -44,21 +44,21 @@ class UtbetalingsperiodeUtilTest {
 
         val vedtak = lagVedtak()
 
-        val andelPerson1MarsTilApril = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelPerson1MarsTilApril = lagAndelTilkjentYtelse(
             fom = mars2020,
             tom = april2020,
             beløp = 1000,
             person = person1
         )
 
-        val andelPerson1MaiTilJuli = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelPerson1MaiTilJuli = lagAndelTilkjentYtelse(
             fom = mai2020,
             tom = juli2020,
             beløp = 1000,
             person = person1
         )
 
-        val andelPerson2MarsTilJuli = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelPerson2MarsTilJuli = lagAndelTilkjentYtelse(
             fom = mars2020,
             tom = juli2020,
             beløp = 1000,
@@ -119,14 +119,14 @@ class UtbetalingsperiodeUtilTest {
 
         val vedtak = lagVedtak()
 
-        val andelPerson1MarsTilMai = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelPerson1MarsTilMai = lagAndelTilkjentYtelse(
             fom = mars2020,
             tom = mai2020,
             beløp = 1000,
             person = person1
         )
 
-        val andelPerson2MaiTilJuli = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelPerson2MaiTilJuli = lagAndelTilkjentYtelse(
             fom = mai2020,
             tom = juli2020,
             beløp = 1000,
@@ -194,14 +194,14 @@ class UtbetalingsperiodeUtilTest {
 
         val vedtak = lagVedtak()
 
-        val andelBarn1MarsTilJuli = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelBarn1MarsTilJuli = lagAndelTilkjentYtelse(
             fom = mars2020,
             tom = juli2020,
             beløp = 1000,
             person = barn1
         )
 
-        val andelBarn2MarsTilJuli = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelBarn2MarsTilJuli = lagAndelTilkjentYtelse(
             fom = mars2020,
             tom = juli2020,
             beløp = 2000,
@@ -329,13 +329,13 @@ class UtbetalingsperiodeUtilTest {
         val barn1 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(9))
         val vedtak = lagVedtak()
 
-        val andelBarn1MarsTilApril = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelBarn1MarsTilApril = lagAndelTilkjentYtelse(
             fom = mars2020,
             tom = april2020,
             beløp = 1000,
             person = barn1
         )
-        val andelBarn1JuliTilJuli = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelBarn1JuliTilJuli = lagAndelTilkjentYtelse(
             fom = juli2020,
             tom = juli2020,
             beløp = 1000,
@@ -389,7 +389,7 @@ class UtbetalingsperiodeUtilTest {
 
         val vedtak = lagVedtak()
 
-        val andelBarnMarsTilJuli = lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+        val andelBarnMarsTilJuli = lagAndelTilkjentYtelse(
             fom = mars2020,
             tom = juli2020,
             beløp = 1000,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Endrer funksjonaliteten som finner ut om det er endring i beløp til å ta hensyn til ytelsetypen. For søker kan man få både småbarnstillegg og utvidet, og med eksisterende kode får man da en feil fordi man får overlapp på tidslinjen. Ønsker derfor å skille de to

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei. Kunne sikkert ha løst det på en smudere måte, men siden vi må sikre at alle personer og alle ytelsetyper blir sjekket (uavhengig om de bare finnes nå eller forrige gang) så syns jeg dette var lettest og mest forståelig.
### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
