### PR TITLE
Send migreringsbehandling til totrinnskontroll dersom manuelle posteringer i simulering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -176,6 +176,17 @@ class SimuleringService(
             sjekkOmBehandlingHarFeilutbetalingInnenforBeløpsgrenser(behandling, antallBarn)
     }
 
+    fun harMigreringsbehandlingManuellePosteringerFørMars2023(behandling: Behandling): Boolean {
+        if (!behandling.erManuellMigrering()) throw Feil("Sjekk for manuelle posteringer skal bare gjøres for manuelle migreringsbehandlinger")
+
+        val februar2023 = LocalDate.of(2023, 2, 1)
+
+        return filterBortUrelevanteVedtakSimuleringPosteringer(hentSimuleringPåBehandling(behandling.id))
+            .flatMap { it.økonomiSimuleringPostering }
+            .filter { it.fom.isSameOrBefore(februar2023) }
+            .any { it.erManuellPostering }
+    }
+
     private fun sjekkOmBehandlingHarEtterbetalingInnenforBeløpsgrenser(
         behandling: Behandling,
         antallBarn: Int

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -176,14 +176,11 @@ class SimuleringService(
             sjekkOmBehandlingHarFeilutbetalingInnenforBeløpsgrenser(behandling, antallBarn)
     }
 
-    fun harMigreringsbehandlingManuellePosteringerFørMars2023(behandling: Behandling): Boolean {
+    fun harMigreringsbehandlingManuellePosteringer(behandling: Behandling): Boolean {
         if (!behandling.erManuellMigrering()) throw Feil("Sjekk for manuelle posteringer skal bare gjøres for manuelle migreringsbehandlinger")
-
-        val februar2023 = LocalDate.of(2023, 2, 1)
 
         return filterBortUrelevanteVedtakSimuleringPosteringer(hentSimuleringPåBehandling(behandling.id))
             .flatMap { it.økonomiSimuleringPostering }
-            .filter { it.fom.isSameOrBefore(februar2023) }
             .any { it.erManuellPostering }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -68,7 +68,7 @@ class SendTilBeslutter(
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
         // oppretter ikke GodkjenneVedtak task for manuell migrering som har avvik innenfor beløpsgrenser eller manuelle posteringer
-        if (!behandling.erManuellMigrering() || simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(
+        if (!behandling.erManuellMigrering() || simuleringService.harMigreringsbehandlingManuellePosteringer(
                 behandling
             ) || !simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
         ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -68,7 +68,10 @@ class SendTilBeslutter(
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
         // oppretter ikke GodkjenneVedtak task for manuell migrering som har avvik innenfor beløpsgrenser
-        if (!behandling.erManuellMigrering() || !simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)) {
+        if (!behandling.erManuellMigrering() || simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(
+                behandling
+            )
+        ) {
             val godkjenneVedtakTask = OpprettOppgaveTask.opprettTask(
                 behandlingId = behandling.id,
                 oppgavetype = Oppgavetype.GodkjenneVedtak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -67,10 +67,10 @@ class SendTilBeslutter(
     ): StegType {
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
-        // oppretter ikke GodkjenneVedtak task for manuell migrering som har avvik innenfor beløpsgrenser
+        // oppretter ikke GodkjenneVedtak task for manuell migrering som har avvik innenfor beløpsgrenser eller manuelle posteringer
         if (!behandling.erManuellMigrering() || simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(
                 behandling
-            )
+            ) || !simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
         ) {
             val godkjenneVedtakTask = OpprettOppgaveTask.opprettTask(
                 behandlingId = behandling.id,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -221,7 +221,7 @@ internal class SimuleringServiceEnhetTest {
         every { øknomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
 
         val behandlingHarManuellePosteringerFørMars2023 =
-            simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(behandling)
+            simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
 
         assertThat(behandlingHarManuellePosteringerFørMars2023, Is(true))
     }
@@ -254,7 +254,7 @@ internal class SimuleringServiceEnhetTest {
         every { øknomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
 
         val behandlingHarManuellePosteringerFørMars2023 =
-            simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(behandling)
+            simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
 
         assertThat(behandlingHarManuellePosteringerFørMars2023, Is(false))
     }
@@ -274,7 +274,7 @@ internal class SimuleringServiceEnhetTest {
             førsteSteg = StegType.VURDER_TILBAKEKREVING
         )
 
-        assertThrows<Feil> { simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(behandling) }
+        assertThrows<Feil> { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) }
     }
 
     private fun mockØkonomiSimuleringMottaker(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -115,8 +115,18 @@ internal class SimuleringServiceEnhetTest {
 
         // feilutbetaling 1 KR per barn i hver periode
         val posteringer = listOf(
-            mockVedtakSimuleringPostering(fom = fom, tom = tom, beløp = 2, posteringType = PosteringType.FEILUTBETALING),
-            mockVedtakSimuleringPostering(fom = fom2, tom = tom2, beløp = 2, posteringType = PosteringType.FEILUTBETALING)
+            mockVedtakSimuleringPostering(
+                fom = fom,
+                tom = tom,
+                beløp = 2,
+                posteringType = PosteringType.FEILUTBETALING
+            ),
+            mockVedtakSimuleringPostering(
+                fom = fom2,
+                tom = tom2,
+                beløp = 2,
+                posteringType = PosteringType.FEILUTBETALING
+            )
         )
 
         val simuleringMottaker =
@@ -134,7 +144,9 @@ internal class SimuleringServiceEnhetTest {
 
     @ParameterizedTest
     @EnumSource(value = BehandlingÅrsak::class, names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"])
-    fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal returnere false dersom det finnes avvik i form av feilutbetaling som er utenfor beløpsgrense`(behandlingÅrsak: BehandlingÅrsak) {
+    fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal returnere false dersom det finnes avvik i form av feilutbetaling som er utenfor beløpsgrense`(
+        behandlingÅrsak: BehandlingÅrsak
+    ) {
         val behandling: Behandling = no.nav.familie.ba.sak.common.lagBehandling(
             behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
             årsak = behandlingÅrsak,
@@ -163,8 +175,14 @@ internal class SimuleringServiceEnhetTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = BehandlingÅrsak::class, mode = EnumSource.Mode.EXCLUDE, names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"])
-    fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal kaste feil dersom behandlingen ikke er en manuell migrering`(behandlingÅrsak: BehandlingÅrsak) {
+    @EnumSource(
+        value = BehandlingÅrsak::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"]
+    )
+    fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal kaste feil dersom behandlingen ikke er en manuell migrering`(
+        behandlingÅrsak: BehandlingÅrsak
+    ) {
         val behandling: Behandling = no.nav.familie.ba.sak.common.lagBehandling(
             behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
             årsak = behandlingÅrsak,
@@ -172,6 +190,91 @@ internal class SimuleringServiceEnhetTest {
         )
 
         assertThrows<Feil> { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BehandlingÅrsak::class, names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"])
+    fun `harMigreringsbehandlingManuellePosteringerFørMars2023 skal returnere true dersom det finnes manuelle posteringer i simuleringsresultat før mars 2023`(
+        behandlingÅrsak: BehandlingÅrsak
+    ) {
+        val behandling: Behandling = no.nav.familie.ba.sak.common.lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = behandlingÅrsak,
+            førsteSteg = StegType.VURDER_TILBAKEKREVING
+        )
+        every { featureToggleService.isEnabled(FeatureToggleConfig.IKKE_STOPP_MIGRERINGSBEHANDLING) } returns false
+        every { simuleringService.hentFeilutbetaling(behandling.id) } returns BigDecimal.ZERO
+
+        // etterbetaling 200 KR
+        val posteringer = listOf(
+            mockVedtakSimuleringPostering(beløp = 200, betalingType = BetalingType.DEBIT),
+            mockVedtakSimuleringPostering(beløp = -200, betalingType = BetalingType.KREDIT),
+            mockVedtakSimuleringPostering(
+                beløp = 200,
+                betalingType = BetalingType.DEBIT,
+                fagOmrådeKode = FagOmrådeKode.BARNETRYGD_INFOTRYGD_MANUELT
+            )
+        )
+        val simuleringMottaker =
+            listOf(mockØkonomiSimuleringMottaker(behandling = behandling, økonomiSimuleringPostering = posteringer))
+
+        every { øknomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
+
+        val behandlingHarManuellePosteringerFørMars2023 =
+            simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(behandling)
+
+        assertThat(behandlingHarManuellePosteringerFørMars2023, Is(true))
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = BehandlingÅrsak::class,
+        names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"]
+    )
+    fun `harMigreringsbehandlingManuellePosteringerFørMars2023 skal returnere false dersom det ikke finnes manuelle posteringer i simuleringsresultat før mars 2023`(
+        behandlingÅrsak: BehandlingÅrsak
+    ) {
+        val behandling: Behandling = no.nav.familie.ba.sak.common.lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = behandlingÅrsak,
+            førsteSteg = StegType.VURDER_TILBAKEKREVING
+        )
+        every { featureToggleService.isEnabled(FeatureToggleConfig.IKKE_STOPP_MIGRERINGSBEHANDLING) } returns false
+        every { simuleringService.hentFeilutbetaling(behandling.id) } returns BigDecimal.ZERO
+
+        // etterbetaling 200 KR
+        val posteringer = listOf(
+            mockVedtakSimuleringPostering(beløp = 200, betalingType = BetalingType.DEBIT),
+            mockVedtakSimuleringPostering(beløp = -200, betalingType = BetalingType.KREDIT),
+            mockVedtakSimuleringPostering(beløp = 200, betalingType = BetalingType.DEBIT)
+        )
+        val simuleringMottaker =
+            listOf(mockØkonomiSimuleringMottaker(behandling = behandling, økonomiSimuleringPostering = posteringer))
+
+        every { øknomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
+
+        val behandlingHarManuellePosteringerFørMars2023 =
+            simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(behandling)
+
+        assertThat(behandlingHarManuellePosteringerFørMars2023, Is(false))
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = BehandlingÅrsak::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"]
+    )
+    fun `harMigreringsbehandlingManuellePosteringerFørMars2023 skal kaste feil dersom behandlingen ikke er en manuell migrering`(
+        behandlingÅrsak: BehandlingÅrsak
+    ) {
+        val behandling: Behandling = no.nav.familie.ba.sak.common.lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = behandlingÅrsak,
+            førsteSteg = StegType.VURDER_TILBAKEKREVING
+        )
+
+        assertThrows<Feil> { simuleringService.harMigreringsbehandlingManuellePosteringerFørMars2023(behandling) }
     }
 
     private fun mockØkonomiSimuleringMottaker(


### PR DESCRIPTION
Favro: [NAV-12350](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12350)

### 💰 Hva skal gjøres, og hvorfor?
Vi har tidligere hatt logikk for å sende migreringsbehandlinger til totrinnskontroll dersom simulering får en feilutbetaling eller en etterbetaling som er større enn 100 kr. Nå viser det seg at denne logikken mest sannsynlig blir feil da måten vi beregner feilutbetaling og etterbetaling på med manuelle posteringer ikke nødvendigvis gir oss riktig beløp.

Denne PR'en sørger for at alle migreringsbehandlinger med manuelle posteringer i simuleringsresultat uansett blir sendt til totrinnskontroll. Lar logikken for avvik også gjelde.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
I koden der vi beregnet avvik ut over 100 kr så vi bare på simuleringsperioder før mars 2023. Jeg har også lagt inn denne begrensningen i nå sjekk etter manuelle posteringer. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
