### PR TITLE
Chore/erstatt tidslinjer for å finne ugyldig etterbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.KONTAKT_TEAMET_SUFFIX
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
-import no.nav.familie.ba.sak.common.overlapperHeltEllerDelvisMed
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.maksBeløp
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -196,19 +195,6 @@ object TilkjentYtelseValidering {
             }
         }
     }
-
-    private fun erAndelMedØktBeløpFørDato(
-        forrigeAndeler: List<AndelTilkjentYtelse>?,
-        andeler: List<AndelTilkjentYtelse>,
-        måned: YearMonth?
-    ): Boolean = andeler
-        .filter { it.stønadFom < måned }
-        .any { andel ->
-            forrigeAndeler?.any {
-                it.periode.overlapperHeltEllerDelvisMed(andel.periode) &&
-                    it.kalkulertUtbetalingsbeløp < andel.kalkulertUtbetalingsbeløp
-            } ?: false
-        }
 }
 
 private fun validerAtBeløpForPartStemmerMedSatser(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -89,7 +89,7 @@ class TilkjentYtelseValideringService(
             forrigeBehandling?.let { beregningService.hentOptionalTilkjentYtelseForBehandling(behandlingId = it.id) }?.andelerTilkjentYtelse?.toList()
 
         val aktørIderMedUgyldigEtterbetaling = finnAktørIderMedUgyldigEtterbetalingsperiode(
-            forrigeAndelerTilkjentYtelse = forrigeAndelerTilkjentYtelse,
+            forrigeAndelerTilkjentYtelse = forrigeAndelerTilkjentYtelse ?: emptyList(),
             andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.toList(),
             kravDato = tilkjentYtelse.behandling.opprettetTidspunkt
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -33,7 +33,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.fpsak.tidsserie.LocalDateInterval
 import no.nav.fpsak.tidsserie.LocalDateSegment
-import no.nav.fpsak.tidsserie.LocalDateTimeline
 import java.math.BigDecimal
 import java.time.YearMonth
 import java.util.Objects
@@ -282,17 +281,6 @@ fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.hentAndelerForSegment(
         )
     )
 }
-
-fun List<AndelTilkjentYtelse>?.hentTidslinje() =
-    LocalDateTimeline(
-        this?.map {
-            LocalDateSegment(
-                it.stønadFom.førsteDagIInneværendeMåned(),
-                it.stønadTom.sisteDagIInneværendeMåned(),
-                it
-            )
-        } ?: emptyList()
-    )
 
 fun List<AndelTilkjentYtelse>.tilTidslinjerPerPersonOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseTidslinje> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -67,4 +67,20 @@ object EndringIUtbetalingUtil {
 
         return endringIBeløpTidslinje
     }
+    fun lagEtterbetalingstidslinjeForPersonOgType(
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
+        forrigeAndeler: List<AndelTilkjentYtelse>
+    ): Tidslinje<Boolean, Måned> {
+        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndeler)
+        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndeler)
+
+        val etterbetaling = nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
+            val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp ?: 0
+            val forrigeBeløp = forrige?.kalkulertUtbetalingsbeløp ?: 0
+
+            nåværendeBeløp > forrigeBeløp
+        }
+
+        return etterbetaling
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
@@ -1,13 +1,9 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 
 object EndringUtil {
-
     internal fun Tidslinje<Boolean, Måned>.tilFørsteEndringstidspunkt() = this.perioder().filter { it.innhold == true }.minOfOrNull { it.fraOgMed }?.tilYearMonth()
-
-    internal fun Tidslinje<Boolean, Dag>.tilFørsteEndringstidspunktForDagtidslinje() = this.perioder().filter { it.innhold == true }.minOfOrNull { it.fraOgMed }?.tilYearMonth()
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
@@ -42,7 +42,7 @@ class TilkjentYtelseValideringTest {
         )
         Assertions.assertTrue(
             TilkjentYtelseValidering.erUgyldigEtterbetalingPåPerson(
-                forrigeAndelerForPerson = null,
+                forrigeAndelerForPerson = emptyList(),
                 andelerForPerson = andeler1,
                 gyldigEtterbetalingFom = gyldigEtterbetalingFom
             )
@@ -80,7 +80,7 @@ class TilkjentYtelseValideringTest {
         )
         Assertions.assertTrue(
             TilkjentYtelseValidering.erUgyldigEtterbetalingPåPerson(
-                forrigeAndelerForPerson = null,
+                forrigeAndelerForPerson = emptyList(),
                 andelerForPerson = andeler2,
                 gyldigEtterbetalingFom = gyldigEtterbetalingFom
             )
@@ -194,7 +194,7 @@ class TilkjentYtelseValideringTest {
 
         Assertions.assertFalse(
             TilkjentYtelseValidering.erUgyldigEtterbetalingPåPerson(
-                forrigeAndelerForPerson = null,
+                forrigeAndelerForPerson = emptyList(),
                 andelerForPerson = andeler,
                 gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(LocalDateTime.now().minusYears(2))
             )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bytter ut fra LocalDateTimeline til å bruke tidslinje-rammeverket vårt til å finne ugyldig etterbetaling. Dvs. at det er etterbetaling før gyldigEtterbetalingFom (som er lik behandling opprettet tidspunkt minus 3 år).

Er mange tester på dette fra før, som kjører grønt.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Finnes masse tester fra før på funksjonen

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
