### PR TITLE
Tea-10089: Antall uker må ganges med 7 før vi forlenger fristen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -136,7 +136,7 @@ class DokumentService(
                 frist = LocalDate.now()
                     .plusDays(
                         manueltBrevRequest.brevmal.ventefristDager(
-                            manuellFrist = manueltBrevRequest.antallUkerSvarfrist?.toLong(),
+                            manuellFrist = manueltBrevRequest.antallUkerSvarfrist?.let { it * 7 }?.toLong(),
                             behandlingKategori = behandling.kategori
                         )
                     ),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10089

Bug per i dag:
Setter man antall uker svarfrist til 10 i frontend, så forlenges fristen bare med 10 dager.
Dette er fordi at vi ikke ganger tallet med 7 før vi setter det videre i backend.