### PR TITLE
Sett rollingUpdate strategi

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -127,3 +127,8 @@ spec:
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError"
   kafka:
     pool: nav-dev
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 99%
+

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -126,3 +126,7 @@ spec:
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError"
   kafka:
     pool: nav-prod
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 99%


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Setter rolling update strategi for å få deploy til å gå fortere.  Se [Nais doc](https://doc.nais.io/nais-application/application/#strategyrollingupdate) og [slacktråd](https://nav-it.slack.com/archives/C01DE3M9YBV/p1680273231054969) for mer info

Setter maxSurge til 100% og maxUnavailable til 99%.

### Eksempel: 
Gitt 4 replicas, maxSurge: 100% og maxUnavailable: 99% så vil følgende skje ved utrulling av en ny deploy:
* Det spinnes opp 4 nye podder samtidig
* Det tas ned 3 gamle podder samtidig (i.e. Math.floor(0.99*10))
* Minst 1 pod vil være kjørende til enhver tid under utrullingen
