### PR TITLE
Logger ut mismatch mellom fødselsdato og fom i 18års-vilkåret for satsendring og autobrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -48,6 +48,7 @@ class VilkårsvurderingSteg(
             valider18ÅrsVilkårEksistererFraFødselsdato(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 vilkårsvurdering = this,
+                behandling = behandling,
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -63,7 +63,7 @@ fun valider18ÅrsVilkårEksistererFraFødselsdato(
     vilkårsvurdering.personResultater.forEach { personResultat ->
         val person = personopplysningGrunnlag.personer.find { it.aktør == personResultat.aktør }
         if (person?.type == PersonType.BARN && !personResultat.vilkårResultater.finnesUnder18VilkårFraFødselsdato(person.fødselsdato)) {
-            if (behandling.skalBehandlesAutomatisk) {
+            if (behandling.erSatsendring() || behandling.opprettetÅrsak.erOmregningsårsak()) {
                 secureLogger.warn(
                     "Fødselsdato ${person.fødselsdato} ulik fom ${
                         personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Validering av 18års-vilkåret feiler for alle behandlinger hvor barnets fødselsdato ikke stemmer overens med fom i vilkåret. Dette skaper issues for automatiske behandlinger. 

Løsning på dette er foreløpig å ikke feile på denne valideringen dersom behandlingsårsak er satsendring eller autobrev. Feilen logges med warn slik at vi kan lage en liste over fagsaker med denne feilen.
