### PR TITLE
Legger til sjekk om det er kjørt satsendring før autovedtak for småbarnstillegg og 6/18 år

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
@@ -25,7 +25,7 @@ class SatsendringController(
     @PostMapping(path = ["/kjorsatsendringForListeMedIdenter"])
     fun utførSatsendringPåListeIdenter(@RequestBody listeMedIdenter: Set<String>): ResponseEntity<Ressurs<String>> {
         listeMedIdenter.forEach {
-            startSatsendring.opprettSatsendringForIdent(it)
+            startSatsendring.sjekkOgOpprettSatsendringVedGammelSats(it)
         }
         return ResponseEntity.ok(Ressurs.success("Trigget satsendring for liste med identer ${listeMedIdenter.size}"))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
 import no.nav.familie.ba.sak.common.isSameOrAfter
-import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
@@ -259,7 +258,7 @@ class StartSatsendring(
                     SATSENDRINGMÅNED_2023
                 ) && satskjøringRepository.findByFagsakId(fagsakId) == null
             ) {
-                secureLogger.info("Oppretter satsendringtask fagsakID=$fagsakId")
+                logger.info("Oppretter satsendringtask fagsakID=$fagsakId")
                 opprettSatsendringForFagsak(fagsakId = fagsakId)
                 return true
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -234,31 +234,37 @@ class StartSatsendring(
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun opprettSatsendringForIdent(ident: String): Boolean {
+    fun sjekkOgOpprettSatsendringVedGammelSats(ident: String): Boolean {
         val aktør = personidentService.hentAktør(ident)
         val løpendeFagsakerForAktør = fagsakRepository.finnFagsakerForAktør(aktør)
             .filter { !it.arkivert && it.status == FagsakStatus.LØPENDE }
 
         løpendeFagsakerForAktør.forEach { fagsak ->
-            val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsak.id)
-            if (sisteIverksatteBehandling != null) {
-                val andelerTilkjentYtelseMedEndreteUtbetalinger =
-                    andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                        sisteIverksatteBehandling.id
-                    )
+            sjekkOgOpprettSatsendringVedGammelSats(fagsak.id)
+        }
+        return false
+    }
 
-                if (!AutovedtakSatsendringService.harAlleredeSisteSats(
-                        andelerTilkjentYtelseMedEndreteUtbetalinger,
-                        SATSENDRINGMÅNED_2023
-                    ) && satskjøringRepository.findByFagsakId(fagsak.id) == null
-                ) {
-                    secureLogger.info("Oppretter satsendringtask for $ident og fagsakID=${fagsak.id}")
-                    opprettSatsendringForFagsak(fagsakId = fagsak.id)
-                    return true
-                }
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun sjekkOgOpprettSatsendringVedGammelSats(fagsakId: Long): Boolean {
+        val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
+        if (sisteIverksatteBehandling != null) {
+            val andelerTilkjentYtelseMedEndreteUtbetalinger =
+                andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
+                    sisteIverksatteBehandling.id
+                )
+
+            if (!AutovedtakSatsendringService.harAlleredeSisteSats(
+                    andelerTilkjentYtelseMedEndreteUtbetalinger,
+                    SATSENDRINGMÅNED_2023
+                ) && satskjøringRepository.findByFagsakId(fagsakId) == null
+            ) {
+                secureLogger.info("Oppretter satsendringtask fagsakID=$fagsakId")
+                opprettSatsendringForFagsak(fagsakId = fagsakId)
+                return true
             }
         }
+
         return false
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
@@ -58,7 +58,8 @@ class BehandleFødselshendelseTask(
 
         when (velgFagsystemService.velgFagsystem(nyBehandling).first) {
             FagsystemRegelVurdering.SEND_TIL_BA -> {
-                val harOpprettetSatsendring = startSatsendring.opprettSatsendringForIdent(nyBehandling.morsIdent)
+                val harOpprettetSatsendring =
+                    startSatsendring.sjekkOgOpprettSatsendringVedGammelSats(nyBehandling.morsIdent)
                 if (harOpprettetSatsendring) {
                     throw RekjørSenereException(
                         "Satsedring skal kjøre ferdig før man behandler fødselsehendelse",

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -53,6 +54,7 @@ internal class Autobrev6og18ÅrServiceTest {
     private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
     private val endretUtbetalingAndelRepository = mockk<EndretUtbetalingAndelRepository>(relaxed = true)
     private val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
+    private val startSatsendring = mockk<StartSatsendring>(relaxed = true)
 
     private val autovedtakBrevService = AutovedtakBrevService(
         behandlingService = behandlingService,
@@ -75,7 +77,8 @@ internal class Autobrev6og18ÅrServiceTest {
             endretUtbetalingAndelRepository,
             mockk(),
             featureToggleService
-        )
+        ),
+        startSatsendring = startSatsendring
     )
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
@@ -50,6 +51,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
     private val taskRepository = mockk<TaskRepositoryWrapper>(relaxed = true)
     private val vedtaksperiodeService = mockk<VedtaksperiodeService>()
     private val periodeOvergangsstønadGrunnlagRepository = mockk<PeriodeOvergangsstønadGrunnlagRepository>()
+    private val startSatsendring = mockk<StartSatsendring>(relaxed = true)
 
     private val autovedtakBrevService = AutovedtakBrevService(
         fagsakService = fagsakService,
@@ -67,7 +69,8 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
         persongrunnlagService = persongrunnlagService,
         behandlingHentOgPersisterService = behandlingHentOgPersisterService,
         periodeOvergangsstønadGrunnlagRepository = periodeOvergangsstønadGrunnlagRepository,
-        autovedtakStegService = autovedtakStegService
+        autovedtakStegService = autovedtakStegService,
+        startSatsendring = startSatsendring
     )
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTaskTest.kt
@@ -74,8 +74,8 @@ internal class BehandleFødselshendelseTaskTest {
                 personidentService = mockk<PersonidentService>().apply { every { hentAktør(any()) } returns mockk() },
                 startSatsendring = mockk<StartSatsendring>().apply {
                     every {
-                        opprettSatsendringForIdent(
-                            any()
+                        sjekkOgOpprettSatsendringVedGammelSats(
+                            any<String>()
                         )
                     } returns true
                 }
@@ -107,8 +107,8 @@ internal class BehandleFødselshendelseTaskTest {
             personidentService = mockk<PersonidentService>().apply { every { hentAktør(any()) } returns mockk() },
             startSatsendring = mockk<StartSatsendring>().apply {
                 every {
-                    opprettSatsendringForIdent(
-                        any()
+                    sjekkOgOpprettSatsendringVedGammelSats(
+                        any<String>()
                     )
                 } returns false
             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi ønsker å kjøre autovedtak-taskene for småbarnstillegg og 6/18 år, men de stopper opp fordi det ikke er kjørt satsendring.

Lagt til samme logikk som for fødselshendelse. Altså at man sjekker om fagsaken har seneste sats. Hvis den har seneste sats, så trigges det en satsendring før tasken prøver igjen om en liten stund

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
