### PR TITLE
Endepunkt for å trigge satsendring for en liste med identer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -4,7 +4,6 @@ import no.nav.familie.leader.LeaderClient
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
-import java.time.YearMonth
 
 @Service
 class AutovedtakSatsendringScheduler(private val startSatsendring: StartSatsendring) {
@@ -13,7 +12,10 @@ class AutovedtakSatsendringScheduler(private val startSatsendring: StartSatsendr
     fun triggSatsendring() {
         if (LeaderClient.isLeader() == true) {
             logger.info("Satsendring trigges av schedulert jobb")
-            startSatsendring.startSatsendring(antallFagsaker = 10, satsTidspunkt = YearMonth.of(2023, 3))
+            startSatsendring.startSatsendring(
+                antallFagsaker = 10,
+                satsTidspunkt = StartSatsendring.SATSENDRINGMÅNED_2023
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
@@ -1,32 +1,32 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
-import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
-import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
-import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.YearMonth
 
 @RestController
 @RequestMapping("/api/satsendring")
 @ProtectedWithClaims(issuer = "azuread")
 class SatsendringController(
-    private val satskjøringRepository: SatskjøringRepository,
-    private val opprettTaskService: OpprettTaskService
+    private val startSatsendring: StartSatsendring
 ) {
-
-    private val logger = LoggerFactory.getLogger(SatsendringController::class.java)
-
     @GetMapping(path = ["/kjorsatsendring/{fagsakId}"])
     fun utførSatsendringPåFagsak(@PathVariable fagsakId: Long): ResponseEntity<Ressurs<String>> {
-        satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
-        opprettTaskService.opprettSatsendringTask(fagsakId, YearMonth.of(2023, 3))
+        startSatsendring.opprettSatsendringForFagsak(fagsakId)
         return ResponseEntity.ok(Ressurs.success("Trigget satsendring for fagsak $fagsakId"))
+    }
+
+    @PostMapping(path = ["/kjorsatsendringForListeMedIdenter"])
+    fun utførSatsendringPåListeIdenter(@RequestBody listeMedIdenter: Set<String>): ResponseEntity<Ressurs<String>> {
+        listeMedIdenter.forEach {
+            startSatsendring.opprettSatsendringForIdent(it)
+        }
+        return ResponseEntity.ok(Ressurs.success("Trigget satsendring for liste med identer ${listeMedIdenter.size}"))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -254,8 +254,7 @@ class StartSatsendring(
                     )
                 ) {
                     secureLogger.info("Oppretter satsendringtask for $ident og fagsakID=${fagsak.id}")
-                    satskjøringRepository.save(Satskjøring(fagsakId = fagsak.id))
-                    opprettTaskService.opprettSatsendringTask(fagsak.id, SATSENDRINGMÅNED_2023)
+                    opprettSatsendringForFagsak(fagsakId = fagsak.id)
                 }
             }
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
 import no.nav.familie.ba.sak.common.isSameOrAfter
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
@@ -12,11 +13,14 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.YearMonth
@@ -28,7 +32,8 @@ class StartSatsendring(
     private val opprettTaskService: OpprettTaskService,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val satskjøringRepository: SatskjøringRepository,
-    private val featureToggleService: FeatureToggleService
+    private val featureToggleService: FeatureToggleService,
+    private val personidentService: PersonidentService
 
 ) {
 
@@ -229,8 +234,41 @@ class StartSatsendring(
         }
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun opprettSatsendringForIdent(ident: String) {
+        val aktør = personidentService.hentAktør(ident)
+        val løpendeFagsakerForAktør = fagsakRepository.finnFagsakerForAktør(aktør)
+            .filter { !it.arkivert && it.status == FagsakStatus.LØPENDE }
+
+        løpendeFagsakerForAktør.forEach { fagsak ->
+            val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsak.id)
+            if (sisteIverksatteBehandling != null) {
+                val andelerTilkjentYtelseMedEndreteUtbetalinger =
+                    andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
+                        sisteIverksatteBehandling.id
+                    )
+
+                if (!AutovedtakSatsendringService.harAlleredeSisteSats(
+                        andelerTilkjentYtelseMedEndreteUtbetalinger,
+                        SATSENDRINGMÅNED_2023
+                    )
+                ) {
+                    secureLogger.info("Oppretter satsendringtask for $ident og fagsakID=${fagsak.id}")
+                    satskjøringRepository.save(Satskjøring(fagsakId = fagsak.id))
+                    opprettTaskService.opprettSatsendringTask(fagsak.id, SATSENDRINGMÅNED_2023)
+                }
+            }
+        }
+    }
+
+    fun opprettSatsendringForFagsak(fagsakId: Long) {
+        satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
+        opprettTaskService.opprettSatsendringTask(fagsakId, SATSENDRINGMÅNED_2023)
+    }
+
     companion object {
         val logger: Logger = LoggerFactory.getLogger(StartSatsendring::class.java)
         const val PAGE_STØRRELSE = 1000
+        val SATSENDRINGMÅNED_2023: YearMonth = YearMonth.of(2023, 3)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETR
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.SMÅBARNSTILLEGG
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.UTVIDET_BARNETRYGD
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -44,6 +45,7 @@ internal class StartSatsendringTest {
         mockk()
     private val satskjøringRepository: SatskjøringRepository = mockk()
     private val featureToggleService: FeatureToggleService = mockk()
+    private val personidentService: PersonidentService = mockk()
 
     lateinit var startSatsendring: StartSatsendring
 
@@ -59,7 +61,8 @@ internal class StartSatsendringTest {
             opprettTaskService,
             andelerTilkjentYtelseOgEndreteUtbetalingerService,
             satskjøringRepository,
-            featureToggleService
+            featureToggleService,
+            personidentService
         )
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Endepunkt for å trigge satsendring basert på en liste med personidenter i input. Den henter alle fagsaker for en aktør, sjekker om siste iverksatte behandling har oppdatert sats. Hvis den ikke har oppdatert sats så opprettes det en ny entry i satskjøring-tabellen og en SatsendringTask, som utfører selve satsendringen

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
