### PR TITLE
Beslutter vedtak automatisk for "Endre migreringsdato"-behandlinger uavhengig av avvik i simulering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -317,7 +317,7 @@ class StegService(
             simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
         }
 
-        if (behandlingEtterBeslutterSteg.erManuellMigrering() && harMigreringsbehandlingAvvikInnenforbeløpsgrenser && !harMigreringsbehandlingManuellePosteringer) {
+        if ((behandlingEtterBeslutterSteg.erHelmanuellMigrering() && harMigreringsbehandlingAvvikInnenforbeløpsgrenser && !harMigreringsbehandlingManuellePosteringer) || behandlingEtterBeslutterSteg.erManuellMigreringForEndreMigreringsdato()) {
             return håndterBeslutningForVedtak(
                 behandlingEtterBeslutterSteg,
                 RestBeslutningPåVedtak(Beslutning.GODKJENT),


### PR DESCRIPTION
Favro: [NAV-12736](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12736)

### 💰 Hva skal gjøres, og hvorfor?
Det dukker opp varsel til saksbehandler på simuleringssiden dersom det finnes avvik (feilutbetaling eller etterbetaling) i en "Endre migreringsdato"-behandling som sier at saksbehandler må sende melding til NØS for å hindre feilutbetalingen/etterbetalingen samt at behandlingen vil sendes til totrinnskontroll.

I og med at vi ikke sender noe til oppdrag/økonomi i "Endre migreringsdato"-behandlinger ønsker vi ikke lenger å sende slike behandlinger til totrinnskontroll uavhengig av om simulering viser feilutbetaling eller etterbetaling. Varselmeldingen i frontend endres også for "Endre migreringsdato"-behandlinger til å ikke inkludere tekst om at behandlingen sendes til totrinngskontroll samt at saksbehandler ikke trenger å sende melding til NØS.

![image](https://github.com/navikt/familie-ba-sak/assets/70642183/3501400e-a8e3-45b0-99e7-eb8bf9dba0f6)

### ✅ Checklist
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
