### PR TITLE
Endre logikken på "Fyll ut vilkårsvurdering"-knappen i preprod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
@@ -20,10 +20,11 @@ class TestVerktøyService(
 
         vilkårsvurdering?.personResultater?.forEach { personResultat ->
             personResultat.vilkårResultater.forEach { vilkårResultat ->
-                if (vilkårResultat.periodeFom == null && vilkårResultat.resultat != Resultat.OPPFYLT) {
+                if (vilkårResultat.resultat == Resultat.IKKE_VURDERT) {
                     vilkårResultat.periodeFom =
                         persongrunnlag?.personer?.find { it.aktør == personResultat.aktør }?.fødselsdato
                     vilkårResultat.resultat = Resultat.OPPFYLT
+                    vilkårResultat.begrunnelse = "Opprettet automatisk fra \"Fyll ut vilkårsvurdering\"-knappen"
                 }
             }
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når man trykker på "Fyll ut vilkårsvurdering"-knappen i preprod endrer vi nå alle som ikke er oppfylt og uten fom-dato. 

Gjør så vi kun endrer vilkårene som ikke er vurdert. I tillegg endrer jeg så vi setter begrunnelsesteksten til vilkårene.

![image](https://github.com/navikt/familie-ba-sak/assets/17828446/76bdc7e3-29c8-40ef-95fb-d8ec2800469c)
