### PR TITLE
Bruk fødselsdato for å finne endring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIEndretUtbetalingAndelUtil
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIKompetanseUtil
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIVilkårsvurderingUtil
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
@@ -36,6 +37,8 @@ object BehandlingsresultatEndringUtils {
         forrigePersonResultat: Set<PersonResultat>,
         nåværendeEndretAndeler: List<EndretUtbetalingAndel>,
         forrigeEndretAndeler: List<EndretUtbetalingAndel>,
+        personerIBehandling: Set<Person>,
+        personerIForrigeBehandling: Set<Person>,
     ): Endringsresultat {
         val erEndringIBeløp = erEndringIBeløp(
             nåværendeAndeler = nåværendeAndeler,
@@ -52,6 +55,8 @@ object BehandlingsresultatEndringUtils {
         val erEndringIVilkårsvurdering = erEndringIVilkårsvurdering(
             nåværendePersonResultat = nåværendePersonResultat,
             forrigePersonResultat = forrigePersonResultat,
+            personerIBehandling = personerIBehandling,
+            personerIForrigeBehandling = personerIForrigeBehandling,
         )
 
         val erEndringIEndretUtbetalingAndeler = erEndringIEndretUtbetalingAndeler(
@@ -143,10 +148,14 @@ object BehandlingsresultatEndringUtils {
     internal fun erEndringIVilkårsvurdering(
         nåværendePersonResultat: Set<PersonResultat>,
         forrigePersonResultat: Set<PersonResultat>,
+        personerIBehandling: Set<Person>,
+        personerIForrigeBehandling: Set<Person>,
     ): Boolean {
         val endringIVilkårsvurderingTidslinje = EndringIVilkårsvurderingUtil.lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultater = nåværendePersonResultat,
             forrigePersonResultater = forrigePersonResultat,
+            personerIBehandling = personerIBehandling,
+            personerIForrigeBehandling = personerIForrigeBehandling,
         )
         return endringIVilkårsvurderingTidslinje.perioder().any { it.innhold == true }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -16,8 +16,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -132,11 +130,5 @@ class BehandlingsresultatService(
         val behandlingsresultat = BehandlingsresultatUtils.kombinerResultaterTilBehandlingsresultat(søknadsresultat, endringsresultat, opphørsresultat)
 
         return behandlingsresultat
-    }
-
-    companion object {
-
-        private val logger: Logger = LoggerFactory.getLogger(BehandlingsresultatService::class.java)
-        private val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -71,6 +71,9 @@ class BehandlingsresultatService(
 
         val vilkårsvurdering = vilkårsvurderingService.hentAktivForBehandlingThrows(behandlingId = behandlingId)
 
+        val personerIBehandling = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id).personer.toSet()
+        val personerIForrigeBehandling = forrigeBehandling?.let { persongrunnlagService.hentAktivThrows(behandlingId = forrigeBehandling.id).personer.toSet() } ?: emptySet()
+
         val personerFremstiltKravFor = finnPersonerFremstiltKravFor(
             behandling = behandling,
             søknadDTO = søknadDTO,
@@ -110,6 +113,8 @@ class BehandlingsresultatService(
                 nåværendeKompetanser = kompetanser.toList(),
                 forrigeKompetanser = forrigeKompetanser.toList(),
                 personerFremstiltKravFor = personerFremstiltKravFor,
+                personerIBehandling = personerIBehandling,
+                personerIForrigeBehandling = personerIForrigeBehandling,
             )
         } else {
             Endringsresultat.INGEN_ENDRING

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/endringstidspunkt/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/endringstidspunkt/EndringstidspunktService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIEndretUtbetalingAn
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIKompetanseUtil
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIVilkårsvurderingUtil
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -23,6 +24,7 @@ class EndringstidspunktService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingAndelHentOgPersisterService: EndretUtbetalingAndelHentOgPersisterService,
     private val vilkårsvurderingService: VilkårsvurderingService,
+    private val persongrunnlagService: PersongrunnlagService,
 ) {
     @Deprecated("Skal bruke VedtaksperiodeService.finnEndringstidspunktForBehandling()")
     fun finnEndringstidspunktForBehandling(behandlingId: Long): LocalDate {
@@ -79,9 +81,14 @@ class EndringstidspunktService(
         val nåværendeVilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandlingId = inneværendeBehandlingId) ?: return null
         val forrigeVilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandlingId = forrigeBehandlingId) ?: return null
 
+        val personerIBehandling = persongrunnlagService.hentAktivThrows(behandlingId = inneværendeBehandlingId).personer.toSet()
+        val personerIForrigeBehandling = persongrunnlagService.hentAktivThrows(behandlingId = forrigeBehandlingId).personer.toSet()
+
         return EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
             nåværendePersonResultat = nåværendeVilkårsvurdering.personResultater,
             forrigePersonResultat = forrigeVilkårsvurdering.personResultater,
+            personerIBehandling = personerIBehandling,
+            personerIForrigeBehandling = personerIForrigeBehandling,
         )
     }
     private fun finnEndringstidspunktForEndretUtbetalingAndel(inneværendeBehandlingId: Long, forrigeBehandlingId: Long): YearMonth? {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -43,7 +43,7 @@ object EndringIVilkårsvurderingUtil {
 
         val tidslinjerPerPersonOgVilkår = allePersonerMedPersonResultat.flatMap { aktør ->
             val personIBehandling = personerIBehandling.single { it.aktør == aktør }
-            val personIForrigeBehandling = personerIForrigeBehandling.single { it.aktør == aktør }
+            val personIForrigeBehandling = personerIForrigeBehandling.singleOrNull { it.aktør == aktør }
 
             Vilkår.values().map { vilkår ->
                 lagEndringIVilkårsvurderingForPersonOgVilkårTidslinje(
@@ -78,13 +78,13 @@ object EndringIVilkårsvurderingUtil {
         forrigeOppfylteVilkårResultater: List<VilkårResultat>,
         vilkår: Vilkår,
         personIBehandling: Person,
-        personIForrigeBehandling: Person,
+        personIForrigeBehandling: Person?,
     ): Tidslinje<Boolean, Måned> {
         val nåværendeVilkårResultatTidslinje = nåværendeOppfylteVilkårResultater
             .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIBehandling.fødselsdato)
 
         val tidligereVilkårResultatTidslinje = forrigeOppfylteVilkårResultater
-            .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIForrigeBehandling.fødselsdato)
+            .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIForrigeBehandling?.fødselsdato)
 
         val endringIVilkårResultat =
             nåværendeVilkårResultatTidslinje.kombinerUtenNullMed(tidligereVilkårResultatTidslinje) { nåværende, forrige ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunkt
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinjeForOppfyltVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -19,10 +19,14 @@ object EndringIVilkårsvurderingUtil {
     fun utledEndringstidspunktForVilkårsvurdering(
         nåværendePersonResultat: Set<PersonResultat>,
         forrigePersonResultat: Set<PersonResultat>,
+        personerIBehandling: Set<Person>,
+        personerIForrigeBehandling: Set<Person>,
     ): YearMonth? {
         val endringIVilkårsvurderingTidslinje = lagEndringIVilkårsvurderingTidslinje(
             nåværendePersonResultater = nåværendePersonResultat,
             forrigePersonResultater = forrigePersonResultat,
+            personerIBehandling = personerIBehandling,
+            personerIForrigeBehandling = personerIForrigeBehandling,
         )
 
         return endringIVilkårsvurderingTidslinje.tilFørsteEndringstidspunkt()
@@ -31,11 +35,16 @@ object EndringIVilkårsvurderingUtil {
     fun lagEndringIVilkårsvurderingTidslinje(
         nåværendePersonResultater: Set<PersonResultat>,
         forrigePersonResultater: Set<PersonResultat>,
+        personerIBehandling: Set<Person>,
+        personerIForrigeBehandling: Set<Person>,
     ): Tidslinje<Boolean, Måned> {
         val allePersonerMedPersonResultat =
             (nåværendePersonResultater.map { it.aktør } + forrigePersonResultater.map { it.aktør }).distinct()
 
         val tidslinjerPerPersonOgVilkår = allePersonerMedPersonResultat.flatMap { aktør ->
+            val personIBehandling = personerIBehandling.single { it.aktør == aktør }
+            val personIForrigeBehandling = personerIForrigeBehandling.single { it.aktør == aktør }
+
             Vilkår.values().map { vilkår ->
                 lagEndringIVilkårsvurderingForPersonOgVilkårTidslinje(
                     nåværendeOppfylteVilkårResultater = nåværendePersonResultater
@@ -47,6 +56,8 @@ object EndringIVilkårsvurderingUtil {
                         .flatMap { it.vilkårResultater }
                         .filter { it.vilkårType == vilkår && it.resultat == Resultat.OPPFYLT },
                     vilkår = vilkår,
+                    personIBehandling = personIBehandling,
+                    personIForrigeBehandling = personIForrigeBehandling,
                 )
             }
         }
@@ -66,35 +77,20 @@ object EndringIVilkårsvurderingUtil {
         nåværendeOppfylteVilkårResultater: List<VilkårResultat>,
         forrigeOppfylteVilkårResultater: List<VilkårResultat>,
         vilkår: Vilkår,
+        personIBehandling: Person,
+        personIForrigeBehandling: Person,
     ): Tidslinje<Boolean, Måned> {
-        // Antar fødselsdato er første oppfylte fom for 18-årsvilkåret.
-        // Denne koden er ikke i bruk i prod og skal fjernes når denne toggelen:
-        // https://unleash.nais.io/#/features/strategies/familie-ba-sak.endringstidspunkt
-        // har levd lenge nok
-        val nåværendeVilkårResultatTidslinje =
-            if (nåværendeOppfylteVilkårResultater.isNotEmpty()) {
-                nåværendeOppfylteVilkårResultater.tilForskjøvetTidslinjeForOppfyltVilkår(
-                    vilkår = vilkår,
-                    fødselsdato = nåværendeOppfylteVilkårResultater.mapNotNull { it.periodeFom }.minOrNull(),
-                )
-            } else {
-                tidslinje { emptyList() }
-            }
+        val nåværendeVilkårResultatTidslinje = nåværendeOppfylteVilkårResultater
+            .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIBehandling.fødselsdato)
 
-        val tidligereVilkårResultatTidslinje =
-            if (forrigeOppfylteVilkårResultater.isNotEmpty()) {
-                forrigeOppfylteVilkårResultater.tilForskjøvetTidslinjeForOppfyltVilkår(
-                    vilkår = vilkår,
-                    fødselsdato = forrigeOppfylteVilkårResultater.mapNotNull { it.periodeFom }.minOrNull(),
-                )
-            } else {
-                tidslinje { emptyList() }
-            }
+        val tidligereVilkårResultatTidslinje = forrigeOppfylteVilkårResultater
+            .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIForrigeBehandling.fødselsdato)
 
         val endringIVilkårResultat =
             nåværendeVilkårResultatTidslinje.kombinerUtenNullMed(tidligereVilkårResultatTidslinje) { nåværende, forrige ->
 
-                val erEndringerIUtdypendeVilkårsvurdering = nåværende.utdypendeVilkårsvurderinger.toSet() != forrige.utdypendeVilkårsvurderinger.toSet()
+                val erEndringerIUtdypendeVilkårsvurdering =
+                    nåværende.utdypendeVilkårsvurderinger.toSet() != forrige.utdypendeVilkårsvurderinger.toSet()
                 val erEndringerIRegelverk = nåværende.vurderesEtter != forrige.vurderesEtter
                 val erVilkårSomErSplittetOpp = nåværende.periodeFom != forrige.periodeFom
 
@@ -118,6 +114,7 @@ object EndringIVilkårsvurderingUtil {
                 Vilkår.BOSATT_I_RIKET,
                 Vilkår.BOR_MED_SØKER,
                 -> true
+
                 Vilkår.UNDER_18_ÅR,
                 Vilkår.LOVLIG_OPPHOLD,
                 Vilkår.GIFT_PARTNERSKAP,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
@@ -68,6 +69,8 @@ object VilkårsvurderingForskyvningUtils {
     }
 
     fun Collection<VilkårResultat>.tilForskjøvetTidslinjeForOppfyltVilkår(vilkår: Vilkår, fødselsdato: LocalDate?): Tidslinje<VilkårResultat, Måned> {
+        if (this.isEmpty()) return TomTidslinje()
+
         val tidslinje = this.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår)
 
         return tidslinje.beskjærPå18ÅrHvisUnder18ÅrVilkår(vilkår = vilkår, fødselsdato = fødselsdato)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -62,6 +62,8 @@ class BehandlingsresultatEndringUtilsTest {
             forrigePersonResultat = emptySet(),
             nåværendeEndretAndeler = emptyList(),
             forrigeEndretAndeler = emptyList(),
+            personerIBehandling = emptySet(),
+            personerIForrigeBehandling = emptySet(),
         )
 
         assertThat(endringsresultat, Is(Endringsresultat.INGEN_ENDRING))
@@ -87,6 +89,8 @@ class BehandlingsresultatEndringUtilsTest {
             forrigePersonResultat = emptySet(),
             nåværendeEndretAndeler = emptyList(),
             forrigeEndretAndeler = emptyList(),
+            personerIBehandling = emptySet(),
+            personerIForrigeBehandling = emptySet(),
         )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -94,6 +98,8 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i vilkårsvurderingen`() {
+        val fødselsdato = LocalDate.of(2015, 1, 1)
+        val barn = lagPerson(aktør = barn1Aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
         val forrigeAndeler = listOf(
             lagAndelTilkjentYtelse(
                 fom = YearMonth.of(2015, 2),
@@ -113,7 +119,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -130,7 +136,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -167,6 +173,8 @@ class BehandlingsresultatEndringUtilsTest {
             nåværendePersonResultat = setOf(nåværendePersonResultat),
             nåværendeEndretAndeler = emptyList(),
             forrigeEndretAndeler = emptyList(),
+            personerIBehandling = setOf(barn),
+            personerIForrigeBehandling = setOf(barn),
         )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -200,6 +208,8 @@ class BehandlingsresultatEndringUtilsTest {
             forrigePersonResultat = emptySet(),
             nåværendeEndretAndeler = emptyList(),
             forrigeEndretAndeler = emptyList(),
+            personerIBehandling = emptySet(),
+            personerIForrigeBehandling = emptySet(),
         )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -227,6 +237,8 @@ class BehandlingsresultatEndringUtilsTest {
             forrigePersonResultat = emptySet(),
             forrigeEndretAndeler = listOf(forrigeEndretAndel),
             nåværendeEndretAndeler = listOf(forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)),
+            personerIBehandling = emptySet(),
+            personerIForrigeBehandling = emptySet(),
         )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -937,12 +949,13 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere false dersom vilkårresultatene er helt like`() {
+        val fødselsdato = LocalDate.of(2015, 1, 1)
         val nåværendeVilkårResultat = setOf(
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -973,7 +986,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -1000,10 +1013,13 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val aktør = randomAktør()
+        val barn = lagPerson(aktør = aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
             forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
+            personerIBehandling = setOf(barn),
+            personerIForrigeBehandling = setOf(barn),
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(false))
@@ -1011,12 +1027,13 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere true dersom det har vært endringer i regelverk`() {
+        val fødselsdato = LocalDate.of(2015, 1, 1)
         val nåværendeVilkårResultat = setOf(
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -1033,7 +1050,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -1046,10 +1063,13 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val aktør = randomAktør()
+        val barn = lagPerson(aktør = aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
             forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
+            personerIBehandling = setOf(barn),
+            personerIForrigeBehandling = setOf(barn),
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1057,12 +1077,13 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere true dersom det har vært endringer i utdypendevilkårsvurdering`() {
+        val fødselsdato = LocalDate.of(2015, 1, 1)
         val nåværendeVilkårResultat = setOf(
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -1078,7 +1099,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -1091,10 +1112,13 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val aktør = randomAktør()
+        val barn = lagPerson(aktør = aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
             forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
+            personerIBehandling = setOf(barn),
+            personerIForrigeBehandling = setOf(barn),
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1102,12 +1126,13 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere true dersom det har oppstått splitt i vilkårsvurderingen`() {
+        val fødselsdato = jan22.førsteDagIInneværendeMåned()
         val forrigeVilkårResultat = setOf(
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = jan22.førsteDagIInneværendeMåned(),
+                periodeFom = fødselsdato,
                 periodeTom = null,
                 begrunnelse = "",
                 behandlingId = 0,
@@ -1121,7 +1146,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = jan22.førsteDagIInneværendeMåned(),
+                periodeFom = fødselsdato,
                 periodeTom = mai22.atDay(7),
                 begrunnelse = "",
                 behandlingId = 0,
@@ -1142,10 +1167,13 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val aktør = randomAktør()
+        val barn = lagPerson(aktør = aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
             forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
+            personerIBehandling = setOf(barn),
+            personerIForrigeBehandling = setOf(barn),
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(true))
@@ -1153,12 +1181,13 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere false hvis det kun er opphørt`() {
+        val fødselsdato = LocalDate.of(2015, 1, 1)
         val nåværendeVilkårResultat = setOf(
             VilkårResultat(
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = LocalDate.of(2020, 1, 1),
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -1175,7 +1204,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personResultat = null,
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
-                periodeFom = LocalDate.of(2015, 1, 1),
+                periodeFom = fødselsdato,
                 periodeTom = null,
                 begrunnelse = "begrunnelse",
                 behandlingId = 0,
@@ -1188,10 +1217,13 @@ class BehandlingsresultatEndringUtilsTest {
         )
 
         val aktør = randomAktør()
+        val barn = lagPerson(aktør = aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
 
         val erEndringIVilkårvurderingForPerson = erEndringIVilkårsvurdering(
             nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
             forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
+            personerIBehandling = setOf(barn),
+            personerIForrigeBehandling = setOf(barn),
         )
 
         assertThat(erEndringIVilkårvurderingForPerson, Is(false))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
@@ -32,7 +32,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
@@ -252,21 +251,20 @@ class VilkårsvurderingForskyvningUtilsTest {
     }
 
     @Test
-    fun `Skal ikke kaste feil dersom vi ikke sender med noen vilkårresultater`() {
+    fun `Skal gi tom liste og ikke kaste feil dersom vi ikke sender med noen vilkårresultater`() {
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
-        assertDoesNotThrow {
-            emptyList<VilkårResultat>().tilForskjøvetTidslinjeForOppfyltVilkår(
-                vilkår = Vilkår.UNDER_18_ÅR,
-                barn.fødselsdato,
-            )
-        }
-        assertDoesNotThrow {
-            emptyList<VilkårResultat>().tilForskjøvetTidslinje(
-                vilkår = Vilkår.UNDER_18_ÅR,
-                barn.fødselsdato,
-            )
-        }
+        val forskjøvedeOppfylteVilkårTomListe = emptyList<VilkårResultat>().tilForskjøvetTidslinjeForOppfyltVilkår(
+            vilkår = Vilkår.UNDER_18_ÅR,
+            fødselsdato = barn.fødselsdato,
+        ).perioder()
+        Assertions.assertEquals(forskjøvedeOppfylteVilkårTomListe.size, 0)
+
+        val forskjøvedeVilkårTomListe = emptyList<VilkårResultat>().tilForskjøvetTidslinje(
+            vilkår = Vilkår.UNDER_18_ÅR,
+            fødselsdato = barn.fødselsdato,
+        ).perioder()
+        Assertions.assertEquals(forskjøvedeVilkårTomListe.size, 0)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ser at kode jeg trodde lå bak toggle og skulle bort brukes flere steder enn jeg antok. Vi må derfor sende fødselsdagen til personene ned til funksjonen. 

Endrer så vi sender med fødselsdagen til funksjonen som forskyver vilkårene slik at vi kan beskjære vilkårene etter 18-årsdagen basert på fødselsdagen og ikke vilkårene. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
