### PR TITLE
Småforbedringer i satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -44,11 +44,10 @@ class StartSatsendring(
         var antallSatsendringerStartet = 0
         var startSide = 0
         while (antallSatsendringerStartet < antallFagsaker) {
-            val page =
-                fagsakRepository.finnLøpendeFagsakerForSatsendring(
-                    hentAktivSatsendringstidspunkt().atDay(1),
-                    Pageable.ofSize(antallFagsaker + 200).withPage(startSide)
-                )
+            val page = fagsakRepository.finnLøpendeFagsakerForSatsendring(
+                hentAktivSatsendringstidspunkt().atDay(1),
+                Pageable.ofSize(antallFagsaker + 200).withPage(startSide),
+            )
 
             val fagsakerForSatsendring = page.toList()
             logger.info("Fant ${fagsakerForSatsendring.size} personer for satsendring på side $startSide")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -4,11 +4,8 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
-import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
-import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
@@ -26,7 +23,6 @@ class StartSatsendring(
     private val fagsakRepository: FagsakRepository,
     private val behandlingRepository: BehandlingRepository,
     private val opprettTaskService: OpprettTaskService,
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val satskjøringRepository: SatskjøringRepository,
     private val featureToggleService: FeatureToggleService,
     private val personidentService: PersonidentService,
@@ -49,7 +45,10 @@ class StartSatsendring(
         var startSide = 0
         while (antallSatsendringerStartet < antallFagsaker) {
             val page =
-                fagsakRepository.finnLøpendeFagsakerForSatsendring(hentAktivSatsendringstidspunkt().atDay(1), Pageable.ofSize(antallFagsaker).withPage(startSide))
+                fagsakRepository.finnLøpendeFagsakerForSatsendring(
+                    hentAktivSatsendringstidspunkt().atDay(1),
+                    Pageable.ofSize(antallFagsaker + 200).withPage(startSide)
+                )
 
             val fagsakerForSatsendring = page.toList()
             logger.info("Fant ${fagsakerForSatsendring.size} personer for satsendring på side $startSide")
@@ -94,23 +93,6 @@ class StartSatsendring(
 
         val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
         if (sisteIverksatteBehandling != null) {
-            val andelerTilkjentYtelseMedEndreteUtbetalinger =
-                andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                    sisteIverksatteBehandling.id,
-                )
-
-            if (andelerTilkjentYtelseMedEndreteUtbetalinger.erOppdatertMedSisteSatser()) {
-                satskjøringRepository.save(
-                    Satskjøring(
-                        fagsakId = fagsakId,
-                        ferdigTidspunkt = sisteIverksatteBehandling.endretTidspunkt,
-                        satsTidspunkt = satsTidspunkt,
-                    ),
-                )
-                logger.info("Fagsak=$fagsakId har alt siste satser")
-                return true
-            }
-
             val aktivOgÅpenBehandling = behandlingRepository.findByFagsakAndAktivAndOpen(fagsakId = fagsakId)
             if (aktivOgÅpenBehandling != null) {
                 logger.info("Oppretter ikke satsendringtask for fagsak=$fagsakId. Har åpen behandling ${aktivOgÅpenBehandling.id}")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -50,7 +50,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
     fun finnLøpendeFagsaker(page: Pageable): Slice<Long>
 
     @Query(
-        value = """SELECT f.*
+        value = """SELECT f.id
             FROM   Fagsak f
             WHERE  NOT EXISTS (
                     SELECT 1
@@ -60,7 +60,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
                 ) AND f.status = 'LØPENDE' AND f.arkivert = false""",
         nativeQuery = true,
     )
-    fun finnLøpendeFagsakerForSatsendring(satsTidspunkt: LocalDate, page: Pageable): Page<Fagsak>
+    fun finnLøpendeFagsakerForSatsendring(satsTidspunkt: LocalDate, page: Pageable): Page<Long>
 
     @Query(
         value = """SELECT id FROM fagsak

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -132,7 +132,7 @@ internal class StartSatsendringTest {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns null
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns Satskjøring(
             fagsakId = 1L,
-            satsTidspunkt = SATSENDRINGMÅNED_MARS_2023
+            satsTidspunkt = SATSENDRINGMÅNED_MARS_2023,
         )
 
         assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
@@ -143,7 +143,7 @@ internal class StartSatsendringTest {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns Satskjøring(
             fagsakId = 1L,
-            satsTidspunkt = SATSENDRINGMÅNED_MARS_2023
+            satsTidspunkt = SATSENDRINGMÅNED_MARS_2023,
         )
 
         assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -5,9 +5,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
@@ -15,13 +13,10 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring.Comp
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.prosessering.domene.Task
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -30,14 +25,11 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import java.time.YearMonth
 
 internal class StartSatsendringTest {
 
     private val fagsakRepository: FagsakRepository = mockk()
     private val behandlingRepository: BehandlingRepository = mockk()
-    private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService =
-        mockk()
     private val satskjøringRepository: SatskjøringRepository = mockk()
     private val featureToggleService: FeatureToggleService = mockk()
     private val personidentService: PersonidentService = mockk()
@@ -64,7 +56,6 @@ internal class StartSatsendringTest {
                 fagsakRepository = fagsakRepository,
                 behandlingRepository = behandlingRepository,
                 opprettTaskService = opprettTaskService,
-                andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
                 satskjøringRepository = satskjøringRepository,
                 featureToggleService = featureToggleService,
                 personidentService = personidentService,
@@ -89,79 +80,9 @@ internal class StartSatsendringTest {
 
         every { behandlingRepository.finnSisteIverksatteBehandling(behandling.fagsak.id) } returns behandling
 
-        every {
-            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                behandling.id,
-            )
-        } returns
-            listOf(
-                lagAndelTilkjentYtelseMedEndreteUtbetalinger(
-                    YearMonth.of(2022, 12),
-                    YearMonth.of(2039, 11),
-                    ORDINÆR_BARNETRYGD,
-                    behandling = behandling,
-                    person = lagPerson(),
-                    aktør = lagPerson().aktør,
-                    periodeIdOffset = 1,
-                    beløp = 1676,
-                ),
-                lagAndelTilkjentYtelseMedEndreteUtbetalinger(
-                    YearMonth.of(2030, 12),
-                    YearMonth.of(2039, 11),
-                    ORDINÆR_BARNETRYGD,
-                    behandling = behandling,
-                    person = lagPerson(),
-                    aktør = lagPerson().aktør,
-                    periodeIdOffset = 1,
-                    beløp = 1054,
-                ),
-            )
-
         startSatsendring.startSatsendring(5)
 
         verify(exactly = 1) { taskRepository.save(any()) }
-    }
-
-    @Test
-    fun `Ikke start satsendring på sak hvis ytelsen utløper før satstidspunkt, men marker at sastsendring alt er kjørt`() {
-        every { featureToggleService.isEnabled(any(), any()) } returns true
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_OPPRETT_TASKER) } returns true
-
-        val behandling = lagBehandling()
-
-        every { fagsakRepository.finnLøpendeFagsakerForSatsendring(any(), any()) } returns PageImpl(
-            listOf(behandling.fagsak.id),
-            Pageable.ofSize(5),
-            0,
-        )
-
-        every { behandlingRepository.finnSisteIverksatteBehandling(behandling.fagsak.id) } returns behandling
-
-        every {
-            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                behandling.id,
-            )
-        } returns
-            listOf(
-                lagAndelTilkjentYtelseMedEndreteUtbetalinger(
-                    fom = YearMonth.of(2022, 12),
-                    tom = YearMonth.of(2023, 2),
-                    ytelseType = ORDINÆR_BARNETRYGD,
-                    behandling = behandling,
-                    person = lagPerson(),
-                    aktør = lagPerson().aktør,
-                    periodeIdOffset = 1,
-                    beløp = 1676,
-                ),
-            )
-
-        startSatsendring.startSatsendring(5)
-
-        val satskjøringSlot = slot<Satskjøring>()
-        verify(exactly = 1) { satskjøringRepository.save(capture(satskjøringSlot)) }
-        assertThat(satskjøringSlot.captured.fagsakId).isEqualTo(behandling.fagsak.id)
-        assertThat(satskjøringSlot.captured.fagsakId).isEqualTo(behandling.fagsak.id)
-        assertThat(satskjøringSlot.captured.ferdigTidspunkt).isEqualTo(behandling.endretTidspunkt)
     }
 
     @Test
@@ -179,24 +100,6 @@ internal class StartSatsendringTest {
 
         every { behandlingRepository.finnSisteIverksatteBehandling(behandling.fagsak.id) } returns behandling
 
-        every {
-            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                behandling.id,
-            )
-        } returns
-            listOf(
-                lagAndelTilkjentYtelseMedEndreteUtbetalinger(
-                    fom = YearMonth.of(2022, 12),
-                    tom = YearMonth.of(2040, 12),
-                    ytelseType = ORDINÆR_BARNETRYGD,
-                    behandling = behandling,
-                    person = lagPerson(),
-                    aktør = lagPerson().aktør,
-                    periodeIdOffset = 1,
-                    beløp = 1676,
-                ),
-            )
-
         startSatsendring.startSatsendring(5)
 
         verify(exactly = 5) { taskRepository.save(any()) }
@@ -210,33 +113,6 @@ internal class StartSatsendringTest {
 
         val behandling = lagBehandling()
         every { behandlingRepository.finnSisteIverksatteBehandling(behandling.fagsak.id) } returns behandling
-        every {
-            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                behandling.id,
-            )
-        } returns
-            listOf(
-                lagAndelTilkjentYtelseMedEndreteUtbetalinger(
-                    YearMonth.of(2022, 12),
-                    YearMonth.of(2039, 11),
-                    ORDINÆR_BARNETRYGD,
-                    behandling = behandling,
-                    person = lagPerson(),
-                    aktør = lagPerson().aktør,
-                    periodeIdOffset = 1,
-                    beløp = 1676,
-                ),
-                lagAndelTilkjentYtelseMedEndreteUtbetalinger(
-                    YearMonth.of(2030, 12),
-                    YearMonth.of(2039, 11),
-                    ORDINÆR_BARNETRYGD,
-                    behandling = behandling,
-                    person = lagPerson(),
-                    aktør = lagPerson().aktør,
-                    periodeIdOffset = 1,
-                    beløp = 1054,
-                ),
-            )
 
         every { behandlingRepository.findByFagsakAndAktivAndOpen(any()) } returns behandling
 
@@ -254,7 +130,10 @@ internal class StartSatsendringTest {
     @Test
     fun `kanStarteSatsendringPåFagsak gir false når vi ikke har noen tidligere behandling`() {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns null
-        every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns Satskjøring(fagsakId = 1L, satsTidspunkt = SATSENDRINGMÅNED_MARS_2023)
+        every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns Satskjøring(
+            fagsakId = 1L,
+            satsTidspunkt = SATSENDRINGMÅNED_MARS_2023
+        )
 
         assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
@@ -262,7 +141,10 @@ internal class StartSatsendringTest {
     @Test
     fun `kanStarteSatsendringPåFagsak gir false når vi har en satskjøring for fagsaken i satskjøringsrepoet`() {
         every { behandlingRepository.finnSisteIverksatteBehandling(1L) } returns lagBehandling()
-        every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns Satskjøring(fagsakId = 1L, satsTidspunkt = SATSENDRINGMÅNED_MARS_2023)
+        every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns Satskjøring(
+            fagsakId = 1L,
+            satsTidspunkt = SATSENDRINGMÅNED_MARS_2023
+        )
 
         assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -82,7 +82,7 @@ internal class StartSatsendringTest {
         val behandling = lagBehandling()
 
         every { fagsakRepository.finnLøpendeFagsakerForSatsendring(any(), any()) } returns PageImpl(
-            listOf(behandling.fagsak),
+            listOf(behandling.fagsak.id),
             Pageable.ofSize(5),
             0,
         )
@@ -130,7 +130,7 @@ internal class StartSatsendringTest {
         val behandling = lagBehandling()
 
         every { fagsakRepository.finnLøpendeFagsakerForSatsendring(any(), any()) } returns PageImpl(
-            listOf(behandling.fagsak),
+            listOf(behandling.fagsak.id),
             Pageable.ofSize(5),
             0,
         )
@@ -172,7 +172,7 @@ internal class StartSatsendringTest {
         val behandling = lagBehandling()
 
         every { fagsakRepository.finnLøpendeFagsakerForSatsendring(any(), any()) } returns PageImpl(
-            listOf(behandling.fagsak, behandling.fagsak),
+            listOf(behandling.fagsak.id, behandling.fagsak.id),
             Pageable.ofSize(2), // 5/2 gir totalt 3 sider, så finnLøpendeFagsakerForSatsendring skal trigges 3 ganger
             5,
         )
@@ -241,7 +241,7 @@ internal class StartSatsendringTest {
         every { behandlingRepository.findByFagsakAndAktivAndOpen(any()) } returns behandling
 
         every { fagsakRepository.finnLøpendeFagsakerForSatsendring(any(), any()) } returns PageImpl(
-            listOf(behandling.fagsak),
+            listOf(behandling.fagsak.id),
             Pageable.ofSize(5),
             0,
         )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Henter kun fagsakId fra spørring for å unngå at man henter hele fagsaken og allt koblet til den
Sjekker ikke om den er oppdatert med siste satsen, som gjøres i `AutovedtakSatsendringService::kjørBehandling` som då hver task kan være ansvarlig for
Plusser også på 200 på hver side for å prøve å hente alle behandlinger på første siden

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
