### PR TITLE
Gjør om til funksjonell feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.NullablePeriode
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
@@ -48,7 +49,7 @@ data class BegrunnelseMedTriggere(
                 !erUregistrerteBarnPåbehandling &&
                 !this.triggesAv.satsendring
             ) {
-                throw Feil(
+                throw FunksjonellFeil(
                     "Begrunnelse '${this.standardbegrunnelse}' var ikke knyttet til noen personer."
                 )
             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har en del feil som skyldes at saksbehandlerene har valgt en annen begrunnelse enn de burde. 

I en perfekt verden burde de ikke ha mulighet til å velge feil begrunnelse, men enn så lenge gi vi dem en feilmelding. 

Gjør slik at ikke vi får varsel dersom feil begrunnelse er valgt
