### PR TITLE
Forbedre feilmelding ved ingen søknadsresultat ved utledning av behandlingsresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -129,7 +129,7 @@ object BehandlingsresultatSøknadUtils {
         val resultaterUtenIngenEndringer = this.filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
         return when {
-            this.isEmpty() -> throw Feil(frontendFeilmelding = "Du har opprettet en behandling som følge av søknad, men har enten ikke krysset av på noen barn det er søkt for eller avslått/innvilget noen perioder.", message = "Klarer ikke utlede søknadsresultat. Finner ingen resultater.")
+            this.isEmpty() -> throw Feil(frontendFeilmelding = "Du har opprettet en behandling som følge av søknad, men har enten ikke krysset av for noen barn det er søkt for eller avslått/innvilget noen perioder.", message = "Klarer ikke utlede søknadsresultat. Finner ingen resultater.")
             this.size == 1 -> this.single()
             resultaterUtenIngenEndringer.size == 1 -> resultaterUtenIngenEndringer.single()
             resultaterUtenIngenEndringer.size == 2 && resultaterUtenIngenEndringer.containsAll(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -129,7 +129,7 @@ object BehandlingsresultatSøknadUtils {
         val resultaterUtenIngenEndringer = this.filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
         return when {
-            this.isEmpty() -> throw Feil(frontendFeilmelding = "Du har opprettet en behandling som følge av søknad, men har ikke avslått eller innvilget noen perioder.", message = "Klarer ikke utlede søknadsresultat. Finner ingen resultater.")
+            this.isEmpty() -> throw Feil(frontendFeilmelding = "Du har opprettet en behandling som følge av søknad, men har enten ikke krysset av på noen barn det er søkt for eller avslått/innvilget noen perioder.", message = "Klarer ikke utlede søknadsresultat. Finner ingen resultater.")
             this.size == 1 -> this.single()
             resultaterUtenIngenEndringer.size == 1 -> resultaterUtenIngenEndringer.single()
             resultaterUtenIngenEndringer.size == 2 && resultaterUtenIngenEndringer.containsAll(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Forbedrer feilmeldingen. Man kan havne i den tilstanden også hvis man ikke har krysset av for noen barn, så legger til det i feilmeldingen.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Kan også vurdere å sende inn listen med personer fremstilt krav for, og heller lage to forskjellige feilmeldinger avhengig av om listen med personer fremstilt krav for er tom. Hva tenker du/dere?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Kun feilmeldingstekst

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
