### PR TITLE
Riktig fortegn på sum av manuelle posteringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
@@ -173,8 +173,9 @@ fun hentTidligereUtbetaltIPeriode(periode: List<ØkonomiSimuleringPostering>): B
 
     val feilutbetaling = hentFeilutbetalingIPeriode(periode, false)
 
-    // Manuelle posteringer brukes for å justere hva som faktisk skal bli betalt ut i en periode
-    val sumManuellePosteringer = hentManuellPosteringIPeriode(periode)
+    // Manuelle posteringer brukes for å justere hva som faktisk skal bli betalt ut i en periode.
+    // Endrer fortegn da en negativ sum skal øke tidligere utbetalt og en positiv sum redusere tidligere utbetalt.
+    val sumManuellePosteringer = -hentManuellPosteringIPeriode(periode)
 
     return if (feilutbetaling < BigDecimal.ZERO) {
         -(sumNegativeYtelser - feilutbetaling)
@@ -191,7 +192,7 @@ fun hentManuellPosteringIPeriode(periode: List<ØkonomiSimuleringPostering>): Bi
 
     val manuellFeilutbetaling = hentManuellFeilutbetalingIPeriode(periode)
 
-    return -(sumManuellePosteringer - manuellFeilutbetaling)
+    return sumManuellePosteringer - manuellFeilutbetaling
 }
 
 private fun hentManuellFeilutbetalingIPeriode(periode: List<ØkonomiSimuleringPostering>) =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
@@ -278,17 +278,17 @@ class SimuleringUtilTest {
 
         assertThat(simuleringFebruar22.tidligereUtbetalt).isEqualTo(0.toBigDecimal())
         assertThat(simuleringFebruar22.resultat).isEqualTo(305.toBigDecimal())
-        assertThat(simuleringFebruar22.manuellPostering).isEqualTo((-305).toBigDecimal())
+        assertThat(simuleringFebruar22.manuellPostering).isEqualTo(305.toBigDecimal())
 
         assertThat(simuleringMars22.tidligereUtbetalt).isEqualTo(0.toBigDecimal())
         assertThat(simuleringMars22.resultat).isEqualTo(305.toBigDecimal())
-        assertThat(simuleringMars22.manuellPostering).isEqualTo((-305).toBigDecimal())
+        assertThat(simuleringMars22.manuellPostering).isEqualTo(305.toBigDecimal())
 
         assertThat(simuleringApril22.tidligereUtbetalt).isEqualTo(140.toBigDecimal())
         assertThat(simuleringApril22.resultat).isEqualTo(165.toBigDecimal())
-        assertThat(simuleringApril22.manuellPostering).isEqualTo((-165).toBigDecimal())
+        assertThat(simuleringApril22.manuellPostering).isEqualTo(165.toBigDecimal())
 
-        assertThat(simuleringsperioder.sumOf { it.manuellPostering }).isEqualTo((-775).toBigDecimal())
+        assertThat(simuleringsperioder.sumOf { it.manuellPostering }).isEqualTo(775.toBigDecimal())
         assertThat(oppsummering.etterbetaling).isEqualTo(775.toBigDecimal())
     }
 
@@ -376,7 +376,7 @@ class SimuleringUtilTest {
 
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(305.toBigDecimal())
-        assertThat(simuleringsperioder[0].manuellPostering).isEqualTo((-165).toBigDecimal())
+        assertThat(simuleringsperioder[0].manuellPostering).isEqualTo(165.toBigDecimal())
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(140.toBigDecimal())
         assertThat(simuleringsperioder[0].resultat).isEqualTo(165.toBigDecimal())
         assertThat(simuleringsperioder[0].feilutbetaling).isEqualTo(0.toBigDecimal())
@@ -424,7 +424,7 @@ class SimuleringUtilTest {
 
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(305.toBigDecimal())
-        assertThat(simuleringsperioder[0].manuellPostering).isEqualTo((-165).toBigDecimal())
+        assertThat(simuleringsperioder[0].manuellPostering).isEqualTo((165).toBigDecimal())
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(140.toBigDecimal())
         assertThat(simuleringsperioder[0].resultat).isEqualTo(165.toBigDecimal())
         assertThat(simuleringsperioder[0].feilutbetaling).isEqualTo(0.toBigDecimal())
@@ -474,7 +474,7 @@ class SimuleringUtilTest {
         val simuleringsperiode = simuleringsperioder.single()
 
         assertThat(simuleringsperiode.nyttBeløp).isEqualTo(305.toBigDecimal())
-        assertThat(simuleringsperiode.manuellPostering).isEqualTo((-305).toBigDecimal())
+        assertThat(simuleringsperiode.manuellPostering).isEqualTo(305.toBigDecimal())
         assertThat(simuleringsperiode.tidligereUtbetalt).isEqualTo(0.toBigDecimal())
         assertThat(simuleringsperiode.resultat).isEqualTo(305.toBigDecimal())
         assertThat(simuleringsperiode.feilutbetaling).isEqualTo(0.toBigDecimal())
@@ -661,7 +661,7 @@ class SimuleringUtilTest {
         val simuleringsperiode = simuleringsperioder.single()
 
         assertThat(simuleringsperiode.nyttBeløp).isEqualTo(658.toBigDecimal())
-        assertThat(simuleringsperiode.manuellPostering).isEqualTo(50.toBigDecimal())
+        assertThat(simuleringsperiode.manuellPostering).isEqualTo((-50).toBigDecimal())
         assertThat(simuleringsperiode.tidligereUtbetalt).isEqualTo(707.toBigDecimal())
         assertThat(simuleringsperiode.feilutbetaling).isEqualTo((49).toBigDecimal())
         assertThat(simuleringsperiode.resultat).isEqualTo((-49).toBigDecimal())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Sum av manuelle posteringer vises med motsatt fortegn av det som faktisk er postert manuelt. Når det posteres et negativt beløp (KREDIT) viser vi det som et postitivt beløp og når det posteres et positivt beløp (DEBIT) viser vi det som et negativt beløp. Denne PR'en sørger for at fortegnet vi viser for manuelle posteringer stemmer overens med de faktiske posteringene.

### ✅ Checklist
Jeg har ikke skrevet tester fordi: Har ikke endret logikk ut over endring av fortegn på manuelle posteringer. Eksisterende tester er fortsatt dekkende. Forventet beløp på manuelle posteringer i testene er justert ved å endre fortegn.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
