### PR TITLE
Nedskalering etter satsendring

### DIFF
--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -98,8 +98,8 @@ spec:
       external:
         - host: xsrv1mh6.api.sanity.io
   replicas:
-    min: 3
-    max: 5
+    min: 2
+    max: 4
     cpuThresholdPercentage: 50
   resources:
     limits:

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service
 @Service
 class AutovedtakSatsendringScheduler(private val startSatsendring: StartSatsendring) {
 
-    @Scheduled(cron = CRON_HVERT_10_MIN_ARBEIDSTID_UKEDAG)
+    @Scheduled(cron = CRON_KL_7_OG_14_UKEDAGER)
     fun triggSatsendring() {
         if (LeaderClient.isLeader() == true) {
             logger.info("Satsendring trigges av schedulert jobb")
@@ -21,6 +21,6 @@ class AutovedtakSatsendringScheduler(private val startSatsendring: StartSatsendr
 
     companion object {
         val logger = LoggerFactory.getLogger(AutovedtakSatsendringScheduler::class.java)
-        const val CRON_HVERT_10_MIN_ARBEIDSTID_UKEDAG = "0 */10 6-19 * * MON-FRI"
+        const val CRON_KL_7_OG_14_UKEDAGER = "0 0 7,14 * * MON-FRI"
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Hoveddelen av satsendring er ferdig, og man trenger ikke å kjøre like ofte og med like mye ressurser

- Kjør scheduler kun 2 ganger om dagen
- Reduser antall podder til før satsendring