### PR TITLE
Sender vedtak til feed hvis sak har vært migrert, flyttet tilbake til Infotrygd og så migrert igjen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/IverksettMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/IverksettMotOppdrag.kt
@@ -66,7 +66,8 @@ class IverksettMotOppdrag(
         val forrigeIverksatteBehandling =
             behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling)
         if (forrigeIverksatteBehandling == null ||
-            forrigeIverksatteBehandling.type == BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT
+            forrigeIverksatteBehandling.type == BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT ||
+            behandling.erManuellMigrering()
         ) {
             taskRepository.save(
                 SendVedtakTilInfotrygdTask.opprettTask(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendVedtakTilInfotrygdTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendVedtakTilInfotrygdTaskTest.kt
@@ -1,0 +1,63 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseUtvidet
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdFeedClient
+import no.nav.familie.ba.sak.integrasjoner.infotrygd.domene.InfotrygdVedtakFeedDto
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+internal class SendVedtakTilInfotrygdTaskTest {
+
+    val infotrygdFeedClient: InfotrygdFeedClient = mockk()
+    val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService = mockk()
+    private val sendVedtakTilInfotrygdTask = SendVedtakTilInfotrygdTask(
+        infotrygdFeedClient,
+        andelerTilkjentYtelseOgEndreteUtbetalingerService,
+    )
+
+    @Test
+    fun `skal sende vedtak til infotrygd ved første gang behandling`() {
+        val behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET)
+        val fom = YearMonth.now().minusMonths(2)
+        every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id) } returns lagAndelerMedFom(behandling, fom)
+        val slot = slot<InfotrygdVedtakFeedDto>()
+        every { infotrygdFeedClient.sendVedtakFeedTilInfotrygd(capture(slot)) } returns Unit
+
+        sendVedtakTilInfotrygdTask.doTask(SendVedtakTilInfotrygdTask.opprettTask(behandling.fagsak.aktør.aktivFødselsnummer(), behandling.id))
+
+        assertThat(slot.captured.fnrStoenadsmottaker).isEqualTo(behandling.fagsak.aktør.aktivFødselsnummer())
+        assertThat(slot.captured.datoStartNyBa).isEqualTo(fom.atDay(1))
+    }
+
+    private fun lagAndelerMedFom(behandling: Behandling, fom: YearMonth): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
+        val andel1 = lagAndelTilkjentYtelseUtvidet(
+            fom.toString(),
+            fom.plusYears(6).toString(),
+            YtelseType.ORDINÆR_BARNETRYGD,
+            behandling = behandling,
+            person = lagPerson(),
+            periodeIdOffset = 1,
+        )
+
+        val andel2 = lagAndelTilkjentYtelseUtvidet(
+            fom.plusYears(6).toString(),
+            fom.plusYears(12).toString(),
+            YtelseType.ORDINÆR_BARNETRYGD,
+            behandling = behandling,
+            person = lagPerson(),
+            periodeIdOffset = 2,
+        )
+        return listOf(AndelTilkjentYtelseMedEndreteUtbetalinger.utenEndringer(andel1), AndelTilkjentYtelseMedEndreteUtbetalinger.utenEndringer(andel2))
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Manuelle migreringer som tidligere har vært migrert, men flyttet tilbake til infotrygd, har ikke blitt sendt til feed.  Lagt til sjekk om at det er manuell migrering, og hvis det er det så sendes det til feed.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
