### PR TITLE
Legg til en måned når BrevPeriodeGenerator matcher vilkårresultat med…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -181,6 +181,7 @@ class BrevPeriodeService(
                 )
             },
             dødeBarnForrigePeriode = dødeBarnForrigePeriode,
+            featureToggleService = featureToggleService,
         )
 
         if (skalLogge) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevperiodeData.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.brev.BrevPeriodeGenerator
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
@@ -16,6 +17,7 @@ data class BrevperiodeData(
     val minimerteKompetanserForPeriode: List<MinimertKompetanse>,
     val minimerteKompetanserSomStopperRettFørPeriode: List<MinimertKompetanse>,
     val dødeBarnForrigePeriode: List<String>,
+    val featureToggleService: FeatureToggleService,
 ) : Comparable<BrevperiodeData> {
 
     fun tilBrevPeriodeGenerator() = BrevPeriodeGenerator(
@@ -28,13 +30,14 @@ data class BrevperiodeData(
         minimerteKompetanserForPeriode = minimerteKompetanserForPeriode,
         minimerteKompetanserSomStopperRettFørPeriode = minimerteKompetanserSomStopperRettFørPeriode,
         dødeBarnForrigePeriode = dødeBarnForrigePeriode,
+        featureToggleService = featureToggleService,
     )
 
     fun hentBegrunnelserOgFritekster(): List<Begrunnelse> {
-        val brevPeriodeGenereator = this.tilBrevPeriodeGenerator()
-        return brevPeriodeGenereator.byggBegrunnelserOgFritekster(
-            begrunnelserGrunnlagMedPersoner = brevPeriodeGenereator.hentBegrunnelsegrunnlagMedPersoner(),
-            eøsBegrunnelserMedKompetanser = brevPeriodeGenereator.hentEøsBegrunnelserMedKompetanser(),
+        val brevPeriodeGenerator = this.tilBrevPeriodeGenerator()
+        return brevPeriodeGenerator.byggBegrunnelserOgFritekster(
+            begrunnelserGrunnlagMedPersoner = brevPeriodeGenerator.hentBegrunnelsegrunnlagMedPersoner(),
+            eøsBegrunnelserMedKompetanser = brevPeriodeGenerator.hentEøsBegrunnelserMedKompetanser(),
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeUtilTest.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.brev
 
+import io.mockk.mockk
 import no.nav.familie.ba.sak.common.MånedPeriode
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.brev.lagMinimertPerson
 import no.nav.familie.ba.sak.kjerne.brev.domene.BrevperiodeData
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertUregistrertBarn
@@ -20,6 +22,8 @@ import java.time.YearMonth
 
 class BrevPeriodeUtilTest {
 
+    private val featureToggleService: FeatureToggleService = mockk()
+
     @Test
     fun `Skal sortere perioder kronologisk, med avslag til slutt`() {
         val liste = listOf(
@@ -27,21 +31,25 @@ class BrevPeriodeUtilTest {
                 fom = LocalDate.now().minusMonths(12),
                 tom = LocalDate.now().minusMonths(8),
                 type = Vedtaksperiodetype.UTBETALING,
+                featureToggleService = featureToggleService,
             ),
             lagBrevperiodeData(
                 fom = LocalDate.now().minusMonths(4),
                 tom = null,
                 type = Vedtaksperiodetype.AVSLAG,
+                featureToggleService = featureToggleService,
             ),
             lagBrevperiodeData(
                 fom = LocalDate.now().minusMonths(7),
                 tom = LocalDate.now().minusMonths(4),
                 type = Vedtaksperiodetype.OPPHØR,
+                featureToggleService = featureToggleService,
             ),
             lagBrevperiodeData(
                 fom = LocalDate.now().minusMonths(3),
                 tom = LocalDate.now(),
                 type = Vedtaksperiodetype.UTBETALING,
+                featureToggleService = featureToggleService,
             ),
         )
 
@@ -154,7 +162,7 @@ class BrevPeriodeUtilTest {
     }
 }
 
-private fun lagBrevperiodeData(fom: LocalDate?, tom: LocalDate?, type: Vedtaksperiodetype): BrevperiodeData {
+private fun lagBrevperiodeData(fom: LocalDate?, tom: LocalDate?, type: Vedtaksperiodetype, featureToggleService: FeatureToggleService): BrevperiodeData {
     val restBehandlingsgrunnlagForBrev = RestBehandlingsgrunnlagForBrev(
         personerPåBehandling = emptyList(),
         minimertePersonResultater = emptyList(),
@@ -176,5 +184,6 @@ private fun lagBrevperiodeData(fom: LocalDate?, tom: LocalDate?, type: Vedtakspe
         minimerteKompetanserForPeriode = emptyList(),
         minimerteKompetanserSomStopperRettFørPeriode = emptyList(),
         dødeBarnForrigePeriode = emptyList(),
+        featureToggleService = featureToggleService,
     )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
@@ -102,6 +102,7 @@ class BrevperiodeTest {
                         )
                     } ?: emptyList(),
                     dødeBarnForrigePeriode = emptyList(),
+                    featureToggleService = featureToggleService,
                 ).genererBrevPeriode()
             } catch (e: Exception) {
                 testReporter.publishEntry(


### PR DESCRIPTION
… behandlingsgrunnlag når det er avslag.

### 💰 Hva skal gjøres, og hvorfor?
Flettefeltet barns fødselsdato fungerer ikke for eøsavslag siden nyere vedtaksperiodeløsning legger avslagsperioder til å begynne i neste måned. Den gamle begrunnelsetekstgeneratoren forventer at periodene skjer i samme måned. Har derfor lagt en .førsteDagINesteMåned() til sjekken ved datoer når brevGeneratoren prøver å matche vilkår med behandlingsGrunnlag. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
