### PR TITLE
legg til valgbarhet i RestSanityBegrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityQueries.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityQueries.kt
@@ -1,23 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.sanity
 
 const val hentBegrunnelser =
-    "*[_type == \"begrunnelse\" && tema != \"EØS\" && apiNavn != null && navnISystem != null]{" +
-        "apiNavn," +
-        "navnISystem," +
-        "hjemler," +
-        "hjemlerFolketrygdloven," +
-        "vilkaar," +
-        "rolle," +
-        "lovligOppholdTriggere," +
-        "bosattIRiketTriggere," +
-        "giftPartnerskapTriggere," +
-        "borMedSokerTriggere," +
-        "ovrigeTriggere," +
-        "endretUtbetalingsperiodeTriggere," +
-        "endretUtbetalingsperiodeDeltBostedUtbetalingTrigger," +
-        "endringsaarsaker," +
-        "utvidetBarnetrygdTriggere" +
-        "}"
+    "*[_type == \"begrunnelse\" && tema != \"EØS\" && apiNavn != null && navnISystem != null]"
 
 const val hentEØSBegrunnelser =
     "*[_type == \"begrunnelse\" && tema == \"EØS\" && apiNavn != null && navnISystem != null]"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -23,7 +23,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Begrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.EØSBegrunnelseData
@@ -324,8 +324,7 @@ class BrevPeriodeGenerator(
         begrunnelser: List<IVedtakBegrunnelse>,
     ): String? {
         val erAutobrev = begrunnelser.any {
-            it == Standardbegrunnelse.REDUKSJON_UNDER_6_ÅR_AUTOVEDTAK ||
-                it == Standardbegrunnelse.REDUKSJON_UNDER_18_ÅR_AUTOVEDTAK
+            this.minimertVedtaksperiode.begrunnelser.any { it.triggesAv.valgbarhet == Valgbarhet.AUTOMATISK }
         }
         return if (erAutobrev && fom != null) {
             val fra = if (målform == Målform.NB) "Fra" else "Frå"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårRolle.SOKER
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -37,6 +38,7 @@ data class SanityBegrunnelse(
     val endretUtbetalingsperiodeDeltBostedUtbetalingTrigger: EndretUtbetalingsperiodeDeltBostedTriggere? = null,
     val endretUtbetalingsperiodeTriggere: List<EndretUtbetalingsperiodeTrigger>? = null,
     val utvidetBarnetrygdTriggere: List<UtvidetBarnetrygdTrigger>? = null,
+    val valgbarhet: Valgbarhet? = null,
 ) : ISanityBegrunnelse {
 
     val triggesAv: TriggesAv by lazy { this.tilTriggesAv() }
@@ -58,6 +60,7 @@ data class RestSanityBegrunnelse(
     val endretUtbetalingsperiodeDeltBostedUtbetalingTrigger: String?,
     val endretUtbetalingsperiodeTriggere: List<String>? = emptyList(),
     val utvidetBarnetrygdTriggere: List<String>? = emptyList(),
+    val valgbarhet: String? = null,
 ) {
     fun tilSanityBegrunnelse(): SanityBegrunnelse? {
         if (apiNavn == null) return null
@@ -107,6 +110,7 @@ data class RestSanityBegrunnelse(
             utvidetBarnetrygdTriggere = utvidetBarnetrygdTriggere?.mapNotNull {
                 finnEnumverdi(it, UtvidetBarnetrygdTrigger.values(), apiNavn)
             },
+            valgbarhet = valgbarhet?.let { finnEnumverdi(valgbarhet, Valgbarhet.values(), apiNavn) },
         )
     }
 }
@@ -213,6 +217,7 @@ private fun SanityBegrunnelse.tilTriggesAv(): TriggesAv {
         deltbosted = this.inneholderBorMedSøkerTrigger(VilkårTrigger.DELT_BOSTED),
         deltBostedSkalIkkeDeles = this.inneholderBorMedSøkerTrigger(VilkårTrigger.DELT_BOSTED_SKAL_IKKE_DELES),
         valgbar = !this.inneholderØvrigTrigger(ØvrigTrigger.ALLTID_AUTOMATISK),
+        valgbarhet = this.valgbarhet,
         etterEndretUtbetaling = this.endretUtbetalingsperiodeTriggere
             ?.contains(EndretUtbetalingsperiodeTrigger.ETTER_ENDRET_UTBETALINGSPERIODE) ?: false,
         endretUtbetalingSkalUtbetales = this.endretUtbetalingsperiodeDeltBostedUtbetalingTrigger

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/TriggesAv.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/TriggesAv.kt
@@ -22,6 +22,7 @@ data class TriggesAv(
     val deltbosted: Boolean,
     val deltBostedSkalIkkeDeles: Boolean,
     val valgbar: Boolean,
+    val valgbarhet: Valgbarhet?,
     val endringsaarsaker: Set<Årsak>,
     val etterEndretUtbetaling: Boolean,
     val endretUtbetalingSkalUtbetales: EndretUtbetalingsperiodeDeltBostedTriggere,
@@ -144,4 +145,11 @@ private fun endretUtbetalingBegrunnelseOppfyllerUtvidetScenario(
     }?.erPåvirketAvEndring == true
 
     return begrunnelseGjelderUtvidet == periodeInneholderUtvidetMedEndring
+}
+
+enum class Valgbarhet {
+    STANDARD,
+    AUTOMATISK,
+    TILLEGSTEKST,
+    SAKSPESIFIKK,
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -77,6 +77,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksbegrunnelseFritekst
@@ -1208,6 +1209,7 @@ fun lagSanityBegrunnelse(
     hjemlerFolketrygdloven: List<String> = emptyList(),
     endretUtbetalingsperiodeDeltBostedTriggere: EndretUtbetalingsperiodeDeltBostedTriggere? = null,
     endretUtbetalingsperiodeTriggere: List<EndretUtbetalingsperiodeTrigger>? = null,
+    valgbarhet: Valgbarhet? = null,
 ): SanityBegrunnelse = SanityBegrunnelse(
     apiNavn = apiNavn,
     navnISystem = navnISystem,
@@ -1223,6 +1225,7 @@ fun lagSanityBegrunnelse(
     hjemlerFolketrygdloven = hjemlerFolketrygdloven,
     endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = endretUtbetalingsperiodeDeltBostedTriggere,
     endretUtbetalingsperiodeTriggere = endretUtbetalingsperiodeTriggere,
+    valgbarhet = valgbarhet,
 )
 
 fun lagSanityEøsBegrunnelse(
@@ -1261,6 +1264,7 @@ fun lagTriggesAv(
     medlemskap: Boolean = false,
     deltbosted: Boolean = false,
     valgbar: Boolean = true,
+    valgbarhet: Valgbarhet? = null,
     endringsaarsaker: Set<Årsak> = emptySet(),
     etterEndretUtbetaling: Boolean = false,
     endretUtbetalingSkalUtbetales: EndretUtbetalingsperiodeDeltBostedTriggere = EndretUtbetalingsperiodeDeltBostedTriggere.UTBETALING_IKKE_RELEVANT,
@@ -1283,6 +1287,7 @@ fun lagTriggesAv(
     deltBostedSkalIkkeDeles = false,
     gjelderFraInnvilgelsestidspunkt = false,
     gjelderFørstePeriode = false,
+    valgbarhet = valgbarhet,
 )
 
 fun oppfyltVilkår(vilkår: Vilkår, regelverk: Regelverk? = null) =


### PR DESCRIPTION
endre query til å returnere alle verdier og bruk valgbarhet for å styre fomTekst i autoBrev

### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12362
bruker feil tittel-tekst ved autobrev til tider. Ønsker å hele bruke valgbarhet-feltet i sanity enn å gå utifra at det er autobrec dersom vi har reduksjon_18_år eller reduksjon_6_år. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Blir det riktig å gå utifra at man kan bruke valgbarhet og kunne man bare fjernet `?: "Du får:"`

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
