### PR TITLE
Kopierer ikke over personopplysninger og personresultater for barn uten tilkjent ytelse fra forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlag.kt
@@ -71,11 +71,16 @@ data class PersonopplysningGrunnlag(
             .toYearMonth() == (fom?.toYearMonth() ?: TIDENES_ENDE.toYearMonth())
     }
 
-    fun tilKopiForNyBehandling(behandling: Behandling): PersonopplysningGrunnlag =
-        copy(id = 0, behandlingId = behandling.id, personer = mutableSetOf()).also {
-            it.personer.addAll(
-                personer.map { person -> person.tilKopiForNyttPersonopplysningGrunnlag(it) },
-            )
+    fun tilKopiForNyBehandling(
+        behandling: Behandling,
+        søkerOgBarnMedTilkjentYtelseFraForrigeBehandling: List<Aktør>,
+    ): PersonopplysningGrunnlag =
+        copy(id = 0, behandlingId = behandling.id, personer = mutableSetOf()).also { it ->
+            it.personer
+                .addAll(
+                    personer.filter { person -> søkerOgBarnMedTilkjentYtelseFraForrigeBehandling.any { søkerEllerBarn -> søkerEllerBarn.aktørId == person.aktør.aktørId } }
+                        .map { person -> person.tilKopiForNyttPersonopplysningGrunnlag(it) },
+                )
         }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -128,10 +128,15 @@ class VilkårsvurderingForNyBehandlingService(
         inneværendeBehandling: Behandling,
     ): Vilkårsvurdering {
         return if (featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_KOPIER_GRUNNLAG_FRA_FORRIGE_BEHANDLING)) {
+            val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(inneværendeBehandling.id)
+
             val forrigeBehandlingVilkårsvurdering = hentVilkårsvurderingThrows(forrigeBehandlingSomErVedtatt.id)
 
             val nyVilkårsvurdering =
-                forrigeBehandlingVilkårsvurdering.tilKopiForNyBehandling(nyBehandling = inneværendeBehandling)
+                forrigeBehandlingVilkårsvurdering.tilKopiForNyBehandling(
+                    nyBehandling = inneværendeBehandling,
+                    personopplysningGrunnlag,
+                )
 
             return vilkårsvurderingService.lagreNyOgDeaktiverGammel(nyVilkårsvurdering)
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/PersonResultat.kt
@@ -138,6 +138,7 @@ class PersonResultat(
         )
 
         val nyeVilkårResultater = vilkårResultater
+            .filter { it.erOppfylt() }
             .map {
                 it.tilKopiForNyttPersonResultat(
                     nyttPersonResultat = nyttPersonResultat,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/Vilkårsvurdering.kt
@@ -15,6 +15,7 @@ import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 
 @EntityListeners(RollestyringMotDatabase::class)
@@ -68,12 +69,17 @@ data class Vilkårsvurdering(
         return nyVilkårsvurdering
     }
 
-    fun tilKopiForNyBehandling(nyBehandling: Behandling): Vilkårsvurdering {
+    fun tilKopiForNyBehandling(
+        nyBehandling: Behandling,
+        personopplysningGrunnlag: PersonopplysningGrunnlag,
+    ): Vilkårsvurdering {
         val nyVilkårsvurdering = Vilkårsvurdering(behandling = nyBehandling)
 
-        nyVilkårsvurdering.personResultater = personResultater.map {
-            it.tilKopiForNyVilkårsvurdering(nyVilkårsvurdering = nyVilkårsvurdering)
-        }.toSet()
+        nyVilkårsvurdering.personResultater =
+            personResultater.filter { personopplysningGrunnlag.personer.any { person -> person.aktør.aktørId == it.aktør.aktørId } }
+                .map {
+                    it.tilKopiForNyVilkårsvurdering(nyVilkårsvurdering = nyVilkårsvurdering)
+                }.toSet()
 
         return nyVilkårsvurdering
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Saker med VilkårResultater som har status `IKKE_OPPFYLT` kopieres over og skaper problemer i Behandlingsresultat. Vi kopierer også over personer som ikke har tilkjent ytelse i forrige behandling til ny behandling.

Nå sjekker vi personer fra forrige behandling og filtrerer ut barn som ikke har tilkjent ytelse i forrige behandling ved kopiering. Når vi senere kopierer over vilkår, kopierer vi kun over oppfylte vilkår for personer som finnes i Personopplysningsgrunnlaget.


### ✅ Checklist
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
