### PR TITLE
Filterer ut ikke oppfylte vilkår ved kopiering av vilkårsvurdering fra forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
@@ -138,6 +138,7 @@ class PersonResultat(
         )
 
         val nyeVilkårResultater = vilkårResultater
+            .filter { it.erOppfylt() }
             .map {
                 it.tilKopiForNyttPersonResultat(
                     nyttPersonResultat = nyttPersonResultat,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi kopierer over vilkår som har status `IKKE_OPPFYLT` fra forrige behandling ved satsendring. Dette skaper problemer.

Sørger nå for at vilkår som ikke er oppfylt ikke kopieres over ved satsendring.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
