### PR TITLE
Opprett manuell oppgave for med en manuell oppgave type, som styrer om det skal sendes med behandlesAvApplikasjon.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -14,7 +14,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.prosessering.error.RekjørSenereException
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -172,13 +172,12 @@ class AutovedtakStegService(
             oppgaveService.opprettOppgaveForManuellBehandling(
                 behandling = åpenBehandling,
                 begrunnelse = "${autovedtaktype.displayName}: Bruker har åpen behandling",
-                oppgavetype = Oppgavetype.VurderLivshendelse,
+                manuellOppgaveType = ManuellOppgaveType.ÅPEN_BEHANDLING,
             )
-
             true
-        } else if (åpenBehandling.status == BehandlingStatus.IVERKSETTER_VEDTAK) {
+        } else if (åpenBehandling.status == BehandlingStatus.IVERKSETTER_VEDTAK || åpenBehandling.status == BehandlingStatus.SATT_PÅ_MASKINELL_VENT) {
             throw RekjørSenereException(
-                årsak = "Åpen behandling iverksettes, prøver igjen om 1 time",
+                årsak = "Åpen behandling med status ${åpenBehandling.status}, prøver igjen om 1 time",
                 triggerTid = LocalDateTime.now().plusHours(1),
             )
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -34,6 +34,7 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import org.slf4j.LoggerFactory
@@ -232,7 +233,7 @@ class AutovedtakFødselshendelseService(
         oppgaveService.opprettOppgaveForManuellBehandling(
             behandling = behandling,
             begrunnelse = "Fødselshendelse: $begrunnelseForManuellOppgave",
-            oppgavetype = Oppgavetype.VurderLivshendelse,
+            manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
         )
 
         return "Henlegger behandling $behandling automatisk på grunn av ugyldig resultat"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
@@ -26,7 +26,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPe
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -193,8 +193,8 @@ class AutovedtakSmåbarnstilleggService(
         return oppgaveService.opprettOppgaveForManuellBehandling(
             behandling = omgjortBehandling,
             begrunnelse = meldingIOppgave,
-            oppgavetype = Oppgavetype.VurderLivshendelse,
             opprettLogginnslag = true,
+            manuellOppgaveType = ManuellOppgaveType.SMÅBARNSTILLEGG,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTask.kt
@@ -28,6 +28,7 @@ class OpprettOppgaveTask(
             fristForFerdigstillelse = opprettOppgaveTaskDTO.fristForFerdigstillelse,
             tilordnetNavIdent = opprettOppgaveTaskDTO.tilordnetRessurs,
             beskrivelse = opprettOppgaveTaskDTO.beskrivelse,
+            manuellOppgaveType = opprettOppgaveTaskDTO.manuellOppgaveType,
         )
     }
 
@@ -51,6 +52,7 @@ class OpprettOppgaveTask(
                         fristForFerdigstillelse,
                         tilordnetRessurs,
                         beskrivelse,
+                        null,
                     ),
                 ),
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.task.dto.Autobrev6og18ÅrDTO
 import no.nav.familie.ba.sak.task.dto.AutobrevOpphørSmåbarnstilleggDTO
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
+import no.nav.familie.ba.sak.task.dto.OpprettOppgaveTaskDTO
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.log.IdUtils
@@ -36,6 +38,29 @@ class OpprettTaskService(
                 oppgavetype = oppgavetype,
                 fristForFerdigstillelse = fristForFerdigstillelse,
                 beskrivelse = beskrivelse,
+            ),
+        )
+    }
+
+    fun opprettOppgaveForManuellBehandlingTask(
+        behandlingId: Long,
+        beskrivelse: String? = null,
+        fristForFerdigstillelse: LocalDate = LocalDate.now(),
+        manuellOppgaveType: ManuellOppgaveType,
+    ) {
+        taskRepository.save(
+            Task(
+                type = OpprettOppgaveTask.TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(
+                    OpprettOppgaveTaskDTO(
+                        behandlingId,
+                        Oppgavetype.VurderLivshendelse,
+                        fristForFerdigstillelse,
+                        null,
+                        beskrivelse,
+                        manuellOppgaveType,
+                    ),
+                ),
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettOppgaveTaskDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettOppgaveTaskDTO.kt
@@ -9,4 +9,11 @@ data class OpprettOppgaveTaskDTO(
     val fristForFerdigstillelse: LocalDate,
     val tilordnetRessurs: String? = null,
     val beskrivelse: String?,
+    val manuellOppgaveType: ManuellOppgaveType? = null,
 )
+
+enum class ManuellOppgaveType(val settBehandlesAvApplikasjon: Boolean) {
+    SMÅBARNSTILLEGG(true),
+    FØDSELSHENDELSE(false),
+    ÅPEN_BEHANDLING(true),
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.FØRSTE_STEG
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
@@ -45,6 +46,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
@@ -125,6 +128,63 @@ class OppgaveServiceTest {
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.BAR)
         assertThat(slot.captured.beskrivelse).contains("https://barnetrygd.intern.nav.no/fagsak/$FAGSAK_ID")
+        assertThat(slot.captured.behandlesAvApplikasjon).isEqualTo("familie-ba-sak")
+    }
+
+    @ParameterizedTest
+    @EnumSource(ManuellOppgaveType::class)
+    fun `Opprett oppgave med manuell oppgavetype skal lage oppgave med behandlesAvApplikasjon ikke satt`(manuellOppgaveType: ManuellOppgaveType) {
+        every { behandlingHentOgPersisterService.hent(BEHANDLING_ID) } returns lagTestBehandling(aktørId = AKTØR_ID_FAGSAK)
+        every { behandlingHentOgPersisterService.lagreEllerOppdater(any()) } returns lagTestBehandling()
+        every { oppgaveRepository.save(any()) } returns lagTestOppgave()
+        every {
+            oppgaveRepository.findByOppgavetypeAndBehandlingAndIkkeFerdigstilt(
+                any(),
+                any(),
+            )
+        } returns null
+        every { personidentService.hentAktør(any()) } returns Aktør(AKTØR_ID_FAGSAK)
+
+        every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
+            behandlingId = 1,
+            behandlendeEnhetId = ENHETSNUMMER,
+            behandlendeEnhetNavn = "enhet",
+        )
+
+        every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
+            behandlingId = 1,
+            behandlendeEnhetId = ENHETSNUMMER,
+            behandlendeEnhetNavn = "enhet",
+        )
+
+        val slot = slot<OpprettOppgaveRequest>()
+        every { integrasjonClient.opprettOppgave(capture(slot)) } returns OppgaveResponse(OPPGAVE_ID.toLong())
+
+        oppgaveService.opprettOppgave(
+            behandlingId = BEHANDLING_ID,
+            oppgavetype = Oppgavetype.VurderLivshendelse,
+            fristForFerdigstillelse = FRIST_FERDIGSTILLELSE_BEH_SAK,
+            manuellOppgaveType = manuellOppgaveType,
+        )
+
+        assertThat(slot.captured.enhetsnummer).isEqualTo(ENHETSNUMMER)
+        assertThat(slot.captured.saksId).isEqualTo(FAGSAK_ID.toString())
+        assertThat(slot.captured.ident).isEqualTo(
+            OppgaveIdentV2(
+                ident = AKTØR_ID_FAGSAK,
+                gruppe = IdentGruppe.AKTOERID,
+            ),
+        )
+        assertThat(slot.captured.behandlingstema).isEqualTo(Behandlingstema.OrdinærBarnetrygd.value)
+        assertThat(slot.captured.fristFerdigstillelse).isEqualTo(LocalDate.now().plusDays(1))
+        assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
+        assertThat(slot.captured.tema).isEqualTo(Tema.BAR)
+        assertThat(slot.captured.beskrivelse).contains("https://barnetrygd.intern.nav.no/fagsak/$FAGSAK_ID")
+
+        when (manuellOppgaveType) {
+            ManuellOppgaveType.SMÅBARNSTILLEGG, ManuellOppgaveType.ÅPEN_BEHANDLING -> assertThat(slot.captured.behandlesAvApplikasjon).isEqualTo("familie-ba-sak")
+            ManuellOppgaveType.FØDSELSHENDELSE -> assertThat(slot.captured.behandlesAvApplikasjon).isNull()
+        }
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -133,7 +133,7 @@ class OppgaveServiceTest {
 
     @ParameterizedTest
     @EnumSource(ManuellOppgaveType::class)
-    fun `Opprett oppgave med manuell oppgavetype skal lage oppgave med behandlesAvApplikasjon ikke satt`(manuellOppgaveType: ManuellOppgaveType) {
+    fun `Opprett oppgave med manuell oppgavetype skal lage oppgave med behandlesAvApplikasjon satt for småbarnstillegg og åpen behandling, men ikke fødselshendelse`(manuellOppgaveType: ManuellOppgaveType) {
         every { behandlingHentOgPersisterService.hent(BEHANDLING_ID) } returns lagTestBehandling(aktørId = AKTØR_ID_FAGSAK)
         every { behandlingHentOgPersisterService.lagreEllerOppdater(any()) } returns lagTestBehandling()
         every { oppgaveRepository.save(any()) } returns lagTestOppgave()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
@@ -45,14 +45,14 @@ class AutobrevStegServiceTest {
         every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
         every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
-        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) } returns ""
+        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
 
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
             behandlingsdata = aktør,
         )
 
-        verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) }
+        verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
     }
 
     @Test
@@ -66,14 +66,14 @@ class AutobrevStegServiceTest {
         every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
         every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
-        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) } returns ""
+        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
 
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
             behandlingsdata = aktør,
         )
 
-        verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) }
+        verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
     }
 
     @Test
@@ -87,7 +87,7 @@ class AutobrevStegServiceTest {
         every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
         every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
-        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any()) } returns ""
+        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
 
         assertThrows<RekjørSenereException> {
             autovedtakStegService.kjørBehandlingSmåbarnstillegg(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -53,6 +53,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.ba.sak.util.sisteSmåbarnstilleggSatsTilTester
 import no.nav.familie.ba.sak.util.sisteUtvidetSatsTilTester
 import no.nav.familie.ba.sak.util.tilleggOrdinærSatsTilTester
@@ -60,7 +61,6 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.Datakilde
 import no.nav.familie.kontrakter.felles.ef.EksternPeriode
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderResponse
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -359,10 +359,10 @@ class BehandleSmåbarnstilleggTest(
         )
 
         verify(exactly = 1) {
-            opprettTaskService.opprettOppgaveTask(
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = aktivBehandling.id,
-                oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Småbarnstillegg: endring i overgangsstønad må behandles manuelt",
+                manuellOppgaveType = ManuellOppgaveType.SMÅBARNSTILLEGG,
             )
         }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -32,12 +32,13 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
+import no.nav.familie.ba.sak.task.OpprettOppgaveTask
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.ba.sak.util.sisteTilleggOrdinærSats
 import no.nav.familie.ba.sak.util.sisteUtvidetSatsTilTester
 import no.nav.familie.ba.sak.util.tilleggOrdinærSatsNesteMånedTilTester
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
@@ -63,6 +64,7 @@ class FødselshendelseHenleggelseTest(
     @Autowired private val vedtaksperiodeService: VedtaksperiodeService,
     @Autowired private val utvidetBehandlingService: UtvidetBehandlingService,
     @Autowired private val brevmalService: BrevmalService,
+    @Autowired private val opprettOppgaveForManuellBehandlingTask: OpprettOppgaveTask,
 ) : AbstractVerdikjedetest() {
 
     @BeforeEach
@@ -165,10 +167,10 @@ class FødselshendelseHenleggelseTest(
         assertEquals(StegType.BEHANDLING_AVSLUTTET, behandling?.steg)
 
         verify(exactly = 1) {
-            opprettTaskService.opprettOppgaveTask(
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = behandling!!.id,
-                oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Fødselshendelse: Mor er under 18 år.",
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
             )
         }
 
@@ -252,10 +254,10 @@ class FødselshendelseHenleggelseTest(
         assertEquals(StegType.BEHANDLING_AVSLUTTET, behandling?.steg)
 
         verify(exactly = 1) {
-            opprettTaskService.opprettOppgaveTask(
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = behandling!!.id,
-                oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Fødselshendelse: Mor har flere bostedsadresser uten fra- og med dato",
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
             )
         }
     }
@@ -296,13 +298,13 @@ class FødselshendelseHenleggelseTest(
         assertEquals(StegType.BEHANDLING_AVSLUTTET, behandling?.steg)
 
         verify(exactly = 1) {
-            opprettTaskService.opprettOppgaveTask(
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = behandling!!.id,
-                oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Fødselshendelse: Barnet (fødselsdato: ${
                     LocalDate.parse(scenario.barna.first().fødselsdato)
                         .tilKortString()
                 }) er ikke bosatt med mor.",
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
             )
         }
 
@@ -386,10 +388,10 @@ class FødselshendelseHenleggelseTest(
         assertEquals(StegType.BEHANDLING_AVSLUTTET, revurdering?.steg)
 
         verify(exactly = 1) {
-            opprettTaskService.opprettOppgaveTask(
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = revurdering!!.id,
-                oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Fødselshendelse: Mor mottar utvidet barnetrygd.",
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
             )
         }
     }
@@ -455,10 +457,10 @@ class FødselshendelseHenleggelseTest(
         assertEquals(StegType.BEHANDLING_AVSLUTTET, revurdering?.steg)
 
         verify(exactly = 1) {
-            opprettTaskService.opprettOppgaveTask(
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = revurdering!!.id,
-                oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Fødselshendelse: Mor har EØS-barnetrygd",
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
             )
         }
     }
@@ -516,10 +518,10 @@ class FødselshendelseHenleggelseTest(
         assertEquals(StegType.BEHANDLING_AVSLUTTET, behandling.steg)
 
         verify(exactly = 1) {
-            opprettTaskService.opprettOppgaveTask(
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = behandling.id,
-                oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Fødselshendelse: ${VilkårKanskjeOppfyltÅrsak.LOVLIG_OPPHOLD_MÅ_VURDERE_LENGDEN_PÅ_OPPHOLDSTILLATELSEN.beskrivelse}",
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-12761
Opprettet manuell oppgave for med en manuell oppgave type, som styrer om det skal sendes med behandlesAvApplikasjon. Brukes på de steder hvor det opprettes manuelle vurder livshendelse oppgaver.

Småbarnstillegg skal ha behandles av applikasjon
fødselsehendeler skal ikke ha behandles av applikasjon

dødsfall, sivilstand, utflytting behandles i baks-mottak og setter ikke behandlesAvApplikasjon

Lar åpne behandlinger fortsatt ha behandles av applikasjon, for der opprettes oppgaven på den åpne oppgaven, og bevarer dermed autolukking av disse

oppgaver som ikke er VurderLivshendelse skal oppføre seg som før.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
