### PR TITLE
Satsendring tillater FORTSATT_INNVILGET for EØS-behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -328,6 +329,8 @@ fun hentNesteSteg(behandling: Behandling, utførendeStegType: StegType): StegTyp
                 VILKÅRSVURDERING -> BEHANDLINGSRESULTAT
                 BEHANDLINGSRESULTAT -> if (behandling.resultat == Behandlingsresultat.ENDRET_UTBETALING) {
                     IVERKSETT_MOT_OPPDRAG
+                } else if (behandling.kategori == BehandlingKategori.EØS && behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET) {
+                    FERDIGSTILLE_BEHANDLING
                 } else {
                     throw Feil("Resultat ${behandling.resultat} er ikke støttet etter behandlingsresultat for satsendringsbehandling.")
                 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Hopper over IVERKSET_MOT_OPPDRAG for satsendringer ved FORTSATT_INNVILGET på EØS. Dette for å støtte satsendringtasker med 0 utbetaling, som blir FORTSATT_INNVILGET


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
