### PR TITLE
Fiks sammenligning mellom oppdrag og tilkjent ytelse og delay taskene med 60 sekunder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingService.kt
@@ -17,7 +17,6 @@ import no.nav.familie.log.IdUtils
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class InternKonsistensavstemmingService(
@@ -27,7 +26,6 @@ class InternKonsistensavstemmingService(
     val fagsakRepository: FagsakRepository,
     val taskService: TaskService
 ) {
-    @Transactional
     fun validerLikUtbetalingIAndeleneOgUtbetalingsoppdragetPåAlleFagsaker(maksAntallTasker: Int = Int.MAX_VALUE) {
         fagsakRepository.hentFagsakerSomIkkeErArkivert()
             .map { it.id }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingService.kt
@@ -27,12 +27,14 @@ class InternKonsistensavstemmingService(
     val taskService: TaskService
 ) {
     fun validerLikUtbetalingIAndeleneOgUtbetalingsoppdragetPåAlleFagsaker(maksAntallTasker: Int = Int.MAX_VALUE) {
-        val fagsakerSomIkkeErArkivert = fagsakRepository.hentFagsakerSomIkkeErArkivert()
+        val fagsakerSomIkkeErArkivert = fagsakRepository
+            .hentFagsakerSomIkkeErArkivert()
+            .map { it.id }
+            .sortedBy { it }
+
         val startTid = LocalDateTime.now()
 
         fagsakerSomIkkeErArkivert
-            .map { it.id }
-            .sortedBy { it }
             // Antall fagsaker per task burde være en multippel av 3000 siden vi chunker databasekallet i 3000 i familie-oppdrag
             .chunked(3000)
             .take(maksAntallTasker)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
@@ -55,7 +55,9 @@ private fun hentForskjellIAndelerOgUtbetalingsoppdrag(
 
     return if (perioderMedForskjell.isEmpty()) {
         INGEN_FORSKJELL
-    } else OPPDRAGSPERIODER_UTEN_TILSVARENDE_ANDEL(perioderMedForskjell)
+    } else {
+        OPPDRAGSPERIODER_UTEN_TILSVARENDE_ANDEL(perioderMedForskjell)
+    }
 }
 
 private fun List<Utbetalingsperiode>.tilBeløpstidslinje(): Tidslinje<BigDecimal, Måned> = tidslinje {
@@ -87,4 +89,3 @@ private data class OPPDRAGSPERIODER_UTEN_TILSVARENDE_ANDEL(val perioderMedForskj
     AndelOgOppdragForskjell
 
 private object INGEN_FORSKJELL : AndelOgOppdragForskjell
-

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
@@ -39,7 +39,7 @@ fun erForskjellMellomAndelerOgOppdrag(
         is INGEN_FORSKJELL -> Unit
     }
 
-    return forskjellMellomAndeleneOgUtbetalingsoppdraget is INGEN_FORSKJELL
+    return forskjellMellomAndeleneOgUtbetalingsoppdraget !is INGEN_FORSKJELL
 }
 
 private fun hentForskjellIAndelerOgUtbetalingsoppdrag(

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
@@ -30,7 +30,7 @@ fun erForskjellMellomAndelerOgOppdrag(
     when (forskjellMellomAndeleneOgUtbetalingsoppdraget) {
         is UTBETALINGSPERIODER_UTEN_TILSVARENDE_ANDEL -> secureLogger.info(
             "Fagsak $fagsakId har sendt utbetalingsperiode(r) til økonomi som ikke har tilsvarende andel tilkjent ytelse." +
-                "\nDet er differanse i periodene ${forskjellMellomAndeleneOgUtbetalingsoppdraget.utbetalingsperioder.tilTidStrenger()}." +
+                "\nDet er differanse i perioden(e) ${forskjellMellomAndeleneOgUtbetalingsoppdraget.utbetalingsperioder.tilTidStrenger()}." +
                 "\n\nSiste utbetalingsoppdrag som er sendt til familie-øknonomi på fagsaken er:" +
                 "\n$utbetalingsoppdrag"
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
@@ -21,8 +21,8 @@ fun erForskjellMellomAndelerOgOppdrag(
     when (forskjellMellomAndeleneOgUtbetalingsoppdraget) {
         AndelOgOppdragForskjell.OPPDRAGSPERIODE_UTEN_TILSVARENDE_ANDEL -> secureLogger.info(
             "Fagsak $fagsakId har sendt utbetalingsperiode(r) til økonomi som ikke har tilsvarende andel tilkjent ytelse" +
-                "Siste utbetalingsoppdrag som er sendt til familie-øknonomi på fagsaken er:" +
-                "\n\n $utbetalingsoppdrag"
+                "\n\nSiste utbetalingsoppdrag som er sendt til familie-øknonomi på fagsaken er:" +
+                "\n $utbetalingsoppdrag"
         )
         AndelOgOppdragForskjell.INGEN_FORSKJELL -> Unit
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
@@ -1,57 +1,90 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.InternKonsistendsavstemming
 
+import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.secureLogger
-import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilMånedTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import java.math.BigDecimal
 
 fun erForskjellMellomAndelerOgOppdrag(
     andeler: List<AndelTilkjentYtelse>,
     utbetalingsoppdrag: Utbetalingsoppdrag?,
     fagsakId: Long
 ): Boolean {
-    val oppdragsperioder =
+    val utbetalingsperioder =
         utbetalingsoppdrag?.utbetalingsperiode
             ?.filter { it.opphør == null }
             ?: emptyList()
 
-    val forskjellMellomAndeleneOgUtbetalingsoppdraget: AndelOgOppdragForskjell = hentForskjellIAndelerOgUtbetalingsoppdrag(oppdragsperioder, andeler)
+    val forskjellMellomAndeleneOgUtbetalingsoppdraget =
+        hentForskjellIAndelerOgUtbetalingsoppdrag(utbetalingsperioder, andeler)
 
     when (forskjellMellomAndeleneOgUtbetalingsoppdraget) {
-        AndelOgOppdragForskjell.OPPDRAGSPERIODE_UTEN_TILSVARENDE_ANDEL -> secureLogger.info(
-            "Fagsak $fagsakId har sendt utbetalingsperiode(r) til økonomi som ikke har tilsvarende andel tilkjent ytelse" +
+        is OPPDRAGSPERIODER_UTEN_TILSVARENDE_ANDEL -> secureLogger.info(
+            "Fagsak $fagsakId har sendt utbetalingsperiode(r) til økonomi som ikke har tilsvarende andel tilkjent ytelse." +
+                "\nDet er differanse i periodene ${forskjellMellomAndeleneOgUtbetalingsoppdraget.perioderMedForskjell.tilTidStrenger()}." +
                 "\n\nSiste utbetalingsoppdrag som er sendt til familie-øknonomi på fagsaken er:" +
-                "\n $utbetalingsoppdrag"
+                "\n$utbetalingsoppdrag"
         )
-        AndelOgOppdragForskjell.INGEN_FORSKJELL -> Unit
+
+        is INGEN_FORSKJELL -> Unit
     }
 
-    return forskjellMellomAndeleneOgUtbetalingsoppdraget != AndelOgOppdragForskjell.INGEN_FORSKJELL
+    return forskjellMellomAndeleneOgUtbetalingsoppdraget is INGEN_FORSKJELL
 }
 
 private fun hentForskjellIAndelerOgUtbetalingsoppdrag(
-    oppdragsperioder: List<Utbetalingsperiode>,
+    utbetalingsperioder: List<Utbetalingsperiode>,
     andeler: List<AndelTilkjentYtelse>
-) = when {
-    erOppdragsperiodeUtenTilsvarendeAndel(oppdragsperioder, andeler) ->
-        AndelOgOppdragForskjell.OPPDRAGSPERIODE_UTEN_TILSVARENDE_ANDEL
+): AndelOgOppdragForskjell {
+    val erBeløpLiktTidslinje = utbetalingsperioder.tilBeløpstidslinje()
+        .kombinerMed(andeler.tilBeløpstidslinje()) { utbetaling, andel ->
+            utbetaling == andel
+        }
 
-    else -> AndelOgOppdragForskjell.INGEN_FORSKJELL
+    val perioderMedForskjell = erBeløpLiktTidslinje.perioder().filter { it.innhold == false }
+
+    return if (perioderMedForskjell.isEmpty()) {
+        INGEN_FORSKJELL
+    } else OPPDRAGSPERIODER_UTEN_TILSVARENDE_ANDEL(perioderMedForskjell)
 }
 
-private fun erOppdragsperiodeUtenTilsvarendeAndel(
-    oppdragsperioder: List<Utbetalingsperiode>,
-    andeler: List<AndelTilkjentYtelse>
-) = !oppdragsperioder.all { oppdragsperiode ->
-    andeler.any {
-        it.kalkulertUtbetalingsbeløp.toBigDecimal() == oppdragsperiode.sats &&
-            it.stønadFom == oppdragsperiode.vedtakdatoFom.toYearMonth() &&
-            it.stønadTom == oppdragsperiode.vedtakdatoTom.toYearMonth()
+private fun List<Utbetalingsperiode>.tilBeløpstidslinje(): Tidslinje<BigDecimal, Måned> = tidslinje {
+    this.map {
+        Periode(
+            fraOgMed = it.vedtakdatoFom.tilMånedTidspunkt(),
+            tilOgMed = it.vedtakdatoTom.tilMånedTidspunkt(),
+            innhold = it.sats
+        )
     }
 }
 
-enum class AndelOgOppdragForskjell {
-    OPPDRAGSPERIODE_UTEN_TILSVARENDE_ANDEL,
-    INGEN_FORSKJELL
+private fun List<AndelTilkjentYtelse>.tilBeløpstidslinje(): Tidslinje<BigDecimal, Måned> = tidslinje {
+    this.map {
+        Periode(
+            fraOgMed = it.stønadFom.tilTidspunkt(),
+            tilOgMed = it.stønadTom.tilTidspunkt(),
+            innhold = it.kalkulertUtbetalingsbeløp.toBigDecimal()
+        )
+    }
 }
+
+private fun List<Periode<*, Måned>>.tilTidStrenger() =
+    Utils.slåSammen(this.map { "${it.fraOgMed.tilYearMonth()} - ${it.tilOgMed.tilYearMonth()}" })
+
+private sealed interface AndelOgOppdragForskjell
+
+private data class OPPDRAGSPERIODER_UTEN_TILSVARENDE_ANDEL(val perioderMedForskjell: List<Periode<Boolean, Måned>>) :
+    AndelOgOppdragForskjell
+
+private object INGEN_FORSKJELL : AndelOgOppdragForskjell
+

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/InternKonsistendsavstemming/InternKonsistensavstemmingUtil.kt
@@ -70,6 +70,7 @@ private fun List<Utbetalingsperiode>.tilBeløpstidslinje(): Tidslinje<BigDecimal
     }
 }
 
+@JvmName("atyListeTilBeløpstidslinje")
 private fun List<AndelTilkjentYtelse>.tilBeløpstidslinje(): Tidslinje<BigDecimal, Måned> = tidslinje {
     this.map {
         Periode(

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
@@ -100,8 +100,9 @@ class TestVerktøyController(
     @Unprotected
     fun kjørInternKonsistensavstemming(@PathVariable maksAntallTasker: Int): ResponseEntity<Ressurs<String>> {
         if (!envService.erPreprod() && !envService.erDev()) {
-            internKonsistensavstemmingService
-                .validerLikUtbetalingIAndeleneOgUtbetalingsoppdragetPåAlleFagsaker(maksAntallTasker = 12)
+            internKonsistensavstemmingService.validerLikUtbetalingIAndeleneOgUtbetalingsoppdragetPåAlleFagsaker(
+                maksAntallTasker = minOf(maksAntallTasker, 12)
+            )
 
             return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/InternKonsistensavstemmingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/InternKonsistensavstemmingTask.kt
@@ -12,6 +12,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 import java.util.Properties
 import kotlin.system.measureTimeMillis
 
@@ -19,7 +20,7 @@ import kotlin.system.measureTimeMillis
 @TaskStepBeskrivelse(
     taskStepType = InternKonsistensavstemmingTask.TASK_STEP_TYPE,
     beskrivelse = "Kjør intern konsistensavstemming",
-    maxAntallFeil = 1
+    maxAntallFeil = 3
 )
 class InternKonsistensavstemmingTask(
     val internKonsistensavstemmingService: InternKonsistensavstemmingService
@@ -39,7 +40,7 @@ class InternKonsistensavstemmingTask(
     }
 
     companion object {
-        fun opprettTask(fagsakIder: Set<Long>): Task {
+        fun opprettTask(fagsakIder: Set<Long>, startTid: LocalDateTime): Task {
             val metadata = Properties().apply {
                 this["fagsakerIder"] = "${fagsakIder.min()} til ${fagsakIder.max()}"
                 this[MDCConstants.MDC_CALL_ID] = MDC.get(MDCConstants.MDC_CALL_ID) ?: ""
@@ -48,6 +49,7 @@ class InternKonsistensavstemmingTask(
             return Task(
                 type = this.TASK_STEP_TYPE,
                 payload = objectMapper.writeValueAsString(fagsakIder),
+                triggerTid = startTid,
                 metadataWrapper = PropertiesWrapper(metadata)
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/InternKonsistensavstemmingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/InternKonsistensavstemmingTask.kt
@@ -19,7 +19,7 @@ import kotlin.system.measureTimeMillis
 @TaskStepBeskrivelse(
     taskStepType = InternKonsistensavstemmingTask.TASK_STEP_TYPE,
     beskrivelse = "Kjør intern konsistensavstemming",
-    maxAntallFeil = 3
+    maxAntallFeil = 1
 )
 class InternKonsistensavstemmingTask(
     val internKonsistensavstemmingService: InternKonsistensavstemmingService

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettInternKonsistensavstemmingTaskerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettInternKonsistensavstemmingTaskerTask.kt
@@ -1,0 +1,49 @@
+package no.nav.familie.ba.sak.task.InternKonsistensavstemming
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ba.sak.integrasjoner.økonomi.InternKonsistendsavstemming.InternKonsistensavstemmingService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.log.IdUtils
+import no.nav.familie.log.mdc.MDCConstants
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.PropertiesWrapper
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.MDC
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.Properties
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = OpprettInternKonsistensavstemmingTaskerTask.TASK_STEP_TYPE,
+    beskrivelse = "Start intern konsistensavstemming tasker",
+    maxAntallFeil = 3
+)
+class OpprettInternKonsistensavstemmingTaskerTask(
+    val internKonsistensavstemmingService: InternKonsistensavstemmingService
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val maksAntallTasker: Int = objectMapper.readValue(task.payload)
+        internKonsistensavstemmingService
+            .validerLikUtbetalingIAndeleneOgUtbetalingsoppdragetPåAlleFagsaker(maksAntallTasker)
+    }
+
+    companion object {
+        fun opprettTask(maksAntallTasker: Int = Int.MAX_VALUE): Task {
+            val metadata = Properties().apply {
+                this[MDCConstants.MDC_CALL_ID] = MDC.get(MDCConstants.MDC_CALL_ID) ?: IdUtils.generateId()
+            }
+
+            return Task(
+                type = TASK_STEP_TYPE,
+                payload = maksAntallTasker.toString(),
+                triggerTid = LocalDateTime.now(),
+                metadataWrapper = PropertiesWrapper(metadata)
+            )
+        }
+
+        const val TASK_STEP_TYPE = "startInternKonsistensavstemmingTasker"
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Som en del av denne favrooppgaven: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11936

Taskene kjøres fortere i Ba-sak enn familie oppdrag klarer å ta imot requests, så venter litt mellom hver task slik at vi har litt mer slack. 

Det var også en feil i sammenligningen mellom oppdrag og tilkjent ytelse. I enkelte tilfeller er andelene delt opp i revurderingen uten at det fører til endring i beløp. Da er fom og tom ulik. Vi må derfor se om utbetalingen over tid er lik og ikke om fom + tom + utbetaling er lik. 
