### PR TITLE
Endringer i hvordan man oppdaterer satsendring-statistikk, og økning i antall satsendringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -13,7 +13,7 @@ class AutovedtakSatsendringScheduler(private val startSatsendring: StartSatsendr
         if (LeaderClient.isLeader() == true) {
             logger.info("Satsendring trigges av schedulert jobb")
             startSatsendring.startSatsendring(
-                antallFagsaker = 600,
+                antallFagsaker = 700,
                 satsTidspunkt = StartSatsendring.SATSENDRINGMÅNED_2023
             )
         }
@@ -21,7 +21,6 @@ class AutovedtakSatsendringScheduler(private val startSatsendring: StartSatsendr
 
     companion object {
         val logger = LoggerFactory.getLogger(AutovedtakSatsendringScheduler::class.java)
-        const val CRON_HVERT_5_MIN_ARBEIDSTID_UKEDAG = "0 */5 7-17 * * MON-FRI"
-        const val CRON_HVERT_10_MIN_ARBEIDSTID_UKEDAG = "0 */10 6-18 * * MON-FRI"
+        const val CRON_HVERT_10_MIN_ARBEIDSTID_UKEDAG = "0 */10 6-19 * * MON-FRI"
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Øker antall satsendringer

Statistikk for satsendring oppdateres ikke før det har gått minst en halv time etter deploy, og etter det så blir den ikke oppdatert før neste deploy. Legger til initial delay slik at den kjøres rett etter oppstart, og fjerner leader-sjekken, siden det er relativt billige spørringer, og utvider til timelige oppdateringer, siden den nå kjører på flere poder.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
