### PR TITLE
Kast funksjonell feil om saksbehandler ikke har satt fra og med dato for under 18 vilkåret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.erUnder18ÅrVilkårTidslinje
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
@@ -116,7 +117,7 @@ object VilkårsvurderingForskyvningUtils {
     ): Tidslinje<VilkårResultat, Måned> {
         return if (vilkår == Vilkår.UNDER_18_ÅR) {
             val minstePeriodeFom = vilkårResultater.minOf {
-                it.periodeFom ?: throw Feil("Finner ikke fra og med dato på 'under 18 år'-vilkåret")
+                it.periodeFom ?: throw FunksjonellFeil("Finner ikke fra og med dato på 'under 18 år'-vilkåret")
             } // Fra og med dato skal være lik fødselsdato for under 18-vilkåret
             this.beskjærPå18År(fødselsdato = minstePeriodeFom)
         } else {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Her har saksbehandler mest sannsynlig gjort feil og ønsker å avslå fra barnet blir 18 og ikke på generelt grunnlag. Nå får saksbehandleren kun en diffus feilmelding "Noe har gått galt". 

![image](https://github.com/navikt/familie-ba-sak/assets/17828446/3128e5f4-63ef-4e4c-a9ec-e51d09c89d4b)

Endrer så hen får "Finner ikke fra og med dato på 'under 18 år'-vilkåret. Det gjør også så utviklerene ikke får varsel

