### PR TITLE
Behandlingsresultat bug: ingen vedtaksperioder ble generert ved resultat "endret og fortsatt innvilget"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -290,11 +290,21 @@ class VedtaksperiodeService(
         gjelderFortsattInnvilget: Boolean = false,
         manueltOverstyrtEndringstidspunkt: LocalDate? = null
     ): List<VedtaksperiodeMedBegrunnelser> {
+        /**
+         * Hvis endringstidspunktet er overskrevet av saksbehandler skal man bruke det saksbehandler har valgt
+         * Hvis toggle for behandlingsresultat er AV og man ønsker å ha fortsatt innvilget MED perioder:
+         *         - alle perioder skal med -> endringstidspunkt = tidenes morgen
+         * Hvis toggle for behandlingsresultat er PÅ og behandlingsresultat = endret og fortsatt innvilget (betyr i praksis det samme som den over, fordi med toggle på oppfører "endret og fortsatt innvilget" seg likt som fortsatt innvilget med perioder )
+         *         - alle perioder skal med -> endringstidspunkt = tidenes morgen
+         * Ellers: endringstidspunkt skal utledes
+         **/
         val endringstidspunkt = manueltOverstyrtEndringstidspunkt
-            ?: if (!gjelderFortsattInnvilget) {
-                endringstidspunktService.finnEndringstidpunkForBehandling(behandlingId = vedtak.behandling.id)
-            } else {
+            ?: if (
+                (gjelderFortsattInnvilget && !featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_BEREGNE_BEHANDLINGSRESULTAT)) || vedtak.behandling.resultat == Behandlingsresultat.ENDRET_OG_FORTSATT_INNVILGET
+            ) {
                 TIDENES_MORGEN
+            } else {
+                endringstidspunktService.finnEndringstidpunkForBehandling(behandlingId = vedtak.behandling.id)
             }
         val opphørsperioder =
             hentOpphørsperioder(vedtak.behandling, endringstidspunkt).map { it.tilVedtaksperiodeMedBegrunnelse(vedtak) }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
#### Bakgrunn
Før har vi hatt:
- Fortsatt innvilget (klassisk, uten perioder): genererer én periode (utenfor funksjonen som er endret her)
- Fortsatt innvilget (med perioder): det er noe saksbehandler kan overstyre i løsningen, og da ønsker man å få med alle vedtaksperioder, selv om resultatet er fortsatt innvilget

Dette skal delvis erstattes av et nytt resultat: "endret og fortsatt innvilget"

Ønsket løsning:
- Fortsatt innvilget: genererer én periode
- Endret og fortsatt innvilget: genererer flere perioder

Dette gjør at saksbehandler ikke skal få mulighet til å justere på om de ønsker én eller flere perioder hvis behandlingsresultatet var "fortsatt innvilget".

#### Problem
- Hvis resultatet var "endret og fortsatt innvilget" så ble ingen vedtaksperioder generert
- Grunnen til det var at man prøvde å utlede endringstidspunkt, men dette ble satt til "tidenes ende" fordi det ikke var noen endringer i andeler eller kompetanse (som er de to tingene endringstidspunkt-funksjonen ser på til nå)

#### Løsning
- "Endret og fortsatt innvilget" skal oppføre seg likt som dagens "fortsatt innvilget med perioder". Sørger derfor at hvis toggle er av så bruker vi den klassiske fortsatt innvilget med perioder, og hvis toggle er på så skal erstatteren "endret og fortsatt innvilget" gjøre det samme.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Følte ikke at det var verdt det, fordi testene vil kreve mye oppsett. Men gjerne si ifra hvis du er uenig 😊

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
