### PR TITLE
Valider at satsendring kun oppdaterer sats

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -9,8 +9,11 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidering.validerAtAlleOpprettedeEndringerErUtfylt
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidering.validerAtEndringerErTilknyttetAndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidering.validerPeriodeInnenforTilkjentytelse
@@ -43,6 +46,7 @@ class BehandlingsresultatSteg(
     private val persongrunnlagService: PersongrunnlagService,
     private val beregningService: BeregningService,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
 ) : BehandlingSteg<String> {
 
     override fun preValiderSteg(behandling: Behandling, stegService: StegService?) {
@@ -57,6 +61,10 @@ class BehandlingsresultatSteg(
 
         val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandling.id)
         val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id)
+
+        if (behandling.erSatsendring()) {
+            validerSatsendring(tilkjentYtelse)
+        }
 
         validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
             tilkjentYtelse = tilkjentYtelse,
@@ -160,7 +168,7 @@ class BehandlingsresultatSteg(
         return behandlingHentOgPersisterService.lagreEllerOppdater(behandling)
     }
 
-    fun validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling: Behandling) {
+    private fun validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling: Behandling) {
         if (behandling.status == BehandlingStatus.AVSLUTTET) return
 
         val endringIUtbetalingTidslinje =
@@ -171,6 +179,20 @@ class BehandlingsresultatSteg(
             .minOf { it.stønadFom }
 
         endringIUtbetalingTidslinje.kastFeilVedEndringEtter(migreringsdatoForrigeIverksatteBehandling, behandling)
+    }
+
+    private fun validerSatsendring(tilkjentYtelse: TilkjentYtelse) {
+        val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(tilkjentYtelse.behandling)
+        val andelerFraForrigeBehandling = if (forrigeBehandling != null) {
+            andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = forrigeBehandling.id)
+        } else {
+            throw FunksjonellFeil("Kan ikke kjøre satsendring når det ikke finnes en tidligere behandling på fagsaken")
+        }
+
+        validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+            andelerFraForrigeBehandling = andelerFraForrigeBehandling,
+            andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.toList(),
+        )
     }
 
     companion object {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
@@ -57,6 +58,8 @@ class BehandlingsresultatStegTest {
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService =
         mockk<AndelerTilkjentYtelseOgEndreteUtbetalingerService>()
 
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository = mockk()
+
     @BeforeEach
     fun init() {
         behandlingsresultatSteg = BehandlingsresultatSteg(
@@ -70,6 +73,7 @@ class BehandlingsresultatStegTest {
             persongrunnlagService,
             beregningService,
             andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            andelTilkjentYtelseRepository,
         )
 
         behandling = lagBehandling(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
@@ -1,11 +1,20 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.inneværendeMåned
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
+import java.time.YearMonth
 
 class TilkjentYtelseValideringTest {
 
@@ -207,5 +216,241 @@ class TilkjentYtelseValideringTest {
                 gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(LocalDateTime.now().minusYears(2)),
             ),
         )
+    }
+
+    @Nested
+    inner class `Valider at satsendring kun oppdaterer sats på eksisterende perioder` {
+        @Test
+        fun `Skal kaste feil hvis person har lagt til andel som ikke hadde utbetaling i forrige behandling`() {
+            val person = lagPerson(type = PersonType.BARN)
+            val forrigeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2022, 1),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            val nåværendeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2020, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 3),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 1083,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            assertThrows<Feil> {
+                TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+                    andelerFraForrigeBehandling = forrigeAndeler,
+                    andelerTilkjentYtelse = nåværendeAndeler,
+                )
+            }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis person har fått fjernet andel i periode som hadde utbetaling før`() {
+            val person = lagPerson(type = PersonType.BARN)
+            val forrigeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2020, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            val nåværendeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2022, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            assertThrows<Feil> {
+                TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+                    andelerFraForrigeBehandling = forrigeAndeler,
+                    andelerTilkjentYtelse = nåværendeAndeler,
+                )
+            }
+        }
+
+        @Test
+        fun `Skal ikke kaste feil hvis det eneste som er gjort er å oppdatere sats`() {
+            val person = lagPerson(type = PersonType.BARN)
+            val forrigeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2022, 1),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            val nåværendeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2022, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 3),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 1083,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            assertDoesNotThrow {
+                TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+                    andelerFraForrigeBehandling = forrigeAndeler,
+                    andelerTilkjentYtelse = nåværendeAndeler,
+                )
+            }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis det ikke eksisterte andeler forrige gang men gjør det nå`() {
+            val person = lagPerson(type = PersonType.BARN)
+            val forrigeAndeler = emptyList<AndelTilkjentYtelse>()
+
+            val nåværendeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2022, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 3),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 1083,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            assertThrows<Feil> {
+                TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+                    andelerFraForrigeBehandling = forrigeAndeler,
+                    andelerTilkjentYtelse = nåværendeAndeler,
+                )
+            }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis det eksisterte andeler forrige gang men ikke gjør det nå`() {
+            val person = lagPerson(type = PersonType.BARN)
+
+            val forrigeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2022, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 3),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 1083,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = person.aktør,
+                ),
+            )
+
+            val nåværendeAndeler = emptyList<AndelTilkjentYtelse>()
+
+            assertThrows<Feil> {
+                TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+                    andelerFraForrigeBehandling = forrigeAndeler,
+                    andelerTilkjentYtelse = nåværendeAndeler,
+                )
+            }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis det eksisterer andeler i lik periode som forrige gang men av ulik type`() {
+            val barn = lagPerson(type = PersonType.BARN)
+
+            val forrigeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = barn.aktør,
+                ),
+            )
+
+            val nåværendeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.UTVIDET_BARNETRYGD, // barn kan ha utvidet på enslig mindreårig-saker
+                    aktør = barn.aktør,
+                ),
+            )
+
+            assertThrows<Feil> {
+                TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+                    andelerFraForrigeBehandling = forrigeAndeler,
+                    andelerTilkjentYtelse = nåværendeAndeler,
+                )
+            }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis det eksisterer andeler i lik periode som forrige gang men på forskjellige personer`() {
+            val barn1 = lagPerson(type = PersonType.BARN)
+            val barn2 = lagPerson(type = PersonType.BARN)
+
+            val forrigeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = barn1.aktør,
+                ),
+            )
+
+            val nåværendeAndeler = listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 2),
+                    beløp = 1054,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    aktør = barn2.aktør,
+                ),
+            )
+
+            assertThrows<Feil> {
+                TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder(
+                    andelerFraForrigeBehandling = forrigeAndeler,
+                    andelerTilkjentYtelse = nåværendeAndeler,
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12468

Etter prat på denne PRen https://github.com/navikt/familie-ba-sak/pull/3601, så har jeg skilt ut validering av satsendring i egen PR. 

Vi ønsker kun at satsendrings skal oppdatere sats på eksisterende andeler. Sørger for at det blir kastet en feil hvis det blir lagt til en ny andel, fjernet en andel eller endring i prosent i periode.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
