### PR TITLE
Fikser feil i metrikker for satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringStatistikk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringStatistikk.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.leader.LeaderClient
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.YearMonth
 
 @Component
 class SatsendringStatistikk(
@@ -20,42 +19,42 @@ class SatsendringStatistikk(
         MultiGauge.builder("satsendring").register(Metrics.globalRegistry)
 
     @Scheduled(
-        fixedRate = OPPDATERING_HVER_TIME
+        fixedRate = OPPDATERING_HVER_HALV_TIME
     )
     fun antallSatsendringerKjørt() {
         if (LeaderClient.isLeader() == true) {
             val antallKjørt = satskjøringRepository.countByFerdigTidspunktIsNotNull()
             val antallTriggetTotalt = satskjøringRepository.count()
-            val antallFagsakerTotalt = fagsakRepository.finnAntallFagsakerTotalt()
+            val antallLøpendeFagsakerTotalt = fagsakRepository.finnAntallFagsakerLøpende()
 
             val rows = listOf(
                 MultiGauge.Row.of(
                     Tags.of(
-                        "totalt",
-                        "${YearMonth.now().year}-${YearMonth.now().month}"
+                        "satsendring",
+                        "totalt"
                     ),
                     antallTriggetTotalt
                 ),
                 MultiGauge.Row.of(
                     Tags.of(
-                        "antallkjort",
-                        "${YearMonth.now().year}-${YearMonth.now().month}"
+                        "satsendring",
+                        "antallkjort"
                     ),
                     antallKjørt
                 ),
                 MultiGauge.Row.of(
                     Tags.of(
-                        "antallfagsaker",
-                        "${YearMonth.now().year}-${YearMonth.now().month}"
+                        "satsendring",
+                        "antallfagsaker"
                     ),
-                    antallFagsakerTotalt
+                    antallLøpendeFagsakerTotalt
                 ),
                 MultiGauge.Row.of(
                     Tags.of(
-                        "antallgjenstaaende",
-                        "${YearMonth.now().year}-${YearMonth.now().month}"
+                        "satsendring",
+                        "antallgjenstaaende"
                     ),
-                    antallFagsakerTotalt - antallKjørt
+                    antallLøpendeFagsakerTotalt - antallKjørt
                 )
             )
 
@@ -64,6 +63,6 @@ class SatsendringStatistikk(
     }
 
     companion object {
-        const val OPPDATERING_HVER_TIME: Long = 1000 * 60
+        const val OPPDATERING_HVER_HALV_TIME: Long = 1000 * 30
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Metrikkene for satsendring var opprettet feil. Nå dukker de opp som forventet. Og teller antall løpende i stedet for antall.
![Screenshot 2023-02-03 at 12 01 24](https://user-images.githubusercontent.com/1121978/216588135-a85f0481-1e57-46a3-abcf-3e6e24eff501.png)
