### PR TITLE
Legger til aktivert_tid på behandling som skal brukes for sortering a…

### DIFF
--- a/src/main/resources/db/migration/V242__behandling_aktivert_tid.sql
+++ b/src/main/resources/db/migration/V242__behandling_aktivert_tid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE behandling
+    ADD COLUMN aktivert_tid TIMESTAMP(3) DEFAULT localtimestamp NOT NULL;


### PR DESCRIPTION
…v behandlinger når noe sniket seg i køen

### 💰 Hva skal gjøres, og hvorfor?
Legge til kolonne for å kunne håndtere sniking i køen

* Setter til default sånn at alle behandlinger får en verdi, dette blir senere oppdatert Neste PR
* Aktivert_tid settes til opprettet_tid
* DEFAULT blir slettet

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12540

Dette er trukket ut fra 
https://github.com/navikt/familie-ba-sak/pull/3630/files#diff-74660ce33ab602a23d554cd0c987b61be43ac098f9c2ec039bc821a60c637869

Det ble trukket ut for å unngå at feltet legges til, og kun er tatt i bruk av en kjørende pod. Av den grunnen oppdateres det i 
* https://github.com/navikt/familie-ba-sak/pull/3630
