### PR TITLE
Kan opprette manuell migrering dersom forrige behandling var et opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -138,7 +138,7 @@ class StegService(
     private fun validerHelmanuelMigrering(nyBehandling: NyBehandling) {
         val sisteBehandlingSomErVedtatt =
             behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(nyBehandling.fagsakId)
-        if (sisteBehandlingSomErVedtatt != null && !sisteBehandlingSomErVedtatt.erTekniskEndringMedOpphør()) {
+        if (sisteBehandlingSomErVedtatt != null && !sisteBehandlingSomErVedtatt.resultat.erOpphør()) {
             throw FunksjonellFeil(
                 melding = "Det finnes allerede en vedtatt behandling på fagsak ${nyBehandling.fagsakId}." +
                     "Behandling kan ikke opprettes med årsak " +

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -55,31 +55,10 @@ internal class StegServiceTest {
     }
 
     @Test
-    fun `skal feile validering av helmanuell migrering når fagsak har aktivt vedtak som IKKE var teknisk endring med opphør`() {
-        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
-            lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE, resultat = Behandlingsresultat.INNVILGET)
-
-        assertThrows<FunksjonellFeil>(message = "Det finnes allerede en vedtatt behandling på fagsak") {
-            stegService.håndterNyBehandling(
-                NyBehandling(
-                    kategori = BehandlingKategori.NASJONAL,
-                    underkategori = BehandlingUnderkategori.ORDINÆR,
-                    behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                    behandlingÅrsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
-                    søkersIdent = randomFnr(),
-                    barnasIdenter = listOf(randomFnr()),
-                    nyMigreringsdato = LocalDate.now().minusMonths(6),
-                    fagsakId = 1L,
-                ),
-            )
-        }
-    }
-
-    @Test
-    fun `skal IKKE feile validering av helmanuell migrering når fagsak har aktivt vedtak som var teknisk endring med opphør`() {
+    fun `skal IKKE feile validering av helmanuell migrering når fagsak har aktivt vedtak som er et opphør`() {
         Behandlingsresultat.values().filter { it.erOpphør() }.forEach {
             every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
-                lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING, resultat = it)
+                lagBehandling(resultat = it)
 
             assertDoesNotThrow {
                 stegService.håndterNyBehandling(
@@ -99,10 +78,10 @@ internal class StegServiceTest {
     }
 
     @Test
-    fun `skal feile validering av helmanuell migrering når fagsak har aktivt vedtak som er teknisk endring men ikke opphør`() {
+    fun `skal feile validering av helmanuell migrering når fagsak har aktivt vedtak som IKKE er et opphør`() {
         Behandlingsresultat.values().filter { !it.erOpphør() }.forEach {
             every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
-                lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING, resultat = it)
+                lagBehandling(resultat = it)
 
             assertThrows<FunksjonellFeil> {
                 stegService.håndterNyBehandling(


### PR DESCRIPTION
Favro: [NAV-12692](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12692)

### 💰 Hva skal gjøres, og hvorfor?
Vi sjekket tidligere både om forrige behandling var en "Teknisk endring"-behandling og at resultatet var et opphør for å avgjøre om saksbehandler skal få opprette en "Manuell migrering". Nå sjekker vi kun om den forrige behandlingen var et opphør. Dette vil redusere behovet for at våre fagressurser må inn for å fikse opp ting saksbehandlerne selv skal kunne gjøre.

### ✅ Checklist
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
