### PR TITLE
Bruk ny vedtaksperiodeløsning for å utlede endringstidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -18,6 +18,7 @@ class FeatureToggleConfig {
         const val FEILUTBETALT_VALUTA_PR_MND = "familie-ba-sak.feilutbetalt-valuta-pr-mnd"
         const val SATSENDRING_KOPIER_GRUNNLAG_FRA_FORRIGE_BEHANDLING = "familie-ba-sak.satsendring.kopier-grunnlag-fra-forrige-behandling"
         const val BEGRUNNELSER_NY = "familie-ba-sak.begrunnelser-ny"
+        const val ENDRINGSTIDSPUNKT = "familie-ba-sak.endringstidspunkt"
 
         // unleash toggles for satsendring, kan slettes etter at satsendring er skrudd på for alle satstyper
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.VergeInfo
 import no.nav.familie.ba.sak.ekstern.restDomene.tilDto
@@ -73,6 +75,7 @@ class UtvidetBehandlingService(
     private val feilutbetaltValutaService: FeilutbetaltValutaService,
     private val brevmottakerService: BrevmottakerService,
     private val refusjonEøsService: RefusjonEøsService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     fun lagRestUtvidetBehandling(behandlingId: Long): RestUtvidetBehandling {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId)
@@ -95,7 +98,11 @@ class UtvidetBehandlingService(
 
         val tilbakekreving = tilbakekrevingRepository.findByBehandlingId(behandling.id)
 
-        val endringstidspunkt = endringstidspunktService.finnEndringstidspunktForBehandling(behandlingId)
+        val endringstidspunkt = if (featureToggleService.isEnabled(FeatureToggleConfig.ENDRINGSTIDSPUNKT)) {
+            vedtaksperiodeService.finnEndringstidspunktForBehandling(behandlingId = behandling.id)
+        } else {
+            endringstidspunktService.finnEndringstidspunktForBehandling(behandlingId = behandling.id)
+        }
 
         val kompetanser: Collection<Kompetanse> = kompetanseRepository.finnFraBehandlingId(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/endringstidspunkt/EndringstidspunktController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/endringstidspunkt/EndringstidspunktController.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.beregning.endringstidspunkt
 
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
@@ -14,13 +17,19 @@ import java.time.LocalDate
 @ProtectedWithClaims(issuer = "azuread")
 class EndringstidspunktController(
     val endringstidspunktService: EndringstidspunktService,
+    val featureToggleService: FeatureToggleService,
+    val vedtaksperiodeService: VedtaksperiodeService,
 ) {
     @GetMapping("/behandlinger/{behandlingId}/endringstidspunkt")
     fun hentEndringstidspunkt(
         @PathVariable behandlingId: Long,
     ): ResponseEntity<Ressurs<LocalDate>> = ResponseEntity.ok(
         Ressurs.success(
-            endringstidspunktService.finnEndringstidspunktForBehandling(behandlingId),
+            if (featureToggleService.isEnabled(FeatureToggleConfig.ENDRINGSTIDSPUNKT)) {
+                vedtaksperiodeService.finnEndringstidspunktForBehandling(behandlingId)
+            } else {
+                endringstidspunktService.finnEndringstidspunktForBehandling(behandlingId)
+            },
         ),
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -1,0 +1,52 @@
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPerson
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonIkkeInnvilget
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonInnvilget
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForVedtaksperioder
+import java.time.LocalDate
+
+fun utledEndringstidspunkt(
+    grunnlagForVedtaksperioder: GrunnlagForVedtaksperioder,
+    grunnlagForVedtaksperioderForrigeBehandling: GrunnlagForVedtaksperioder?,
+): LocalDate {
+    val grunnlagTidslinjePerPerson = grunnlagForVedtaksperioder.utledGrunnlagTidslinjePerPerson()
+    val grunnlagTidslinjePerPersonForrigeBehandling =
+        grunnlagForVedtaksperioderForrigeBehandling?.utledGrunnlagTidslinjePerPerson() ?: emptyMap()
+
+    val erPeriodeLikSammePeriodeIForrigeBehandlingTidslinjer =
+        grunnlagTidslinjePerPerson.outerJoin(grunnlagTidslinjePerPersonForrigeBehandling) { grunnlagForVedtaksperiode, grunnlagForVedtaksperiodeForrigeBehandling ->
+            grunnlagForVedtaksperiode.erLik(grunnlagForVedtaksperiodeForrigeBehandling)
+        }
+
+    return erPeriodeLikSammePeriodeIForrigeBehandlingTidslinjer.finnTidligsteForskjell() ?: TIDENES_ENDE
+}
+
+private fun Map<Aktør, Tidslinje<Boolean, Måned>>.finnTidligsteForskjell() = this
+    .minOfOrNull { (_, erPeriodeLikTidslinje) ->
+        erPeriodeLikTidslinje.perioder()
+            .filter { it.innhold == false }
+            .minOfOrNull { it.fraOgMed.tilYearMonth().førsteDagIInneværendeMåned() } ?: TIDENES_ENDE
+    }
+
+private fun GrunnlagForPerson?.erLik(
+    grunnlagForVedtaksperiodeForrigeBehandling: GrunnlagForPerson?,
+): Boolean = when (this) {
+    is GrunnlagForPersonInnvilget ->
+        grunnlagForVedtaksperiodeForrigeBehandling is GrunnlagForPersonInnvilget &&
+            this.vilkårResultaterForVedtaksperiode.toSet() == grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode.toSet() &&
+            this.kompetanse == grunnlagForVedtaksperiodeForrigeBehandling.kompetanse &&
+            this.endretUtbetalingAndel == grunnlagForVedtaksperiodeForrigeBehandling.endretUtbetalingAndel &&
+            this.overgangsstønad == grunnlagForVedtaksperiodeForrigeBehandling.overgangsstønad
+
+    is GrunnlagForPersonIkkeInnvilget ->
+        grunnlagForVedtaksperiodeForrigeBehandling is GrunnlagForPersonIkkeInnvilget &&
+            this.vilkårResultaterForVedtaksperiode.toSet() == grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode.toSet()
+
+    null -> true
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -611,12 +611,12 @@ class VedtaksperiodeService(
         val andelerTilkjentYtelse = andelerTilkjentYtelseOgEndreteUtbetalingerService
             .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
 
-        if (featureToggleService.isEnabled(BRUKE_TIDSLINJE_I_STEDET_FOR)) {
-            return andelerTilkjentYtelse.mapTilUtbetalingsperioder(
+        return if (featureToggleService.isEnabled(BRUKE_TIDSLINJE_I_STEDET_FOR)) {
+            andelerTilkjentYtelse.mapTilUtbetalingsperioder(
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
         } else {
-            return mapTilUtbetalingsperioderGammel(personopplysningGrunnlag, andelerTilkjentYtelse)
+            mapTilUtbetalingsperioderGammel(personopplysningGrunnlag, andelerTilkjentYtelse)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -94,6 +94,7 @@ class VedtaksperiodeServiceTest {
     fun init() {
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns forrigeBehandling
         every { endringstidspunktService.finnEndringstidspunktForBehandling(vedtak.behandling.id) } returns endringstidspunkt
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(vedtak.behandling.id) } returns endringstidspunkt
         every { persongrunnlagService.hentAktiv(any()) } returns
             lagTestPersonopplysningGrunnlag(vedtak.behandling.id, person)
         every {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -34,7 +34,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
     private var kompetanser = mutableMapOf<Long, List<Kompetanse>>()
     private var endredeUtbetalinger = mutableMapOf<Long, List<EndretUtbetalingAndel>>()
     private var andelerTilkjentYtelse = mutableMapOf<Long, List<AndelTilkjentYtelse>>()
-    private var endringstidspunkt = mapOf<Long, LocalDate?>()
+    private var overstyrtEndringstidspunkt = mapOf<Long, LocalDate?>()
 
     private var gjeldendeBehandlingId: Long? = null
 
@@ -87,9 +87,9 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
         }.toSet()
     }
 
-    @Og("med endringstidspunkt")
+    @Og("med overstyrt endringstidspunkt")
     fun settEndringstidspunkt(dataTable: DataTable) {
-        endringstidspunkt = dataTable.asMaps().associate { rad ->
+        overstyrtEndringstidspunkt = dataTable.asMaps().associate { rad ->
             parseLong(Domenebegrep.BEHANDLING_ID, rad) to
                 parseDato(DomenebegrepVedtaksperiodeMedBegrunnelser.ENDRINGSTIDSPUNKT, rad)
         }
@@ -117,15 +117,15 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
         gjeldendeBehandlingId = behandlingId
 
         vedtaksperioderMedBegrunnelser = lagVedtaksPerioder(
-            behandlingId,
-            vedtaksliste,
-            behandlingTilForrigeBehandling,
-            persongrunnlag,
-            personResultater,
-            kompetanser,
-            endredeUtbetalinger,
-            andelerTilkjentYtelse,
-            endringstidspunkt,
+            behandlingId = behandlingId,
+            vedtaksListe = vedtaksliste,
+            behandlingTilForrigeBehandling = behandlingTilForrigeBehandling,
+            personGrunnlag = persongrunnlag,
+            personResultater = personResultater,
+            kompetanser = kompetanser,
+            endredeUtbetalinger = endredeUtbetalinger,
+            andelerTilkjentYtelse = andelerTilkjentYtelse,
+            endringstidspunkt = overstyrtEndringstidspunkt,
         )
     }
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
@@ -8,11 +8,14 @@ Egenskap: Endringstidspunkt påvirker periodene
     Gitt følgende vedtak
       | BehandlingId |
       | 1            |
+      | 2            |
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1234    | SØKER      | 24.12.1987  |
-      | 1            | 3456    | BARN       | 01.02.2016  |
+      | 1            | 3456    | BARN       | 02.12.2016  |
+      | 2            | 1234    | SØKER      | 24.12.1987  |
+      | 2            | 3456    | BARN       | 02.12.2016  |
 
 
   Scenario: Skal kun ta med vedtaksperioder som kommer etter
@@ -25,7 +28,7 @@ Egenskap: Endringstidspunkt påvirker periodene
 
       | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 02.12.2016 |            | Oppfylt  |                      |
       | 3456    | BOR_MED_SØKER                                    | 02.12.2016 | 01.12.2020 | Oppfylt  |                      |
-      | 3456    | UNDER_18_ÅR                                      | 02.12.2016 | 30.11.2034 | Oppfylt  |                      |
+      | 3456    | UNDER_18_ÅR                                      | 02.12.2016 | 01.12.2034 | Oppfylt  |                      |
 
     Og legg til nye vilkårresultater for behandling 1
       | AktørId | Vilkår         | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
@@ -40,7 +43,7 @@ Egenskap: Endringstidspunkt påvirker periodene
       | 3456    | 01.12.2016 | 31.12.2020 | 1234  | 1            |
       | 3456    | 01.10.2021 | 30.11.2034 | 1234  | 1            |
 
-    Og med endringstidspunkt
+    Og med overstyrt endringstidspunkt
       | Endringstidspunkt | BehandlingId |
       | 01.11.2021        | 1            |
 
@@ -51,3 +54,51 @@ Egenskap: Endringstidspunkt påvirker periodene
       | 01.01.2021 | 31.10.2021 | Avslag             | Avslag skal alltid med, selv om de er før endringstidspunktet |
       | 01.11.2021 | 30.11.2034 | Utbetaling         | Etter endringstidspunktet                                     |
       | 01.12.2034 |            | Opphør             | Barn er over 18                                               |
+
+  Scenario: Skal ta med eøs-perioder som kommer før første periode
+    Og lag personresultater for behandling 1
+    Og med overstyring av vilkår for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 15.07.2021 |            | Oppfylt  |                      |
+
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 15.07.2021 |            | Oppfylt  |                      |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt  |                      |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.08.2021 | 30.11.2034 | 1234  | 1            |
+
+    Og med overstyrt endringstidspunkt
+      | Endringstidspunkt | BehandlingId |
+      | 01.11.2021        | 1            |
+
+
+    Og lag personresultater for behandling 2
+    Og med overstyring av vilkår for behandling 2
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 15.07.2021 |            | Oppfylt  |
+
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 15.07.2021 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt  |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår           | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET   | 15.06.2021 | 14.07.2021 | Oppfylt  |
+      | 1234    | LOVLIG_OPPHOLD   | 15.06.2021 | 14.07.2021 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP | 15.06.2021 | 14.07.2021 | Oppfylt  |
+      | 3456    | BOSATT_I_RIKET   | 15.06.2021 | 14.07.2021 | Oppfylt  |
+      | 3456    | LOVLIG_OPPHOLD   | 15.06.2021 | 14.07.2021 | Oppfylt  |
+      | 3456    | BOR_MED_SØKER    | 15.06.2021 | 14.07.2021 | Oppfylt  |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.07.2021 | 31.07.2021 | 0     | 2            |
+      | 3456    | 01.08.2021 | 30.11.2034 | 1234  | 2            |
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 2
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar        |
+      | 01.07.2021 | 31.07.2021 | Utbetaling         | Sekundærland EØS |
+      | 01.08.2021 | 30.11.2034 | Utbetaling         |                  |
+      | 01.12.2034 |            | Opphør             | Barn er over 18  |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Nå som vi har logikk til på å finne endringer i vedtaksperiodene periodene kan vi gjenbruke logikken når vi finner endringstidspunktet. 

Bruker `GrunnlagForVedtaksperioder` til å finne endringstidspunktet. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
