### PR TITLE
sende med manuelleBrevmottakere ved tilbakekreving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>1.20230207133526_5430e48</prosessering.version>
         <felles.version>1.20230116145510_2afcc20</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20230314075921_27fa962-JAKARTA</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20230313155154_f9438bd</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20230223155122_2e81c44</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>1.20230207133526_5430e48</prosessering.version>
         <felles.version>1.20230116145510_2afcc20</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>2.0_20230223121809_a777026</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20230314075921_27fa962-JAKARTA</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20230223155122_2e81c44</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
@@ -54,13 +54,13 @@ class TilbakekrevingService(
     private val personidentService: PersonidentService,
     private val personopplysningerService: PersonopplysningerService,
     private val featureToggleService: FeatureToggleService,
-    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService
 ) {
 
     fun validerRestTilbakekreving(restTilbakekreving: RestTilbakekreving?, behandlingId: Long) {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
-            handling = "opprette tilbakekreving",
+            handling = "opprette tilbakekreving"
         )
 
         val feilutbetaling = simuleringService.hentFeilutbetaling(behandlingId)
@@ -77,7 +77,7 @@ class TilbakekrevingService(
             valg = restTilbakekreving.valg,
             varsel = restTilbakekreving.varsel,
             tilbakekrevingsbehandlingId = tilbakekrevingRepository
-                .findByBehandlingId(behandling.id)?.tilbakekrevingsbehandlingId,
+                .findByBehandlingId(behandling.id)?.tilbakekrevingsbehandlingId
         )
 
         tilbakekrevingRepository.deleteByBehandlingId(behandlingId)
@@ -93,17 +93,17 @@ class TilbakekrevingService(
 
     fun hentForhåndsvisningVarselbrev(
         behandlingId: Long,
-        forhåndsvisTilbakekrevingsvarselbrevRequest: ForhåndsvisTilbakekrevingsvarselbrevRequest,
+        forhåndsvisTilbakekrevingsvarselbrevRequest: ForhåndsvisTilbakekrevingsvarselbrevRequest
     ): ByteArray {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.VEILEDER,
-            handling = "hent forhåndsvisning av varselbrev for tilbakekreving",
+            handling = "hent forhåndsvisning av varselbrev for tilbakekreving"
         )
 
         val vedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandlingId)
             ?: throw Feil(
                 "Fant ikke vedtak for behandling $behandlingId ved forhåndsvisning av varselbrev" +
-                    " for tilbakekreving.",
+                    " for tilbakekreving."
             )
 
         val persongrunnlag = persongrunnlagService.hentAktivThrows(behandlingId)
@@ -122,16 +122,16 @@ class TilbakekrevingService(
                     sumFeilutbetaling = simuleringService.hentFeilutbetaling(behandlingId).toLong(),
                     perioder = hentTilbakekrevingsperioderISimulering(
                         simuleringService.hentSimuleringPåBehandling(behandlingId),
-                        featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
-                    ),
+                        featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ)
+                    )
                 ),
                 fagsystem = Fagsystem.BA,
                 eksternFagsakId = vedtak.behandling.fagsak.id.toString(),
                 ident = persongrunnlag.søker.aktør.aktivFødselsnummer(),
                 saksbehandlerIdent = SikkerhetContext.hentSaksbehandlerNavn(),
                 verge = verge,
-                institusjon = institusjon,
-            ),
+                institusjon = institusjon
+            )
         )
     }
 
@@ -153,7 +153,7 @@ class TilbakekrevingService(
 
         val revurderingsvedtaksdato = aktivtVedtak.vedtaksdato?.toLocalDate() ?: throw Feil(
             message = "Finner ikke revurderingsvedtaksdato på vedtak ${aktivtVedtak.id} " +
-                "ved iverksetting av tilbakekreving mot familie-tilbake",
+                "ved iverksetting av tilbakekreving mot familie-tilbake"
         )
 
         val tilbakekreving = tilbakekrevingRepository.findByBehandlingId(behandling.id)
@@ -181,8 +181,8 @@ class TilbakekrevingService(
                         adresselinje2 = baSakBrevMottaker.adresselinje2,
                         postnummer = baSakBrevMottaker.postnummer,
                         poststed = baSakBrevMottaker.poststed,
-                        landkode = baSakBrevMottaker.landkode,
-                    ),
+                        landkode = baSakBrevMottaker.landkode
+                    )
                 )
             }.toSet()
 
@@ -203,14 +203,14 @@ class TilbakekrevingService(
             varsel = opprettVarsel(
                 tilbakekreving,
                 simuleringService.hentSimuleringPåBehandling(behandling.id),
-                featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
+                featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ)
             ),
             revurderingsvedtaksdato = revurderingsvedtaksdato,
             // Verge er per nå ikke støttet i familie-ba-sak.
             verge = verge,
             faktainfo = hentFaktainfoForTilbakekreving(behandling, tilbakekreving),
             institusjon = institusjon,
-            manuelleBrevmottakere = manuelleBrevMottakere,
+            manuelleBrevmottakere = manuelleBrevMottakere
         )
     }
 
@@ -219,7 +219,7 @@ class TilbakekrevingService(
         if (!kanOpprettesRespons.kanBehandlingOpprettes) {
             return Ressurs.funksjonellFeil(
                 frontendFeilmelding = kanOpprettesRespons.melding,
-                melding = "familie-tilbake svarte nei på om tilbakekreving kunne opprettes",
+                melding = "familie-tilbake svarte nei på om tilbakekreving kunne opprettes"
             )
         }
 
@@ -233,8 +233,8 @@ class TilbakekrevingService(
                 OpprettManueltTilbakekrevingRequest(
                     eksternFagsakId = fagsakId.toString(),
                     ytelsestype = Ytelsestype.BARNETRYGD,
-                    eksternId = kanOpprettesRespons.kravgrunnlagsreferanse!!,
-                ),
+                    eksternId = kanOpprettesRespons.kravgrunnlagsreferanse!!
+                )
             )
 
             Ressurs.success("Tilbakekreving opprettet")
@@ -242,7 +242,7 @@ class TilbakekrevingService(
             logger.error("Kan ikke opprette tilbakekrevingsbehandling. Respons inneholder referanse til en ukjent behandling")
             Ressurs.funksjonellFeil(
                 melding = "Kan ikke opprette tilbakekrevingsbehandling. Respons inneholder referanse til en ukjent behandling",
-                frontendFeilmelding = "Av tekniske årsaker så kan ikke behandling opprettes. Kontakt brukerstøtte for å rapportere feilen.",
+                frontendFeilmelding = "Av tekniske årsaker så kan ikke behandling opprettes. Kontakt brukerstøtte for å rapportere feilen."
             )
         }
     }
@@ -254,7 +254,7 @@ class TilbakekrevingService(
                 Verge(
                     vergetype = Vergetype.VERGE_FOR_BARN,
                     navn = it.navn!!,
-                    personIdent = aktør.aktivFødselsnummer(),
+                    personIdent = aktør.aktivFødselsnummer()
                 )
             }
         } else {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Lenke til Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11855
Vil sende videre manuelle brevmottakere som er lagret i ba-sak til familie-tilbake når vi oppretter tilbakekrevinger. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Hvorvidt testen heller skulle vært en på annen form og om det er nødvendig at den dekker alle casene. Gjorde et forsøk med Junit.parameterizedTest, men da får jeg trøbbel med at testene går i beina på hverandre (alle funker hver for seg, men ikke hvis de kjøres samtidig). 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
