### PR TITLE
Krev saksbehandlertilgang for å legge til eller endre feilutbetalt valuta

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaController.kt
@@ -28,30 +28,41 @@ class FeilutbetaltValutaController(
     private val feilutbetaltValutaService: FeilutbetaltValutaService,
     private val utvidetBehandlingService: UtvidetBehandlingService
 ) {
-    @PostMapping(path = ["behandling/{behandlingId}"], produces = [MediaType.APPLICATION_JSON_VALUE], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping(
+        path = ["behandling/{behandlingId}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
     fun leggTilFeilutbetaltValutaPeriode(
         @PathVariable behandlingId: Long,
         @RequestBody feilutbetaltValuta: RestFeilutbetaltValuta
     ):
         ResponseEntity<Ressurs<RestUtvidetBehandling>> {
         tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.VEILEDER,
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "legg til periode med feilutbetalt valuta"
         )
 
-        feilutbetaltValutaService.leggTilFeilutbetaltValutaPeriode(feilutbetaltValuta = feilutbetaltValuta, behandlingId = behandlingId)
+        feilutbetaltValutaService.leggTilFeilutbetaltValutaPeriode(
+            feilutbetaltValuta = feilutbetaltValuta,
+            behandlingId = behandlingId
+        )
 
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
     }
 
-    @PutMapping(path = ["behandling/{behandlingId}/periode/{id}"], produces = [MediaType.APPLICATION_JSON_VALUE], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @PutMapping(
+        path = ["behandling/{behandlingId}/periode/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
     fun oppdaterFeilutbetaltValutaPeriode(
         @PathVariable behandlingId: Long,
         @PathVariable id: Long,
         @RequestBody feilutbetaltValuta: RestFeilutbetaltValuta
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
         tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.VEILEDER,
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "oppdater periode med feilutbetalt valuta"
         )
 
@@ -66,7 +77,7 @@ class FeilutbetaltValutaController(
         @PathVariable id: Long
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
         tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.VEILEDER,
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "Fjerner periode med feilutbetalt valuta"
         )
         feilutbetaltValutaService.fjernFeilutbetaltValutaPeriode(id = id, behandlingId = behandlingId)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi oppdaget under utvikling av #3553 at tilgangene som kreves for feilutbetalt valuta er feil. Nå krever vi VEILEDER for alle handlingene, men det bør være SAKSBEHANDLER for alle handlinger som legger til eller endrer data. Vi beholder VEILEDER for å kun lese ut data. 

Har tatt avsjekk med Eivind om dette.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
