### PR TITLE
Lag avslagsperiode ved uregistrerte barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -365,6 +365,7 @@ class VedtaksperiodeService(
             endredeUtbetalinger = endretUtbetalingAndelRepository.findByBehandlingId(this.id),
             andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(this.id),
             perioderOvergangsstønad = småbarnstilleggService.hentPerioderMedFullOvergangsstønad(this),
+            uregistrerteBarn = søknadGrunnlagService.hentAktiv(behandlingId = this.id)?.hentUregistrerteBarn() ?: emptyList(),
         )
 
     @Deprecated("skal bruke genererVedtaksperioderMedBegrunnelser når den er klar")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForVedtaksperioder.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
@@ -55,6 +56,7 @@ data class GrunnlagForVedtaksperioder(
     val endredeUtbetalinger: List<EndretUtbetalingAndel>,
     val andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
     val perioderOvergangsstønad: List<InternPeriodeOvergangsstønad>,
+    val uregistrerteBarn: List<BarnMedOpplysninger>,
 ) {
     private val utfylteEndredeUtbetalinger = endredeUtbetalinger
         .map { it.tilIEndretUtbetalingAndel() }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
@@ -67,7 +67,7 @@ private fun List<VedtaksperiodeMedBegrunnelser>.leggTilPeriodeForUregistrerteBar
         ),
     )
 
-    val avslagsperiodeUtenDatoer = find { it.fom == null && it.tom == null }
+    val avslagsperiodeUtenDatoer = this.find { it.fom == null && it.tom == null }
 
     return if (avslagsperiodeUtenDatoer != null) {
         avslagsperiodeUtenDatoer.leggTilAvslagUregistrertBarnBegrunnelse()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
@@ -47,7 +47,41 @@ fun genererVedtaksperioder(
             endringstidspunkt = endringstidspunkt,
         )
 
-    return perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak) }
+    val vedtaksperioder =
+        perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak) }
+
+    return if (grunnlagForVedtakPerioder.uregistrerteBarn.isNotEmpty()) {
+        vedtaksperioder.leggTilPeriodeForUregistrerteBarn(vedtak)
+    } else {
+        vedtaksperioder
+    }
+}
+
+private fun List<VedtaksperiodeMedBegrunnelser>.leggTilPeriodeForUregistrerteBarn(
+    vedtak: Vedtak,
+): List<VedtaksperiodeMedBegrunnelser> {
+    fun VedtaksperiodeMedBegrunnelser.leggTilAvslagUregistrertBarnBegrunnelse() = this.begrunnelser.add(
+        Vedtaksbegrunnelse(
+            vedtaksperiodeMedBegrunnelser = this,
+            standardbegrunnelse = Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN,
+        ),
+    )
+
+    val avslagsperiodeUtenDatoer = find { it.fom == null && it.tom == null }
+
+    return if (avslagsperiodeUtenDatoer != null) {
+        avslagsperiodeUtenDatoer.leggTilAvslagUregistrertBarnBegrunnelse()
+        this
+    } else {
+        val avslagsperiode: VedtaksperiodeMedBegrunnelser = VedtaksperiodeMedBegrunnelser(
+            vedtak = vedtak,
+            fom = null,
+            tom = null,
+            type = Vedtaksperiodetype.AVSLAG,
+        ).also { it.leggTilAvslagUregistrertBarnBegrunnelse() }
+
+        this + avslagsperiode
+    }
 }
 
 fun finnPerioderSomSkalBegrunnes(
@@ -89,7 +123,8 @@ fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.fjernOv
             .filter { it.innhold != null }
             .partition { periode -> periode.innhold!!.any { it.gjeldende?.erEksplisittAvslag() == true } }
 
-    val førsteOpphørEtterSisteInnvilgedePeriode = opphørEtterSisteInnvilgedePeriode.firstOrNull()?.copy(tilOgMed = MånedTidspunkt.uendeligLengeTil())
+    val førsteOpphørEtterSisteInnvilgedePeriode =
+        opphørEtterSisteInnvilgedePeriode.firstOrNull()?.copy(tilOgMed = MånedTidspunkt.uendeligLengeTil())
 
     return (perioderTilOgMedSisteInnvilgede + førsteOpphørEtterSisteInnvilgedePeriode + eksplisitteAvslagEtterSisteInnvilgedePeriode).filterNotNull()
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -109,6 +109,7 @@ class BegrunnelseTeksterStepDefinition {
             endredeUtbetalinger = endredeUtbetalinger[behandlingId] ?: emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse[behandlingId] ?: emptyList(),
             perioderOvergangsstønad = emptyList(),
+            uregistrerteBarn = emptyList(),
         )
         val forrigeBehandlingId = behandlingTilForrigeBehandling[behandlingId]
 
@@ -123,6 +124,7 @@ class BegrunnelseTeksterStepDefinition {
                 endredeUtbetalinger = endredeUtbetalinger[forrigeBehandlingId] ?: emptyList(),
                 andelerTilkjentYtelse = andelerTilkjentYtelse[forrigeBehandlingId] ?: emptyList(),
                 perioderOvergangsstønad = emptyList(),
+                uregistrerteBarn = emptyList(),
             )
         }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.parseAktørId
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseDato
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseLong
+import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
@@ -37,6 +38,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
     private var andelerTilkjentYtelse = mutableMapOf<Long, List<AndelTilkjentYtelse>>()
     private var overstyrtEndringstidspunkt = mapOf<Long, LocalDate>()
     private var overgangsstønad = mapOf<Long, List<InternPeriodeOvergangsstønad>>()
+    private var uregistrerteBarn = listOf<BarnMedOpplysninger>()
 
     private var gjeldendeBehandlingId: Long? = null
 
@@ -97,6 +99,11 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
         overgangsstønad = lagOvergangsstønad(dataTable, persongrunnlag)
     }
 
+    @Og("med uregistrerte barn")
+    fun `med uregistrerte barn`() {
+        uregistrerteBarn = listOf(BarnMedOpplysninger(ident = ""))
+    }
+
     @Når("vedtaksperioder med begrunnelser genereres for behandling {}")
     fun `generer vedtaksperiode med begrunnelse`(behandlingId: Long) {
         gjeldendeBehandlingId = behandlingId
@@ -112,6 +119,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             endringstidspunkt = overstyrtEndringstidspunkt,
             overgangsstønad = overgangsstønad,
+            uregistrerteBarn = uregistrerteBarn
         )
     }
 
@@ -129,6 +137,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
             endredeUtbetalinger = endredeUtbetalinger,
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             overgangsstønad = overgangsstønad,
+            uregistrerteBarn = uregistrerteBarn
         )
     }
 
@@ -142,6 +151,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
 
         val vedtaksperioderComparator = compareBy<VedtaksperiodeMedBegrunnelser>({ it.type }, { it.fom }, { it.tom })
         Assertions.assertThat(vedtaksperioderMedBegrunnelser.sortedWith(vedtaksperioderComparator))
+            .usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*endretTidspunkt", ".*opprettetTidspunkt")
             .isEqualTo(forventedeVedtaksperioder.sortedWith(vedtaksperioderComparator))
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -119,7 +119,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             endringstidspunkt = overstyrtEndringstidspunkt,
             overgangsstønad = overgangsstønad,
-            uregistrerteBarn = uregistrerteBarn
+            uregistrerteBarn = uregistrerteBarn,
         )
     }
 
@@ -137,7 +137,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
             endredeUtbetalinger = endredeUtbetalinger,
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             overgangsstønad = overgangsstønad,
-            uregistrerteBarn = uregistrerteBarn
+            uregistrerteBarn = uregistrerteBarn,
         )
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -30,7 +30,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertUregistrertBarn
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
@@ -315,7 +314,7 @@ fun lagVedtaksPerioderMedUtledetEndringsTidspunkt(
     endredeUtbetalinger: Map<Long, List<EndretUtbetalingAndel>>,
     andelerTilkjentYtelse: Map<Long, List<AndelTilkjentYtelse>>,
     overgangsstønad: Map<Long, List<InternPeriodeOvergangsstønad>?>,
-    uregistrerteBarn: List<BarnMedOpplysninger>
+    uregistrerteBarn: List<BarnMedOpplysninger>,
 ): List<VedtaksperiodeMedBegrunnelser> {
     val vedtak = vedtaksListe.find { it.behandling.id == behandlingId && it.aktiv }
         ?: error("Finner ikke vedtak")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -24,11 +24,13 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriDato
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriEnum
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriLong
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriString
+import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertUregistrertBarn
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
@@ -263,6 +265,7 @@ fun lagVedtaksPerioder(
     andelerTilkjentYtelse: Map<Long, List<AndelTilkjentYtelse>>,
     endringstidspunkt: Map<Long, LocalDate?>,
     overgangsstønad: Map<Long, List<InternPeriodeOvergangsstønad>?>,
+    uregistrerteBarn: List<BarnMedOpplysninger>,
 ): List<VedtaksperiodeMedBegrunnelser> {
     val vedtak = vedtaksListe.find { it.behandling.id == behandlingId && it.aktiv }
         ?: error("Finner ikke vedtak")
@@ -274,6 +277,7 @@ fun lagVedtaksPerioder(
         endredeUtbetalinger = endredeUtbetalinger[behandlingId] ?: emptyList(),
         andelerTilkjentYtelse = andelerTilkjentYtelse[behandlingId] ?: emptyList(),
         perioderOvergangsstønad = overgangsstønad[behandlingId] ?: emptyList(),
+        uregistrerteBarn = uregistrerteBarn,
     )
 
     val forrigeBehandlingId = behandlingTilForrigeBehandling[behandlingId]
@@ -289,6 +293,7 @@ fun lagVedtaksPerioder(
             endredeUtbetalinger = endredeUtbetalinger[forrigeBehandlingId] ?: emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse[forrigeBehandlingId] ?: emptyList(),
             perioderOvergangsstønad = overgangsstønad[behandlingId] ?: emptyList(),
+            uregistrerteBarn = emptyList(),
         )
     }
 
@@ -310,6 +315,7 @@ fun lagVedtaksPerioderMedUtledetEndringsTidspunkt(
     endredeUtbetalinger: Map<Long, List<EndretUtbetalingAndel>>,
     andelerTilkjentYtelse: Map<Long, List<AndelTilkjentYtelse>>,
     overgangsstønad: Map<Long, List<InternPeriodeOvergangsstønad>?>,
+    uregistrerteBarn: List<BarnMedOpplysninger>
 ): List<VedtaksperiodeMedBegrunnelser> {
     val vedtak = vedtaksListe.find { it.behandling.id == behandlingId && it.aktiv }
         ?: error("Finner ikke vedtak")
@@ -321,6 +327,7 @@ fun lagVedtaksPerioderMedUtledetEndringsTidspunkt(
         endredeUtbetalinger = endredeUtbetalinger[behandlingId] ?: emptyList(),
         andelerTilkjentYtelse = andelerTilkjentYtelse[behandlingId] ?: emptyList(),
         perioderOvergangsstønad = overgangsstønad[behandlingId] ?: emptyList(),
+        uregistrerteBarn = uregistrerteBarn,
     )
 
     val forrigeBehandlingId = behandlingTilForrigeBehandling[behandlingId]
@@ -336,6 +343,7 @@ fun lagVedtaksPerioderMedUtledetEndringsTidspunkt(
             endredeUtbetalinger = endredeUtbetalinger[forrigeBehandlingId] ?: emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse[forrigeBehandlingId] ?: emptyList(),
             perioderOvergangsstønad = overgangsstønad[behandlingId] ?: emptyList(),
+            uregistrerteBarn = uregistrerteBarn,
         )
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.cucumber.domeneparser
 
 import io.cucumber.datatable.DataTable
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 
 object VedtaksperiodeMedBegrunnelserParser {
@@ -16,12 +18,24 @@ object VedtaksperiodeMedBegrunnelserParser {
                 fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad),
                 tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad),
                 type = parseEnum(DomenebegrepVedtaksperiodeMedBegrunnelser.VEDTAKSPERIODE_TYPE, rad),
-            )
+            ).also { vedtaksperiodeMedBegrunnelser ->
+                val begrunnelser =
+                    parseEnumListe<Standardbegrunnelse>(DomenebegrepVedtaksperiodeMedBegrunnelser.BEGRUNNELSER, rad)
+
+                vedtaksperiodeMedBegrunnelser.begrunnelser.addAll(
+                    begrunnelser.map {
+                        Vedtaksbegrunnelse(
+                            vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                            standardbegrunnelse = it
+                        )
+                    })
+            }
         }
     }
 
     fun parseAktørId(rad: MutableMap<String, String>) =
         parseString(DomenebegrepPersongrunnlag.AKTØR_ID, rad).padEnd(13, '0')
+
     fun parseAktørIdListe(rad: MutableMap<String, String>) =
         parseStringList(DomenebegrepPersongrunnlag.AKTØR_ID, rad).map { it.padEnd(13, '0') }
 
@@ -38,6 +52,7 @@ object VedtaksperiodeMedBegrunnelserParser {
         BELØP("Beløp"),
         ER_EKSPLISITT_AVSLAG("Er eksplisitt avslag"),
         ENDRINGSTIDSPUNKT("Endringstidspunkt"),
+        BEGRUNNELSER("Begrunnelser"),
     }
 
     enum class DomenebegrepKompetanse(override val nøkkel: String) : Domenenøkkel {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -26,9 +26,10 @@ object VedtaksperiodeMedBegrunnelserParser {
                     begrunnelser.map {
                         Vedtaksbegrunnelse(
                             vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
-                            standardbegrunnelse = it
+                            standardbegrunnelse = it,
                         )
-                    })
+                    },
+                )
             }
         }
     }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
@@ -1,0 +1,32 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Vedtaksperioder med mor og to barn
+
+  Bakgrunn:
+    Gitt følgende vedtak
+      | BehandlingId |
+      | 1            |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |
+
+  Scenario: Skal lage avslagsperiode uten datoer når vi har uregistrerte barn
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                         | Fra dato   | Til dato | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD | 11.01.1970 |          | Oppfylt  |
+
+    Og med uregistrerte barn
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato | Til dato | Vedtaksperiodetype | Kommentar | Begrunnelser            |
+      |          |          | Avslag             |           | AVSLAG_UREGISTRERT_BARN |
+
+
+
+

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
@@ -1,18 +1,18 @@
 # language: no
 # encoding: UTF-8
 
-Egenskap: Behandling med uregristrert barn
+Egenskap: Behandling med uregistrert barn
 
   Bakgrunn:
     Gitt følgende vedtak
       | BehandlingId |
       | 1            |
 
+  Scenario: Skal lage avslagsperiode uten datoer når vi har et uregistrert barn
+
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1234    | SØKER      | 11.01.1970  |
-
-  Scenario: Skal lage avslagsperiode uten datoer når vi har uregistrerte barn
 
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1
@@ -26,6 +26,56 @@ Egenskap: Behandling med uregristrert barn
     Så forvent følgende vedtaksperioder med begrunnelser
       | Fra dato | Til dato | Vedtaksperiodetype | Kommentar | Begrunnelser            |
       |          |          | Avslag             |           | AVSLAG_UREGISTRERT_BARN |
+
+  Scenario: Skal lage avslagsperiode uten datoer når vi har uregistrert barn og barn med eksplistt avslag
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |
+      | 1            | 3456    | BARN       | 02.12.2016  |
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt      |                      |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER |            |            | Ikke_oppfylt | Ja                   |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt      |                      |
+
+    Og med uregistrerte barn
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato | Til dato | Vedtaksperiodetype | Kommentar | Begrunnelser            |
+      |          |          | Avslag             |           | AVSLAG_UREGISTRERT_BARN |
+
+  Scenario: Skal lage avslagsperiode uten datoer når vi har uregistrert barn og et barn med utbetaling
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |
+      | 1            | 3456    | BARN       | 02.12.2016  |
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |                      |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 02.12.2016 |            | Oppfylt  |                      |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt  |                      |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.01.2017 | 30.11.2034 | 1234  | 1            |
+
+    Og med uregistrerte barn
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar | Begrunnelser            |
+      | 01.01.2017 | 30.11.2034 | Utbetaling         |           |                         |
+      | 01.12.2034 |            | Opphør             |           |                         |
+      |            |            | Avslag             |           | AVSLAG_UREGISTRERT_BARN |
 
 
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
@@ -1,7 +1,7 @@
 # language: no
 # encoding: UTF-8
 
-Egenskap: Vedtaksperioder med mor og to barn
+Egenskap: Behandling med uregristrert barn
 
   Bakgrunn:
     Gitt følgende vedtak


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13886)

Dersom vi har et uregistrert barn skal vi få en avslagsperiode uten fom-
eller tomdato med begrunnelsen `AVSLAG_UREGISTRERT_BARN`

Endrer så avslagsperioden kommer med sammen med begrunnelsen

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene
🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell
deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. 