### PR TITLE
Flytter logikken for å sjekke om det er dupliserte utbetalinger på barn til selve AutovedtakTjenesten.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -2,21 +2,15 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
-import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
-import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.SatsendringTaskDto
@@ -36,9 +30,7 @@ class StartSatsendring(
     private val satskjøringRepository: SatskjøringRepository,
     private val featureToggleService: FeatureToggleService,
     private val personidentService: PersonidentService,
-    private val autovedtakSatsendringService: AutovedtakSatsendringService,
-    private val beregningService: BeregningService,
-    private val persongrunnlagService: PersongrunnlagService
+    private val autovedtakSatsendringService: AutovedtakSatsendringService
 ) {
 
     private val ignorerteFagsaker = mutableSetOf<Long>()
@@ -127,14 +119,6 @@ class StartSatsendring(
                 logger.info("Fagsak=${fagsak.id} har alt siste satser")
                 return true
             }
-            if (featureToggleService.isEnabled(
-                    FeatureToggleConfig.SATSENDRING_SJEKK_UTBETALING,
-                    true
-                ) && harUtbetalingerSomOverstiger100Prosent(sisteIverksatteBehandling)
-            ) {
-                ignorerteFagsaker.add(fagsak.id)
-                return false
-            }
 
             if (featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_OPPRETT_TASKER)) {
                 logger.info("Oppretter satsendringtask for fagsak=${fagsak.id}")
@@ -148,32 +132,6 @@ class StartSatsendring(
             ignorerteFagsaker.add(fagsak.id)
             return false
         }
-    }
-
-    private fun harUtbetalingerSomOverstiger100Prosent(sisteIverksatteBehandling: Behandling): Boolean {
-        val tilkjentYtelse =
-            beregningService.hentTilkjentYtelseForBehandling(behandlingId = sisteIverksatteBehandling.id)
-        val personopplysningGrunnlag =
-            persongrunnlagService.hentAktivThrows(behandlingId = sisteIverksatteBehandling.id)
-
-        val barnMedAndreRelevanteTilkjentYtelser = personopplysningGrunnlag.barna.map {
-            Pair(
-                it,
-                beregningService.hentRelevanteTilkjentYtelserForBarn(it.aktør, sisteIverksatteBehandling.fagsak.id)
-            )
-        }
-
-        try {
-            TilkjentYtelseValidering.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(
-                behandlendeBehandlingTilkjentYtelse = tilkjentYtelse,
-                barnMedAndreRelevanteTilkjentYtelser = barnMedAndreRelevanteTilkjentYtelser,
-                personopplysningGrunnlag = personopplysningGrunnlag
-            )
-        } catch (e: UtbetalingsikkerhetFeil) {
-            secureLogger.info("fagsakId=${sisteIverksatteBehandling.fagsak.id} har UtbetalingsikkerhetFeil. Skipper satsendring: ${e.frontendFeilmelding}")
-            return true
-        }
-        return false
     }
 
     fun sjekkOgOpprettSatsendringVedGammelSats(ident: String): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/domene/Satskjøring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/domene/Satskjøring.kt
@@ -29,7 +29,10 @@ data class Satskjøring(
     val startTidspunkt: LocalDateTime = LocalDateTime.now(),
 
     @Column(name = "ferdig_tid")
-    var ferdigTidspunkt: LocalDateTime? = null
+    var ferdigTidspunkt: LocalDateTime? = null,
+
+    @Column(name = "feiltype")
+    var feiltype: String? = null
 ) {
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/resources/db/migration/V238__satskjoering_feiltype.sql
+++ b/src/main/resources/db/migration/V238__satskjoering_feiltype.sql
@@ -1,0 +1,2 @@
+ALTER TABLE satskjoering
+    ADD COLUMN feiltype VARCHAR DEFAULT NULL;

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -23,7 +23,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.SMÅBARNSTILLEGG
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.UTVIDET_BARNETRYGD
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
@@ -50,7 +49,6 @@ internal class StartSatsendringTest {
     private val featureToggleService: FeatureToggleService = mockk()
     private val personidentService: PersonidentService = mockk()
     private val autovedtakSatsendringService: AutovedtakSatsendringService = mockk()
-    private val kompetanseService: KompetanseService = mockk()
 
     lateinit var startSatsendring: StartSatsendring
 
@@ -73,9 +71,7 @@ internal class StartSatsendringTest {
             satskjøringRepository = satskjøringRepository,
             featureToggleService = featureToggleService,
             personidentService = personidentService,
-            autovedtakSatsendringService = autovedtakSatsendringService,
-            beregningService = mockk(),
-            persongrunnlagService = mockk()
+            autovedtakSatsendringService = autovedtakSatsendringService
         )
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi la til logikk i scheduleren for å filtrere bort de med utbetalinger på barn på flere fagsaker. Dette gjorden at antall saker man klarte å gjøre  hver dag gikk ned til 24k. Flytter nå denne logikke til tasken, og oppdaterer oversikten om satskjøringen med feiltype for å kunne identifisere de.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
