### PR TITLE
forsøker å populere mottakerident og mottakernavn i backend

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentController.kt
@@ -3,12 +3,13 @@ package no.nav.familie.ba.sak.kjerne.brev
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.byggMottakerdata
-import no.nav.familie.ba.sak.kjerne.brev.domene.leggTilEnhet
+import no.nav.familie.ba.sak.kjerne.brev.domene.leggTilEnhetMottakerIdentOgMottakerNavn
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
@@ -40,7 +41,8 @@ class DokumentController(
     private val tilgangService: TilgangService,
     private val persongrunnlagService: PersongrunnlagService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
-    private val utvidetBehandlingService: UtvidetBehandlingService
+    private val utvidetBehandlingService: UtvidetBehandlingService,
+    private val personopplysningerService: PersonopplysningerService
 ) {
 
     @PostMapping(path = ["vedtaksbrev/{vedtakId}"])
@@ -148,8 +150,13 @@ class DokumentController(
             handling = "hente forhåndsvisning brev"
         )
 
+        val fagsak = fagsakService.hentPåFagsakId(fagsakId)
         return dokumentGenereringService.genererManueltBrev(
-            manueltBrevRequest = manueltBrevRequest.leggTilEnhet(arbeidsfordelingService),
+            manueltBrevRequest = manueltBrevRequest.leggTilEnhetMottakerIdentOgMottakerNavn(
+                arbeidsfordelingService,
+                personopplysningerService,
+                fagsak
+            ),
             erForhåndsvisning = true
         ).let { Ressurs.success(it) }
     }
@@ -164,9 +171,13 @@ class DokumentController(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "sende brev"
         )
-
+        val fagsak = fagsakService.hentPåFagsakId(fagsakId)
         dokumentService.sendManueltBrev(
-            manueltBrevRequest = manueltBrevRequest.leggTilEnhet(arbeidsfordelingService),
+            manueltBrevRequest = manueltBrevRequest.leggTilEnhetMottakerIdentOgMottakerNavn(
+                arbeidsfordelingService,
+                personopplysningerService,
+                fagsak
+            ),
             fagsakId = fagsakId
         )
         return ResponseEntity.ok(Ressurs.success(fagsakService.lagRestMinimalFagsak(fagsakId = fagsakId)))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -27,6 +28,7 @@ class DokumentControllerTest(
     private val vedtakService: VedtakService = mockk(relaxed = true)
     private val fagsakService: FagsakService = mockk()
     private val tilgangService: TilgangService = mockk(relaxed = true)
+    private val mockPersonopplysningerService: PersonopplysningerService = mockk(relaxed = true)
     val mockDokumentController =
         DokumentController(
             dokumentGenereringService = mockDokumentGenereringService,
@@ -37,7 +39,8 @@ class DokumentControllerTest(
             tilgangService = tilgangService,
             persongrunnlagService = mockk(relaxed = true),
             arbeidsfordelingService = mockk(relaxed = true),
-            utvidetBehandlingService = mockk(relaxed = true)
+            utvidetBehandlingService = mockk(relaxed = true),
+            personopplysningerService = mockPersonopplysningerService
         )
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._

I dag får ba-sak mottakerIdent og mottakerNavn fra frontend og bruker det for å sende brev. Siden SB ikke har anledning til å velge mottaker nå, kan det utledes i backend. Denne PR-en er et forsøk for å populære dem i backend slik at frontend kan stoppe å sende det.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
