### PR TITLE
Overstyrer utbetalesTil ved konsistensavstemming for å støtte institusjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>1.20230207133526_5430e48</prosessering.version>
         <felles.version>1.20230116145510_2afcc20</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>2.0_20230213114103_78130d1</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20230223121809_a777026</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20221123134052_8bdd6c8</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
@@ -160,6 +160,11 @@ class AvstemmingService(
                         relevanteAndeler.mapNotNull { it.kildeBehandlingId }
                     )
 
+                val tssEksternIdForBehandlinger =
+                    behandlingHentOgPersisterService.hentTssEksternIdForBehandlinger(
+                        relevanteAndeler.mapNotNull { it.kildeBehandlingId }
+                    )
+
                 relevanteAndeler.groupBy { it.kildeBehandlingId }
                     .map { (kildeBehandlingId, andeler) ->
                         if (kildeBehandlingId == null) {
@@ -174,7 +179,8 @@ class AvstemmingService(
                                     it.periodeOffset
                                         ?: error("Andel ${it.id} på iverksatt behandling på løpende fagsak mangler periodeOffset")
                                 }
-                                .toSet()
+                                .toSet(),
+                            utebetalesTil = tssEksternIdForBehandlinger[kildeBehandlingId]
                         )
                     }
             }.flatten()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
@@ -109,7 +109,7 @@ class BehandlingHentOgPersisterService(
         behandlingRepository.finnAktivtFødselsnummerForBehandlinger(behandlingIder).associate { it.first to it.second }
 
     fun hentTssEksternIdForBehandlinger(behandlingIder: List<Long>): Map<Long, String> =
-        behandlingRepository.finnAktivtFødselsnummerForBehandlinger(behandlingIder).associate { it.first to it.second }
+        behandlingRepository.finnTssEksternIdForBehandlinger(behandlingIder).associate { it.first to it.second }
 
     fun hentIverksatteBehandlinger(fagsakId: Long): List<Behandling> {
         return behandlingRepository.finnIverksatteBehandlinger(fagsakId = fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
@@ -36,7 +36,8 @@ class BehandlingHentOgPersisterService(
     }
 
     fun hent(behandlingId: Long): Behandling {
-        return behandlingRepository.finnBehandlingNullable(behandlingId) ?: throw Feil("Finner ikke behandling med id $behandlingId")
+        return behandlingRepository.finnBehandlingNullable(behandlingId)
+            ?: throw Feil("Finner ikke behandling med id $behandlingId")
     }
 
     /**
@@ -105,6 +106,9 @@ class BehandlingHentOgPersisterService(
         hentBehandlinger(fagsakId).filter { it.erVedtatt() }
 
     fun hentAktivtFødselsnummerForBehandlinger(behandlingIder: List<Long>): Map<Long, String> =
+        behandlingRepository.finnAktivtFødselsnummerForBehandlinger(behandlingIder).associate { it.first to it.second }
+
+    fun hentTssEksternIdForBehandlinger(behandlingIder: List<Long>): Map<Long, String> =
         behandlingRepository.finnAktivtFødselsnummerForBehandlinger(behandlingIder).associate { it.first to it.second }
 
     fun hentIverksatteBehandlinger(fagsakId: Long): List<Behandling> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -177,6 +177,14 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnAktivtFødselsnummerForBehandlinger(behandlingIder: List<Long>): List<Pair<Long, String>>
 
     @Query(
+        "SELECT new kotlin.Pair(b.id, i.tssEksternId) from Behandling b " +
+            "INNER JOIN Fagsak f ON f.id = b.fagsak.id " +
+            "INNER JOIN Institusjon i on i.id = f.institusjon.id " +
+            "where b.id in (:behandlingIder) AND f.institusjon IS NOT NULL AND f.status = 'LØPENDE' "
+    )
+    fun finnTssEksternIdForBehandlinger(behandlingIder: List<Long>): List<Pair<Long, String>>
+
+    @Query(
         """select distinct b.id from AndelTilkjentYtelse aty
             inner join Behandling b on b.id = aty.behandlingId
             where b.resultat not in (:ugyldigeResultater)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingTest.kt
@@ -500,6 +500,7 @@ class KonsistensavstemmingTest {
         )
         val aktivFødselsnummere = mapOf(behandlingId.toLong() to "test")
         every { behandlingHentOgPersisterService.hentAktivtFødselsnummerForBehandlinger(any()) } returns aktivFødselsnummere
+        every { behandlingHentOgPersisterService.hentTssEksternIdForBehandlinger(any()) } returns emptyMap()
     }
 
     private fun lagMockOppdragDataHappeCase(transaksjonsId: UUID) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ved sending av oppdrag av Institusjon-saker så settes utbetalesTil til tss ident for Organisasjonen, men ved konsistensavstemming så ble fnr sendt som utbetalesTil.  Dette fordi oppdrag overskriver med siste aktive fødselsnummer ved konsistensavstemming. Slik at gamle oppdrag får riktig fnr

For å støtte at man ikke overskriver utbetalesTil til fødselsnummer for institusjonsaker, så har man lagt til et felt i kontrakten mot oppdrag hvor man spesifikt kan sette utbetalesTil på institusjons-sakene

https://github.com/navikt/familie-oppdrag/pull/537

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
