### PR TITLE
Legg til støtte for enslig barn for vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/Fagsak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/Fagsak.kt
@@ -83,4 +83,7 @@ enum class FagsakType {
     NORMAL,
     BARN_ENSLIG_MINDREÅRIG,
     INSTITUSJON,
+    ;
+
+    fun erBarnSøker() = this == BARN_ENSLIG_MINDREÅRIG || this == INSTITUSJON
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -542,7 +542,6 @@ class VedtaksperiodeService(
                         grunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
                         sanityBegrunnelser = sanityBegrunnelser,
                         behandlingUnderkategori = behandling.underkategori,
-                        fagsakType = behandling.fagsak.type,
                     ).toList()
                 } else {
                     hentGyldigeBegrunnelserForPeriodeGammel(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent
 
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.isSameOrAfter
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
@@ -85,8 +84,8 @@ private fun List<VedtaksperiodeMedBegrunnelser>.leggTilPeriodeForUregistrerteBar
 }
 
 fun finnPerioderSomSkalBegrunnes(
-    grunnlagTidslinjePerPerson: Map<Aktør, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
-    grunnlagTidslinjePerPersonForrigeBehandling: Map<Aktør, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
+    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
+    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
     endringstidspunkt: LocalDate,
 ): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
     val gjeldendeOgForrigeGrunnlagKombinert = kombinerGjeldendeOgForrigeGrunnlag(
@@ -129,7 +128,7 @@ fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.fjernOv
     return (perioderTilOgMedSisteInnvilgede + førsteOpphørEtterSisteInnvilgedePeriode + eksplisitteAvslagEtterSisteInnvilgedePeriode).filterNotNull()
 }
 
-private fun Map<Aktør, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>.lagOverlappendeGenerelleAvslagsPerioder() =
+private fun Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>.lagOverlappendeGenerelleAvslagsPerioder() =
     map {
         it.value.overlappendeGenerelleAvslagGrunnlagForPerson
     }.kombiner {
@@ -227,8 +226,8 @@ private fun GrunnlagForGjeldendeOgForrigeBehandling.medVilkårSomHarEksplisitteA
  * ikke er det.
  **/
 private fun kombinerGjeldendeOgForrigeGrunnlag(
-    grunnlagTidslinjePerPerson: Map<Aktør, Tidslinje<GrunnlagForPerson, Måned>>,
-    grunnlagTidslinjePerPersonForrigeBehandling: Map<Aktør, Tidslinje<GrunnlagForPerson, Måned>>,
+    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<GrunnlagForPerson, Måned>>,
+    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<GrunnlagForPerson, Måned>>,
 ): List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>> =
     grunnlagTidslinjePerPerson.map { (aktørId, grunnlagstidslinje) ->
         val grunnlagForrigeBehandling = grunnlagTidslinjePerPersonForrigeBehandling[aktørId]

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -51,7 +51,13 @@ class BegrunnelseTeksterStepDefinition {
 
     @Gitt("følgende behandling")
     fun `følgende behandling`(dataTable: DataTable) {
-        lagVedtak(dataTable, behandlinger, behandlingTilForrigeBehandling, vedtaksliste)
+        lagVedtak(
+            dataTable = dataTable,
+            behandlinger = behandlinger,
+            behandlingTilForrigeBehandling = behandlingTilForrigeBehandling,
+            vedtaksListe = vedtaksliste,
+            fagsaker = emptyMap(),
+        )
     }
 
     @Og("følgende persongrunnlag for begrunnelse")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -155,7 +155,6 @@ class BegrunnelseTeksterStepDefinition {
                     grunnlagForVedtaksperiodeForrigeBehandling,
                     mockHentSanityBegrunnelser(),
                     behandling.underkategori,
-                    behandling.fagsak.type,
                 ).toList(),
             )
         }.toMutableList()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
@@ -27,6 +28,7 @@ import java.time.LocalDate
 
 class VedtaksperiodeMedBegrunnelserStepDefinition {
 
+    private var fagsaker: Map<Long, Fagsak> = emptyMap()
     private var behandlinger = mutableMapOf<Long, Behandling>()
     private var behandlingTilForrigeBehandling = mutableMapOf<Long, Long?>()
     private var vedtaksliste = mutableListOf<Vedtak>()
@@ -42,9 +44,14 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
 
     private var gjeldendeBehandlingId: Long? = null
 
+    @Gitt("følgende fagsaker")
+    fun `følgende fagsaker`(dataTable: DataTable) {
+        fagsaker = lagFagsaker(dataTable)
+    }
+
     @Gitt("følgende vedtak")
     fun `følgende vedtak`(dataTable: DataTable) {
-        lagVedtak(dataTable, behandlinger, behandlingTilForrigeBehandling, vedtaksliste)
+        lagVedtak(dataTable, behandlinger, behandlingTilForrigeBehandling, vedtaksliste, fagsaker)
     }
 
     @Og("følgende persongrunnlag")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/DomeneparserUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/DomeneparserUtil.kt
@@ -7,6 +7,8 @@ interface Domenenøkkel {
 }
 
 enum class Domenebegrep(override val nøkkel: String) : Domenenøkkel {
+    FAGSAK_ID("FagsakId"),
+    FAGSAK_TYPE("Fagsaktype"),
     BEHANDLING_ID("BehandlingId"),
     FORRIGE_BEHANDLING_ID("ForrigeBehandlingId"),
     FRA_DATO("Fra dato"),

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/enslig_mindreårig.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/enslig_mindreårig.feature
@@ -1,0 +1,62 @@
+# language: no
+# encoding: UTF-8
+
+
+Egenskap: Endringstidspunkt påvirker periodene
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype             |
+      | 1        | BARN_ENSLIG_MINDREÅRIG |
+
+    Gitt følgende vedtak
+      | BehandlingId | FagsakId |
+      | 1            | 1        |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 3456    | BARN       | 02.12.2016  |
+
+
+  Scenario: Enslig barn har utvidet oppfylt
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 02.12.2016 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt  |
+      | 3456    | UTVIDET_BARNETRYGD                                              | 02.12.2016 |            | Oppfylt  |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId | Ytelse type        |
+      | 3456    | 01.12.2016 | 30.11.2034 | 1234  | 1            | Ordinær_barnetrygd |
+      | 3456    | 01.12.2016 | 30.11.2034 | 2000  | 1            | Utvidet_barnetrygd |
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar       |
+      | 01.01.2017 | 30.11.2034 | Utbetaling         |                 |
+      | 01.12.2034 |            | Opphør             | Barn er over 18 |
+
+
+  Scenario: Enslig barn har rett til barnetrygd oppfylt, men avslag på utvidet barnetrygd
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 02.12.2016 |            | Oppfylt      |                      |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt      |                      |
+      | 3456    | UTVIDET_BARNETRYGD                                              |            |            | ikke_oppfylt | Ja                   |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId | Ytelse type        |
+      | 3456    | 01.12.2016 | 30.11.2034 | 1234  | 1            | Ordinær_barnetrygd |
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar       |
+      | 01.01.2017 | 30.11.2034 | Utbetaling         |                 |
+      | 01.12.2034 |            | Opphør             | Barn er over 18 |
+      |            |            | Avslag             |                 |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14061)
Når fagsaktypen er barn enslig mindreårig fungerer barnet som både søker og barn. Dette skaper krøll for vedtaksprodusenten. Splitter opp vilkårene til barnet slik at vi vurderer barnet førs som søker og så som barn. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

