### PR TITLE
Legger til utsendt arbeidstaker i annen forelders aktivitet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
         <felles-kontrakter.version>2.0_20230213114103_78130d1</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
-        <familie.kontrakter.stønadsstatistikk>2.0_20221123134052_8bdd6c8</familie.kontrakter.stønadsstatistikk>
+        <familie.kontrakter.stønadsstatistikk>2.0_20230223155122_2e81c44</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>
         <mockk.version>1.13.4</mockk.version>
         <token-validation-spring.version>2.1.9</token-validation-spring.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -133,7 +133,8 @@ enum class AnnenForeldersAktivitet {
     FORSIKRET_I_BOSTEDSLAND,
     MOTTAR_PENSJON,
     INAKTIV,
-    IKKE_AKTUELT
+    IKKE_AKTUELT,
+    UTSENDT_ARBEIDSTAKER
 }
 
 enum class KompetanseResultat {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?onShow=mycards&card=Tea-11399

Det er ønskelig å kunne velge Utsendt arbeidstaker i nedtrekksmenyen for annen forelders aktivitet.
Ny verdi er lagt til i enumn AnnenForeldersAktivitet.

PS:
Testene feiler siden vi må bruke ny versjon av familie-eksterne-kontrakter der utsendt arbeidstaker er lagt til.
PR på det ligger her: https://github.com/navikt/familie-eksterne-kontrakter/pull/132