### PR TITLE
Bug: endret andeler oppdaterer ikke aty ved kopiering fra forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
@@ -189,6 +190,14 @@ class BeregningService(
                 }
             }
 
+        return genererOgLagreTilkjentYtelse(
+            behandling = behandling,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            endreteUtbetalingAndeler = endreteUtbetalingAndeler
+        )
+    }
+
+    private fun genererOgLagreTilkjentYtelse(behandling: Behandling, personopplysningGrunnlag: PersonopplysningGrunnlag, endreteUtbetalingAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>): TilkjentYtelse{
         tilkjentYtelseRepository.slettTilkjentYtelseFor(behandling)
         val vilkårsvurdering = vilkårsvurderingRepository.findByBehandlingAndAktiv(behandling.id)
             ?: throw IllegalStateException("Kunne ikke hente vilkårsvurdering for behandling med id ${behandling.id}")
@@ -209,6 +218,24 @@ class BeregningService(
         val lagretTilkjentYtelse = tilkjentYtelseRepository.save(tilkjentYtelse)
         tilkjentYtelseEndretAbonnenter.forEach { it.endretTilkjentYtelse(lagretTilkjentYtelse) }
         return lagretTilkjentYtelse
+    }
+
+    // For at endret utbetaling andeler skal fungere så må man generere andeler før man kobler endringene på andelene
+    // Dette er fordi en endring regnes som gyldig når den overlapper med en andel og har gyldig årsak
+    // Hvis man ikke genererer andeler før man kobler på endringene så vil ingen av endringene ses på som gyldige, altså ikke oppdatere noen andeler
+    fun genererTilkjentYtelseFraVilkårsvurdering(
+        behandling: Behandling,
+        personopplysningGrunnlag: PersonopplysningGrunnlag
+    ): TilkjentYtelse {
+        // 1: Genererer andeler fra vilkårsvurderingen uten å ta hensyn til endret utbetaling andeler
+        genererOgLagreTilkjentYtelse(
+            behandling = behandling,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            endreteUtbetalingAndeler = emptyList()
+        )
+
+        // 2: Genererer andeler som også tar hensyn til endret utbetaling andeler
+        return oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
     }
 
     fun oppdaterTilkjentYtelseMedUtbetalingsoppdrag(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -197,7 +197,11 @@ class BeregningService(
         )
     }
 
-    private fun genererOgLagreTilkjentYtelse(behandling: Behandling, personopplysningGrunnlag: PersonopplysningGrunnlag, endreteUtbetalingAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>): TilkjentYtelse{
+    private fun genererOgLagreTilkjentYtelse(
+        behandling: Behandling,
+        personopplysningGrunnlag: PersonopplysningGrunnlag,
+        endreteUtbetalingAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>
+    ): TilkjentYtelse {
         tilkjentYtelseRepository.slettTilkjentYtelseFor(behandling)
         val vilkårsvurdering = vilkårsvurderingRepository.findByBehandlingAndAktiv(behandling.id)
             ?: throw IllegalStateException("Kunne ikke hente vilkårsvurdering for behandling med id ${behandling.id}")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -66,7 +66,7 @@ class VilkårsvurderingSteg(
         }
 
         tilbakestillBehandlingService.tilbakestillDataTilVilkårsvurderingssteg(behandling)
-        beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
+        beregningService.genererTilkjentYtelseFraVilkårsvurdering(behandling, personopplysningGrunnlag)
 
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
@@ -77,7 +77,7 @@ class VilkårsvurderingStegTest {
             barnasIdenter = listOf(barnIdent)
         )
         every { tilbakestillBehandlingService.tilbakestillDataTilVilkårsvurderingssteg(behandling) } returns Unit
-        every { beregningService.oppdaterBehandlingMedBeregning(any(), any()) } returns lagInitiellTilkjentYtelse(
+        every { beregningService.genererTilkjentYtelseFraVilkårsvurdering(any(), any()) } returns lagInitiellTilkjentYtelse(
             behandling
         )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -245,6 +245,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
             assertEquals(BigDecimal.ZERO, andelPåvirketAvEndringer.prosent)
             assertEquals(endretAndelFom, andelPåvirketAvEndringer.stønadFom)
             assertEquals(endretAndelTom, andelPåvirketAvEndringer.stønadTom)
-            assertTrue(andelPåvirketAvEndringer.endreteUtbetalinger.any { it.id == kopierteEndredeUtbetalingAndeler.single().id }) }
+            assertTrue(andelPåvirketAvEndringer.endreteUtbetalinger.any { it.id == kopierteEndredeUtbetalingAndeler.single().id })
+        }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -4,6 +4,8 @@ import no.nav.familie.ba.sak.common.lagSøknadDTO
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.nyRevurdering
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestEndretUtbetalingAndel
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestPersonResultat
@@ -70,7 +72,10 @@ class RevurderingMedEndredeUtbetalingandelerTest(
     private val vilkårsvurderingForNyBehandlingService: VilkårsvurderingForNyBehandlingService,
 
     @Autowired
-    private val søknadGrunnlagRepository: SøknadGrunnlagRepository
+    private val søknadGrunnlagRepository: SøknadGrunnlagRepository,
+
+    @Autowired
+    private val featureToggleService: FeatureToggleService
 
 ) : AbstractVerdikjedetest() {
     @Test
@@ -234,9 +239,12 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         val andelPåvirketAvEndringer = andelerTilkjentYtelse.first()
 
         assertEquals(1, kopierteEndredeUtbetalingAndeler.size)
-        assertEquals(BigDecimal.ZERO, andelPåvirketAvEndringer.prosent)
-        assertEquals(endretAndelFom, andelPåvirketAvEndringer.stønadFom)
-        assertEquals(endretAndelTom, andelPåvirketAvEndringer.stønadTom)
-        assertTrue(andelPåvirketAvEndringer.endreteUtbetalinger.any { it.id == kopierteEndredeUtbetalingAndeler.single().id })
+
+        // Andel skal kun oppdateres direkte hvis toggle er på
+        if (featureToggleService.isEnabled(FeatureToggleConfig.BRUK_FRIKOBLEDE_ANDELER_OG_ENDRINGER)) {
+            assertEquals(BigDecimal.ZERO, andelPåvirketAvEndringer.prosent)
+            assertEquals(endretAndelFom, andelPåvirketAvEndringer.stønadFom)
+            assertEquals(endretAndelTom, andelPåvirketAvEndringer.stønadTom)
+            assertTrue(andelPåvirketAvEndringer.endreteUtbetalinger.any { it.id == kopierteEndredeUtbetalingAndeler.single().id }) }
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11444

Etter Jobi sine endringer som ikke lagrer ned koblingen mellom andeler og endringer i databasen så har vi fått en feil på revurderinger hvor vi har kopiert med oss endret utbetaling andelene fra forrige behandling uten å oppdatere andelene med disse endringene.

- Etter vilkårsvurderingen genereres andeler tilkjent ytelse. Her ønsker vi kun å ta med endringsandeler som er validert riktig (endret utbetaling andel har gyldig årsak og overlapper med andel tilkjent ytelse). Problemet er den siste biten der, første gang vi skal oppdatere beregning så finnes det ingen tilkjent ytelse og dermed er ingen endringer gyldige heller. Altså blir ikke endringen tatt hensyn til og andelen blir generert uten å legge på endringen.
- På andre siden, når man har kommet seg til behandlingsresultat-siden: endret utbetaling andelene man viser frem her ser gyldige ut så lenge de har gyldig årsak og overlapper med en andel. Og her kommer det som er tricky: nå finnes det jo andeler, så da vil endringen se gyldig ut, selv om den ikke har påvirket andelen den overlapper med.

Løsningen er å sørge for at andeler tilkjent ytelse blir generert to ganger når man trykker neste på vilkårsvurderingssteget.

- Første gang genererer man andelene uten endringer
- Andre gang oppdaterer man beregningen også til å ta hensyn til endringer

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Ikke akkurat nå nei. Men dette burde nok skrives om på sikt. Ikke en optimal løsning.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, har allerede gått gjennom med Halvor
