### PR TITLE
Lagt til alle eksterne tjenester utenfor dev-gcp i external hosts

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -100,6 +100,7 @@ spec:
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io
+        - host: familie-integrasjoner.dev-fss-pub.nais.io
   replicas:
     min: 2
     max: 2

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -95,6 +95,8 @@ spec:
           cluster: dev-fss
         - application: familie-klage
           cluster: dev-gcp
+        - application: pdl-api
+          cluster: dev-fss
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -101,7 +101,7 @@ spec:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io
         - host: familie-integrasjoner.dev-fss-pub.nais.io
-        - host: familie-oppdrag.prod-fss-pub.nais.io
+        - host: familie-oppdrag.dev-fss-pub.nais.io
         - host: familie-ba-statistikk.dev-fss-pub.nais.io
         - host: familie-ba-infotrygd.dev-fss-pub.nais.io
         - host: familie-ba-infotrygd-feed.dev-fss-pub.nais.io

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -101,6 +101,10 @@ spec:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io
         - host: familie-integrasjoner.dev-fss-pub.nais.io
+        - host: familie-oppdrag.prod-fss-pub.nais.io
+        - host: familie-ba-statistikk.dev-fss-pub.nais.io
+        - host: familie-ba-infotrygd.dev-fss-pub.nais.io
+        - host: familie-ba-infotrygd-feed.dev-fss-pub.nais.io
   replicas:
     min: 2
     max: 2

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -97,6 +97,7 @@ spec:
           cluster: dev-gcp
       external:
         - host: xsrv1mh6.api.sanity.io
+        - host: unleash.nais.io
   replicas:
     min: 2
     max: 2

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -95,11 +95,10 @@ spec:
           cluster: dev-fss
         - application: familie-klage
           cluster: dev-gcp
-        - application: pdl-api
-          cluster: dev-fss
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io
+        - host: pdl-api.dev-fss-pub.nais.io
         - host: familie-integrasjoner.dev-fss-pub.nais.io
         - host: familie-oppdrag.dev-fss-pub.nais.io
         - host: familie-ba-statistikk.dev-fss-pub.nais.io

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -95,6 +95,8 @@ spec:
           cluster: prod-fss
         - application: familie-klage
           cluster: prod-gcp
+        - application: pdl-api
+          cluster: prod-fss
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -100,6 +100,11 @@ spec:
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io
+        - host: familie-integrasjoner.prod-fss-pub.nais.io
+        - host: familie-oppdrag.prod-fss-pub.nais.io
+        - host: familie-ba-statistikk.prod-fss-pub.nais.io
+        - host: familie-ba-infotrygd.prod-fss-pub.nais.io
+        - host: familie-ba-infotrygd-feed.prod-fss-pub.nais.io
   replicas:
     min: 2
     max: 4

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -95,11 +95,10 @@ spec:
           cluster: prod-fss
         - application: familie-klage
           cluster: prod-gcp
-        - application: pdl-api
-          cluster: prod-fss
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io
+        - host: pdl-api.prod-fss-pub.nais.io
         - host: familie-integrasjoner.prod-fss-pub.nais.io
         - host: familie-oppdrag.prod-fss-pub.nais.io
         - host: familie-ba-statistikk.prod-fss-pub.nais.io

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -97,6 +97,7 @@ spec:
           cluster: prod-gcp
       external:
         - host: xsrv1mh6.api.sanity.io
+        - host: unleash.nais.io
   replicas:
     min: 2
     max: 4


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Kall mot Unleash, PDL og andre applikasjoner utenfor dev-gcp feilet etter en justering av egress-policy i NAIS.

Har nå lagt til alle disse eksterne appene i `accessPolicy.outbound.external` i henholdsvis `app-preprod.yaml` og `app-prod.yaml`

Endringene er testet i pre-prod og applikasjonen kommuniserer nå med de eksterne tjenestene uten problem.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
