### PR TITLE
Ikke valider at det ikke er endring på avsluttede behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -158,6 +158,8 @@ class BehandlingsresultatSteg(
     }
 
     fun validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling: Behandling) {
+        if (behandling.status == BehandlingStatus.AVSLUTTET) return
+
         val endringIUtbetalingTidslinje =
             beregningService.hentEndringerIUtbetalingMellomNåværendeOgForrigeBehandlingTidslinje(behandling)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Jeg visste ikke at vi kjørte BehandlingsresultatSteg.preValiderSteg() på avsluttede behandlinger 🤯 

Det er ingen vits i å validere at endrede migreringsbehanldinger ikke har noen endringer på behandlinger som er avsluttet. De kommer til å ha feil uansett. 
