### PR TITLE
Legg til AVSLÅTT i listen av søknadsresultat dersom det finnes uregistrerte barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -66,6 +66,7 @@ class BehandlingsresultatService(
         val forrigeBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id)
 
         val søknadGrunnlag = søknadGrunnlagService.hentAktiv(behandlingId = behandling.id)
+        val søknadDTO = søknadGrunnlag?.hentSøknadDto()
 
         val forrigeAndelerTilkjentYtelse = forrigeBehandling?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = it.id) } ?: emptyList()
         val andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = behandlingId)
@@ -74,7 +75,7 @@ class BehandlingsresultatService(
 
         val personerFremstiltKravFor = finnPersonerFremstiltKravFor(
             behandling = behandling,
-            søknadDTO = søknadGrunnlag?.hentSøknadDto(),
+            søknadDTO = søknadDTO,
             forrigeBehandling = forrigeBehandling
         )
 
@@ -86,7 +87,8 @@ class BehandlingsresultatService(
                 endretUtbetalingAndeler = endretUtbetalingAndeler,
                 personerFremstiltKravFor = personerFremstiltKravFor,
                 nåværendePersonResultater = vilkårsvurdering.personResultater,
-                behandlingÅrsak = behandling.opprettetÅrsak
+                behandlingÅrsak = behandling.opprettetÅrsak,
+                finnesUregistrerteBarn = søknadGrunnlag?.hentUregistrerteBarn()?.isNotEmpty() ?: false
             )
         } else {
             null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -28,7 +28,8 @@ object BehandlingsresultatSøknadUtils {
         nåværendePersonResultater: Set<PersonResultat>,
         personerFremstiltKravFor: List<Aktør>,
         endretUtbetalingAndeler: List<EndretUtbetalingAndel>,
-        behandlingÅrsak: BehandlingÅrsak
+        behandlingÅrsak: BehandlingÅrsak,
+        finnesUregistrerteBarn: Boolean
     ): Søknadsresultat {
         val resultaterFraAndeler = utledSøknadResultatFraAndelerTilkjentYtelse(
             forrigeAndeler = forrigeAndeler,
@@ -49,7 +50,7 @@ object BehandlingsresultatSøknadUtils {
         }
 
         val alleResultater = (
-            if (erEksplisittAvslagPåMinstEnPersonFremstiltKravFor || erFødselshendelseMedAvslag) {
+            if (erEksplisittAvslagPåMinstEnPersonFremstiltKravFor || erFødselshendelseMedAvslag || finnesUregistrerteBarn) {
                 resultaterFraAndeler.plus(Søknadsresultat.AVSLÅTT)
             } else {
                 resultaterFraAndeler


### PR DESCRIPTION
Tok å gjennomgikk uregistrert barn logikken med Anna.

Dersom det eksisterer uregistrerte barn i søknadsgrunnlaget så skal vi automatisk legge til AVSLAG i listen av søknadsresultater. 

Eksempel case:
Man har 2 barn, 1 uregistrert og registrert. Begge er søkt barnetrygd om.
Hvis man får innvilget på det registrerte barnet så blir søknadsresultatet delvis innvilget.
Hvis ikke blir det avslått.
