### PR TITLE
Forbedring: finnSisteIverksatteBehandling sql i stedet for å hente alle behandlin…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
@@ -45,8 +45,7 @@ class BehandlingHentOgPersisterService(
      * Henter siste iverksatte behandling på fagsak
      */
     fun hentSisteBehandlingSomErIverksatt(fagsakId: Long): Behandling? {
-        val iverksatteBehandlinger = hentIverksatteBehandlinger(fagsakId)
-        return Behandlingutils.hentSisteBehandlingSomErIverksatt(iverksatteBehandlinger)
+        return behandlingRepository.finnSisteIverksatteBehandling(fagsakId = fagsakId)
     }
 
     /**

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -81,6 +81,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
             WHERE f.id = :fagsakId
               AND ty.utbetalingsoppdrag IS NOT NULL
               AND f.arkivert = false
+              AND b.status = 'AVSLUTTET'
             ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC""",
         nativeQuery = true,
     )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -44,18 +44,18 @@ class BehandlingRepositoryTest(
         }
 
         @Test
-        fun `skal finne siste iverksatte behandlingen som har utbetalingsoppdrag, uavhengig behandlingsstatus`() {
+        fun `skal finne siste iverksatte behandlingen som har utbetalingsoppdrag, som er avsluttet`() {
             opprettBehandling(fagsak, AVSLUTTET, LocalDateTime.now().minusDays(3))
                 .medTilkjentYtelse(true)
-            opprettBehandling(fagsak, AVSLUTTET, LocalDateTime.now().minusDays(2))
+            val behandling2 = opprettBehandling(fagsak, AVSLUTTET, LocalDateTime.now().minusDays(2))
                 .medTilkjentYtelse(true)
-            val behandling3 = opprettBehandling(fagsak, IVERKSETTER_VEDTAK, LocalDateTime.now().minusDays(1))
+            opprettBehandling(fagsak, IVERKSETTER_VEDTAK, LocalDateTime.now().minusDays(1))
                 .medTilkjentYtelse(true)
 
             val behandling4 = opprettBehandling(fagsak2, AVSLUTTET, LocalDateTime.now())
                 .medTilkjentYtelse(true)
 
-            assertThat(behandlingRepository.finnSisteIverksatteBehandling(fagsak.id)!!).isEqualTo(behandling3)
+            assertThat(behandlingRepository.finnSisteIverksatteBehandling(fagsak.id)!!).isEqualTo(behandling2)
             assertThat(behandlingRepository.finnSisteIverksatteBehandling(fagsak2.id)!!).isEqualTo(behandling4)
         }
 


### PR DESCRIPTION
…ger og filtrere

Sql-metoden,`finnSisteIverksatteBehandling` er i bruk fra satsendring, så burde ju gå fint å bruke den ellers pg

Forskjell er at sql ikke ser på avsluttet behandling

### 💰 Hva skal gjøres, og hvorfor?

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Forskjellen er at sql ikke ser på avsluttet behandling, men har det egentligen noe å si? 
Det eneste som då er forskjell er at den kanskje ikke har gått igjennom siste stegene. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
