### PR TITLE
Query i TeamStatistikk trenger LocalDateTime og ikke Yearmonth

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -50,7 +50,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                                                      WHERE b.opprettet_tid = silp.opprettet_tid)""",
         nativeQuery = true
     )
-    fun hentTotalUtbetalingForMåned(måned: YearMonth): Long
+    fun hentTotalUtbetalingForMåned(måned: LocalDateTime): Long
 
     /* Denne henter først siste iverksatte behandling på en løpende fagsak.
      * Finner så alle perioder på siste iverksatte behandling

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.metrikker
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.MultiGauge
 import io.micrometer.core.instrument.Tags
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.leader.LeaderClient
@@ -38,7 +39,7 @@ class TeamStatistikkService(
                 YearMonth.now(),
                 YearMonth.now().plusMonths(1)
             ).associateWith {
-                behandlingRepository.hentTotalUtbetalingForMåned(it)
+                behandlingRepository.hentTotalUtbetalingForMåned(it.førsteDagIInneværendeMåned().atStartOfDay())
             }
 
         val rows = månederMedTotalUtbetaling.map {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
ref https://github.com/navikt/familie-ba-sak/pull/3445
Må enten ha LocalDateTime eller legge til Cast i query.

Den feiler nå med
ERROR: operator does not exist: timestamp without time zone <= bytea
Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
