### PR TITLE
Forvalter endepunkt over 100% utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ba.sak.internal
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 
 @RestController
 @RequestMapping("/api/forvalter")
@@ -279,6 +283,17 @@ class ForvalterController(
                 logger.warn("Klarte ikke kjøre satsendring for fagsakId=$fagsakId", e)
             }
         }
+    }
+
+    @PostMapping("/identifiser-utbetalinger-over-100-prosent")
+    @Transactional
+    fun identifiserUtbetalingerOver100Prosent(): ResponseEntity<Pair<String, String>> {
+        val callId = UUID.randomUUID().toString()
+        val scope = CoroutineScope(SupervisorJob())
+        scope.launch {
+            forvalterService.identifiserUtbetalingerOver100Prosent(callId)
+        }
+        return ResponseEntity.ok(Pair("callId", callId))
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -1,8 +1,5 @@
 package no.nav.familie.ba.sak.internal
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
@@ -33,6 +30,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import kotlin.concurrent.thread
 
 @RestController
 @RequestMapping("/api/forvalter")
@@ -286,11 +284,9 @@ class ForvalterController(
     }
 
     @PostMapping("/identifiser-utbetalinger-over-100-prosent")
-    @Transactional
     fun identifiserUtbetalingerOver100Prosent(): ResponseEntity<Pair<String, String>> {
         val callId = UUID.randomUUID().toString()
-        val scope = CoroutineScope(SupervisorJob())
-        scope.launch {
+        thread {
             forvalterService.identifiserUtbetalingerOver100Prosent(callId)
         }
         return ResponseEntity.ok(Pair("callId", callId))

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -132,7 +132,7 @@ class ForvalterService(
 
     @OptIn(InternalCoroutinesApi::class) // for å få lov til å hente CancellationException
     suspend fun f(callId: String) {
-        var slice = fagsakRepository.finnLøpendeFagsaker(PageRequest.of(0, 200))
+        var slice = fagsakRepository.finnLøpendeFagsaker(PageRequest.of(0, 10000))
         val scope = CoroutineScope(Dispatchers.Default)
         val deffereds = mutableListOf<Deferred<Unit>>()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -1,24 +1,39 @@
 package no.nav.familie.ba.sak.internal
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForIverksettingFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
+import no.nav.familie.log.mdc.MDCConstants
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -35,7 +50,12 @@ class ForvalterService(
     private val behandlingService: BehandlingService,
     private val taskRepository: TaskRepositoryWrapper,
     private val autovedtakService: AutovedtakService,
+    private val fagsakRepository: FagsakRepository,
+    private val behandlingRepository: BehandlingRepository,
+    private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
 ) {
+    private val logger = LoggerFactory.getLogger(ForvalterService::class.java)
 
     @Transactional
     fun lagOgSendUtbetalingsoppdragTilØkonomiForBehandling(behandlingId: Long) {
@@ -97,5 +117,27 @@ class ForvalterService(
         val task =
             IverksettMotOppdragTask.opprettTask(nyBehandling, opprettetVedtak, SikkerhetContext.hentSaksbehandler())
         taskRepository.save(task)
+    }
+
+    @Transactional(readOnly = true)
+    suspend fun identifiserUtbetalingerOver100Prosent(callId: String) {
+        val slice: Slice<Long> = fagsakRepository.finnLøpendeFagsaker(PageRequest.of(0, 200))
+
+        (0..slice.pageable.pageSize)
+            .map { side ->
+                CoroutineScope(Dispatchers.Default).async {
+                    MDC.put(MDCConstants.MDC_CALL_ID, callId)
+                    logger.info("identifiserUtbetalingerOver100Prosent side $side")
+                    fagsakRepository.finnLøpendeFagsaker(PageRequest.of(side, 10000)).get().toList().forEach { fagsakId ->
+                        val sisteIverksatteBehandling = behandlingRepository.finnSisteIverksatteBehandling(fagsakId = fagsakId)!!
+                        try {
+                            tilkjentYtelseValideringService.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(sisteIverksatteBehandling)
+                        } catch (e: UtbetalingsikkerhetFeil) {
+                            val arbeidsfordelingService = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = sisteIverksatteBehandling.id)
+                            secureLogger.warn("Over 100% utbetaling for fagsak=$fagsakId, enhet=${arbeidsfordelingService.behandlendeEnhetId}, melding=${e.message}")
+                        }
+                    }
+                }
+            }.awaitAll()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -133,7 +133,7 @@ class ForvalterService(
     @OptIn(InternalCoroutinesApi::class) // for å få lov til å hente CancellationException
     suspend fun finnOgLoggUtbetalingerOver100Prosent(callId: String) {
         var slice = fagsakRepository.finnLøpendeFagsaker(PageRequest.of(0, 10000))
-        val scope = CoroutineScope(Dispatchers.Default)
+        val scope = CoroutineScope(Dispatchers.Default.limitedParallelism(10))
         val deffereds = mutableListOf<Deferred<Unit>>()
 
         // coroutineScope {

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -153,7 +153,8 @@ class ForvalterService(
         }
         deffereds.forEach {
             if (it.isCancelled) {
-                logger.warn("Async jobb kansellert med: ${it.getCancellationException().message} ${it.getCancellationException().stackTraceToString()}")
+                logger.warn("Async jobb med status kansellert. Se securelog")
+                secureLogger.warn("Async jobb kansellert med: ${it.getCancellationException().message} ${it.getCancellationException().stackTraceToString()}")
             }
 
             it.await()

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -124,14 +124,14 @@ class ForvalterService(
         MDC.put(MDCConstants.MDC_CALL_ID, callId)
 
         runBlocking {
-            f(callId)
+            finnOgLoggUtbetalingerOver100Prosent(callId)
         }
 
         logger.info("Ferdig med å kjøre identifiserUtbetalingerOver100Prosent")
     }
 
     @OptIn(InternalCoroutinesApi::class) // for å få lov til å hente CancellationException
-    suspend fun f(callId: String) {
+    suspend fun finnOgLoggUtbetalingerOver100Prosent(callId: String) {
         var slice = fagsakRepository.finnLøpendeFagsaker(PageRequest.of(0, 10000))
         val scope = CoroutineScope(Dispatchers.Default)
         val deffereds = mutableListOf<Deferred<Unit>>()

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -121,9 +121,10 @@ class ForvalterService(
 
     @Transactional(readOnly = true)
     suspend fun identifiserUtbetalingerOver100Prosent(callId: String) {
+        MDC.put(MDCConstants.MDC_CALL_ID, callId)
         var slice: Slice<Long> = fagsakRepository.finnLøpendeFagsaker(PageRequest.of(0, 200))
         val scope = CoroutineScope(Dispatchers.Default)
-        var sideNr: Int = 0
+        var sideNr = 0
         val deffereds = mutableListOf(
             scope.async {
                 sjekkChunkMedFagsakerOmDeHarUtbetalingerOver100Prosent(callId, slice, sideNr)
@@ -140,6 +141,7 @@ class ForvalterService(
             )
         }
 
+        logger.info("Startet ${slice.size} sider")
         deffereds.awaitAll()
         logger.info("Ferdig med å kjøre identifiserUtbetalingerOver100Prosent")
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
@@ -17,10 +17,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
-import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -39,12 +37,11 @@ class AutovedtakSatsendringService(
     private val autovedtakService: AutovedtakService,
     private val satskjøringRepository: SatskjøringRepository,
     private val behandlingService: BehandlingService,
-    private val beregningService: BeregningService,
-    private val persongrunnlagService: PersongrunnlagService,
     private val satsendringService: SatsendringService,
     private val loggService: LoggService,
     private val featureToggleService: FeatureToggleService,
     private val snikeIKøenService: SnikeIKøenService,
+    private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
 ) {
 
     private val satsendringAlleredeUtført = Metrics.counter("satsendring.allerede.utfort")
@@ -191,24 +188,8 @@ class AutovedtakSatsendringService(
     }
 
     private fun harUtbetalingerSomOverstiger100Prosent(sisteIverksatteBehandling: Behandling): Boolean {
-        val tilkjentYtelse =
-            beregningService.hentTilkjentYtelseForBehandling(behandlingId = sisteIverksatteBehandling.id)
-        val personopplysningGrunnlag =
-            persongrunnlagService.hentAktivThrows(behandlingId = sisteIverksatteBehandling.id)
-
-        val barnMedAndreRelevanteTilkjentYtelser = personopplysningGrunnlag.barna.map {
-            Pair(
-                it,
-                beregningService.hentRelevanteTilkjentYtelserForBarn(it.aktør, sisteIverksatteBehandling.fagsak.id),
-            )
-        }
-
         try {
-            TilkjentYtelseValidering.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(
-                behandlendeBehandlingTilkjentYtelse = tilkjentYtelse,
-                barnMedAndreRelevanteTilkjentYtelser = barnMedAndreRelevanteTilkjentYtelser,
-                personopplysningGrunnlag = personopplysningGrunnlag,
-            )
+            tilkjentYtelseValideringService.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(sisteIverksatteBehandling)
         } catch (e: UtbetalingsikkerhetFeil) {
             secureLogger.info("fagsakId=${sisteIverksatteBehandling.fagsak.id} har UtbetalingsikkerhetFeil. Skipper satsendring: ${e.frontendFeilmelding}")
             return true

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -24,30 +24,34 @@ class TilkjentYtelseValideringService(
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(behandling.id)
 
         if (totrinnskontroll?.godkjent == true) {
-            val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandling.id)
+            validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(behandling)
+        }
+    }
 
-            val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id)
+    fun validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(behandling: Behandling) {
+        val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandling.id)
 
-            val barnMedAndreRelevanteTilkjentYtelser = personopplysningGrunnlag.barna.map {
-                Pair(
-                    it,
-                    beregningService.hentRelevanteTilkjentYtelserForBarn(it.aktør, behandling.fagsak.id),
-                )
-            }
+        val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id)
 
-            secureLogger.info("Andeler tilkjent ytelse i inneværende behandling: " + tilkjentYtelse.andelerTilkjentYtelse)
-            secureLogger.info(
-                "Barn og deres andeler tilkjent ytelse fra andre fagsaker: " + barnMedAndreRelevanteTilkjentYtelser.map {
-                    "${it.first} -> ${it.second}"
-                },
-            )
-
-            TilkjentYtelseValidering.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(
-                behandlendeBehandlingTilkjentYtelse = tilkjentYtelse,
-                barnMedAndreRelevanteTilkjentYtelser = barnMedAndreRelevanteTilkjentYtelser,
-                personopplysningGrunnlag = personopplysningGrunnlag,
+        val barnMedAndreRelevanteTilkjentYtelser = personopplysningGrunnlag.barna.map {
+            Pair(
+                it,
+                beregningService.hentRelevanteTilkjentYtelserForBarn(it.aktør, behandling.fagsak.id),
             )
         }
+
+        secureLogger.info("Andeler tilkjent ytelse i inneværende behandling: " + tilkjentYtelse.andelerTilkjentYtelse)
+        secureLogger.info(
+            "Barn og deres andeler tilkjent ytelse fra andre fagsaker: " + barnMedAndreRelevanteTilkjentYtelser.map {
+                "${it.first} -> ${it.second}"
+            },
+        )
+
+        TilkjentYtelseValidering.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(
+            behandlendeBehandlingTilkjentYtelse = tilkjentYtelse,
+            barnMedAndreRelevanteTilkjentYtelser = barnMedAndreRelevanteTilkjentYtelser,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+        )
     }
 
     fun validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(behandlingId: Long) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Forvalterendepunkt som itererer gjennom alle løpende fagsaker og validerer om det er mer enn 100% utbetaling på barna. Dette logges til securelogs

Tjenesten er fire and forget. Man får umiddelbart tilbake en callId som man kan taile loggene med. 
![Screenshot 2023-08-01 at 13 20 52](https://github.com/navikt/familie-ba-sak/assets/1121978/90a8b0f9-bc46-4c1e-8769-6d0071d585a0)

Videre kjøres det async i chunker på 10000. Det vil logges slik til securelogs

![Screenshot 2023-08-01 at 13 20 42](https://github.com/navikt/familie-ba-sak/assets/1121978/4b500e57-c684-49af-9dc4-9ef153c34f26)


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
