### PR TITLE
Spesifiser at beløp er månedlig for feilutbetalt valuta og refusjon EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -14,6 +14,7 @@ class FeatureToggleConfig {
         const val EØS_INFORMASJON_OM_ÅRLIG_KONTROLL = "familie-ba-sak.eos-informasjon-om-aarlig-kontroll"
         const val ER_MANUEL_POSTERING_TOGGLE_PÅ = "familie-ba-sak.manuell-postering"
         const val VEDTAKSPERIODE_NY = "familie-ba-sak.vedtaksperiode-ny"
+        const val FEILUTBETALT_VALUTA_PR_MND = "familie-ba-sak.feilutbetalt-valuta-pr-mnd"
 
         // unleash toggles for satsendring, kan slettes etter at satsendring er skrudd på for alle satstyper
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
@@ -5,6 +5,8 @@ import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.tilddMMyyyy
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.RolleConfig
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
@@ -31,7 +33,8 @@ import java.time.LocalDateTime
 @Service
 class LoggService(
     private val loggRepository: LoggRepository,
-    private val rolleConfig: RolleConfig
+    private val rolleConfig: RolleConfig,
+    private val featureToggleService: FeatureToggleService
 ) {
 
     private val metrikkPerLoggType: Map<LoggType, Counter> = LoggType.values().associateWith {
@@ -534,7 +537,7 @@ class LoggService(
                 ),
                 tekst = """
                 Periode: ${feilutbetaltValuta.fom.tilKortString()} - ${feilutbetaltValuta.tom.tilKortString()}
-                Beløp: ${feilutbetaltValuta.feilutbetaltBeløp} kr
+                Beløp: ${feilutbetaltValuta.feilutbetaltBeløp} ${if (featureToggleService.isEnabled(FeatureToggleConfig.FEILUTBETALT_VALUTA_PR_MND)) "kr/mnd" else "kr"}
                 """.trimIndent()
             )
         )
@@ -550,7 +553,7 @@ class LoggService(
                 ),
                 tekst = """
                 Periode: ${feilutbetaltValuta.fom.tilKortString()} - ${feilutbetaltValuta.tom.tilKortString()}
-                Beløp: ${feilutbetaltValuta.feilutbetaltBeløp} kr
+                Beløp: ${feilutbetaltValuta.feilutbetaltBeløp} ${if (featureToggleService.isEnabled(FeatureToggleConfig.FEILUTBETALT_VALUTA_PR_MND)) "kr/mnd" else "kr"}
                 """.trimIndent()
             )
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
@@ -569,7 +569,7 @@ class LoggService(
                 ),
                 tekst = """
                 Periode: ${refusjonEøs.fom.tilKortString()} - ${refusjonEøs.tom.tilKortString()}
-                Beløp: ${refusjonEøs.refusjonsbeløp} kr
+                Beløp: ${refusjonEøs.refusjonsbeløp} kr/mnd
                 """.trimIndent()
             )
         )
@@ -585,7 +585,7 @@ class LoggService(
                 ),
                 tekst = """
                 Periode: ${refusjonEøs.fom.tilKortString()} - ${refusjonEøs.tom.tilKortString()}
-                Beløp: ${refusjonEøs.refusjonsbeløp} kr
+                Beløp: ${refusjonEøs.refusjonsbeløp} kr/mnd
                 """.trimIndent()
             )
         )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-11404 og NAV-12397
Historikkinnslagene må vise at beløpet gjelder "kr/mnd", tilsvarende skjemafeltene og andre steder vi omtaler beløpene.

For feilutbetalt valuta er dette en endring i en lansert feature, derfor legges det bak feature toggle. Den kommer til å bli aktivert sammen med flere endringer som kommer for feilutbetalt valuta i forbindelse med at beløpet skal gjelde per måned.

Refusjon EØS er ennå ikke lansert, men der er beløpet allerede omtalt som "kr/mnd" alle andre steder enn her. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
