### PR TITLE
Finner ut av siste andelen i en kjede med sql i stedet for å hente al…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
@@ -102,7 +102,7 @@ class ØkonomiService(
         val oppdaterteKjeder = grupperAndeler(oppdatertTilstand)
 
         val erFørsteIverksatteBehandlingPåFagsak =
-            beregningService.hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId = oppdatertBehandling.fagsak.id)
+            beregningService.hentSisteAndelPerIdent(fagsakId = oppdatertBehandling.fagsak.id)
                 .isEmpty()
 
         val utbetalingsoppdrag = if (erFørsteIverksatteBehandlingPåFagsak) {
@@ -124,12 +124,7 @@ class ØkonomiService(
 
             val forrigeKjeder = grupperAndeler(forrigeTilstand)
 
-            val sisteOffsetPerIdent = beregningService.hentSisteOffsetPerIdent(
-                forrigeBehandling.fagsak.id,
-                andelTilkjentYtelseForUtbetalingsoppdragFactory
-            )
-
-            val sisteOffsetPåFagsak = beregningService.hentSisteOffsetPåFagsak(behandling = oppdatertBehandling)
+            val sisteAndelPerIdent = beregningService.hentSisteAndelPerIdent(forrigeBehandling.fagsak.id)
 
             if (oppdatertTilstand.isNotEmpty()) {
                 oppdaterBeståendeAndelerMedOffset(oppdaterteKjeder = oppdaterteKjeder, forrigeKjeder = forrigeKjeder)
@@ -142,8 +137,7 @@ class ØkonomiService(
                 vedtak = vedtak,
                 erFørsteBehandlingPåFagsak = erFørsteIverksatteBehandlingPåFagsak,
                 forrigeKjeder = forrigeKjeder,
-                sisteOffsetPerIdent = sisteOffsetPerIdent,
-                sisteOffsetPåFagsak = sisteOffsetPåFagsak,
+                sisteAndelPerIdent = sisteAndelPerIdent,
                 oppdaterteKjeder = oppdaterteKjeder,
                 erSimulering = erSimulering,
                 endretMigreringsDato = beregnOmMigreringsDatoErEndret(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -1,10 +1,9 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdragFactory
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForSimuleringFactory
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdrag
 import no.nav.familie.ba.sak.integrasjoner.økonomi.IdentOgYtelse
-import no.nav.familie.ba.sak.integrasjoner.økonomi.pakkInnForUtbetaling
-import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
@@ -76,18 +75,15 @@ class BeregningService(
     fun hentOptionalTilkjentYtelseForBehandling(behandlingId: Long) =
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
 
-    fun hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId: Long): List<TilkjentYtelse> {
-        val avsluttedeBehandlingerSomIkkeErHenlagtPåFagsak = behandlingHentOgPersisterService.finnAvsluttedeBehandlingerPåFagsak(
-            fagsakId = fagsakId
-        ).filter { !it.erHenlagt() }
+    fun hentSisteAndelPerIdent(fagsakId: Long): Map<IdentOgYtelse, AndelTilkjentYtelseForUtbetalingsoppdrag> {
+        return sisteAndelerPerIdentOgType(fagsakId)
+            .groupBy { IdentOgYtelse(it.aktør.aktivFødselsnummer(), it.type) }
+            .mapValues { AndelTilkjentYtelseForSimuleringFactory().pakkInnForUtbetaling(it.value).single() }
+    }
 
-        return avsluttedeBehandlingerSomIkkeErHenlagtPåFagsak.mapNotNull {
-            tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(
-                it.id
-            )?.takeIf { tilkjentYtelse ->
-                tilkjentYtelse.andelerTilkjentYtelse.any { aty -> aty.erAndelSomSkalSendesTilOppdrag() }
-            }
-        }
+    private fun sisteAndelerPerIdentOgType(fagsakId: Long): MutableList<AndelTilkjentYtelse> {
+        val sisteAndelIdPerIdent = andelTilkjentYtelseRepository.hentSisteAndelPerIdent(fagsakId)
+        return andelTilkjentYtelseRepository.findAllById(sisteAndelIdPerIdent)
     }
 
     /**
@@ -289,32 +285,6 @@ class BeregningService(
                 andelerTilkjentYtelse.any { aty -> aty.aktør == it }
             } ?: emptyList()
     }
-
-    fun hentSisteOffsetPerIdent(
-        fagsakId: Long,
-        andelTilkjentYtelseForUtbetalingsoppdragFactory: AndelTilkjentYtelseForUtbetalingsoppdragFactory
-    ): Map<IdentOgYtelse, Int> {
-        val alleAndelerTilkjentYtelserIverksattMotØkonomi =
-            hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId)
-                .flatMap { it.andelerTilkjentYtelse }
-                .filter { it.erAndelSomSkalSendesTilOppdrag() }
-                .pakkInnForUtbetaling(andelTilkjentYtelseForUtbetalingsoppdragFactory)
-
-        val alleTideligereKjederIverksattMotØkonomi =
-            ØkonomiUtils.grupperAndeler(alleAndelerTilkjentYtelserIverksattMotØkonomi)
-
-        return ØkonomiUtils.gjeldendeForrigeOffsetForKjede(alleTideligereKjederIverksattMotØkonomi)
-    }
-
-    fun hentSisteOffsetPåFagsak(behandling: Behandling): Int? =
-        behandlingHentOgPersisterService.hentBehandlingerSomErIverksatt(behandling = behandling)
-            .mapNotNull { iverksattBehandling ->
-                hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(iverksattBehandling.id)
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { andelerTilkjentYtelse ->
-                        andelerTilkjentYtelse.maxByOrNull { it.periodeOffset!! }?.periodeOffset?.toInt()
-                    }
-            }.maxByOrNull { it }
 
     fun populerTilkjentYtelse(
         behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -65,4 +65,23 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
         fom: LocalDateTime,
         tom: LocalDateTime
     ): List<AndelTilkjentYtelsePeriode>
+
+    @Query(
+        """
+        WITH andeler AS (
+            SELECT
+             aty.id,
+             row_number() OVER (PARTITION BY aty.type, aty.fk_aktoer_id ORDER BY aty.periode_offset DESC) rn
+             FROM andel_tilkjent_ytelse aty
+              JOIN tilkjent_ytelse ty ON ty.id = aty.tilkjent_ytelse_id
+              JOIN Behandling b ON b.id = aty.fk_behandling_id
+             WHERE b.fk_fagsak_id = :fagsakId
+               AND ty.utbetalingsoppdrag IS NOT NULL
+               AND aty.periode_offset IS NOT NULL
+               AND b.status = 'AVSLUTTET')
+        SELECT id FROM andeler aty WHERE rn = 1
+    """,
+        nativeQuery = true
+    )
+    fun hentSisteAndelPerIdent(fagsakId: Long): List<Long>
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtilsTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.andelerTilOppr
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.grupperAndeler
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.oppdaterBeståendeAndelerMedOffset
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.sisteBeståendeAndelPerKjede
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningTestUtil.sisteAndelPerIdent
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.SMÅBARNSTILLEGG
@@ -236,7 +237,9 @@ internal class ØkonomiUtilsTest {
                     ORDINÆR_BARNETRYGD,
                     1054,
                     person = person,
-                    aktør = person.aktør
+                    aktør = person.aktør,
+                    periodeIdOffset = 0,
+                    forrigeperiodeIdOffset = null
                 ),
                 lagAndelTilkjentYtelse(
                     årMnd(datoSomSkalOppdateres),
@@ -244,7 +247,9 @@ internal class ØkonomiUtilsTest {
                     ORDINÆR_BARNETRYGD,
                     1054,
                     person = person,
-                    aktør = person.aktør
+                    aktør = person.aktør,
+                    periodeIdOffset = 1,
+                    forrigeperiodeIdOffset = 0
                 ),
                 lagAndelTilkjentYtelse(
                     årMnd("2025-04"),
@@ -252,7 +257,9 @@ internal class ØkonomiUtilsTest {
                     ORDINÆR_BARNETRYGD,
                     1054,
                     person = person,
-                    aktør = person.aktør
+                    aktør = person.aktør,
+                    periodeIdOffset = 2,
+                    forrigeperiodeIdOffset = 1
                 )
             ).forIverksetting()
         )
@@ -298,7 +305,8 @@ internal class ØkonomiUtilsTest {
         val andelerTilOpphørMedDato =
             andelerTilOpphørMedDato(
                 forrigeKjeder = kjederBehandling1,
-                sisteBeståendeAndelIHverKjede = sisteBeståendePerKjede
+                sisteBeståendeAndelIHverKjede = sisteBeståendePerKjede,
+                sisteAndelPerIdent = sisteAndelPerIdent(kjederBehandling1.values.flatten())
             )
 
         assertEquals(1, andelerTilOpprettelse.size)
@@ -320,7 +328,9 @@ internal class ØkonomiUtilsTest {
                     ORDINÆR_BARNETRYGD,
                     1054,
                     person = førsteBarn,
-                    aktør = førsteBarn.aktør
+                    aktør = førsteBarn.aktør,
+                    periodeIdOffset = 0,
+                    forrigeperiodeIdOffset = null
                 ),
                 lagAndelTilkjentYtelse(
                     årMnd("2020-02"),
@@ -328,7 +338,9 @@ internal class ØkonomiUtilsTest {
                     ORDINÆR_BARNETRYGD,
                     1345,
                     person = førsteBarn,
-                    aktør = førsteBarn.aktør
+                    aktør = førsteBarn.aktør,
+                    periodeIdOffset = 1,
+                    forrigeperiodeIdOffset = 0
                 ),
                 lagAndelTilkjentYtelse(
                     årMnd("2023-02"),
@@ -336,7 +348,9 @@ internal class ØkonomiUtilsTest {
                     ORDINÆR_BARNETRYGD,
                     1654,
                     person = førsteBarn,
-                    aktør = førsteBarn.aktør
+                    aktør = førsteBarn.aktør,
+                    periodeIdOffset = 2,
+                    forrigeperiodeIdOffset = 1
                 )
             ).forIverksetting()
         )
@@ -382,7 +396,8 @@ internal class ØkonomiUtilsTest {
         val andelerTilOpphørMedDato =
             andelerTilOpphørMedDato(
                 forrigeKjeder = kjederBehandling1,
-                sisteBeståendeAndelIHverKjede = sisteBeståendePerKjede
+                sisteBeståendeAndelIHverKjede = sisteBeståendePerKjede,
+                sisteAndelPerIdent = sisteAndelPerIdent(kjederBehandling1.values.flatten())
             )
 
         assertEquals(1, andelerTilOpphørMedDato.size)
@@ -449,7 +464,8 @@ internal class ØkonomiUtilsTest {
         val andelerTilOpphørMedDato =
             andelerTilOpphørMedDato(
                 forrigeKjeder = kjederBehandling1,
-                sisteBeståendeAndelIHverKjede = sisteBeståendePerKjede
+                sisteBeståendeAndelIHverKjede = sisteBeståendePerKjede,
+                sisteAndelPerIdent = sisteAndelPerIdent(kjederBehandling1.values.flatten())
             )
 
         assertEquals(2, andelerTilOpprettelse.size)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -20,10 +20,10 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbeta
 import no.nav.familie.ba.sak.integrasjoner.økonomi.IdentOgYtelse
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGenerator
 import no.nav.familie.ba.sak.integrasjoner.økonomi.pakkInnForUtbetaling
-import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.gjeldendeForrigeOffsetForKjede
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.grupperAndeler
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiUtils.oppdaterBeståendeAndelerMedOffset
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningTestUtil.sisteAndelPerIdent
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
@@ -72,31 +72,19 @@ class OppdragSteg {
         val vedtak = lagVedtak(behandling = tilkjentYtelse.behandling)
         val forrigeKjeder = tilKjeder(forrigeTilkjentYtelse, erSimulering)
         val oppdaterteKjeder = tilKjeder(tilkjentYtelse, erSimulering)
-        val sisteOffsetPåFagsak = maxOffsetPåFagsak(acc)
-        val sisteOffsetPerIdent = gjeldendeForrigeOffsetForKjede(forrigeKjeder)
+        val sisteAndelPerIdent = sisteAndelPerIdent(acc)
         oppdaterBeståendeAndelerMedOffset(oppdaterteKjeder, forrigeKjeder)
         return utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             saksbehandlerId = "saksbehandlerId",
             vedtak = vedtak,
             erFørsteBehandlingPåFagsak = forrigeTilkjentYtelse == null,
             forrigeKjeder = forrigeKjeder,
-            sisteOffsetPerIdent = sisteOffsetPerIdent,
-            sisteOffsetPåFagsak = sisteOffsetPåFagsak?.toInt(),
+            sisteAndelPerIdent = sisteAndelPerIdent,
             oppdaterteKjeder = oppdaterteKjeder,
             erSimulering = erSimulering,
             endretMigreringsDato = null
         )
     }
-
-    private fun maxOffsetPåFagsak(acc: List<TilkjentYtelse>) =
-        acc.maxOfOrNull { ty ->
-            ty.andelerTilkjentYtelse.maxOfOrNull {
-                it.periodeOffset ?: error(
-                    "Mangler offset for behandling=${it.behandlingId} " +
-                        "andel=${it.id} fom=${it.stønadFom} tom=${it.stønadTom}"
-                )
-            } ?: 0
-        }
 
     @Så("forvent følgende utbetalingsoppdrag")
     fun `forvent følgende utbetalingsoppdrag`(dataTable: DataTable) {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragIntegrasjonTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningTestUtil.sisteAndelPerIdent
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -40,7 +41,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -218,11 +218,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 forrigeKjeder = ØkonomiUtils.grupperAndeler(
                     andelerTilkjentYtelse.forIverksetting()
                 ),
-                sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
-                    ØkonomiUtils.grupperAndeler(
-                        andelerTilkjentYtelse.forIverksetting()
-                    )
-                )
+                sisteAndelPerIdent = sisteAndelPerIdent(andelerTilkjentYtelse)
             )
 
         assertEquals(Utbetalingsoppdrag.KodeEndring.ENDR, utbetalingsoppdrag.kodeEndring)
@@ -311,6 +307,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 andelerFørstegangsbehandling.forIverksetting()
             )
         )
+        avsluttOgLagreBehandling(behandling)
 
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
         val tilkjentYtelse2 = lagInitiellTilkjentYtelse(behandling2)
@@ -351,7 +348,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             )
         )
         tilkjentYtelse2.andelerTilkjentYtelse.addAll(andelerRevurdering)
-        val sisteOffsetPåFagsak = beregningService.hentSisteOffsetPåFagsak(behandling = behandling2)
+        val sisteAndelPerIdent = beregningService.hentSisteAndelPerIdent(behandling.fagsak.id)
 
         val utbetalingsoppdrag =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
@@ -361,16 +358,12 @@ class UtbetalingsoppdragIntegrasjonTest(
                 forrigeKjeder = ØkonomiUtils.grupperAndeler(
                     andelerFørstegangsbehandling.forIverksetting()
                 ),
-                sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
-                    ØkonomiUtils.grupperAndeler(
-                        andelerFørstegangsbehandling.forIverksetting()
-                    )
-                ),
-                sisteOffsetPåFagsak = sisteOffsetPåFagsak,
+                sisteAndelPerIdent = sisteAndelPerIdent,
                 oppdaterteKjeder = ØkonomiUtils.grupperAndeler(
                     andelerRevurdering.forIverksetting()
                 )
             )
+        avsluttOgLagreBehandling(behandling2)
 
         assertEquals(Utbetalingsoppdrag.KodeEndring.ENDR, utbetalingsoppdrag.kodeEndring)
         assertEquals(3, utbetalingsoppdrag.utbetalingsperiode.size)
@@ -459,6 +452,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 andelerFørstegangsbehandling.forIverksetting()
             )
         )
+        avsluttOgLagreBehandling(behandling)
 
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
         val tilkjentYtelse2 = lagInitiellTilkjentYtelse(behandling2)
@@ -490,7 +484,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             )
         )
         tilkjentYtelse2.andelerTilkjentYtelse.addAll(andelerRevurdering)
-        val sisteOffsetPåFagsak = beregningService.hentSisteOffsetPåFagsak(behandling = behandling2)
+        val sisteAndelPerIdent = beregningService.hentSisteAndelPerIdent(behandling2.fagsak.id)
 
         val utbetalingsoppdrag =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
@@ -500,12 +494,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 forrigeKjeder = ØkonomiUtils.grupperAndeler(
                     andelerFørstegangsbehandling.forIverksetting()
                 ),
-                sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
-                    ØkonomiUtils.grupperAndeler(
-                        andelerFørstegangsbehandling.forIverksetting()
-                    )
-                ),
-                sisteOffsetPåFagsak = sisteOffsetPåFagsak,
+                sisteAndelPerIdent = sisteAndelPerIdent,
                 oppdaterteKjeder = ØkonomiUtils.grupperAndeler(
                     andelerRevurdering.forIverksetting()
                 )
@@ -704,6 +693,8 @@ class UtbetalingsoppdragIntegrasjonTest(
             )
         )
 
+        avsluttOgLagreBehandling(behandling)
+
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
         val tilkjentYtelse2 = lagInitiellTilkjentYtelse(behandling2)
         val vedtak2 = lagVedtak(behandling2)
@@ -743,7 +734,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             )
         )
         tilkjentYtelse2.andelerTilkjentYtelse.addAll(andelerRevurdering)
-        val sisteOffsetPåFagsak = beregningService.hentSisteOffsetPåFagsak(behandling = behandling2)
+        val sisteAndelPerIdent = beregningService.hentSisteAndelPerIdent(behandling2.fagsak.id)
 
         val utbetalingsoppdrag =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
@@ -753,12 +744,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 forrigeKjeder = ØkonomiUtils.grupperAndeler(
                     andelerFørstegangsbehandling.forIverksetting()
                 ),
-                sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
-                    ØkonomiUtils.grupperAndeler(
-                        andelerFørstegangsbehandling.forIverksetting()
-                    )
-                ),
-                sisteOffsetPåFagsak = sisteOffsetPåFagsak,
+                sisteAndelPerIdent = sisteAndelPerIdent,
                 oppdaterteKjeder = ØkonomiUtils.grupperAndeler(
                     andelerRevurdering.forIverksetting()
                 ),
@@ -872,6 +858,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 andelerFørstegangsbehandling.forIverksetting()
             )
         )
+        avsluttOgLagreBehandling(behandling)
 
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
         val tilkjentYtelse2 = lagInitiellTilkjentYtelse(behandling2)
@@ -913,7 +900,7 @@ class UtbetalingsoppdragIntegrasjonTest(
         )
         tilkjentYtelse2.andelerTilkjentYtelse.addAll(andelerRevurdering)
 
-        val sisteOffsetPåFagsak = beregningService.hentSisteOffsetPåFagsak(behandling = behandling2)
+        val sisteAndelPerIdent = beregningService.hentSisteAndelPerIdent(behandling2.fagsak.id)
 
         val utbetalingsoppdrag =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
@@ -923,12 +910,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 forrigeKjeder = ØkonomiUtils.grupperAndeler(
                     andelerFørstegangsbehandling.forIverksetting()
                 ),
-                sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
-                    ØkonomiUtils.grupperAndeler(
-                        andelerFørstegangsbehandling.forIverksetting()
-                    )
-                ),
-                sisteOffsetPåFagsak = sisteOffsetPåFagsak,
+                sisteAndelPerIdent = sisteAndelPerIdent,
                 oppdaterteKjeder = ØkonomiUtils.grupperAndeler(
                     andelerRevurdering.forIverksetting()
                 ),
@@ -984,95 +966,6 @@ class UtbetalingsoppdragIntegrasjonTest(
     }
 
     @Test
-    fun `Skal teste at forrige offset er samme som den høyeste offsetten for den identen`() {
-        val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(randomFnr())
-        val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(
-            lagBehandling(
-                fagsak,
-                førsteSteg = StegType.BEHANDLING_AVSLUTTET
-            )
-        )
-
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling)
-        val person = tilfeldigPerson()
-        val vedtak = lagVedtak(behandling)
-        val andelerFørstegangsbehandling = listOf(
-            lagAndelTilkjentYtelse(
-                årMnd("2020-01"),
-                årMnd("2024-12"),
-                YtelseType.ORDINÆR_BARNETRYGD,
-                1054,
-                behandling,
-                periodeIdOffset = 0,
-                person = person,
-                aktør = personidentService.hentOgLagreAktør(person.aktør.aktivFødselsnummer(), true),
-                tilkjentYtelse = tilkjentYtelse
-            ),
-            lagAndelTilkjentYtelse(
-                årMnd("2025-01"),
-                årMnd("2029-12"),
-                YtelseType.ORDINÆR_BARNETRYGD,
-                1654,
-                behandling,
-                periodeIdOffset = 1,
-                forrigeperiodeIdOffset = 0,
-                person = person,
-                aktør = personidentService.hentOgLagreAktør(person.aktør.aktivFødselsnummer(), true),
-                tilkjentYtelse = tilkjentYtelse
-            )
-        )
-
-        val andelerAndregangsbehandling = listOf(
-            lagAndelTilkjentYtelse(
-                årMnd("2020-01"),
-                årMnd("2024-12"),
-                YtelseType.ORDINÆR_BARNETRYGD,
-                1254,
-                behandling,
-                periodeIdOffset = 0,
-                person = person,
-                aktør = personidentService.hentOgLagreAktør(person.aktør.aktivFødselsnummer(), true),
-                tilkjentYtelse = tilkjentYtelse
-            )
-        )
-        val andelerRevurderingsbehandling = listOf(
-            lagAndelTilkjentYtelse(
-                årMnd("2020-01"),
-                årMnd("2029-12"),
-                YtelseType.ORDINÆR_BARNETRYGD,
-                1654,
-                behandling,
-                person = person,
-                aktør = personidentService.hentOgLagreAktør(person.aktør.aktivFødselsnummer(), true),
-                tilkjentYtelse = tilkjentYtelse
-            )
-        )
-        tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerRevurderingsbehandling)
-        tilkjentYtelse.utbetalingsoppdrag = "Oppdrag"
-
-        val utbetalingsoppdrag = utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
-            "saksbehandler",
-            vedtak,
-            false,
-            sisteOffsetPåFagsak = 1,
-            forrigeKjeder = ØkonomiUtils.grupperAndeler(
-                andelerAndregangsbehandling.forIverksetting()
-            ),
-            sisteOffsetPerIdent = ØkonomiUtils.gjeldendeForrigeOffsetForKjede(
-                ØkonomiUtils.grupperAndeler(
-                    (andelerFørstegangsbehandling + andelerAndregangsbehandling).forIverksetting()
-                )
-            ),
-            oppdaterteKjeder = ØkonomiUtils.grupperAndeler(
-                andelerRevurderingsbehandling.forIverksetting()
-            )
-        )
-
-        assertEquals(1, utbetalingsoppdrag.utbetalingsperiode.single() { it.opphør == null }.forrigePeriodeId)
-        assertEquals(2, utbetalingsoppdrag.utbetalingsperiode.single() { it.opphør == null }.periodeId)
-    }
-
-    @Test
     fun `Skal teste uthenting av offset på revurderinger`() {
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(randomFnr())
         val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(
@@ -1109,6 +1002,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 andelerFørstegangsbehandling.forIverksetting()
             )
         )
+        avsluttOgLagreBehandling(behandling)
 
         val behandling2 = behandlingService.lagreNyOgDeaktiverGammelBehandling(
             (
@@ -1131,6 +1025,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 andelerRevurdering.forIverksetting()
             )
         )
+        avsluttOgLagreBehandling(behandling2)
 
         val behandling3 = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
         val tilkjentYtelse3 = lagInitiellTilkjentYtelse(behandling3)
@@ -1149,7 +1044,7 @@ class UtbetalingsoppdragIntegrasjonTest(
         )
         tilkjentYtelse3.andelerTilkjentYtelse.addAll(andelerRevurdering2)
 
-        assertEquals(0, beregningService.hentSisteOffsetPåFagsak(behandling = behandling3))
+        assertEquals(0, beregningService.hentSisteAndelPerIdent(behandling3.fagsak.id).maxOf { it.value.periodeOffset!! })
     }
 
     @Test
@@ -1411,7 +1306,6 @@ class UtbetalingsoppdragIntegrasjonTest(
         }
 
         @Test
-        @Disabled // Denne virker ikke ennå, men skal bli fikset
         fun `skal alltid peke til siste andelen i kjeden ved opphør, selv opphør etter opphør`() {
             fun assertHarKunOpphør(utbetalingsoppdrag: Utbetalingsoppdrag, opphørFom: YearMonth) {
                 assertThat(utbetalingsoppdrag.kodeEndring).isEqualTo(Utbetalingsoppdrag.KodeEndring.ENDR)
@@ -1525,11 +1419,13 @@ class UtbetalingsoppdragIntegrasjonTest(
                 aktør = aktør ?: aktørSøker,
                 tilkjentYtelse = tilkjentYtelse
             )
-        private fun opprettRevurdering() =
-            behandlingService.lagreNyOgDeaktiverGammelBehandling(
-                lagBehandling(fagsak, behandlingType = BehandlingType.REVURDERING)
-            )
+        private fun opprettRevurdering() = opprettRevurdering(fagsak)
     }
+
+    private fun opprettRevurdering(fagsak: Fagsak) =
+        behandlingService.lagreNyOgDeaktiverGammelBehandling(
+            lagBehandling(fagsak, behandlingType = BehandlingType.REVURDERING)
+        )
 
     private fun genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(vedtak: Vedtak): Utbetalingsoppdrag {
         return økonomiService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -15,20 +15,29 @@ import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.tilAktør
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdrag
+import no.nav.familie.ba.sak.integrasjoner.økonomi.IdentOgYtelse
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
@@ -277,6 +286,306 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
         Assertions.assertEquals(1, andelBarn2.filter { it.kalkulertUtbetalingsbeløp == 1054 }.size)
         Assertions.assertEquals(1, andelBarn2.filter { it.kalkulertUtbetalingsbeløp == 1654 }.size)
         Assertions.assertEquals(1, andelBarn2.filter { it.kalkulertUtbetalingsbeløp == 1676 }.size)
+    }
+
+    @Nested
+    inner class HentSisteAndelPerIdent {
+
+        val søker = tilfeldigPerson()
+        val barn1 = tilfeldigPerson()
+        val barn2 = tilfeldigPerson()
+
+        val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søker.aktør.aktivFødselsnummer())
+        val aktørSøker = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
+        val aktørBarn1 = personidentService.hentOgLagreAktør(barn1.aktør.aktivFødselsnummer(), true)
+        val aktørBarn2 = personidentService.hentOgLagreAktør(barn2.aktør.aktivFødselsnummer(), true)
+
+        lateinit var førsteBehandling: Behandling
+
+        @BeforeEach
+        fun setUp() {
+            førsteBehandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
+        }
+
+        @Test
+        fun `ingen andeler`() {
+            assertThat(hentSisteAndelPerIdent()).isEmpty()
+        }
+
+        @Test
+        fun `uten utbetalingsoppdrag`() {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = null)) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        aktør = aktørBarn1,
+                        person = barn1,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 2),
+                        offset = 0
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(førsteBehandling)
+            val sisteAndelPerIdent = hentSisteAndelPerIdent()
+            assertThat(sisteAndelPerIdent).isEmpty()
+        }
+
+        @Test
+        fun `behandling er ikke avsluttet`() {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        aktør = aktørBarn1,
+                        person = barn1,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 2),
+                        offset = 0
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            val sisteAndelPerIdent = hentSisteAndelPerIdent()
+            assertThat(sisteAndelPerIdent).isEmpty()
+        }
+
+        @Test
+        fun `gitt fagsak har ikke noen andeler`() {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        aktør = aktørBarn1,
+                        person = barn1,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 2),
+                        offset = 0
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(førsteBehandling)
+            assertThat(beregningService.hentSisteAndelPerIdent(fagsak.id + 1)).isEmpty()
+        }
+
+        @Test
+        fun `2 ulike personer med samme type`() {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        aktør = aktørBarn1,
+                        person = barn1,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 2),
+                        offset = 0
+                    ),
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        aktør = aktørBarn2,
+                        person = barn2,
+                        fom = YearMonth.of(2020, 3),
+                        tom = YearMonth.of(2020, 5),
+                        offset = 1
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(førsteBehandling)
+            val sisteAndelPerIdent = hentSisteAndelPerIdent()
+            assertThat(sisteAndelPerIdent).hasSize(2)
+            with(sisteAndelPerIdent[IdentOgYtelse(barn1.aktør.aktivFødselsnummer(), YtelseType.SMÅBARNSTILLEGG)]!!) {
+                assertThat(periodeOffset).isEqualTo(0L)
+                assertThat(forrigePeriodeOffset).isNull()
+                assertThat(stønadFom).isEqualTo(YearMonth.of(2020, 1))
+                assertThat(stønadTom).isEqualTo(YearMonth.of(2020, 2))
+            }
+            with(sisteAndelPerIdent[IdentOgYtelse(barn2.aktør.aktivFødselsnummer(), YtelseType.SMÅBARNSTILLEGG)]!!) {
+                assertThat(periodeOffset).isEqualTo(1L)
+                assertThat(forrigePeriodeOffset).isNull()
+                assertThat(stønadFom).isEqualTo(YearMonth.of(2020, 3))
+                assertThat(stønadTom).isEqualTo(YearMonth.of(2020, 5))
+            }
+        }
+
+        @Test
+        fun `førstegångsbehandling med flere andeler per person`() {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 2),
+                        offset = 0
+                    ),
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        fom = YearMonth.of(2020, 3),
+                        tom = YearMonth.of(2020, 5),
+                        offset = 1,
+                        forrigeOffset = 0
+                    ),
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                        fom = YearMonth.of(2020, 3),
+                        tom = YearMonth.of(2020, 3),
+                        offset = 2,
+                        forrigeOffset = null
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(førsteBehandling)
+            val sisteAndelPerIdent = hentSisteAndelPerIdent()
+            assertThat(sisteAndelPerIdent).hasSize(2)
+            val fødselsnummer = aktørSøker.aktivFødselsnummer()
+            with(sisteAndelPerIdent[IdentOgYtelse(fødselsnummer, YtelseType.SMÅBARNSTILLEGG)]!!) {
+                assertThat(periodeOffset).isEqualTo(1L)
+                assertThat(forrigePeriodeOffset).isEqualTo(0L)
+                assertThat(stønadFom).isEqualTo(YearMonth.of(2020, 3))
+                assertThat(stønadTom).isEqualTo(YearMonth.of(2020, 5))
+            }
+            with(sisteAndelPerIdent[IdentOgYtelse(fødselsnummer, YtelseType.UTVIDET_BARNETRYGD)]!!) {
+                assertThat(periodeOffset).isEqualTo(2L)
+                assertThat(forrigePeriodeOffset).isNull()
+                assertThat(stønadFom).isEqualTo(YearMonth.of(2020, 3))
+                assertThat(stønadTom).isEqualTo(YearMonth.of(2020, 3))
+            }
+        }
+
+        @Test
+        fun `siste andelen kommer fra revurderingen`() {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 2),
+                        offset = 0
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(førsteBehandling)
+            val revurdering = lagRevurdering()
+            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 3),
+                        offset = 1,
+                        forrigeOffset = 0
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(revurdering)
+            val sisteAndelPerIdent = hentSisteAndelPerIdent()
+            assertThat(sisteAndelPerIdent).hasSize(1)
+            val fødselsnummer = aktørSøker.aktivFødselsnummer()
+            with(sisteAndelPerIdent[IdentOgYtelse(fødselsnummer, YtelseType.SMÅBARNSTILLEGG)]!!) {
+                assertThat(periodeOffset).isEqualTo(1L)
+                assertThat(forrigePeriodeOffset).isEqualTo(0L)
+                assertThat(stønadFom).isEqualTo(YearMonth.of(2020, 1))
+                assertThat(stønadTom).isEqualTo(YearMonth.of(2020, 3))
+                assertThat(kildeBehandlingId).isEqualTo(revurdering.id)
+            }
+        }
+
+        @Test
+        fun `en revurdering opphører en andel, sånn at siste andelen finnes i en tidligere behandling`() {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 3),
+                        offset = 0
+                    ),
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        fom = YearMonth.of(2020, 4),
+                        tom = YearMonth.of(2020, 5),
+                        offset = 1,
+                        forrigeOffset = 0
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(førsteBehandling)
+            val revurdering = lagRevurdering()
+            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+                val andeler = listOf(
+                    lagAndel(
+                        tilkjentYtelse = this,
+                        fom = YearMonth.of(2020, 1),
+                        tom = YearMonth.of(2020, 3),
+                        offset = 0
+                    )
+                )
+                andelerTilkjentYtelse.addAll(andeler)
+                tilkjentYtelseRepository.saveAndFlush(this)
+            }
+            avsluttOgLagreBehandling(revurdering)
+            val sisteAndelPerIdent = hentSisteAndelPerIdent()
+            assertThat(sisteAndelPerIdent).hasSize(1)
+            val fødselsnummer = aktørSøker.aktivFødselsnummer()
+            with(sisteAndelPerIdent[IdentOgYtelse(fødselsnummer, YtelseType.SMÅBARNSTILLEGG)]!!) {
+                assertThat(periodeOffset).isEqualTo(1L)
+                assertThat(forrigePeriodeOffset).isEqualTo(0L)
+                assertThat(stønadFom).isEqualTo(YearMonth.of(2020, 4))
+                assertThat(stønadTom).isEqualTo(YearMonth.of(2020, 5))
+                assertThat(kildeBehandlingId).isEqualTo(førsteBehandling.id)
+            }
+        }
+
+        fun hentSisteAndelPerIdent(): Map<IdentOgYtelse, AndelTilkjentYtelseForUtbetalingsoppdrag> {
+            return beregningService.hentSisteAndelPerIdent(fagsak.id)
+        }
+
+        fun lagAndel(
+            tilkjentYtelse: TilkjentYtelse,
+            ytelseType: YtelseType = YtelseType.SMÅBARNSTILLEGG,
+            person: Person? = null,
+            aktør: Aktør? = null,
+            fom: YearMonth,
+            tom: YearMonth,
+            offset: Long,
+            forrigeOffset: Long? = null
+        ): AndelTilkjentYtelse =
+            lagAndelTilkjentYtelse(
+                fom,
+                tom,
+                ytelseType,
+                1345,
+                tilkjentYtelse.behandling,
+                person = person ?: søker,
+                aktør = aktør ?: aktørSøker,
+                tilkjentYtelse = tilkjentYtelse,
+                periodeIdOffset = offset,
+                forrigeperiodeIdOffset = forrigeOffset
+            )
+
+        private fun lagRevurdering() = behandlingService.lagreNyOgDeaktiverGammelBehandling(
+            lagBehandling(fagsak, behandlingType = BehandlingType.REVURDERING)
+        )
+    }
+
+    private fun avsluttOgLagreBehandling(behandling: Behandling) {
+        behandling.status = BehandlingStatus.AVSLUTTET
+        behandlingService.oppdaterStatusPåBehandling(behandlingId = behandling.id, BehandlingStatus.AVSLUTTET)
     }
 
     private fun opprettTilkjentYtelse(behandling: Behandling) {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningTestUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningTestUtil.kt
@@ -1,0 +1,32 @@
+package no.nav.familie.ba.sak.kjerne.beregning
+
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForSimuleringFactory
+import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdrag
+import no.nav.familie.ba.sak.integrasjoner.økonomi.IdentOgYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+
+object BeregningTestUtil {
+
+    /**
+     * Denne erstatter det som [no.nav.familie.ba.sak.kjerne.beregning.BeregningService.hentSisteAndelPerIdent] gjør
+     * Pga at det ikke er den samme implementasjonen burde bruket av denne minimeres
+     */
+    fun sisteAndelPerIdent(tilkjenteYtelser: List<TilkjentYtelse>): Map<IdentOgYtelse, AndelTilkjentYtelseForUtbetalingsoppdrag> {
+        val andeler = tilkjenteYtelser.flatMap { it.andelerTilkjentYtelse }
+        return sisteAndelPerIdent(andeler)
+    }
+
+    @JvmName("sisteAndelTilkjentYtelsePerIdent")
+    fun sisteAndelPerIdent(andeler: List<AndelTilkjentYtelse>): Map<IdentOgYtelse, AndelTilkjentYtelseForUtbetalingsoppdrag> {
+        val factory = AndelTilkjentYtelseForSimuleringFactory()
+        return sisteAndelPerIdent(factory.pakkInnForUtbetaling(andeler))
+    }
+
+    @JvmName("sisteAndelPerIdentAndelUtbetalingsoppdrag")
+    fun sisteAndelPerIdent(andeler: List<AndelTilkjentYtelseForUtbetalingsoppdrag>): Map<IdentOgYtelse, AndelTilkjentYtelseForUtbetalingsoppdrag> {
+        return andeler
+            .groupBy { IdentOgYtelse(it.aktør.aktivFødselsnummer(), it.type) }
+            .mapValues { it.value.maxBy { it.periodeOffset!! } }
+    }
+}


### PR DESCRIPTION
…le tilkjente ytelser til alle behandlinger for å sen finne ut hvilken som er siste

* Fikser også at opphør på opphør peker til siste andelen

### 💰 Hva skal gjøres, og hvorfor?
Forenkler uthenting av siste andel i hver kjede, med bruk av query mot databasen.
Den tidligere versjonen henter alle tilkjente ytelser for alle behandlinger, tilkjente ytelser og all data koblet til disse, før den finner ut av den siste. Dvs man henter unødvendig mye data fra databasen. På en også relativt kompleks måte. 

Når man sen opphører så opphører man den siste gjeldende andelen i en kjede, som ikke nødvendigvis er den siste andelen.
Hvis man eks har dette tilfellet
```
Behandling 1
<---->                      lid 0
         <--->               lid 1
                  <----->  lid 2

Behandling 2 - opphører den siste andelen
<---->                      lid 0
         <--->               lid 1

Behandling 3 - opphører andel nr 2, i dette tilfelle sender man ett opphør mot lid 1, då lid 1 er siste gjeldende andelen i listen. Det som egentlige skal gjøres er å opphøre mot 2.
<---->                      lid 0
```


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er det riktig å bruke filtrering på behandlingstatus AVSLUTTET? 
Hvis forrige behandlingen ikke er avsluttet, si eks at den ikke helt blitt iverksatt ennå, så går det fortsatt å opprette en ny behandling, som i seg er skummelt... 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
- [x] Hvis det er ønskelig
