### PR TITLE
Funksjon returnerer ikke om den har opprettet satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
@@ -84,7 +84,7 @@ class Autobrev6og18ÅrService(
         if (startSatsendring.sjekkOgOpprettSatsendringVedGammelSats(autobrev6og18ÅrDTO.fagsakId)) {
             throw RekjørSenereException(
                 "Satsedring skal kjøre ferdig før man behandler autobrev 6 og 18 år",
-                LocalDateTime.now().plusMinutes(15)
+                LocalDateTime.now().plusHours(1)
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
@@ -65,7 +65,7 @@ class AutobrevOpphørSmåbarnstilleggService(
         if (startSatsendring.sjekkOgOpprettSatsendringVedGammelSats(fagsakId)) {
             throw RekjørSenereException(
                 "Satsedring skal kjøre ferdig før man behandler autobrev småbarnstillegg",
-                LocalDateTime.now().plusMinutes(15)
+                LocalDateTime.now().plusHours(1)
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -233,19 +233,24 @@ class StartSatsendring(
         }
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun sjekkOgOpprettSatsendringVedGammelSats(ident: String): Boolean {
         val aktør = personidentService.hentAktør(ident)
         val løpendeFagsakerForAktør = fagsakRepository.finnFagsakerForAktør(aktør)
             .filter { !it.arkivert && it.status == FagsakStatus.LØPENDE }
 
         løpendeFagsakerForAktør.forEach { fagsak ->
-            sjekkOgOpprettSatsendringVedGammelSats(fagsak.id)
+            opprettSatsendringTaskVedGammelSats(fagsak.id)
         }
         return false
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun sjekkOgOpprettSatsendringVedGammelSats(fagsakId: Long): Boolean {
+        return opprettSatsendringTaskVedGammelSats(fagsakId)
+    }
+
+    private fun opprettSatsendringTaskVedGammelSats(fagsakId: Long): Boolean {
         val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
         if (sisteIverksatteBehandling != null) {
             val andelerTilkjentYtelseMedEndreteUtbetalinger =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -239,10 +239,13 @@ class StartSatsendring(
         val løpendeFagsakerForAktør = fagsakRepository.finnFagsakerForAktør(aktør)
             .filter { !it.arkivert && it.status == FagsakStatus.LØPENDE }
 
+        var harOpprettetSatsendring = false
         løpendeFagsakerForAktør.forEach { fagsak ->
-            opprettSatsendringTaskVedGammelSats(fagsak.id)
+            if (opprettSatsendringTaskVedGammelSats(fagsak.id)) {
+                harOpprettetSatsendring = true
+            }
         }
-        return false
+        return harOpprettetSatsendring
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Funksjon returnerer ikke om den har opprettet satsendring, sikrer at hver metode har Transaction med Propagation_required_new.

Utvid rekjørintervall ved satsendring for autobrev til 1 time, siden mange tasker stoppet opp på venter på iverksett behandling


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
