### PR TITLE
Oppdatert kontrakter - Ident returneres i tilgangskontrollen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20221118130052_e2abd9f</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20230509152247_36d24db</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20230605154245_3d182db</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20220216121145_5a268ac</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20230223155122_2e81c44</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.skatteetaten>2.0_20210920094114_9c74239</familie.kontrakter.skatteetaten>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/FamilieIntegrasjonerTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/FamilieIntegrasjonerTilgangskontrollClient.kt
@@ -29,7 +29,7 @@ class FamilieIntegrasjonerTilgangskontrollClient(
 
     fun sjekkTilgangTilPersoner(personIdenter: List<String>): Tilgang {
         if (SikkerhetContext.erSystemKontekst()) {
-            return Tilgang(true, null)
+            return Tilgang(personIdent = personIdenter.first(), true, null)
         }
 
         val tilganger = kallEksternTjeneste<List<Tilgang>>(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
@@ -188,9 +188,9 @@ class IntegrasjonClientMock {
                 mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(capture(idSlot))
             } answers {
                 if (idSlot.captured.isNotEmpty() && idSlot.captured.contains(BARN_DET_IKKE_GIS_TILGANG_TIL_FNR)) {
-                    Tilgang(false, null)
+                    Tilgang(idSlot.captured.first(), false, null)
                 } else {
-                    Tilgang(true, null)
+                    Tilgang(idSlot.captured.first(), true, null)
                 }
             }
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdControllerTest.kt
@@ -49,7 +49,7 @@ class InfotrygdControllerTest {
         val fnr = "12345678910"
 
         every { personidentService.hentAktør(fnr) } returns tilAktør(fnr)
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(true)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(fnr, true)
         every {
             infotrygdBarnetrygdClient.hentSaker(
                 any(),
@@ -68,7 +68,7 @@ class InfotrygdControllerTest {
         val fnr = "12345678910"
 
         every { personidentService.hentAktør(fnr) } returns tilAktør(fnr)
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(false)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(fnr, false)
         every { personopplysningerService.hentAdressebeskyttelseSomSystembruker(any()) } returns ADRESSEBESKYTTELSEGRADERING.FORTROLIG
 
         val respons = infotrygdController.hentInfotrygdsakerForSøker(Personident(fnr))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
@@ -79,7 +79,8 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal kaste RolleTilgangskontrollFeil dersom saksbehandler ikke har tilgang til person eller dets barn`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(false)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), false)
 
         assertThrows<RolleTilgangskontrollFeil> {
             tilgangService.validerTilgangTilPersoner(
@@ -91,14 +92,16 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal ikke feile når saksbehandler har tilgang til person og dets barn`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(true)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), true)
 
         tilgangService.validerTilgangTilPersoner(listOf(aktør.aktivFødselsnummer()), AuditLoggerEvent.ACCESS)
     }
 
     @Test
     internal fun `skal kaste RolleTilgangskontrollFeil dersom saksbehandler ikke har tilgang til behandling`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(false)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), false)
 
         assertThrows<RolleTilgangskontrollFeil> {
             tilgangService.validerTilgangTilBehandling(
@@ -110,14 +113,16 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal ikke feile når saksbehandler har tilgang til behandling`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(true)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), true)
 
         tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS)
     }
 
     @Test
     internal fun `validerTilgangTilPersoner - hvis samme saksbehandler kaller skal den ha cachet`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(true)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), true)
 
         mockBrukerContext("A")
         tilgangService.validerTilgangTilPersoner(listOf(olaIdent), AuditLoggerEvent.ACCESS)
@@ -129,7 +134,8 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilPersoner - hvis to ulike saksbehandler kaller skal den sjekke tilgang på nytt`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(true)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), true)
 
         mockBrukerContext("A")
         tilgangService.validerTilgangTilPersoner(listOf(olaIdent), AuditLoggerEvent.ACCESS)
@@ -143,7 +149,8 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilBehandling - hvis samme saksbehandler kaller skal den ha cachet`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(true)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), true)
 
         mockBrukerContext("A")
 
@@ -157,7 +164,8 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilBehandling - hvis to ulike saksbehandler kaller skal den sjekke tilgang på nytt`() {
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns Tilgang(true)
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any()) } returns
+            Tilgang(aktør.aktivFødselsnummer(), true)
 
         mockBrukerContext("A")
         tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS)
@@ -182,7 +190,7 @@ class TilgangServiceTest {
                 ),
             ),
         )
-        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf("65434563721", "12345678910")) }.returns(Tilgang(false, null))
+        every { mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf("65434563721", "12345678910")) }.returns(Tilgang("", false, null))
         mockBrukerContext("A")
         assertThrows<RolleTilgangskontrollFeil> { tilgangService.validerTilgangTilFagsak(fagsak.id, AuditLoggerEvent.ACCESS) }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/util/BrukerContextUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/util/BrukerContextUtil.kt
@@ -40,4 +40,13 @@ object BrukerContextUtil {
         every { jwtTokenClaims.get("oid") } returns UUID.randomUUID().toString()
         every { jwtTokenClaims.get("sub") } returns UUID.randomUUID().toString()
     }
+
+    fun <T> testWithBrukerContext(preferredUsername: String = "A", groups: List<String> = emptyList(), fn: () -> T): T {
+        try {
+            mockBrukerContext(preferredUsername, groups)
+            return fn()
+        } finally {
+            clearBrukerContext()
+        }
+    }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerServiceTest.kt
@@ -56,10 +56,10 @@ internal class PersonopplysningerServiceTest(
     fun `hentPersoninfoMedRelasjonerOgRegisterinformasjon() skal return riktig personinfo`() {
         every {
             mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf(ID_BARN_1))
-        } returns Tilgang(true, null)
+        } returns Tilgang(ID_BARN_1, true)
         every {
             mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf(ID_BARN_2))
-        } returns Tilgang(false, null)
+        } returns Tilgang(ID_BARN_2, false)
 
         val personInfo = personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(ID_MOR))
 
@@ -75,10 +75,10 @@ internal class PersonopplysningerServiceTest(
     fun `hentPersoninfoMedRelasjonerOgRegisterinformasjon() skal returnere riktig personinfo for død person`() {
         every {
             mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf(ID_BARN_1))
-        } returns Tilgang(true, null)
+        } returns Tilgang(ID_BARN_1, true)
         every {
             mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf(ID_BARN_2))
-        } returns Tilgang(false, null)
+        } returns Tilgang(ID_BARN_2, false)
 
         val personInfo = personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(
             tilAktør(
@@ -95,7 +95,7 @@ internal class PersonopplysningerServiceTest(
     fun `hentPersoninfoMedRelasjonerOgRegisterinformasjon() skal filtrere bort relasjoner med opphørte folkreregisteridenter eller uten fødselsdato`() {
         every {
             mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(any())
-        } returns Tilgang(true, null)
+        } returns Tilgang(ID_MOR_3BARN_1OPPHØRT_1UTENFØDSELSDATO, true)
 
         val personInfo = personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(
             tilAktør(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangControllerTest.kt
@@ -30,7 +30,7 @@ class TilgangControllerTest(
         } returns ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
         every {
             mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf(fnr))
-        } returns Tilgang(harTilgang = true)
+        } returns Tilgang(fnr, harTilgang = true)
 
         val response = tilgangController.hentTilgangOgDiskresjonskode(TilgangRequestDTO(fnr))
         val tilgangDTO = response.body?.data ?: error("Fikk ikke forventet respons")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Då den andre PR'en sikkert kommer bli liggendes litt før den blir godkjent tenker jeg det kan være fint å bare få oppdatert kontrakter for å unngå krøll for andre når de ønsker å oppdatere kontrakter

Annen PR som tar i bruk identen
* https://github.com/navikt/familie-ba-sak/pull/3683

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
