### PR TITLE
Reverterer sletting av dekprikert enum, siden vi har mange av denne enumsverdien i databasen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.brev
 
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.NullablePeriode
 import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.erSenereEnnInneværendeMåned
@@ -216,6 +217,7 @@ class BrevPeriodeGenerator(
             Vedtaksperiodetype.OPPHØR -> emptyList()
             Vedtaksperiodetype.AVSLAG -> emptyList()
             Vedtaksperiodetype.FORTSATT_INNVILGET -> barnMedUtbetaling + barnMedNullutbetaling
+            Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
         }
 
         val utbetalingsbeløp = minimertVedtaksperiode.minimerteUtbetalingsperiodeDetaljer.totaltUtbetalt()
@@ -252,6 +254,7 @@ class BrevPeriodeGenerator(
         Vedtaksperiodetype.OPPHØR -> minimertVedtaksperiode.fom!!.tilDagMånedÅr()
         Vedtaksperiodetype.AVSLAG -> if (minimertVedtaksperiode.fom != null) minimertVedtaksperiode.fom.tilDagMånedÅr() else ""
         Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING -> minimertVedtaksperiode.fom!!.tilDagMånedÅr()
+        Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
     }
 
     private fun hentPeriodetype(
@@ -269,6 +272,7 @@ class BrevPeriodeGenerator(
             Vedtaksperiodetype.AVSLAG -> if (fom != null) BrevPeriodeType.AVSLAG_INSTITUSJON else BrevPeriodeType.AVSLAG_UTEN_PERIODE_INSTITUSJON
             Vedtaksperiodetype.OPPHØR -> BrevPeriodeType.OPPHOR_INSTITUSJON
             Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING -> BrevPeriodeType.INNVILGELSE_INSTITUSJON
+            Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
         }
     } else {
         when (minimertVedtaksperiode.type) {
@@ -282,6 +286,7 @@ class BrevPeriodeGenerator(
             Vedtaksperiodetype.AVSLAG -> if (fom != null) BrevPeriodeType.AVSLAG else BrevPeriodeType.AVSLAG_UTEN_PERIODE
             Vedtaksperiodetype.OPPHØR -> BrevPeriodeType.OPPHOR
             Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING -> BrevPeriodeType.INNVILGELSE
+            Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiode.kt
@@ -82,7 +82,10 @@ enum class Vedtaksperiodetype(val tillatteBegrunnelsestyper: List<VedtakBegrunne
             VedtakBegrunnelseType.INSTITUSJON_FORTSATT_INNVILGET,
             VedtakBegrunnelseType.EØS_FORTSATT_INNVILGET
         )
-    )
+    ),
+
+    @Deprecated("Legacy. Kan ikke fjernes uten at det ryddes opp i Vedtaksperioder-tabellen")
+    ENDRET_UTBETALING(emptyList())
 }
 
 fun Vedtaksperiode.tilVedtaksperiodeMedBegrunnelse(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Reverterer sletting av dekprekert enum, siden vi har mange av denne enumsverdien i databasen. Slik at  blant annet autobrev-tasker ender opp som manuell