### PR TITLE
Fikser bug om at grensesnitt avstemming ikke opprettet tasker til å kjøre på fredag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdrag.kt
@@ -7,6 +7,7 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.util.VirkedagerProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -44,8 +45,7 @@ class GrensesnittavstemMotOppdrag(val avstemmingService: AvstemmingService, val 
     fun nesteAvstemmingDTO(tideligereTriggerDato: LocalDate): GrensesnittavstemmingTaskDTO =
         GrensesnittavstemmingTaskDTO(
             tideligereTriggerDato.atStartOfDay(),
-            nesteGyldigeTriggertidForBehandlingIHverdager((24 * 60).toLong(), tideligereTriggerDato.atTime(8, 0))
-                .toLocalDate().atStartOfDay(),
+            VirkedagerProvider.nesteVirkedag(tideligereTriggerDato).atStartOfDay(),
         )
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdrag.kt
@@ -44,7 +44,7 @@ class GrensesnittavstemMotOppdrag(val avstemmingService: AvstemmingService, val 
     fun nesteAvstemmingDTO(tideligereTriggerDato: LocalDate): GrensesnittavstemmingTaskDTO =
         GrensesnittavstemmingTaskDTO(
             tideligereTriggerDato.atStartOfDay(),
-            nesteGyldigeTriggertidForBehandlingIHverdager((24 * 60).toLong(), tideligereTriggerDato.atStartOfDay())
+            nesteGyldigeTriggertidForBehandlingIHverdager((24 * 60).toLong(), tideligereTriggerDato.atTime(8, 0))
                 .toLocalDate().atStartOfDay(),
         )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/TaskUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/TaskUtils.kt
@@ -34,6 +34,14 @@ fun nesteGyldigeTriggertidForBehandlingIHverdager(
         date.dayOfMonth == 26 && date.month == Month.DECEMBER -> date = date.plusDays(1)
     }
 
+    when (date.dayOfWeek) {
+        DayOfWeek.SATURDAY -> date = date.plusDays(2)
+        DayOfWeek.SUNDAY -> date = date.plusDays(1)
+        else -> {
+            // NOP
+        }
+    }
+
     return date
 }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det opprettes ikke tasker for å kjøre grensesnittavstemming på en fredag. Når torsdagens jobb er ferdig og ny task lages, så ble neste triggertid mandag.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
