### PR TITLE
Stans manuell satsendring dersom det løper mer enn 100% utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
@@ -253,5 +253,5 @@ enum class SatsendringSvar(val melding: String) {
     TILBAKESTILLER_BEHANDLINGEN_TIL_VILKÅRSVURDERINGEN(melding = "Tilbakestiller behandlingen til vilkårsvurderingen"),
     BEHANDLINGEN_ER_UNDER_UTREDNING_MEN_I_RIKTIG_TILSTAND(
         melding = "Behandlingen er under utredning, men er allerede i riktig tilstand."
-    ),
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
@@ -43,8 +43,8 @@ class SatsendringController(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER
         )
 
-        val erSatsendringOpprettetOk = startSatsendring.opprettSatsendringSynkrontVedGammelSats(fagsakId)
-        return ResponseEntity.ok(if (erSatsendringOpprettetOk) Ressurs.success(Unit) else Ressurs.failure())
+        startSatsendring.opprettSatsendringSynkrontVedGammelSats(fagsakId)
+        return ResponseEntity.ok(Ressurs.success(Unit))
     }
 
     @GetMapping(path = ["/{fagsakId}/kan-kjore-satsendring"])

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -2,19 +2,15 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
-import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.SatsendringTaskDto
@@ -35,7 +31,6 @@ class StartSatsendring(
     private val featureToggleService: FeatureToggleService,
     private val personidentService: PersonidentService,
     private val autovedtakSatsendringService: AutovedtakSatsendringService
-    private val tilkjentYtelseValideringService: TilkjentYtelseValideringService
 ) {
 
     private val ignorerteFagsaker = mutableSetOf<Long>()
@@ -178,39 +173,33 @@ class StartSatsendring(
     }
 
     @Transactional
-    fun opprettSatsendringSynkrontVedGammelSats(fagsakId: Long): Boolean {
-        val aktivOgÅpenBehandling =
-            behandlingRepository.findByFagsakAndAktivAndOpen(fagsakId = fagsakId)
-
-        if (aktivOgÅpenBehandling != null) {
-            throw FunksjonellFeil("Det finnes en åpen behandling på fagsaken som må avsluttes før satsendring kan gjennomføres.")
+    fun opprettSatsendringSynkrontVedGammelSats(fagsakId: Long) {
+        if (!kanStarteSatsendringPåFagsak(fagsakId)) {
+            throw Feil("Kan ikke starte Satsendring på fagsak=$fagsakId")
         }
 
-        try {
-            tilkjentYtelseValideringService
-                .validerAtIngenUtbetalingerOverstiger100ProsentISisteIverksatteBehandling(fagsakId = fagsakId)
-        } catch (feil: UtbetalingsikkerhetFeil) {
-            throw FunksjonellFeil(
-                "Satsendring kan ikke gjennomføres fordi det er mer enn 100% utbetaling for barn i fagsaken.\n" +
-                    "Barnetrygden til en av mottakerne må revurderes."
+        satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
+        val resultatSatsendringBehandling = autovedtakSatsendringService.kjørBehandling(
+            SatsendringTaskDto(
+                fagsakId = fagsakId,
+                satstidspunkt = SATSENDRINGMÅNED_2023
             )
-        }
+        )
 
-        return if (kanStarteSatsendringPåFagsak(fagsakId)) {
-            satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
-            val resultattekstSatsendringBehandling = autovedtakSatsendringService.kjørBehandling(
-                SatsendringTaskDto(
-                    fagsakId = fagsakId,
-                    satstidspunkt = SATSENDRINGMÅNED_2023
+        when (resultatSatsendringBehandling) {
+            is SatsendringSvar.SATSENDRING_KJØRT_OK -> Unit
+
+            is SatsendringSvar.FANT_OVER_100_PROSENT_UTBETALING ->
+                throw FunksjonellFeil(
+                    "Satsendring kan ikke gjennomføres fordi det er mer enn 100% utbetaling for barn i fagsaken.\n" +
+                        "Barnetrygden til en av mottakerne må revurderes."
                 )
-            )
-            if (resultattekstSatsendringBehandling == "Satsendring kjørt OK") {
-                true
-            } else {
-                throw Feil("Satsendring kjørte ikke OK for fagsak $fagsakId")
-            }
-        } else {
-            false
+
+            is SatsendringSvar.SATSENDRING_ER_ALLEREDE_UTFØRT ->
+                throw FunksjonellFeil("Satsendring er allerede gjennomført på fagsaken. Last inn siden på nytt for å få opp siste behandling.")
+
+            is SatsendringSvar.ÅpenBehandlingSvar ->
+                throw FunksjonellFeil("Det finnes en åpen behandling på fagsaken som må avsluttes før satsendring kan gjennomføres.")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -226,7 +226,8 @@ class StartSatsendring(
         }
 
         try {
-            tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(fagsakId = fagsakId)
+            tilkjentYtelseValideringService
+                .validerAtIngenUtbetalingerOverstiger100ProsentISisteIverksatteBehandling(fagsakId = fagsakId)
         } catch (feil: UtbetalingsikkerhetFeil) {
             throw FunksjonellFeil(
                 "Satsendring kan ikke gjennomføres fordi det er mer enn 100% utbetaling for barn i fagsaken.\n" +

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -187,18 +187,21 @@ class StartSatsendring(
         )
 
         when (resultatSatsendringBehandling) {
-            is SatsendringSvar.SATSENDRING_KJØRT_OK -> Unit
+            SatsendringSvar.SATSENDRING_KJØRT_OK -> Unit
 
-            is SatsendringSvar.FANT_OVER_100_PROSENT_UTBETALING ->
+            SatsendringSvar.FANT_OVER_100_PROSENT_UTBETALING ->
                 throw FunksjonellFeil(
                     "Satsendring kan ikke gjennomføres fordi det er mer enn 100% utbetaling for barn i fagsaken.\n" +
                         "Barnetrygden til en av mottakerne må revurderes."
                 )
 
-            is SatsendringSvar.SATSENDRING_ER_ALLEREDE_UTFØRT ->
+            SatsendringSvar.SATSENDRING_ER_ALLEREDE_UTFØRT ->
                 throw FunksjonellFeil("Satsendring er allerede gjennomført på fagsaken. Last inn siden på nytt for å få opp siste behandling.")
 
-            is SatsendringSvar.ÅpenBehandlingSvar ->
+            SatsendringSvar.HAR_ALLEREDE_SISTE_SATS,
+            SatsendringSvar.BEHANDLING_ER_LÅST_SATSENDRING_TRIGGES_NESTE_VIRKEDAG,
+            SatsendringSvar.TILBAKESTILLER_BEHANDLINGEN_TIL_VILKÅRSVURDERINGEN,
+            SatsendringSvar.BEHANDLINGEN_ER_UNDER_UTREDNING_MEN_I_RIKTIG_TILSTAND ->
                 throw FunksjonellFeil("Det finnes en åpen behandling på fagsaken som må avsluttes før satsendring kan gjennomføres.")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -52,7 +52,7 @@ class TilkjentYtelseValideringService(
         }
     }
 
-    fun validerAtIngenUtbetalingerOverstiger100Prosent(fagsakId: Long) {
+    fun validerAtIngenUtbetalingerOverstiger100ProsentISisteIverksatteBehandling(fagsakId: Long) {
         val forrigeBehanlding = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId = fagsakId)
         forrigeBehanlding?.let { validerAtIngenUtbetalingerOverstiger100Prosent(forrigeBehanlding) }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -51,7 +51,7 @@ class TilkjentYtelseValideringService(
             )
         }
     }
-    
+
     fun validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(behandlingId: Long) {
         val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.finnAktørIderMedUgyldigEtterbetalingsperiode
@@ -51,6 +50,11 @@ class TilkjentYtelseValideringService(
                 personopplysningGrunnlag = personopplysningGrunnlag
             )
         }
+    }
+
+    fun validerAtIngenUtbetalingerOverstiger100Prosent(fagsakId: Long) {
+        val forrigeBehanlding = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId = fagsakId)
+        forrigeBehanlding?.let { validerAtIngenUtbetalingerOverstiger100Prosent(forrigeBehanlding) }
     }
 
     fun validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(behandlingId: Long) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -51,12 +51,7 @@ class TilkjentYtelseValideringService(
             )
         }
     }
-
-    fun validerAtIngenUtbetalingerOverstiger100ProsentISisteIverksatteBehandling(fagsakId: Long) {
-        val forrigeBehanlding = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId = fagsakId)
-        forrigeBehanlding?.let { validerAtIngenUtbetalingerOverstiger100Prosent(forrigeBehanlding) }
-    }
-
+    
     fun validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(behandlingId: Long) {
         val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SatsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SatsendringTask.kt
@@ -23,7 +23,7 @@ class SatsendringTask(
 
         val resultat = autovedtakSatsendringService.kjørBehandling(dto)
 
-        task.metadata.put("resultat", resultat)
+        task.metadata["resultat"] = resultat.melding
     }
 
     companion object {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -23,7 +23,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.SMÅBARNSTILLEGG
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.UTVIDET_BARNETRYGD
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
@@ -50,7 +49,6 @@ internal class StartSatsendringTest {
     private val featureToggleService: FeatureToggleService = mockk()
     private val personidentService: PersonidentService = mockk()
     private val autovedtakSatsendringService: AutovedtakSatsendringService = mockk()
-    private val kompetanseService: KompetanseService = mockk()
 
     lateinit var startSatsendring: StartSatsendring
 
@@ -75,7 +73,8 @@ internal class StartSatsendringTest {
             personidentService = personidentService,
             autovedtakSatsendringService = autovedtakSatsendringService,
             beregningService = mockk(),
-            persongrunnlagService = mockk()
+            persongrunnlagService = mockk(),
+            tilkjentYtelseValideringService = mockk()
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.common.lagBehandling
@@ -32,6 +33,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import java.time.YearMonth
@@ -50,7 +53,7 @@ internal class StartSatsendringTest {
     private val personidentService: PersonidentService = mockk()
     private val autovedtakSatsendringService: AutovedtakSatsendringService = mockk()
 
-    lateinit var startSatsendring: StartSatsendring
+    private lateinit var startSatsendring: StartSatsendring
 
     @BeforeEach
     fun setUp() {
@@ -63,16 +66,17 @@ internal class StartSatsendringTest {
         val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository)
         every { featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_SJEKK_UTBETALING, true) } returns false
 
-        startSatsendring = StartSatsendring(
-            fagsakRepository = fagsakRepository,
-            behandlingRepository = behandlingRepository,
-            opprettTaskService = opprettTaskService,
-            andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
-            satskjøringRepository = satskjøringRepository,
-            featureToggleService = featureToggleService,
-            personidentService = personidentService,
-            autovedtakSatsendringService = autovedtakSatsendringService,
-            tilkjentYtelseValideringService = mockk()
+        startSatsendring = spyk(
+            StartSatsendring(
+                fagsakRepository = fagsakRepository,
+                behandlingRepository = behandlingRepository,
+                opprettTaskService = opprettTaskService,
+                andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+                satskjøringRepository = satskjøringRepository,
+                featureToggleService = featureToggleService,
+                personidentService = personidentService,
+                autovedtakSatsendringService = autovedtakSatsendringService
+            )
         )
     }
 
@@ -479,5 +483,35 @@ internal class StartSatsendringTest {
         every { autovedtakSatsendringService.harAlleredeNySats(any(), any()) } returns false
 
         assertTrue(startSatsendring.kanStarteSatsendringPåFagsak(1L))
+    }
+
+    @Test
+    fun `opprettSatsendringSynkrontVedGammelSats skal kaste dersom man ikke kan starte satsendring`() {
+        every { startSatsendring.kanStarteSatsendringPåFagsak(any()) } returns false
+
+        assertThrows<Exception> {
+            startSatsendring.opprettSatsendringSynkrontVedGammelSats(0L)
+        }
+    }
+
+    @Test
+    fun `opprettSatsendringSynkrontVedGammelSats skal kaste feil for alle andre resultater enn OK`() {
+        every { startSatsendring.kanStarteSatsendringPåFagsak(any()) } returns true
+
+        val satsendringSvar = SatsendringSvar.values()
+
+        satsendringSvar.forEach {
+            every { autovedtakSatsendringService.kjørBehandling(any()) } returns it
+
+            when (it) {
+                SatsendringSvar.SATSENDRING_KJØRT_OK -> assertDoesNotThrow {
+                    startSatsendring.opprettSatsendringSynkrontVedGammelSats(0L)
+                }
+
+                else -> assertThrows<Exception> {
+                    startSatsendring.opprettSatsendringSynkrontVedGammelSats(0L)
+                }
+            }
+        }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import no.nav.familie.ba.sak.common.LocalDateService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.AutovedtakSatsendringService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.SatsendringSvar
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -124,7 +125,7 @@ class BehandlingSatsendringTest(
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, YearMonth.of(2023, 3)))
 
-        assertEquals(satsendringResultat, "Satsendring kjørt OK")
+        assertEquals(satsendringResultat, SatsendringSvar.SATSENDRING_KJØRT_OK)
 
         val satsendringBehandling = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = behandling.fagsak.id)
         assertEquals(Behandlingsresultat.ENDRET_UTBETALING, satsendringBehandling?.resultat)
@@ -231,7 +232,7 @@ class BehandlingSatsendringTest(
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, YearMonth.of(2023, 3)))
 
-        assertTrue(satsendringResultat.contains("Tilbakestiller behandling"))
+        assertTrue(satsendringResultat == SatsendringSvar.TILBAKESTILLER_BEHANDLINGEN_TIL_VILKÅRSVURDERINGEN)
 
         val åpenBehandling = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = behandling.fagsak.id)
         assertEquals(revurdering.data!!.behandlingId, åpenBehandling!!.id)
@@ -303,7 +304,7 @@ class BehandlingSatsendringTest(
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, YearMonth.of(2023, 3)))
 
-        assertEquals(satsendringResultat, "Satsendring allerede utført for fagsak=${behandling.fagsak.id}")
+        assertTrue(satsendringResultat == SatsendringSvar.SATSENDRING_ER_ALLEREDE_UTFØRT)
 
         val satskjøring = satskjøringRepository.findByFagsakId(behandling.fagsak.id)
         assertThat(satskjøring?.ferdigTidspunkt)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
@@ -33,7 +33,6 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
@@ -125,7 +124,7 @@ class BehandlingSatsendringTest(
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, YearMonth.of(2023, 3)))
 
-        assertEquals(satsendringResultat, SatsendringSvar.SATSENDRING_KJØRT_OK)
+        assertEquals(SatsendringSvar.SATSENDRING_KJØRT_OK, satsendringResultat)
 
         val satsendringBehandling = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = behandling.fagsak.id)
         assertEquals(Behandlingsresultat.ENDRET_UTBETALING, satsendringBehandling?.resultat)
@@ -232,7 +231,7 @@ class BehandlingSatsendringTest(
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, YearMonth.of(2023, 3)))
 
-        assertTrue(satsendringResultat == SatsendringSvar.TILBAKESTILLER_BEHANDLINGEN_TIL_VILKÅRSVURDERINGEN)
+        assertEquals(SatsendringSvar.TILBAKESTILLER_BEHANDLINGEN_TIL_VILKÅRSVURDERINGEN, satsendringResultat)
 
         val åpenBehandling = behandlingHentOgPersisterService.hentAktivForFagsak(fagsakId = behandling.fagsak.id)
         assertEquals(revurdering.data!!.behandlingId, åpenBehandling!!.id)
@@ -304,7 +303,7 @@ class BehandlingSatsendringTest(
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, YearMonth.of(2023, 3)))
 
-        assertTrue(satsendringResultat == SatsendringSvar.SATSENDRING_ER_ALLEREDE_UTFØRT)
+        assertEquals(SatsendringSvar.SATSENDRING_ER_ALLEREDE_UTFØRT, satsendringResultat)
 
         val satskjøring = satskjøringRepository.findByFagsakId(behandling.fagsak.id)
         assertThat(satskjøring?.ferdigTidspunkt)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dersom vi starter satsendringen manuelt fra saksoversikten og det løper mer enn 100% utbetaling på barnet får vi nå en feil i iverksett tasken, og saken må teknisk henlegges.

Endrer så saksbehandler får en feilmelding når de prøver å trykke på knappen i stedet

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
