### PR TITLE
erLik() sammenlinger om perioder inneholder null slik at vi får perio…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -138,5 +138,5 @@ private fun GrunnlagForPerson?.erLik(
         grunnlagForVedtaksperiodeForrigeBehandling is GrunnlagForPersonIkkeInnvilget &&
             this.vilkårResultaterForVedtaksperiode.toSet() == grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode.toSet()
 
-    null -> true
+    null -> grunnlagForVedtaksperiodeForrigeBehandling == null
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -35,7 +35,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
     private var kompetanser = mutableMapOf<Long, List<Kompetanse>>()
     private var endredeUtbetalinger = mutableMapOf<Long, List<EndretUtbetalingAndel>>()
     private var andelerTilkjentYtelse = mutableMapOf<Long, List<AndelTilkjentYtelse>>()
-    private var overstyrtEndringstidspunkt = mapOf<Long, LocalDate?>()
+    private var overstyrtEndringstidspunkt = mapOf<Long, LocalDate>()
     private var overgangsstønad = mapOf<Long, List<InternPeriodeOvergangsstønad>>()
 
     private var gjeldendeBehandlingId: Long? = null
@@ -111,6 +111,23 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
             endredeUtbetalinger = endredeUtbetalinger,
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             endringstidspunkt = overstyrtEndringstidspunkt,
+            overgangsstønad = overgangsstønad,
+        )
+    }
+
+    @Når("vedtaksperioder med begrunnelser genereres der forrige behandling allerede er vedtatt for behandling {}")
+    fun `generer vedtaksperiode med begrunnelse med utledet endringstidspunkt`(behandlingId: Long) {
+        gjeldendeBehandlingId = behandlingId
+
+        vedtaksperioderMedBegrunnelser = lagVedtaksPerioderMedUtledetEndringsTidspunkt(
+            behandlingId = behandlingId,
+            vedtaksListe = vedtaksliste,
+            behandlingTilForrigeBehandling = behandlingTilForrigeBehandling,
+            personGrunnlag = persongrunnlag,
+            personResultater = personResultater,
+            kompetanser = kompetanser,
+            endredeUtbetalinger = endredeUtbetalinger,
+            andelerTilkjentYtelse = andelerTilkjentYtelse,
             overgangsstønad = overgangsstønad,
         )
     }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_endrede_utbetalinger.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_endrede_utbetalinger.feature
@@ -5,8 +5,9 @@ Egenskap: Vedtaksperioder med endrede utbetalinger
 
   Bakgrunn:
     Gitt følgende vedtak
-      | BehandlingId |
-      | 1            |
+      | BehandlingId | ForrigeBehandlingId |
+      | 1            |                     |
+      | 2            | 1                   |
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
@@ -37,3 +38,98 @@ Egenskap: Vedtaksperioder med endrede utbetalinger
       | 01.05.2020 | 30.04.2021 | Utbetaling         | Barn og søker |
       | 01.05.2021 | 31.03.2038 | Utbetaling         | Barn og søker |
       | 01.04.2038 |            | Opphør             | Kun søker     |
+
+
+  Scenario: Skal lage opphørsperiode når bor_med_søker-vilkåret ikke er oppfylt ved revurdering
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 15.12.1976  |
+      | 1            | 3456    | BARN       | 16.06.2016  |
+      | 1            | 5678    | BARN       | 11.09.2013  |
+      | 2            | 1234    | SØKER      | 15.12.1976  |
+      | 2            | 3456    | BARN       | 16.06.2016  |
+      | 2            | 5678    | BARN       | 11.09.2013  |
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                           | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                   | 15.12.1976 |            | Oppfylt  |
+      | 1234    | UTVIDET_BARNETRYGD                               | 31.05.2022 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                      | 16.06.2016 | 15.06.2034 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 16.06.2016 |            | Oppfylt  |
+      | 3456    | BOR_MED_SØKER                                    | 08.12.2021 |            | Oppfylt  |
+      | 5678    | BOSATT_I_RIKET, LOVLIG_OPPHOLD, GIFT_PARTNERSKAP | 11.09.2013 |            | Oppfylt  |
+      | 5678    | BOR_MED_SØKER                                    | 08.12.2021 |            | Oppfylt  |
+      | 5678    | UNDER_18_ÅR                                      | 11.09.2013 | 10.09.2031 | Oppfylt  |
+
+    Og lag personresultater for behandling 2
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                                           | Fra dato   | Til dato   | Resultat     |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                   | 15.12.1976 |            | Oppfylt      |
+      | 1234    | UTVIDET_BARNETRYGD                               | 31.05.2022 |            | Oppfylt      |
+      | 3456    | UNDER_18_ÅR                                      | 16.06.2016 | 15.06.2034 | Oppfylt      |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 16.06.2016 |            | Oppfylt      |
+      | 3456    | BOR_MED_SØKER                                    | 08.12.2021 |            | IKKE_OPPFYLT |
+      | 5678    | BOSATT_I_RIKET, LOVLIG_OPPHOLD, GIFT_PARTNERSKAP | 11.09.2013 |            | Oppfylt      |
+      | 5678    | BOR_MED_SØKER                                    | 08.12.2021 |            | IKKE_OPPFYLT |
+      | 5678    | UNDER_18_ÅR                                      | 11.09.2013 | 10.09.2031 | Oppfylt      |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 1234    | 31.05.2022 | 31.06.2034 | 1354  | 1            |
+      | 3456    | 08.12.2021 | 31.06.2034 | 1354  | 1            |
+      | 3456    | 08.12.2021 | 31.06.2034 | 1354  | 2            |
+      | 5678    | 08.12.2021 | 31.10.2031 | 1354  | 1            |
+      | 5678    | 08.12.2021 | 31.10.2031 | 1354  | 2            |
+
+    Når vedtaksperioder med begrunnelser genereres der forrige behandling allerede er vedtatt for behandling 2
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
+      | 01.01.2022 |          | Opphør             | Kun søker |
+
+
+  Scenario: Skal ta med etterfølgende perioder når den første endres
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 09.08.1991  |
+      | 1            | 3456    | BARN       | 31.10.2015  |
+      | 2            | 1234    | SØKER      | 09.08.1991  |
+      | 2            | 3456    | BARN       | 31.10.2015  |
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                           | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                   | 09.08.1991 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                      | 31.10.2015 | 30.10.2033 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 31.10.2015 |            | Oppfylt  |
+      | 3456    | BOR_MED_SØKER                                    | 04.05.2021 | 02.03.2023 | Oppfylt  |
+      | 3456    | BOR_MED_SØKER                                    | 03.03.2023 |            | Oppfylt  |
+
+
+    Og lag personresultater for behandling 2
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                                           | Fra dato   | Til dato   | Resultat     |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                   | 09.08.1991 |            | Oppfylt      |
+      | 3456    | UNDER_18_ÅR                                      | 31.10.2015 | 30.10.2033 | Oppfylt      |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 31.10.2015 |            | Oppfylt      |
+      | 3456    | BOR_MED_SØKER                                    | 04.05.2021 | 02.03.2023 | IKKE_OPPFYLT |
+      | 3456    | BOR_MED_SØKER                                    | 03.03.2023 |            | Oppfylt      |
+
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 1234    | 31.05.2021 | 30.10.2033 | 1354  | 1            |
+      | 3456    | 31.05.2021 | 30.10.2033 | 1354  | 1            |
+      | 3456    | 31.04.2023 | 30.10.2033 | 1354  | 2            |
+
+    Når vedtaksperioder med begrunnelser genereres der forrige behandling allerede er vedtatt for behandling 2
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar                                              |
+      | 01.06.2021 | 31.03.2023 | Opphør             | Barnet bodde ikke hos søker i denne perioden allikevel |
+      | 01.04.2023 | 30.09.2033 | Utbetaling         |                                                        |
+      | 01.10.2033 |            | Opphør             | Over 18                                                |
+


### PR DESCRIPTION
…der når ny behandling ikke er oppfylt

### 💰 Hva skal gjøres, og hvorfor?
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13856
Vi har flere tilfeller der vi ikke får vedtaksperioder siden disse filtreres vekk pga feilberegning av endringstidspunkt. Dette skyldes at vi tidligere sa at det ikke var noen endring dersom nåværende periode var null / ikke oppfylt. Dette blir feil siden nåværende periode kan være null samtidig som forrige behandling kan ha en oppfylt periode. 

Har lagt til støtte for testing av endringstidspunkt med cucumber også. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Burde alle cucumbertestene skrives om til å bruke ´vedtaksperioder med begrunnelser genereres der forrige behandling allerede er vedtatt for behandling {}´ i stedet?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
