### PR TITLE
Bruk InternPeriodeOvergangsstønad som er splittet opp og slått sammen slik som vi vil ha det

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -202,10 +202,12 @@ class BeregningService(
                 endretUtbetalingAndeler = endreteUtbetalingAndeler,
                 fagsakType = behandling.fagsak.type
             ) { søkerAktør ->
-                småbarnstilleggService.hentOgLagrePerioderMedFullOvergangsstønad(
+                småbarnstilleggService.hentOgLagrePerioderMedFullOvergangsstønadFraEf(
                     søkerAktør = søkerAktør,
                     behandlingId = behandling.id
                 )
+
+                småbarnstilleggService.hentPerioderMedFullOvergangsstønad(behandling.id)
             }
 
         val lagretTilkjentYtelse = tilkjentYtelseRepository.save(tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
@@ -12,7 +12,10 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønadTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.domene.slåSammenTidligerePerioder
+import no.nav.familie.ba.sak.kjerne.beregning.domene.splitFramtidigePerioderFraForrigeBehandling
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
+import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlag
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
@@ -32,6 +35,12 @@ import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+
+fun List<PeriodeOvergangsstønadGrunnlag>.splittOgSlåSammen(
+    overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>
+) = map { InternPeriodeOvergangsstønad(it) }
+    .slåSammenTidligerePerioder()
+    .splitFramtidigePerioderFraForrigeBehandling(overgangsstønadPerioderFraForrigeBehandling)
 
 class VedtaksperiodefinnerSmåbarnstilleggFeil(
     melding: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -17,7 +17,7 @@ data class InternPeriodeOvergangsstønad(
     val fomDato: LocalDate,
     val tomDato: LocalDate
 ) {
-    constructor(periodeOvergangsstønadGrunnlag: PeriodeOvergangsstønadGrunnlag): this(
+    constructor(periodeOvergangsstønadGrunnlag: PeriodeOvergangsstønadGrunnlag) : this(
         personIdent = periodeOvergangsstønadGrunnlag.aktør.aktivFødselsnummer(),
         fomDato = periodeOvergangsstønadGrunnlag.fom,
         tomDato = periodeOvergangsstønadGrunnlag.tom

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.beregning.domene
 import no.nav.familie.ba.sak.common.forrigeMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlag
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.kontrakter.felles.ef.EksternPeriode
 import org.slf4j.Logger
@@ -15,7 +16,13 @@ data class InternPeriodeOvergangsstønad(
     val personIdent: String,
     val fomDato: LocalDate,
     val tomDato: LocalDate
-)
+) {
+    constructor(periodeOvergangsstønadGrunnlag: PeriodeOvergangsstønadGrunnlag): this(
+        personIdent = periodeOvergangsstønadGrunnlag.aktør.aktivFødselsnummer(),
+        fomDato = periodeOvergangsstønadGrunnlag.fom,
+        tomDato = periodeOvergangsstønadGrunnlag.tom
+    )
+}
 
 fun EksternPeriode.tilInternPeriodeOvergangsstønad() = InternPeriodeOvergangsstønad(
     personIdent = this.personIdent,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.beregning.SmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -41,7 +42,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform.NB
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform.NN
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
-import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
@@ -89,7 +89,7 @@ class VedtaksperiodeService(
     private val brevmalService: BrevmalService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val vilkårsvurderingService: VilkårsvurderingService,
-    private val periodeOvergangsstønadGrunnlagRepository: PeriodeOvergangsstønadGrunnlagRepository
+    private val småbarnstilleggService: SmåbarnstilleggService,
 ) {
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,
@@ -318,7 +318,7 @@ class VedtaksperiodeService(
             kompetanser = kompetanseRepository.finnFraBehandlingId(behandling.id).toList(),
             endredeUtbetalinger = endretUtbetalingAndelRepository.findByBehandlingId(behandling.id),
             andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id),
-            perioderOvergangsstønad = periodeOvergangsstønadGrunnlagRepository.findByBehandlingId(behandling.id)
+            perioderOvergangsstønad = småbarnstilleggService.hentPerioderMedFullOvergangsstønad(behandling.id)
         )
 
     @Deprecated("skal bruke genererVedtaksperioderMedBegrunnelser når den er klar")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -89,7 +89,7 @@ class VedtaksperiodeService(
     private val brevmalService: BrevmalService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val vilkårsvurderingService: VilkårsvurderingService,
-    private val småbarnstilleggService: SmåbarnstilleggService,
+    private val småbarnstilleggService: SmåbarnstilleggService
 ) {
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
@@ -102,10 +102,10 @@ data class KompetanseForVedtaksperiode(
 
 data class OvergangsstønadForVedtaksperiode(
     val fom: LocalDate,
-    val tom: LocalDate,
+    val tom: LocalDate
 ) {
     constructor(periodeOvergangsstønad: InternPeriodeOvergangsstønad) : this(
         fom = periodeOvergangsstønad.fomDato,
-        tom = periodeOvergangsstønad.tomDato,
+        tom = periodeOvergangsstønad.tomDato
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent
 
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.IUtfyltEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
@@ -10,13 +11,11 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.SøkersAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlag
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import no.nav.familie.kontrakter.felles.ef.Datakilde
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -49,7 +48,7 @@ data class VilkårResultatForVedtaksperiode(
     val fom: LocalDate?,
     val tom: LocalDate?
 ) {
-    constructor(vilkårResultat: VilkårResultat) : this (
+    constructor(vilkårResultat: VilkårResultat) : this(
         vilkårType = vilkårResultat.vilkårType,
         resultat = vilkårResultat.resultat,
         utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger,
@@ -104,11 +103,9 @@ data class KompetanseForVedtaksperiode(
 data class OvergangsstønadForVedtaksperiode(
     val fom: LocalDate,
     val tom: LocalDate,
-    val datakilde: Datakilde
 ) {
-    constructor(periodeOvergangsstønad: PeriodeOvergangsstønadGrunnlag) : this(
-        fom = periodeOvergangsstønad.fom,
-        tom = periodeOvergangsstønad.tom,
-        datakilde = periodeOvergangsstønad.datakilde
+    constructor(periodeOvergangsstønad: InternPeriodeOvergangsstønad) : this(
+        fom = periodeOvergangsstønad.fomDato,
+        tom = periodeOvergangsstønad.tomDato,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForVedtaksperioder.kt
@@ -1,11 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent
 
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
-import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlag
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 
 data class GrunnlagForVedtaksperioder(
@@ -15,5 +15,5 @@ data class GrunnlagForVedtaksperioder(
     val kompetanser: List<Kompetanse>,
     val endredeUtbetalinger: List<EndretUtbetalingAndel>,
     val andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-    val perioderOvergangsstønad: List<PeriodeOvergangsstønadGrunnlag>
+    val perioderOvergangsstønad: List<InternPeriodeOvergangsstønad>
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerBeløpOgType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.IUtfyltEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilIEndretUtbetalingAndel
@@ -12,7 +13,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlag
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
@@ -184,7 +184,7 @@ private fun utledGrunnlagTidslinjePerPerson(
                 endredeUtbetalinger = utfylteEndredeUtbetalinger
                     .filter { endretUtbetaling -> endretUtbetaling.person.aktør == personResultat.aktør },
                 andelerTilkjentYtelse = andelerTilkjentYtelse.filter { andelTilkjentYtelse -> andelTilkjentYtelse.aktør == personResultat.aktør },
-                perioderOvergangsstønad = perioderOvergangsstønad.filter { it.aktør == person.aktør }
+                perioderOvergangsstønad = perioderOvergangsstønad.filter { it.personIdent == person.aktør.aktivFødselsnummer() }
             ).perioder()
                 .dropWhile { it.innhold !is GrunnlagForPersonInnvilget }
                 .tilTidslinje()
@@ -238,7 +238,7 @@ private fun PersonResultat.tilGrunnlagForPersonTidslinje(
     kompetanser: List<UtfyltKompetanse>,
     endredeUtbetalinger: List<IUtfyltEndretUtbetalingAndel>,
     andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-    perioderOvergangsstønad: List<PeriodeOvergangsstønadGrunnlag>
+    perioderOvergangsstønad: List<InternPeriodeOvergangsstønad>
 ): Tidslinje<GrunnlagForPerson, Måned> {
     val forskjøvedeVilkårResultater = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår().kombiner { it }
     val forskjøvedeVilkårResultaterForPerson = when (person.type) {
@@ -305,7 +305,7 @@ private fun PersonResultat.tilGrunnlagForPersonTidslinje(
     return grunnlagTidslinje.slåSammenLike()
 }
 
-private fun List<PeriodeOvergangsstønadGrunnlag>.tilPeriodeOvergangsstønadForVedtaksperiodeTidslinje() = this
+private fun List<InternPeriodeOvergangsstønad>.tilPeriodeOvergangsstønadForVedtaksperiodeTidslinje() = this
     .map { OvergangsstønadForVedtaksperiode(it) }
     .map { Periode(it.fom.tilMånedTidspunkt(), it.tom.tilMånedTidspunkt(), it) }
     .tilTidslinje()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -425,7 +425,11 @@ class BeregningServiceTest {
 
         val tilleggFom = SatsService.hentDatoForSatsendring(satstype = SatsType.TILLEGG_ORBA, oppdatertBeløp = 1354)
 
-        val søkerVilkår = Vilkår.hentVilkårFor(personType = PersonType.SØKER, fagsakType = FagsakType.NORMAL, behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR)
+        val søkerVilkår = Vilkår.hentVilkårFor(
+            personType = PersonType.SØKER,
+            fagsakType = FagsakType.NORMAL,
+            behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR
+        )
         val vilkårResultaterSøker = søkerVilkår.map {
             lagVilkårResultat(
                 vilkårType = it,
@@ -1071,7 +1075,11 @@ class BeregningServiceTest {
             aktør = barn.aktør
         )
 
-        val vilkårForBarn = Vilkår.hentVilkårFor(personType = PersonType.BARN, fagsakType = FagsakType.NORMAL, behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR)
+        val vilkårForBarn = Vilkår.hentVilkårFor(
+            personType = PersonType.BARN,
+            fagsakType = FagsakType.NORMAL,
+            behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR
+        )
         val vilkårResultaterBarn =
             vilkårForBarn.lagVilkårResultaterForPerson(
                 fom = førstePeriodeFomForBarnet,
@@ -1321,7 +1329,8 @@ class BeregningServiceTest {
         }
         every { vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId = behandling.id) } answers { vilkårsvurdering }
         every { tilkjentYtelseRepository.save(any()) } returns lagInitiellTilkjentYtelse(behandling)
-        every { småbarnstilleggService.hentOgLagrePerioderMedFullOvergangsstønad(any(), any()) } answers {
+        every { småbarnstilleggService.hentOgLagrePerioderMedFullOvergangsstønadFraEf(any(), any()) } just Runs
+        every { småbarnstilleggService.hentPerioderMedFullOvergangsstønad(any()) } answers {
             listOf(
                 InternPeriodeOvergangsstønad(
                     personIdent = søker.aktør.aktivFødselsnummer(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
@@ -14,11 +14,11 @@ import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
+import no.nav.familie.ba.sak.kjerne.beregning.SmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.beregning.endringstidspunkt.EndringstidspunktService
 import no.nav.familie.ba.sak.kjerne.brev.BrevmalService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
-import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.feilutbetaltValuta.FeilutbetaltValuta
@@ -41,7 +41,7 @@ class VedtaksperiodeServiceEnhetstest {
     private val feilutbetaltValutaRepository: FeilutbetaltValutaRepository = mockk()
     private val brevmalService: BrevmalService = mockk()
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
-    private val periodeOvergangsstønadGrunnlagRepository: PeriodeOvergangsstønadGrunnlagRepository = mockk()
+    private val småbarnstilleggService: SmåbarnstilleggService = mockk()
 
     private val vedtaksperiodeService = VedtaksperiodeService(
         personidentService = mockk(),
@@ -61,7 +61,7 @@ class VedtaksperiodeServiceEnhetstest {
         feilutbetaltValutaRepository = feilutbetaltValutaRepository,
         brevmalService = brevmalService,
         behandlingHentOgPersisterService = behandlingHentOgPersisterService,
-        periodeOvergangsstønadGrunnlagRepository = periodeOvergangsstønadGrunnlagRepository
+        småbarnstilleggService = småbarnstilleggService
     )
 
     private val person = lagPerson()
@@ -105,7 +105,7 @@ class VedtaksperiodeServiceEnhetstest {
             )
         } returns true
         every { feilutbetaltValutaRepository.finnFeilutbetaltValutaForBehandling(any()) } returns emptyList()
-        every { periodeOvergangsstønadGrunnlagRepository.findByBehandlingId(any()) } returns emptyList()
+        every { småbarnstilleggService.hentPerioderMedFullOvergangsstønad(any())} returns emptyList()
     }
 
     @Test
@@ -123,7 +123,10 @@ class VedtaksperiodeServiceEnhetstest {
                 .last().tom
 
         val returnerteVedtaksperioderNårOverstyrtEndringstidspunktErFørsteOpphørFom = vedtaksperiodeService
-            .genererVedtaksperioderMedBegrunnelserGammel(vedtak, manueltOverstyrtEndringstidspunkt = førsteOpphørFomDato)
+            .genererVedtaksperioderMedBegrunnelserGammel(
+                vedtak,
+                manueltOverstyrtEndringstidspunkt = førsteOpphørFomDato
+            )
             .filter { it.type == Vedtaksperiodetype.OPPHØR }
         val returnerteVedtaksperioderNårOverstyrtEndringstidspunktErFørFørsteOpphør = vedtaksperiodeService
             .genererVedtaksperioderMedBegrunnelserGammel(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceEnhetstest.kt
@@ -105,7 +105,7 @@ class VedtaksperiodeServiceEnhetstest {
             )
         } returns true
         every { feilutbetaltValutaRepository.finnFeilutbetaltValutaForBehandling(any()) } returns emptyList()
-        every { småbarnstilleggService.hentPerioderMedFullOvergangsstønad(any())} returns emptyList()
+        every { småbarnstilleggService.hentPerioderMedFullOvergangsstønad(any()) } returns emptyList()
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi bruker overgangsstønadsperiodene slik som vi får dem fra EF. De har flere splitter enn det vi trenger, og vi har allerede funskjonalitet for å slå de sammen og splitte på diff fra forrige behandling. 

Deler opp koden for å slå sammen og splitte overgangsstønadsperiodene slik at vi kan gjenbruke den og bruker dette i ny vedtakspreiode løsning. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
