### PR TITLE
Endre regler for manuel postering etter prat med økonomi

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
@@ -20,9 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 class SimuleringController(
     private val simuleringService: SimuleringService,
     private val tilgangService: TilgangService,
-    private val featureToggleService: FeatureToggleService,
-    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService
-
+    private val featureToggleService: FeatureToggleService
 ) {
 
     @GetMapping(path = ["/{behandlingId}/simulering"])
@@ -33,8 +31,7 @@ class SimuleringController(
         val vedtakSimuleringMottaker = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId)
         val restSimulering = vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = vedtakSimuleringMottaker,
-            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
-            erMigreringsbehandling = behandlingHentOgPersisterService.hent(behandlingId).erMigrering()
+            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ)
         )
         return ResponseEntity.ok(Ressurs.success(restSimulering))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -119,8 +119,7 @@ class SimuleringService(
         val simulering = hentSimuleringPåBehandling(behandlingId)
         val restSimulering = vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = simulering,
-            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
-            erMigreringsbehandling = behandling.erMigrering()
+            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ)
         )
 
         return if (!behandlingErFerdigBesluttet && simuleringErUtdatert(restSimulering)) {
@@ -167,16 +166,14 @@ class SimuleringService(
     fun hentEtterbetaling(økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>): BigDecimal {
         return vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = økonomiSimuleringMottakere,
-            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
-            erMigreringsbehandling = false // ikke relevant når vi henter etterbetaling
+            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ)
         ).etterbetaling
     }
 
     fun hentFeilutbetaling(økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>): BigDecimal {
         return vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere,
-            featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
-            erMigreringsbehandling = false // ikke relevant når vi henter feilutbetaling
+            featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ)
         ).feilutbetaling
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/RestSimulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/RestSimulering.kt
@@ -23,7 +23,6 @@ data class SimuleringsPeriode(
     val tidligereUtbetalt: BigDecimal,
     val manuellPostering: BigDecimal,
     val resultat: BigDecimal,
-    val korrigertResultat: BigDecimal,
     val feilutbetaling: BigDecimal,
     val etterbetaling: BigDecimal
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingSteg.kt
@@ -78,7 +78,6 @@ class VurderTilbakekrevingSteg(
         val simuleringPerioder = vedtakSimuleringMottakereTilSimuleringPerioder(
             simuleringMottaker,
             featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
-            erMigreringsbehandling = false // ikke relevant for etterbetaling
         )
         return simuleringPerioder.any { it.etterbetaling > BigDecimal(HELMANUELL_MIGRERING_MAKS_ETTERBETALING) }
     }
@@ -88,7 +87,6 @@ class VurderTilbakekrevingSteg(
         val simuleringPerioder = vedtakSimuleringMottakereTilSimuleringPerioder(
             simuleringMottaker,
             featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
-            erMigreringsbehandling = false // ikke relevant for feilutbetaling
         )
         return simuleringPerioder.all { it.resultat <= BigDecimal.ZERO && it.resultat >= BigDecimal(-1) } &&
             simuleringService.hentFeilutbetaling(behandlingId) < BigDecimal(HELMANUELL_MIGRERING_FEILUTBETALING_BELØPSGRENSE)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtil.kt
@@ -60,8 +60,7 @@ fun hentTilbakekrevingsperioderISimulering(
     slåsammenNærliggendeFeilutbtalingPerioder(
         vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = simulering,
-            erManuellPosteringTogglePå = erManuelPosteringTogglePå,
-            erMigreringsbehandling = false // ikke relevant når vi henter tilbakekrevingsperioder
+            erManuellPosteringTogglePå = erManuelPosteringTogglePå
         ).perioder
     )
 
@@ -74,8 +73,7 @@ fun opprettVarsel(
         val varseltekst = tilbakekreving.varsel ?: throw Feil("Varseltekst er ikke satt")
         val restSimulering = vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = simulering,
-            erManuellPosteringTogglePå = erManuelPosteringTogglePå,
-            erMigreringsbehandling = false // ikke relevant for tilbakekreving
+            erManuellPosteringTogglePå = erManuelPosteringTogglePå
         )
 
         Varsel(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
@@ -245,13 +245,12 @@ class SimuleringUtilTest {
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(10_000.toBigDecimal())
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(2_000.toBigDecimal())
         assertThat(simuleringsperioder[0].resultat).isEqualTo(-8_000.toBigDecimal())
-        assertThat(simuleringsperioder[0].korrigertResultat).isEqualTo(simuleringsperioder[0].resultat)
         assertThat(simuleringsperioder[0].feilutbetaling).isEqualTo(8_000.toBigDecimal())
         assertThat(oppsummering.etterbetaling).isEqualTo(0.toBigDecimal())
     }
 
     @Test
-    fun `ytelse med manuelle posteringer på trekk av 305 over 3 mnd`() {
+    fun `ytelse med manuelle posteringer på trekk av 770 over 3 mnd`() {
         val fil = File("./src/test/resources/kjerne.simulering/simulering_med_manuell_postering.json")
 
         val ytelseMedManuellePosteringer =
@@ -268,8 +267,29 @@ class SimuleringUtilTest {
         val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(vedtakSimuleringMottakere, true)
         val oppsummering = vedtakSimuleringMottakereTilRestSimulering(vedtakSimuleringMottakere, true)
 
-        assertThat(simuleringsperioder[0].resultat).isEqualTo(0.toBigDecimal())
-        assertThat(oppsummering.etterbetaling).isEqualTo(0.toBigDecimal())
+        val simuleringJanuar22 = simuleringsperioder.single { it.fom == LocalDate.of(2022, 1, 1) }
+        val simuleringFebruar22 = simuleringsperioder.single { it.fom == LocalDate.of(2022, 2, 1) }
+        val simuleringMars22 = simuleringsperioder.single { it.fom == LocalDate.of(2022, 3, 1) }
+        val simuleringApril22 = simuleringsperioder.single { it.fom == LocalDate.of(2022, 4, 1) }
+
+        assertThat(simuleringJanuar22.tidligereUtbetalt).isEqualTo(305.toBigDecimal())
+        assertThat(simuleringJanuar22.resultat).isEqualTo(0.toBigDecimal())
+        assertThat(simuleringJanuar22.manuellPostering).isEqualTo(0.toBigDecimal())
+
+        assertThat(simuleringFebruar22.tidligereUtbetalt).isEqualTo(0.toBigDecimal())
+        assertThat(simuleringFebruar22.resultat).isEqualTo(305.toBigDecimal())
+        assertThat(simuleringFebruar22.manuellPostering).isEqualTo((-305).toBigDecimal())
+
+        assertThat(simuleringMars22.tidligereUtbetalt).isEqualTo(0.toBigDecimal())
+        assertThat(simuleringMars22.resultat).isEqualTo(305.toBigDecimal())
+        assertThat(simuleringMars22.manuellPostering).isEqualTo((-305).toBigDecimal())
+
+        assertThat(simuleringApril22.tidligereUtbetalt).isEqualTo(140.toBigDecimal())
+        assertThat(simuleringApril22.resultat).isEqualTo(165.toBigDecimal())
+        assertThat(simuleringApril22.manuellPostering).isEqualTo((-165).toBigDecimal())
+
+        assertThat(simuleringsperioder.sumOf { it.manuellPostering }).isEqualTo((-775).toBigDecimal())
+        assertThat(oppsummering.etterbetaling).isEqualTo(775.toBigDecimal())
     }
 
     @Test
@@ -316,7 +336,7 @@ class SimuleringUtilTest {
     }
 
     @Test
-    fun `ytelse med manuellt trekk av valutajustering`() {
+    fun `ytelse med manuellt trekk av valutajustering deler er trukket`() {
         val YtelsefraBA = listOf(
             mockVedtakSimuleringPostering(
                 beløp = 305,
@@ -359,13 +379,12 @@ class SimuleringUtilTest {
         assertThat(simuleringsperioder[0].manuellPostering).isEqualTo((-165).toBigDecimal())
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(140.toBigDecimal())
         assertThat(simuleringsperioder[0].resultat).isEqualTo(165.toBigDecimal())
-        assertThat(simuleringsperioder[0].korrigertResultat).isEqualTo(0.toBigDecimal())
         assertThat(simuleringsperioder[0].feilutbetaling).isEqualTo(0.toBigDecimal())
-        assertThat(oppsummering.etterbetaling).isEqualTo(0.toBigDecimal())
+        assertThat(oppsummering.etterbetaling).isEqualTo(165.toBigDecimal())
     }
 
     @Test
-    fun `ytelse med manuellt trekk av valutajustering 2`() {
+    fun `ytelse med manuellt trekk av valutajustering alt er trukket`() {
         val YtelsefraBA = listOf(
             mockVedtakSimuleringPostering(
                 beløp = 305,
@@ -404,14 +423,14 @@ class SimuleringUtilTest {
         val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
         val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, true)
 
-        assertThat(simuleringsperioder.size).isEqualTo(1)
-        assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(305.toBigDecimal())
-        assertThat(simuleringsperioder[0].manuellPostering).isEqualTo((-305).toBigDecimal())
-        assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(0.toBigDecimal())
-        assertThat(simuleringsperioder[0].resultat).isEqualTo(305.toBigDecimal())
-        assertThat(simuleringsperioder[0].korrigertResultat).isEqualTo(0.toBigDecimal())
-        assertThat(simuleringsperioder[0].feilutbetaling).isEqualTo(0.toBigDecimal())
-        assertThat(oppsummering.etterbetaling).isEqualTo(0.toBigDecimal())
+        val simuleringsperiode = simuleringsperioder.single()
+
+        assertThat(simuleringsperiode.nyttBeløp).isEqualTo(305.toBigDecimal())
+        assertThat(simuleringsperiode.manuellPostering).isEqualTo((-305).toBigDecimal())
+        assertThat(simuleringsperiode.tidligereUtbetalt).isEqualTo(0.toBigDecimal())
+        assertThat(simuleringsperiode.resultat).isEqualTo(305.toBigDecimal())
+        assertThat(simuleringsperiode.feilutbetaling).isEqualTo(0.toBigDecimal())
+        assertThat(oppsummering.etterbetaling).isEqualTo(305.toBigDecimal())
     }
 
     @Test
@@ -453,7 +472,6 @@ class SimuleringUtilTest {
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(3_000.toBigDecimal())
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(12_000.toBigDecimal())
         assertThat(simuleringsperioder[0].resultat).isEqualTo(9_000.toBigDecimal())
-        assertThat(simuleringsperioder[0].korrigertResultat).isEqualTo(simuleringsperioder[0].resultat)
         assertThat(simuleringsperioder[0].feilutbetaling).isEqualTo(0.toBigDecimal())
         assertThat(oppsummering.etterbetaling).isEqualTo(2_000.toBigDecimal())
     }
@@ -538,29 +556,6 @@ class SimuleringUtilTest {
 
     @Test
     fun `ytelse med ikke reelle feilutbetalinger skal gi riktig resultat`() {
-        val fil = File("./src/test/resources/kjerne.simulering/simulering_med_mottrekk.json")
-
-        val ytelseMedManuellePosteringer =
-            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
-                .readValue<DetaljertSimuleringResultat>(fil)
-
-        val vedtakSimuleringMottakere = ytelseMedManuellePosteringer.simuleringMottaker.map {
-            it.tilBehandlingSimuleringMottaker(
-                lagBehandling()
-            )
-        }
-
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(vedtakSimuleringMottakere, true)
-
-        simuleringsperioder
-            .forEach {
-                assertThat(it.korrigertResultat.abs()).isLessThanOrEqualTo(BigDecimal.ONE)
-            }
-    }
-
-    @Test
-    fun `ytelse med ikke reelle feilutbetalinger skal gi riktig resultat2`() {
         val ytelseMetMotposteringerOgManuellePosteringer = listOf(
             mockVedtakSimuleringPostering(
                 beløp = 658,
@@ -620,10 +615,9 @@ class SimuleringUtilTest {
         assertThat(simuleringsperiode.nyttBeløp).isEqualTo(658.toBigDecimal())
         assertThat(simuleringsperiode.manuellPostering).isEqualTo(50.toBigDecimal())
         assertThat(simuleringsperiode.tidligereUtbetalt).isEqualTo(707.toBigDecimal())
-        assertThat(simuleringsperiode.feilutbetaling).isEqualTo((0).toBigDecimal())
+        assertThat(simuleringsperiode.feilutbetaling).isEqualTo((49).toBigDecimal())
         assertThat(simuleringsperiode.resultat).isEqualTo((-49).toBigDecimal())
-        assertThat(simuleringsperiode.korrigertResultat).isEqualTo((1).toBigDecimal())
-        assertThat(simuleringsperiode.etterbetaling).isEqualTo((1).toBigDecimal())
+        assertThat(simuleringsperiode.etterbetaling).isEqualTo((0).toBigDecimal())
     }
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtilTest.kt
@@ -124,6 +124,5 @@ class TilbakekrevingUtilTest {
         tidligereUtbetalt = BigDecimal.ZERO,
         resultat = BigDecimal.ZERO,
         etterbetaling = BigDecimal.ZERO,
-        korrigertResultat = BigDecimal.ZERO
     )
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Endrer reglene for hva vi gjør med manuelle posteringer bak toggle
Nytt beløp = Alle postivite ytelser som ikke er manuelle
Tidligere utbetalt = Alle negative ytelser pluss alle manuelle ytelser
Resultat = Nytt beløp - Tidligere utbetalt
Manuell postering = Sum alle manuelle posteringsytelser. Skal kun vises frontend dersom resultat ikke er null. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har endret eksisterende tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
