### PR TITLE
"Endre migreringsdato"-behandlinger skal ikke opprette GodkjenneVedtak-oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/AutomatiskBeslutningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/AutomatiskBeslutningService.kt
@@ -1,0 +1,20 @@
+package no.nav.familie.ba.sak.kjerne.behandling
+
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
+import org.springframework.stereotype.Service
+
+@Service
+class AutomatiskBeslutningService(private val simuleringService: SimuleringService) {
+
+    fun behandlingSkalAutomatiskBesluttes(behandling: Behandling): Boolean {
+        val harMigreringsbehandlingAvvikInnenforbeløpsgrenser by lazy {
+            simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
+        }
+
+        val harMigreringsbehandlingManuellePosteringer by lazy {
+            simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
+        }
+        return (behandling.erHelmanuellMigrering() && harMigreringsbehandlingAvvikInnenforbeløpsgrenser && !harMigreringsbehandlingManuellePosteringer) || behandling.erManuellMigreringForEndreMigreringsdato()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -304,7 +304,7 @@ class BehandlingService(
             ?.let { behandlingMigreringsinfoRepository.delete(it) }
     }
 
-    fun skalAutomatiskBesluttes(behandling: Behandling): Boolean {
+    fun behandlingSkalAutomatiskBesluttes(behandling: Behandling): Boolean {
         val harMigreringsbehandlingAvvikInnenforbeløpsgrenser by lazy {
             simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -23,7 +23,6 @@ import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValid
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.logg.BehandlingLoggRequest
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.FØRSTE_STEG
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
@@ -59,7 +58,6 @@ class BehandlingService(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val taskRepository: TaskRepositoryWrapper,
     private val vilkårsvurderingService: VilkårsvurderingService,
-    private val simuleringService: SimuleringService,
 ) {
 
     @Transactional
@@ -302,17 +300,6 @@ class BehandlingService(
     fun deleteMigreringsdatoVedHenleggelse(behandlingId: Long) {
         behandlingMigreringsinfoRepository.findByBehandlingId(behandlingId)
             ?.let { behandlingMigreringsinfoRepository.delete(it) }
-    }
-
-    fun behandlingSkalAutomatiskBesluttes(behandling: Behandling): Boolean {
-        val harMigreringsbehandlingAvvikInnenforbeløpsgrenser by lazy {
-            simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
-        }
-
-        val harMigreringsbehandlingManuellePosteringer by lazy {
-            simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
-        }
-        return (behandling.erHelmanuellMigrering() && harMigreringsbehandlingAvvikInnenforbeløpsgrenser && !harMigreringsbehandlingManuellePosteringer) || behandling.erManuellMigreringForEndreMigreringsdato()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValid
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.logg.BehandlingLoggRequest
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
+import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.FØRSTE_STEG
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
@@ -58,6 +59,7 @@ class BehandlingService(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val taskRepository: TaskRepositoryWrapper,
     private val vilkårsvurderingService: VilkårsvurderingService,
+    private val simuleringService: SimuleringService,
 ) {
 
     @Transactional
@@ -300,6 +302,17 @@ class BehandlingService(
     fun deleteMigreringsdatoVedHenleggelse(behandlingId: Long) {
         behandlingMigreringsinfoRepository.findByBehandlingId(behandlingId)
             ?.let { behandlingMigreringsinfoRepository.delete(it) }
+    }
+
+    fun skalAutomatiskBesluttes(behandling: Behandling): Boolean {
+        val harMigreringsbehandlingAvvikInnenforbeløpsgrenser by lazy {
+            simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
+        }
+
+        val harMigreringsbehandlingManuellePosteringer by lazy {
+            simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
+        }
+        return (behandling.erHelmanuellMigrering() && harMigreringsbehandlingAvvikInnenforbeløpsgrenser && !harMigreringsbehandlingManuellePosteringer) || behandling.erManuellMigreringForEndreMigreringsdato()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -66,17 +66,12 @@ class BeslutteVedtak(
             )
         }
 
-        val behandlingErAutomatiskBesluttet =
-            (
-                behandling.erHelmanuellMigrering() && simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(
-                    behandling,
-                ) && !simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
-                ) || behandling.erManuellMigreringForEndreMigreringsdato()
+        val skalAutomatiskBesluttes = behandlingService.skalAutomatiskBesluttes(behandling)
 
         val beslutter =
-            if (behandlingErAutomatiskBesluttet) SikkerhetContext.SYSTEM_NAVN else saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+            if (skalAutomatiskBesluttes) SikkerhetContext.SYSTEM_NAVN else saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
         val beslutterId =
-            if (behandlingErAutomatiskBesluttet) SikkerhetContext.SYSTEM_FORKORTELSE else SikkerhetContext.hentSaksbehandler()
+            if (skalAutomatiskBesluttes) SikkerhetContext.SYSTEM_FORKORTELSE else SikkerhetContext.hentSaksbehandler()
 
         val totrinnskontroll = totrinnskontrollService.besluttTotrinnskontroll(
             behandling = behandling,
@@ -89,7 +84,7 @@ class BeslutteVedtak(
         opprettTaskFerdigstillGodkjenneVedtak(
             behandling = behandling,
             beslutning = data,
-            behandlingErAutomatiskBesluttet = behandlingErAutomatiskBesluttet,
+            behandlingErAutomatiskBesluttet = skalAutomatiskBesluttes,
         )
 
         return if (data.beslutning.erGodkjent()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
@@ -14,7 +15,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -42,7 +42,7 @@ class BeslutteVedtak(
     private val featureToggleService: FeatureToggleService,
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val saksbehandlerContext: SaksbehandlerContext,
-    private val simuleringService: SimuleringService,
+    private val automatiskBeslutningService: AutomatiskBeslutningService,
 ) : BehandlingSteg<RestBeslutningPåVedtak> {
 
     override fun utførStegOgAngiNeste(
@@ -66,7 +66,8 @@ class BeslutteVedtak(
             )
         }
 
-        val behandlingSkalAutomatiskBesluttes = behandlingService.behandlingSkalAutomatiskBesluttes(behandling)
+        val behandlingSkalAutomatiskBesluttes =
+            automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)
 
         val beslutter =
             if (behandlingSkalAutomatiskBesluttes) SikkerhetContext.SYSTEM_NAVN else saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -66,12 +66,12 @@ class BeslutteVedtak(
             )
         }
 
-        val skalAutomatiskBesluttes = behandlingService.skalAutomatiskBesluttes(behandling)
+        val behandlingSkalAutomatiskBesluttes = behandlingService.behandlingSkalAutomatiskBesluttes(behandling)
 
         val beslutter =
-            if (skalAutomatiskBesluttes) SikkerhetContext.SYSTEM_NAVN else saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+            if (behandlingSkalAutomatiskBesluttes) SikkerhetContext.SYSTEM_NAVN else saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
         val beslutterId =
-            if (skalAutomatiskBesluttes) SikkerhetContext.SYSTEM_FORKORTELSE else SikkerhetContext.hentSaksbehandler()
+            if (behandlingSkalAutomatiskBesluttes) SikkerhetContext.SYSTEM_FORKORTELSE else SikkerhetContext.hentSaksbehandler()
 
         val totrinnskontroll = totrinnskontrollService.besluttTotrinnskontroll(
             behandling = behandling,
@@ -84,7 +84,7 @@ class BeslutteVedtak(
         opprettTaskFerdigstillGodkjenneVedtak(
             behandling = behandling,
             beslutning = data,
-            behandlingErAutomatiskBesluttet = skalAutomatiskBesluttes,
+            behandlingErAutomatiskBesluttet = behandlingSkalAutomatiskBesluttes,
         )
 
         return if (data.beslutning.erGodkjent()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -67,11 +67,7 @@ class SendTilBeslutter(
     ): StegType {
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
-        // oppretter ikke GodkjenneVedtak task for manuell migrering som har avvik innenfor beløpsgrenser eller manuelle posteringer
-        if (!behandling.erManuellMigrering() || simuleringService.harMigreringsbehandlingManuellePosteringer(
-                behandling,
-            ) || !simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
-        ) {
+        if (!behandlingService.skalAutomatiskBesluttes(behandling)) {
             val godkjenneVedtakTask = OpprettOppgaveTask.opprettTask(
                 behandlingId = behandling.id,
                 oppgavetype = Oppgavetype.GodkjenneVedtak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -67,7 +67,7 @@ class SendTilBeslutter(
     ): StegType {
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
-        if (!behandlingService.skalAutomatiskBesluttes(behandling)) {
+        if (!behandlingService.behandlingSkalAutomatiskBesluttes(behandling)) {
             val godkjenneVedtakTask = OpprettOppgaveTask.opprettTask(
                 behandlingId = behandling.id,
                 oppgavetype = Oppgavetype.GodkjenneVedtak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -5,13 +5,13 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
@@ -34,7 +34,7 @@ class SendTilBeslutter(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val vedtakService: VedtakService,
     private val vedtaksperiodeService: VedtaksperiodeService,
-    private val simuleringService: SimuleringService,
+    private val automatiskBeslutningService: AutomatiskBeslutningService,
 ) : BehandlingSteg<String> {
 
     override fun preValiderSteg(
@@ -67,7 +67,7 @@ class SendTilBeslutter(
     ): StegType {
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
-        if (!behandlingService.behandlingSkalAutomatiskBesluttes(behandling)) {
+        if (!automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)) {
             val godkjenneVedtakTask = OpprettOppgaveTask.opprettTask(
                 behandlingId = behandling.id,
                 oppgavetype = Oppgavetype.GodkjenneVedtak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -308,7 +308,7 @@ class StegService(
             behandlingSteg.utførStegOgAngiNeste(behandling, behandlendeEnhet)
         }
 
-        if (behandlingService.skalAutomatiskBesluttes(behandling)) {
+        if (behandlingService.behandlingSkalAutomatiskBesluttes(behandling)) {
             return håndterBeslutningForVedtak(
                 behandlingEtterBeslutterSteg,
                 RestBeslutningPåVedtak(Beslutning.GODKJENT),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.ekstern.restDomene.writeValueAsString
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdFeedService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.SatsendringService
+import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
@@ -34,7 +35,6 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
-import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.domene.JournalførVedtaksbrevDTO
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
@@ -59,8 +59,8 @@ class StegService(
     private val tilgangService: TilgangService,
     private val infotrygdFeedService: InfotrygdFeedService,
     private val satsendringService: SatsendringService,
-    private val simuleringService: SimuleringService,
     private val personopplysningerService: PersonopplysningerService,
+    private val automatiskBeslutningService: AutomatiskBeslutningService,
 ) {
 
     private val stegSuksessMetrics: Map<StegType, Counter> = initStegMetrikker("suksess")
@@ -308,7 +308,7 @@ class StegService(
             behandlingSteg.utførStegOgAngiNeste(behandling, behandlendeEnhet)
         }
 
-        if (behandlingService.behandlingSkalAutomatiskBesluttes(behandling)) {
+        if (automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)) {
             return håndterBeslutningForVedtak(
                 behandlingEtterBeslutterSteg,
                 RestBeslutningPåVedtak(Beslutning.GODKJENT),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -308,15 +308,7 @@ class StegService(
             behandlingSteg.utførStegOgAngiNeste(behandling, behandlendeEnhet)
         }
 
-        val harMigreringsbehandlingAvvikInnenforbeløpsgrenser by lazy {
-            simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
-        }
-
-        val harMigreringsbehandlingManuellePosteringer by lazy {
-            simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
-        }
-
-        if ((behandlingEtterBeslutterSteg.erHelmanuellMigrering() && harMigreringsbehandlingAvvikInnenforbeløpsgrenser && !harMigreringsbehandlingManuellePosteringer) || behandlingEtterBeslutterSteg.erManuellMigreringForEndreMigreringsdato()) {
+        if (behandlingService.skalAutomatiskBesluttes(behandling)) {
             return håndterBeslutningForVedtak(
                 behandlingEtterBeslutterSteg,
                 RestBeslutningPåVedtak(Beslutning.GODKJENT),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/AutomatiskBeslutningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/AutomatiskBeslutningServiceTest.kt
@@ -1,0 +1,101 @@
+package no.nav.familie.ba.sak.kjerne.behandling
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
+import no.nav.familie.ba.sak.kjerne.simulering.lagBehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+@ExtendWith(MockKExtension::class)
+class AutomatiskBeslutningServiceTest {
+    @MockK
+    private lateinit var simuleringService: SimuleringService
+
+    @InjectMockKs
+    private lateinit var automatiskBeslutningService: AutomatiskBeslutningService
+
+    @Test
+    fun `behandlingSkalAutomatiskBesluttes - skal returnere true dersom behandling er helmanuell migrering med avvik innenfor beløpsgrenser og det ikke finnes manuelle posteringer`() {
+        val behandling = lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+        )
+        every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns true
+        every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns false
+
+        assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isTrue
+    }
+
+    @Test
+    fun `behandlingSkalAutomatiskBesluttes - skal returnere true dersom behandling er endre migreringsdato behandling`() {
+        val behandling = lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
+        )
+
+        assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isTrue
+    }
+
+    @Test
+    fun `behandlingSkalAutomatiskBesluttes - skal returnere false dersom behandling er helmanuell migrering med avvik innenfor beløpsgrenser men det finnes manuelle posteringer`() {
+        val behandling = lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+        )
+        every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns true
+        every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns true
+
+        assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
+    }
+
+    @Test
+    fun `behandlingSkalAutomatiskBesluttes - skal returnere false dersom behandling er helmanuell migrering med avvik utenfor beløpsgrenser og det ikke finnes manuelle posteringer`() {
+        val behandling = lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+        )
+        every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns false
+        every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns false
+
+        assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
+    }
+
+    @Test
+    fun `behandlingSkalAutomatiskBesluttes - skal returnere false dersom behandling er helmanuell migrering med avvik utenfor beløpsgrenser og det finnes manuelle posteringer`() {
+        val behandling = lagBehandling(
+            behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+        )
+        every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns false
+        every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns true
+
+        assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BehandlingÅrsak::class, names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"])
+    fun `behandlingSkalAutomatiskBesluttes - skal returnere false dersom behandling ikke er migrering uavhengig av avvik og manuelle posteringer`(
+        behandlingÅrsak: BehandlingÅrsak,
+    ) {
+        BehandlingType.values().filter {
+            !listOf(
+                BehandlingType.MIGRERING_FRA_INFOTRYGD,
+                BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT,
+            ).contains(it)
+        }.forEach { behandlingType ->
+            val behandling = lagBehandling(
+                behandlingType = behandlingType,
+                årsak = behandlingÅrsak,
+            )
+            assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
+import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
@@ -48,6 +49,7 @@ class LagreMigreringsdatoTest {
     val taskRepository = mockk<TaskRepositoryWrapper>()
     val behandlingMigreringsinfoRepository = mockk<BehandlingMigreringsinfoRepository>()
     val vilkårsvurderingService = mockk<VilkårsvurderingService>()
+    val simuleringService = mockk<SimuleringService>()
 
     private val behandlingService = BehandlingService(
         behandlingHentOgPersisterService,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -123,6 +123,7 @@ class BeslutteVedtakTest {
         mockkObject(FerdigstillOppgaver.Companion)
         every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
         every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
+        every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -150,6 +151,8 @@ class BeslutteVedtakTest {
                 any(),
             )
         } returns Task(OpprettOppgaveTask.TASK_STEP_TYPE, "")
+
+        every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -186,6 +189,8 @@ class BeslutteVedtakTest {
             )
         } returns Task(OpprettOppgaveTask.TASK_STEP_TYPE, "")
 
+        every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
         verify(exactly = 1) { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling) }
@@ -215,6 +220,8 @@ class BeslutteVedtakTest {
             OpprettOppgaveTask.TASK_STEP_TYPE,
             "",
         )
+
+        every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
 
         beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
         verify(exactly = 1) { behandlingService.opprettOgInitierNyttVedtakForBehandling(behandling, true, emptyList()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -52,6 +53,7 @@ class BeslutteVedtakTest {
     private lateinit var featureToggleService: FeatureToggleService
     private lateinit var tilkjentYtelseValideringService: TilkjentYtelseValideringService
     private lateinit var simuleringService: SimuleringService
+    private lateinit var automatiskBeslutningService: AutomatiskBeslutningService
 
     private val saksbehandlerContext = mockk<SaksbehandlerContext>()
 
@@ -69,6 +71,7 @@ class BeslutteVedtakTest {
         featureToggleService = mockk()
         tilkjentYtelseValideringService = mockk()
         simuleringService = mockk()
+        automatiskBeslutningService = mockk()
 
         val loggService = mockk<LoggService>()
 
@@ -104,7 +107,7 @@ class BeslutteVedtakTest {
             featureToggleService,
             tilkjentYtelseValideringService,
             saksbehandlerContext,
-            simuleringService,
+            automatiskBeslutningService,
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -41,8 +41,8 @@ internal class StegServiceTest {
         tilgangService = mockk(relaxed = true),
         infotrygdFeedService = mockk(),
         satsendringService = satsendringService,
-        simuleringService = simuleringService,
         personopplysningerService = mockk(),
+        automatiskBeslutningService = mockk(),
     )
 
     @BeforeEach


### PR DESCRIPTION
Favro: [NAV-13778](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13778)

### 💰 Hva skal gjøres, og hvorfor?
Etter at totrinnskontroll gikk fra å være manuell til å bli automatisk for "Endre migreringsdato"-behandlinger ble det fortsatt opprettet manuell "GodkjennVedtak"-oppgave. 

Denne PR'en sørger for at "GodkjennVedtak"-oppgave ikke opprettes for "Endre migreringsdato"-behandlinger. Har også flyttet kode som bestemmer om en behandling skal automatisk besluttes eller ikke inn i den nye servicen`AutomatiskBeslutningService` slik at vi slipper duplisert kode for dette som kan være vanskelig å huske på å oppdatere ved fremtidige endringer i logikk. Koden for dette ble ikke lagt i en allerede eksisterende service da jeg fikk en del problemer med sirkulære avhengigheter da jeg forsøkte på dette.


### ✅ Checklist
- [ ] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
