### PR TITLE
Test feilet fordi dato tom satt ut i fra dagens dato, minus antall måneder

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
@@ -194,7 +194,7 @@ class RestartAvSmåbarnstilleggTest(
                 EksternPeriode(
                     personIdent = personScenario.søker.ident!!,
                     fomDato = barnFødselsdato.plusYears(1),
-                    tomDato = LocalDate.now().minusMonths(4).førsteDagIInneværendeMåned(),
+                    tomDato = satsendringDato.minusMonths(2),
                     datakilde = Datakilde.EF,
                 ),
                 EksternPeriode(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Test feilet fordi dato tom satt ut i fra dagens dato, minus antall måneder. Endret til å bruke satsendringstidspunktet
