### PR TITLE
Avslag bor ikke fast med barnet skal være en standardbegrunnelse og i…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -284,10 +284,6 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_AVSLAG
         override val sanityApiNavn = "avslagEosUregistrertBarn"
     },
-    AVSLAG_EØS_BOR_IKKE_FAST_MED_BARNET {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_AVSLAG
-        override val sanityApiNavn = "avslagEosBorIkkeFastMedBarnet"
-    },
     FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD {
         override val sanityApiNavn = "fortsattInnvilgetPrimaerlandStandard"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_FORTSATT_INNVILGET

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -965,6 +965,10 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override val sanityApiNavn = "avslagIkkeOppholdstillatelseMerEnn12Maaneder"
     },
+    AVSLAG_BOR_IKKE_FAST_MED_BARNET {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
+        override val sanityApiNavn = "avslagBorIkkeFastMedBarnet"
+    },
     OPPHØR_BARN_FLYTTET_FRA_SØKER {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override val sanityApiNavn = "opphorBarnBorIkkeMedSoker"


### PR DESCRIPTION
…kke EØS.

### 💰 Hva skal gjøres, og hvorfor?
Flytte avslagstekst for utvidet der søker ikke bor fast med søker til standardbegrunnelse siden teksten kan brukes til mer enn bare EØS-saker. https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12268
