### PR TITLE
Skipp sjekk av fagsak hvis den alt er ignorert

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -22,6 +22,6 @@ class AutovedtakSatsendringScheduler(private val startSatsendring: StartSatsendr
     companion object {
         val logger = LoggerFactory.getLogger(AutovedtakSatsendringScheduler::class.java)
         const val CRON_HVERT_5_MIN_ARBEIDSTID_UKEDAG = "0 */5 7-17 * * MON-FRI"
-        const val CRON_HVERT_10_MIN_ARBEIDSTID_UKEDAG = "0 */10 7-17 * * MON-FRI"
+        const val CRON_HVERT_10_MIN_ARBEIDSTID_UKEDAG = "0 */10 6-18 * * MON-FRI"
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -63,7 +63,7 @@ internal class StartSatsendringTest {
         val taskSlot = slot<Task>()
         every { taskRepository.save(capture(taskSlot)) } answers { taskSlot.captured }
         val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository)
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_SJEKK_UTBETALING, false) } returns false
+        every { featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_SJEKK_UTBETALING, true) } returns false
 
         startSatsendring = StartSatsendring(
             fagsakRepository = fagsakRepository,
@@ -173,7 +173,7 @@ internal class StartSatsendringTest {
     fun `finnLøpendeFagsaker har totalt antall sider 3, så den skal kalle finnLøpendeFagsaker 3 ganger for å få 5 satsendringer`() {
         every { featureToggleService.isEnabled(any(), any()) } returns true
         every { featureToggleService.isEnabled(any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_SJEKK_UTBETALING, false) } returns false
+        every { featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_SJEKK_UTBETALING, true) } returns false
 
         val behandling = lagBehandling()
 


### PR DESCRIPTION
Tar vare på ignorerte satsendringer i minne, slik at man slipper å sjekke de flere enn en gang på podden. Denne vil bli bygget opp hver gang en ny pod blir leader, men det er greit.

Vinduet for når man kjører satsendring har blitt utvidet

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
