### PR TITLE
Send med flettefeltene til delmal med delmalen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/FellesDelmaler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/FellesDelmaler.kt
@@ -79,7 +79,7 @@ data class FeilutbetaltValuta(
 }
 
 data class RefusjonEøsAvklart(
-    val perioderMedRefusjonEøsAvklart: Flettefelt,
+    val perioderMedRefusjonEosAvklart: Flettefelt,
 ) {
     constructor(perioderMedRefusjonEøsAvklart: Set<String>) : this(
         flettefelt(perioderMedRefusjonEøsAvklart.toList()),
@@ -87,7 +87,7 @@ data class RefusjonEøsAvklart(
 }
 
 data class RefusjonEøsUavklart(
-    val perioderMedRefusjonEøsUavklart: Flettefelt,
+    val perioderMedRefusjonEosUavklart: Flettefelt,
 ) {
     constructor(perioderMedRefusjonEøsUavklart: Set<String>) : this(
         flettefelt(perioderMedRefusjonEøsUavklart.toList()),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
@@ -32,12 +32,15 @@ data class ForsattInnvilget(
                     etterbetalingInstitusjon = etterbetalingInstitusjon,
                     korrigertVedtak = vedtakFellesfelter.korrigertVedtakData,
                     informasjonOmAarligKontroll = informasjonOmAarligKontroll,
-                    refusjonEosAvklart = refusjonEosAvklart != null,
-                    refusjonEosUavklart = refusjonEosUavklart != null,
+                    refusjonEosAvklart = refusjonEosAvklart,
+                    refusjonEosUavklart = refusjonEosUavklart,
                 ),
                 flettefelter = object : FlettefelterForDokument {
-                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEøsAvklart
-                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEøsUavklart
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEosAvklart
+
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEosUavklart
                     override val brevOpprettetDato = flettefelt(LocalDate.now().tilDagMånedÅr())
                     override val navn = flettefelt(vedtakFellesfelter.søkerNavn)
                     override val fodselsnummer = flettefelt(vedtakFellesfelter.søkerFødselsnummer)
@@ -62,7 +65,7 @@ data class ForsattInnvilgetData(
         val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
         val korrigertVedtak: KorrigertVedtakData?,
         val informasjonOmAarligKontroll: Boolean,
-        val refusjonEosAvklart: Boolean,
-        val refusjonEosUavklart: Boolean,
+        val refusjonEosAvklart: RefusjonEøsAvklart?,
+        val refusjonEosUavklart: RefusjonEøsUavklart?,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
@@ -32,13 +32,16 @@ data class Førstegangsvedtak(
                     etterbetalingInstitusjon = etterbetalingInstitusjon,
                     korrigertVedtak = vedtakFellesfelter.korrigertVedtakData,
                     informasjonOmAarligKontroll = informasjonOmAarligKontroll,
-                    refusjonEosAvklart = refusjonEosAvklart != null,
-                    refusjonEosUavklart = refusjonEosUavklart != null,
+                    refusjonEosAvklart = refusjonEosAvklart,
+                    refusjonEosUavklart = refusjonEosUavklart,
                 ),
                 perioder = vedtakFellesfelter.perioder,
                 flettefelter = object : FlettefelterForDokument {
-                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEøsAvklart
-                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEøsUavklart
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEosAvklart
+
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEosUavklart
                     override val brevOpprettetDato = flettefelt(LocalDate.now().tilDagMånedÅr())
                     override val navn = flettefelt(vedtakFellesfelter.søkerNavn)
                     override val fodselsnummer = flettefelt(vedtakFellesfelter.søkerFødselsnummer)
@@ -62,7 +65,7 @@ data class FørstegangsvedtakData(
         val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
         val korrigertVedtak: KorrigertVedtakData?,
         val informasjonOmAarligKontroll: Boolean,
-        val refusjonEosAvklart: Boolean,
-        val refusjonEosUavklart: Boolean,
+        val refusjonEosAvklart: RefusjonEøsAvklart?,
+        val refusjonEosUavklart: RefusjonEøsUavklart?,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/OpphørMedEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/OpphørMedEndring.kt
@@ -32,12 +32,15 @@ data class OpphørMedEndring(
                     etterbetaling = etterbetaling,
                     etterbetalingInstitusjon = etterbetalingInstitusjon,
                     korrigertVedtak = vedtakFellesfelter.korrigertVedtakData,
-                    refusjonEosAvklart = refusjonEosAvklart != null,
-                    refusjonEosUavklart = refusjonEosUavklart != null,
+                    refusjonEosAvklart = refusjonEosAvklart,
+                    refusjonEosUavklart = refusjonEosUavklart,
                 ),
                 flettefelter = object : FlettefelterForDokument {
-                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEøsAvklart
-                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEøsUavklart
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEosAvklart
+
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEosUavklart
                     override val brevOpprettetDato = flettefelt(LocalDate.now().tilDagMånedÅr())
                     override val navn = flettefelt(vedtakFellesfelter.søkerNavn)
                     override val fodselsnummer = flettefelt(vedtakFellesfelter.søkerFødselsnummer)
@@ -61,7 +64,7 @@ data class OpphørMedEndringData(
         val etterbetaling: Etterbetaling?,
         val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
         val korrigertVedtak: KorrigertVedtakData?,
-        val refusjonEosAvklart: Boolean,
-        val refusjonEosUavklart: Boolean,
+        val refusjonEosAvklart: RefusjonEøsAvklart?,
+        val refusjonEosUavklart: RefusjonEøsUavklart?,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.brev.domene.maler
 
-import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriode
-import java.time.LocalDate
 
 data class VedtakEndring(
     override val mal: Brevmal,
@@ -38,20 +36,16 @@ data class VedtakEndring(
                     etterbetalingInstitusjon = etterbetalingInstitusjon,
                     korrigertVedtak = vedtakFellesfelter.korrigertVedtakData,
                     informasjonOmAarligKontroll = informasjonOmAarligKontroll,
-                    forMyeUtbetaltBarnetrygd = feilutbetaltValuta != null,
-                    refusjonEosAvklart = refusjonEosAvklart != null,
-                    refusjonEosUavklart = refusjonEosUavklart != null,
+                    forMyeUtbetaltBarnetrygd = feilutbetaltValuta,
+                    refusjonEosAvklart = refusjonEosAvklart,
+                    refusjonEosUavklart = refusjonEosUavklart,
                 ),
-                flettefelter = object : FlettefelterForDokument {
-                    val perioderMedForMyeUtbetalt: Flettefelt = feilutbetaltValuta?.perioderMedForMyeUtbetalt
-                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEøsAvklart
-                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEøsUavklart
-                    override val navn = flettefelt(vedtakFellesfelter.søkerNavn)
-                    override val fodselsnummer = flettefelt(vedtakFellesfelter.søkerFødselsnummer)
-                    override val brevOpprettetDato = flettefelt(LocalDate.now().tilDagMånedÅr())
-                    override val organisasjonsnummer = flettefelt(vedtakFellesfelter.organisasjonsnummer)
-                    override val gjelder = flettefelt(vedtakFellesfelter.gjelder)
-                },
+                flettefelter = FlettefelterForDokumentImpl(
+                    navn = vedtakFellesfelter.søkerNavn,
+                    fodselsnummer = vedtakFellesfelter.søkerFødselsnummer,
+                    organisasjonsnummer = vedtakFellesfelter.organisasjonsnummer,
+                    gjelder = vedtakFellesfelter.gjelder,
+                ),
                 perioder = vedtakFellesfelter.perioder,
             ),
         )
@@ -73,8 +67,8 @@ data class EndringVedtakData(
         val etterbetalingInstitusjon: EtterbetalingInstitusjon?,
         val korrigertVedtak: KorrigertVedtakData?,
         val informasjonOmAarligKontroll: Boolean,
-        val forMyeUtbetaltBarnetrygd: Boolean,
-        val refusjonEosAvklart: Boolean,
-        val refusjonEosUavklart: Boolean,
+        val forMyeUtbetaltBarnetrygd: FeilutbetaltValuta?,
+        val refusjonEosAvklart: RefusjonEøsAvklart?,
+        val refusjonEosUavklart: RefusjonEøsUavklart?,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.brev.domene.maler
 
+import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriode
+import java.time.LocalDate
 
 data class VedtakEndring(
     override val mal: Brevmal,
@@ -40,12 +42,21 @@ data class VedtakEndring(
                     refusjonEosAvklart = refusjonEosAvklart,
                     refusjonEosUavklart = refusjonEosUavklart,
                 ),
-                flettefelter = FlettefelterForDokumentImpl(
-                    navn = vedtakFellesfelter.søkerNavn,
-                    fodselsnummer = vedtakFellesfelter.søkerFødselsnummer,
-                    organisasjonsnummer = vedtakFellesfelter.organisasjonsnummer,
-                    gjelder = vedtakFellesfelter.gjelder,
-                ),
+                flettefelter = object : FlettefelterForDokument {
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedForMyeUtbetalt: Flettefelt = feilutbetaltValuta?.perioderMedForMyeUtbetalt
+
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosAvklart: Flettefelt = refusjonEosAvklart?.perioderMedRefusjonEosAvklart
+
+                    @Deprecated("Skal bort når vi har lagt til støtte for å sende inn felttefelter som types i delmaler i familie-brev")
+                    val perioderMedRefusjonEosUavklart: Flettefelt = refusjonEosUavklart?.perioderMedRefusjonEosUavklart
+                    override val navn = flettefelt(vedtakFellesfelter.søkerNavn)
+                    override val fodselsnummer = flettefelt(vedtakFellesfelter.søkerFødselsnummer)
+                    override val brevOpprettetDato = flettefelt(LocalDate.now().tilDagMånedÅr())
+                    override val organisasjonsnummer = flettefelt(vedtakFellesfelter.organisasjonsnummer)
+                    override val gjelder = flettefelt(vedtakFellesfelter.gjelder)
+                },
                 perioder = vedtakFellesfelter.perioder,
             ),
         )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Til nå har vi manglet støtte for å sende inn flettefeltene som blokker i delmalene i [familie-brev](https://github.com/navikt/familie-brev). Det betyr at det egentlig ikke skal gå å bruke flettefelter som lister i en delmal slik som vi gjør i Refusjon EØS-delmalen 👇. 
<img width="731" alt="image" src="https://github.com/navikt/familie-ba-sak/assets/17828446/f1ee7253-59c1-495b-b67c-1bdfa9a8e064">

Av en eller annen magisk grunn kicker serializeren til hoveddokumentet inn i dette tilfellet og gjør at det er mulig likevel, men dette krever at vi sender med flettefeltene med hoveddokumentet og ikke delmalen. 

Dette støttes ikke av den nye versjonen til `@portabletext/react`. 

For å få det til å fungere må vi:
1. Sende med flettefeltene både global i hoveddokumentet og lokalt i delmalen (denne PRen)
1. Legge til støtte for å bruke flettetelt som blokk i lokalt i delmalen (https://github.com/navikt/familie-brev/pull/501)
1. Ikke sende med flettefeltene med til hoveddokumentet
1. Oppdatere familie-brev til den nyeste versjonen av `@portabletext/react`
