### PR TITLE
Fikser håndtering av uendelighet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/TidspunktKonvertering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/TidspunktKonvertering.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 
@@ -68,5 +70,7 @@ fun <T : Tidsenhet> Tidspunkt<T>.somTilOgMed() = when (uendelighet) {
 
 fun <T : Tidsenhet> Tidspunkt<T>.tilYearMonth() = this.tilInneværendeMåned().tilYearMonth()
 fun <T : Tidsenhet> Tidspunkt<T>.tilYearMonthEllerNull() = this.tilInneværendeMåned().tilYearMonthEllerNull()
+fun <T : Tidsenhet> Tidspunkt<T>.tilYearMonthEllerUendeligFortid() = this.tilInneværendeMåned().tilYearMonthEllerNull() ?: TIDENES_MORGEN.toYearMonth()
+fun <T : Tidsenhet> Tidspunkt<T>.tilYearMonthEllerUendeligFramtid() = this.tilInneværendeMåned().tilYearMonthEllerNull() ?: TIDENES_ENDE.toYearMonth()
 fun <T : Tidsenhet> Tidspunkt<T>.tilLocalDate() = this.tilDagEllerSisteDagIPerioden().tilLocalDate()
 fun <T : Tidsenhet> Tidspunkt<T>.tilLocalDateEllerNull() = this.tilDagEllerSisteDagIPerioden().tilLocalDateEllerNull()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -32,7 +32,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilFørsteDagIMåneden
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilSisteDagIMåneden
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonthEllerUendeligFortid
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
@@ -197,7 +197,7 @@ fun VedtaksperiodeMedBegrunnelser.hentUtbetalingsperiodeDetaljerNy(
 
         Vedtaksperiodetype.FORTSATT_INNVILGET -> {
             val løpendeUtbetalingsperiode = utbetalingsperiodeDetaljer.perioder()
-                .lastOrNull { it.fraOgMed.tilYearMonth() <= inneværendeMåned() }
+                .lastOrNull { it.fraOgMed.tilYearMonthEllerUendeligFortid() <= inneværendeMåned() }
                 ?: utbetalingsperiodeDetaljer.perioder().firstOrNull()
 
             løpendeUtbetalingsperiode?.innhold?.toList()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonthEllerUendeligFortid
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonIkkeInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonInnvilget
@@ -31,7 +31,7 @@ private fun Map<Aktør, Tidslinje<Boolean, Måned>>.finnTidligsteForskjell() = t
     .minOfOrNull { (_, erPeriodeLikTidslinje) ->
         erPeriodeLikTidslinje.perioder()
             .filter { it.innhold == false }
-            .minOfOrNull { it.fraOgMed.tilYearMonth().førsteDagIInneværendeMåned() } ?: TIDENES_ENDE
+            .minOfOrNull { it.fraOgMed.tilYearMonthEllerUendeligFortid().førsteDagIInneværendeMåned() } ?: TIDENES_ENDE
     }
 
 private fun GrunnlagForPerson?.erLik(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
`tilYearMonth` støtter ikke uendelighet, så vi vår feil ved avlag uten dato. 

Lager funksjon tilYearMonthEllerUendeligFortid og tar den i bruk

