### PR TITLE
Fødselshendelser ignorerer barn hvis de finnes på en henlagt behandling.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -197,7 +197,7 @@ class AutovedtakFødselshendelseService(
 
         val barnaSomHarBlittBehandlet =
             if (fagsak != null) {
-                behandlingHentOgPersisterService.hentBehandlinger(fagsakId = fagsak.id).flatMap {
+                behandlingHentOgPersisterService.hentBehandlinger(fagsakId = fagsak.id).filter { !it.erHenlagt() }.flatMap {
                     persongrunnlagService.hentBarna(behandling = it).map { barn -> barn.aktør.aktivFødselsnummer() }
                 }.distinct()
             } else {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Henla en fødselshendelsebehandling som var opprettet med feil data, og skulle rekjøre, men da ble den ignorert fordi det barnet fantes på en henlagt behandling 