### PR TITLE
fikset bug slik at endringstidspunkt er beregnet basert på siste vedtatt behandling istendenfor siste iverksatt behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
@@ -17,6 +17,10 @@ object Behandlingutils {
             .maxByOrNull { it.opprettetTidspunkt }
     }
 
+    fun hentSisteBehandlingSomErVedtatt(vedtattBehandlinger: List<Behandling>): Behandling? = vedtattBehandlinger
+        .filter { it.steg == StegType.BEHANDLING_AVSLUTTET }
+        .maxByOrNull { it.opprettetTidspunkt }
+
     fun hentForrigeBehandlingSomErVedtatt(
         behandlinger: List<Behandling>,
         behandlingFørFølgende: Behandling

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
@@ -18,7 +18,7 @@ object Behandlingutils {
     }
 
     fun hentSisteBehandlingSomErVedtatt(vedtattBehandlinger: List<Behandling>): Behandling? = vedtattBehandlinger
-        .filter { it.steg == StegType.BEHANDLING_AVSLUTTET }
+        .filter { !it.erHenlagt() }
         .maxByOrNull { it.opprettetTidspunkt }
 
     fun hentForrigeBehandlingSomErVedtatt(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -106,6 +106,13 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnIverksatteBehandlinger(fagsakId: Long): List<Behandling>
 
     @Query(
+        """select b from Behandling b 
+                            inner join Vedtak v on b.id = v.behandling.id 
+                        where b.fagsak.id = :fagsakId AND v.aktiv=true"""
+    )
+    fun finnVedtattBehandlinger(fagsakId: Long): List<Behandling>
+
+    @Query(
         """WITH sisteiverksattebehandlingfraløpendefagsak AS (
                     SELECT f.id AS fagsakid, MAX(b.opprettet_tid) AS opprettet_tid
                     FROM behandling b

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -106,11 +106,6 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnIverksatteBehandlinger(fagsakId: Long): List<Behandling>
 
     @Query(
-        """select b from Behandling b where b.fagsak.id = :fagsakId AND b.status='AVSLUTTET'"""
-    )
-    fun finnVedtattBehandlinger(fagsakId: Long): List<Behandling>
-
-    @Query(
         """WITH sisteiverksattebehandlingfraløpendefagsak AS (
                     SELECT f.id AS fagsakid, MAX(b.opprettet_tid) AS opprettet_tid
                     FROM behandling b

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -106,9 +106,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnIverksatteBehandlinger(fagsakId: Long): List<Behandling>
 
     @Query(
-        """select b from Behandling b 
-                            inner join Vedtak v on b.id = v.behandling.id 
-                        where b.fagsak.id = :fagsakId AND b.status='AVSLUTTET' AND v.aktiv=true"""
+        """select b from Behandling b where b.fagsak.id = :fagsakId AND b.status='AVSLUTTET' AND v.aktiv=true"""
     )
     fun finnVedtattBehandlinger(fagsakId: Long): List<Behandling>
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -106,7 +106,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnIverksatteBehandlinger(fagsakId: Long): List<Behandling>
 
     @Query(
-        """select b from Behandling b where b.fagsak.id = :fagsakId AND b.status='AVSLUTTET' AND v.aktiv=true"""
+        """select b from Behandling b where b.fagsak.id = :fagsakId AND b.status='AVSLUTTET'"""
     )
     fun finnVedtattBehandlinger(fagsakId: Long): List<Behandling>
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -108,7 +108,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Query(
         """select b from Behandling b 
                             inner join Vedtak v on b.id = v.behandling.id 
-                        where b.fagsak.id = :fagsakId AND v.aktiv=true"""
+                        where b.fagsak.id = :fagsakId AND b.status='AVSLUTTET' AND v.aktiv=true"""
     )
     fun finnVedtattBehandlinger(fagsakId: Long): List<Behandling>
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -21,22 +21,22 @@ class EndringstidspunktService(
     fun finnEndringstidpunkForBehandling(behandlingId: Long): LocalDate {
         val nyBehandling = behandlingRepository.finnBehandling(behandlingId)
 
-        val iverksatteBehandlinger = behandlingRepository.finnIverksatteBehandlinger(fagsakId = nyBehandling.fagsak.id)
-        val sistIverksatteBehandling = Behandlingutils.hentSisteBehandlingSomErIverksatt(iverksatteBehandlinger)
+        val vedtattBehandlinger = behandlingRepository.finnVedtattBehandlinger(fagsakId = nyBehandling.fagsak.id)
+        val sisteVedtattBehandling = Behandlingutils.hentSisteBehandlingSomErVedtatt(vedtattBehandlinger)
             ?: return TIDENES_MORGEN
 
         val nyeAndelerTilkjentYtelse = andelerTilkjentYtelseOgEndreteUtbetalingerService
             .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId)
 
         val forrigeAndelerTilkjentYtelse = andelerTilkjentYtelseOgEndreteUtbetalingerService
-            .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(sistIverksatteBehandling.id)
+            .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(sisteVedtattBehandling.id)
 
         val førsteEndringstidspunktFraAndelTilkjentYtelse = nyeAndelerTilkjentYtelse.hentFørsteEndringstidspunkt(
             forrigeAndelerTilkjentYtelse = forrigeAndelerTilkjentYtelse
         ) ?: TIDENES_ENDE
 
         val kompetansePerioder = kompetanseRepository.finnFraBehandlingId(nyBehandling.id)
-        val forrigeKompetansePerioder = kompetanseRepository.finnFraBehandlingId(sistIverksatteBehandling.id)
+        val forrigeKompetansePerioder = kompetanseRepository.finnFraBehandlingId(sisteVedtattBehandling.id)
         val førsteEndringstidspunkt = kompetansePerioder.finnFørsteEndringstidspunkt(forrigeKompetansePerioder)
 
         val førsteEndringstidspunktIKompetansePerioder =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -21,8 +21,9 @@ class EndringstidspunktService(
     fun finnEndringstidpunkForBehandling(behandlingId: Long): LocalDate {
         val nyBehandling = behandlingRepository.finnBehandling(behandlingId)
 
-        val vedtattBehandlinger = behandlingRepository.finnVedtattBehandlinger(fagsakId = nyBehandling.fagsak.id)
-        val sisteVedtattBehandling = Behandlingutils.hentSisteBehandlingSomErVedtatt(vedtattBehandlinger)
+        val alleAvsluttetBehandlingerPåFagsak =
+            behandlingRepository.findByFagsakAndAvsluttet(fagsakId = nyBehandling.fagsak.id)
+        val sisteVedtattBehandling = Behandlingutils.hentSisteBehandlingSomErVedtatt(alleAvsluttetBehandlingerPåFagsak)
             ?: return TIDENES_MORGEN
 
         val nyeAndelerTilkjentYtelse = andelerTilkjentYtelseOgEndreteUtbetalingerService

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -528,21 +528,22 @@ class VedtaksperiodeService(
     ): List<Opphørsperiode> {
         if (behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET) return emptyList()
 
-        val vedtattBehandlinger = behandlingRepository.finnVedtattBehandlinger(fagsakId = behandling.fagsak.id)
+        val alleAvsluttetBehandlingerPåFagsak =
+            behandlingRepository.findByFagsakAndAvsluttet(fagsakId = behandling.fagsak.id)
 
-        val forrigeVedtattBehandling: Behandling? = Behandlingutils.hentSisteBehandlingSomErVedtatt(
-            vedtattBehandlinger
+        val sisteVedtattBehandling: Behandling? = Behandlingutils.hentSisteBehandlingSomErVedtatt(
+            alleAvsluttetBehandlingerPåFagsak
         )
 
         val forrigePersonopplysningGrunnlag: PersonopplysningGrunnlag? =
-            if (forrigeVedtattBehandling != null) {
-                persongrunnlagService.hentAktiv(behandlingId = forrigeVedtattBehandling.id)
+            if (sisteVedtattBehandling != null) {
+                persongrunnlagService.hentAktiv(behandlingId = sisteVedtattBehandling.id)
             } else {
                 null
             }
-        val forrigeAndelerMedEndringer = if (forrigeVedtattBehandling != null) {
+        val forrigeAndelerMedEndringer = if (sisteVedtattBehandling != null) {
             andelerTilkjentYtelseOgEndreteUtbetalingerService
-                .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(forrigeVedtattBehandling.id)
+                .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(sisteVedtattBehandling.id)
         } else {
             emptyList()
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11439

I dag beregner ba-sak endringstidspunkt basert på endringer mellom nåværende behandling og siste iverksatt behandling. Men det gir av og til feil endringstidspunkt fordi alle behandlinger som gjør endringer i utbetaling ikke er iverksatt, f.eks. migreringsbehandling med årsak ENDRE_MIGRERINGS_DATO som kan endre utbetalingsperiode uten å sende data til økonomi. 

For å fikse denne endrer jeg logikken slik at beregningen skjer basert på siste vedtatt behandling og nåværende behandling for å finne ut endringstidspunkt.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
