### PR TITLE
Ikke beregn endringstidspunktVilkårsvurdering før etter vilkårsvurderingen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndringstidspunktService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIEndretUtbetalingAn
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIKompetanseUtil
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIVilkårsvurderingUtil
+import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -20,7 +21,6 @@ import java.time.YearMonth
 @Service
 class EndringstidspunktService(
     private val kompetanseRepository: PeriodeOgBarnSkjemaRepository<Kompetanse>,
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingAndelHentOgPersisterService: EndretUtbetalingAndelHentOgPersisterService,
@@ -36,7 +36,9 @@ class EndringstidspunktService(
 
         val endringstidspunktKompetanse = finnEndringstidspunktForKompetanse(inneværendeBehandlingId = behandlingId, forrigeBehandlingId = forrigeBehandling.id)
 
-        val endringstidspunktVilkårsvurdering = finnEndringstidspunktForVilkårsvurdering(inneværendeBehandlingId = behandlingId, forrigeBehandlingId = forrigeBehandling.id)
+        val endringstidspunktVilkårsvurdering = if (behandling.steg.kommerEtter(StegType.VILKÅRSVURDERING)) {
+            finnEndringstidspunktForVilkårsvurdering(inneværendeBehandlingId = behandlingId, forrigeBehandlingId = forrigeBehandling.id)
+        } else null
 
         val endringstidspunktEndretUtbetalingAndeler = finnEndringstidspunktForEndretUtbetalingAndel(inneværendeBehandlingId = behandlingId, forrigeBehandlingId = forrigeBehandling.id)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Denne](https://barnetrygd.intern.nav.no/fagsak/1330378/2941430) fagsaken sitter fast siden det er overlapp i utvidetvilkåret. Den har én utvidet periode som går fra 2019-10-01 og ut i uendeligheten, og en som går fra 2022-06-03 til 2022-12-01. Se feil i [Sentry](https://sentry.gc.nav.no/organizations/nav/issues/413284/?project=112&referrer=slack) for mer info. 

Selv om den beste løsningen er å fikse slik at vi ikke havner i denne tilstanden, må vi kunne rette opp denne behandlingen. Siden den er helt låst må vi kunne endre på vilkårsvurderingen uten å få opp denne feilen. 

Venter derfor med å beregne endringstidspunktet for vilkårvurderingen til etter vilkårvurderingssteget. Vi trenger det ikke før vedtakssteget uansett. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Jeg klarer ikke å gjenskape dette i [preprod](http://localhost:8000/fagsak/1000701/1001101). Når jeg prøver splittes vilkåret opp. Skjønner ikke hvorfor dette ikke har skjed i prod 🤔

Jeg er heller ikke sikker på at dette løser problemet, men da kommer vi oss i alle fall forbi første feil som blir kastet. Tar gjerne imot bedre forslag

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
