### PR TITLE
Fix: Skal kun vurdere vilkår som er oppfylt i forrige behandling ved kopiering til ny

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
@@ -259,8 +259,11 @@ data class VilkårsvurderingForNyBehandlingUtils(
                 vilkårResultater,
                 forrigeBehandlingVilkårsvurdering,
                 person,
+                personResultat,
             )
-            vilkårResultater.addAll(manglendePerioder.map { it.kopierMedParent(personResultat) }.toSet())
+
+            vilkårResultater.addAll(manglendePerioder)
+
             personResultat.setSortedVilkårResultater(vilkårResultater)
 
             personResultat

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingMigreringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingMigreringUtils.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
@@ -15,13 +16,11 @@ object VilkårsvurderingMigreringUtils {
         person: Person,
         nyMigreringsdato: LocalDate,
     ): LocalDate {
-        val forrigeVilkårResultat = hentForrigeVilkårsvurderingVilkårResultater(
+        val forrigeVilkårsPeriodeFom = hentForrigeVilkårsvurderingVilkårResultaterSomErOppfylt(
             forrigeBehandlingsvilkårsvurdering,
             vilkår,
             person,
-        ).filter { it.periodeFom != null }
-        val forrigeVilkårsPeriodeFom =
-            if (forrigeVilkårResultat.isNotEmpty()) forrigeVilkårResultat.minOf { it.periodeFom!! } else null
+        ).minWithOrNull(VilkårResultat.VilkårResultatComparator)?.periodeFom
         return when {
             person.fødselsdato.isAfter(nyMigreringsdato) ||
                 vilkår.gjelderAlltidFraBarnetsFødselsdato() -> person.fødselsdato
@@ -39,7 +38,7 @@ object VilkårsvurderingMigreringUtils {
         person: Person,
         periodeFom: LocalDate,
     ): LocalDate? {
-        val forrigeVilkårsPeriodeTom: LocalDate? = hentForrigeVilkårsvurderingVilkårResultater(
+        val forrigeVilkårsPeriodeTom: LocalDate? = hentForrigeVilkårsvurderingVilkårResultaterSomErOppfylt(
             forrigeBehandlingsvilkårsvurdering,
             vilkår,
             person,
@@ -56,22 +55,27 @@ object VilkårsvurderingMigreringUtils {
         vilkårResulater: Set<VilkårResultat>,
         forrigeBehandlingsvilkårsvurdering: Vilkårsvurdering,
         person: Person,
+        personResultat: PersonResultat,
     ): List<VilkårResultat> {
         val manglendeVilkårResultater = mutableListOf<VilkårResultat>()
         vilkårResulater.forEach {
             val forrigeVilkårResultater =
-                hentForrigeVilkårsvurderingVilkårResultater(forrigeBehandlingsvilkårsvurdering, it.vilkårType, person)
+                hentForrigeVilkårsvurderingVilkårResultaterSomErOppfylt(
+                    forrigeBehandlingsvilkårsvurdering,
+                    it.vilkårType,
+                    person,
+                )
             manglendeVilkårResultater.addAll(
                 forrigeVilkårResultater.filter { forrigeVilkårResultat ->
                     forrigeVilkårResultat.periodeFom != it.periodeFom &&
                         forrigeVilkårResultat.periodeTom != it.periodeTom
-                },
+                }.map { vilkårResultat -> vilkårResultat.kopierMedParent(personResultat) }.toSet(),
             )
         }
         return manglendeVilkårResultater
     }
 
-    private fun hentForrigeVilkårsvurderingVilkårResultater(
+    private fun hentForrigeVilkårsvurderingVilkårResultaterSomErOppfylt(
         forrigeBehandlingsvilkårsvurdering: Vilkårsvurdering,
         vilkår: Vilkår,
         person: Person,
@@ -79,6 +83,6 @@ object VilkårsvurderingMigreringUtils {
         val personResultat = forrigeBehandlingsvilkårsvurdering.personResultater
             .first { it.aktør == person.aktør }
         return personResultat.vilkårResultater
-            .filter { it.vilkårType == vilkår }
+            .filter { it.vilkårType == vilkår && it.erOppfylt() }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -350,6 +350,7 @@ fun lagTestPersonopplysningGrunnlag(
     søkerPersonIdent: String,
     barnasIdenter: List<String>,
     barnasFødselsdatoer: List<LocalDate> = barnasIdenter.map { LocalDate.of(2019, 1, 1) },
+    søkerFødselsdato: LocalDate = LocalDate.of(2019, 1, 1),
     søkerAktør: Aktør = tilAktør(søkerPersonIdent).also {
         it.personidenter.add(
             Personident(
@@ -384,7 +385,7 @@ fun lagTestPersonopplysningGrunnlag(
         aktør = søkerAktør,
         type = PersonType.SØKER,
         personopplysningGrunnlag = personopplysningGrunnlag,
-        fødselsdato = LocalDate.of(2019, 1, 1),
+        fødselsdato = søkerFødselsdato,
         navn = "",
         kjønn = Kjønn.KVINNE,
     ).also { søker ->
@@ -1042,7 +1043,7 @@ fun lagVilkårResultat(
     personResultat: PersonResultat? = null,
     vilkårType: Vilkår = Vilkår.BOSATT_I_RIKET,
     resultat: Resultat = Resultat.OPPFYLT,
-    periodeFom: LocalDate = LocalDate.of(2009, 12, 24),
+    periodeFom: LocalDate? = LocalDate.of(2009, 12, 24),
     periodeTom: LocalDate? = LocalDate.of(2010, 1, 31),
     begrunnelse: String = "",
     behandlingId: Long = lagBehandling().id,


### PR DESCRIPTION
Favro: [NAV-13252](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13252)

### 💰 Hva skal gjøres, og hvorfor?
Det har oppstått en del Tidslinje-feil for "Endre migreringsdato"-behandlinger i tilfeller hvor forrige behandling hadde noen vilkår som var `IKKE_OPPFYLT` med `fom` og `tom` satt til `null`. Dette skyldes logikken rundt kopiering av vilkår fra forrige behandling inn i ny, og gjelder spesifikt for "Endre migreringsdato"-behandlinger.

Feilen førte til at vi i noen tilfeller fikk 2 perioder for et vilkår [2021-01-01 -> null, 2022-01-01 -> 2023-01-01] hvor den første går til Uendelig, men allikevel har en etterfølgende periode, som igjen skapte kluss med Tidslinjer. 

Sørger nå for at vi kun ser på vilkår som står som `OPPFYLT` fra forrige behandling for all logikk tilknyttet kopiering av vilkår inn i ny behandling, slik at vi ikke tar med oss vilkår-perioder med `fom` og `tom` lik `null`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er nok kanskje ikke så lett å forstå nøyaktig hva som har skjedd feil og hvorfor det feiler ut ifra teksten over her og koden, så tar gjerne en prat om det hvis ønskelig.

### ✅ Checklist
- [x] Jeg har skrevet tester.


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
