### PR TITLE
Fix: Får ikke henlagt behandling som har kommet til FERDIGSTILLE_BEHANDLING steg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -193,6 +193,8 @@ data class Behandling(
     }
 
     fun leggTilHenleggStegOmDetIkkeFinnesFraFør(): Behandling {
+        behandlingStegTilstand.filter { it.behandlingSteg == StegType.FERDIGSTILLE_BEHANDLING }
+            .forEach { behandlingStegTilstand.remove(it) }
         leggTilStegOmDetIkkeFinnesFraFør(StegType.HENLEGG_BEHANDLING)
         return this
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
@@ -361,8 +361,10 @@ class StegServiceIntegrationTest(
         }
     }
 
+    // I de fleste tilfeller vil det ikke være mulig å henlegge en behandling som har kommet forbi iverksett steget.
+    // Disse vil bli stoppet i BehandlingStegController.
     @Test
-    fun `Henlegge etter behandling er kommet til iverksett eller senere`() {
+    fun `Henlegge dersom behandling står på FERDIGSTILLE_BEHANDLING steget`() {
         val søkerFnr = randomFnr()
 
         mockHentPersoninfoForMedIdenter(mockPersonopplysningerService, søkerFnr, "98765432110")
@@ -386,6 +388,7 @@ class StegServiceIntegrationTest(
 
         assertThat(behandlingEtterHenleggelse.steg).isEqualTo(StegType.BEHANDLING_AVSLUTTET)
         assertThat(behandlingEtterHenleggelse.status).isEqualTo(BehandlingStatus.AVSLUTTET)
+        assertThat(behandlingEtterHenleggelse.behandlingStegTilstand.any { it.behandlingSteg == StegType.FERDIGSTILLE_BEHANDLING && it.behandlingStegStatus == BehandlingStegStatus.UTFØRT })
     }
 
     @Test


### PR DESCRIPTION
Favro: [NAV-12827](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12827)

### 💰 Hva skal gjøres, og hvorfor?
Man får ikke henlagt en behandling som har kommet til `FERDIGSTILLE_BEHANDLING`-steget. Dette skyldes at `HENLEGG_BEHANDLING`-steget også kjører `FERDIGSTILLE_BEHANDLING`-steget og vi får kluss med rekkefølgen på stegene i `behandlingStegTilstand`. 

Før henleggelse ligger steget `FERDIGSTILLE_BEHANDLING` allerede i `behandlingStegTilstand` som `IKKE_UTFØRT`. Når vi så kjører henleggelse legger vi til steget `HENLEGG_BEHANDLING` i `behandlingStegTilstand`, og når vi deretter forsøker å kjøre `FERDIGSTILLE_BEHANDLING` legges ikke steget til i `behandlingStegTilstand` fordi det finnes fra før. For å finne ut nåværende steg brukes siste steg i `behandlingStegTilstand`, så når vi forsøker å kjøre `FERDIGSTILLE_BEHANDLING` mener steg-motoren at steget vi står på er `HENLEGG_BEHANDLING` og ikke `FERDIGSTILLE_BEHANDLING` som den forventet og kaster en feil.

For å fikse dette ☝️ sørger jeg for å fjerne `FERDIGSTILLE_BEHANDLING` fra `behandlingStegTilstand` ved henleggelse, slik at det havner til slutt i lista igjen når steget skal kjøres.

### ✅ Checklist
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
