### PR TITLE
Autovedtak: gå rett fra behandlingsresultat til iverksetting for alle fødselshendelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -197,9 +197,10 @@ class AutovedtakFødselshendelseService(
 
         val barnaSomHarBlittBehandlet =
             if (fagsak != null) {
-                behandlingHentOgPersisterService.hentBehandlinger(fagsakId = fagsak.id).filter { !it.erHenlagt() }.flatMap {
-                    persongrunnlagService.hentBarna(behandling = it).map { barn -> barn.aktør.aktivFødselsnummer() }
-                }.distinct()
+                behandlingHentOgPersisterService.hentBehandlinger(fagsakId = fagsak.id).filter { !it.erHenlagt() }
+                    .flatMap {
+                        persongrunnlagService.hentBarna(behandling = it).map { barn -> barn.aktør.aktivFødselsnummer() }
+                    }.distinct()
             } else {
                 emptyList()
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -205,7 +205,7 @@ data class Behandling(
                 resultat in listOf(Behandlingsresultat.FORTSATT_INNVILGET, Behandlingsresultat.FORTSATT_OPPHØRT) -> true
 
             skalBehandlesAutomatisk && erMigrering() && !erManuellMigreringForEndreMigreringsdato() && resultat == Behandlingsresultat.INNVILGET -> true
-            skalBehandlesAutomatisk && erFødselshendelse() && resultat == Behandlingsresultat.INNVILGET -> true
+            skalBehandlesAutomatisk && erFødselshendelse() -> true
             skalBehandlesAutomatisk && erSatsendring() && erEndringFraForrigeBehandlingSendtTilØkonomi -> true
             else -> false
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -184,7 +184,7 @@ class StegService(
         return håndterNyBehandlingOgSendInfotrygdFeed(
             NyBehandling(
                 søkersIdent = nyBehandlingHendelse.morsIdent,
-                behandlingType = if (fagsak.status in listOf(FagsakStatus.LØPENDE, FagsakStatus.AVSLUTTET)) {
+                behandlingType = if (fagsak.status == FagsakStatus.LØPENDE) {
                     BehandlingType.REVURDERING
                 } else {
                     BehandlingType.FØRSTEGANGSBEHANDLING

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -184,7 +184,7 @@ class StegService(
         return håndterNyBehandlingOgSendInfotrygdFeed(
             NyBehandling(
                 søkersIdent = nyBehandlingHendelse.morsIdent,
-                behandlingType = if (fagsak.status == FagsakStatus.LØPENDE) {
+                behandlingType = if (fagsak.status in listOf(FagsakStatus.LØPENDE, FagsakStatus.AVSLUTTET)) {
                     BehandlingType.REVURDERING
                 } else {
                     BehandlingType.FØRSTEGANGSBEHANDLING

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
@@ -5,29 +5,51 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import no.nav.familie.ba.sak.common.defaultFagsak
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.common.lagVilkårResultat
+import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.config.IntegrasjonClientMock
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.config.tilAktør
+import no.nav.familie.ba.sak.datagenerator.vilkårsvurdering.lagVilkårsvurderingMedOverstyrendeResultater
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregler.FiltreringsreglerService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.StatsborgerskapService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.Month
 
 class FødselshendelseServiceTest {
     val filtreringsreglerService = mockk<FiltreringsreglerService>()
@@ -111,6 +133,100 @@ class FødselshendelseServiceTest {
                 oppgavetype = Oppgavetype.Fremlegg,
                 beskrivelse = "Kontroller gyldig opphold",
                 fristForFerdigstillelse = LocalDate.now().plusYears(1),
+            )
+        }
+    }
+
+    @Test
+    fun `Skal opprette manuell oppgave hvis resultat av fødselshendelse blir INNVILGET_OG_ENDRET`() {
+        val søkerPerson = lagPerson(type = PersonType.SØKER)
+        val fagsak = defaultFagsak(aktør = søkerPerson.aktør)
+
+        val søkerAktør = fagsak.aktør
+        val søker = søkerAktør.aktivFødselsnummer()
+        val barn1Person = lagPerson(type = PersonType.BARN)
+        val barn1 = barn1Person.aktør.aktivFødselsnummer()
+        val barn2Person = lagPerson(type = PersonType.BARN)
+        val barn2 = barn2Person.aktør.aktivFødselsnummer()
+        val nyBehandlingHendelse = NyBehandlingHendelse(søker, listOf(barn2))
+
+        every { fagsakService.hentNormalFagsak(søkerAktør) } returns fagsak
+        every {
+            fagsakService.hentEllerOpprettFagsakForPersonIdent(
+                søker,
+                true,
+                FagsakType.NORMAL,
+                null
+            )
+        } returns fagsak
+
+        val forrigeBehandling = lagBehandling(
+            fagsak = fagsak,
+            behandlingType = BehandlingType.REVURDERING,
+            årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+            førsteSteg = StegType.BEHANDLING_AVSLUTTET,
+            resultat = Behandlingsresultat.OPPHØRT,
+            status = BehandlingStatus.AVSLUTTET,
+        )
+        val nyBehandling = lagBehandling(
+            fagsak,
+            behandlingKategori = BehandlingKategori.NASJONAL,
+            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            årsak = BehandlingÅrsak.FØDSELSHENDELSE,
+            skalBehandlesAutomatisk = true
+        )
+        every { behandlingHentOgPersisterService.hent(forrigeBehandling.id) } returns forrigeBehandling
+        every { behandlingHentOgPersisterService.lagreEllerOppdater(forrigeBehandling) } returns forrigeBehandling
+        every { behandlingHentOgPersisterService.hentBehandlinger(fagsak.id) } returns listOf(forrigeBehandling)
+        every { behandlingHentOgPersisterService.hent(nyBehandling.id) } returns nyBehandling
+        every { stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandlingHendelse) } returns nyBehandling
+        every {
+            stegService.håndterFiltreringsreglerForFødselshendelser(
+                nyBehandling,
+                nyBehandlingHendelse
+            )
+        } returns nyBehandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
+        every { stegService.håndterVilkårsvurdering(nyBehandling) } returns nyBehandling.copy(resultat = Behandlingsresultat.INNVILGET_OG_ENDRET)
+            .leggTilBehandlingStegTilstand(StegType.IVERKSETT_MOT_OPPDRAG)
+        every { stegService.håndterHenleggBehandling(any(), any()) } returns nyBehandling
+        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
+        every { persongrunnlagService.hentSøker(nyBehandling.id) } returns søkerPerson
+        every { persongrunnlagService.hentBarna(nyBehandling) } returns listOf(barn1Person, barn2Person)
+
+        every { personidentService.hentAktør(søker) } returns søkerAktør
+        every { personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(søkerAktør) } returns PersonInfo(
+            fødselsdato = LocalDate.of(1990, Month.JANUARY, 5),
+            navn = "Mor Mocksen",
+            kjønn = Kjønn.KVINNE,
+            forelderBarnRelasjon = setOf(
+                ForelderBarnRelasjon(aktør = tilAktør(barn1), relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN),
+                ForelderBarnRelasjon(aktør = tilAktør(barn2), relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN)
+            )
+        )
+        every { persongrunnlagService.hentBarna(forrigeBehandling) } returns listOf(
+            barn1Person
+        )
+        every { vilkårsvurderingRepository.findByBehandlingAndAktiv(nyBehandling.id) } returns lagVilkårsvurderingMedOverstyrendeResultater(
+            søkerPerson, listOf(barn1Person, barn2Person), nyBehandling, id = 1, mapOf(
+                Pair(
+                    barn1Person.aktør.aktørId,
+                    listOf(
+                        lagVilkårResultat(
+                            vilkårType = Vilkår.BOR_MED_SØKER,
+                            resultat = Resultat.IKKE_OPPFYLT,
+                            behandlingId = nyBehandling.id,
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        autovedtakFødselshendelseService.kjørBehandling(nyBehandlingHendelse)
+        verify(exactly = 0) {
+            opprettTaskService.opprettOppgaveForManuellBehandlingTask(
+                behandlingId = any(),
+                beskrivelse = "Fødselshendelse: Barnet (fødselsdato: ${barn1Person.fødselsdato.tilKortString()}) er ikke bosatt med mor.",
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE
             )
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
@@ -156,7 +156,7 @@ class FødselshendelseServiceTest {
                 søker,
                 true,
                 FagsakType.NORMAL,
-                null
+                null,
             )
         } returns fagsak
 
@@ -173,7 +173,7 @@ class FødselshendelseServiceTest {
             behandlingKategori = BehandlingKategori.NASJONAL,
             behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
             årsak = BehandlingÅrsak.FØDSELSHENDELSE,
-            skalBehandlesAutomatisk = true
+            skalBehandlesAutomatisk = true,
         )
         every { behandlingHentOgPersisterService.hent(forrigeBehandling.id) } returns forrigeBehandling
         every { behandlingHentOgPersisterService.lagreEllerOppdater(forrigeBehandling) } returns forrigeBehandling
@@ -183,7 +183,7 @@ class FødselshendelseServiceTest {
         every {
             stegService.håndterFiltreringsreglerForFødselshendelser(
                 nyBehandling,
-                nyBehandlingHendelse
+                nyBehandlingHendelse,
             )
         } returns nyBehandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
         every { stegService.håndterVilkårsvurdering(nyBehandling) } returns nyBehandling.copy(resultat = Behandlingsresultat.INNVILGET_OG_ENDRET)
@@ -200,14 +200,18 @@ class FødselshendelseServiceTest {
             kjønn = Kjønn.KVINNE,
             forelderBarnRelasjon = setOf(
                 ForelderBarnRelasjon(aktør = tilAktør(barn1), relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN),
-                ForelderBarnRelasjon(aktør = tilAktør(barn2), relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN)
-            )
+                ForelderBarnRelasjon(aktør = tilAktør(barn2), relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN),
+            ),
         )
         every { persongrunnlagService.hentBarna(forrigeBehandling) } returns listOf(
-            barn1Person
+            barn1Person,
         )
         every { vilkårsvurderingRepository.findByBehandlingAndAktiv(nyBehandling.id) } returns lagVilkårsvurderingMedOverstyrendeResultater(
-            søkerPerson, listOf(barn1Person, barn2Person), nyBehandling, id = 1, mapOf(
+            søkerPerson,
+            listOf(barn1Person, barn2Person),
+            nyBehandling,
+            id = 1,
+            mapOf(
                 Pair(
                     barn1Person.aktør.aktørId,
                     listOf(
@@ -218,7 +222,7 @@ class FødselshendelseServiceTest {
                         ),
                     ),
                 ),
-            )
+            ),
         )
 
         autovedtakFødselshendelseService.kjørBehandling(nyBehandlingHendelse)
@@ -226,7 +230,7 @@ class FødselshendelseServiceTest {
             opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = any(),
                 beskrivelse = "Fødselshendelse: Barnet (fødselsdato: ${barn1Person.fødselsdato.tilKortString()}) er ikke bosatt med mor.",
-                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE
+                manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
             )
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -179,10 +179,10 @@ class BehandlingsresultatStegTest {
         val fødselshendelseBehandling = behandling.copy(
             skalBehandlesAutomatisk = true,
             opprettetÅrsak = BehandlingÅrsak.FØDSELSHENDELSE,
-            type = BehandlingType.FØRSTEGANGSBEHANDLING
+            type = BehandlingType.FØRSTEGANGSBEHANDLING,
         )
         val vedtak = lagVedtak(
-            fødselshendelseBehandling
+            fødselshendelseBehandling,
         )
         every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.INNVILGET_OG_ENDRET
         every { behandlingService.nullstillEndringstidspunkt(fødselshendelseBehandling.id) } just runs
@@ -195,7 +195,7 @@ class BehandlingsresultatStegTest {
         every {
             behandlingService.oppdaterStatusPåBehandling(
                 fødselshendelseBehandling.id,
-                BehandlingStatus.IVERKSETTER_VEDTAK
+                BehandlingStatus.IVERKSETTER_VEDTAK,
             )
         } returns fødselshendelseBehandling.copy(status = BehandlingStatus.IVERKSETTER_VEDTAK)
         every { vedtakService.hentAktivForBehandlingThrows(fødselshendelseBehandling.id) } returns vedtak
@@ -204,7 +204,7 @@ class BehandlingsresultatStegTest {
 
         assertEquals(
             behandlingsresultatSteg.utførStegOgAngiNeste(fødselshendelseBehandling, ""),
-            StegType.IVERKSETT_MOT_OPPDRAG
+            StegType.IVERKSETT_MOT_OPPDRAG,
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -1,13 +1,17 @@
 package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -16,6 +20,8 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
+import no.nav.familie.ba.sak.kjerne.steg.EndringerIUtbetalingForBehandlingSteg
+import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
@@ -166,6 +172,40 @@ class BehandlingsresultatStegTest {
         assertDoesNotThrow {
             endringTidslinje.kastFeilVedEndringEtter(treMånederEtterStartdato, lagBehandling())
         }
+    }
+
+    @Test
+    fun `skal gå rett fra behandlingsresultat til iverksetting for alle fødselshendelser`() {
+        val fødselshendelseBehandling = behandling.copy(
+            skalBehandlesAutomatisk = true,
+            opprettetÅrsak = BehandlingÅrsak.FØDSELSHENDELSE,
+            type = BehandlingType.FØRSTEGANGSBEHANDLING
+        )
+        val vedtak = lagVedtak(
+            fødselshendelseBehandling
+        )
+        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.INNVILGET_OG_ENDRET
+        every { behandlingService.nullstillEndringstidspunkt(fødselshendelseBehandling.id) } just runs
+        every {
+            behandlingService.oppdaterBehandlingsresultat(
+                any(),
+                any(),
+            )
+        } returns fødselshendelseBehandling.copy(resultat = Behandlingsresultat.INNVILGET_OG_ENDRET)
+        every {
+            behandlingService.oppdaterStatusPåBehandling(
+                fødselshendelseBehandling.id,
+                BehandlingStatus.IVERKSETTER_VEDTAK
+            )
+        } returns fødselshendelseBehandling.copy(status = BehandlingStatus.IVERKSETTER_VEDTAK)
+        every { vedtakService.hentAktivForBehandlingThrows(fødselshendelseBehandling.id) } returns vedtak
+        every { vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(vedtak) } just runs
+        every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(fødselshendelseBehandling) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
+
+        assertEquals(
+            behandlingsresultatSteg.utførStegOgAngiNeste(fødselshendelseBehandling, ""),
+            StegType.IVERKSETT_MOT_OPPDRAG
+        )
     }
 
     fun String.tilBoolskTidslinje(startdato: YearMonth): Tidslinje<Boolean, Måned> {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fra vakt ser vi at enkelte fødselshendelser feiler:
- Mor har et barn fra tidligere, som ikke bor med mor. Siste behandling er et opphør og fagsaken er avsluttet
- Fødselshendelsen gir behandlingsresultat INNVILGET_OG_ENDRET, som ikke passerer sjekken i `skalRettFraBehandlingsresultatTilIverksetting`
- Vi får feilmelding `Steg 'Iverksett mot oppdrag' kan ikke settes på behandling i kombinasjon med status UTREDES`

Fjerner sjekken av behandlingsresultat for fødselshendelser i `skalRettFraBehandlingsresultatTilIverksetting`, da vi kontrollerer at resultat ble `INNVILGET` når vi går videre med behandlingen i `AutovedtakFødselshendelseService` (se [kode](https://github.com/navikt/familie-ba-sak/blob/master/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/f%C3%B8dselshendelse/AutovedtakF%C3%B8dselshendelseService.kt#L142))

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
