### PR TITLE
Sett på vent skal oppdatere behandlingsstatus for å enklere kunne validere behandlingsstate

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -446,6 +446,7 @@ fun initStatus(): BehandlingStatus {
 
 enum class BehandlingStatus {
     UTREDES,
+    SATT_PÅ_VENT,
     FATTER_VEDTAK,
     IVERKSETTER_VEDTAK,
     AVSLUTTET,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import org.slf4j.Logger
@@ -49,6 +50,8 @@ class SettPåVentService(
 
         val settPåVent = lagreEllerOppdater(SettPåVent(behandling = behandling, frist = frist, årsak = årsak))
 
+        behandling.status = BehandlingStatus.SATT_PÅ_VENT
+        behandlingHentOgPersisterService.lagreOgFlush(behandling)
         oppgaveService.forlengFristÅpneOppgaverPåBehandling(
             behandlingId = behandling.id,
             forlengelse = Period.between(LocalDate.now(), frist),
@@ -86,6 +89,7 @@ class SettPåVentService(
         return settPåVent
     }
 
+    @Transactional
     fun gjenopptaBehandling(behandlingId: Long, nå: LocalDate = LocalDate.now()): SettPåVent {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val aktivSettPåVent =
@@ -106,6 +110,8 @@ class SettPåVentService(
             behandlingId = behandlingId,
             nyFrist = LocalDate.now().plusDays(1),
         )
+        behandling.status = BehandlingStatus.UTREDES
+        behandlingHentOgPersisterService.lagreOgFlush(behandling)
 
         return settPåVent
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
@@ -92,7 +92,6 @@ class SettPåVentService(
     @Transactional
     fun gjenopptaBehandling(behandlingId: Long, nå: LocalDate = LocalDate.now()): SettPåVent {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
-        validerKanGjenopptaBehandling(behandling)
 
         val aktivSettPåVent =
             finnAktivSettPåVentPåBehandling(behandlingId)
@@ -100,6 +99,7 @@ class SettPåVentService(
                     melding = "Behandling $behandlingId er ikke satt på vent.",
                     frontendFeilmelding = "Behandlingen er ikke på vent og det er ikke mulig å gjenoppta behandling.",
                 )
+        validerKanGjenopptaBehandling(behandling)
 
         loggService.gjenopptaBehandlingLogg(behandling)
         logger.info("Gjenopptar behandling $behandlingId")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
@@ -18,12 +18,7 @@ fun validerBehandlingKanSettesPåVent(
         )
     }
 
-    if (frist.isBefore(LocalDate.now())) {
-        throw FunksjonellFeil(
-            melding = "Frist for å vente på behandling ${behandling.id} er satt før dagens dato.",
-            frontendFeilmelding = "Fristen er satt før dagens dato.",
-        )
-    }
+    validerFristErFremITiden(behandling, frist)
 
     if (behandling.status != BehandlingStatus.UTREDES) {
         throw FunksjonellFeil(
@@ -39,8 +34,23 @@ fun validerBehandlingKanSettesPåVent(
     }
 }
 
+fun validerOppdaterSettBehandlingPåVent() {
+}
+
+fun validerFristErFremITiden(
+    behandling: Behandling,
+    frist: LocalDate,
+) {
+    if (frist.isBefore(LocalDate.now())) {
+        throw FunksjonellFeil(
+            melding = "Frist for å vente på behandling ${behandling.id} er satt før dagens dato.",
+            frontendFeilmelding = "Fristen er satt før dagens dato.",
+        )
+    }
+}
+
 fun validerKanGjenopptaBehandling(behandling: Behandling) {
-    if(behandling.status != BehandlingStatus.SATT_PÅ_VENT) {
+    if (behandling.status != BehandlingStatus.SATT_PÅ_VENT) {
         throw FunksjonellFeil(
             melding = "Behandling ${behandling.id} har status=${behandling.status} og kan ikke gjenopptas.",
             frontendFeilmelding = "Behandlingen må ha status satt på vent for å kunne gjenopptas",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
@@ -25,16 +25,25 @@ fun validerBehandlingKanSettesPåVent(
         )
     }
 
-    if (behandling.status == BehandlingStatus.AVSLUTTET) {
+    if (behandling.status != BehandlingStatus.UTREDES) {
         throw FunksjonellFeil(
-            melding = "Behandling ${behandling.id} er avsluttet og kan ikke settes på vent.",
-            frontendFeilmelding = "Kan ikke sette en avsluttet behandling på vent.",
+            melding = "Behandling ${behandling.id} har status=${behandling.status} og kan ikke settes på vent.",
+            frontendFeilmelding = "Behandlingen må ha status utredes for å kunne settes på vent",
         )
     }
 
     if (!behandling.aktiv) {
         throw Feil(
             "Behandling ${behandling.id} er ikke aktiv og kan ikke settes på vent.",
+        )
+    }
+}
+
+fun validerKanGjenopptaBehandling(behandling: Behandling) {
+    if(behandling.status != BehandlingStatus.SATT_PÅ_VENT) {
+        throw FunksjonellFeil(
+            melding = "Behandling ${behandling.id} har status=${behandling.status} og kan ikke gjenopptas.",
+            frontendFeilmelding = "Behandlingen må ha status satt på vent for å kunne gjenopptas",
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
@@ -34,9 +34,6 @@ fun validerBehandlingKanSettesPåVent(
     }
 }
 
-fun validerOppdaterSettBehandlingPåVent() {
-}
-
 fun validerFristErFremITiden(
     behandling: Behandling,
     frist: LocalDate,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -19,11 +19,11 @@ import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.kjerne.behandling.RestHenleggBehandlingInfo
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
@@ -56,7 +56,6 @@ class StegService(
     private val søknadGrunnlagService: SøknadGrunnlagService,
     private val tilgangService: TilgangService,
     private val infotrygdFeedService: InfotrygdFeedService,
-    private val settPåVentService: SettPåVentService,
     private val satsendringService: SatsendringService,
     private val simuleringService: SimuleringService,
 ) {
@@ -533,7 +532,7 @@ class StegService(
         behandling: Behandling,
         behandlingSteg: BehandlingSteg<*>,
     ) {
-        if (settPåVentService.finnAktivSettPåVentPåBehandling(behandlingId = behandling.id) != null) {
+        if (behandling.status == BehandlingStatus.SATT_PÅ_VENT) {
             throw FunksjonellFeil(
                 "${SikkerhetContext.hentSaksbehandlerNavn()} prøver å utføre steg " +
                     behandlingSteg.stegType() +

--- a/src/main/resources/db/migration/V241__oppdater_behandlinger_satt_på_vent.sql
+++ b/src/main/resources/db/migration/V241__oppdater_behandlinger_satt_på_vent.sql
@@ -1,0 +1,3 @@
+UPDATE behandling
+SET status = 'SATT_PÅ_VENT'
+WHERE id IN (SELECT fk_behandling_id from sett_paa_vent WHERE aktiv = true);

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -11,12 +11,13 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -27,7 +28,6 @@ internal class StegServiceTest {
 
     private val behandlingService: BehandlingService = mockk()
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
-    private val settPåVentService: SettPåVentService = mockk()
     private val satsendringService: SatsendringService = mockk()
     private val simuleringService: SimuleringService = mockk()
 
@@ -40,7 +40,6 @@ internal class StegServiceTest {
         søknadGrunnlagService = mockk(),
         tilgangService = mockk(relaxed = true),
         infotrygdFeedService = mockk(),
-        settPåVentService = settPåVentService,
         satsendringService = satsendringService,
         simuleringService = simuleringService,
     )
@@ -51,7 +50,6 @@ internal class StegServiceTest {
         every { behandlingService.opprettBehandling(any()) } returns behandling
         every { behandlingService.leggTilStegPåBehandlingOgSettTidligereStegSomUtført(any(), any()) } returns behandling
         every { behandlingHentOgPersisterService.hent(any()) } returns behandling
-        every { settPåVentService.finnAktivSettPåVentPåBehandling(any()) } returns null
     }
 
     @Test
@@ -114,6 +112,14 @@ internal class StegServiceTest {
         )
 
         assertThrows<FunksjonellFeil> { stegService.håndterNyBehandling(nyBehandling) }
+    }
+
+    @Test
+    fun `Skal feile dersom behandlingen er satt på vent`() {
+        val behandling = lagBehandling(status = BehandlingStatus.SATT_PÅ_VENT)
+        val grunnlag = RegistrerPersongrunnlagDTO("", emptyList())
+        assertThatThrownBy { stegService.håndterPersongrunnlag(behandling, grunnlag) }
+            .hasMessageContaining("er på vent")
     }
 
     private fun mockRegistrerPersongrunnlag() = object : RegistrerPersongrunnlag(mockk(), mockk(), mockk(), mockk()) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12540

For å enklere kunne validere en behandling, så gjøres dette. I stegService trenger man ikke et kall til på-vent-service men kan sjekke behandlingen direkte. 

En behandling kan kun settes på vent hvis den har status `UTREDES`
En behandling kan kun tas av vent hvis den har status `SATT_PÅ_VENT`, for å unngå at man prøver å gjennoppta en behandling som senere kan ha status `SATT_PÅ_MASKINELL_VENT` som settes når man sniker i køen.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
