### PR TITLE
sammenlign uten fom og tom for VilkårResultatForVedtaksperiode når vi…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForP
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonIkkeInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForVedtaksperioder
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.sammenlignUtenFomOgTom
 import java.time.LocalDate
 
 fun utledEndringstidspunkt(
@@ -119,7 +120,9 @@ private fun GrunnlagForPerson?.erLik(
 ): Boolean = when (this) {
     is GrunnlagForPersonInnvilget ->
         grunnlagForVedtaksperiodeForrigeBehandling is GrunnlagForPersonInnvilget &&
-            this.vilkårResultaterForVedtaksperiode.toSet() == grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode.toSet() &&
+            this.vilkårResultaterForVedtaksperiode.sammenlignUtenFomOgTom(
+                grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode,
+            ) &&
             this.kompetanse == grunnlagForVedtaksperiodeForrigeBehandling.kompetanse &&
             this.endretUtbetalingAndel == grunnlagForVedtaksperiodeForrigeBehandling.endretUtbetalingAndel &&
             this.overgangsstønad == grunnlagForVedtaksperiodeForrigeBehandling.overgangsstønad &&

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -66,7 +66,10 @@ private fun loggEndringstidspunktOgEndringer(
     when (grunnlagIPeriodeMedEndring) {
         is GrunnlagForPersonInnvilget -> {
             if (grunnlagIPeriodeMedEndringForrigeBehanlding is GrunnlagForPersonInnvilget) {
-                if (grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.toSet() == grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode.toSet()) {
+                if (grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.sammenlignUtenFomOgTom(
+                        grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode,
+                    )
+                ) {
                     endringer.add("Endring i vilkårene")
                 }
                 if (grunnlagIPeriodeMedEndring.kompetanse == grunnlagIPeriodeMedEndringForrigeBehanlding.kompetanse) {
@@ -88,7 +91,10 @@ private fun loggEndringstidspunktOgEndringer(
 
         is GrunnlagForPersonIkkeInnvilget ->
             if (grunnlagIPeriodeMedEndringForrigeBehanlding is GrunnlagForPersonIkkeInnvilget) {
-                if (grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.toSet() == grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode.toSet()) {
+                if (grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.sammenlignUtenFomOgTom(
+                        grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode,
+                    )
+                ) {
                     endringer.add("Endring i vilkårene")
                 }
             } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
@@ -85,26 +85,6 @@ fun List<VilkårResultatForVedtaksperiode>.sammenlignUtenFomOgTom(other: List<Vi
     return this.map { it.copy(fom = null, tom = null) }.toSet() == other.map { it.copy(fom = null, tom = null) }.toSet()
 }
 
-private data class ComparableVilkårResultat(
-    val vilkårType: Vilkår,
-    val resultat: Resultat,
-    val utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering>,
-    val vurderesEtter: Regelverk?,
-    val erEksplisittAvslagPåSøknad: Boolean?,
-    val standardbegrunnelser: List<IVedtakBegrunnelse>,
-    val aktørId: AktørId,
-) {
-    constructor(vilkårResultat: VilkårResultatForVedtaksperiode) : this(
-        vilkårType = vilkårResultat.vilkårType,
-        resultat = vilkårResultat.resultat,
-        utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger,
-        vurderesEtter = vilkårResultat.vurderesEtter,
-        erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
-        standardbegrunnelser = vilkårResultat.standardbegrunnelser,
-        aktørId = vilkårResultat.aktørId,
-    )
-}
-
 data class EndretUtbetalingAndelForVedtaksperiode(
     val prosent: BigDecimal,
     val årsak: Årsak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
@@ -81,6 +81,30 @@ data class VilkårResultatForVedtaksperiode(
     )
 }
 
+fun List<VilkårResultatForVedtaksperiode>.sammenlignUtenFomOgTom(other: List<VilkårResultatForVedtaksperiode>): Boolean {
+    return this.map { ComparableVilkårResultat(it) }.toSet() == other.map { ComparableVilkårResultat(it) }.toSet()
+}
+
+private data class ComparableVilkårResultat(
+    val vilkårType: Vilkår,
+    val resultat: Resultat,
+    val utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering>,
+    val vurderesEtter: Regelverk?,
+    val erEksplisittAvslagPåSøknad: Boolean?,
+    val standardbegrunnelser: List<IVedtakBegrunnelse>,
+    val aktørId: AktørId,
+) {
+    constructor(vilkårResultat: VilkårResultatForVedtaksperiode) : this(
+        vilkårType = vilkårResultat.vilkårType,
+        resultat = vilkårResultat.resultat,
+        utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger,
+        vurderesEtter = vilkårResultat.vurderesEtter,
+        erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
+        standardbegrunnelser = vilkårResultat.standardbegrunnelser,
+        aktørId = vilkårResultat.aktørId,
+    )
+}
+
 data class EndretUtbetalingAndelForVedtaksperiode(
     val prosent: BigDecimal,
     val årsak: Årsak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
@@ -82,7 +82,7 @@ data class VilkårResultatForVedtaksperiode(
 }
 
 fun List<VilkårResultatForVedtaksperiode>.sammenlignUtenFomOgTom(other: List<VilkårResultatForVedtaksperiode>): Boolean {
-    return this.map { ComparableVilkårResultat(it) }.toSet() == other.map { ComparableVilkårResultat(it) }.toSet()
+    return this.map { it.copy(fom = null, tom = null) }.toSet() == other.map { it.copy(fom = null, tom = null) }.toSet()
 }
 
 private data class ComparableVilkårResultat(


### PR DESCRIPTION
… skal finne siste endrigstidspunkt

### 💰 Hva skal gjøres, og hvorfor?
https://sentry.gc.nav.no/organizations/nav/issues/447639/?project=112&referrer=slack
Får flere feil i prod siden vi får flere perioder ved rent opphør og en validering feiler. 

Ønsker å ikke sammenligne fom og tom på vedtaksResultater siden en endring i f.eks. tom vil gi utslag i en tidligere periode i så fall. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?tere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
