### PR TITLE
Ta høyde for begrunnelsene som er satt i vilkåret når vi ser på personene vi skal ha med i begrunnelser for eksplisitte avslag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BegrunnelseUtil.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.somOverlapper
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.hentPersonerForEtterEndretUtbetalingsperiode
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
@@ -23,6 +24,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 
 fun hentPersonidenterGjeldendeForBegrunnelse(
     triggesAv: TriggesAv,
+    begrunnelse: IVedtakBegrunnelse,
     periode: NullablePeriode,
     vedtakBegrunnelseType: VedtakBegrunnelseType,
     vedtaksperiodetype: Vedtaksperiodetype,
@@ -53,6 +55,7 @@ fun hentPersonidenterGjeldendeForBegrunnelse(
             vedtakBegrunnelseType,
             identerMedUtbetalingPåPeriode,
         ),
+        begrunnelse = begrunnelse,
         triggesAv = triggesAv,
         erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
         featureToggleService = featureToggleService,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/UtgjørendeVilkårUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/UtgjørendeVilkårUtils.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertRestPersonResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertVilkårResultat
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.MinimertRestPerson
@@ -37,6 +38,7 @@ fun hentPersonerForAlleUtgjørendeVilkår(
     oppdatertBegrunnelseType: VedtakBegrunnelseType,
     aktuellePersonerForVedtaksperiode: List<MinimertRestPerson>,
     triggesAv: TriggesAv,
+    begrunnelse: IVedtakBegrunnelse,
     erFørsteVedtaksperiodePåFagsak: Boolean,
     featureToggleService: FeatureToggleService,
 ): Set<MinimertRestPerson> {
@@ -48,6 +50,7 @@ fun hentPersonerForAlleUtgjørendeVilkår(
             vilkårGjeldendeForBegrunnelse = vilkår,
             aktuellePersonerForVedtaksperiode = aktuellePersonerForVedtaksperiode,
             triggesAv = triggesAv,
+            begrunnelse = begrunnelse,
             erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
             featureToggleService = featureToggleService,
         )
@@ -61,6 +64,7 @@ private fun hentPersonerMedUtgjørendeVilkår(
     vilkårGjeldendeForBegrunnelse: Vilkår,
     aktuellePersonerForVedtaksperiode: List<MinimertRestPerson>,
     triggesAv: TriggesAv,
+    begrunnelse: IVedtakBegrunnelse,
     erFørsteVedtaksperiodePåFagsak: Boolean,
     featureToggleService: FeatureToggleService,
 ): List<MinimertRestPerson> {
@@ -83,6 +87,7 @@ private fun hentPersonerMedUtgjørendeVilkår(
                             vedtaksperiode = vedtaksperiode,
                             erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
                             featureToggleService = featureToggleService,
+                            begrunnelse = begrunnelse,
                         )
                     }
 
@@ -107,6 +112,7 @@ private fun erVilkårResultatUtgjørende(
     nesteMinimerteVilkårResultat: MinimertVilkårResultat?,
     begrunnelseType: VedtakBegrunnelseType,
     triggesAv: TriggesAv,
+    begrunnelse: IVedtakBegrunnelse,
     vedtaksperiode: Periode,
     erFørsteVedtaksperiodePåFagsak: Boolean,
     featureToggleService: FeatureToggleService,
@@ -152,7 +158,12 @@ private fun erVilkårResultatUtgjørende(
         }
 
         VedtakBegrunnelseType.AVSLAG, VedtakBegrunnelseType.INSTITUSJON_AVSLAG ->
-            vilkårResultatPasserForAvslagsperiode(minimertVilkårResultat, vedtaksperiode, featureToggleService)
+            vilkårResultatPasserForAvslagsperiode(
+                minimertVilkårResultat = minimertVilkårResultat,
+                vedtaksperiode = vedtaksperiode,
+                begrunnelse = begrunnelse,
+                featureToggleService = featureToggleService,
+            )
 
         else -> throw Feil("Henting av personer med utgjørende vilkår when: Ikke implementert")
     }
@@ -224,6 +235,7 @@ private fun erInnvilgetVilkårResultatUtgjørende(
 private fun vilkårResultatPasserForAvslagsperiode(
     minimertVilkårResultat: MinimertVilkårResultat,
     vedtaksperiode: Periode,
+    begrunnelse: IVedtakBegrunnelse,
     featureToggleService: FeatureToggleService,
 ): Boolean {
     val erAvslagUtenFomDato = minimertVilkårResultat.periodeFom == null
@@ -240,7 +252,8 @@ private fun vilkårResultatPasserForAvslagsperiode(
         }
 
     return fomVilkår == vedtaksperiode.fom.toYearMonth() &&
-        minimertVilkårResultat.resultat == Resultat.IKKE_OPPFYLT
+        minimertVilkårResultat.resultat == Resultat.IKKE_OPPFYLT &&
+        minimertVilkårResultat.standardbegrunnelser.contains(begrunnelse)
 }
 
 fun erFørstePeriodeOgVilkårIkkeOppfylt(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BegrunnelseMedTriggere.kt
@@ -35,6 +35,7 @@ data class BegrunnelseMedTriggere(
             )
         } else {
             val personidenterGjeldendeForBegrunnelse: Set<String> = hentPersonidenterGjeldendeForBegrunnelse(
+                begrunnelse = this.standardbegrunnelse,
                 triggesAv = this.triggesAv,
                 vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
                 periode = periode,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
@@ -26,7 +26,6 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.harBarnMedSeksår
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
-import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 fun Standardbegrunnelse.triggesForPeriode(
@@ -64,6 +63,7 @@ fun Standardbegrunnelse.triggesForPeriode(
         oppdatertBegrunnelseType = this.vedtakBegrunnelseType,
         aktuellePersonerForVedtaksperiode = aktuellePersoner.map { it.tilMinimertRestPerson() },
         triggesAv = triggesAv,
+        begrunnelse = this,
         erFørsteVedtaksperiodePåFagsak = erFørsteVedtaksperiodePåFagsak,
         featureToggleService = featureToggleService,
     )
@@ -156,8 +156,6 @@ private fun erEtterEndretPeriodeAvSammeÅrsak(
         aktuellePersoner.any { person -> person.aktørId == endretUtbetalingAndel.aktørId } &&
         triggesAv.endringsaarsaker.contains(endretUtbetalingAndel.årsak)
 }
-
-private val logger = LoggerFactory.getLogger(Standardbegrunnelse::class.java)
 
 fun List<LocalDate>.tilBrevTekst(): String = Utils.slåSammen(this.sorted().map { it.tilKortString() })
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -75,6 +75,7 @@ import no.nav.familie.ba.sak.kjerne.steg.domene.JournalførVedtaksbrevDTO
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
@@ -1051,6 +1052,7 @@ fun lagVilkårResultat(
     behandlingId: Long = lagBehandling().id,
     utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = emptyList(),
     erEksplisittAvslagPåSøknad: Boolean = false,
+    standardbegrunnelser: List<IVedtakBegrunnelse> = emptyList(),
 ) = VilkårResultat(
     personResultat = personResultat,
     vilkårType = vilkårType,
@@ -1061,6 +1063,7 @@ fun lagVilkårResultat(
     behandlingId = behandlingId,
     utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
     erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
+    standardbegrunnelser = standardbegrunnelser,
 )
 
 val guttenBarnesenFødselsdato = LocalDate.now().withDayOfMonth(10).minusYears(6)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/UtgjørendePersonerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/UtgjørendePersonerTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.Periode
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagTriggesAv
@@ -146,6 +147,7 @@ class UtgjørendePersonerTest {
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false,
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE,
         )
 
         assertEquals(2, personerMedUtgjørendeVilkårLovligOpphold.size)
@@ -166,6 +168,7 @@ class UtgjørendePersonerTest {
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false,
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
         )
 
         assertEquals(1, personerMedUtgjørendeVilkårBosattIRiket.size)
@@ -242,6 +245,7 @@ class UtgjørendePersonerTest {
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false,
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.REDUKSJON_BOSATT_I_RIKTET,
         )
 
         assertEquals(1, personerMedUtgjørendeVilkårBosattIRiket.size)
@@ -262,6 +266,7 @@ class UtgjørendePersonerTest {
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false,
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.OPPHØR_UTVANDRET,
         )
 
         assertEquals(1, personerMedUtgjørendeVilkårBarnUtvandret.size)
@@ -333,6 +338,7 @@ class UtgjørendePersonerTest {
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false,
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
         )
 
         val personerMedUtgjørendeVilkårBosattIRiket = hentPersonerForAlleUtgjørendeVilkår(
@@ -347,6 +353,7 @@ class UtgjørendePersonerTest {
                 .map { it.tilMinimertPerson() },
             erFørsteVedtaksperiodePåFagsak = false,
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
         )
 
         assertEquals(1, personerMedUtgjørendeVilkårBosattIRiketMedlemskap.size)
@@ -359,6 +366,108 @@ class UtgjørendePersonerTest {
         assertEquals(
             barn2Fnr,
             personerMedUtgjørendeVilkårBosattIRiket.first().personIdent,
+        )
+    }
+
+    @Test
+    fun `Skal ta med riktig personer på avslag som er samtidige`() {
+        val søkerFnr = randomFnr()
+        val barn1Fnr = randomFnr()
+        val barn2Fnr = randomFnr()
+
+        val barn1AktørId = tilAktør(barn1Fnr)
+        val barn2AktørId = tilAktør(barn2Fnr)
+
+        val behandling = lagBehandling()
+        val personopplysningGrunnlag =
+            lagTestPersonopplysningGrunnlag(
+                behandling.id,
+                søkerFnr,
+                listOf(barn1Fnr, barn2Fnr),
+            )
+
+        val vilkårsvurdering = Vilkårsvurdering(
+            behandling = behandling,
+        )
+
+        val barn1PersonResultat =
+            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1AktørId)
+        val barn2PersonResultat =
+            PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn2AktørId)
+
+        val avslagBegrunnelse1 = Standardbegrunnelse.AVSLAG_IKKE_AVTALE_OM_DELT_BOSTED
+        barn1PersonResultat.setSortedVilkårResultater(
+            setOf(
+                lagVilkårResultat(
+                    barn1PersonResultat,
+                    vilkårType = Vilkår.BOR_MED_SØKER,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_OPPFYLT,
+                    erEksplisittAvslagPåSøknad = true,
+                    standardbegrunnelser = listOf(avslagBegrunnelse1),
+                ),
+            ),
+        )
+
+        val avslagBegrunnelse2 = Standardbegrunnelse.AVSLAG_BOR_HOS_SØKER
+        barn2PersonResultat.setSortedVilkårResultater(
+            setOf(
+                lagVilkårResultat(
+                    barn2PersonResultat,
+                    vilkårType = Vilkår.BOR_MED_SØKER,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_OPPFYLT,
+                    erEksplisittAvslagPåSøknad = true,
+                    standardbegrunnelser = listOf(avslagBegrunnelse2),
+                ),
+            ),
+        )
+
+        vilkårsvurdering.personResultater =
+            setOf(barn1PersonResultat, barn2PersonResultat)
+
+        val personerMedUtgjørendeVilkårAvslag1 = hentPersonerForAlleUtgjørendeVilkår(
+            minimertePersonResultater = vilkårsvurdering.personResultater.map { it.tilMinimertPersonResultat() },
+            vedtaksperiode = Periode(
+                fom = TIDENES_MORGEN,
+                tom = TIDENES_ENDE,
+            ),
+            oppdatertBegrunnelseType = VedtakBegrunnelseType.AVSLAG,
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER), medlemskap = true),
+            aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
+                .map { it.tilMinimertPerson() },
+            erFørsteVedtaksperiodePåFagsak = false,
+            featureToggleService = featureToggleService,
+            begrunnelse = avslagBegrunnelse1,
+        )
+
+        val personerMedUtgjørendeVilkårAvslag2 = hentPersonerForAlleUtgjørendeVilkår(
+            minimertePersonResultater = vilkårsvurdering.personResultater.map { it.tilMinimertPersonResultat() },
+            vedtaksperiode = Periode(
+                fom = TIDENES_MORGEN,
+                tom = TIDENES_ENDE,
+            ),
+            oppdatertBegrunnelseType = VedtakBegrunnelseType.AVSLAG,
+            triggesAv = lagTriggesAv(vilkår = setOf(Vilkår.BOR_MED_SØKER)),
+            aktuellePersonerForVedtaksperiode = personopplysningGrunnlag.personer.toList()
+                .map { it.tilMinimertPerson() },
+            erFørsteVedtaksperiodePåFagsak = false,
+            featureToggleService = featureToggleService,
+            begrunnelse = avslagBegrunnelse2,
+        )
+
+        assertEquals(1, personerMedUtgjørendeVilkårAvslag1.size)
+        assertEquals(
+            barn1Fnr,
+            personerMedUtgjørendeVilkårAvslag1.first().personIdent,
+        )
+
+        assertEquals(1, personerMedUtgjørendeVilkårAvslag2.size)
+        assertEquals(
+            barn2Fnr,
+            personerMedUtgjørendeVilkårAvslag2.first().personIdent,
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceUtilsTest.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.tilMinimertRestEndretUtbetalingA
 import no.nav.familie.ba.sak.kjerne.brev.hentPersonidenterGjeldendeForBegrunnelse
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.periodeErOppyltForYtelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilMinimertPerson
@@ -62,6 +63,7 @@ class VedtaksperiodeServiceUtilsTest {
             minimerteUtbetalingsperiodeDetaljer = listOf(),
             dødeBarnForrigePeriode = emptyList(),
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.INNVILGET_BOR_ALENE_MED_BARN,
         )
 
         Assertions.assertEquals(
@@ -117,6 +119,7 @@ class VedtaksperiodeServiceUtilsTest {
             minimerteUtbetalingsperiodeDetaljer = listOf(),
             dødeBarnForrigePeriode = emptyList(),
             featureToggleService = featureToggleService,
+            begrunnelse = Standardbegrunnelse.INNVILGET_BOR_ALENE_MED_BARN,
         )
 
         Assertions.assertEquals(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har et case der to personer har forskjellige avslagsbegrunnelser på samme vilkår på i samme periode. Det er derfor ikke nok å se hvem som har avslag på vilkåret i perioden for å se hvem vi skal ha med i begrunnelsen, vi må også dobbeltsjekke at den spesifikke begrunnelsen er den samme. 

Drar med begrunnelsen hele veien ned i funksjonskallene slik at vi kun tar med personene som har avslag på samme begrunnelse. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
