### PR TITLE
Må opprette satskjøring rad ved manuell start av satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -187,6 +187,7 @@ class StartSatsendring(
             throw Feil("Kan ikke starte Satsendring på fagsak=$fagsakId")
         }
 
+        satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
         val resultatSatsendringBehandling = autovedtakSatsendringService.kjørBehandling(
             SatsendringTaskDto(
                 fagsakId = fagsakId,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Trigging av satskjøring manuelt må også opprette en rad i satskjøring. Denne ble fjernet i forrige endring i manuell satsendring
