### PR TITLE
NAV-13868 - Validering ved oppretting av ny manuell brevmottaker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/ValiderBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/ValiderBrevmottakerService.kt
@@ -2,19 +2,24 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
-import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.Brevmottaker
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import org.springframework.stereotype.Service
 
 @Service
 class ValiderBrevmottakerService(
-    private val brevmottakerService: BrevmottakerService,
+    private val brevmottakerRepository: BrevmottakerRepository,
     private val persongrunnlagService: PersongrunnlagService,
     private val familieIntegrasjonerTilgangskontrollService: FamilieIntegrasjonerTilgangskontrollService,
 ) {
-    fun validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(behandlingId: Long) {
-        val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId).takeIf { it.isNotEmpty() } ?: return
-        val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandlingId)
+    fun validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(behandlingId: Long, nyBrevmottaker: Brevmottaker? = null) {
+        var brevmottakere = brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId)
+        nyBrevmottaker?.let {
+            brevmottakere += it
+        }
+        brevmottakere.takeIf { it.isNotEmpty() } ?: return
+        val personopplysningGrunnlag = persongrunnlagService.hentAktiv(behandlingId = behandlingId) ?: return
         val personIdenter = personopplysningGrunnlag.søkerOgBarn
             .takeIf { it.isNotEmpty() }
             ?.map { it.aktør.aktivFødselsnummer() }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
@@ -83,12 +83,12 @@ class BrevmottakerService(
             .zeroSingleOrThrow {
                 FunksjonellFeil("Mottakerfeil: Det er registrert mer enn en utenlandsk adresse tilhørende bruker")
             }?.let {
-            lagMottakerInfoMedBrukerId(
-                brukerId = søkersident,
-                navn = søkersnavn,
-                manuellAdresseInfo = lagManuellAdresseInfo(it),
-            )
-        }
+                lagMottakerInfoMedBrukerId(
+                    brukerId = søkersident,
+                    navn = søkersnavn,
+                    manuellAdresseInfo = lagManuellAdresseInfo(it),
+                )
+            }
 
         // brev sendes til brukers (manuelt) registerte adresse (i utlandet)
         val bruker = manuellAdresseUtenlands ?: lagMottakerInfoMedBrukerId(brukerId = søkersident, navn = søkersnavn)
@@ -98,8 +98,8 @@ class BrevmottakerService(
             .zeroSingleOrThrow {
                 FunksjonellFeil("Mottakerfeil: ${first().type.visningsnavn} kan ikke kombineres med ${last().type.visningsnavn}")
             }?.let {
-            lagMottakerInfoUtenBrukerId(navn = it.navn, manuellAdresseInfo = lagManuellAdresseInfo(it))
-        }
+                lagMottakerInfoUtenBrukerId(navn = it.navn, manuellAdresseInfo = lagManuellAdresseInfo(it))
+            }
 
         return listOfNotNull(bruker, manuellTilleggsmottaker)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.ekstern.restDomene.RestBrevmottaker
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.kjerne.behandling.ValiderBrevmottakerService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -32,6 +33,9 @@ internal class BrevmottakerServiceTest {
 
     @MockK
     private lateinit var personopplysningerService: PersonopplysningerService
+
+    @MockK
+    private lateinit var validerBrevmottakerService: ValiderBrevmottakerService
 
     @MockK
     private lateinit var loggService: LoggService
@@ -168,6 +172,7 @@ internal class BrevmottakerServiceTest {
     fun `leggTilBrevmottaker skal lagre logg på at brevmottaker legges til`() {
         val restBrevmottaker = mockk<RestBrevmottaker>(relaxed = true)
 
+        every { validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(any(), any()) } just runs
         every { loggService.opprettBrevmottakerLogg(any(), false) } just runs
         every { brevmottakerRepository.save(any()) } returns mockk()
 


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13868

### 💰 Hva skal gjøres, og hvorfor?
Det er lagt til validering ved oppretting av manuell brevmottaker, på at det ikke er tillatt med manuelle brevmottakere dersom det fins fortrolige brukere i behandlingen (personer med adressebeskyttelse STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND). 
* Visning av feilmelding i frontend er allerede merget i familie-ba-sak-frontend PR https://github.com/navikt/familie-ba-sak-frontend/pull/2714

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
