### PR TITLE
Ta med uregistrerte barn i EØS-begrunnelsesdata for avslag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -93,13 +93,16 @@ class BrevPeriodeGenerator(
                     restBehandlingsgrunnlagForBrev.personerPåBehandling.filter { it.type == PersonType.BARN }
                 val barnIBegrunnelse = personerIBegrunnelse.filter { it.type == PersonType.BARN }
                 val gjelderSøker = personerIBegrunnelse.any { it.type == PersonType.SØKER }
+                val barnasFødselsdatoer =
+                    if (gjelderSøker) barnPåBehandling.tilBarnasFødselsdatoer() else barnIBegrunnelse.tilBarnasFødselsdatoer()
+                val antallBarn = if (gjelderSøker) barnPåBehandling.size else barnIBegrunnelse.size
 
                 listOf(
                     EØSBegrunnelseDataUtenKompetanse(
                         vedtakBegrunnelseType = begrunnelse.vedtakBegrunnelseType,
                         apiNavn = begrunnelse.sanityApiNavn,
-                        barnasFodselsdatoer = if (gjelderSøker) barnPåBehandling.tilBarnasFødselsdatoer() else barnIBegrunnelse.tilBarnasFødselsdatoer(),
-                        antallBarn = if (gjelderSøker) barnPåBehandling.size else barnIBegrunnelse.size,
+                        barnasFodselsdatoer = barnasFødselsdatoer + uregistrerteBarn.mapNotNull { it.fødselsdato },
+                        antallBarn = antallBarn + uregistrerteBarn.size,
                         maalform = brevMålform.tilSanityFormat(),
                         gjelderSoker = gjelderSøker
                     )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -93,16 +93,26 @@ class BrevPeriodeGenerator(
                     restBehandlingsgrunnlagForBrev.personerPåBehandling.filter { it.type == PersonType.BARN }
                 val barnIBegrunnelse = personerIBegrunnelse.filter { it.type == PersonType.BARN }
                 val gjelderSøker = personerIBegrunnelse.any { it.type == PersonType.SØKER }
-                val barnasFødselsdatoer =
-                    if (gjelderSøker) barnPåBehandling.tilBarnasFødselsdatoer() else barnIBegrunnelse.tilBarnasFødselsdatoer()
-                val antallBarn = if (gjelderSøker) barnPåBehandling.size else barnIBegrunnelse.size
+
+                val barnasFødselsdatoer = hentBarnasFødselsdatoerForAvslagsbegrunnelse(
+                    barnIBegrunnelse = barnIBegrunnelse,
+                    barnPåBehandling = barnPåBehandling,
+                    uregistrerteBarn = uregistrerteBarn,
+                    gjelderSøker = gjelderSøker
+                )
+                val antallBarn = hentAntallBarnForAvslagsbegrunnelse(
+                    barnIBegrunnelse = barnIBegrunnelse,
+                    barnPåBehandling = barnPåBehandling,
+                    uregistrerteBarn = uregistrerteBarn,
+                    gjelderSøker = gjelderSøker
+                )
 
                 listOf(
                     EØSBegrunnelseDataUtenKompetanse(
                         vedtakBegrunnelseType = begrunnelse.vedtakBegrunnelseType,
                         apiNavn = begrunnelse.sanityApiNavn,
-                        barnasFodselsdatoer = barnasFødselsdatoer + uregistrerteBarn.mapNotNull { it.fødselsdato },
-                        antallBarn = antallBarn + uregistrerteBarn.size,
+                        barnasFodselsdatoer = barnasFødselsdatoer,
+                        antallBarn = antallBarn,
                         maalform = brevMålform.tilSanityFormat(),
                         gjelderSoker = gjelderSøker
                     )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjær
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilMinimertPerson
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import java.time.LocalDate
 import java.time.YearMonth
 
 fun List<MinimertRestPerson>.tilBarnasFødselsdatoer(): String =
@@ -34,6 +35,8 @@ fun List<MinimertRestPerson>.tilBarnasFødselsdatoer(): String =
             }
     )
 
+fun List<LocalDate>.tilSammenslåttKortString(): String = Utils.slåSammen(this.sorted().map { it.tilKortString() })
+
 fun hentBarnasFødselsdatoerForAvslagsbegrunnelse(
     barnIBegrunnelse: List<MinimertRestPerson>,
     barnPåBehandling: List<MinimertRestPerson>,
@@ -41,10 +44,11 @@ fun hentBarnasFødselsdatoerForAvslagsbegrunnelse(
     gjelderSøker: Boolean
 ): String {
     val registrerteBarnFødselsdatoer =
-        if (gjelderSøker) barnPåBehandling.tilBarnasFødselsdatoer() else barnIBegrunnelse.tilBarnasFødselsdatoer()
-    val uregistrerteBarnFødselsdatoer = Utils.slåSammen(
-        uregistrerteBarn.mapNotNull { it.fødselsdato }.sorted().map { it.tilKortString() })
-    return registrerteBarnFødselsdatoer + uregistrerteBarnFødselsdatoer
+        if (gjelderSøker) barnPåBehandling.map { it.fødselsdato } else barnIBegrunnelse.map { it.fødselsdato }
+    val uregistrerteBarnFødselsdatoer =
+        uregistrerteBarn.mapNotNull { it.fødselsdato }
+    val alleBarnaFødselsdatoer = registrerteBarnFødselsdatoer + uregistrerteBarnFødselsdatoer
+    return alleBarnaFødselsdatoer.tilSammenslåttKortString()
 }
 
 fun hentAntallBarnForAvslagsbegrunnelse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
@@ -42,7 +42,9 @@ fun hentBarnasFødselsdatoerForAvslagsbegrunnelse(
 ): String {
     val registrerteBarnFødselsdatoer =
         if (gjelderSøker) barnPåBehandling.tilBarnasFødselsdatoer() else barnIBegrunnelse.tilBarnasFødselsdatoer()
-    return registrerteBarnFødselsdatoer + uregistrerteBarn.mapNotNull { it.fødselsdato }
+    val uregistrerteBarnFødselsdatoer = Utils.slåSammen(
+        uregistrerteBarn.mapNotNull { it.fødselsdato }.sorted().map { it.tilKortString() })
+    return registrerteBarnFødselsdatoer + uregistrerteBarnFødselsdatoer
 }
 
 fun hentAntallBarnForAvslagsbegrunnelse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.tilKortString
+import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertKompetanse
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestBehandlingsgrunnlagForBrev
@@ -32,6 +33,27 @@ fun List<MinimertRestPerson>.tilBarnasFødselsdatoer(): String =
                 person.fødselsdato.tilKortString()
             }
     )
+
+fun hentBarnasFødselsdatoerForAvslagsbegrunnelse(
+    barnIBegrunnelse: List<MinimertRestPerson>,
+    barnPåBehandling: List<MinimertRestPerson>,
+    uregistrerteBarn: List<MinimertUregistrertBarn>,
+    gjelderSøker: Boolean
+): String {
+    val registrerteBarnFødselsdatoer =
+        if (gjelderSøker) barnPåBehandling.tilBarnasFødselsdatoer() else barnIBegrunnelse.tilBarnasFødselsdatoer()
+    return registrerteBarnFødselsdatoer + uregistrerteBarn.mapNotNull { it.fødselsdato }
+}
+
+fun hentAntallBarnForAvslagsbegrunnelse(
+    barnIBegrunnelse: List<MinimertRestPerson>,
+    barnPåBehandling: List<MinimertRestPerson>,
+    uregistrerteBarn: List<MinimertUregistrertBarn>,
+    gjelderSøker: Boolean
+): Int {
+    val antallRegistrerteBarn = if (gjelderSøker) barnPåBehandling.size else barnIBegrunnelse.size
+    return antallRegistrerteBarn + uregistrerteBarn.size
+}
 
 fun hentRestBehandlingsgrunnlagForBrev(
     persongrunnlag: PersonopplysningGrunnlag,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
@@ -111,7 +111,7 @@ class BrevPeriodeUtilTest {
         val uregistrerteBarn = listOf(
             MinimertUregistrertBarn(personIdent = "", navn = "Ole", fødselsdato = LocalDate.of(2021, 4, 4)),
             MinimertUregistrertBarn(personIdent = "", navn = "Dole", fødselsdato = LocalDate.of(2021, 5, 5)),
-            MinimertUregistrertBarn(personIdent = "", navn = "Doffen", fødselsdato = LocalDate.of(2021, 6, 6)),
+            MinimertUregistrertBarn(personIdent = "", navn = "Doffen", fødselsdato = LocalDate.of(2021, 6, 6))
         )
 
         Assertions.assertEquals(
@@ -120,7 +120,8 @@ class BrevPeriodeUtilTest {
                 barnPåBehandling,
                 uregistrerteBarn,
                 gjelderSøker = true
-            ), "01.01.21, 02.02.21, 03.03.21, 04.04.21, 05.05.21 og 06.06.21"
+            ),
+            "01.01.21, 02.02.21, 03.03.21, 04.04.21, 05.05.21 og 06.06.21"
         )
         Assertions.assertEquals(
             hentBarnasFødselsdatoerForAvslagsbegrunnelse(
@@ -128,7 +129,8 @@ class BrevPeriodeUtilTest {
                 barnPåBehandling,
                 uregistrerteBarn,
                 gjelderSøker = false
-            ), "01.01.21, 02.02.21, 04.04.21, 05.05.21 og 06.06.21"
+            ),
+            "01.01.21, 02.02.21, 04.04.21, 05.05.21 og 06.06.21"
         )
         Assertions.assertEquals(
             hentBarnasFødselsdatoerForAvslagsbegrunnelse(
@@ -136,7 +138,8 @@ class BrevPeriodeUtilTest {
                 barnPåBehandling,
                 emptyList(),
                 gjelderSøker = true
-            ), "01.01.21, 02.02.21 og 03.03.21"
+            ),
+            "01.01.21, 02.02.21 og 03.03.21"
         )
         Assertions.assertEquals(
             hentBarnasFødselsdatoerForAvslagsbegrunnelse(
@@ -144,7 +147,8 @@ class BrevPeriodeUtilTest {
                 emptyList(),
                 uregistrerteBarn,
                 gjelderSøker = true
-            ), "04.04.21, 05.05.21 og 06.06.21"
+            ),
+            "04.04.21, 05.05.21 og 06.06.21"
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
@@ -1,12 +1,15 @@
 package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.common.MånedPeriode
+import no.nav.familie.ba.sak.dataGenerator.brev.lagMinimertPerson
+import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
 import no.nav.familie.ba.sak.kjerne.brev.domene.BrevperiodeData
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestBehandlingsgrunnlagForBrev
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.SøkersAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagKompetanse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import org.junit.jupiter.api.Assertions
@@ -91,6 +94,57 @@ class BrevPeriodeUtilTest {
             listOf(kompetanse1, kompetanse2, kompetanse3.copy(tom = periode2.tom)),
             listOf(kompetanse1, kompetanse2, kompetanse3, kompetanse4)
                 .hentIPeriode(periode1.fom, periode2.tom)
+        )
+    }
+
+    @Test
+    fun `Skal kunne kombinere registrerte og uregistrerte barns fødselsdatoer til avslagsbegrunnelse`() {
+        val barnIBegrunnelse = listOf(
+            lagMinimertPerson(fødselsdato = LocalDate.of(2021, 1, 1), type = PersonType.BARN),
+            lagMinimertPerson(fødselsdato = LocalDate.of(2021, 2, 2), type = PersonType.BARN)
+        ).map { it.tilMinimertRestPerson() }
+        val barnPåBehandling = listOf(
+            lagMinimertPerson(fødselsdato = LocalDate.of(2021, 1, 1), type = PersonType.BARN),
+            lagMinimertPerson(fødselsdato = LocalDate.of(2021, 2, 2), type = PersonType.BARN),
+            lagMinimertPerson(fødselsdato = LocalDate.of(2021, 3, 3), type = PersonType.BARN)
+        ).map { it.tilMinimertRestPerson() }
+        val uregistrerteBarn = listOf(
+            MinimertUregistrertBarn(personIdent = "", navn = "Ole", fødselsdato = LocalDate.of(2021, 4, 4)),
+            MinimertUregistrertBarn(personIdent = "", navn = "Dole", fødselsdato = LocalDate.of(2021, 5, 5)),
+            MinimertUregistrertBarn(personIdent = "", navn = "Doffen", fødselsdato = LocalDate.of(2021, 6, 6)),
+        )
+
+        Assertions.assertEquals(
+            hentBarnasFødselsdatoerForAvslagsbegrunnelse(
+                barnIBegrunnelse,
+                barnPåBehandling,
+                uregistrerteBarn,
+                gjelderSøker = true
+            ), "01.01.21, 02.02.21, 03.03.21, 04.04.21, 05.05.21 og 06.06.21"
+        )
+        Assertions.assertEquals(
+            hentBarnasFødselsdatoerForAvslagsbegrunnelse(
+                barnIBegrunnelse,
+                barnPåBehandling,
+                uregistrerteBarn,
+                gjelderSøker = false
+            ), "01.01.21, 02.02.21, 04.04.21, 05.05.21 og 06.06.21"
+        )
+        Assertions.assertEquals(
+            hentBarnasFødselsdatoerForAvslagsbegrunnelse(
+                barnIBegrunnelse,
+                barnPåBehandling,
+                emptyList(),
+                gjelderSøker = true
+            ), "01.01.21, 02.02.21 og 03.03.21"
+        )
+        Assertions.assertEquals(
+            hentBarnasFødselsdatoerForAvslagsbegrunnelse(
+                emptyList(),
+                emptyList(),
+                uregistrerteBarn,
+                gjelderSøker = true
+            ), "04.04.21, 05.05.21 og 06.06.21"
         )
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: [Tea-11365](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11365)

Vi får `flettefeltet barnasFodselsdatoer mangler for begrunnelse`-feil i tilfeller der EØS-søknad kun inneholder uregistrerte barn og man setter en avslagsbegrunnelse på søkers vilkår. Sender derfor med fødselsdatoer også for manuelt registrerte barn, på samme måte som vi gjør for nasjonale begrunnelser (se [koden her](https://github.com/navikt/familie-ba-sak/blob/master/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlagMedPersoner.kt#L49))

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

### Skjermbilde
Behandling der søker har avslag på LOVLIG_OPPHOLD, jobber ikke, og har uregistrerte barn `"uregistrerteBarn":[{"personIdent":"","navn":"","fødselsdato":"2023-01-02"},{"personIdent":"","navn":"","fødselsdato":"2021-12-05"}]`
Vi sender følgende data til familie-brev: `EØSBegrunnelseDataUtenKompetanse(vedtakBegrunnelseType=EØS_AVSLAG, apiNavn=avslagEosJobberIkke, barnasFodselsdatoer=05.12.21 og 02.01.23, antallBarn=2, maalform=bokmaal, gjelderSoker=true)`
<img width="860" alt="Screenshot 2023-02-15 at 10 31 46" src="https://user-images.githubusercontent.com/2379098/218989651-bebdb6e6-e210-4019-a067-6237324ee0e5.png">
