### PR TITLE
Legg til VedtaksBegrunnelseType.Avslag i Vedtaksperiodetype.OPPHØR sl…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseType.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseType.kt
@@ -40,7 +40,7 @@ enum class VedtakBegrunnelseType(val sorteringsrekkefølge: Int) {
     }
 
     fun erAvslag(): Boolean {
-        return this == AVSLAG || this == INSTITUSJON_AVSLAG
+        return this == AVSLAG || this == INSTITUSJON_AVSLAG || this == EØS_AVSLAG
     }
 
     fun erOpphør(): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiode.kt
@@ -67,6 +67,7 @@ enum class Vedtaksperiodetype(val tillatteBegrunnelsestyper: Set<VedtakBegrunnel
             VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING,
             VedtakBegrunnelseType.INSTITUSJON_OPPHØR,
             VedtakBegrunnelseType.EØS_OPPHØR,
+            VedtakBegrunnelseType.AVSLAG,
         ),
     ),
     AVSLAG(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -124,6 +124,12 @@ class VedtaksperiodeService(
         val vedtaksperiodeMedBegrunnelser =
             vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(vedtaksperiodeId)
 
+        validerAvslagHarAvslagBegrunnelse(
+            vedtaksperiodeMedBegrunnelser,
+            standardbegrunnelserFraFrontend,
+            eøsStandardbegrunnelserFraFrontend,
+        )
+
         val behandling = vedtaksperiodeMedBegrunnelser.vedtak.behandling
 
         val persongrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id)
@@ -169,6 +175,31 @@ class VedtaksperiodeService(
         vedtaksperiodeHentOgPersisterService.lagre(vedtaksperiodeMedBegrunnelser)
 
         return vedtaksperiodeMedBegrunnelser.vedtak
+    }
+
+    private fun validerAvslagHarAvslagBegrunnelse(
+        vedtaksperiodeMedBegrunnelser: VedtaksperiodeMedBegrunnelser,
+        standardbegrunnelserFraFrontend: List<Standardbegrunnelse>,
+        eøsStandardbegrunnelserFraFrontend: List<EØSStandardbegrunnelse>,
+    ) {
+        if (vedtaksperiodeMedBegrunnelser.begrunnelser.any { it.standardbegrunnelse.vedtakBegrunnelseType == VedtakBegrunnelseType.AVSLAG } &&
+            !standardbegrunnelserFraFrontend.any {
+                listOf(
+                    VedtakBegrunnelseType.AVSLAG,
+                    VedtakBegrunnelseType.EØS_AVSLAG,
+                    VedtakBegrunnelseType.INSTITUSJON_AVSLAG,
+                ).contains(it.vedtakBegrunnelseType)
+            } &&
+            !eøsStandardbegrunnelserFraFrontend.any {
+                listOf(
+                    VedtakBegrunnelseType.AVSLAG,
+                    VedtakBegrunnelseType.EØS_AVSLAG,
+                    VedtakBegrunnelseType.INSTITUSJON_AVSLAG,
+                ).contains(it.vedtakBegrunnelseType)
+            }
+        ) {
+            throw FunksjonellFeil("Kan ikke fjerne avslags-begrunnelse fra vedtaksperiode som har blitt satt til avslag i vilkårsvurdering.")
+        }
     }
 
     private fun validerEndretUtbetalingsbegrunnelse(
@@ -744,28 +775,30 @@ class VedtaksperiodeService(
         val målform = persongrunnlagService.hentAktiv(behandlingId = behandling.id)?.søker?.målform
         val landkoderISO2 = integrasjonClient.hentLandkoderISO2()
 
-        return refusjonEøsRepository.finnRefusjonEøsForBehandling(behandling.id).filter { it.refusjonAvklart == avklart }.map {
-            val (fom, tom) = it.fom.tilMånedÅr() to it.tom.tilMånedÅr()
-            val land = landkoderISO2[it.land]?.storForbokstav() ?: throw Feil("Fant ikke navn for landkode ${it.land}")
-            val beløp = it.refusjonsbeløp
+        return refusjonEøsRepository.finnRefusjonEøsForBehandling(behandling.id)
+            .filter { it.refusjonAvklart == avklart }.map {
+                val (fom, tom) = it.fom.tilMånedÅr() to it.tom.tilMånedÅr()
+                val land = landkoderISO2[it.land]?.storForbokstav() ?: throw Feil("Fant ikke navn for landkode ${it.land}")
+                val beløp = it.refusjonsbeløp
 
-            when (målform) {
-                NN -> {
-                    if (avklart) {
-                        "Frå $fom til $tom blir etterbetaling på $beløp kroner per måned utbetalt til myndighetene i $land."
-                    } else {
-                        "Frå $fom til $tom blir ikkje etterbetaling på $beløp kroner per månad utbetalt no sidan det er utbetalt barnetrygd i $land."
+                when (målform) {
+                    NN -> {
+                        if (avklart) {
+                            "Frå $fom til $tom blir etterbetaling på $beløp kroner per måned utbetalt til myndighetene i $land."
+                        } else {
+                            "Frå $fom til $tom blir ikkje etterbetaling på $beløp kroner per månad utbetalt no sidan det er utbetalt barnetrygd i $land."
+                        }
+                    }
+
+                    else -> {
+                        if (avklart) {
+                            "Fra $fom til $tom blir etterbetaling på $beløp kroner per måned utbetalt til myndighetene i $land."
+                        } else {
+                            "Fra $fom til $tom blir ikke etterbetaling på $beløp kroner per måned utbetalt nå siden det er utbetalt barnetrygd i $land."
+                        }
                     }
                 }
-                else -> {
-                    if (avklart) {
-                        "Fra $fom til $tom blir etterbetaling på $beløp kroner per måned utbetalt til myndighetene i $land."
-                    } else {
-                        "Fra $fom til $tom blir ikke etterbetaling på $beløp kroner per måned utbetalt nå siden det er utbetalt barnetrygd i $land."
-                    }
-                }
-            }
-        }.toSet().takeIf { it.isNotEmpty() }
+            }.toSet().takeIf { it.isNotEmpty() }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -182,13 +182,11 @@ class VedtaksperiodeService(
         standardbegrunnelserFraFrontend: List<Standardbegrunnelse>,
         eøsStandardbegrunnelserFraFrontend: List<EØSStandardbegrunnelse>,
     ) {
-        val erMinstEnNyBegrunnelseMedAvslag =
-            standardbegrunnelserFraFrontend.any { it.vedtakBegrunnelseType.erAvslag() } || eøsStandardbegrunnelserFraFrontend.any { it.vedtakBegrunnelseType.erAvslag() }
-        val eksisterendeBegrunnelser = vedtaksperiodeMedBegrunnelser.begrunnelser
+        val eksisterendeAvslagBegrunnelser = vedtaksperiodeMedBegrunnelser.begrunnelser.filter { it.standardbegrunnelse.vedtakBegrunnelseType.erAvslag() }.map { it.standardbegrunnelse.sanityApiNavn }
 
-        if (eksisterendeBegrunnelser.any { it.standardbegrunnelse.vedtakBegrunnelseType.erAvslag() } &&
-            !erMinstEnNyBegrunnelseMedAvslag
-        ) {
+        val nyeAvslagBegrunnelser = (standardbegrunnelserFraFrontend.filter { it.vedtakBegrunnelseType.erAvslag() } + eøsStandardbegrunnelserFraFrontend.filter { it.vedtakBegrunnelseType.erAvslag() }).map { it.sanityApiNavn }
+
+        if (!nyeAvslagBegrunnelser.containsAll(eksisterendeAvslagBegrunnelser)) {
             throw FunksjonellFeil("Kan ikke fjerne avslags-begrunnelse fra vedtaksperiode som har blitt satt til avslag i vilkårsvurdering.")
         }
     }


### PR DESCRIPTION
…ik at man kan oppdatere opphørsperioder med begrunnelser.

Fjern mulighet til å slette avslagsbegrunnelse definert i vilkårsvurdering i vedtakssteg.

### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12765
Vi vil kunne oppdatere perioder som inneholder både avslag og opphør med begrunnelser. Det har tidligere ikke gått siden valideringen på avslagstekster i opphør har slått ut. 
Vil også hindre muligheten til å fjerne avslagsbegrunnelser i vedtakssteget siden denne begrunnelsen velger når man sier at vilkåret er et avslag. Har nå gjort dette ved å sjekke hvorvidt det fantes en avslagsbegrunnelse på perioden fra før og kaste feil dersom oppdateringen/overskrivningen ikke inneholder en avslagsbegrunnelse. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
* Logikk på validering. 
* Formulering på feilmelding når man prøver å fjerne avslag.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
