### PR TITLE
Bug: setter ikke opphør hvis opphørsdato er neste måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -38,10 +38,9 @@ object BehandlingsresultatOpphørUtils {
         return when {
             // Rekkefølgen av sjekkene er viktig for å komme fram til riktig opphørsresultat.
             nåværendeBehandlingOpphørsdato == null -> Opphørsresultat.IKKE_OPPHØRT // Både forrige og nåværende behandling har ingen andeler
-            nåværendeAndeler.isEmpty() -> Opphørsresultat.OPPHØRT // Alle andeler fra forrige behandling er fjernet
-            nåværendeBehandlingOpphørsdato > nesteMåned -> Opphørsresultat.IKKE_OPPHØRT
-            forrigeBehandlingOpphørsdato > nesteMåned || forrigeBehandlingOpphørsdato > nåværendeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT
-            else -> Opphørsresultat.FORTSATT_OPPHØRT
+            nåværendeBehandlingOpphørsdato <= nesteMåned && forrigeBehandlingOpphørsdato > nåværendeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige har senere opphørsdato
+            nåværendeBehandlingOpphørsdato <= nesteMåned && nåværendeBehandlingOpphørsdato == forrigeBehandlingOpphørsdato -> Opphørsresultat.FORTSATT_OPPHØRT
+            else -> Opphørsresultat.IKKE_OPPHØRT
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -33,14 +33,14 @@ object BehandlingsresultatOpphørUtils {
         val forrigeBehandlingOpphørsdato =
             forrigeAndeler.utledOpphørsdatoForForrigeBehandling(forrigeEndretAndeler = forrigeEndretAndeler)
 
-        val dagensDato = YearMonth.now()
+        val nesteMåned = YearMonth.now().plusMonths(1)
 
         return when {
             // Rekkefølgen av sjekkene er viktig for å komme fram til riktig opphørsresultat.
             nåværendeBehandlingOpphørsdato == null -> Opphørsresultat.IKKE_OPPHØRT // Både forrige og nåværende behandling har ingen andeler
             nåværendeAndeler.isEmpty() -> Opphørsresultat.OPPHØRT // Alle andeler fra forrige behandling er fjernet
-            nåværendeBehandlingOpphørsdato > dagensDato -> Opphørsresultat.IKKE_OPPHØRT
-            forrigeBehandlingOpphørsdato > dagensDato || forrigeBehandlingOpphørsdato > nåværendeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT
+            nåværendeBehandlingOpphørsdato > nesteMåned -> Opphørsresultat.IKKE_OPPHØRT
+            forrigeBehandlingOpphørsdato > nesteMåned || forrigeBehandlingOpphørsdato > nåværendeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT
             else -> Opphørsresultat.FORTSATT_OPPHØRT
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -255,6 +255,55 @@ class BehandlingsresultatOpphørUtilsTest {
         assertEquals(Opphørsresultat.FORTSATT_OPPHØRT, opphørsresultat)
     }
 
+    @Test
+    fun `hentOpphørsresultatPåBehandling skal returnere IKKE_OPPHØRT dersom nåværende andeler har lik opphørsdato som forrige andeler men det er i fremtiden`() {
+        val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
+        val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
+        val apr22 = YearMonth.of(2022, 4)
+
+        mockkStatic(YearMonth::class)
+        every { YearMonth.now() } returns apr22
+
+        val forrigeAndeler = listOf(
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = aug22,
+                beløp = 1054,
+                aktør = barn1Aktør
+            ),
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = mar22,
+                beløp = 1054,
+                aktør = barn2Aktør
+            )
+        )
+
+        val nåværendeAndeler = listOf(
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = aug22,
+                beløp = 1054,
+                aktør = barn1Aktør
+            ),
+            lagAndelTilkjentYtelse(
+                fom = jan22,
+                tom = mar22,
+                beløp = 1054,
+                aktør = barn2Aktør
+            )
+        )
+
+        val opphørsresultat = hentOpphørsresultatPåBehandling(
+            nåværendeAndeler = nåværendeAndeler,
+            forrigeAndeler = forrigeAndeler,
+            nåværendeEndretAndeler = emptyList(),
+            forrigeEndretAndeler = emptyList()
+        )
+
+        assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
+    }
+
     @ParameterizedTest
     @EnumSource(Årsak::class, names = ["ALLEREDE_UTBETALT", "ENDRE_MOTTAKER", "ETTERBETALING_3ÅR"])
     internal fun `filtrerBortIrrelevanteAndeler - skal filtrere andeler som har 0 i beløp og endret utbetaling andel med årsak ALLEREDE_UTBETALT, ENDRE_MOTTAKER eller ETTERBETALING_3ÅR`(årsak: Årsak) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har en feil i koden som setter opphørsresultat. 

Eksempel: det er februar 2023 og du behandler en sak som har andeler som strekker seg ut februar 2023. Opphørstidspunkt er da mars 2023. 
Den gamle koden ville ikke ha sagt at det er et opphør, men det skal det egentlig være. Retter derfor det opp ved å bruke neste måned i stedet for inneværende måned.

Har i tillegg refaktorert litt rundt utledning av opphørsresultat, da jeg syns det var tungt å forstå selv om jeg har jobbet en del med det.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Dobbeltsjekk at logikken fortsatt er riktig. Ganske sikker på at det skal være det, men fint med et par øyne til 😊

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Finnes allerede en del tester, har i tillegg skrevet en til som er relevant å ta høyde for.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
