### PR TITLE
Slå sammen like utbetalingsdetaljer for ny vedtaksperiodeløsning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.common.convertDataClassToJson
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
@@ -49,7 +51,8 @@ class BrevPeriodeService(
     private val personidentService: PersonidentService,
     private val kompetanseService: KompetanseService,
     private val integrasjonClient: IntegrasjonClient,
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
+    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
+    private val featureToggleService: FeatureToggleService,
 ) {
 
     fun hentBrevperioderData(
@@ -127,7 +130,8 @@ class BrevPeriodeService(
 
         val utvidetVedtaksperiodeMedBegrunnelse = vedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
             personopplysningGrunnlag = personopplysningGrunnlag,
-            andelerTilkjentYtelse = andelerTilkjentYtelse
+            andelerTilkjentYtelse = andelerTilkjentYtelse,
+            skalBrukeNyVedtaksperiodeLøsning = featureToggleService.isEnabled(FeatureToggleConfig.VEDTAKSPERIODE_NY)
         )
 
         val ytelserForrigePeriode =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -52,7 +52,7 @@ class BrevPeriodeService(
     private val kompetanseService: KompetanseService,
     private val integrasjonClient: IntegrasjonClient,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
-    private val featureToggleService: FeatureToggleService,
+    private val featureToggleService: FeatureToggleService
 ) {
 
     fun hentBrevperioderData(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -27,6 +27,12 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.hentAndelerForSegment
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilFørsteDagIMåneden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilSisteDagIMåneden
+import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
@@ -38,6 +44,7 @@ import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.fpsak.tidsserie.LocalDateSegment
 import java.time.LocalDate
 import java.time.YearMonth
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode as TidslinjePeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "Vedtaksperiode")
@@ -121,6 +128,7 @@ data class VedtaksperiodeMedBegrunnelser(
         return fritekster.isNotEmpty() && begrunnelser.isNotEmpty()
     }
 
+    @Deprecated("Skal bruke hentUtbetalingsperiodeDetaljerNy når den er klar")
     fun hentUtbetalingsperiodeDetaljer(
         andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
         personopplysningGrunnlag: PersonopplysningGrunnlag
@@ -174,3 +182,39 @@ private fun hentLøpendeAndelForVedtaksperiode(andelerTilkjentYtelse: List<Andel
         ?: sorterteSegmenter.firstOrNull()
         ?: throw Feil("Finner ikke gjeldende segment ved fortsatt innvilget")
 }
+
+fun VedtaksperiodeMedBegrunnelser.hentUtbetalingsperiodeDetaljerNy(
+    andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+    personopplysningGrunnlag: PersonopplysningGrunnlag
+): List<UtbetalingsperiodeDetalj> {
+    if (this.type == Vedtaksperiodetype.OPPHØR) return emptyList()
+
+    val utbetalingsperiodeDetaljer = andelerTilkjentYtelse.tilUtbetalingerTidslinje(personopplysningGrunnlag)
+
+    val utbetalingsperioderRelevantForVedtaksperiode =
+        utbetalingsperiodeDetaljer.perioder().find { andelerVertikal ->
+            andelerVertikal.fraOgMed.tilFørsteDagIMåneden().tilLocalDate().isSameOrBefore(this.fom ?: TIDENES_MORGEN) &&
+                andelerVertikal.tilOgMed.tilSisteDagIMåneden().tilLocalDate().isSameOrAfter(this.tom ?: TIDENES_ENDE)
+        }?.innhold ?: throw Feil(
+            "Finner ikke segment for vedtaksperiode (${this.fom}, ${this.tom}) blant segmenter ${andelerTilkjentYtelse.utledSegmenter()}"
+        )
+
+    return utbetalingsperioderRelevantForVedtaksperiode.toList()
+}
+
+private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalingerTidslinje(
+    personopplysningGrunnlag: PersonopplysningGrunnlag
+) = groupBy { it.aktør }
+    .map { (_, andelerForAktør) ->
+        andelerForAktør.map {
+            TidslinjePeriode(
+                fraOgMed = it.stønadFom.tilTidspunkt(),
+                tilOgMed = it.stønadTom.tilTidspunkt(),
+                innhold = UtbetalingsperiodeDetalj(
+                    andel = it,
+                    personopplysningGrunnlag = personopplysningGrunnlag
+                )
+            )
+        }.tilTidslinje()
+    }.kombiner { it.takeIf { it.toList().isNotEmpty() } }
+    .slåSammenLike()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -194,12 +194,9 @@ fun VedtaksperiodeMedBegrunnelser.hentUtbetalingsperiodeDetaljerNy(
         Vedtaksperiodetype.OPPHØR -> emptyList()
 
         Vedtaksperiodetype.FORTSATT_INNVILGET -> {
-            val løpendeUtbetalingsperiode =
-                (
-                    utbetalingsperiodeDetaljer.perioder()
-                        .lastOrNull { it.fraOgMed.tilYearMonth() <= inneværendeMåned() }
-                        ?: utbetalingsperiodeDetaljer.perioder().firstOrNull()
-                    )
+            val løpendeUtbetalingsperiode = utbetalingsperiodeDetaljer.perioder()
+                .lastOrNull { it.fraOgMed.tilYearMonth() <= inneværendeMåned() }
+                ?: utbetalingsperiodeDetaljer.perioder().firstOrNull()
 
             løpendeUtbetalingsperiode?.innhold?.toList()
                 ?: throw Feil("Finner ikke gjeldende segment ved fortsatt innvilget")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -204,9 +204,9 @@ fun VedtaksperiodeMedBegrunnelser.hentUtbetalingsperiodeDetaljerNy(
 
 private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalingerTidslinje(
     personopplysningGrunnlag: PersonopplysningGrunnlag
-) = groupBy { it.aktør }
-    .map { (_, andelerForAktør) ->
-        andelerForAktør.map {
+) = groupBy { Pair(it.aktør, it.type) }
+    .map { (_, andelerForAktørOgType) ->
+        andelerForAktørOgType.map {
             TidslinjePeriode(
                 fraOgMed = it.stønadFom.tilTidspunkt(),
                 tilOgMed = it.stønadTom.tilTidspunkt(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Utbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Utbetalingsperiode.kt
@@ -41,7 +41,19 @@ data class UtbetalingsperiodeDetalj(
     val utbetaltPerMnd: Int,
     val erPåvirketAvEndring: Boolean,
     val prosent: BigDecimal
-)
+) {
+    constructor(
+        andel: AndelTilkjentYtelseMedEndreteUtbetalinger,
+        personopplysningGrunnlag: PersonopplysningGrunnlag
+    ) : this(
+        person = personopplysningGrunnlag.søkerOgBarn.find { person -> andel.aktør == person.aktør }?.tilRestPerson()
+            ?: throw IllegalStateException("Fant ikke personopplysningsgrunnlag for andel"),
+        ytelseType = andel.type,
+        utbetaltPerMnd = andel.kalkulertUtbetalingsbeløp,
+        erPåvirketAvEndring = andel.endreteUtbetalinger.isNotEmpty(),
+        prosent = andel.prosent
+    )
+}
 
 fun List<UtbetalingsperiodeDetalj>.totaltUtbetalt(): Int =
     this.sumOf { it.utbetaltPerMnd }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -746,28 +746,28 @@ class VedtaksperiodeService(
 
         return refusjonEøsRepository.finnRefusjonEøsForBehandling(behandling.id)
             .filter { it.refusjonAvklart == avklart }.map {
-            val (fom, tom) = it.fom.tilDagMånedÅr() to it.tom.tilDagMånedÅr()
-            val land = landkoderISO2[it.land]?.storForbokstav() ?: throw Feil("Fant ikke navn for landkode ${it.land}")
-            val beløp = it.refusjonsbeløp
+                val (fom, tom) = it.fom.tilDagMånedÅr() to it.tom.tilDagMånedÅr()
+                val land = landkoderISO2[it.land]?.storForbokstav() ?: throw Feil("Fant ikke navn for landkode ${it.land}")
+                val beløp = it.refusjonsbeløp
 
-            when (målform) {
-                NN -> {
-                    if (avklart) {
-                        "Frå $fom til $tom blir $beløp kroner av etterbetalinga di utbetalt til myndighetene i $land"
-                    } else {
-                        "Frå $fom til $tom blir ikkje etterbetalinga på $beløp kroner utbetalt no sidan det er utbetalt barnetrygd i $land"
+                when (målform) {
+                    NN -> {
+                        if (avklart) {
+                            "Frå $fom til $tom blir $beløp kroner av etterbetalinga di utbetalt til myndighetene i $land"
+                        } else {
+                            "Frå $fom til $tom blir ikkje etterbetalinga på $beløp kroner utbetalt no sidan det er utbetalt barnetrygd i $land"
+                        }
+                    }
+
+                    else -> {
+                        if (avklart) {
+                            "Fra $fom til $tom blir $beløp kroner av etterbetalingen din utbetalt til myndighetene i $land"
+                        } else {
+                            "Fra $fom til $tom blir ikke etterbetalingen på ${it.refusjonsbeløp} kroner utbetalt nå siden det er utbetalt barnetrygd i $land"
+                        }
                     }
                 }
-
-                else -> {
-                    if (avklart) {
-                        "Fra $fom til $tom blir $beløp kroner av etterbetalingen din utbetalt til myndighetene i $land"
-                    } else {
-                        "Fra $fom til $tom blir ikke etterbetalingen på ${it.refusjonsbeløp} kroner utbetalt nå siden det er utbetalt barnetrygd i $land"
-                    }
-                }
-            }
-        }.toSet().takeIf { it.isNotEmpty() }
+            }.toSet().takeIf { it.isNotEmpty() }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -442,7 +442,8 @@ class VedtaksperiodeService(
         val utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser.map {
             it.tilUtvidetVedtaksperiodeMedBegrunnelser(
                 andelerTilkjentYtelse = andelerTilkjentYtelse,
-                personopplysningGrunnlag = persongrunnlag
+                personopplysningGrunnlag = persongrunnlag,
+                skalBrukeNyVedtaksperiodeLøsning = featureToggleService.isEnabled(FeatureToggleConfig.VEDTAKSPERIODE_NY)
             )
         }
 
@@ -743,7 +744,8 @@ class VedtaksperiodeService(
         val målform = persongrunnlagService.hentAktiv(behandlingId = behandling.id)?.søker?.målform
         val landkoderISO2 = integrasjonClient.hentLandkoderISO2()
 
-        return refusjonEøsRepository.finnRefusjonEøsForBehandling(behandling.id).filter { it.refusjonAvklart == avklart }.map {
+        return refusjonEøsRepository.finnRefusjonEøsForBehandling(behandling.id)
+            .filter { it.refusjonAvklart == avklart }.map {
             val (fom, tom) = it.fom.tilDagMånedÅr() to it.tom.tilDagMånedÅr()
             val land = landkoderISO2[it.land]?.storForbokstav() ?: throw Feil("Fant ikke navn for landkode ${it.land}")
             val beløp = it.refusjonsbeløp
@@ -756,6 +758,7 @@ class VedtaksperiodeService(
                         "Frå $fom til $tom blir ikkje etterbetalinga på $beløp kroner utbetalt no sidan det er utbetalt barnetrygd i $land"
                     }
                 }
+
                 else -> {
                     if (avklart) {
                         "Fra $fom til $tom blir $beløp kroner av etterbetalingen din utbetalt til myndighetene i $land"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
@@ -38,12 +38,17 @@ fun List<UtvidetVedtaksperiodeMedBegrunnelser>.sorter(): List<UtvidetVedtaksperi
 
 fun VedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
-    andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
+    andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+    skalBrukeNyVedtaksperiodeLøsning: Boolean
 ): UtvidetVedtaksperiodeMedBegrunnelser {
-    val utbetalingsperiodeDetaljer = hentUtbetalingsperiodeDetaljer(
-        andelerTilkjentYtelse = andelerTilkjentYtelse,
-        personopplysningGrunnlag = personopplysningGrunnlag
-    )
+    val utbetalingsperiodeDetaljer = if (skalBrukeNyVedtaksperiodeLøsning) {
+        emptyList()
+    } else {
+        hentUtbetalingsperiodeDetaljer(
+            andelerTilkjentYtelse = andelerTilkjentYtelse,
+            personopplysningGrunnlag = personopplysningGrunnlag
+        )
+    }
 
     return UtvidetVedtaksperiodeMedBegrunnelser(
         id = this.id,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
@@ -1,9 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene
 
-import no.nav.familie.ba.sak.common.MånedPeriode
-import no.nav.familie.ba.sak.common.TIDENES_ENDE
-import no.nav.familie.ba.sak.common.TIDENES_MORGEN
-import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
@@ -25,12 +21,7 @@ data class UtvidetVedtaksperiodeMedBegrunnelser(
     val fritekster: List<String> = emptyList(),
     val gyldigeBegrunnelser: List<IVedtakBegrunnelse> = emptyList(),
     val utbetalingsperiodeDetaljer: List<UtbetalingsperiodeDetalj> = emptyList()
-) {
-    fun hentMånedPeriode() = MånedPeriode(
-        (this.fom ?: TIDENES_MORGEN).toYearMonth(),
-        (this.tom ?: TIDENES_ENDE).toYearMonth()
-    )
-}
+)
 
 fun List<UtvidetVedtaksperiodeMedBegrunnelser>.sorter(): List<UtvidetVedtaksperiodeMedBegrunnelser> {
     val (perioderMedFom, perioderUtenFom) = this.partition { it.fom != null }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.hentUtbetalingsperiodeDetaljerNy
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.UtbetalingsperiodeDetalj
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import java.time.LocalDate
@@ -42,7 +43,10 @@ fun VedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
     skalBrukeNyVedtaksperiodeLøsning: Boolean
 ): UtvidetVedtaksperiodeMedBegrunnelser {
     val utbetalingsperiodeDetaljer = if (skalBrukeNyVedtaksperiodeLøsning) {
-        emptyList()
+        this.hentUtbetalingsperiodeDetaljerNy(
+            andelerTilkjentYtelse = andelerTilkjentYtelse,
+            personopplysningGrunnlag = personopplysningGrunnlag
+        )
     } else {
         hentUtbetalingsperiodeDetaljer(
             andelerTilkjentYtelse = andelerTilkjentYtelse,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/behandling/KjørRevurdering.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/dataGenerator/behandling/KjørRevurdering.kt
@@ -359,7 +359,8 @@ fun leggTilAlleGyldigeBegrunnelserPåVedtaksperiodeIBehandling(
 
     val utvidetVedtaksperiodeMedBegrunnelser = vedtaksperiode.tilUtvidetVedtaksperiodeMedBegrunnelser(
         personopplysningGrunnlag = personopplysningGrunnlag,
-        andelerTilkjentYtelse = andelerTilkjentYtelse
+        andelerTilkjentYtelse = andelerTilkjentYtelse,
+        skalBrukeNyVedtaksperiodeLøsning = false
     )
 
     val aktørerMedUtbetaling =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtvidetVedtaksperiodeMedBegrunnelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtvidetVedtaksperiodeMedBegrunnelserTest.kt
@@ -78,7 +78,8 @@ class UtvidetVedtaksperiodeMedBegrunnelserTest {
         val utvidetVedtaksperiodeMedBegrunnelser =
             vedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                andelerTilkjentYtelse = andelerTilkjentYtelse
+                andelerTilkjentYtelse = andelerTilkjentYtelse,
+                skalBrukeNyVedtaksperiodeLøsning = false
             )
 
         Assertions.assertEquals(1, utvidetVedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.size)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.ekstern.restDomene.tilRestPersonResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.writeValueAsString
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
@@ -167,7 +166,6 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         behandling: Behandling,
         barnetsFødselsdato: LocalDate
     ) {
-
         vilkårsvurdering.personResultater.map { personResultat ->
             personResultat.tilRestPersonResultat().vilkårResultater.map {
                 vilkårService.endreVilkår(
@@ -179,8 +177,11 @@ class RevurderingMedEndredeUtbetalingandelerTest(
                         vilkårResultater = listOf(
                             it.copy(
                                 resultat = Resultat.OPPFYLT,
-                                periodeFom = if (it.vilkårType == Vilkår.UNDER_18_ÅR) barnetsFødselsdato else
-                                    LocalDate.now().minusYears(3).minusMonths(5).withDayOfMonth(8),
+                                periodeFom = if (it.vilkårType == Vilkår.UNDER_18_ÅR) {
+                                    barnetsFødselsdato
+                                } else {
+                                    LocalDate.now().minusYears(3).minusMonths(5).withDayOfMonth(8)
+                                },
                                 utdypendeVilkårsvurderinger = listOfNotNull(
                                     if (it.vilkårType == Vilkår.BOR_MED_SØKER) UtdypendeVilkårsvurdering.DELT_BOSTED else null
                                 )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -173,7 +173,11 @@ class RevurderingMedEndredeUtbetalingandelerTest(
                         vilkårResultater = listOf(
                             it.copy(
                                 resultat = Resultat.OPPFYLT,
-                                periodeFom = barnetsFødselsdato,
+                                periodeFom = if (it.vilkårType == Vilkår.UNDER_18_ÅR) {
+                                    barnetsFødselsdato
+                                } else {
+                                    LocalDate.now().minusYears(3).minusMonths(5).withDayOfMonth(8)
+                                },
                                 utdypendeVilkårsvurderinger = listOfNotNull(
                                     if (it.vilkårType == Vilkår.BOR_MED_SØKER) UtdypendeVilkårsvurdering.DELT_BOSTED else null
                                 )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -45,9 +45,6 @@ import java.time.YearMonth
 
 class RevurderingMedEndredeUtbetalingandelerTest(
     @Autowired
-    private val behandlingService: BehandlingService,
-
-    @Autowired
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
 
     @Autowired
@@ -88,7 +85,11 @@ class RevurderingMedEndredeUtbetalingandelerTest(
     fun `Endrede utbetalingsandeler fra forrige behandling kopieres riktig og oppdaterer andel med riktig beløp`() {
         val scenario = mockServerKlient().lagScenario(
             RestScenario(
-                søker = RestScenarioPerson(fødselsdato = "1993-01-12", fornavn = "Mor", etternavn = "Søker"),
+                søker = RestScenarioPerson(
+                    fødselsdato = "${LocalDate.now().minusYears(28)}",
+                    fornavn = "Mor",
+                    etternavn = "Søker"
+                ),
                 barna = listOf(
                     RestScenarioPerson(
                         fødselsdato = LocalDate.now().minusYears(4).toString(),
@@ -104,8 +105,8 @@ class RevurderingMedEndredeUtbetalingandelerTest(
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
 
-        val endretAndelFom = YearMonth.of(2019, 6)
-        val endretAndelTom = YearMonth.of(2020, 10)
+        val endretAndelFom = YearMonth.now().minusYears(3).minusMonths(4)
+        val endretAndelTom = YearMonth.now().minusYears(3)
 
         // Behandling 1 - førstegangsbehandling
         val iverksattFørstegangsbehandling =
@@ -119,7 +120,8 @@ class RevurderingMedEndredeUtbetalingandelerTest(
             )
 
         // Behandling 2 - revurdering
-        val behandlingRevurdering = stegService.håndterNyBehandling(nyRevurdering(søkersIdent = fnr, fagsakId = fagsak.id))
+        val behandlingRevurdering =
+            stegService.håndterNyBehandling(nyRevurdering(søkersIdent = fnr, fagsakId = fagsak.id))
 
         persongrunnlagService.lagreOgDeaktiverGammel(
             lagTestPersonopplysningGrunnlag(
@@ -138,10 +140,18 @@ class RevurderingMedEndredeUtbetalingandelerTest(
             forrigeBehandlingSomErVedtatt = iverksattFørstegangsbehandling
         )
 
-        gjennomførVilkårsvurdering(vilkårsvurdering = vilkårsvurderingRevurdering, behandling = behandlingRevurdering, barnetsFødselsdato = barnetsFødselsdato)
+        gjennomførVilkårsvurdering(
+            vilkårsvurdering = vilkårsvurderingRevurdering,
+            behandling = behandlingRevurdering,
+            barnetsFødselsdato = barnetsFødselsdato
+        )
 
-        val kopierteEndredeUtbetalingAndeler = endretUtbetalingAndelHentOgPersisterService.hentForBehandling(behandlingRevurdering.id)
-        val andelerTilkjentYtelse = andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingRevurdering.id)
+        val kopierteEndredeUtbetalingAndeler =
+            endretUtbetalingAndelHentOgPersisterService.hentForBehandling(behandlingRevurdering.id)
+        val andelerTilkjentYtelse =
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
+                behandlingRevurdering.id
+            )
         val andelPåvirketAvEndringer = andelerTilkjentYtelse.first()
 
         assertEquals(1, kopierteEndredeUtbetalingAndeler.size)
@@ -152,7 +162,12 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         assertTrue(andelPåvirketAvEndringer.endreteUtbetalinger.any { it.id == kopierteEndredeUtbetalingAndeler.single().id })
     }
 
-    private fun gjennomførVilkårsvurdering(vilkårsvurdering: Vilkårsvurdering, behandling: Behandling, barnetsFødselsdato: LocalDate) {
+    private fun gjennomførVilkårsvurdering(
+        vilkårsvurdering: Vilkårsvurdering,
+        behandling: Behandling,
+        barnetsFødselsdato: LocalDate
+    ) {
+
         vilkårsvurdering.personResultater.map { personResultat ->
             personResultat.tilRestPersonResultat().vilkårResultater.map {
                 vilkårService.endreVilkår(
@@ -164,7 +179,8 @@ class RevurderingMedEndredeUtbetalingandelerTest(
                         vilkårResultater = listOf(
                             it.copy(
                                 resultat = Resultat.OPPFYLT,
-                                periodeFom = if (it.vilkårType == Vilkår.UNDER_18_ÅR) barnetsFødselsdato else LocalDate.of(2019, 5, 8),
+                                periodeFom = if (it.vilkårType == Vilkår.UNDER_18_ÅR) barnetsFødselsdato else
+                                    LocalDate.now().minusYears(3).minusMonths(5).withDayOfMonth(8),
                                 utdypendeVilkårsvurderinger = listOfNotNull(
                                     if (it.vilkårType == Vilkår.BOR_MED_SØKER) UtdypendeVilkårsvurdering.DELT_BOSTED else null
                                 )
@@ -181,13 +197,25 @@ class RevurderingMedEndredeUtbetalingandelerTest(
         stegService.håndterVilkårsvurdering(behandling)
     }
 
-    private fun lagFørstegangsbehandlingMedEndretUtbetalingAndel(endretAndelFom: YearMonth, endretAndelTom: YearMonth, søkersIdent: String, barnFnr: String, fagsak: Fagsak, barnetsFødselsdato: LocalDate): Behandling {
-        val førstegangsbehandling = stegService.håndterNyBehandling(nyOrdinærBehandling(søkersIdent = søkersIdent, fagsakId = fagsak.id))
+    private fun lagFørstegangsbehandlingMedEndretUtbetalingAndel(
+        endretAndelFom: YearMonth,
+        endretAndelTom: YearMonth,
+        søkersIdent: String,
+        barnFnr: String,
+        fagsak: Fagsak,
+        barnetsFødselsdato: LocalDate
+    ): Behandling {
+        val førstegangsbehandling =
+            stegService.håndterNyBehandling(nyOrdinærBehandling(søkersIdent = søkersIdent, fagsakId = fagsak.id))
 
         val søknadGrunnlag = SøknadGrunnlag(
             behandlingId = førstegangsbehandling.id,
             aktiv = true,
-            søknad = lagSøknadDTO(søkersIdent, barnasIdenter = listOf(barnFnr), underkategori = BehandlingUnderkategori.ORDINÆR).writeValueAsString()
+            søknad = lagSøknadDTO(
+                søkersIdent,
+                barnasIdenter = listOf(barnFnr),
+                underkategori = BehandlingUnderkategori.ORDINÆR
+            ).writeValueAsString()
         )
 
         søknadGrunnlagRepository.save(søknadGrunnlag)
@@ -209,7 +237,11 @@ class RevurderingMedEndredeUtbetalingandelerTest(
             forrigeBehandlingSomErVedtatt = null
         )
 
-        gjennomførVilkårsvurdering(vilkårsvurdering = vilkårsvurdering, behandling = førstegangsbehandling, barnetsFødselsdato = barnetsFødselsdato)
+        gjennomførVilkårsvurdering(
+            vilkårsvurdering = vilkårsvurdering,
+            behandling = førstegangsbehandling,
+            barnetsFødselsdato = barnetsFødselsdato
+        )
 
         val endretUtbetalingAndel =
             endretUtbetalingAndelService.opprettTomEndretUtbetalingAndelOgOppdaterTilkjentYtelse(førstegangsbehandling)
@@ -218,8 +250,8 @@ class RevurderingMedEndredeUtbetalingandelerTest(
             id = endretUtbetalingAndel.id,
             fom = endretAndelFom,
             tom = endretAndelTom,
-            avtaletidspunktDeltBosted = LocalDate.of(2019, 5, 8),
-            søknadstidspunkt = LocalDate.of(2019, 5, 8),
+            avtaletidspunktDeltBosted = LocalDate.now().minusYears(3).withDayOfMonth(8),
+            søknadstidspunkt = LocalDate.now().minusYears(3).withDayOfMonth(8),
             begrunnelse = "begrunnelse",
             personIdent = barnFnr,
             årsak = Årsak.DELT_BOSTED,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Med den nye vedtaksperiodeløsningen slår vi sammen perioder med lik data. Det betyr at perioder med lik utbetaling kan bli slått sammen. Dette skaper trøbbel når vi senere skal se hvilken utbetalingsperiodedetalj som perioden hører til ettersom vi nå kan ha to andeler som hører til én periode. 

For å løse dette slår vi sammen like utbetalingsperiodedetaljer slik at det ikke kan være to utbetalingsperiodedetaljer for en vedtaksperiode. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
