### PR TITLE
Legger til valg av eøs avslags tekst for uregistrerte barn dersom kategori er EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlagMedPersoner.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevBegrunnelseGrunnlagMedPersoner.kt
@@ -3,9 +3,9 @@ package no.nav.familie.ba.sak.kjerne.brev.domene
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.MinimertUregistrertBarn
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.erAvslagUregistrerteBarnBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
 import java.time.LocalDate
 
@@ -21,8 +21,7 @@ data class BrevBegrunnelseGrunnlagMedPersoner(
         gjelderSøker: Boolean,
         barnasFødselsdatoer: List<LocalDate>
     ): Int {
-        val erAvslagUregistrerteBarn =
-            this.standardbegrunnelse == Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN
+        val erAvslagUregistrerteBarn = standardbegrunnelse.erAvslagUregistrerteBarnBegrunnelse()
 
         return when {
             erAvslagUregistrerteBarn -> uregistrerteBarn.size
@@ -38,8 +37,7 @@ data class BrevBegrunnelseGrunnlagMedPersoner(
         personerPåBegrunnelse: List<MinimertRestPerson>,
         personerMedUtbetaling: List<MinimertRestPerson>
     ) = when {
-        this.standardbegrunnelse == Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN ->
-            uregistrerteBarn.mapNotNull { it.fødselsdato }
+        this.standardbegrunnelse.erAvslagUregistrerteBarnBegrunnelse() -> uregistrerteBarn.mapNotNull { it.fødselsdato }
 
         gjelderSøker && this.vedtakBegrunnelseType != VedtakBegrunnelseType.ENDRET_UTBETALING && this.vedtakBegrunnelseType != VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING -> {
             if (this.vedtakBegrunnelseType == VedtakBegrunnelseType.AVSLAG) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -276,6 +276,10 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_AVSLAG
         override val sanityApiNavn = "avslagEosVurderingIkkeAnsvarForBarn"
     },
+    AVSLAG_EØS_UREGISTRERT_BARN {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_AVSLAG
+        override val sanityApiNavn = "avslagEosUregistrertBarn"
+    },
     FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD {
         override val sanityApiNavn = "fortsattInnvilgetPrimaerlandStandard"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_FORTSATT_INNVILGET

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/IVedtakBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/IVedtakBegrunnelse.kt
@@ -39,6 +39,8 @@ interface IVedtakBegrunnelse {
     }
 }
 
+fun IVedtakBegrunnelse.erAvslagUregistrerteBarnBegrunnelse() = this in setOf(Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN, EØSStandardbegrunnelse.AVSLAG_EØS_UREGISTRERT_BARN)
+
 class IVedtakBegrunnelseDeserializer : StdDeserializer<List<IVedtakBegrunnelse>>(List::class.java) {
     override fun deserialize(jsonParser: JsonParser?, p1: DeserializationContext?): List<IVedtakBegrunnelse> {
         val node: ArrayNode = jsonParser!!.codec.readTree(jsonParser)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.erAvslagUregistrerteBarnBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.hentMånedOgÅrForBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.tilBrevTekst
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestVedtaksbegrunnelse
@@ -294,8 +295,7 @@ private fun BrevBegrunnelseGrunnlagMedPersoner.validerBrevbegrunnelse(
     barnasFødselsdatoer: List<LocalDate>
 ) {
     if (!gjelderSøker && barnasFødselsdatoer.isEmpty() &&
-        !this.triggesAv.satsendring &&
-        this.standardbegrunnelse != Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN
+        !this.triggesAv.satsendring && !this.standardbegrunnelse.erAvslagUregistrerteBarnBegrunnelse()
     ) {
         throw IllegalStateException("Ingen personer på brevbegrunnelse")
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -672,12 +672,20 @@ class VedtaksperiodeService(
         return avslagsperioderMedTomPeriode.map {
             if (it.fom == null && it.tom == null && uregistrerteBarn.isNotEmpty()) {
                 it.apply {
-                    begrunnelser.add(
-                        Vedtaksbegrunnelse(
-                            vedtaksperiodeMedBegrunnelser = this,
-                            standardbegrunnelse = Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN
+                    when (vedtak.behandling.kategori) {
+                        BehandlingKategori.NASJONAL -> begrunnelser.add(
+                            Vedtaksbegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = this,
+                                standardbegrunnelse = Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN
+                            )
                         )
-                    )
+                        BehandlingKategori.EØS -> eøsBegrunnelser.add(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = this,
+                                begrunnelse = EØSStandardbegrunnelse.AVSLAG_EØS_UREGISTRERT_BARN
+                            )
+                        )
+                    }
                 }
             } else {
                 it

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -659,7 +659,8 @@ fun kjørStegprosessForFGB(
     behandlingUnderkategori: BehandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
     institusjon: InstitusjonInfo? = null,
     verge: VergeInfo? = null,
-    brevmalService: BrevmalService
+    brevmalService: BrevmalService,
+    behandlingKategori: BehandlingKategori = BehandlingKategori.NASJONAL
 ): Behandling {
     val fagsakType = utledFagsaktype(institusjon, verge)
     val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(
@@ -669,7 +670,7 @@ fun kjørStegprosessForFGB(
     )
     val behandling = stegService.håndterNyBehandling(
         NyBehandling(
-            kategori = BehandlingKategori.NASJONAL,
+            kategori = behandlingKategori,
             underkategori = behandlingUnderkategori,
             behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
             behandlingÅrsak = BehandlingÅrsak.SØKNAD,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11745
Når et barn er lagt til med kun fødselsdato i registrer søknad steget, og det er sendt innhentingsbrev til bruker, går dette barnet direkte til avslag. 

I dag er det kun lagt til begrunnelsestekst for dette som er tilpasset behandlingstema nasjonal ordinær/utvidet.
Det er nå lagt til en egen tekst som er tilpasset EØS saker som brukes dersom kategori er EØS.

Se bilder:

Tekst som brukes ved nasjonale saker:
![nasjonal](https://user-images.githubusercontent.com/110383605/221578719-7d1992cc-932b-4590-aa20-5038f82a8edc.png)


Tekst som brukes ved eøs saker:
![eøs](https://user-images.githubusercontent.com/110383605/221578732-228c742d-7a98-453c-a79c-f85c573aad3b.png)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇