### PR TITLE
Legg på validering om at det ikke er noen behandling etter behandlingen vi sender inn som har send til økonomi

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.internal
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForIverksettingFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import org.springframework.stereotype.Service
@@ -12,20 +13,29 @@ import org.springframework.transaction.annotation.Transactional
 class ForvalterService(
     private val økonomiService: ØkonomiService,
     private val vedtakService: VedtakService,
-    private val beregningService: BeregningService
+    private val beregningService: BeregningService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService
 ) {
 
     @Transactional
     fun lagOgSendUtbetalingsoppdragTilØkonomiForBehandling(behandlingId: Long) {
-        val vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId)
         val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId)
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+
+        val forrigeBehandlingSendtTilØkonomi =
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling)
+        val erBehandlingOpprettetEtterDenneSomErSendtTilØkonomi = forrigeBehandlingSendtTilØkonomi != null &&
+            forrigeBehandlingSendtTilØkonomi.opprettetTidspunkt.isAfter(behandling.opprettetTidspunkt)
 
         if (tilkjentYtelse.utbetalingsoppdrag != null) {
             throw Feil("Behandling $behandlingId har allerede opprettet utbetalingsoppdrag")
         }
+        if (erBehandlingOpprettetEtterDenneSomErSendtTilØkonomi) {
+            throw Feil("Det finnes en behandling opprettet etter $behandlingId som er sendt til økonomi")
+        }
 
         økonomiService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
-            vedtak = vedtak,
+            vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId),
             saksbehandlerId = "VL",
             andelTilkjentYtelseForUtbetalingsoppdragFactory = AndelTilkjentYtelseForIverksettingFactory()
         )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fikk litt kalde føtter da jeg skulle sende behandlingene fra [denne slacktråden](https://nav-it.slack.com/archives/GU4MVCGCD/p1680086515073979) til økonomi (Gjelder fagsakene
1930559
~1921798~ Opphører også barnetrygden, så her må vi ha totrinnskontroll før vi sender det til økonomi. 
1911023
1908278
1433738
1315137
1284726
1206564
1208015
1192307
1176083
1156455).

Legger på validering på et det ikke er sendt utbetalingsoppdrag til økonomi etter at behandlingen vi ønsker å sende manuelt til økonomi er opprettet


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
