### PR TITLE
Ikke send med tilbakekreving for Simuleringen for nav-12506 fiks

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.internal
 
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
-import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
@@ -31,7 +30,6 @@ import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
-import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -326,10 +324,7 @@ class ForvalterController(
         val behandlingEtterBehandlingsresultat = stegService.håndterVilkårsvurdering(nyBehandling)
         val behandlingEtterSimulering = stegService.håndterVurderTilbakekreving(
             behandlingEtterBehandlingsresultat,
-            RestTilbakekreving(
-                Tilbakekrevingsvalg.IGNORER_TILBAKEKREVING,
-                begrunnelse = "satsendring",
-            ),
+            null,
         )
         behandlingService.oppdaterStatusPåBehandling(nyBehandling.id, BehandlingStatus.IVERKSETTER_VEDTAK)
         stegService.håndterFerdigstillBehandling(behandlingEtterSimulering)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Oppretting av endre migreringsdato med simulering stoppet opp med:

no.nav.familie.ba.sak.common.FunksjonellFeil: Simuleringen har ikke en feilutbetaling, men restTilbakekreving var ikke null

Som jo høres greit resultat ut. Var en av de tingene som var vanskelig å teste lokalt siden det der mockes alltid til å ha feilutbetaling. Så fjernet RestTilbakekreving

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
