### PR TITLE
Kast funksjonell feil i stedet for feil når saksbehandler har puttet inn feil dato i vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.endretutbetaling
 
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.Periode
@@ -338,7 +337,7 @@ fun validerBarnasVilkår(barna: List<Person>, vilkårsvurdering: Vilkårsvurderi
     }
 
     if (listeAvFeil.isNotEmpty()) {
-        throw Feil(listeAvFeil.joinToString(separator = "\n"))
+        throw FunksjonellFeil(listeAvFeil.joinToString(separator = "\n"))
     }
 }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til feil på sentry. F.eks. denne: https://sentry.gc.nav.no/organizations/nav/issues/421297/?environment=prod&project=112&query=is%3Aunresolved&referrer=issue-stream

Det er saksbehandler som har puttet inn feil fom-dato på barnas vilkår. Burde være funksjonell feil og ikke feil. Skulle egentlig ha vært stoppet av validering frontend. Jeg har rettet opp valideringen frontend her: https://github.com/navikt/familie-ba-sak-frontend/pull/2635

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
bare endret feiltype

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
