### PR TITLE
Splitt ut koden for å distribuere brev slik at vi er sikker på at logikken som kun skal skje på behandlingsnivå kun brukes fra behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentDistribueringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentDistribueringService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.task.DistribuerDokumentDTO
-import no.nav.familie.ba.sak.task.DistribuerDødsfallDokumentPåFagsakTask
+import no.nav.familie.ba.sak.task.DistribuerDokumentPåFagsakTask
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.Logger
@@ -29,7 +29,6 @@ class DokumentDistribueringService(
     } catch (ressursException: RessursException) {
         val journalpostId = distribuerDokumentDTO.journalpostId
         val behandlingId = distribuerDokumentDTO.behandlingId
-        val brevmal = distribuerDokumentDTO.brevmal
 
         logger.info(
             "Klarte ikke å distribuere brev til journalpost $journalpostId på behandling $behandlingId. " +
@@ -41,27 +40,45 @@ class DokumentDistribueringService(
                 "Melding: ${ressursException.cause?.message}"
         )
 
-        when {
-            mottakerErIkkeDigitalOgHarUkjentAdresse(ressursException) && behandlingId != null ->
-                loggBrevIkkeDistribuertUkjentAdresse(journalpostId, behandlingId, brevmal)
-
-            mottakerErDødUtenDødsboadresse(ressursException) && behandlingId != null ->
-                håndterMottakerDødIngenAdressePåBehandling(distribuerDokumentDTO)
-
-            dokumentetErAlleredeDistribuert(ressursException) ->
-                logger.warn(alleredeDistribuertMelding(journalpostId, behandlingId))
-
-            else -> throw ressursException
+        if (dokumentetErAlleredeDistribuert(ressursException)) {
+            logger.warn(alleredeDistribuertMelding(journalpostId, behandlingId))
+        } else {
+            throw ressursException
         }
     }
 
-    internal fun håndterMottakerDødIngenAdressePåBehandling(distribuerDokumentDTO: DistribuerDokumentDTO) {
-        val task = DistribuerDødsfallDokumentPåFagsakTask.opprettTask(distribuerDokumentDTO)
+    fun prøvDistribuerBrevOgLoggHendelseFraBehandling(
+        distribuerDokumentDTO: DistribuerDokumentDTO,
+        loggBehandlerRolle: BehandlerRolle
+    ) {
+        try {
+            prøvDistribuerBrevOgLoggHendelse(distribuerDokumentDTO, loggBehandlerRolle)
+        } catch (ressursException: RessursException) {
+            val journalpostId = distribuerDokumentDTO.journalpostId
+            val behandlingId = distribuerDokumentDTO.behandlingId
+            val brevmal = distribuerDokumentDTO.brevmal
+
+            when {
+                mottakerErDødUtenDødsboadresse(ressursException) && behandlingId != null ->
+                    distribuerBrevetPåFagsaknivå(distribuerDokumentDTO)
+
+                mottakerErIkkeDigitalOgHarUkjentAdresse(ressursException) && behandlingId != null ->
+                    loggBrevIkkeDistribuertUkjentAdresse(journalpostId, behandlingId, brevmal)
+
+                else -> throw ressursException
+            }
+        }
+    }
+
+    internal fun distribuerBrevetPåFagsaknivå(distribuerDokumentDTO: DistribuerDokumentDTO) {
+        val task = DistribuerDokumentPåFagsakTask.opprettTask(distribuerDokumentDTO.copy(behandlingId = null))
         taskService.save(task)
+
         logger.info(
             "Klarte ikke å distribuere brev for journalpostId ${distribuerDokumentDTO.journalpostId} " +
                 "på behandling ${distribuerDokumentDTO.behandlingId}. Bruker har ukjent dødsboadresse."
         )
+
         loggService.opprettBrevIkkeDistribuertUkjentDødsboadresseLogg(
             behandlingId = checkNotNull(distribuerDokumentDTO.behandlingId),
             brevnavn = distribuerDokumentDTO.brevmal.visningsTekst

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/DistribuerVedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/DistribuerVedtaksbrev.kt
@@ -19,7 +19,7 @@ class DistribuerVedtaksbrev(
         data: DistribuerDokumentDTO
     ): StegType {
         logger.info("Iverksetter distribusjon av vedtaksbrev med journalpostId ${data.journalpostId}")
-        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelse(
+        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
             distribuerDokumentDTO = data,
             loggBehandlerRolle = BehandlerRolle.SYSTEM
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/DistribuerDokumentPåFagsakTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/DistribuerDokumentPåFagsakTask.kt
@@ -21,7 +21,7 @@ const val ANTALL_SEKUNDER_I_EN_UKE = 604800L
 
 @Service
 @TaskStepBeskrivelse(
-    taskStepType = DistribuerDødsfallDokumentPåFagsakTask.TASK_STEP_TYPE,
+    taskStepType = DistribuerDokumentPåFagsakTask.TASK_STEP_TYPE,
     beskrivelse = "Send dødsfall dokument til Dokdist",
     triggerTidVedFeilISekunder = ANTALL_SEKUNDER_I_EN_UKE,
     // ~8 måneder dersom vi prøver én gang i uka.
@@ -29,7 +29,7 @@ const val ANTALL_SEKUNDER_I_EN_UKE = 604800L
     maxAntallFeil = 4 * 8,
     settTilManuellOppfølgning = true
 )
-class DistribuerDødsfallDokumentPåFagsakTask(
+class DistribuerDokumentPåFagsakTask(
     private val dokumentDistribueringService: DokumentDistribueringService
 ) : AsyncTaskStep {
 
@@ -73,6 +73,8 @@ class DistribuerDødsfallDokumentPåFagsakTask(
 
     companion object {
         fun opprettTask(distribuerDokumentDTO: DistribuerDokumentDTO): Task {
+            check(distribuerDokumentDTO.behandlingId == null)
+
             return Task(
                 type = this.TASK_STEP_TYPE,
                 payload = objectMapper.writeValueAsString(distribuerDokumentDTO),

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/DistribuerVedtaksbrevTilInstitusjonVergeEllerManuellBrevMottakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/DistribuerVedtaksbrevTilInstitusjonVergeEllerManuellBrevMottakerTask.kt
@@ -21,7 +21,7 @@ class DistribuerVedtaksbrevTilInstitusjonVergeEllerManuellBrevMottakerTask(
 
     override fun doTask(task: Task) {
         val distribuerDokumentDTO = objectMapper.readValue(task.payload, DistribuerDokumentDTO::class.java)
-        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelse(
+        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
             distribuerDokumentDTO = distribuerDokumentDTO,
             loggBehandlerRolle = BehandlerRolle.SYSTEM
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentDistribueringServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentDistribueringServiceEnhetstest.kt
@@ -44,7 +44,7 @@ internal class DokumentDistribueringServiceEnhetstest {
             cause = RestClientResponseException("Mottaker har ukjent adresse", 400, "", null, null, null)
         )
 
-        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelse(
+        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
             distribuerDokumentDTO = lagDistribuerDokumentDTO(),
             loggBehandlerRolle = BehandlerRolle.BESLUTTER
         )
@@ -62,7 +62,7 @@ internal class DokumentDistribueringServiceEnhetstest {
             cause = RestClientResponseException("", 410, "", null, null, null)
         )
 
-        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelse(
+        dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
             distribuerDokumentDTO = lagDistribuerDokumentDTO(),
             loggBehandlerRolle = BehandlerRolle.BESLUTTER
         )
@@ -83,7 +83,7 @@ internal class DokumentDistribueringServiceEnhetstest {
         )
 
         assertDoesNotThrow {
-            dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelse(
+            dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
                 distribuerDokumentDTO = lagDistribuerDokumentDTO(),
                 loggBehandlerRolle = BehandlerRolle.BESLUTTER
             )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når vi distribuerer et dokument fra en behandling og brukeren er død uten dødsboadresse, skal vi fullføre behandlingen som vanlig med en logg om at vi ikke fikk distribuert dokumentet. I tillegg skal vi prøve å sende dokumentet fra fagsaknivå en gang i uken. Dersom brukeren ikke har fått dødsboadresse etter 6 måneder gir vi opp. 

Vi hadde en feil der tasken som sender dokumentet fra fagsaken opprettet seg selv.

Splitter opp logikken for å distribuere dokument slik at enklere kan skille mellom det som skal skje fra fagsak-nivå og det som skal skje fra behandling-nivå

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
