### PR TITLE
Bump spring-boot-starter-parent 2.7.6 -> 2.7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.10</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Fikser en sikkerhetsoppdatering som er markert som kritisk