### PR TITLE
Fjerner midlertidig feiling av fødselshendelsetask ved manglende satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -288,7 +288,6 @@ class AutovedtakFødselshendelseService(
         }
 
         logger.error("Fant ikke begrunnelse for at fødselshendelse ikke kunne automatisk behandles.")
-        error("Fant ikke begrunnelse for at fødselshendelse ikke kunne automatisk behandles.")
 
         return ""
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
@@ -62,8 +62,8 @@ class BehandleFødselshendelseTask(
                     startSatsendring.sjekkOgOpprettSatsendringVedGammelSats(nyBehandling.morsIdent)
                 if (harOpprettetSatsendring) {
                     throw RekjørSenereException(
-                        "Satsedring skal kjøre ferdig før man behandler fødselsehendelse",
-                        LocalDateTime.now().plusMinutes(5)
+                        "Satsendring skal kjøre ferdig før man behandler fødselsehendelse",
+                        LocalDateTime.now().plusMinutes(60)
                     )
                 }
                 autovedtakStegService.kjørBehandlingFødselshendelse(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I forbindelse med en feil med fødselshendelser på saker hvor det ikke var kjørt satsendring på, så ble det gjort slik at alle tasker feilet hvis det manglet henleggbegrunnelser. Reverterer denne feilhåndteringen og utvider rekjør senere tidspunktet til 60min ved evt satsendring

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
