### PR TITLE
Fjern validering på at delt bosted endringer ikke krysser utvidet ytelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -19,7 +19,6 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValide
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.validerBarnasVilkår
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.validerDeltBostedEndringerIkkeKrysserUtvidetYtelse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlingSteg
@@ -77,10 +76,6 @@ class BehandlingsresultatSteg(
         )
 
         if (toggleFrikobleAndelerOgEndringer) {
-            validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-                endreteUtbetalingerMedAndeler.map { it.endretUtbetalingAndel },
-                tilkjentYtelse.andelerTilkjentYtelse
-            )
             validerPeriodeInnenforTilkjentytelse(
                 endreteUtbetalingerMedAndeler.map { it.endretUtbetalingAndel },
                 tilkjentYtelse.andelerTilkjentYtelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
@@ -16,14 +16,12 @@ import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.slåSammenOverlappendePerioder
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
-import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.tilMånedPeriode
 import no.nav.familie.ba.sak.common.toPeriode
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.hentGyldigEtterbetalingFom
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
@@ -172,37 +170,6 @@ object EndretUtbetalingAndelValidering {
                 melding = "Det er opprettet instanser av EndretUtbetalingandel som ikke er tilknyttet noen andeler. De må enten lagres eller slettes av SB.",
                 frontendFeilmelding = "Du har endrede utbetalingsperioder. Bekreft, slett eller oppdater periodene i listen."
             )
-        }
-    }
-}
-
-fun validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-    endretUtbetalingAndeler: List<EndretUtbetalingAndel>,
-    andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>
-) {
-    fun EndretUtbetalingAndel.finnKryssendeUtvidetYtelse(
-        andelTilkjentYtelser: Collection<AndelTilkjentYtelse>
-    ): AndelTilkjentYtelse? =
-        andelTilkjentYtelser
-            .filter { it.type == YtelseType.UTVIDET_BARNETRYGD }
-            .find {
-                it.overlapperPeriode(MånedPeriode(this.fom!!, this.tom!!)) &&
-                    (this.fom!! < it.stønadFom || this.tom!! > it.stønadTom)
-            }
-
-    endretUtbetalingAndeler.forEach {
-        val kryssendeTilkjentYtelse = it.finnKryssendeUtvidetYtelse(
-            andelerTilkjentYtelse
-        )
-        if (it.årsakErDeltBosted() && kryssendeTilkjentYtelse != null) {
-            val feilmelding =
-                "Delt bosted endring fra ${it.fom?.tilKortString()} til ${it.tom?.tilKortString()} krysser " +
-                    "starten eller slutten på den utvidede perioden fra " +
-                    "${kryssendeTilkjentYtelse.stønadFom.tilKortString()} " +
-                    "til ${kryssendeTilkjentYtelse.stønadTom.tilKortString()}. " +
-                    "Om endringen er i riktig periode må du opprette to endringsperioder, en utenfor" +
-                    " og en inni den utvidede ytelsen."
-            throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -52,11 +52,6 @@ class EndretUtbetalingAndelValideringTest {
     val endretUtbetalingAndelDeltBostedNullutbetaling =
         endretUtbetalingAndel(barn, YtelseType.ORDINÆR_BARNETRYGD, BigDecimal.ZERO)
 
-    val endretUtbetalingAndelUtvidetFullUtbetaling =
-        endretUtbetalingAndel(søker, YtelseType.UTVIDET_BARNETRYGD, BigDecimal.valueOf(100))
-    val endretUtbetalingAndelDeltBostedFullUtbetaling =
-        endretUtbetalingAndel(barn, YtelseType.ORDINÆR_BARNETRYGD, BigDecimal.valueOf(100))
-
     @Test
     fun `skal sjekke at en endret periode ikke overlapper med eksisterende endringsperioder`() {
         val barn1 = tilfeldigPerson()
@@ -679,144 +674,10 @@ class EndretUtbetalingAndelValideringTest {
     }
 
     @Test
-    fun `skal feile dersom endring strekker seg over utvidet og ordinær ytelse`() {
-        val fom1 = inneværendeMåned().minusMonths(2)
-        val tom1 = inneværendeMåned().minusMonths(2)
-        val fom2 = inneværendeMåned().minusMonths(1)
-        val tom2 = inneværendeMåned().minusMonths(1)
-
-        val andelTilkjentYtelser = mutableListOf(
-            lagAndelTilkjentYtelse(
-                fom = fom1,
-                tom = tom1,
-                ytelseType = YtelseType.UTVIDET_BARNETRYGD
-            ),
-            lagAndelTilkjentYtelse(
-                fom = fom2,
-                tom = tom2,
-                ytelseType = YtelseType.ORDINÆR_BARNETRYGD
-            )
-        )
-
-        val utvidetEndring = lagEndretUtbetalingAndelMedAndelerTilkjentYtelse(
-            fom = fom1,
-            tom = tom2,
-            person = søker,
-            årsak = Årsak.DELT_BOSTED,
-            prosent = BigDecimal.ZERO,
-            andelTilkjentYtelser = andelTilkjentYtelser
-        )
-
-        val deltBostedEndring =
-            endretUtbetalingAndel(
-                barn,
-                YtelseType.ORDINÆR_BARNETRYGD,
-                BigDecimal.ZERO,
-                fomUtvidet = fom1,
-                tomUtvidet = tom2
-            )
-
-        Assertions.assertThrows(FunksjonellFeil::class.java) {
-            validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-                listOf(utvidetEndring, deltBostedEndring).map { it.endretUtbetalingAndel },
-                andelTilkjentYtelser
-            )
-        }
-    }
-
-    @Test
     fun `skal kaste feil dersom det er en endring på utvidet ytelse uten en endring på delt bosted i samme periode`() {
         Assertions.assertThrows(FunksjonellFeil::class.java) {
             validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(
                 listOf(endretUtbetalingAndelUtvidetNullutbetaling)
-            )
-        }
-    }
-
-    @Test
-    fun `skal kaste feil dersom delt bosted endring krysser utvidet tilkjent ytelse og ikke ellers`() {
-        val fomUtvidet: YearMonth = inneværendeMåned().minusMonths(4)
-        val tomUtvidet: YearMonth = inneværendeMåned().minusMonths(2)
-
-        val førFomutvidet = inneværendeMåned().minusMonths(5)
-        val iPeriode = inneværendeMåned().minusMonths(3)
-        val etterPeriode = inneværendeMåned().minusMonths(1)
-
-        val andelerTilkjentYtelse = listOf(
-            lagAndelTilkjentYtelse(
-                fom = fomUtvidet,
-                tom = tomUtvidet,
-                ytelseType = YtelseType.UTVIDET_BARNETRYGD
-            )
-        )
-
-        Assertions.assertDoesNotThrow {
-            validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-                endretUtbetalingAndeler = listOf(
-                    lagEndretUtbetalingAndel(
-                        fom = førFomutvidet,
-                        tom = førFomutvidet,
-                        årsak = Årsak.DELT_BOSTED,
-                        person = søker
-                    )
-                ),
-                andelerTilkjentYtelse = andelerTilkjentYtelse
-            )
-        }
-
-        Assertions.assertThrows(FunksjonellFeil::class.java) {
-            validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-                endretUtbetalingAndeler = listOf(
-                    lagEndretUtbetalingAndel(
-                        fom = førFomutvidet,
-                        tom = fomUtvidet,
-                        årsak = Årsak.DELT_BOSTED,
-                        person = søker
-                    )
-                ),
-                andelerTilkjentYtelse = andelerTilkjentYtelse
-            )
-        }
-
-        Assertions.assertDoesNotThrow {
-            validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-                endretUtbetalingAndeler = listOf(
-                    lagEndretUtbetalingAndel(
-                        fom = fomUtvidet,
-                        tom = iPeriode,
-                        årsak = Årsak.DELT_BOSTED,
-                        person = søker
-                    )
-                ),
-                andelerTilkjentYtelse = andelerTilkjentYtelse
-            )
-        }
-
-        Assertions.assertDoesNotThrow {
-            validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-                endretUtbetalingAndeler = listOf(
-                    lagEndretUtbetalingAndel(
-                        fom = fomUtvidet,
-                        tom = tomUtvidet,
-                        årsak = Årsak.DELT_BOSTED,
-                        person = søker
-                    )
-                ),
-                andelerTilkjentYtelse = andelerTilkjentYtelse
-            )
-        }
-
-        Assertions.assertDoesNotThrow {
-            validerDeltBostedEndringerIkkeKrysserUtvidetYtelse(
-                endretUtbetalingAndeler = listOf(
-                    lagEndretUtbetalingAndel(
-                        fom = etterPeriode,
-                        tom = etterPeriode,
-                        årsak = Årsak.DELT_BOSTED,
-                        person = søker
-                    )
-                ),
-                andelerTilkjentYtelse = andelerTilkjentYtelse
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har en validering som jeg trodde vi hadde fjernet for lenge siden. 

Det kan se ut som funkjsonen for valideringen ikke ble fjernet og at valideringen tatt med på nytt i denne PRen: https://github.com/navikt/familie-ba-sak/commit/cfafdd1c188f4fd530bdd616de66a468a4190590

Fjerner den nå. Har testa det og alt ser riktig ut, men det er ikke helt lett å se konsekvensen av dette. Ser ut som valideringen kun har blitt kjørt når "toggleFrikobleAndelerOgEndringer" er på

