### PR TITLE
Fjern alle ugyldige kompetanseperioder for brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -168,7 +168,9 @@ class BrevPeriodeService(
             minimerteKompetanserSomStopperRettFørPeriode = hentKompetanserSomStopperRettFørPeriode(
                 kompetanser = kompetanser,
                 periodeFom = minimertVedtaksperiode.fom?.toYearMonth()
-            ).map {
+            ).filter {
+                it.erFelterSatt()
+            }.map {
                 it.tilMinimertKompetanse(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     landkoderISO2 = landkoderISO2

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtil.kt
@@ -83,6 +83,7 @@ fun hentMinimerteKompetanserForPeriode(
     landkoderISO2: Map<String, String>
 ): List<MinimertKompetanse> {
     val minimerteKompetanser = kompetanser.hentIPeriode(fom, tom)
+        .filter { it.erFelterSatt() }
         .map {
             it.tilMinimertKompetanse(
                 personopplysningGrunnlag = personopplysningGrunnlag,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11384

Dersom det er ugyldige kompetanser i siste behandling slik som det er [i denne saken](https://barnetrygd.intern.nav.no/fagsak/1919322/2190804/tilkjent-ytelse) vil autovedtak feile. Fikser det ved å filtrere bort ugyldige kompetanser før vi genererer brev. 

