### PR TITLE
Endrer valideringen for helmanuell migrering i stegService

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -272,6 +272,9 @@ data class Behandling(
 
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 
+    fun erTekniskEndringMedOpphør() =
+        erTekniskEndring() && resultat in listOf(Behandlingsresultat.OPPHØRT, Behandlingsresultat.ENDRET_OG_OPPHØRT)
+
     fun erTekniskBehandling() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_OPPHØR || erTekniskEndring()
 
     fun erKorrigereVedtak() = opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -116,7 +116,8 @@ class StegService(
     }
 
     private fun validerHelmanuelMigrering(behandling: Behandling) {
-        if (behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id) != null) {
+        val sisteBehandlingSomErVedtatt = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+        if (sisteBehandlingSomErVedtatt != null && !sisteBehandlingSomErVedtatt.erTekniskEndringMedOpphør()) {
             throw FunksjonellFeil(
                 melding = "Det finnes allerede en vedtatt behandling på fagsak ${behandling.fagsak.id}." +
                     "Behandling kan ikke opprettes med årsak " +

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceEnhetstest.kt
@@ -1,0 +1,103 @@
+package no.nav.familie.ba.sak.kjerne.steg
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ba.sak.kjerne.behandling.NyBehandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+internal class StegServiceEnhetstest {
+
+    private val behandlingService: BehandlingService = mockk()
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
+    private val settPåVentService: SettPåVentService = mockk()
+
+    private val stegService = StegService(
+        steg = listOf(mockRegistrerPersongrunnlag()),
+        fagsakService = mockk(),
+        behandlingService = behandlingService,
+        behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+        beregningService = mockk(),
+        søknadGrunnlagService = mockk(),
+        tilgangService = mockk(relaxed = true),
+        infotrygdFeedService = mockk(),
+        settPåVentService = settPåVentService
+    )
+
+    @BeforeEach
+    fun setup() {
+        val behandling = lagBehandling()
+        every { behandlingService.opprettBehandling(any()) } returns behandling
+        every { behandlingService.leggTilStegPåBehandlingOgSettTidligereStegSomUtført(any(), any()) } returns behandling
+        every { behandlingHentOgPersisterService.hent(any()) } returns behandling
+        every { settPåVentService.finnAktivSettPåVentPåBehandling(any()) } returns null
+    }
+
+    @Test
+    fun `skal feile validering av helmanuell migrering når fagsak har aktivt vedtak som IKKE var teknisk endring med opphør`() {
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
+            lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE, resultat = Behandlingsresultat.INNVILGET)
+
+        assertThrows<FunksjonellFeil>(message = "Det finnes allerede en vedtatt behandling på fagsak") {
+            stegService.håndterNyBehandling(
+                NyBehandling(
+                    kategori = BehandlingKategori.NASJONAL,
+                    underkategori = BehandlingUnderkategori.ORDINÆR,
+                    behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+                    behandlingÅrsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+                    søkersIdent = randomFnr(),
+                    barnasIdenter = listOf(randomFnr()),
+                    nyMigreringsdato = LocalDate.now().minusMonths(6),
+                    fagsakId = 1L
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `skal IKKE feile validering av helmanuell migrering når fagsak har aktivt vedtak som var teknisk endring med opphør`() {
+        listOf(Behandlingsresultat.OPPHØRT, Behandlingsresultat.ENDRET_OG_OPPHØRT).forEach {
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
+                lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING, resultat = it)
+
+            assertDoesNotThrow {
+                stegService.håndterNyBehandling(
+                    NyBehandling(
+                        kategori = BehandlingKategori.NASJONAL,
+                        underkategori = BehandlingUnderkategori.ORDINÆR,
+                        behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+                        behandlingÅrsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+                        søkersIdent = randomFnr(),
+                        barnasIdenter = listOf(randomFnr()),
+                        nyMigreringsdato = LocalDate.now().minusMonths(6),
+                        fagsakId = 1L
+                    )
+                )
+            }
+        }
+    }
+
+    private fun mockRegistrerPersongrunnlag() = object : RegistrerPersongrunnlag(mockk(), mockk(), mockk(), mockk()) {
+        override fun utførStegOgAngiNeste(behandling: Behandling, data: RegistrerPersongrunnlagDTO): StegType {
+            return StegType.VILKÅRSVURDERING
+        }
+        override fun stegType(): StegType {
+            return StegType.REGISTRERE_PERSONGRUNNLAG
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11361)
Endrer valideringen for helmanuell migrering i stegService.håndterNyBehandling slik at den godtar ny migrering på fagsak med vedtak fra før, så lenge siste vedtatte behandling var en teknisk endring med opphør.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
