### PR TITLE
Støtte for å sende manuelt brev til manuell mottakere

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/UtgåendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/UtgåendeJournalføringService.kt
@@ -30,7 +30,7 @@ class UtgåendeJournalføringService(
         dokumenttype: Dokumenttype,
         førsteside: Førsteside?,
         avsenderMottaker: AvsenderMottaker? = null,
-        tilVerge: Boolean = false
+        tilManuellMottakerEllerVerge: Boolean = false
     ): String {
         return journalførDokument(
             fnr = fnr,
@@ -45,7 +45,7 @@ class UtgåendeJournalføringService(
             ),
             førsteside = førsteside,
             avsenderMottaker = avsenderMottaker,
-            tilManuellMottakerEllerVerge = tilVerge
+            tilManuellMottakerEllerVerge = tilManuellMottakerEllerVerge
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -15,8 +15,12 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.erTilInstitusjon
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.kjerne.steg.domene.MottakerInfo
+import no.nav.familie.ba.sak.kjerne.steg.domene.toList
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
@@ -48,7 +52,8 @@ class DokumentService(
     private val fagsakRepository: FagsakRepository,
     private val organisasjonService: OrganisasjonService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
-    private val dokumentGenereringService: DokumentGenereringService
+    private val dokumentGenereringService: DokumentGenereringService,
+    private val brevmottakerService: BrevmottakerService
 ) {
 
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -64,13 +69,8 @@ class DokumentService(
     }
 
     @Transactional
-    fun sendManueltBrev(
-        manueltBrevRequest: ManueltBrevRequest,
-        behandling: Behandling? = null,
-        fagsakId: Long
-    ) {
+    fun sendManueltBrev(manueltBrevRequest: ManueltBrevRequest, behandling: Behandling? = null, fagsakId: Long) {
         val generertBrev = dokumentGenereringService.genererManueltBrev(manueltBrevRequest)
-
         val førsteside = if (manueltBrevRequest.brevmal.skalGenerereForside()) {
             Førsteside(
                 språkkode = manueltBrevRequest.mottakerMålform.tilSpråkkode(),
@@ -81,56 +81,40 @@ class DokumentService(
             null
         }
 
-        val fagsak = fagsakRepository.finnFagsak(fagsakId)
+        val fagsak = fagsakRepository.finnFagsak(fagsakId) ?: error("Finnes ikke fagsak for fagsakId=$fagsakId")
+        val søkersident = fagsak.aktør.aktivFødselsnummer()
 
-        val journalpostId = utgåendeJournalføringService.journalførManueltBrev(
-            fnr = fagsak!!.aktør.aktivFødselsnummer(),
-            fagsakId = fagsakId.toString(),
-            journalførendeEnhet = manueltBrevRequest.enhet?.enhetId
-                ?: DEFAULT_JOURNALFØRENDE_ENHET,
-            brev = generertBrev,
-            førsteside = førsteside,
-            dokumenttype = manueltBrevRequest.brevmal.tilFamilieKontrakterDokumentType(),
-            avsenderMottaker = utledAvsenderMottaker(manueltBrevRequest)
-        )
+        val mottakere = lagMottakere(manueltBrevRequest, fagsak, behandling)
+        val journalposterTilDistribusjon = mutableMapOf<String, MottakerInfo>()
 
-        if (behandling != null) {
-            journalføringRepository.save(
-                DbJournalpost(
-                    behandling = behandling,
-                    journalpostId = journalpostId,
-                    type = DbJournalpostType.U
+        mottakere.forEach { mottakerInfo ->
+            val journalpostId = utgåendeJournalføringService.journalførManueltBrev(
+                fnr = fagsak.aktør.aktivFødselsnummer(),
+                fagsakId = fagsakId.toString(),
+                journalførendeEnhet = manueltBrevRequest.enhet?.enhetId ?: DEFAULT_JOURNALFØRENDE_ENHET,
+                brev = generertBrev,
+                førsteside = førsteside,
+                dokumenttype = manueltBrevRequest.brevmal.tilFamilieKontrakterDokumentType(),
+                avsenderMottaker = utledAvsenderMottaker(manueltBrevRequest, mottakerInfo),
+                // mottakersnavn fyller ut kun når manuell mottaker finnes
+                tilManuellMottakerEllerVerge = mottakerInfo.navn != null &&
+                    mottakerInfo.navn != brevmottakerService.hentMottakerNavn(søkersident)
+            ).also { journalposterTilDistribusjon[it] = mottakerInfo }
+
+            behandling?.let {
+                journalføringRepository.save(
+                    DbJournalpost(behandling = it, journalpostId = journalpostId, type = DbJournalpostType.U)
                 )
-            )
+            }
         }
 
         if (behandling != null && manueltBrevRequest.brevmal.førerTilOpplysningsplikt()) {
             leggTilOpplysningspliktIVilkårsvurdering(behandling)
         }
 
-        DistribuerDokumentTask.opprettDistribuerDokumentTask(
-            distribuerDokumentDTO = DistribuerDokumentDTO(
-                personEllerInstitusjonIdent = manueltBrevRequest.mottakerIdent,
-                behandlingId = behandling?.id,
-                journalpostId = journalpostId,
-                brevmal = manueltBrevRequest.brevmal,
-                erManueltSendt = true
-            ),
-            properties = Properties().apply {
-                this["fagsakIdent"] = behandling?.fagsak?.aktør?.aktivFødselsnummer() ?: ""
-                this["mottakerIdent"] = manueltBrevRequest.mottakerIdent
-                this["journalpostId"] = journalpostId
-                this["behandlingId"] = behandling?.id.toString()
-                this["fagsakId"] = fagsakId.toString()
-            }
-        ).also {
-            taskRepository.save(it)
-        }
+        lagTaskerForÅDistribuereBrev(journalposterTilDistribusjon, behandling, manueltBrevRequest, fagsak)
 
-        if (
-            behandling != null &&
-            manueltBrevRequest.brevmal.setterBehandlingPåVent()
-        ) {
+        if (behandling != null && manueltBrevRequest.brevmal.setterBehandlingPåVent()) {
             settPåVentService.settBehandlingPåVent(
                 behandlingId = behandling.id,
                 frist = LocalDate.now()
@@ -145,15 +129,54 @@ class DokumentService(
         }
     }
 
-    private fun utledAvsenderMottaker(manueltBrevRequest: ManueltBrevRequest): AvsenderMottaker? {
-        return if (manueltBrevRequest.erTilInstitusjon) {
-            AvsenderMottaker(
-                idType = BrukerIdType.ORGNR,
-                id = manueltBrevRequest.mottakerIdent,
-                navn = utledInstitusjonNavn(manueltBrevRequest)
+    private fun lagMottakere(
+        manueltBrevRequest: ManueltBrevRequest,
+        fagsak: Fagsak,
+        behandling: Behandling?
+    ): List<MottakerInfo> {
+        val søkersident = fagsak.aktør.aktivFødselsnummer()
+        val brevmottakere = behandling?.let { brevmottakerService.hentBrevmottakere(it.id) } ?: emptyList()
+        return when {
+            behandling == null -> MottakerInfo(
+                brukerId = søkersident,
+                brukerIdType = BrukerIdType.FNR,
+                erInstitusjonVerge = false
+            ).toList()
+            manueltBrevRequest.erTilInstitusjon -> MottakerInfo(
+                brukerId = manueltBrevRequest.mottakerIdent,
+                brukerIdType = BrukerIdType.ORGNR,
+                erInstitusjonVerge = false
+            ).toList()
+            brevmottakere.isNotEmpty() -> brevmottakerService.lagMottakereFraBrevMottakere(
+                brevmottakere,
+                søkersident
             )
-        } else {
-            null
+            else -> MottakerInfo(
+                brukerIdType = BrukerIdType.FNR,
+                brukerId = søkersident,
+                erInstitusjonVerge = false
+            ).toList()
+        }
+    }
+
+    private fun utledAvsenderMottaker(
+        manueltBrevRequest: ManueltBrevRequest,
+        mottakerInfo: MottakerInfo
+    ): AvsenderMottaker? {
+        return when {
+            manueltBrevRequest.erTilInstitusjon -> {
+                AvsenderMottaker(
+                    idType = BrukerIdType.ORGNR,
+                    id = manueltBrevRequest.mottakerIdent,
+                    navn = utledInstitusjonNavn(manueltBrevRequest)
+                )
+            }
+            mottakerInfo.brukerIdType == BrukerIdType.FNR && mottakerInfo.navn != null -> {
+                AvsenderMottaker(idType = BrukerIdType.FNR, id = mottakerInfo.brukerId, navn = mottakerInfo.navn)
+            }
+            else -> {
+                null
+            }
         }
     }
 
@@ -173,6 +196,31 @@ class DokumentService(
             )
         vilkårsvurdering.personResultater.single { it.erSøkersResultater() }
             .leggTilBlankAnnenVurdering(AnnenVurderingType.OPPLYSNINGSPLIKT)
+    }
+
+    private fun lagTaskerForÅDistribuereBrev(
+        journalposterTilDistribusjon: Map<String, MottakerInfo>,
+        behandling: Behandling?,
+        manueltBrevRequest: ManueltBrevRequest,
+        fagsak: Fagsak
+    ) = journalposterTilDistribusjon.forEach { journalPostTilDistribusjon ->
+        DistribuerDokumentTask.opprettDistribuerDokumentTask(
+            distribuerDokumentDTO = DistribuerDokumentDTO(
+                personEllerInstitusjonIdent = journalPostTilDistribusjon.value.brukerId,
+                behandlingId = behandling?.id,
+                journalpostId = journalPostTilDistribusjon.key,
+                brevmal = manueltBrevRequest.brevmal,
+                erManueltSendt = true
+            ),
+            properties = Properties().apply
+            {
+                this["fagsakIdent"] = fagsak.aktør.aktivFødselsnummer()
+                this["mottakerIdent"] = manueltBrevRequest.mottakerIdent
+                this["journalpostId"] = journalPostTilDistribusjon.key
+                this["behandlingId"] = behandling?.id.toString()
+                this["fagsakId"] = fagsak.id.toString()
+            }
+        ).also { taskRepository.save(it) }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -143,7 +143,7 @@ class DokumentService(
                 erInstitusjonVerge = false
             ).toList()
             manueltBrevRequest.erTilInstitusjon -> MottakerInfo(
-                brukerId = søkersident,
+                brukerId = checkNotNull(fagsak.institusjon).orgNummer,
                 brukerIdType = BrukerIdType.ORGNR,
                 erInstitusjonVerge = false
             ).toList()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -143,7 +143,7 @@ class DokumentService(
                 erInstitusjonVerge = false
             ).toList()
             manueltBrevRequest.erTilInstitusjon -> MottakerInfo(
-                brukerId = manueltBrevRequest.mottakerIdent,
+                brukerId = søkersident,
                 brukerIdType = BrukerIdType.ORGNR,
                 erInstitusjonVerge = false
             ).toList()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -215,7 +215,7 @@ class DokumentService(
             properties = Properties().apply
             {
                 this["fagsakIdent"] = fagsak.aktør.aktivFødselsnummer()
-                this["mottakerIdent"] = manueltBrevRequest.mottakerIdent
+                this["mottakerIdent"] = journalPostTilDistribusjon.value.brukerId
                 this["journalpostId"] = journalPostTilDistribusjon.key
                 this["behandlingId"] = behandling?.id.toString()
                 this["fagsakId"] = fagsak.id.toString()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
@@ -3,17 +3,20 @@ package no.nav.familie.ba.sak.kjerne.brev.mottaker
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.ekstern.restDomene.RestBrevmottaker
 import no.nav.familie.ba.sak.ekstern.restDomene.tilBrevMottaker
+import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.domene.ManuellAdresseInfo
 import no.nav.familie.ba.sak.kjerne.steg.domene.MottakerInfo
+import no.nav.familie.ba.sak.kjerne.steg.domene.toList
 import no.nav.familie.kontrakter.felles.BrukerIdType
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class BrevmottakerService(
-    @Autowired
-    private val brevmottakerRepository: BrevmottakerRepository
+    private val brevmottakerRepository: BrevmottakerRepository,
+    private val personidentService: PersonidentService,
+    private val personopplysningerService: PersonopplysningerService
 ) {
 
     @Transactional
@@ -58,7 +61,7 @@ class BrevmottakerService(
     fun lagMottakereFraBrevMottakere(
         brevMottakere: List<Brevmottaker>,
         søkersident: String,
-        søkersnavn: String
+        søkersnavn: String = hentMottakerNavn(søkersident)
     ): List<MottakerInfo> =
         brevMottakere.map { brevmottaker ->
             when (brevmottaker.type) {
@@ -66,15 +69,13 @@ class BrevmottakerService(
                     val finnesBrevmottakerMedUtenlandskAdresse =
                         brevMottakere.any { it.type == MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE }
                     if (finnesBrevmottakerMedUtenlandskAdresse) { // brev sendes til fullmektig adresse og bruker sin manuell adresse
-                        listOf(
-                            MottakerInfo(
-                                brukerId = søkersident,
-                                brukerIdType = BrukerIdType.FNR,
-                                erInstitusjonVerge = false,
-                                navn = brevmottaker.navn,
-                                manuellAdresseInfo = lagManuellAdresseInfo(brevmottaker)
-                            )
-                        )
+                        MottakerInfo(
+                            brukerId = søkersident,
+                            brukerIdType = BrukerIdType.FNR,
+                            erInstitusjonVerge = false,
+                            navn = brevmottaker.navn,
+                            manuellAdresseInfo = lagManuellAdresseInfo(brevmottaker)
+                        ).toList()
                     } else { // brev sendes til fullmektig adresse og bruker sin registerte adresse
                         listOf(
                             MottakerInfo(
@@ -94,17 +95,23 @@ class BrevmottakerService(
                     }
                 }
                 MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE, MottakerType.DØDSBO ->
-                    listOf(
-                        MottakerInfo(
-                            brukerId = søkersident,
-                            brukerIdType = BrukerIdType.FNR,
-                            erInstitusjonVerge = false,
-                            navn = søkersnavn,
-                            manuellAdresseInfo = lagManuellAdresseInfo(brevmottaker)
-                        )
-                    )
+                    // brev sendes til kun bruker sin registerte/manuell adresse
+                    MottakerInfo(
+                        brukerId = søkersident,
+                        brukerIdType = BrukerIdType.FNR,
+                        erInstitusjonVerge = false,
+                        navn = søkersnavn,
+                        manuellAdresseInfo = lagManuellAdresseInfo(brevmottaker)
+                    ).toList()
             }
         }.flatten()
+
+    fun hentMottakerNavn(personIdent: String): String {
+        val aktør = personidentService.hentAktør(personIdent)
+        return personopplysningerService.hentPersoninfoNavnOgAdresse(aktør).let {
+            it.navn!!
+        }
+    }
 
     private fun lagManuellAdresseInfo(brevmottaker: Brevmottaker) = ManuellAdresseInfo(
         adresselinje1 = brevmottaker.adresselinje1,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/JournalførVedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/JournalførVedtaksbrev.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClien
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.tilDokumenttype
 import no.nav.familie.ba.sak.integrasjoner.journalføring.UtgåendeJournalføringService
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
-import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.brev.hentBrevmal
@@ -14,7 +13,6 @@ import no.nav.familie.ba.sak.kjerne.brev.hentOverstyrtDokumenttittel
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
-import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.domene.JournalførVedtaksbrevDTO
 import no.nav.familie.ba.sak.kjerne.steg.domene.MottakerInfo
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
@@ -38,8 +36,6 @@ class JournalførVedtaksbrev(
     private val taskRepository: TaskRepositoryWrapper,
     private val fagsakRepository: FagsakRepository,
     private val organisasjonService: OrganisasjonService,
-    private val personidentService: PersonidentService,
-    private val personopplysningerService: PersonopplysningerService,
     private val brevmottakerService: BrevmottakerService
 ) : BehandlingSteg<JournalførVedtaksbrevDTO> {
 
@@ -64,11 +60,7 @@ class JournalførVedtaksbrev(
         } else {
             val brevMottakere = brevmottakerService.hentBrevmottakere(behandling.id)
             if (brevMottakere.isNotEmpty()) {
-                mottakere += brevmottakerService.lagMottakereFraBrevMottakere(
-                    brevMottakere,
-                    søkersident,
-                    hentMottakerNavn(søkersident)
-                )
+                mottakere += brevmottakerService.lagMottakereFraBrevMottakere(brevMottakere, søkersident)
             } else {
                 mottakere += MottakerInfo(søkersident, BrukerIdType.FNR, false)
             }
@@ -88,7 +80,7 @@ class JournalførVedtaksbrev(
                 tilManuellMottakerEllerVerge = if (institusjonVergeIdent != null) {
                     mottakerInfo.erInstitusjonVerge
                 } else {
-                    (mottakerInfo.navn != null && mottakerInfo.navn != hentMottakerNavn(søkersident))
+                    (mottakerInfo.navn != null && mottakerInfo.navn != brevmottakerService.hentMottakerNavn(søkersident))
                 } // mottakersnavn fyller ut kun når manuell mottaker finnes
             ).also { journalposterTilDistribusjon[it] = mottakerInfo }
         }
@@ -105,7 +97,8 @@ class JournalførVedtaksbrev(
     ) {
         journalposterTilDistribusjon.forEach {
             val finnesBrevMottaker =
-                it.value.navn != null && it.value.navn != hentMottakerNavn(behandling.fagsak.aktør.aktivFødselsnummer())
+                it.value.navn != null &&
+                    it.value.navn != brevmottakerService.hentMottakerNavn(behandling.fagsak.aktør.aktivFødselsnummer())
             if (it.value.erInstitusjonVerge || finnesBrevMottaker) { // Denne tasken sender kun vedtaksbrev
                 val distribuerTilVergeTask =
                     DistribuerVedtaksbrevTilInstitusjonVergeEllerManuellBrevMottakerTask
@@ -189,7 +182,7 @@ class JournalførVedtaksbrev(
                 AvsenderMottaker(
                     idType = mottakerInfo.brukerIdType,
                     id = mottakerInfo.brukerId,
-                    navn = hentMottakerNavn(mottakerInfo.brukerId)
+                    navn = brevmottakerService.hentMottakerNavn(mottakerInfo.brukerId)
                 )
             }
             mottakerInfo.brukerIdType == BrukerIdType.FNR && mottakerInfo.navn != null -> {
@@ -202,13 +195,6 @@ class JournalførVedtaksbrev(
             else -> {
                 null
             }
-        }
-    }
-
-    private fun hentMottakerNavn(personIdent: String): String {
-        val aktør = personidentService.hentAktør(personIdent)
-        return personopplysningerService.hentPersoninfoNavnOgAdresse(aktør).let {
-            it.navn!!
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/domene/JournalførVedtaksbrevDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/domene/JournalførVedtaksbrevDTO.kt
@@ -13,6 +13,8 @@ data class MottakerInfo(
     val manuellAdresseInfo: ManuellAdresseInfo? = null
 )
 
+fun MottakerInfo.toList() = listOf(this)
+
 data class ManuellAdresseInfo(
     val adresselinje1: String,
     val adresselinje2: String? = null,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceEnhetstest.kt
@@ -5,9 +5,11 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
+import no.nav.familie.ba.sak.common.defaultFagsak
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.journalføring.UtgåendeJournalføringService
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpost
@@ -18,6 +20,9 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.Brevmottaker
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.MottakerType
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -29,6 +34,7 @@ import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class DokumentServiceEnhetstest {
@@ -37,14 +43,16 @@ internal class DokumentServiceEnhetstest {
     val vilkårsvurderingForNyBehandlingService = mockk<VilkårsvurderingForNyBehandlingService>(relaxed = true)
     val utgåendeJournalføringService = mockk<UtgåendeJournalføringService>(relaxed = true)
     val journalføringRepository = mockk<JournalføringRepository>(relaxed = true)
+    val taskRepository = mockk<TaskRepositoryWrapper>()
     val fagsakRepository = mockk<FagsakRepository>(relaxed = true)
     val organisasjonService = mockk<OrganisasjonService>(relaxed = true)
     val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>(relaxed = true)
+    val brevmottakerService = mockk<BrevmottakerService>(relaxed = true)
 
     private val dokumentService: DokumentService = spyk(
         DokumentService(
             journalføringRepository = journalføringRepository,
-            taskRepository = mockk(relaxed = true),
+            taskRepository = taskRepository,
             vilkårsvurderingService = vilkårsvurderingService,
             vilkårsvurderingForNyBehandlingService = vilkårsvurderingForNyBehandlingService,
             rolleConfig = mockk(relaxed = true),
@@ -53,7 +61,8 @@ internal class DokumentServiceEnhetstest {
             fagsakRepository = fagsakRepository,
             organisasjonService = organisasjonService,
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
-            dokumentGenereringService = mockk(relaxed = true)
+            dokumentGenereringService = mockk(relaxed = true),
+            brevmottakerService = brevmottakerService
         )
     )
 
@@ -214,6 +223,103 @@ internal class DokumentServiceEnhetstest {
                 vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, any(), null)
             }
         }
+    }
+
+    @Test
+    fun `sendManueltBrev skal sende manuelt brev til FULLMEKTIG og bruker som har FULLMEKTIG manuelt brev mottaker`() {
+        val behandling = lagBehandling()
+        val søkersident = behandling.fagsak.aktør.aktivFødselsnummer()
+        val manueltBrevRequest = ManueltBrevRequest(mottakerIdent = søkersident, brevmal = Brevmal.SVARTIDSBREV)
+        val avsenderMottakere = mutableListOf<AvsenderMottaker>()
+
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns listOf(
+            Brevmottaker(
+                behandlingId = behandling.id,
+                type = MottakerType.FULLMEKTIG,
+                navn = "John Doe",
+                adresselinje1 = "Test adresse",
+                postnummer = "0000",
+                poststed = "Oslo",
+                landkode = "NO"
+            )
+        )
+        every { brevmottakerService.lagMottakereFraBrevMottakere(any(), any(), any()) } answers { callOriginal() }
+        every { brevmottakerService.hentMottakerNavn(søkersident) } returns "søker"
+        every {
+            utgåendeJournalføringService.journalførManueltBrev(
+                fnr = any(),
+                fagsakId = any(),
+                journalførendeEnhet = any(),
+                brev = any(),
+                førsteside = any(),
+                dokumenttype = any(),
+                avsenderMottaker = capture(avsenderMottakere),
+                tilManuellMottakerEllerVerge = any()
+            )
+        } returns "mockJournalPostId" andThen "mockJournalPostId1"
+
+        every { journalføringRepository.save(any()) } returns mockk()
+        every { taskRepository.save(any()) } returns mockk()
+
+        dokumentService.sendManueltBrev(manueltBrevRequest, behandling, behandling.fagsak.id)
+
+        verify(exactly = 2) {
+            utgåendeJournalføringService.journalførManueltBrev(
+                fnr = any(),
+                fagsakId = any(),
+                journalførendeEnhet = any(),
+                brev = any(),
+                førsteside = any(),
+                dokumenttype = any(),
+                avsenderMottaker = any(),
+                tilManuellMottakerEllerVerge = any()
+            )
+        }
+        verify(exactly = 2) { journalføringRepository.save(any()) }
+        verify(exactly = 2) { taskRepository.save(any()) }
+
+        assertEquals(2, avsenderMottakere.size)
+        assertEquals("John Doe", avsenderMottakere.first().navn)
+    }
+
+    @Test
+    fun `sendManueltBrev skal sende informasjonsbrev manuelt på fagsak`() {
+        val fagsak = defaultFagsak()
+        val søkersident = fagsak.aktør.aktivFødselsnummer()
+        val manueltBrevRequest =
+            ManueltBrevRequest(mottakerIdent = søkersident, brevmal = Brevmal.INFORMASJONSBREV_KAN_SØKE)
+
+        every {
+            utgåendeJournalføringService.journalførManueltBrev(
+                fnr = any(),
+                fagsakId = any(),
+                journalførendeEnhet = any(),
+                brev = any(),
+                førsteside = any(),
+                dokumenttype = any(),
+                avsenderMottaker = any(),
+                tilManuellMottakerEllerVerge = any()
+            )
+        } returns "mockJournalPostId"
+
+        every { taskRepository.save(any()) } returns mockk()
+
+        dokumentService.sendManueltBrev(manueltBrevRequest, null, fagsak.id)
+
+        verify(exactly = 1) {
+            utgåendeJournalføringService.journalførManueltBrev(
+                fnr = any(),
+                fagsakId = any(),
+                journalførendeEnhet = any(),
+                brev = any(),
+                førsteside = any(),
+                dokumenttype = any(),
+                avsenderMottaker = any(),
+                tilManuellMottakerEllerVerge = any()
+            )
+        }
+        verify(exactly = 0) { journalføringRepository.save(any()) }
+        verify(exactly = 1) { taskRepository.save(any()) }
     }
 
     private fun sendBrev(brevmal: Brevmal, behandling: Behandling) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
@@ -4,6 +4,8 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -14,6 +16,12 @@ internal class BrevmottakerServiceTest {
 
     @MockK
     private lateinit var brevmottakerRepository: BrevmottakerRepository
+
+    @MockK
+    private lateinit var personidentService: PersonidentService
+
+    @MockK
+    private lateinit var personopplysningerService: PersonopplysningerService
 
     @InjectMockKs
     private lateinit var brevmottakerService: BrevmottakerService


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Nå er det mulig for SB å legge til manuell brev mottakere på barnetrygd. Derfor trenges det å gjøre endringer på journalføring og distribuering av brev ved manuelt utsendelse slik at brev kan også sendes til manuell mottakere. PR-en inneholder endringer som støtter dette.
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10504

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
