### PR TITLE
Grupperer ytelsestyper og ident for å kunne ha utvidet og ordinær på …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/IdentOgYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/IdentOgYtelse.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.ba.sak.integrasjoner.økonomi
+
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+
+/**
+ * Data class for å gruppere andeler per ident og [YtelseType], sånn at man kan lage kjeder per ident/type
+ */
+data class IdentOgYtelse(
+    val ident: String,
+    val type: YtelseType
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.SMÅBARNSTILLEGG_SUFFIX
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.andelerTilOpphørMedDato
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.andelerTilOpprettelse
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.sisteAndelPerKjede
@@ -46,10 +45,10 @@ class UtbetalingsoppdragGenerator(
         saksbehandlerId: String,
         vedtak: Vedtak,
         erFørsteBehandlingPåFagsak: Boolean,
-        forrigeKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> = emptyMap(),
-        sisteOffsetPerIdent: Map<String, Int> = emptyMap(),
+        forrigeKjeder: Map<IdentOgYtelse, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> = emptyMap(),
+        sisteOffsetPerIdent: Map<IdentOgYtelse, Int> = emptyMap(),
         sisteOffsetPåFagsak: Int? = null,
-        oppdaterteKjeder: Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> = emptyMap(),
+        oppdaterteKjeder: Map<IdentOgYtelse, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> = emptyMap(),
         erSimulering: Boolean = false,
         endretMigreringsDato: YearMonth? = null
     ): Utbetalingsoppdrag {
@@ -135,7 +134,7 @@ class UtbetalingsoppdragGenerator(
         andeler: List<List<AndelTilkjentYtelseForUtbetalingsoppdrag>>,
         vedtak: Vedtak,
         erFørsteBehandlingPåFagsak: Boolean,
-        sisteOffsetIKjedeOversikt: Map<String, Int>,
+        sisteOffsetIKjedeOversikt: Map<IdentOgYtelse, Int>,
         sisteOffsetPåFagsak: Int? = null,
         skalOppdatereTilkjentYtelse: Boolean
     ): List<Utbetalingsperiode> {
@@ -157,11 +156,7 @@ class UtbetalingsoppdragGenerator(
                 val ytelseType = kjede.first().type
                 var forrigeOffsetIKjede: Int? = null
                 if (!erFørsteBehandlingPåFagsak) {
-                    forrigeOffsetIKjede = if (ytelseType == YtelseType.SMÅBARNSTILLEGG) {
-                        sisteOffsetIKjedeOversikt[ident + SMÅBARNSTILLEGG_SUFFIX]
-                    } else {
-                        sisteOffsetIKjedeOversikt[ident]
-                    }
+                    forrigeOffsetIKjede = sisteOffsetIKjedeOversikt[IdentOgYtelse(ident, ytelseType)]
                 }
                 kjede.sortedBy { it.stønadFom }.mapIndexed { index, andel ->
                     val forrigeOffset = if (index == 0) forrigeOffsetIKjede else offset - 1

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.kjedeinndelteAndeler
+import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.grupperAndeler
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.oppdaterBeståendeAndelerMedOffset
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
@@ -99,7 +99,7 @@ class ØkonomiService(
             beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandlingId = oppdatertBehandling.id)
                 .pakkInnForUtbetaling(andelTilkjentYtelseForUtbetalingsoppdragFactory)
 
-        val oppdaterteKjeder = kjedeinndelteAndeler(oppdatertTilstand)
+        val oppdaterteKjeder = grupperAndeler(oppdatertTilstand)
 
         val erFørsteIverksatteBehandlingPåFagsak =
             beregningService.hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId = oppdatertBehandling.fagsak.id)
@@ -122,7 +122,7 @@ class ØkonomiService(
                 beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(forrigeBehandling.id)
                     .pakkInnForUtbetaling(andelTilkjentYtelseForUtbetalingsoppdragFactory)
 
-            val forrigeKjeder = kjedeinndelteAndeler(forrigeTilstand)
+            val forrigeKjeder = grupperAndeler(forrigeTilstand)
 
             val sisteOffsetPerIdent = beregningService.hentSisteOffsetPerIdent(
                 forrigeBehandling.fagsak.id,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtils.kt
@@ -7,10 +7,6 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
-data class IdentOgYtelse(
-    val ident: String,
-    val type: YtelseType
-)
 object ØkonomiUtils {
 
     /**

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdragFactory
+import no.nav.familie.ba.sak.integrasjoner.økonomi.IdentOgYtelse
 import no.nav.familie.ba.sak.integrasjoner.økonomi.pakkInnForUtbetaling
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -292,7 +293,7 @@ class BeregningService(
     fun hentSisteOffsetPerIdent(
         fagsakId: Long,
         andelTilkjentYtelseForUtbetalingsoppdragFactory: AndelTilkjentYtelseForUtbetalingsoppdragFactory
-    ): Map<String, Int> {
+    ): Map<IdentOgYtelse, Int> {
         val alleAndelerTilkjentYtelserIverksattMotØkonomi =
             hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId)
                 .flatMap { it.andelerTilkjentYtelse }
@@ -300,7 +301,7 @@ class BeregningService(
                 .pakkInnForUtbetaling(andelTilkjentYtelseForUtbetalingsoppdragFactory)
 
         val alleTideligereKjederIverksattMotØkonomi =
-            ØkonomiUtils.kjedeinndelteAndeler(alleAndelerTilkjentYtelserIverksattMotØkonomi)
+            ØkonomiUtils.grupperAndeler(alleAndelerTilkjentYtelserIverksattMotØkonomi)
 
         return ØkonomiUtils.gjeldendeForrigeOffsetForKjede(alleTideligereKjederIverksattMotØkonomi)
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -17,10 +17,11 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.OppdragParser.mapTilkjentYtel
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForIverksettingFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForSimuleringFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdrag
+import no.nav.familie.ba.sak.integrasjoner.økonomi.IdentOgYtelse
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGenerator
 import no.nav.familie.ba.sak.integrasjoner.økonomi.pakkInnForUtbetaling
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.gjeldendeForrigeOffsetForKjede
-import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.kjedeinndelteAndeler
+import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.grupperAndeler
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.oppdaterBeståendeAndelerMedOffset
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -134,7 +135,7 @@ class OppdragSteg {
     private fun tilKjeder(
         tilkjentYtelse: TilkjentYtelse?,
         erSimulering: Boolean = false
-    ): Map<String, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> {
+    ): Map<IdentOgYtelse, List<AndelTilkjentYtelseForUtbetalingsoppdrag>> {
         val andelFactory = if (erSimulering) {
             AndelTilkjentYtelseForSimuleringFactory()
         } else {
@@ -144,7 +145,7 @@ class OppdragSteg {
         return (tilkjentYtelse?.andelerTilkjentYtelse ?: emptyList())
             .filter { it.erAndelSomSkalSendesTilOppdrag() }
             .pakkInnForUtbetaling(andelFactory)
-            .let { kjedeinndelteAndeler(it) }
+            .let { grupperAndeler(it) }
     }
 
     private fun genererBehandlinger(dataTable: DataTable) {

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/ytelsestyper.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/ytelsestyper.feature
@@ -37,3 +37,36 @@ Egenskap: Ulike ytelsestyper på andelene
       | 2            | 03.2021  | 05.2021  | 03.2021     | 800   | SMÅBARNSTILLEGG    | ENDR         | Ja         | 1          |                    |
       | 2            | 03.2021  | 03.2021  |             | 800   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 2          | 1                  |
       | 2            | 04.2021  | 05.2021  |             | 800   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 3          | 2                  |
+
+  Scenario: Forelder og barn har flere stønadstyper, øver hvert beløp med 100kr
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp | Ytelse             | Kildebehandling | Ident |
+      | 1            | 03.2021  | 03.2021  | 100   | UTVIDET_BARNETRYGD | 1               | 1     |
+      | 1            | 03.2021  | 03.2021  | 200   | SMÅBARNSTILLEGG    | 1               | 1     |
+      | 1            | 03.2021  | 03.2021  | 300   | ORDINÆR_BARNETRYGD | 1               | 2     |
+      | 1            | 03.2021  | 03.2021  | 400   | UTVIDET_BARNETRYGD | 1               | 2     |
+
+      | 2            | 03.2021  | 03.2021  | 200   | UTVIDET_BARNETRYGD | 1               | 1     |
+      | 2            | 03.2021  | 03.2021  | 300   | SMÅBARNSTILLEGG    | 1               | 1     |
+      | 2            | 03.2021  | 03.2021  | 400   | ORDINÆR_BARNETRYGD | 1               | 2     |
+      | 2            | 03.2021  | 03.2021  | 500   | UTVIDET_BARNETRYGD | 1               | 2     |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Ytelse             | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 100   | UTVIDET_BARNETRYGD | NY           | Nei        | 0          |                    |
+      | 1            | 03.2021  | 03.2021  |             | 200   | SMÅBARNSTILLEGG    | NY           | Nei        | 1          |                    |
+      | 1            | 03.2021  | 03.2021  |             | 300   | ORDINÆR_BARNETRYGD | NY           | Nei        | 2          |                    |
+      | 1            | 03.2021  | 03.2021  |             | 400   | UTVIDET_BARNETRYGD | NY           | Nei        | 3          |                    |
+
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 100   | UTVIDET_BARNETRYGD | ENDR         | Ja         | 0          |                    |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 200   | SMÅBARNSTILLEGG    | ENDR         | Ja         | 1          |                    |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 300   | ORDINÆR_BARNETRYGD | ENDR         | Ja         | 2          |                    |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 400   | UTVIDET_BARNETRYGD | ENDR         | Ja         | 3          |                    |
+
+      | 2            | 03.2021  | 03.2021  |             | 200   | UTVIDET_BARNETRYGD | ENDR         | Nei        | 4          | 0                  |
+      | 2            | 03.2021  | 03.2021  |             | 300   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 5          | 1                  |
+      | 2            | 03.2021  | 03.2021  |             | 400   | ORDINÆR_BARNETRYGD | ENDR         | Nei        | 6          | 2                  |
+      | 2            | 03.2021  | 03.2021  |             | 500   | UTVIDET_BARNETRYGD | ENDR         | Nei        | 7          | 3                  |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/ytelsestyper.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/ytelsestyper.feature
@@ -38,7 +38,7 @@ Egenskap: Ulike ytelsestyper på andelene
       | 2            | 03.2021  | 03.2021  |             | 800   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 2          | 1                  |
       | 2            | 04.2021  | 05.2021  |             | 800   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 3          | 2                  |
 
-  Scenario: Forelder og barn har flere stønadstyper, øver hvert beløp med 100kr
+  Scenario: Forelder og barn har flere stønadstyper som alle blir egne kjeder. Øker hvert beløp med 100kr i revurderingen for å verifisere at det fortsatt blir 4 ulike kjeder
 
     Gitt følgende tilkjente ytelser
       | BehandlingId | Fra dato | Til dato | Beløp | Ytelse             | Kildebehandling | Ident |


### PR DESCRIPTION
…en og samme person

* Det ble tidligere paritionert på <ident><ytelse> hvis ytelsen var småbarnstillegg, og <ident> ellers. Nå gjøres dette i en data class med bedre typing

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12162

### 💰 Hva skal gjøres, og hvorfor?
Sørge for at utvidet og ordinær kan sendes på samme person til økonomi
For å kunne behandle utvidet enslig mindreårig saker så er vi avhengig av å fikse dette.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
- [x] Hvis ønskelig