### PR TITLE
Behandlinger med status SATT_PÅ_VENT skal trigge manuell vurder-livshendelse oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -84,9 +84,11 @@ class AutovedtakStegService(
             Autovedtaktype.FØDSELSHENDELSE -> {
                 autovedtakFødselshendelseService.skalAutovedtakBehandles(behandlingsdata as NyBehandlingHendelse)
             }
+
             Autovedtaktype.OMREGNING_BREV -> {
                 autovedtakBrevService.skalAutovedtakBehandles(behandlingsdata as AutovedtakBrevBehandlingsdata)
             }
+
             Autovedtaktype.SMÅBARNSTILLEGG -> {
                 autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(behandlingsdata as Aktør)
             }
@@ -119,9 +121,11 @@ class AutovedtakStegService(
             Autovedtaktype.FØDSELSHENDELSE -> {
                 autovedtakFødselshendelseService.kjørBehandling(behandlingsdata as NyBehandlingHendelse)
             }
+
             Autovedtaktype.OMREGNING_BREV -> {
                 autovedtakBrevService.kjørBehandling(behandlingsdata as AutovedtakBrevBehandlingsdata)
             }
+
             Autovedtaktype.SMÅBARNSTILLEGG -> {
                 autovedtakSmåbarnstilleggService.kjørBehandling(behandlingsdata as Aktør)
             }
@@ -163,9 +167,8 @@ class AutovedtakStegService(
 
         return if (åpenBehandling == null) {
             false
-        } else if (åpenBehandling.status == BehandlingStatus.UTREDES || åpenBehandling.status == BehandlingStatus.FATTER_VEDTAK) {
+        } else if (åpenBehandling.status == BehandlingStatus.UTREDES || åpenBehandling.status == BehandlingStatus.FATTER_VEDTAK || åpenBehandling.status == BehandlingStatus.SATT_PÅ_VENT) {
             antallAutovedtakÅpenBehandling[autovedtaktype]?.increment()
-
             oppgaveService.opprettOppgaveForManuellBehandling(
                 behandling = åpenBehandling,
                 begrunnelse = "${autovedtaktype.displayName}: Bruker har åpen behandling",


### PR DESCRIPTION
Tasken `vedtakOmOvergangsstønadTask` feiler med `Ikke håndtert feilsituasjon..`

Som en del av "Snike i køen"-funksjonaliteten har det blitt lagt til to nye behandlingsstatuser `SATT_PÅ_VENT` og `SATT_PÅ_MASKINELL_VENT`. Ved autovedtak får vi nå feil dersom eksisterende behandling har status `SATT_PÅ_VENT` fordi statusen ikke håndteres. Tidligere var statusen til behandlinger som var satt på vent `UTREDES` og ble håndtert. Legger derfor til `SATT_PÅ_VENT` i listen over statuser som skal trigge en manuell oppgave av typen `VurderLivshendelse`.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
