### PR TITLE
Støtte for maskinell migrering selv om satsendring ikke er kjørt i infotrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringService.kt
@@ -5,10 +5,10 @@ import io.micrometer.core.instrument.Metrics
 import no.nav.commons.foedselsnummer.FoedselsNr
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.del
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.domene.MigreringResponseDto
 import no.nav.familie.ba.sak.integrasjoner.migrering.MigreringRestClient
@@ -21,8 +21,11 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
@@ -46,6 +49,7 @@ import no.nav.familie.kontrakter.ba.infotrygd.Sak
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.Month.APRIL
 import java.time.Month.AUGUST
@@ -63,6 +67,7 @@ import java.time.YearMonth
 import javax.validation.ConstraintViolationException
 
 private const val NULLDATO = "000000"
+private val SISTE_DATO_FORRIGE_SATS = LocalDate.of(2023, 2, 28)
 
 @Service
 class MigreringService(
@@ -81,7 +86,6 @@ class MigreringService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val migreringRestClient: MigreringRestClient,
     private val kompetanseService: KompetanseService,
-    private val featureToggleService: FeatureToggleService,
     private val persongrunnlagService: PersongrunnlagService
 ) {
 
@@ -420,10 +424,10 @@ class MigreringService(
     private fun virkningsdatoFra(kjøredato: LocalDate): LocalDate {
         LocalDate.now().run {
             return when {
+                env.erDev() -> this.førsteDagINesteMåned()
                 env.erPreprod() -> LocalDate.of(2022, 1, 1)
                 this.isBefore(kjøredato) -> this.førsteDagIInneværendeMåned()
                 this.isAfter(kjøredato.plusDays(1)) -> this.førsteDagINesteMåned()
-                env.erDev() -> this.førsteDagINesteMåned()
                 else -> {
                     kastOgTellMigreringsFeil(
                         MigreringsfeilType.IKKE_GYLDIG_KJØREDATO,
@@ -498,7 +502,6 @@ class MigreringService(
         fnr: String,
         barnasIdenter: List<String>
     ) {
-        val førsteUtbetalingsbeløp = førsteAndelerTilkjentYtelse.sumOf { it.kalkulertUtbetalingsbeløp }
         val delytelserInfotrygd = infotrygdSak.stønad!!.delytelse.filter { it.tom == null }
         val beløpFraInfotrygd = delytelserInfotrygd.sumOf { it.beløp }.toInt()
 
@@ -520,6 +523,7 @@ class MigreringService(
                 ?: kastOgTellMigreringsFeil(MigreringsfeilType.SMÅBARNSTILLEGG_INFOTRYGD_IKKE_BA_SAK)
         }
 
+        val førsteUtbetalingsbeløp = kalkulerFørsteUtbetalingsbeløpSomFørSatsendring(førsteAndelerTilkjentYtelse)
         if (førsteUtbetalingsbeløp != beløpFraInfotrygd) {
             val beløpfeilType = if (infotrygdSak.undervalg == "MD") {
                 MigreringsfeilType.BEREGNET_DELT_BOSTED_BELØP_ULIKT_BELØP_FRA_INFOTRYGD
@@ -532,6 +536,55 @@ class MigreringService(
             )
             secureLog.info("Beløp fra infotrygd sammsvarer ikke med beløp fra ba-sak for ${infotrygdSak.valg} ${infotrygdSak.undervalg} fnr=$fnr baSak=$førsteUtbetalingsbeløp infotrygd=$beløpFraInfotrygd")
             kastOgTellMigreringsFeil(beløpfeilType)
+        }
+    }
+
+    fun kalkulerFørsteUtbetalingsbeløpSomFørSatsendring(atys: List<AndelTilkjentYtelse>): Int {
+        return atys.sumOf { aty ->
+            when (aty.type) {
+                YtelseType.ORDINÆR_BARNETRYGD -> {
+                    val beløp = if (aty.sats == SatsService.finnSisteSatsFor(SatsType.TILLEGG_ORBA).beløp) {
+                        SatsService.finnAlleSatserFor(SatsType.TILLEGG_ORBA).find {
+                            it.gyldigTom == SISTE_DATO_FORRIGE_SATS
+                        }!!.beløp
+                    } else if (aty.sats == SatsService.finnSisteSatsFor(SatsType.ORBA).beløp) {
+                        SatsService.finnAlleSatserFor(SatsType.ORBA).find {
+                            it.gyldigTom == SISTE_DATO_FORRIGE_SATS
+                        }!!.beløp
+                    } else {
+                        aty.sats
+                    }
+                    if (aty.prosent == BigDecimal(50)) {
+                        beløp.toBigDecimal().del(2.toBigDecimal(), 0).toInt()
+                    } else {
+                        beløp
+                    }
+                }
+
+                YtelseType.SMÅBARNSTILLEGG -> {
+                    val beløp = SatsService.finnAlleSatserFor(SatsType.SMA).find {
+                        it.gyldigTom == SISTE_DATO_FORRIGE_SATS
+                    }!!.beløp
+                    if (aty.prosent == BigDecimal(50)) {
+                        beløp.toBigDecimal().del(2.toBigDecimal(), 0).toInt()
+                    } else {
+                        beløp
+                    }
+                }
+
+                YtelseType.UTVIDET_BARNETRYGD -> {
+                    val beløp = SatsService.finnAlleSatserFor(SatsType.UTVIDET_BARNETRYGD).find {
+                        it.gyldigTom == SISTE_DATO_FORRIGE_SATS
+                    }!!.beløp
+                    if (aty.prosent == BigDecimal(50)) {
+                        beløp.toBigDecimal().del(2.toBigDecimal(), 0).toInt()
+                    } else {
+                        beløp
+                    }
+                }
+
+                else -> Integer.valueOf(0)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -82,8 +82,6 @@ class StartSatsendring(
     ): Int {
         var antallFagsakerSatsendring = antallAlleredeTriggetSatsendring
 
-        fagsakForSatsendring.parallelStream()
-
         for (fagsak in fagsakForSatsendring) {
             if (skalTriggeSatsendring(fagsak, satsTidspunkt)) {
                 antallFagsakerSatsendring++

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -81,6 +81,9 @@ class StartSatsendring(
         satsTidspunkt: YearMonth
     ): Int {
         var antallFagsakerSatsendring = antallAlleredeTriggetSatsendring
+
+        fagsakForSatsendring.parallelStream()
+
         for (fagsak in fagsakForSatsendring) {
             if (skalTriggeSatsendring(fagsak, satsTidspunkt)) {
                 antallFagsakerSatsendring++

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceTest.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
@@ -27,7 +26,6 @@ import java.time.YearMonth
 
 @ExtendWith(MockKExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Disabled
 class MigreringServiceTest() {
     lateinit var migreringServiceMock: MigreringService
     lateinit var mockPersonidentService: PersonidentService
@@ -47,7 +45,6 @@ class MigreringServiceTest() {
             mockk(),
             mockk(),
             mockPersonidentService,
-            mockk(),
             mockk(),
             mockk(),
             mockk(),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/MigreringServiceIntegrasjonTest.kt
@@ -6,6 +6,7 @@ import io.mockk.slot
 import no.nav.commons.foedselsnummer.testutils.FoedselsnummerGenerator
 import no.nav.familie.ba.sak.common.DbContainerInitializer
 import no.nav.familie.ba.sak.common.EnvService
+import no.nav.familie.ba.sak.common.Utils.avrundetHeltallAvProsent
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.toYearMonth
@@ -18,6 +19,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.beregning.SatsService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -48,7 +51,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.tuple
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -58,6 +60,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
@@ -80,7 +83,6 @@ import java.time.format.DateTimeFormatter
     "mock-rest-template-config"
 )
 @Tag("integration")
-@Disabled
 class MigreringServiceIntegrasjonTest(
     @Autowired
     private val databaseCleanupService: DatabaseCleanupService,
@@ -279,8 +281,10 @@ class MigreringServiceIntegrasjonTest(
 
             val vedtakDVHV2 = MockKafkaProducer.sendteMeldinger.values.last() as VedtakDVHV2
             assertThat(vedtakDVHV2.utbetalingsperioderV2.first().stønadFom).isEqualTo(forventetUtbetalingFom)
-            assertThat(vedtakDVHV2.utbetalingsperioderV2.first().utbetaltPerMnd.toDouble()).isEqualTo(
-                SAK_BELØP_2_BARN_1_UNDER_6 / 2
+            assertThat(vedtakDVHV2.utbetalingsperioderV2.first().utbetaltPerMnd).isEqualTo(
+                SatsService.finnSisteSatsFor(SatsType.ORBA).beløp.avrundetHeltallAvProsent(BigDecimal(50)) + SatsService.finnSisteSatsFor(
+                    SatsType.TILLEGG_ORBA
+                ).beløp.avrundetHeltallAvProsent(BigDecimal(50))
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11433

Maskinell migrering/migreringsknappen skal fungere etter satsendring. Man sammenligner summen i sak i ba med summen i infotrygd, mens summen i BA har ny sats, så har den ikke det i infotrygd. For å få lik sum, så oversetter man satsene i saken i ba til satser man har i infotrygd.

Har også enablet igjen alle de gamle testene som var avslått

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
