### PR TITLE
Gjør det mulig å kjøre satsendring selv om det løper over 100% utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
@@ -95,7 +95,7 @@ class AutovedtakSatsendringService(
         }
 
         if (harUtbetalingerSomOverstiger100Prosent(sisteIverksatteBehandling)) {
-            logger.warn("Det løper over 100% utbetaling på fagsak=${sisteIverksatteBehandling.fagsak.id}")
+            logger.warn("Det løper over 100 prosent utbetaling på fagsak=${sisteIverksatteBehandling.fagsak.id}")
         }
 
         val behandlingEtterBehandlingsresultat =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
@@ -95,9 +95,7 @@ class AutovedtakSatsendringService(
         }
 
         if (harUtbetalingerSomOverstiger100Prosent(sisteIverksatteBehandling)) {
-            satskjøringForFagsak.feiltype = "UTBETALING_OVER_100_PROSENT"
-            satskjøringRepository.save(satskjøringForFagsak)
-            return SatsendringSvar.FANT_OVER_100_PROSENT_UTBETALING
+            logger.warn("Det løper over 100% utbetaling på fagsak=${sisteIverksatteBehandling.fagsak.id}")
         }
 
         val behandlingEtterBehandlingsresultat =
@@ -243,7 +241,6 @@ class AutovedtakSatsendringService(
 }
 
 enum class SatsendringSvar(val melding: String) {
-    FANT_OVER_100_PROSENT_UTBETALING(melding = "Fant utbetaling over 100 prosent på barna"),
     SATSENDRING_KJØRT_OK(melding = "Satsendring kjørt OK"),
     SATSENDRING_ER_ALLEREDE_UTFØRT(melding = "Satsendring allerede utført for fagsak"),
     HAR_ALLEREDE_SISTE_SATS(melding = "Åpen behandling har allerede siste sats og vi lar den ligge."),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringController.kt
@@ -43,13 +43,13 @@ class SatsendringController(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER
         )
 
-        startSatsendring.opprettSatsendringSynkrontVedGammelSats(fagsakId)
+        startSatsendring.gjennomførSatsendringManuelt(fagsakId)
         return ResponseEntity.ok(Ressurs.success(Unit))
     }
 
     @GetMapping(path = ["/{fagsakId}/kan-kjore-satsendring"])
     fun kanKjøreSatsendringPåFagsak(@PathVariable fagsakId: Long): ResponseEntity<Ressurs<Boolean>> {
-        return ResponseEntity.ok(Ressurs.success(startSatsendring.kanStarteSatsendringPåFagsak(fagsakId)))
+        return ResponseEntity.ok(Ressurs.success(startSatsendring.kanGjennomføreSatsendringManuelt(fagsakId)))
     }
 
     @PostMapping(path = ["/kjorsatsendringForListeMedIdenter"])

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -175,8 +175,6 @@ class StartSatsendring(
     fun kanGjennomføreSatsendringManuelt(fagsakId: Long): Boolean {
         val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
 
-
-
         return sisteIverksatteBehandling != null && !autovedtakSatsendringService.harAlleredeNySats(
             sisteIverksettBehandlingsId = sisteIverksatteBehandling.id,
             satstidspunkt = SATSENDRINGMÅNED_2023

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -22,7 +22,7 @@ class TilkjentYtelseValideringService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService
 ) {
     fun validerAtIngenUtbetalingerOverstiger100Prosent(behandling: Behandling) {
-        if (behandling.erMigrering() || behandling.erTekniskEndring()) return
+        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring()) return
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(behandling.id)
 
         if (totrinnskontroll?.godkjent == true) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -526,7 +526,7 @@ internal class StartSatsendringTest {
         every { startSatsendring.kanStarteSatsendringPåFagsak(any()) } returns false
 
         assertThrows<Exception> {
-            startSatsendring.opprettSatsendringSynkrontVedGammelSats(0L)
+            startSatsendring.gjennomførSatsendringManuelt(0L)
         }
     }
 
@@ -541,11 +541,11 @@ internal class StartSatsendringTest {
 
             when (it) {
                 SatsendringSvar.SATSENDRING_KJØRT_OK -> assertDoesNotThrow {
-                    startSatsendring.opprettSatsendringSynkrontVedGammelSats(0L)
+                    startSatsendring.gjennomførSatsendringManuelt(0L)
                 }
 
                 else -> assertThrows<Exception> {
-                    startSatsendring.opprettSatsendringSynkrontVedGammelSats(0L)
+                    startSatsendring.gjennomførSatsendringManuelt(0L)
                 }
             }
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -522,6 +522,31 @@ internal class StartSatsendringTest {
     }
 
     @Test
+    fun `kanGjennomføreSatsendringManuelt gir false når vi ikke har noen tidligere behandling`() {
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns null
+
+        assertFalse(startSatsendring.kanGjennomføreSatsendringManuelt(1L))
+    }
+
+    @Test
+    fun `kanGjennomføreSatsendringManuelt gir false når harSisteSats er true`() {
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
+        every { satskjøringRepository.findByFagsakId(1L) } returns null
+        every { autovedtakSatsendringService.harAlleredeNySats(any(), any()) } returns true
+
+        assertFalse(startSatsendring.kanGjennomføreSatsendringManuelt(1L))
+    }
+
+    @Test
+    fun `kanGjennomføreSatsendringManuelt gir true når harSisteSats er false`() {
+        every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
+        every { satskjøringRepository.findByFagsakId(1L) } returns null
+        every { autovedtakSatsendringService.harAlleredeNySats(any(), any()) } returns false
+
+        assertTrue(startSatsendring.kanGjennomføreSatsendringManuelt(1L))
+    }
+
+    @Test
     fun `opprettSatsendringSynkrontVedGammelSats skal kaste dersom man ikke kan starte satsendring`() {
         every { startSatsendring.kanStarteSatsendringPåFagsak(any()) } returns false
 
@@ -532,7 +557,7 @@ internal class StartSatsendringTest {
 
     @Test
     fun `opprettSatsendringSynkrontVedGammelSats skal kaste feil for alle andre resultater enn OK`() {
-        every { startSatsendring.kanStarteSatsendringPåFagsak(any()) } returns true
+        every { startSatsendring.kanGjennomføreSatsendringManuelt(any()) } returns true
 
         val satsendringSvar = SatsendringSvar.values()
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Slacktråd: https://nav-it.slack.com/archives/GU4MVCGCD/p1677245395624259
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11757

#### Hvorfor:
Vi har et case der tilkjent ytelse i en behandling ikke er lik beløpet vi har sendt til økonomi. Det er fordi vi aldri iverksetter mot økonomi ved endre migreringbehandlinger, men enkelte endre migreringbehandlinger har endret på tilkjent ytelse, blant annet ved satsendring og dødsfall. 

Får å unngå dette stopper vi saksbehandlerene fra å gjøre en “endre migreringsdato”-behandling dersom siste behandling ikke er oppdatert med siste sats.

Det skaper problemer i de sakene der det løper over 100% utbetaling fordi vi må endre migreringsdato for å løse dem, men vi får ikke endret migreringsdato fordi da må vi gjøre satsendring og satsendring krever at vi ikke har ikke har over 100% utbetaling. Vi har altså en vranglås der endre migreringsdato krever satsendring som krever <100% utbetaling som krever endre migreringsdato.

#### Faktisk endring:
Gjør det mulig å kjøre satsendring selv om det løper over 100% utbetaling. Logger i stedet ut at det løper over 100% utbetaling  

Gjør det mulig å kjøre satsendring manuelt selv om fagsaken er i listen over kjørte satsendringer dersom fagsaken ikke har siste sats. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

## ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
