### PR TITLE
Autovedtak fødselshendelse: behandlingstype kan ikke være førstegangsbehandling dersom fagsak har status avsluttet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -184,7 +184,7 @@ class StegService(
         return håndterNyBehandlingOgSendInfotrygdFeed(
             NyBehandling(
                 søkersIdent = nyBehandlingHendelse.morsIdent,
-                behandlingType = if (fagsak.status == FagsakStatus.LØPENDE) {
+                behandlingType = if (fagsak.status in listOf(FagsakStatus.LØPENDE, FagsakStatus.AVSLUTTET)) {
                     BehandlingType.REVURDERING
                 } else {
                     BehandlingType.FØRSTEGANGSBEHANDLING


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi ser to feilede autovedtak av fødselshendelser den siste uka, der mor har en fagsak med status avsluttet. Allikevel blir behandlingen som opprettes av autovedtakprosessen en førstegangsbehandling. Det blir feil, korrekt behandlingstype vil være revurdering. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
