### PR TITLE
fjernet mellomrom i poststed og postnummer som forårsaket feilen i brev distribuering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestBrevmottaker.kt
@@ -20,7 +20,7 @@ fun RestBrevmottaker.tilBrevMottaker(behandlingId: Long) = Brevmottaker(
     navn = navn,
     adresselinje1 = adresselinje1,
     adresselinje2 = adresselinje2,
-    postnummer = postnummer,
-    poststed = poststed,
+    postnummer = postnummer.trim(),
+    poststed = poststed.trim(),
     landkode = landkode
 )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._

I dag feiler brev distribuering på dokdist hvis postnummer har en mellomrom på slutten. Fjerner det ved lagring av brevmottaker.
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10504

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
