### PR TITLE
Oppretter endepunktet for å journalføre for bruker til POST for å forhindre logging av ident, deprekerer det gamle

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringController.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.ekstern.restDomene.RestJournalføring
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -34,8 +35,20 @@ class JournalføringController(
     }
 
     @GetMapping(path = ["/for-bruker/{brukerId}"])
-    fun hentJournalposterForBruker(@PathVariable brukerId: String): ResponseEntity<Ressurs<List<Journalpost>>> {
+    @Deprecated("Kan slettes når frontend har byttet over til nytt endepunkt")
+    fun hentJournalposterForBrukerDeprecated(@PathVariable brukerId: String): ResponseEntity<Ressurs<List<Journalpost>>> {
         return ResponseEntity.ok(Ressurs.success(innkommendeJournalføringService.hentJournalposterForBruker(brukerId)))
+    }
+
+    @PostMapping(path = ["/for-bruker"])
+    fun hentJournalposterForBruker(@RequestBody personIdentBody: PersonIdent): ResponseEntity<Ressurs<List<Journalpost>>> {
+        return ResponseEntity.ok(
+            Ressurs.success(
+                innkommendeJournalføringService.hentJournalposterForBruker(
+                    personIdentBody.ident
+                )
+            )
+        )
     }
 
     @GetMapping("/{journalpostId}/hent/{dokumentInfoId}")
@@ -81,7 +94,8 @@ class JournalføringController(
             throw FunksjonellFeil("Minst ett av dokumentene mangler dokumenttittel.")
         }
 
-        val fagsakId = innkommendeJournalføringService.journalfør(request, journalpostId, journalførendeEnhet, oppgaveId)
+        val fagsakId =
+            innkommendeJournalføringService.journalfør(request, journalpostId, journalførendeEnhet, oppgaveId)
         return ResponseEntity.ok(Ressurs.success(fagsakId, "Journalpost $journalpostId Journalført"))
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Oppretter POST endepunkt for å journalføre for bruker som skal erstatte GET endepunktet med ident i URL, for å forhindre logging av ident. GET endepunktet skal slettes når frontend har byttet over til POST-endepunktet 
