### PR TITLE
Fiks sammenligning av måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -50,7 +50,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                                                      WHERE b.opprettet_tid = silp.opprettet_tid)""",
         nativeQuery = true
     )
-    fun hentTotalUtbetalingForMåned(måned: LocalDateTime): Long
+    fun hentTotalUtbetalingForMåned(måned: YearMonth): Long
 
     /* Denne henter først siste iverksatte behandling på en løpende fagsak.
      * Finner så alle perioder på siste iverksatte behandling

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
@@ -34,9 +34,9 @@ class TeamStatistikkService(
         if (!erLeader()) return
 
         val månederMedTotalUtbetaling =
-            listOf<LocalDateTime>(
-                LocalDateTime.now(),
-                LocalDateTime.now().plusMonths(1)
+            listOf<YearMonth>(
+                YearMonth.now(),
+                YearMonth.now().plusMonths(1)
             ).associateWith {
                 behandlingRepository.hentTotalUtbetalingForMåned(it)
             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11477)

aty.stonad_tom lagres som YearMonth. I databasen oversettes dette til en timestamp på første dato i måneden. Om til og med måneden er mars 2023 lagres det som 2023-03-01 i databasen. 

Vi må derfor se på første dato i måneden når vi prøver å finne hvilke andeler som løper til en måned. 

![image](https://user-images.githubusercontent.com/17828446/225287008-cf3c6c54-b7bb-4713-bc3d-8d9c9db85145.png)

Databasespørringen:
![image](https://user-images.githubusercontent.com/17828446/225286773-9de15685-41cc-4d5c-99c2-e185d7b1d7a1.png)

 Dersom datoen er 2. mars vil vi ikke få med andelene som slutter i mars siden `2023-03-02>2023-03-01`. Det så derfor ut som vi utbetalte 0 krones i mars, siden alle andeler ble avsluttet den måneden på grunn av satsendring.
 
![image](https://user-images.githubusercontent.com/17828446/225288741-610b7d8e-4642-426d-8a23-70ae4bcf23a7.png)

