### PR TITLE
Filtrerer vekk barn hvor id ikke lenger eksisterer ved revurdering, slik at man kan teknisk revurdere.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.EksternTjenesteFeilException
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.PdlNotFoundException
+import no.nav.familie.ba.sak.common.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ba.sak.common.RessursUtils.forbidden
 import no.nav.familie.ba.sak.common.RessursUtils.frontendFeil
 import no.nav.familie.ba.sak.common.RessursUtils.funksjonellFeil
@@ -67,6 +68,13 @@ class ApiExceptionHandler {
     @ExceptionHandler(IntegrasjonException::class)
     fun handleIntegrasjonException(integrasjonException: IntegrasjonException): ResponseEntity<Ressurs<Nothing>> {
         return illegalState(integrasjonException.message.toString(), integrasjonException)
+    }
+
+    @ExceptionHandler(PdlPersonKanIkkeBehandlesIFagsystem::class)
+    fun handlePdlPersonKanIkkeBehandlesIFagsystem(feil: PdlPersonKanIkkeBehandlesIFagsystem): ResponseEntity<Ressurs<Nothing>> {
+        logger.warn("Person kan ikke behandles i fagsystem ${feil.årsak}")
+        secureLogger.warn("Person kan ikke behandles i fagsystem", feil)
+        return funksjonellFeil(feil)
     }
 
     @ExceptionHandler(PdlNotFoundException::class)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -42,6 +42,7 @@ internal class StegServiceTest {
         infotrygdFeedService = mockk(),
         satsendringService = satsendringService,
         simuleringService = simuleringService,
+        personopplysningerService = mockk(),
     )
 
     @BeforeEach


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Filtrerer vekk barn hvor id ikke lenger eksisterer ved revurdering, slik at man kan teknisk revurdere.

NAV-12734
Behandling har en ident som ikke lenger eksisterer. Ved revurdering kastets det PdlPersonKanIkkeBehandlesIFagsystem fordi foedsels objekt ikke eksisterer lenger på fnr, siden forrige behandling har dette fødselsnummeret

Dette vil kun funke for teknisk revurdering av en behandling slik at man kan få løst den saken i kortet, mens det er lagd en generell kort for å løse det generelle problemet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
