### PR TITLE
Behandlingsresultat: Ikke returnere ENDRING hvis eneste endring er å sette opphørsdato på vilkår

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -92,6 +92,20 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i vilkårsvurderingen`() {
+        val forrigeAndeler = listOf(
+            lagAndelTilkjentYtelse(
+                fom = YearMonth.of(2015, 2),
+                tom = YearMonth.of(2020, 1)
+            )
+        )
+
+        val nåværendeAndeler = listOf(
+            lagAndelTilkjentYtelse(
+                fom = YearMonth.of(2015, 2),
+                tom = YearMonth.of(2020, 1)
+            )
+        )
+
         val forrigeVilkårResultater = listOf(
             VilkårResultat(
                 personResultat = null,
@@ -142,8 +156,8 @@ class BehandlingsresultatEndringUtilsTest {
             )
 
         val endringsresultat = utledEndringsresultat(
-            forrigeAndeler = emptyList(),
-            nåværendeAndeler = emptyList(),
+            forrigeAndeler = forrigeAndeler,
+            nåværendeAndeler = nåværendeAndeler,
             personerFremstiltKravFor = emptyList(),
             forrigeKompetanser = emptyList(),
             nåværendeKompetanser = emptyList(),
@@ -977,8 +991,9 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårvurderingForPerson(
-            nåværendeVilkårResultat,
-            forrigeVilkårResultat
+            nåværendeVilkårResultat = nåværendeVilkårResultat,
+            forrigeVilkårResultat = forrigeVilkårResultat,
+            opphørstidspunkt = YearMonth.of(2020, 2)
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(false))
@@ -1049,8 +1064,9 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårvurderingForPerson(
-            nåværendeVilkårResultat,
-            forrigeVilkårResultat
+            nåværendeVilkårResultat = nåværendeVilkårResultat,
+            forrigeVilkårResultat = forrigeVilkårResultat,
+            opphørstidspunkt = YearMonth.of(2020, 2)
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1121,8 +1137,9 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårvurderingForPerson(
-            nåværendeVilkårResultat,
-            forrigeVilkårResultat
+            nåværendeVilkårResultat = nåværendeVilkårResultat,
+            forrigeVilkårResultat = forrigeVilkårResultat,
+            opphørstidspunkt = YearMonth.of(2020, 2)
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1207,10 +1224,56 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårvurderingForPerson(
-            nåværendeVilkårResultat,
-            forrigeVilkårResultat
+            nåværendeVilkårResultat = nåværendeVilkårResultat,
+            forrigeVilkårResultat = forrigeVilkårResultat,
+            opphørstidspunkt = YearMonth.of(2020, 2)
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
+    }
+
+    @Test
+    fun `Endring i vilkårsvurdering - skal returnere false hvis det kun er opphørt`() {
+        val nåværendeVilkårResultat = listOf(
+            VilkårResultat(
+                personResultat = null,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeTom = LocalDate.of(2020, 1, 1),
+                begrunnelse = "begrunnelse",
+                behandlingId = 0,
+                utdypendeVilkårsvurderinger = listOf(
+                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
+                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP
+                ),
+                vurderesEtter = Regelverk.NASJONALE_REGLER
+            )
+        )
+
+        val forrigeVilkårResultat = listOf(
+            VilkårResultat(
+                personResultat = null,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeTom = null,
+                begrunnelse = "begrunnelse",
+                behandlingId = 0,
+                utdypendeVilkårsvurderinger = listOf(
+                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
+                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP
+                ),
+                vurderesEtter = Regelverk.NASJONALE_REGLER
+            )
+        )
+
+        val erEndringIVilkårvurderingForPerson = erEndringIVilkårvurderingForPerson(
+            nåværendeVilkårResultat = nåværendeVilkårResultat,
+            forrigeVilkårResultat = forrigeVilkårResultat,
+            opphørstidspunkt = YearMonth.of(2020, 2)
+        )
+
+        assertThat(erEndringIVilkårvurderingForPerson, Is(false))
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ønsker ikke å sette resultat ENDRING hvis eneste endring er å sette opphørsdato på vilkår. Grunnen til at det har skjedd nå er fordi man sammenligner fom og tom på vilkåret i forrige behandling og nåværende behandling. Løsningen er å kun sammenligne tom hvis den ikke fører til opphør.

Eksempel:
- Behandling 1: vilkår oppfylt fra 01.01.22-null ("uendelig")
- Behandling 2: vilkår oppfylt fra 01.01.22-15.10.22

Opphørsdato er da november 22 (fordi andelene strekker seg til og med oktober, som gjør at opphøret starter i november).
Når opphørsdato er november så er tom-dato satt i oktober en gang på vilkårene. 
Derfor sammenligner vi kun tom-dato hvis den er FØR oktober.


Ikke sikkert dette er beste løsningen, men syns det gir mening. Og det bevarer funksjonaliteten med at splitter ellers fører til endring.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
