### PR TITLE
Legger til mulighet for å trigge satsendringsbehandling manuelt fra endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
@@ -120,7 +120,7 @@ class AutovedtakSatsendringService(
         return "Satsendring kjørt OK"
     }
 
-    private fun harAlleredeNySats(sisteIverksettBehandlingsId: Long, satstidspunkt: YearMonth): Boolean {
+    fun harAlleredeNySats(sisteIverksettBehandlingsId: Long, satstidspunkt: YearMonth): Boolean {
         val andeler =
             andelTilkjentYtelseMedEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
                 sisteIverksettBehandlingsId

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
@@ -1,11 +1,15 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
+import no.nav.familie.ba.sak.config.AuditLoggerEvent
+import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -14,12 +18,32 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/satsendring")
 @ProtectedWithClaims(issuer = "azuread")
 class SatsendringController(
-    private val startSatsendring: StartSatsendring
+    private val startSatsendring: StartSatsendring,
+    private val tilgangService: TilgangService
+
 ) {
     @GetMapping(path = ["/kjorsatsendring/{fagsakId}"])
-    fun utførSatsendringPåFagsak(@PathVariable fagsakId: Long): ResponseEntity<Ressurs<String>> {
+    fun utførSatsendringITaskPåFagsak(@PathVariable fagsakId: Long): ResponseEntity<Ressurs<String>> {
         startSatsendring.opprettSatsendringForFagsak(fagsakId)
         return ResponseEntity.ok(Ressurs.success("Trigget satsendring for fagsak $fagsakId"))
+    }
+
+    @PutMapping(path = ["/{fagsakId}/kjor-satsendring-synkront"])
+    fun utførSatsendringSynkrontPåFagsak(@PathVariable fagsakId: Long): ResponseEntity<Ressurs<Unit>> {
+        tilgangService.validerTilgangTilHandlingOgFagsak(
+            fagsakId = fagsakId,
+            handling = "Valider vi kan kjøre satsendring",
+            event = AuditLoggerEvent.UPDATE,
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER
+        )
+
+        val erSatsendringOpprettetOk = startSatsendring.opprettSatsendringSynkrontVedGammelSats(fagsakId)
+        return ResponseEntity.ok(if (erSatsendringOpprettetOk) Ressurs.success(Unit) else Ressurs.failure())
+    }
+
+    @GetMapping(path = ["/{fagsakId}/kan-kjore-satsendring"])
+    fun kanKjøreSatsendringPåFagsak(@PathVariable fagsakId: Long): ResponseEntity<Ressurs<Boolean>> {
+        return ResponseEntity.ok(Ressurs.success(startSatsendring.kanStarteSatsendringPåFagsak(fagsakId)))
     }
 
     @PostMapping(path = ["/kjorsatsendringForListeMedIdenter"])

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -156,23 +156,12 @@ class StartSatsendring(
     fun kanStarteSatsendringPåFagsak(fagsakId: Long): Boolean {
         val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
 
-        return if (sisteIverksatteBehandling == null) {
-            false
-        } else if (satskjøringRepository.findByFagsakId(fagsakId) != null) {
-            false
-        } else {
-            val andelerTilkjentYtelseMedEndreteUtbetalinger =
-                andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                    sisteIverksatteBehandling.id
-                )
-
-            val harSisteSats = AutovedtakSatsendringService.harAlleredeSisteSats(
-                aty = andelerTilkjentYtelseMedEndreteUtbetalinger,
+        return sisteIverksatteBehandling != null &&
+            satskjøringRepository.findByFagsakId(fagsakId) == null &&
+            !autovedtakSatsendringService.harAlleredeNySats(
+                sisteIverksettBehandlingsId = sisteIverksatteBehandling.id,
                 satstidspunkt = SATSENDRINGMÅNED_2023
             )
-
-            !harSisteSats
-        }
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
@@ -11,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.SatsendringTaskDto
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
@@ -26,7 +29,8 @@ class StartSatsendring(
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val satskjøringRepository: SatskjøringRepository,
     private val featureToggleService: FeatureToggleService,
-    private val personidentService: PersonidentService
+    private val personidentService: PersonidentService,
+    private val autovedtakSatsendringService: AutovedtakSatsendringService
 
 ) {
 
@@ -140,26 +144,60 @@ class StartSatsendring(
         return opprettSatsendringTaskVedGammelSats(fagsakId)
     }
 
-    private fun opprettSatsendringTaskVedGammelSats(fagsakId: Long): Boolean {
+    private fun opprettSatsendringTaskVedGammelSats(fagsakId: Long): Boolean =
+        if (kanStarteSatsendringPåFagsak(fagsakId)) {
+            logger.info("Oppretter satsendringtask fagsakID=$fagsakId")
+            opprettSatsendringForFagsak(fagsakId = fagsakId)
+            true
+        } else {
+            false
+        }
+
+    fun kanStarteSatsendringPåFagsak(fagsakId: Long): Boolean {
         val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
-        if (sisteIverksatteBehandling != null) {
+
+        return if (sisteIverksatteBehandling == null) {
+            false
+        } else if (satskjøringRepository.findByFagsakId(fagsakId) != null) {
+            false
+        } else {
             val andelerTilkjentYtelseMedEndreteUtbetalinger =
                 andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
                     sisteIverksatteBehandling.id
                 )
 
-            if (!AutovedtakSatsendringService.harAlleredeSisteSats(
-                    andelerTilkjentYtelseMedEndreteUtbetalinger,
-                    SATSENDRINGMÅNED_2023
-                ) && satskjøringRepository.findByFagsakId(fagsakId) == null
-            ) {
-                logger.info("Oppretter satsendringtask fagsakID=$fagsakId")
-                opprettSatsendringForFagsak(fagsakId = fagsakId)
-                return true
-            }
+            val harSisteSats = AutovedtakSatsendringService.harAlleredeSisteSats(
+                aty = andelerTilkjentYtelseMedEndreteUtbetalinger,
+                satstidspunkt = SATSENDRINGMÅNED_2023
+            )
+
+            !harSisteSats
+        }
+    }
+
+    @Transactional
+    fun opprettSatsendringSynkrontVedGammelSats(fagsakId: Long): Boolean {
+        val aktivOgÅpenBehandling =
+            behandlingRepository.findByFagsakAndAktivAndOpen(fagsakId = fagsakId)
+
+        if (aktivOgÅpenBehandling != null) {
+            throw FunksjonellFeil("Det finnes en åpen behandling på fagsaken som må avsluttes før satsendring kan gjennomføres.")
         }
 
-        return false
+        return if (kanStarteSatsendringPåFagsak(fagsakId)) {
+            satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
+            val resultattekstSatsendringBehandling = autovedtakSatsendringService.kjørBehandling(
+                SatsendringTaskDto(
+                    fagsakId = fagsakId,
+                    satstidspunkt = SATSENDRINGMÅNED_2023
+                )
+            )
+            if (resultattekstSatsendringBehandling == "Satsendring kjørt OK") {
+                true
+            } else throw Feil("Satsendring kjørte ikke OK for fagsak $fagsakId")
+        } else {
+            false
+        }
     }
 
     fun opprettSatsendringForFagsak(fagsakId: Long) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -183,7 +183,9 @@ class StartSatsendring(
             )
             if (resultattekstSatsendringBehandling == "Satsendring kjørt OK") {
                 true
-            } else throw Feil("Satsendring kjørte ikke OK for fagsak $fagsakId")
+            } else {
+                throw Feil("Satsendring kjørte ikke OK for fagsak $fagsakId")
+            }
         } else {
             false
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -465,31 +465,19 @@ internal class StartSatsendringTest {
 
     @Test
     fun `kanStarteSatsendringPåFagsak returnerer false når harSisteSats er true`() {
-        val behandling = lagBehandling()
-        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns behandling
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakId(1L) } returns null
-        val atyMedBareOrba =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(SatsType.ORBA, behandling, ORDINÆR_BARNETRYGD)
-        every {
-            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
-        } returns atyMedBareOrba
+        every { autovedtakSatsendringService.harAlleredeNySats(any(), any()) } returns true
 
-        assertThat(harAlleredeSisteSats(atyMedBareOrba, SATSTIDSPUNKT)).isEqualTo(true)
         assertThat(startSatsendring.kanStarteSatsendringPåFagsak(1L)).isEqualTo(false)
     }
 
     @Test
     fun `kanStarteSatsendringPåFagsak returnerer true når harSisteSats er false`() {
-        val behandling = lagBehandling()
-        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns behandling
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakId(1L) } returns null
-        val atyMedUgyldigSatsBareOrba =
-            lagAndelTilkjentYtelseMedEndreteUtbetalinger(SatsType.ORBA, behandling, ORDINÆR_BARNETRYGD, UGYLDIG_SATS)
-        every {
-            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
-        } returns atyMedUgyldigSatsBareOrba
+        every { autovedtakSatsendringService.harAlleredeNySats(any(), any()) } returns false
 
-        assertThat(harAlleredeSisteSats(atyMedUgyldigSatsBareOrba, SATSTIDSPUNKT)).isEqualTo(false)
         assertThat(startSatsendring.kanStarteSatsendringPåFagsak(1L)).isEqualTo(true)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -29,6 +29,7 @@ import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
@@ -445,39 +446,35 @@ internal class StartSatsendringTest {
     )
 
     @Test
-    fun `kanStarteSatsendringPåFagsak returnerer false når vi ikke har noen tidligere behandling`() {
+    fun `kanStarteSatsendringPåFagsak gir false når vi ikke har noen tidligere behandling`() {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns null
 
-        val result = startSatsendring.kanStarteSatsendringPåFagsak(1L)
-
-        assertFalse(result)
+        assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 
     @Test
-    fun `kanStarteSatsendringPåFagsak returnerer false når vi har en satskjøring i satskjøringsrepoet`() {
+    fun `kanStarteSatsendringPåFagsak gir false når vi har en satskjøring for fagsaken i satskjøringsrepoet`() {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakId(1L) } returns Satskjøring(fagsakId = 1L)
 
-        val result = startSatsendring.kanStarteSatsendringPåFagsak(1L)
-
-        assertFalse(result)
+        assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 
     @Test
-    fun `kanStarteSatsendringPåFagsak returnerer false når harSisteSats er true`() {
+    fun `kanStarteSatsendringPåFagsak gir false når harSisteSats er true`() {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakId(1L) } returns null
         every { autovedtakSatsendringService.harAlleredeNySats(any(), any()) } returns true
 
-        assertThat(startSatsendring.kanStarteSatsendringPåFagsak(1L)).isEqualTo(false)
+        assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 
     @Test
-    fun `kanStarteSatsendringPåFagsak returnerer true når harSisteSats er false`() {
+    fun `kanStarteSatsendringPåFagsak gir true når harSisteSats er false`() {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakId(1L) } returns null
         every { autovedtakSatsendringService.harAlleredeNySats(any(), any()) } returns false
 
-        assertThat(startSatsendring.kanStarteSatsendringPåFagsak(1L)).isEqualTo(true)
+        assertTrue(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -28,6 +28,7 @@ import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
@@ -46,6 +47,7 @@ internal class StartSatsendringTest {
     private val satskjøringRepository: SatskjøringRepository = mockk()
     private val featureToggleService: FeatureToggleService = mockk()
     private val personidentService: PersonidentService = mockk()
+    private val autovedtakSatsendringService: AutovedtakSatsendringService = mockk()
 
     lateinit var startSatsendring: StartSatsendring
 
@@ -57,16 +59,17 @@ internal class StartSatsendringTest {
         val taskRepository: TaskRepositoryWrapper = mockk()
         val taskSlot = slot<Task>()
         every { taskRepository.save(capture(taskSlot)) } answers { taskSlot.captured }
-        val opprettTaskService: OpprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository)
+        val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository)
 
         startSatsendring = StartSatsendring(
-            fagsakRepository,
-            behandlingRepository,
-            opprettTaskService,
-            andelerTilkjentYtelseOgEndreteUtbetalingerService,
-            satskjøringRepository,
-            featureToggleService,
-            personidentService
+            fagsakRepository = fagsakRepository,
+            behandlingRepository = behandlingRepository,
+            opprettTaskService = opprettTaskService,
+            andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            satskjøringRepository = satskjøringRepository,
+            featureToggleService = featureToggleService,
+            personidentService = personidentService,
+            autovedtakSatsendringService = autovedtakSatsendringService
         )
     }
 
@@ -440,4 +443,53 @@ internal class StartSatsendringTest {
             beløp = beløp ?: SatsService.finnSisteSatsFor(satsType).beløp
         )
     )
+
+    @Test
+    fun `kanStarteSatsendringPåFagsak returnerer false når vi ikke har noen tidligere behandling`() {
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns null
+
+        val result = startSatsendring.kanStarteSatsendringPåFagsak(1L)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `kanStarteSatsendringPåFagsak returnerer false når vi har en satskjøring i satskjøringsrepoet`() {
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
+        every { satskjøringRepository.findByFagsakId(1L) } returns Satskjøring(fagsakId = 1L)
+
+        val result = startSatsendring.kanStarteSatsendringPåFagsak(1L)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `kanStarteSatsendringPåFagsak returnerer false når harSisteSats er true`() {
+        val behandling = lagBehandling()
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns behandling
+        every { satskjøringRepository.findByFagsakId(1L) } returns null
+        val atyMedBareOrba =
+            lagAndelTilkjentYtelseMedEndreteUtbetalinger(SatsType.ORBA, behandling, ORDINÆR_BARNETRYGD)
+        every {
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
+        } returns atyMedBareOrba
+
+        assertThat(harAlleredeSisteSats(atyMedBareOrba, SATSTIDSPUNKT)).isEqualTo(true)
+        assertThat(startSatsendring.kanStarteSatsendringPåFagsak(1L)).isEqualTo(false)
+    }
+
+    @Test
+    fun `kanStarteSatsendringPåFagsak returnerer true når harSisteSats er false`() {
+        val behandling = lagBehandling()
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns behandling
+        every { satskjøringRepository.findByFagsakId(1L) } returns null
+        val atyMedUgyldigSatsBareOrba =
+            lagAndelTilkjentYtelseMedEndreteUtbetalinger(SatsType.ORBA, behandling, ORDINÆR_BARNETRYGD, UGYLDIG_SATS)
+        every {
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
+        } returns atyMedUgyldigSatsBareOrba
+
+        assertThat(harAlleredeSisteSats(atyMedUgyldigSatsBareOrba, SATSTIDSPUNKT)).isEqualTo(false)
+        assertThat(startSatsendring.kanStarteSatsendringPåFagsak(1L)).isEqualTo(true)
+    }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11385

Vi ønsker at saksbehandlerene skal kunne starte en satsendringsbehandling på en fagsak manuelt slik at de kan gjøre revurderinger på siste sats. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
