### PR TITLE
Sørger for at vi kopierer over endrede utbetalingsandeler fra forrige vedtatte behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -138,6 +138,11 @@ class VilkårsvurderingForNyBehandlingService(
                     personopplysningGrunnlag,
                 )
 
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                inneværendeBehandling,
+                forrigeBehandlingSomErVedtatt,
+            )
+
             return vilkårsvurderingService.lagreNyOgDeaktiverGammel(nyVilkårsvurdering)
         } else {
             initierVilkårsvurderingForBehandling(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
@@ -1,7 +1,9 @@
 package no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling
 
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.BaseEntitet
@@ -92,6 +94,13 @@ class VilkårsvurderingForNyBehandlingServiceTest {
             barn,
         )
 
+        every {
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling,
+                forrigeBehandling,
+            )
+        } just runs
+
         vilkårsvurderingForNyBehandlingService.opprettVilkårsvurderingUtenomHovedflyt(
             behandling = behandling,
             forrigeBehandlingSomErVedtatt = forrigeBehandling,
@@ -167,6 +176,13 @@ class VilkårsvurderingForNyBehandlingServiceTest {
             barn,
         )
 
+        every {
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling,
+                forrigeBehandling,
+            )
+        } just runs
+
         vilkårsvurderingForNyBehandlingService.opprettVilkårsvurderingUtenomHovedflyt(
             behandling = behandling,
             forrigeBehandlingSomErVedtatt = forrigeBehandling,
@@ -225,6 +241,13 @@ class VilkårsvurderingForNyBehandlingServiceTest {
             søker,
             barn2,
         )
+
+        every {
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling,
+                forrigeBehandling,
+            )
+        } just runs
 
         vilkårsvurderingForNyBehandlingService.opprettVilkårsvurderingUtenomHovedflyt(
             behandling = behandling,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi kopierer ikke over `EndretUtebetalingAndel` fra forrige vedtatte behandling når vi kjører satsendring. Dette fører til at fagsaker hvor den forrige vedtatte behandlingen har `EndretUtbetalingAndel` får feil behandlingsresultat/andelt-tilkjent-ytelse.

Sørger nå for at vi kopierer over disse!

### ✅ Checklist
- [x] Jeg har skrevet tester. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
