### PR TITLE
Alltid simulere i manuelle migreringsbehandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -88,9 +88,19 @@ class SimuleringService(
                     .pakkInnForUtbetaling(
                         andelerTilkjentYtelse,
                     )
-                    .map {
+                    .mapIndexed { index, andel ->
+                        val forrigeIndex = if (index == 0) {
+                            null
+                        } else {
+                            index - 1
+                        }
                         UtbetalingsperiodeMal(vedtak, false)
-                            .lagPeriodeFraAndel(it, 0, null, null)
+                            .lagPeriodeFraAndel(
+                                andel = andel,
+                                periodeIdOffset = index,
+                                forrigePeriodeIdOffset = forrigeIndex,
+                                opphørKjedeFom = null,
+                            )
                     },
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -49,7 +49,12 @@ class SimuleringService(
     private val simulert = Metrics.counter("familie.ba.sak.oppdrag.simulert")
 
     fun hentSimuleringFraFamilieOppdrag(vedtak: Vedtak): DetaljertSimuleringResultat? {
-        if (!beregningService.erEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(vedtak.behandling)) {
+        val forrigeIverksatteBehandling =
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(vedtak.behandling)
+        if (forrigeIverksatteBehandling !== null && !beregningService.erEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(
+                vedtak.behandling,
+            )
+        ) {
             return null
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -86,7 +86,7 @@ class SimuleringService(
                 aktoer = vedtak.behandling.fagsak.aktør.aktivFødselsnummer(),
                 utbetalingsperiode = AndelTilkjentYtelseForSimuleringFactory()
                     .pakkInnForUtbetaling(
-                        andelerTilkjentYtelse,
+                        andelerTilkjentYtelse.map { it.copy(kalkulertUtbetalingsbeløp = 1) },
                     )
                     .mapIndexed { index, andel ->
                         val forrigeIndex = if (index == 0) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -35,6 +35,7 @@ import no.nav.familie.kontrakter.felles.simulering.MottakerType
 import no.nav.familie.kontrakter.felles.simulering.PosteringType
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -300,7 +301,9 @@ internal class SimuleringServiceEnhetTest {
         )
         val vedtak: Vedtak = lagVedtak(behandling = behandling)
 
-        every { beregningService.erEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(any()) } returns true
+        every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(any()) } returns null
+
+        every { beregningService.erEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(any()) } returns false
 
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtak.behandling.id) } returns listOf(
             lagAndelTilkjentYtelse(YearMonth.of(2023, 1), YearMonth.of(2023, 2), beløp = 0),
@@ -331,6 +334,11 @@ internal class SimuleringServiceEnhetTest {
 
         assertThat(utbetalingsoppdrag.utbetalingsperiode, hasSize(2))
         assertThat(utbetalingsoppdrag.utbetalingsperiode[0].sats, Is(BigDecimal.ZERO))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].periodeId, Is(0L))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].forrigePeriodeId, Is(nullValue()))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[1].sats, Is(BigDecimal.ZERO))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[1].periodeId, Is(1L))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[1].forrigePeriodeId, Is(0L))
     }
 
     private fun mockØkonomiSimuleringMottaker(


### PR DESCRIPTION
Favro: [NAV-12557](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12557)

### 💰 Hva skal gjøres, og hvorfor?
Ved manuell migrering av EØS saker fra Infotrygd, kan vi få andeler med 0 kr i `kalkulertUtbetalingsbeløp`. Fordi vi ikke har noen tidligere behandlinger med andeler å sammenligne med, fører dette til at vi ikke simulerer mot Oppdrag. Fordi i ikke simulerer mot Oppdrag vil ikke behandlingen sendes til totrinngskontroll ved eventuelle feilutbetalinger eller etterbetalinger.

Sørger nå for at vi uansett simulerer mot Oppdrag i manuelle migreringsbehandlinger hvor `kalkulertUtbetalingsbeløp` er 0 kr.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
