### PR TITLE
Legger ved behandlingsnummer i header til kall mot pdl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20230403093611_10cc82e-JAKARTA</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20230509152247_36d24db</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20230223155122_2e81c44</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlIdentRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlIdentRestClient.kt
@@ -68,6 +68,7 @@ class PdlIdentRestClient(
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
             add("Tema", PDL_TEMA)
+            add("behandlingsnummer", PDL_BEHANDLINGSNUMMER)
         }
     }
 
@@ -75,5 +76,6 @@ class PdlIdentRestClient(
 
         private const val PATH_GRAPHQL = "graphql"
         private const val PDL_TEMA = "BAR"
+        private const val PDL_BEHANDLINGSNUMMER = "B284"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlIdentRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlIdentRestClient.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonRequest
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonRequestVariables
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.http.util.UriUtil
+import no.nav.familie.kontrakter.felles.Tema
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
@@ -68,7 +69,7 @@ class PdlIdentRestClient(
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
             add("Tema", PDL_TEMA)
-            add("behandlingsnummer", PDL_BEHANDLINGSNUMMER)
+            add("behandlingsnummer", Tema.BAR.behandlingsnummer)
         }
     }
 
@@ -76,6 +77,5 @@ class PdlIdentRestClient(
 
         private const val PATH_GRAPHQL = "graphql"
         private const val PDL_TEMA = "BAR"
-        private const val PDL_BEHANDLINGSNUMMER = "B284"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.http.util.UriUtil
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.personopplysning.Opphold
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import org.apache.commons.lang3.StringUtils
@@ -223,7 +224,7 @@ class PdlRestClient(
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
             add("Tema", PDL_TEMA)
-            add("behandlingsnummer", PDL_BEHANDLINGSNUMMER)
+            add("behandlingsnummer", Tema.BAR.behandlingsnummer)
         }
     }
 
@@ -231,7 +232,6 @@ class PdlRestClient(
 
         private const val PATH_GRAPHQL = "graphql"
         private const val PDL_TEMA = "BAR"
-        private const val PDL_BEHANDLINGSNUMMER = "B284"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -223,6 +223,7 @@ class PdlRestClient(
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
             add("Tema", PDL_TEMA)
+            add("behandlingsnummer", PDL_BEHANDLINGSNUMMER)
         }
     }
 
@@ -230,6 +231,7 @@ class PdlRestClient(
 
         private const val PATH_GRAPHQL = "graphql"
         private const val PDL_TEMA = "BAR"
+        private const val PDL_BEHANDLINGSNUMMER = "B284"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlUtil.kt
@@ -7,6 +7,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
+val logger: Logger = LoggerFactory.getLogger("PdlUtil")
 
 inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
     ident: String?,
@@ -19,6 +20,11 @@ inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
         }
         secureLogger.error("Feil ved henting av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
         throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
+    }
+
+    if (pdlResponse.harAdvarsel()) {
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
+        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
     }
 
     val data = dataMapper.invoke(pdlResponse.data)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlBaseResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlBaseResponse.kt
@@ -4,11 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 open class PdlBaseResponse<T>(
     val data: T,
-    open val errors: List<PdlError>?
+    open val errors: List<PdlError>?,
+    open val extensions: PdlExtensions?
 ) {
 
     fun harFeil(): Boolean {
         return errors != null && errors!!.isNotEmpty()
+    }
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
     }
 
     fun errorMessages(): String {
@@ -19,10 +23,14 @@ open class PdlBaseResponse<T>(
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?
+    val extensions: PdlErrorExtensions?
 )
 
-data class PdlExtensions(val code: String?) {
+data class PdlErrorExtensions(val code: String?) {
 
     fun notFound() = code == "not_found"
 }
+
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._

Favrokort: [NAV-12403](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12403) 

Dersom man henter ut noe fra pdl sendes det med en warning i extensions-objektet i responsen fordi behandlingsnummer ikke blir sendt med i header. Denne PR'en legger til denne headeren. Dette nummeret er knyttet opp mot [behandlingskatalogen](https://behandlingskatalog.nais.adeo.no/process/purpose/BARNETRYGD/9f5fa38c-c6d3-415f-967e-9f961ab8413d). Da får man også en warning dersom man mangler noen opplysningstyper i behandlingskatalogen. 

Det er også lagt til at vi logger dersom man får denne warningen.

Til info: opplysningstypene som manglet for barnetrygd er nå lagt til i behandlingskatalogen også.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
