### PR TITLE
Bug: utleder endring i vilkårsvurdering feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -51,8 +51,7 @@ object BehandlingsresultatEndringUtils {
 
         val erEndringIVilkårsvurdering = erEndringIVilkårsvurdering(
             nåværendePersonResultat = nåværendePersonResultat,
-            forrigePersonResultat = forrigePersonResultat,
-            opphørstidspunkt = nåværendeAndeler.utledOpphørsdatoForNåværendeBehandlingMedFallback(forrigeAndeler = forrigeAndeler, nåværendeEndretAndeler = nåværendeEndretAndeler)
+            forrigePersonResultat = forrigePersonResultat
         )
 
         val erEndringIEndretUtbetalingAndeler = erEndringIEndretUtbetalingAndeler(
@@ -143,15 +142,11 @@ object BehandlingsresultatEndringUtils {
 
     internal fun erEndringIVilkårsvurdering(
         nåværendePersonResultat: Set<PersonResultat>,
-        forrigePersonResultat: Set<PersonResultat>,
-        opphørstidspunkt: YearMonth?
+        forrigePersonResultat: Set<PersonResultat>
     ): Boolean {
-        if (opphørstidspunkt == null) return false // Returnerer false hvis verken forrige eller nåværende behandling har andeler
-
         val endringIVilkårsvurderingTidslinje = EndringIVilkårsvurderingUtil.lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultat = nåværendePersonResultat,
-            forrigePersonResultat = forrigePersonResultat,
-            opphørstidspunkt = opphørstidspunkt
+            forrigePersonResultat = forrigePersonResultat
         )
         return endringIVilkårsvurderingTidslinje.perioder().any { it.innhold == true }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatOpphørUtils.utledOpphørsdatoForNåværendeBehandlingMedFallback
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelHentOgPersisterService
@@ -73,16 +72,9 @@ class EndringstidspunktService(
         val nåværendeVilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandlingId = inneværendeBehandlingId) ?: return null
         val forrigeVilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandlingId = forrigeBehandlingId) ?: return null
 
-        val nåværendeAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = inneværendeBehandlingId)
-        val forrigeAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = forrigeBehandlingId)
-        val nåværendeEndretAndeler = endretUtbetalingAndelHentOgPersisterService.hentForBehandling(behandlingId = inneværendeBehandlingId)
-
-        val opphørstidspunkt = nåværendeAndeler.utledOpphørsdatoForNåværendeBehandlingMedFallback(forrigeAndeler, nåværendeEndretAndeler) ?: return null
-
         return EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
             nåværendePersonResultat = nåværendeVilkårsvurdering.personResultater,
-            forrigePersonResultat = forrigeVilkårsvurdering.personResultater,
-            opphørstidspunkt = opphørstidspunkt
+            forrigePersonResultat = forrigeVilkårsvurdering.personResultater
         )
     }
     private fun finnEndringstidspunktForEndretUtbetalingAndel(inneværendeBehandlingId: Long, forrigeBehandlingId: Long): YearMonth? {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -18,13 +18,11 @@ object EndringIVilkårsvurderingUtil {
 
     fun utledEndringstidspunktForVilkårsvurdering(
         nåværendePersonResultat: Set<PersonResultat>,
-        forrigePersonResultat: Set<PersonResultat>,
-        opphørstidspunkt: YearMonth
+        forrigePersonResultat: Set<PersonResultat>
     ): YearMonth? {
         val endringIVilkårsvurderingTidslinje = lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultat = nåværendePersonResultat,
-            forrigePersonResultat = forrigePersonResultat,
-            opphørstidspunkt = opphørstidspunkt
+            forrigePersonResultat = forrigePersonResultat
         )
 
         return endringIVilkårsvurderingTidslinje.tilFørsteEndringstidspunktForDagtidslinje()
@@ -32,8 +30,7 @@ object EndringIVilkårsvurderingUtil {
 
     fun lagEndringIVilkårsvurderingTidslinje(
         nåværendePersonResultat: Set<PersonResultat>,
-        forrigePersonResultat: Set<PersonResultat>,
-        opphørstidspunkt: YearMonth
+        forrigePersonResultat: Set<PersonResultat>
     ): Tidslinje<Boolean, Dag> {
         val allePersonerMedPersonResultat =
             (nåværendePersonResultat.map { it.aktør } + forrigePersonResultat.map { it.aktør }).distinct()
@@ -48,8 +45,7 @@ object EndringIVilkårsvurderingUtil {
                     forrigePersonResultat
                         .filter { it.aktør == aktør }
                         .flatMap { it.vilkårResultater }
-                        .filter { it.vilkårType == vilkår && it.resultat == Resultat.OPPFYLT },
-                    opphørstidspunkt = opphørstidspunkt
+                        .filter { it.vilkårType == vilkår && it.resultat == Resultat.OPPFYLT }
                 )
             }
         }
@@ -67,8 +63,7 @@ object EndringIVilkårsvurderingUtil {
     // 3. Splitt i vilkårsvurderingen
     private fun lagEndringIVilkårsvurderingForPersonOgVilkårTidslinje(
         nåværendeVilkårResultat: List<VilkårResultat>,
-        forrigeVilkårResultat: List<VilkårResultat>,
-        opphørstidspunkt: YearMonth
+        forrigeVilkårResultat: List<VilkårResultat>
     ): Tidslinje<Boolean, Dag> {
         val nåværendeVilkårResultatTidslinje = nåværendeVilkårResultat.tilTidslinje()
         val tidligereVilkårResultatTidslinje = forrigeVilkårResultat.tilTidslinje()
@@ -78,8 +73,7 @@ object EndringIVilkårsvurderingUtil {
 
                 nåværende.utdypendeVilkårsvurderinger.toSet() != forrige.utdypendeVilkårsvurderinger.toSet() ||
                     nåværende.vurderesEtter != forrige.vurderesEtter ||
-                    nåværende.periodeFom != forrige.periodeFom ||
-                    (nåværende.periodeTom != forrige.periodeTom && nåværende.periodeTom.førerIkkeTilOpphør(opphørstidspunkt))
+                    nåværende.periodeFom != forrige.periodeFom
             }
 
         return endringIVilkårResultat

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -1003,8 +1003,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(false))
@@ -1050,8 +1049,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1096,8 +1094,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1157,8 +1154,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1204,8 +1200,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(false))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -1102,50 +1102,41 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere true dersom det har oppstått splitt i vilkårsvurderingen`() {
-        val nåværendeVilkårResultat = setOf(
-            VilkårResultat(
-                personResultat = null,
-                vilkårType = Vilkår.BOSATT_I_RIKET,
-                resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
-                periodeTom = LocalDate.of(2020, 1, 1),
-                begrunnelse = "begrunnelse",
-                behandlingId = 0,
-                utdypendeVilkårsvurderinger = listOf(
-                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
-                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP
-                ),
-                vurderesEtter = Regelverk.NASJONALE_REGLER
-            )
-        )
-
         val forrigeVilkårResultat = setOf(
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
-                periodeTom = LocalDate.of(2019, 1, 14),
-                begrunnelse = "begrunnelse",
+                periodeFom = jan22.førsteDagIInneværendeMåned(),
+                periodeTom = null,
+                begrunnelse = "",
                 behandlingId = 0,
-                utdypendeVilkårsvurderinger = listOf(
-                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
-                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP
-                ),
+                utdypendeVilkårsvurderinger = listOf(),
+                vurderesEtter = Regelverk.NASJONALE_REGLER
+            )
+        )
+
+        val nåværendeVilkårResultat = setOf(
+            VilkårResultat(
+                personResultat = null,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = jan22.førsteDagIInneværendeMåned(),
+                periodeTom = mai22.atDay(7),
+                begrunnelse = "",
+                behandlingId = 0,
+                utdypendeVilkårsvurderinger = listOf(),
                 vurderesEtter = Regelverk.NASJONALE_REGLER
             ),
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2019, 1, 15),
-                periodeTom = LocalDate.of(2020, 1, 1),
-                begrunnelse = "begrunnelse",
+                periodeFom = mai22.atDay(8),
+                periodeTom = null,
+                begrunnelse = "",
                 behandlingId = 0,
-                utdypendeVilkårsvurderinger = listOf(
-                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP,
-                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE
-                ),
+                utdypendeVilkårsvurderinger = listOf(),
                 vurderesEtter = Regelverk.NASJONALE_REGLER
             )
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Uendelighet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
@@ -61,16 +62,14 @@ class EndringIVilkårsvurderingUtilTest {
 
         val perioderMedEndring = EndringIVilkårsvurderingUtil.lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør))
         ).perioder().filter { it.innhold == true }
 
         Assertions.assertTrue(perioderMedEndring.isEmpty())
 
         val endringstidspunkt = EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør))
         )
 
         Assertions.assertNull(endringstidspunkt)
@@ -116,8 +115,7 @@ class EndringIVilkårsvurderingUtilTest {
 
         val perioderMedEndring = EndringIVilkårsvurderingUtil.lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         ).perioder().filter { it.innhold == true }
 
         Assertions.assertEquals(1, perioderMedEndring.size)
@@ -126,8 +124,7 @@ class EndringIVilkårsvurderingUtilTest {
 
         val endringstidspunkt = EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
         Assertions.assertEquals(jan22, endringstidspunkt)
@@ -135,49 +132,42 @@ class EndringIVilkårsvurderingUtilTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere periode med endring dersom det har oppstått splitt i vilkårsvurderingen`() {
-        val nåværendeVilkårResultat = setOf(
-            VilkårResultat(
-                personResultat = null,
-                vilkårType = Vilkår.BOSATT_I_RIKET,
-                resultat = Resultat.OPPFYLT,
-                periodeFom = jan22.førsteDagIInneværendeMåned(),
-                periodeTom = mai22.sisteDagIInneværendeMåned(),
-                begrunnelse = "begrunnelse",
-                behandlingId = 0,
-                utdypendeVilkårsvurderinger = listOf(
-                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
-                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP
-                ),
-                vurderesEtter = Regelverk.NASJONALE_REGLER
-            )
-        )
-
         val forrigeVilkårResultat = setOf(
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
                 periodeFom = jan22.førsteDagIInneværendeMåned(),
-                periodeTom = feb22.atDay(14),
-                begrunnelse = "begrunnelse",
+                periodeTom = null,
+                begrunnelse = "",
                 behandlingId = 0,
-                utdypendeVilkårsvurderinger = listOf(
-                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
-                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP
-                ),
+                utdypendeVilkårsvurderinger = listOf(),
+                vurderesEtter = Regelverk.NASJONALE_REGLER
+            )
+        )
+
+        val nåværendeVilkårResultat = setOf(
+            VilkårResultat(
+                personResultat = null,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = jan22.førsteDagIInneværendeMåned(),
+                periodeTom = mai22.atDay(7),
+                begrunnelse = "",
+                behandlingId = 0,
+                utdypendeVilkårsvurderinger = listOf(),
                 vurderesEtter = Regelverk.NASJONALE_REGLER
             ),
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = feb22.atDay(15),
-                periodeTom = mai22.sisteDagIInneværendeMåned(),
+                periodeFom = mai22.atDay(8),
+                periodeTom = null,
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
                 utdypendeVilkårsvurderinger = listOf(
-                    UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP,
-                    UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE
+                    UtdypendeVilkårsvurdering.VURDERING_ANNET_GRUNNLAG
                 ),
                 vurderesEtter = Regelverk.NASJONALE_REGLER
             )
@@ -187,21 +177,19 @@ class EndringIVilkårsvurderingUtilTest {
 
         val perioderMedEndring = EndringIVilkårsvurderingUtil.lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         ).perioder().filter { it.innhold == true }
 
         Assertions.assertEquals(1, perioderMedEndring.size)
-        Assertions.assertEquals(feb22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        Assertions.assertEquals(mai22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        Assertions.assertEquals(mai22, perioderMedEndring.single().fraOgMed.tilYearMonth())
+        Assertions.assertEquals(Uendelighet.FREMTID, perioderMedEndring.single().tilOgMed.uendelighet)
 
         val endringstidspunkt = EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
-        Assertions.assertEquals(feb22, endringstidspunkt)
+        Assertions.assertEquals(mai22, endringstidspunkt)
     }
 
     @Test
@@ -244,16 +232,14 @@ class EndringIVilkårsvurderingUtilTest {
 
         val perioderMedEndring = EndringIVilkårsvurderingUtil.lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         ).perioder().filter { it.innhold == true }
 
         Assertions.assertTrue(perioderMedEndring.isEmpty())
 
         val endringstidspunkt = EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
-            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
-            opphørstidspunkt = YearMonth.of(2020, 2)
+            forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør))
         )
 
         Assertions.assertNull(endringstidspunkt)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
@@ -164,11 +164,9 @@ class EndringIVilkårsvurderingUtilTest {
                 resultat = Resultat.OPPFYLT,
                 periodeFom = mai22.atDay(8),
                 periodeTom = null,
-                begrunnelse = "begrunnelse",
+                begrunnelse = "",
                 behandlingId = 0,
-                utdypendeVilkårsvurderinger = listOf(
-                    UtdypendeVilkårsvurdering.VURDERING_ANNET_GRUNNLAG
-                ),
+                utdypendeVilkårsvurderinger = listOf(),
                 vurderesEtter = Regelverk.NASJONALE_REGLER
             )
         )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Observasjon fra test:
- Forrige behandling: bosatt i riket oppfylt fra 1987 til uendelig
- Nåværende behandling: bosatt i riket oppfylt fra 1987 til november 2022, og fra november 2022 til uendelig
![image](https://user-images.githubusercontent.com/25459913/221204752-b9a921bf-6a37-4611-acad-bb285b677ef0.png)

Forventer da å få endringstidspunkt = november (eller skal det være desember??). Men ender opp med å få 1987. Dette er fordi man sammenlignet både fom og tom for å reflektere splitter i vilkårsvurderingen.

Det skal bli samme resultat om vi i stedet sammenligner kun på stønadFom. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
