### PR TITLE
Lagt inn støtte for manuelle posteringer på fagområdeKode MBA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>1.20230228091402_e6ac3c2</prosessering.version>
         <felles.version>1.20230116145510_2afcc20</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>2.0_20230328090416_b3e2e55</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20230331160555_be6ec7e</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20230223155122_2e81c44</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/ØkonomiSimuleringPostering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/ØkonomiSimuleringPostering.kt
@@ -95,5 +95,8 @@ data class ØkonomiSimuleringPostering(
             ")"
     }
 
-    val erManuellPostering get() = this.fagOmrådeKode == FagOmrådeKode.BARNETRYGD_INFOTRYGD_MANUELT
+    val erManuellPostering: Boolean
+        get() {
+            return this.fagOmrådeKode == FagOmrådeKode.BARNETRYGD_INFOTRYGD_MANUELT || this.fagOmrådeKode == FagOmrådeKode.BARNETRYGD_MANUELT
+        }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
@@ -384,6 +384,54 @@ class SimuleringUtilTest {
     }
 
     @Test
+    fun `ytelse med manuellt trekk av valutajustering trukket på fagområdekode MBA`() {
+        val YtelsefraBA = listOf(
+            mockVedtakSimuleringPostering(
+                beløp = 305,
+                posteringType = PosteringType.YTELSE
+            ),
+            mockVedtakSimuleringPostering(
+                beløp = -198,
+                posteringType = PosteringType.JUSTERING,
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD
+            ),
+            mockVedtakSimuleringPostering(
+                beløp = 305,
+                posteringType = PosteringType.JUSTERING,
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_MANUELT
+            ),
+            mockVedtakSimuleringPostering(
+                beløp = -305,
+                posteringType = PosteringType.YTELSE,
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_INFOTRYGD
+            ),
+            mockVedtakSimuleringPostering(
+                beløp = -107,
+                posteringType = PosteringType.JUSTERING,
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_MANUELT
+            ),
+            mockVedtakSimuleringPostering(
+                beløp = 165,
+                posteringType = PosteringType.YTELSE,
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_MANUELT
+            )
+        )
+
+        val økonomiSimuleringMottakere =
+            listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = YtelsefraBA))
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, true)
+
+        assertThat(simuleringsperioder.size).isEqualTo(1)
+        assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(305.toBigDecimal())
+        assertThat(simuleringsperioder[0].manuellPostering).isEqualTo((-165).toBigDecimal())
+        assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(140.toBigDecimal())
+        assertThat(simuleringsperioder[0].resultat).isEqualTo(165.toBigDecimal())
+        assertThat(simuleringsperioder[0].feilutbetaling).isEqualTo(0.toBigDecimal())
+        assertThat(oppsummering.etterbetaling).isEqualTo(165.toBigDecimal())
+    }
+
+    @Test
     fun `ytelse med manuellt trekk av valutajustering alt er trukket`() {
         val YtelsefraBA = listOf(
             mockVedtakSimuleringPostering(


### PR DESCRIPTION
Lagt inn støtte for manuelle posteringer på fagområdeKode MBA (Barnetrygd Manuelt)

### 💰 Hva skal gjøres, og hvorfor?
NØS utfører nå manuelle korigeringer på fagområdekode MBA, vi må ha støtte for å ta med disse når vi beregner tidligere utbetalt beløp.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
