### PR TITLE
Behandlingsresultat: eksplisitt avslag på søker skal være lov uansett om det er utvidet eller ordinær

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -87,7 +87,7 @@ class BehandlingsresultatService(
             forrigeBehandling = forrigeBehandling
         )
 
-        BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(personerFremstiltKravFor = personerFremstiltKravFor, vilkårsvurdering = vilkårsvurdering)
+        BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(personerFremstiltKravFor = personerFremstiltKravFor, personResultater = vilkårsvurdering.personResultater)
 
         // 1 SØKNAD
         val søknadsresultat = if (behandling.opprettetÅrsak in listOf(BehandlingÅrsak.FØDSELSHENDELSE, BehandlingÅrsak.SØKNAD) || behandling.erManuellMigrering()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -87,7 +87,7 @@ class BehandlingsresultatService(
             forrigeBehandling = forrigeBehandling
         )
 
-        BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForHarFåttEksplisittAvslag(personerFremstiltKravFor = personerFremstiltKravFor, vilkårsvurdering = vilkårsvurdering)
+        BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(personerFremstiltKravFor = personerFremstiltKravFor, vilkårsvurdering = vilkårsvurdering)
 
         // 1 SØKNAD
         val søknadsresultat = if (behandling.opprettetÅrsak in listOf(BehandlingÅrsak.FØDSELSHENDELSE, BehandlingÅrsak.SØKNAD) || behandling.erManuellMigrering()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -37,7 +37,7 @@ object BehandlingsresultatSøknadUtils {
             endretUtbetalingAndeler = endretUtbetalingAndeler
         )
 
-        val erEksplisittAvslagPåMinstEnPersonFremstiltKravFor = erEksplisittAvslagPåMinstEnPersonFremstiltKravFor(
+        val erEksplisittAvslagPåMinstEnPersonFremstiltKravFor = erEksplisittAvslagPåMinstEnPersonFremstiltKravForEllerSøker(
             nåværendePersonResultater = nåværendePersonResultater,
             personerFremstiltKravFor = personerFremstiltKravFor
         )
@@ -118,12 +118,12 @@ object BehandlingsresultatSøknadUtils {
         return resultatTidslinje.perioder().mapNotNull { it.innhold }.distinct()
     }
 
-    private fun erEksplisittAvslagPåMinstEnPersonFremstiltKravFor(
+    private fun erEksplisittAvslagPåMinstEnPersonFremstiltKravForEllerSøker(
         nåværendePersonResultater: Set<PersonResultat>,
         personerFremstiltKravFor: List<Aktør>
     ): Boolean =
         nåværendePersonResultater
-            .filter { personerFremstiltKravFor.contains(it.aktør) }
+            .filter { personerFremstiltKravFor.contains(it.aktør) || it.erSøkersResultater() }
             .any {
                 it.harEksplisittAvslag()
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -2,15 +2,15 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 
 object BehandlingsresultatValideringUtils {
 
     internal fun validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
         personerFremstiltKravFor: List<Aktør>,
-        vilkårsvurdering: Vilkårsvurdering
+        personResultater: Set<PersonResultat>
     ) {
-        val personerSomHarEksplisittAvslag = vilkårsvurdering.personResultater.filter { it.harEksplisittAvslag() }
+        val personerSomHarEksplisittAvslag = personResultater.filter { it.harEksplisittAvslag() }
 
         if (personerSomHarEksplisittAvslag.any { !personerFremstiltKravFor.contains(it.aktør) && !it.erSøkersResultater() }) {
             throw Feil("Det eksisterer personer som har fått eksplisitt avslag, men som det ikke har blitt fremstilt krav for.")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -6,13 +6,13 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 
 object BehandlingsresultatValideringUtils {
 
-    internal fun validerAtBarePersonerFremstiltKravForHarFåttEksplisittAvslag(
+    internal fun validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
         personerFremstiltKravFor: List<Aktør>,
         vilkårsvurdering: Vilkårsvurdering
     ) {
-        val personerSomHarEksplisittAvslag = vilkårsvurdering.personResultater.filter { it.harEksplisittAvslag() }.map { it.aktør }
+        val personerSomHarEksplisittAvslag = vilkårsvurdering.personResultater.filter { it.harEksplisittAvslag() }
 
-        if (!personerFremstiltKravFor.containsAll(personerSomHarEksplisittAvslag)) {
+        if (personerSomHarEksplisittAvslag.all { personerFremstiltKravFor.contains(it.aktør) || it.erSøkersResultater() }) {
             throw Feil("Det eksisterer personer som har fått eksplisitt avslag, men som det ikke har blitt fremstilt krav for.")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -12,7 +12,7 @@ object BehandlingsresultatValideringUtils {
     ) {
         val personerSomHarEksplisittAvslag = vilkårsvurdering.personResultater.filter { it.harEksplisittAvslag() }
 
-        if (personerSomHarEksplisittAvslag.all { personerFremstiltKravFor.contains(it.aktør) || it.erSøkersResultater() }) {
+        if (personerSomHarEksplisittAvslag.any { !personerFremstiltKravFor.contains(it.aktør) && !it.erSøkersResultater() }) {
             throw Feil("Det eksisterer personer som har fått eksplisitt avslag, men som det ikke har blitt fremstilt krav for.")
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
@@ -425,6 +425,37 @@ internal class BehandlingsresultatSøknadUtilsTest {
         assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
     }
 
+    @Test
+    fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom det er eksplisitt avslag på søker (uten at det er søkt om utvidet)`() {
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+        val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
+
+        val søker = lagPerson(type = PersonType.SØKER)
+
+        val søkersPersonResultat = lagPersonResultat(
+            vilkårsvurdering = vikårsvurdering,
+            aktør = søker.aktør,
+            resultat = Resultat.IKKE_OPPFYLT,
+            periodeFom = des21,
+            periodeTom = LocalDate.now(),
+            personType = PersonType.SØKER,
+            erEksplisittAvslagPåSøknad = true,
+            lagFullstendigVilkårResultat = true
+
+        )
+        val resultatPåSøknad = BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
+            forrigeAndeler = emptyList(),
+            nåværendeAndeler = emptyList(),
+            nåværendePersonResultater = setOf(søkersPersonResultat),
+            personerFremstiltKravFor = emptyList(),
+            endretUtbetalingAndeler = emptyList(),
+            behandlingÅrsak = BehandlingÅrsak.SØKNAD,
+            finnesUregistrerteBarn = false
+        )
+
+        assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
+    }
+
     @ParameterizedTest
     @EnumSource(value = Resultat::class, names = ["IKKE_OPPFYLT", "IKKE_VURDERT"])
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom behandlingen er en fødselshendelse og det finnes vilkårsvurdering som ikke er oppfylt eller vurdert`(resultat: Resultat) {
@@ -468,7 +499,8 @@ internal class BehandlingsresultatSøknadUtilsTest {
             periodeFom = des21,
             periodeTom = LocalDate.now(),
             personType = PersonType.BARN,
-            erEksplisittAvslagPåSøknad = true
+            erEksplisittAvslagPåSøknad = true,
+            lagFullstendigVilkårResultat = true
 
         )
 
@@ -509,7 +541,8 @@ internal class BehandlingsresultatSøknadUtilsTest {
             resultat = Resultat.OPPFYLT,
             periodeFom = des21,
             periodeTom = LocalDate.now(),
-            personType = PersonType.BARN
+            personType = PersonType.BARN,
+            lagFullstendigVilkårResultat = true
         )
 
         val resultatPåSøknad = BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
@@ -549,7 +582,8 @@ internal class BehandlingsresultatSøknadUtilsTest {
             resultat = Resultat.OPPFYLT,
             periodeFom = des21,
             periodeTom = LocalDate.now(),
-            personType = PersonType.BARN
+            personType = PersonType.BARN,
+            lagFullstendigVilkårResultat = true
         )
 
         val resultatPåSøknad = BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
@@ -589,7 +623,8 @@ internal class BehandlingsresultatSøknadUtilsTest {
             resultat = Resultat.OPPFYLT,
             periodeFom = des21,
             periodeTom = LocalDate.now(),
-            personType = PersonType.BARN
+            personType = PersonType.BARN,
+            lagFullstendigVilkårResultat = true
         )
 
         val resultatPåSøknad = BehandlingsresultatSøknadUtils.utledResultatPåSøknad(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
@@ -464,12 +464,12 @@ internal class BehandlingsresultatSøknadUtilsTest {
     @Test
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom det er eksplisitt avslag på søker (uten at det er søkt om utvidet)`() {
         val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
-        val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
 
         val søker = lagPerson(type = PersonType.SØKER)
 
         val søkersPersonResultat = lagPersonResultat(
-            vilkårsvurdering = vikårsvurdering,
+            vilkårsvurdering = vilkårsvurdering,
             aktør = søker.aktør,
             resultat = Resultat.IKKE_OPPFYLT,
             periodeFom = des21,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
@@ -1,0 +1,114 @@
+package no.nav.familie.ba.sak.kjerne.behandlingsresultat
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.common.lagPersonResultat
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+internal class BehandlingsresultatValideringUtilsTest {
+
+    @Test
+    fun `Valider eksplisitt avlag - Skal kaste feil hvis eksplisitt avslått for barn det ikke er fremstilt krav for`() {
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+        val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val barn1 = lagPerson(type = PersonType.BARN)
+        val barn2 = lagPerson(type = PersonType.BARN)
+
+        val barn1PersonResultat = lagPersonResultat(
+            vilkårsvurdering = vikårsvurdering,
+            aktør = barn1.aktør,
+            resultat = Resultat.IKKE_OPPFYLT,
+            periodeFom = LocalDate.now().minusMonths(5),
+            periodeTom = LocalDate.now(),
+            lagFullstendigVilkårResultat = true,
+            personType = PersonType.BARN,
+            erEksplisittAvslagPåSøknad = true
+        )
+        val barn2PersonResultat = lagPersonResultat(
+            vilkårsvurdering = vikårsvurdering,
+            aktør = barn2.aktør,
+            resultat = Resultat.IKKE_OPPFYLT,
+            periodeFom = LocalDate.now().minusMonths(5),
+            periodeTom = LocalDate.now(),
+            lagFullstendigVilkårResultat = true,
+            personType = PersonType.BARN,
+            erEksplisittAvslagPåSøknad = true
+        )
+
+        assertThrows<Feil> {
+            BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
+                personResultater = setOf(barn1PersonResultat, barn2PersonResultat),
+                personerFremstiltKravFor = listOf(barn2.aktør)
+            )
+        }
+    }
+
+    @Test
+    fun `Valider eksplisitt avslag - Skal ikke kaste feil hvis søker er eksplisitt avslått`() {
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+        val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val søker = lagPerson(type = PersonType.SØKER)
+
+        val søkerPersonResultat = lagPersonResultat(
+            vilkårsvurdering = vikårsvurdering,
+            aktør = søker.aktør,
+            resultat = Resultat.IKKE_OPPFYLT,
+            periodeFom = LocalDate.now().minusMonths(5),
+            periodeTom = LocalDate.now(),
+            lagFullstendigVilkårResultat = true,
+            personType = PersonType.SØKER,
+            erEksplisittAvslagPåSøknad = true
+        )
+
+        assertDoesNotThrow {
+            BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
+                personResultater = setOf(søkerPersonResultat),
+                personerFremstiltKravFor = emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun `Valider eksplisitt avslag - Skal ikke kaste feil hvis person med eksplsitt avslag er fremstilt krav for`() {
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+        val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
+        val barn1 = lagPerson(type = PersonType.BARN)
+        val barn2 = lagPerson(type = PersonType.BARN)
+
+        val barn1PersonResultat = lagPersonResultat(
+            vilkårsvurdering = vikårsvurdering,
+            aktør = barn1.aktør,
+            resultat = Resultat.IKKE_OPPFYLT,
+            periodeFom = LocalDate.now().minusMonths(5),
+            periodeTom = LocalDate.now(),
+            lagFullstendigVilkårResultat = true,
+            personType = PersonType.BARN,
+            erEksplisittAvslagPåSøknad = true
+        )
+        val barn2PersonResultat = lagPersonResultat(
+            vilkårsvurdering = vikårsvurdering,
+            aktør = barn2.aktør,
+            resultat = Resultat.OPPFYLT,
+            periodeFom = LocalDate.now().minusMonths(5),
+            periodeTom = LocalDate.now(),
+            lagFullstendigVilkårResultat = true,
+            personType = PersonType.BARN,
+            erEksplisittAvslagPåSøknad = false
+        )
+
+        assertDoesNotThrow {
+            BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
+                personResultater = setOf(barn1PersonResultat, barn2PersonResultat),
+                personerFremstiltKravFor = listOf(barn1.aktør, barn2.aktør)
+            )
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det skal alltid være lov til å sette eksplisitt avslag på søker, noe vi ikke støttet. Legger til at det skal være lov til å legge på eksplisitt avslag på søker, og at det skal føre til avslag på samme måte som eksplisitt avslag for person fremstilt krav for.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
