### PR TITLE
Satsendring oppretter satskjøringrad hvis den ikke eksisterer, eller gjenbruker eksisterendee

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -60,8 +61,10 @@ class AutovedtakSatsendringService(
     @Transactional
     fun kjørBehandling(behandlingsdata: SatsendringTaskDto): SatsendringSvar {
         val fagsakId = behandlingsdata.fagsakId
+
         val satskjøringForFagsak =
-            satskjøringRepository.findByFagsakId(fagsakId) ?: error("Fant ingen satskjøringsrad for fagsak=$fagsakId")
+            satskjøringRepository.findByFagsakId(fagsakId)
+                ?: satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
 
         val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId = fagsakId)
             ?: error("Fant ikke siste iverksette behandling for $fagsakId")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -187,7 +187,6 @@ class StartSatsendring(
             throw Feil("Kan ikke starte Satsendring på fagsak=$fagsakId")
         }
 
-        satskjøringRepository.save(Satskjøring(fagsakId = fagsakId))
         val resultatSatsendringBehandling = autovedtakSatsendringService.kjørBehandling(
             SatsendringTaskDto(
                 fagsakId = fagsakId,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Satsendring oppretter satskjøringrad hvis den ikke eksisterer, eller gjenbruker eksisterende satskjøring rad
Dette for å tillate rekjøring av satsendring for manuell rute selv om det alt eksisterer en rad

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
