### PR TITLE
Sletter deprikert api-kall som ikke lenger er i bruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringController.kt
@@ -34,12 +34,6 @@ class JournalføringController(
         return ResponseEntity.ok(Ressurs.success(innkommendeJournalføringService.hentJournalpost(journalpostId)))
     }
 
-    @GetMapping(path = ["/for-bruker/{brukerId}"])
-    @Deprecated("Kan slettes når frontend har byttet over til nytt endepunkt")
-    fun hentJournalposterForBrukerDeprecated(@PathVariable brukerId: String): ResponseEntity<Ressurs<List<Journalpost>>> {
-        return ResponseEntity.ok(Ressurs.success(innkommendeJournalføringService.hentJournalposterForBruker(brukerId)))
-    }
-
     @PostMapping(path = ["/for-bruker"])
     fun hentJournalposterForBruker(@RequestBody personIdentBody: PersonIdent): ResponseEntity<Ressurs<List<Journalpost>>> {
         return ResponseEntity.ok(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Sletter GET-endepunktet for å hente liste med journalposter for bruker. Frontend har gått over til POST-endepunktet
