### PR TITLE
Ny måte å utlede endringstidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -10,6 +10,7 @@ class FeatureToggleConfig {
         const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
         const val TEKNISK_ENDRING = "familie-ba-sak.behandling.teknisk-endring"
         const val NY_MÅTE_Å_BEREGNE_BEHANDLINGSRESULTAT = "familie-ba-sak.behandling.behandlingsresultat"
+        const val NY_MÅTE_Å_UTLEDE_ENDRINGSTIDSPUNKT = "familie-ba-sak.release.endringstidspunkt-oppgradering"
 
         const val KAN_GENERERE_UTBETALINGSOPPDRAG_NY = "familie-ba-sak.generer.utbetalingsoppdrag.ny"
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -93,7 +93,7 @@ class UtvidetBehandlingService(
 
         val tilbakekreving = tilbakekrevingRepository.findByBehandlingId(behandling.id)
 
-        val endringstidspunkt = endringstidspunktService.finnEndringstidpunkForBehandling(behandlingId)
+        val endringstidspunkt = endringstidspunktService.finnEndringstidpunkForBehandlingGammel(behandlingId)
 
         val kompetanser: Collection<Kompetanse> = kompetanseRepository.finnFraBehandlingId(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.VergeInfo
 import no.nav.familie.ba.sak.ekstern.restDomene.tilDto
@@ -70,7 +72,8 @@ class UtvidetBehandlingService(
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val korrigertVedtakService: KorrigertVedtakService,
     private val feilutbetaltValutaService: FeilutbetaltValutaService,
-    private val brevmottakerService: BrevmottakerService
+    private val brevmottakerService: BrevmottakerService,
+    private val featureToggleService: FeatureToggleService
 ) {
     fun lagRestUtvidetBehandling(behandlingId: Long): RestUtvidetBehandling {
         val behandling = behandlingRepository.finnBehandling(behandlingId)
@@ -93,7 +96,9 @@ class UtvidetBehandlingService(
 
         val tilbakekreving = tilbakekrevingRepository.findByBehandlingId(behandling.id)
 
-        val endringstidspunkt = endringstidspunktService.finnEndringstidpunkForBehandlingGammel(behandlingId)
+        val endringstidspunkt = if (featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_UTLEDE_ENDRINGSTIDSPUNKT)) {
+            endringstidspunktService.finnEndringstidspunktForBehandling(behandlingId)
+        } else endringstidspunktService.finnEndringstidpunkForBehandlingGammel(behandlingId)
 
         val kompetanser: Collection<Kompetanse> = kompetanseRepository.finnFraBehandlingId(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -18,7 +18,8 @@ class EndringstidspunktService(
     private val kompetanseRepository: PeriodeOgBarnSkjemaRepository<Kompetanse>,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
 ) {
-    fun finnEndringstidpunkForBehandling(behandlingId: Long): LocalDate {
+    @Deprecated("Skal erstattes av finnEndringstidpunkForBehandling")
+    fun finnEndringstidpunkForBehandlingGammel(behandlingId: Long): LocalDate {
         val nyBehandling = behandlingRepository.finnBehandling(behandlingId)
 
         val alleAvsluttetBehandlingerPåFagsak =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -2,12 +2,26 @@ package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.kjerne.beregning.EndretUtbetalingAndelTidslinje
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import java.time.YearMonth
 
 object EndringIEndretUtbetalingAndelUtil {
+
+    fun utledEndringstidspunktForEndetUtbetalingAndel(
+        nåværendeEndretAndeler: List<EndretUtbetalingAndel>,
+        forrigeEndretAndeler: List<EndretUtbetalingAndel>
+    ): YearMonth? {
+        val endringIEndretUtbetalingAndelTidslinje = lagEndringIEndretUtbetalingAndelTidslinje(
+            nåværendeEndretAndeler = nåværendeEndretAndeler,
+            forrigeEndretAndeler = forrigeEndretAndeler
+        )
+
+        return endringIEndretUtbetalingAndelTidslinje.tilFørsteEndringstidspunkt()
+    }
 
     fun lagEndringIEndretUtbetalingAndelTidslinje(
         nåværendeEndretAndeler: List<EndretUtbetalingAndel>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIKompetanseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIKompetanseUtil.kt
@@ -2,12 +2,26 @@ package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import java.time.YearMonth
 
 object EndringIKompetanseUtil {
+
+    fun utledEndringstidspunktForKompetanse(
+        nåværendeKompetanser: List<Kompetanse>,
+        forrigeKompetanser: List<Kompetanse>
+    ): YearMonth? {
+        val endringIKompetanseTidslinje = lagEndringIKompetanseTidslinje(
+            nåværendeKompetanser = nåværendeKompetanser,
+            forrigeKompetanser = forrigeKompetanser
+        )
+
+        return endringIKompetanseTidslinje.tilFørsteEndringstidspunkt()
+    }
 
     fun lagEndringIKompetanseTidslinje(
         nåværendeKompetanser: List<Kompetanse>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -2,11 +2,11 @@ package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import java.time.YearMonth
 
 object EndringIUtbetalingUtil {
@@ -34,7 +34,7 @@ object EndringIUtbetalingUtil {
             forrigeAndeler = forrigeAndeler
         )
 
-        return endringIUtbetalingTidslinje.perioder().filter { it.innhold == true }.minOfOrNull { it.fraOgMed }?.tilYearMonth()
+        return endringIUtbetalingTidslinje.tilFørsteEndringstidspunkt()
     }
 
     internal fun lagEndringIUtbetalingTidslinje(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import java.time.YearMonth
 
 object EndringIUtbetalingUtil {
 
@@ -23,7 +25,19 @@ object EndringIUtbetalingUtil {
         return endringIUtbetalingTidslinje.perioder().any { it.innhold == true }
     }
 
-    fun lagEndringIUtbetalingTidslinje(
+    fun utledEndringstidspunktForUtbetalingsbeløp(
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
+        forrigeAndeler: List<AndelTilkjentYtelse>
+    ): YearMonth? {
+        val endringIUtbetalingTidslinje = lagEndringIUtbetalingTidslinje(
+            nåværendeAndeler = nåværendeAndeler,
+            forrigeAndeler = forrigeAndeler
+        )
+
+        return endringIUtbetalingTidslinje.perioder().filter { it.innhold == true }.minOfOrNull { it.fraOgMed }?.tilYearMonth()
+    }
+
+    internal fun lagEndringIUtbetalingTidslinje(
         nåværendeAndeler: List<AndelTilkjentYtelse>,
         forrigeAndeler: List<AndelTilkjentYtelse>
     ): Tidslinje<Boolean, Måned> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunktForDagtidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
@@ -14,6 +15,20 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 object EndringIVilkårsvurderingUtil {
+
+    fun utledEndringstidspunktForVilkårsvurdering(
+        nåværendePersonResultat: Set<PersonResultat>,
+        forrigePersonResultat: Set<PersonResultat>,
+        opphørstidspunkt: YearMonth
+    ): YearMonth? {
+        val endringIVilkårsvurderingTidslinje = lagEndringIVilkårsvurderingTidslinje(
+            nåværendePersonResultat = nåværendePersonResultat,
+            forrigePersonResultat = forrigePersonResultat,
+            opphørstidspunkt = opphørstidspunkt
+        )
+
+        return endringIVilkårsvurderingTidslinje.tilFørsteEndringstidspunktForDagtidslinje()
+    }
 
     fun lagEndringIVilkårsvurderingTidslinje(
         nåværendePersonResultat: Set<PersonResultat>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
@@ -1,10 +1,13 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 
 object EndringUtil {
 
     internal fun Tidslinje<Boolean, Måned>.tilFørsteEndringstidspunkt() = this.perioder().filter { it.innhold == true }.minOfOrNull { it.fraOgMed }?.tilYearMonth()
+
+    internal fun Tidslinje<Boolean, Dag>.tilFørsteEndringstidspunktForDagtidslinje() = this.perioder().filter { it.innhold == true }.minOfOrNull { it.fraOgMed }?.tilYearMonth()
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ba.sak.kjerne.forrigebehandling
+
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+
+object EndringUtil {
+
+    internal fun Tidslinje<Boolean, Måned>.tilFørsteEndringstidspunkt() = this.perioder().filter { it.innhold == true }.minOfOrNull { it.fraOgMed }?.tilYearMonth()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -320,7 +320,7 @@ class VedtaksperiodeService(
             ) {
                 TIDENES_MORGEN
             } else {
-                endringstidspunktService.finnEndringstidpunkForBehandling(behandlingId = vedtak.behandling.id)
+                endringstidspunktService.finnEndringstidpunkForBehandlingGammel(behandlingId = vedtak.behandling.id)
             }
         val opphørsperioder =
             hentOpphørsperioder(vedtak.behandling, endringstidspunkt).map { it.tilVedtaksperiodeMedBegrunnelse(vedtak) }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -315,7 +315,9 @@ class VedtaksperiodeService(
          * Ellers: endringstidspunkt skal utledes
          **/
         val endringstidspunkt = manueltOverstyrtEndringstidspunkt
-            ?: if (
+            ?: if (featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_UTLEDE_ENDRINGSTIDSPUNKT)) {
+                endringstidspunktService.finnEndringstidspunktForBehandling(behandlingId = vedtak.behandling.id)
+            } else if (
                 (gjelderFortsattInnvilget && !featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_BEREGNE_BEHANDLINGSRESULTAT)) || vedtak.behandling.resultat == Behandlingsresultat.ENDRET_OG_FORTSATT_INNVILGET
             ) {
                 TIDENES_MORGEN

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
@@ -84,7 +84,7 @@ class VedtaksperiodeServiceEnhetstest {
     @BeforeEach
     fun init() {
         every { behandlingRepository.findByFagsakAndAvsluttet(any()) } returns listOf(forrigeBehandling)
-        every { endringstidspunktService.finnEndringstidpunkForBehandling(vedtak.behandling.id) } returns endringstidspunkt
+        every { endringstidspunktService.finnEndringstidpunkForBehandlingGammel(vedtak.behandling.id) } returns endringstidspunkt
         every { persongrunnlagService.hentAktiv(any()) } returns
             lagTestPersonopplysningGrunnlag(vedtak.behandling.id, person)
         every {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
@@ -84,7 +84,8 @@ class VedtaksperiodeServiceEnhetstest {
     @BeforeEach
     fun init() {
         every { behandlingRepository.findByFagsakAndAvsluttet(any()) } returns listOf(forrigeBehandling)
-        every { endringstidspunktService.finnEndringstidpunkForBehandlingGammel(vedtak.behandling.id) } returns endringstidspunkt
+        every { featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_UTLEDE_ENDRINGSTIDSPUNKT) } returns true
+        every { endringstidspunktService.finnEndringstidspunktForBehandling(vedtak.behandling.id) } returns endringstidspunkt
         every { persongrunnlagService.hentAktiv(any()) } returns
             lagTestPersonopplysningGrunnlag(vedtak.behandling.id, person)
         every {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Den gamle koden for å utlede endringstidspunkt må oppgraderes, fordi den ikke er fullverdig nok. Den gamle koden så kun på endring i beløp og endring i kompetanse. Vi ønsker også å se på endring i vilkårsvurdering og endring i endret utbetaling andel. Bruker de samme underliggende funksjonen som brukes til behandlingsresultat, så her burde behandlingsresultat gå mer hånd i hånd med hvilke ting endringstidspunkt tar høyde for.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei ikke egentlig

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
