### PR TITLE
Endrer navn på innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder og all logikken i funksjonen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -26,6 +26,8 @@ class FeatureToggleConfig {
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"
         const val SATSENDRING_OPPRETT_TASKER = "familie-ba-sak.satsendring-opprett-satsendring-task"
         const val SATSENDRING_SJEKK_UTBETALING = "familie-ba-sak.satsendring-sjekk-utbetaling"
+        const val BRUK_ATY_FOR_Å_AVGJØRE_DROPPE_SIMULERING =
+            "familie-ba-sak.skal-se-paa-aty-om-vi-skal-hoppe-over-simulering\n"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -123,10 +123,21 @@ class BeregningService(
         }.map { it }
     }
 
-    fun erAlleUtbetalingsperioderPåNullKroner(behandling: Behandling): Boolean {
+    fun erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling: Behandling): Boolean {
         val andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
 
-        return andelerTilkjentYtelse.all { it.kalkulertUtbetalingsbeløp == 0 }
+        val andelerTilkjentYtelseForrigeBehandling =
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling)
+                ?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
+
+        val erIngenUtbetalingIForrigeBehandling =
+            andelerTilkjentYtelseForrigeBehandling?.all { it.kalkulertUtbetalingsbeløp == 0 } ?: true
+
+        val erAlleUtbetalingsperioderIDenneBehandlingenPåNullKroner =
+            andelerTilkjentYtelse.all { it.kalkulertUtbetalingsbeløp == 0 }
+
+        return erIngenUtbetalingIForrigeBehandling &&
+            erAlleUtbetalingsperioderIDenneBehandlingenPåNullKroner
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -9,8 +9,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -40,7 +38,7 @@ class BeregningService(
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val småbarnstilleggService: SmåbarnstilleggService,
     private val tilkjentYtelseEndretAbonnenter: List<TilkjentYtelseEndretAbonnent> = emptyList(),
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
+    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
 ) {
     fun slettTilkjentYtelseForBehandling(behandlingId: Long) =
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
@@ -125,32 +123,10 @@ class BeregningService(
         }.map { it }
     }
 
-    fun innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling: Behandling): Boolean {
-        val barnMedUtbetalingSomIkkeBlittEndretISisteBehandling =
-            finnAlleBarnFraBehandlingMedPerioderSomSkalUtbetales(behandling.id)
+    fun erAlleUtbetalingsperioderPåNullKroner(behandling: Behandling): Boolean {
+        val andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
 
-        val alleBarnISisteBehanlding = finnBarnFraBehandlingMedTilkjentYtelse(behandling.id)
-
-        val alleBarnISistIverksattBehandling =
-            behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling)?.let {
-                finnBarnFraBehandlingMedTilkjentYtelse(
-                    it.id
-                )
-            }
-                ?: emptyList()
-
-        val nyeBarnISisteBehandling = alleBarnISisteBehanlding.minus(alleBarnISistIverksattBehandling.toSet())
-
-        val nyeBarnMedUtebtalingSomIkkeErEndret =
-            barnMedUtbetalingSomIkkeBlittEndretISisteBehandling.intersect(nyeBarnISisteBehandling)
-
-        return behandling.resultat == Behandlingsresultat.INNVILGET_OG_OPPHØRT &&
-            when (behandling.underkategori) {
-                BehandlingUnderkategori.ORDINÆR, BehandlingUnderkategori.INSTITUSJON -> true
-                BehandlingUnderkategori.UTVIDET -> false
-            } &&
-            behandling.erSøknad() &&
-            nyeBarnMedUtebtalingSomIkkeErEndret.isEmpty()
+        return andelerTilkjentYtelse.all { it.kalkulertUtbetalingsbeløp == 0 }
     }
 
     @Transactional
@@ -245,25 +221,7 @@ class BeregningService(
 
         return personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)?.barna?.map { it.aktør }
             ?.filter {
-                andelerTilkjentYtelse
-                    .filter { aty -> aty.aktør == it }.isNotEmpty()
-            } ?: emptyList()
-    }
-
-    /**
-     * Henter alle barn på behandlingen som har minst en periode med tilkjentytelse som ikke er endret til null i utbetaling.
-     */
-    fun finnAlleBarnFraBehandlingMedPerioderSomSkalUtbetales(behandlingId: Long): List<Aktør> {
-        val andelerMedEndringer = andelerTilkjentYtelseOgEndreteUtbetalingerService
-            .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId)
-
-        return personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)?.barna?.map { it.aktør }
-            ?.filter { aktør ->
-                andelerMedEndringer
-                    .filter { it.aktør == aktør }
-                    .filter { aty ->
-                        aty.kalkulertUtbetalingsbeløp != 0 || aty.endreteUtbetalinger.isEmpty()
-                    }.isNotEmpty()
+                andelerTilkjentYtelse.any { aty -> aty.aktør == it }
             } ?: emptyList()
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -9,6 +9,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -123,6 +125,35 @@ class BeregningService(
         }.map { it }
     }
 
+    @Deprecated("Bruk ny funksjon erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling")
+    fun innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling: Behandling): Boolean {
+        val barnMedUtbetalingSomIkkeBlittEndretISisteBehandling =
+            finnAlleBarnFraBehandlingMedPerioderSomSkalUtbetales(behandling.id)
+
+        val alleBarnISisteBehanlding = finnBarnFraBehandlingMedTilkjentYtelse(behandling.id)
+
+        val alleBarnISistIverksattBehandling =
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling)?.let {
+                finnBarnFraBehandlingMedTilkjentYtelse(
+                    it.id
+                )
+            }
+                ?: emptyList()
+
+        val nyeBarnISisteBehandling = alleBarnISisteBehanlding.minus(alleBarnISistIverksattBehandling.toSet())
+
+        val nyeBarnMedUtebtalingSomIkkeErEndret =
+            barnMedUtbetalingSomIkkeBlittEndretISisteBehandling.intersect(nyeBarnISisteBehandling)
+
+        return behandling.resultat == Behandlingsresultat.INNVILGET_OG_OPPHØRT &&
+            when (behandling.underkategori) {
+                BehandlingUnderkategori.ORDINÆR, BehandlingUnderkategori.INSTITUSJON -> true
+                BehandlingUnderkategori.UTVIDET -> false
+            } &&
+            behandling.erSøknad() &&
+            nyeBarnMedUtebtalingSomIkkeErEndret.isEmpty()
+    }
+
     fun erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling: Behandling): Boolean {
         val andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
 
@@ -233,6 +264,23 @@ class BeregningService(
         return personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)?.barna?.map { it.aktør }
             ?.filter {
                 andelerTilkjentYtelse.any { aty -> aty.aktør == it }
+            } ?: emptyList()
+    }
+
+    /**
+     * Henter alle barn på behandlingen som har minst en periode med tilkjentytelse som ikke er endret til null i utbetaling.
+     */
+    fun finnAlleBarnFraBehandlingMedPerioderSomSkalUtbetales(behandlingId: Long): List<Aktør> {
+        val andelerMedEndringer = andelerTilkjentYtelseOgEndreteUtbetalingerService
+            .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId)
+
+        return personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)?.barna?.map { it.aktør }
+            ?.filter { aktør ->
+                andelerMedEndringer
+                    .filter { it.aktør == aktør }
+                    .filter { aty ->
+                        aty.kalkulertUtbetalingsbeløp != 0 || aty.endreteUtbetalinger.isEmpty()
+                    }.isNotEmpty()
             } ?: emptyList()
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -38,7 +38,7 @@ class BeregningService(
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val småbarnstilleggService: SmåbarnstilleggService,
     private val tilkjentYtelseEndretAbonnenter: List<TilkjentYtelseEndretAbonnent> = emptyList(),
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
+    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
 ) {
     fun slettTilkjentYtelseForBehandling(behandlingId: Long) =
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -49,14 +49,14 @@ class SimuleringService(
         if (vedtak.behandling.id == 2199950L) {
             val skalSimuleres = vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
                 vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-                beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = vedtak.behandling)
+                beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = vedtak.behandling)
 
             secureLogger.info("behandling skalSimuleres=$skalSimuleres for behandling 2199950")
         }
 
         if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
             vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-            beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = vedtak.behandling)
+            beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = vedtak.behandling)
         ) {
             return null
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -47,13 +47,17 @@ class SimuleringService(
     fun hentSimuleringFraFamilieOppdrag(vedtak: Vedtak): DetaljertSimuleringResultat? {
         if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
             vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-            (if (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_ATY_FOR_Å_AVGJØRE_DROPPE_SIMULERING)) beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(
-                behandling = vedtak.behandling
-            ) else {
-                beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(
-                    behandling = vedtak.behandling
+            (
+                if (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_ATY_FOR_Å_AVGJØRE_DROPPE_SIMULERING)) {
+                    beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(
+                            behandling = vedtak.behandling
+                        )
+                } else {
+                    beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(
+                            behandling = vedtak.behandling
+                        )
+                }
                 )
-            })
         ) {
             return null
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -45,18 +45,15 @@ class SimuleringService(
     private val simulert = Metrics.counter("familie.ba.sak.oppdrag.simulert")
 
     fun hentSimuleringFraFamilieOppdrag(vedtak: Vedtak): DetaljertSimuleringResultat? {
-        // TODO Fjern dette når vi har logget det vi skal
-        if (vedtak.behandling.id == 2199950L) {
-            val skalSimuleres = vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
-                vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-                beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling = vedtak.behandling)
-
-            secureLogger.info("behandling skalSimuleres=$skalSimuleres for behandling 2199950")
-        }
-
         if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
             vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-            beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling = vedtak.behandling)
+            (if (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_ATY_FOR_Å_AVGJØRE_DROPPE_SIMULERING)) beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(
+                behandling = vedtak.behandling
+            ) else {
+                beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(
+                    behandling = vedtak.behandling
+                )
+            })
         ) {
             return null
         }
@@ -73,15 +70,6 @@ class SimuleringService(
             andelTilkjentYtelseForUtbetalingsoppdragFactory = AndelTilkjentYtelseForSimuleringFactory(),
             erSimulering = true
         )
-
-        // TODO Fjern dette når vi har logget det vi skal
-        if (vedtak.behandling.id == 2199950L) {
-            secureLogger.info(
-                "utbetalingsoppdrag =\n " +
-                    "$utbetalingsoppdrag\n " +
-                    "for behandling 2199950"
-            )
-        }
 
         if (featureToggleService.isEnabled(FeatureToggleConfig.KAN_GENERERE_UTBETALINGSOPPDRAG_NY)) {
             val tilkjentYtelse = utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
@@ -130,21 +118,6 @@ class SimuleringService(
             erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
             erMigreringsbehandling = behandling.erMigrering()
         )
-
-        // TODO Fjern dette når vi har logget det vi skal
-        if (behandlingId == 2199950L) {
-            secureLogger.info(
-                "tidligere lagret simulering =\n" +
-                    objectMapper.writeValueAsString(simulering)
-            )
-            secureLogger.info(
-                "tidligere lagret simulering til restSimulering =\n" +
-                    objectMapper.writeValueAsString(restSimulering)
-            )
-            secureLogger.info(
-                "skal oppdatere Simulering = ${!behandlingErFerdigBesluttet && simuleringErUtdatert(restSimulering)}"
-            )
-        }
 
         return if (!behandlingErFerdigBesluttet && simuleringErUtdatert(restSimulering)) {
             oppdaterSimuleringPåBehandling(behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -49,14 +49,14 @@ class SimuleringService(
         if (vedtak.behandling.id == 2199950L) {
             val skalSimuleres = vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
                 vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-                beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = vedtak.behandling)
+                beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling = vedtak.behandling)
 
             secureLogger.info("behandling skalSimuleres=$skalSimuleres for behandling 2199950")
         }
 
         if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
             vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-            beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = vedtak.behandling)
+            beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling = vedtak.behandling)
         ) {
             return null
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -152,7 +152,7 @@ class BeslutteVedtak(
 
         if (nesteSteg == StegType.IVERKSETT_MOT_OPPDRAG) {
             val erInnvilgetSøknadUtenUtebtalingsperioderGrunnetEndringsperioder =
-                beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = behandling)
+                beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = behandling)
 
             if (erInnvilgetSøknadUtenUtebtalingsperioderGrunnetEndringsperioder) {
                 return StegType.JOURNALFØR_VEDTAKSBREV

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -152,7 +152,7 @@ class BeslutteVedtak(
 
         if (nesteSteg == StegType.IVERKSETT_MOT_OPPDRAG) {
             val erInnvilgetSøknadUtenUtebtalingsperioderGrunnetEndringsperioder =
-                beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = behandling)
+                beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling = behandling)
 
             if (erInnvilgetSøknadUtenUtebtalingsperioderGrunnetEndringsperioder) {
                 return StegType.JOURNALFØR_VEDTAKSBREV

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -191,7 +191,7 @@ class BeregningServiceTest {
     }
 
     @Test
-    fun `Skal ikke iverksettes i økonomi hvis mangler utbetalins perioder grunnet endret utbetalings periode`() {
+    fun `Skal ikke iverksettes i økonomi hvis vi mangler utbetalingsperioder grunnet endret utbetalings periode`() {
         val skalIkkeIverksette = opprettAtyMedEndretUtbetalingsPeriode(
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.ORDINÆR,
@@ -204,7 +204,7 @@ class BeregningServiceTest {
     }
 
     @Test
-    fun `Skal ikke iverksettes i økonomi hvis mangler utbetalingsperioder uavhengig av behandlingsresultat`() {
+    fun `Skal ikke iverksettes i økonomi hvis vi mangler utbetalingsperioder uavhengig av behandlingsresultat`() {
         val skalIkkeIverksette = opprettAtyMedEndretUtbetalingsPeriode(
             behandlinsResultat = Behandlingsresultat.INNVILGET,
             BehandlingUnderkategori.ORDINÆR,
@@ -243,7 +243,7 @@ class BeregningServiceTest {
     }
 
     @Test
-    fun `Skal ikke iverksettes i økonomi hvis mangler utbetalingsperioder men er av underkategori UTVIDET`() {
+    fun `Skal ikke iverksettes i økonomi hvis vi mangler utbetalingsperioder men er av underkategori UTVIDET`() {
         val skalIkkeIverksette = opprettAtyMedEndretUtbetalingsPeriode(
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.UTVIDET,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -196,7 +196,8 @@ class BeregningServiceTest {
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.ORDINÆR,
             0,
-            true
+            true,
+            prosent = BigDecimal.ZERO
         )
 
         Assertions.assertTrue(skalIkkeIverksette)
@@ -208,7 +209,8 @@ class BeregningServiceTest {
             behandlinsResultat = Behandlingsresultat.INNVILGET,
             BehandlingUnderkategori.ORDINÆR,
             0,
-            true
+            true,
+            prosent = BigDecimal.ZERO
         )
 
         Assertions.assertFalse(skalIkkeIverksette)
@@ -220,7 +222,8 @@ class BeregningServiceTest {
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.ORDINÆR,
             100,
-            true
+            true,
+            prosent = BigDecimal.ZERO
         )
 
         Assertions.assertFalse(skalIkkeIverksette)
@@ -232,7 +235,8 @@ class BeregningServiceTest {
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.ORDINÆR,
             0,
-            false
+            false,
+            prosent = BigDecimal.valueOf(100)
         )
 
         Assertions.assertFalse(skalIkkeIverksette)
@@ -244,7 +248,8 @@ class BeregningServiceTest {
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.UTVIDET,
             0,
-            true
+            true,
+            prosent = BigDecimal.ZERO
         )
 
         Assertions.assertFalse(skalIkkeIverksette)
@@ -1043,7 +1048,8 @@ class BeregningServiceTest {
         behandlinsResultat: Behandlingsresultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
         behandlingUnderkategori: BehandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
         beløp: Int,
-        endretUtbetaling: Boolean
+        endretUtbetaling: Boolean,
+        prosent: BigDecimal
     ): Boolean {
         val behandling = lagBehandling(resultat = behandlinsResultat, underkategori = behandlingUnderkategori)
 
@@ -1080,7 +1086,8 @@ class BeregningServiceTest {
             fom = periodeFom,
             tom = periodeTom,
             beløp = beløp,
-            endretUtbetalingAndeler = endreteUtbetalingAndeler
+            endretUtbetalingAndeler = endreteUtbetalingAndeler,
+            prosent = prosent
         )
 
         every { personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) } returns personopplysningGrunnlag
@@ -1094,7 +1101,7 @@ class BeregningServiceTest {
 
         every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(any()) } returns null
 
-        return beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(
+        return beregningService.erAlleUtbetalingsperioderPåNullKroner(
             behandling = behandling
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -1101,7 +1101,7 @@ class BeregningServiceTest {
 
         every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(any()) } returns null
 
-        return beregningService.erAlleUtbetalingsperioderPåNullKroner(
+        return beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(
             behandling = behandling
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -243,7 +243,7 @@ class BeregningServiceTest {
     }
 
     @Test
-    fun `Skal ikke iverksettes i økonomi hvis vi mangler utbetalingsperioder men er av underkategori UTVIDET`() {
+    fun `Skal ikke iverksettes i økonomi hvis vi mangler utbetalingsperioder, selv om underkategorien er UTVIDET`() {
         val skalIkkeIverksette = opprettAtyMedEndretUtbetalingsPeriode(
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.UTVIDET,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -204,7 +204,7 @@ class BeregningServiceTest {
     }
 
     @Test
-    fun `Skal iverksettes i økonomi hvis mangler utbetalins perioder men behandlinsresultat ikke er innvilget og opphørt`() {
+    fun `Skal ikke iverksettes i økonomi hvis mangler utbetalingsperioder uavhengig av behandlingsresultat`() {
         val skalIkkeIverksette = opprettAtyMedEndretUtbetalingsPeriode(
             behandlinsResultat = Behandlingsresultat.INNVILGET,
             BehandlingUnderkategori.ORDINÆR,
@@ -213,7 +213,7 @@ class BeregningServiceTest {
             prosent = BigDecimal.ZERO
         )
 
-        Assertions.assertFalse(skalIkkeIverksette)
+        Assertions.assertTrue(skalIkkeIverksette)
     }
 
     @Test
@@ -230,7 +230,7 @@ class BeregningServiceTest {
     }
 
     @Test
-    fun `Skal iverksettes i økonomi hvis mangler utbetalins perioder men mangler endringsperioder`() {
+    fun `Skal ikke iverksettes i økonomi dersom det ikke er utbetaling, selv uten endringsperioder`() {
         val skalIkkeIverksette = opprettAtyMedEndretUtbetalingsPeriode(
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.ORDINÆR,
@@ -239,11 +239,11 @@ class BeregningServiceTest {
             prosent = BigDecimal.valueOf(100)
         )
 
-        Assertions.assertFalse(skalIkkeIverksette)
+        Assertions.assertTrue(skalIkkeIverksette)
     }
 
     @Test
-    fun `Skal iverksettes i økonomi hvis mangler utbetalins perioder men er av underkategori UTVIDET`() {
+    fun `Skal ikke iverksettes i økonomi hvis mangler utbetalingsperioder men er av underkategori UTVIDET`() {
         val skalIkkeIverksette = opprettAtyMedEndretUtbetalingsPeriode(
             behandlinsResultat = Behandlingsresultat.INNVILGET_OG_OPPHØRT,
             BehandlingUnderkategori.UTVIDET,
@@ -252,7 +252,7 @@ class BeregningServiceTest {
             prosent = BigDecimal.ZERO
         )
 
-        Assertions.assertFalse(skalIkkeIverksette)
+        Assertions.assertTrue(skalIkkeIverksette)
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -109,7 +109,7 @@ class BeslutteVedtakTest {
         every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
         mockkObject(FerdigstillOppgaver.Companion)
         every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
-        every { beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = behandling) } returns false
+        every { beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = behandling) } returns false
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -162,7 +162,7 @@ class BeslutteVedtakTest {
         val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
 
         every { vedtakService.hentAktivForBehandling(any()) } returns vedtak
-        every { beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling) } returns true
+        every { beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling) } returns true
 
         mockkObject(JournalførVedtaksbrevTask.Companion)
         every {
@@ -175,7 +175,7 @@ class BeslutteVedtakTest {
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
-        verify(exactly = 1) { beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling) }
+        verify(exactly = 1) { beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling) }
 
         verify(exactly = 1) {
             JournalførVedtaksbrevTask.opprettTaskJournalførVedtaksbrev(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -109,7 +109,7 @@ class BeslutteVedtakTest {
         every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
         mockkObject(FerdigstillOppgaver.Companion)
         every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
-        every { beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling = behandling) } returns false
+        every { beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling = behandling) } returns false
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -162,7 +162,7 @@ class BeslutteVedtakTest {
         val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
 
         every { vedtakService.hentAktivForBehandling(any()) } returns vedtak
-        every { beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling) } returns true
+        every { beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling) } returns true
 
         mockkObject(JournalførVedtaksbrevTask.Companion)
         every {
@@ -175,7 +175,7 @@ class BeslutteVedtakTest {
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
-        verify(exactly = 1) { beregningService.erAlleUtbetalingsperioderPåNullKroner(behandling) }
+        verify(exactly = 1) { beregningService.erAlleUtbetalingsperioderPåNullKronerIDenneOgForrigeBehandling(behandling) }
 
         verify(exactly = 1) {
             JournalførVedtaksbrevTask.opprettTaskJournalførVedtaksbrev(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10856

Vi har en behandling som ikke blir simulert siden den har resultat innvilget og opphørt og treffer koden som ble laget her:
https://github.com/navikt/familie-ba-sak/pull/2234

Tekst fra https://github.com/navikt/familie-ba-sak/pull/2234
> Hvis alle innvilgede perioder i en søknad er endret til å ikke utbetale for noen periode så skal ikke simulering kjøre. Steget Iverksett mot økonomi skal bypasses til journalfør vedtaksbrevet.

Endrer koden fra https://github.com/navikt/familie-ba-sak/pull/2234 til å trigges dersom alle utbetalinger er endret til 0 kroner, enten gjennom endret utbetaling, eller på grunn av differanseberegning. Dette gjelder kun om vi ikke har noen forrige behandling, eller om forrige behandling ikke hadde noen utbetaling. Dersom det var utbetaling i forrige behandling må økonomi få vite om dette, så da trigges ikke denne koden. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
