### PR TITLE
Håndtere åpne behandlinger som skal ha satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.SATSENDRING
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
@@ -13,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.byggMottakerdata
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.BehandleSak
 import org.springframework.stereotype.Service
 
 @Service
@@ -39,6 +41,9 @@ class HenleggBehandling(
         }
 
         oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling).forEach {
+            if (data.årsak == HenleggÅrsak.TEKNISK_VEDLIKEHOLD && data.begrunnelse == SATSENDRING && it.type == BehandleSak) {
+                return@forEach // continue
+            }
             oppgaveService.ferdigstillOppgaver(behandling.id, it.type)
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -41,10 +41,10 @@ class HenleggBehandling(
         }
 
         oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling)
-        .filter {!(data.årsak == HenleggÅrsak.TEKNISK_VEDLIKEHOLD && data.begrunnelse == SATSENDRING && it.type == BehandleSak)}
-        .forEach {
-            oppgaveService.ferdigstillOppgaver(behandling.id, it.type)
-        }
+            .filter { !(data.årsak == HenleggÅrsak.TEKNISK_VEDLIKEHOLD && data.begrunnelse == SATSENDRING && it.type == BehandleSak) }
+            .forEach {
+                oppgaveService.ferdigstillOppgaver(behandling.id, it.type)
+            }
 
         loggService.opprettHenleggBehandling(behandling, data.årsak.beskrivelse, data.begrunnelse)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -40,10 +40,9 @@ class HenleggBehandling(
             )
         }
 
-        oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling).forEach {
-            if (data.årsak == HenleggÅrsak.TEKNISK_VEDLIKEHOLD && data.begrunnelse == SATSENDRING && it.type == BehandleSak) {
-                return@forEach // continue
-            }
+        oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling)
+        .filter {!(data.årsak == HenleggÅrsak.TEKNISK_VEDLIKEHOLD && data.begrunnelse == SATSENDRING && it.type == BehandleSak)}
+        .forEach {
             oppgaveService.ferdigstillOppgaver(behandling.id, it.type)
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTask.kt
@@ -1,0 +1,85 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
+import no.nav.familie.ba.sak.kjerne.behandling.RestHenleggBehandlingInfo
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.util.Properties
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = HenleggBehandlingTask.TASK_STEP_TYPE,
+    beskrivelse = "Henlegg behandling",
+    maxAntallFeil = 1
+)
+class HenleggBehandlingTask(
+    val arbeidsfordelingService: ArbeidsfordelingService,
+    val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    val stegService: StegService,
+    val oppgaveService: OppgaveService
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val henleggBehandlingTaskDTO = objectMapper.readValue(task.payload, HenleggBehandlingTaskDTO::class.java)
+        val behandling = behandlingHentOgPersisterService.hent(henleggBehandlingTaskDTO.behandlingId)
+
+        if (behandling.status == BehandlingStatus.AVSLUTTET) {
+            task.metadata["Resultat"] = "Behandlingen er allerede avsluttet"
+            return
+        }
+
+        if (henleggBehandlingTaskDTO.validerOppgavefristErEtterDato != null) {
+            val valideringsdato = henleggBehandlingTaskDTO.validerOppgavefristErEtterDato
+            val frist = oppgaveService.hentOppgaverSomIkkeErFerdigstilt(Oppgavetype.BehandleSak, behandling).let {
+                it.singleOrNull()?.run {
+                    oppgaveService.hentOppgave(gsakId.toLong()).fristFerdigstillelse ?: error("Oppgave $gsakId mangler frist")
+                } ?: error("Behandling ${behandling.id} har ingen / mer enn en behandleSak-oppgave: $it")
+            }
+            if (!LocalDate.parse(frist).isAfter(henleggBehandlingTaskDTO.validerOppgavefristErEtterDato)) {
+                task.metadata["Resultat"] = "Stoppet. Behandlingen har frist $frist. Må være etter $valideringsdato"
+                return
+            }
+        }
+
+        stegService.håndterHenleggBehandling(
+            behandling = behandling,
+            henleggBehandlingInfo = henleggBehandlingTaskDTO.run { RestHenleggBehandlingInfo(årsak, begrunnelse) }
+        ).apply {
+            task.metadata["behandlendeEnhetId"] = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(id).behandlendeEnhetId
+            task.metadata["fagsakId"] = fagsak.id
+            task.metadata["Resultat"] = "Henleggelse kjørt OK"
+        }
+    }
+
+    companion object {
+
+        const val TASK_STEP_TYPE = "HenleggBehandling"
+
+        fun opprettTask(henleggBehandlingTaskDTO: HenleggBehandlingTaskDTO): Task {
+            return Task(
+                type = TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(henleggBehandlingTaskDTO),
+                properties = Properties().apply {
+                    this["behandlingId"] = henleggBehandlingTaskDTO.behandlingId.toString()
+                }
+            )
+        }
+    }
+}
+
+class HenleggBehandlingTaskDTO(
+    val behandlingId: Long,
+    val årsak: HenleggÅrsak,
+    val begrunnelse: String,
+    val validerOppgavefristErEtterDato: LocalDate?
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTask.kt
@@ -43,7 +43,7 @@ class HenleggBehandlingTask(
             val frist = oppgaveService.hentOppgaverSomIkkeErFerdigstilt(Oppgavetype.BehandleSak, behandling).let {
                 it.singleOrNull()?.run {
                     oppgaveService.hentOppgave(gsakId.toLong()).fristFerdigstillelse ?: error("Oppgave $gsakId mangler frist")
-                } ?: error("Behandling ${behandling.id} har ingen / mer enn en behandleSak-oppgave: $it")
+                } ?: error("Behandling ${behandling.id} har ingen, eller mer enn en behandleSak-oppgave: $it")
             }
             if (!LocalDate.parse(frist).isAfter(henleggBehandlingTaskDTO.validerOppgavefristErEtterDato)) {
                 task.metadata["Resultat"] = "Stoppet. Behandlingen har frist $frist. Må være etter $valideringsdato"

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.inneværendeMåned
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
+import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.task.dto.Autobrev6og18ÅrDTO
 import no.nav.familie.ba.sak.task.dto.AutobrevOpphørSmåbarnstilleggDTO
@@ -102,6 +103,31 @@ class OpprettTaskService(
             )
         }
         satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
+    }
+
+    @Transactional
+    fun opprettHenleggBehandlingTask(
+        behandlingId: Long,
+        årsak: HenleggÅrsak,
+        begrunnelse: String,
+        validerOppgavefristErEtterDato: LocalDate? = null
+    ) {
+        taskRepository.save(
+            Task(
+                type = HenleggBehandlingTask.TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(
+                    HenleggBehandlingTaskDTO(
+                        behandlingId = behandlingId,
+                        årsak = årsak,
+                        begrunnelse = begrunnelse,
+                        validerOppgavefristErEtterDato = validerOppgavefristErEtterDato
+                    )
+                ),
+                properties = Properties().apply {
+                    this["behandlingId"] = behandlingId.toString()
+                }
+            )
+        )
     }
 
     private inline fun <T> overstyrTaskMedNyCallId(callId: String, body: () -> T): T {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTaskTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.RestHenleggBehandlingInfo
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.steg.StegService
-import no.nav.familie.ba.sak.task.HenleggBehandlingTask.Companion.opprettTask
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
@@ -82,12 +82,15 @@ internal class HenleggBehandlingTaskTest {
     }
 
     private fun opprettTekniskHenleggelseGrunnetSatsendringTask(): Task {
-        return opprettTask(
-            HenleggBehandlingTaskDTO(
-                behandlingId = 1,
-                årsak = HenleggÅrsak.TEKNISK_VEDLIKEHOLD,
-                begrunnelse = "Satsendring",
-                validerOppgavefristErEtterDato = LocalDate.of(2023, 4, 1)
+        return Task(
+            type = HenleggBehandlingTask.TASK_STEP_TYPE,
+            payload = objectMapper.writeValueAsString(
+                HenleggBehandlingTaskDTO(
+                    behandlingId = 1,
+                    årsak = HenleggÅrsak.TEKNISK_VEDLIKEHOLD,
+                    begrunnelse = "Satsendring",
+                    validerOppgavefristErEtterDato = LocalDate.of(2023, 4, 1)
+                )
             )
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/HenleggBehandlingTaskTest.kt
@@ -1,0 +1,89 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.integrasjoner.lagTestOppgaveDTO
+import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
+import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.DbOppgave
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
+import no.nav.familie.ba.sak.kjerne.behandling.RestHenleggBehandlingInfo
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.ba.sak.task.HenleggBehandlingTask.Companion.opprettTask
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.prosessering.domene.Task
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class HenleggBehandlingTaskTest {
+
+    val oppgaveService: OppgaveService = mockk()
+    val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
+    val stegService: StegService = mockk(relaxed = true)
+    private val henleggBehandlingTask = HenleggBehandlingTask(
+        arbeidsfordelingService = mockk(relaxed = true),
+        behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+        stegService = stegService,
+        oppgaveService = oppgaveService
+    )
+
+    @Test
+    fun doTask() {
+        every { behandlingHentOgPersisterService.hent(any()) } returns lagBehandling(status = BehandlingStatus.AVSLUTTET)
+        val task = opprettTask()
+        henleggBehandlingTask.doTask(task)
+        assertThat(task.metadata["Resultat"]).isEqualTo("Behandlingen er allerede avsluttet")
+    }
+
+    @Test
+    fun doTask2() {
+        val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(any()) } returns behandling
+        every { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(any(), any()) } returns
+            listOf(DbOppgave(behandling = behandling, gsakId = "1", type = Oppgavetype.BehandleSak))
+        every { oppgaveService.hentOppgave(any()) } returns lagTestOppgaveDTO(1, Oppgavetype.BehandleSak)
+
+        val task = opprettTask()
+        henleggBehandlingTask.doTask(task)
+
+        assertThat(task.metadata["Resultat"] as String).contains("Stoppet.", "frist", "Må være etter 2023-04-01")
+    }
+
+    @Test
+    fun happy() {
+        val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(any()) } returns behandling
+        every { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(any(), any()) } returns
+            listOf(DbOppgave(behandling = behandling, gsakId = "1", type = Oppgavetype.BehandleSak))
+        every { oppgaveService.hentOppgave(any()) } returns lagTestOppgaveDTO(1, Oppgavetype.BehandleSak).copy(
+            fristFerdigstillelse = LocalDate.of(2023, 4, 2).toString()
+        )
+
+        val task = opprettTask()
+        henleggBehandlingTask.doTask(task)
+
+        val henleggBehandlingInfo = slot<RestHenleggBehandlingInfo>()
+        verify(exactly = 1) {
+            stegService.håndterHenleggBehandling(behandling, capture(henleggBehandlingInfo))
+        }
+        assertThat(henleggBehandlingInfo.captured.årsak).isEqualTo(HenleggÅrsak.TEKNISK_VEDLIKEHOLD)
+        assertThat(henleggBehandlingInfo.captured.begrunnelse).isEqualTo("Satsendring")
+        assertThat(task.metadata["Resultat"]).isEqualTo("Henleggelse kjørt OK")
+    }
+
+    private fun opprettTask(): Task {
+        return opprettTask(
+            HenleggBehandlingTaskDTO(
+                behandlingId = 1,
+                årsak = HenleggÅrsak.TEKNISK_VEDLIKEHOLD,
+                begrunnelse = "Satsendring",
+                validerOppgavefristErEtterDato = LocalDate.of(2023, 4, 1)
+            )
+        )
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro:](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10784)
![image](https://user-images.githubusercontent.com/47184872/218720046-82f47463-675c-4902-9e71-ddf226497041.png)

Legger til et endepunkt det kan sendes en liste med behandlinger til, basert på tidligere uttrekk, som oppretter en HenleggBehandlingTask med årsak TEKNISK_VEDLIKEHOLD og begrunnelse "Satsendring" for hver behandling i listen.
Tasken validerer at behandlingen som skal henlegges fortsatt er åpen og har frist etter 1. april 2023. 

La i tillegg til en sjekk i HenleggBehandling-steget som dropper å ferdigstille behandleSak-oppgaven dersom årsak og begrunnelse matcher kombinasjonen over.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
