### PR TITLE
Chore: renaming i funksjon som henter siste vedtatte behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
@@ -17,8 +17,8 @@ object Behandlingutils {
             .maxByOrNull { it.opprettetTidspunkt }
     }
 
-    fun hentSisteBehandlingSomErVedtatt(vedtattBehandlinger: List<Behandling>): Behandling? = vedtattBehandlinger
-        .filter { !it.erHenlagt() }
+    fun hentSisteBehandlingSomErVedtatt(alleBehandlingerPåFagsak: List<Behandling>): Behandling? = alleBehandlingerPåFagsak
+        .filter { !it.erHenlagt() && it.steg == StegType.BEHANDLING_AVSLUTTET }
         .maxByOrNull { it.opprettetTidspunkt }
 
     fun hentForrigeBehandlingSomErVedtatt(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -74,8 +74,8 @@ class BeregningService(
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
 
     fun hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId: Long): List<TilkjentYtelse> {
-        val iverksatteBehandlinger = behandlingRepository.findByFagsakAndAvsluttet(fagsakId)
-        return iverksatteBehandlinger.mapNotNull {
+        val avsluttedeBehandlingerPåFagsak = behandlingRepository.findByFagsakAndAvsluttet(fagsakId)
+        return avsluttedeBehandlingerPåFagsak.mapNotNull {
             tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(
                 it.id
             )?.takeIf { tilkjentYtelse ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -74,8 +74,8 @@ class BeregningService(
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
 
     fun hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId: Long): List<TilkjentYtelse> {
-        val avsluttedeBehandlingerPåFagsak = behandlingRepository.findByFagsakAndAvsluttet(fagsakId)
-        return avsluttedeBehandlingerPåFagsak.mapNotNull {
+        val avsluttedeBehandlingerSomIkkeErHenlagtPåFagsak = behandlingRepository.findByFagsakAndAvsluttet(fagsakId).filter { !it.erHenlagt() }
+        return avsluttedeBehandlingerSomIkkeErHenlagtPåFagsak.mapNotNull {
             tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(
                 it.id
             )?.takeIf { tilkjentYtelse ->


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Liten forbedring på denne: https://github.com/navikt/familie-ba-sak/pull/3366

Det er ikke kun vedtatte behandlinger som sendes inn (henlagte behandlinger kalles ikke vedtatt), så renamer parameter til alleBehandlingerPåFagsak. I tillegg legger jeg til en sjekk som sjekker at behandlingen som returneres faktisk er avsluttet. Alternativt kan jeg rename parameteret til alleAvsluttedeBehandlingerPåFagsak, men føler den løsningen jeg har kommet med her er hakket tryggere 🤷‍♂️

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Kom gjerne med tilbakemeldinger på det jeg skrev rett over her.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bare småendringer 😊

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
