### PR TITLE
Legg til endepunkt for å hente tilbakekrevingsbehandlinger for fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingController.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.tilbakekreving
 
+import no.nav.familie.ba.sak.kjerne.tilbakekreving.domene.RestTilbakekrevingsbehandling
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -15,7 +17,8 @@ import org.springframework.web.bind.annotation.RestController
 @ProtectedWithClaims(issuer = "azuread")
 @Validated
 class TilbakekrevingController(
-    private val tilbakekrevingService: TilbakekrevingService
+    private val tilbakekrevingService: TilbakekrevingService,
+    private val tilbakekrevingsbehandlingService: TilbakekrevingsbehandlingService
 ) {
 
     @PostMapping("/{behandlingId}/forhandsvis-varselbrev")
@@ -33,6 +36,15 @@ class TilbakekrevingController(
                 )
             )
         )
+    }
+
+    @GetMapping("/fagsaker/{fagsakId}/hent-tilbakekrevingsbehandlinger")
+    fun hentTilbakekrevingsbehandlinger(
+        @PathVariable fagsakId: Long
+    ): ResponseEntity<Ressurs<List<RestTilbakekrevingsbehandling>>> {
+        val tilbakekrevingsbehandlinger = tilbakekrevingsbehandlingService.hentRestTilbakekrevingsbehandlinger(fagsakId)
+
+        return ResponseEntity.ok(Ressurs.success(tilbakekrevingsbehandlinger))
     }
 }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har en hard knytning til tilbakekreving som gjør at vi henter tilbakekrevingsbehandlingene på en fagsak når vi sender fagsaken frontend. Er tilbake nede går det derfor ikke an å hente fagsak på behandlinger i BA-sak. 

Som første steg i å mykne opp denne koblingen endrer lager jeg et endepunkt slik at tilbakekrevingsbehanldingene kan hentes derifra og ikke fra RestFagsak i frontend. 
