### PR TITLE
Justert validering ved opprettelse av manuell migrering behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.domene.initStatus
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValideringUtils
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.logg.BehandlingLoggRequest
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
@@ -52,6 +53,7 @@ class BehandlingService(
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
     private val fagsakRepository: FagsakRepository,
     private val vedtakRepository: VedtakRepository,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val loggService: LoggService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
     private val infotrygdService: InfotrygdService,
@@ -208,7 +210,7 @@ class BehandlingService(
         }
     }
 
-    private fun harAktivInfotrygdSak(behandling: Behandling): Boolean {
+    fun harAktivInfotrygdSak(behandling: Behandling): Boolean {
         val søkerIdenter = behandling.fagsak.aktør.personidenter.map { it.fødselsnummer }
         return infotrygdService.harÅpenSakIInfotrygd(søkerIdenter) ||
             !behandling.erMigrering() && infotrygdService.harLøpendeSakIInfotrygd(søkerIdenter)
@@ -301,6 +303,10 @@ class BehandlingService(
         behandlingMigreringsinfoRepository.findByBehandlingId(behandlingId)
             ?.let { behandlingMigreringsinfoRepository.delete(it) }
     }
+
+    fun erLøpende(behandling: Behandling): Boolean =
+        andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = behandling.id)
+            .any { it.erLøpende() }
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -139,12 +139,13 @@ class StegService(
     private fun validerHelmanuelMigrering(nyBehandling: NyBehandling) {
         val sisteBehandlingSomErVedtatt =
             behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(nyBehandling.fagsakId)
-        if (sisteBehandlingSomErVedtatt != null && !sisteBehandlingSomErVedtatt.resultat.erOpphør()) {
+
+        if (sisteBehandlingSomErVedtatt != null && behandlingService.erLøpende(sisteBehandlingSomErVedtatt)) {
             throw FunksjonellFeil(
-                melding = "Det finnes allerede en vedtatt behandling på fagsak ${nyBehandling.fagsakId}." +
+                melding = "Det finnes allerede en vedtatt behandling med løpende utbetalinger på fagsak ${nyBehandling.fagsakId}." +
                     "Behandling kan ikke opprettes med årsak " +
                     BehandlingÅrsak.HELMANUELL_MIGRERING.visningsnavn,
-                frontendFeilmelding = "Det finnes allerede en vedtatt behandling på fagsak." +
+                frontendFeilmelding = "Det finnes allerede en vedtatt behandling med løpende utbetalinger på fagsak." +
                     "Behandling kan ikke opprettes med årsak " +
                     BehandlingÅrsak.HELMANUELL_MIGRERING.visningsnavn,
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceEnhetstest.kt
@@ -1,0 +1,113 @@
+package no.nav.familie.ba.sak.kjerne.behandling
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.BehandlingstemaService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingMigreringsinfoRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.logg.LoggService
+import no.nav.familie.ba.sak.kjerne.simulering.lagBehandling
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.YearMonth
+
+@ExtendWith(MockKExtension::class)
+class BehandlingServiceEnhetstest {
+
+    @MockK
+    private lateinit var behandlingHentOgPersisterService: BehandlingHentOgPersisterService
+
+    @MockK
+    private lateinit var behandlingstemaService: BehandlingstemaService
+
+    @MockK
+    private lateinit var behandlingSøknadsinfoService: BehandlingSøknadsinfoService
+
+    @MockK
+    private lateinit var behandlingMigreringsinfoRepository: BehandlingMigreringsinfoRepository
+
+    @MockK
+    private lateinit var behandlingMetrikker: BehandlingMetrikker
+
+    @MockK
+    private lateinit var saksstatistikkEventPublisher: SaksstatistikkEventPublisher
+
+    @MockK
+    private lateinit var fagsakRepository: FagsakRepository
+
+    @MockK
+    private lateinit var vedtakRepository: VedtakRepository
+
+    @MockK
+    private lateinit var andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository
+
+    @MockK
+    private lateinit var loggService: LoggService
+
+    @MockK
+    private lateinit var arbeidsfordelingService: ArbeidsfordelingService
+
+    @MockK
+    private lateinit var infotrygdService: InfotrygdService
+
+    @MockK
+    private lateinit var vedtaksperiodeService: VedtaksperiodeService
+
+    @MockK
+    private lateinit var taskRepository: TaskRepositoryWrapper
+
+    @MockK
+    private lateinit var vilkårsvurderingService: VilkårsvurderingService
+
+    @InjectMockKs
+    private lateinit var behandlingService: BehandlingService
+
+    @Test
+    fun `erLøpende - skal returnere true dersom det finnes andeler i en behandling hvor tom er etter YearMonth now`() {
+        val behandling = lagBehandling()
+
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns listOf(
+            lagAndelTilkjentYtelse(YearMonth.now().minusYears(1), YearMonth.now().minusMonths(6)),
+            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(6), YearMonth.now().minusMonths(3)),
+            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(3)),
+        )
+        assertThat(behandlingService.erLøpende(behandling)).isTrue
+    }
+
+    @Test
+    fun `erLøpende - skal returnere false dersom det finnes andeler i en behandling hvor tom er det samme som YearMonth now`() {
+        val behandling = lagBehandling()
+
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns listOf(
+            lagAndelTilkjentYtelse(YearMonth.now().minusYears(1), YearMonth.now().minusMonths(6)),
+            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(6), YearMonth.now().minusMonths(3)),
+            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(3), YearMonth.now()),
+        )
+        assertThat(behandlingService.erLøpende(behandling)).isFalse
+    }
+
+    @Test
+    fun `erLøpende - skal returnere false dersom alle andeler i en behandling har tom før YearMonth now`() {
+        val behandling = lagBehandling()
+
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns listOf(
+            lagAndelTilkjentYtelse(YearMonth.now().minusYears(1), YearMonth.now().minusMonths(6)),
+            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(6), YearMonth.now().minusMonths(3)),
+            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(3), YearMonth.now()),
+        )
+        assertThat(behandlingService.erLøpende(behandling)).isFalse
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceEnhetstest.kt
@@ -106,7 +106,7 @@ class BehandlingServiceEnhetstest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns listOf(
             lagAndelTilkjentYtelse(YearMonth.now().minusYears(1), YearMonth.now().minusMonths(6)),
             lagAndelTilkjentYtelse(YearMonth.now().minusMonths(6), YearMonth.now().minusMonths(3)),
-            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(3), YearMonth.now()),
+            lagAndelTilkjentYtelse(YearMonth.now().minusMonths(3), YearMonth.now().minusMonths(1)),
         )
         assertThat(behandlingService.erLøpende(behandling)).isFalse
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
@@ -60,6 +60,7 @@ class LagreMigreringsdatoTest {
         saksstatistikkEventPublisher,
         fagsakRepository,
         vedtakRepository,
+        andelTilkjentYtelseRepository,
         loggService,
         arbeidsfordelingService,
         infotrygdService,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -14,9 +14,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -29,7 +27,6 @@ internal class StegServiceTest {
     private val behandlingService: BehandlingService = mockk()
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
     private val satsendringService: SatsendringService = mockk()
-    private val simuleringService: SimuleringService = mockk()
 
     private val stegService = StegService(
         steg = listOf(mockRegistrerPersongrunnlag()),
@@ -55,47 +52,47 @@ internal class StegServiceTest {
 
     @Test
     fun `skal IKKE feile validering av helmanuell migrering når fagsak har aktivt vedtak som er et opphør`() {
-        Behandlingsresultat.values().filter { it.erOpphør() }.forEach {
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
-                lagBehandling(resultat = it)
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
+            lagBehandling()
 
-            assertDoesNotThrow {
-                stegService.håndterNyBehandling(
-                    NyBehandling(
-                        kategori = BehandlingKategori.NASJONAL,
-                        underkategori = BehandlingUnderkategori.ORDINÆR,
-                        behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                        behandlingÅrsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
-                        søkersIdent = randomFnr(),
-                        barnasIdenter = listOf(randomFnr()),
-                        nyMigreringsdato = LocalDate.now().minusMonths(6),
-                        fagsakId = 1L,
-                    ),
-                )
-            }
+        every { behandlingService.erLøpende(any()) } returns false
+
+        assertDoesNotThrow {
+            stegService.håndterNyBehandling(
+                NyBehandling(
+                    kategori = BehandlingKategori.NASJONAL,
+                    underkategori = BehandlingUnderkategori.ORDINÆR,
+                    behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+                    behandlingÅrsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+                    søkersIdent = randomFnr(),
+                    barnasIdenter = listOf(randomFnr()),
+                    nyMigreringsdato = LocalDate.now().minusMonths(6),
+                    fagsakId = 1L,
+                ),
+            )
         }
     }
 
     @Test
-    fun `skal feile validering av helmanuell migrering når fagsak har aktivt vedtak som IKKE er et opphør`() {
-        Behandlingsresultat.values().filter { !it.erOpphør() }.forEach {
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
-                lagBehandling(resultat = it)
+    fun `skal feile validering av helmanuell migrering når fagsak har aktivt vedtak med løpende utbetalinger`() {
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = any()) } returns
+            lagBehandling()
 
-            assertThrows<FunksjonellFeil> {
-                stegService.håndterNyBehandling(
-                    NyBehandling(
-                        kategori = BehandlingKategori.NASJONAL,
-                        underkategori = BehandlingUnderkategori.ORDINÆR,
-                        behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                        behandlingÅrsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
-                        søkersIdent = randomFnr(),
-                        barnasIdenter = listOf(randomFnr()),
-                        nyMigreringsdato = LocalDate.now().minusMonths(6),
-                        fagsakId = 1L,
-                    ),
-                )
-            }
+        every { behandlingService.erLøpende(any()) } returns true
+
+        assertThrows<FunksjonellFeil> {
+            stegService.håndterNyBehandling(
+                NyBehandling(
+                    kategori = BehandlingKategori.NASJONAL,
+                    underkategori = BehandlingUnderkategori.ORDINÆR,
+                    behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
+                    behandlingÅrsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
+                    søkersIdent = randomFnr(),
+                    barnasIdenter = listOf(randomFnr()),
+                    nyMigreringsdato = LocalDate.now().minusMonths(6),
+                    fagsakId = 1L,
+                ),
+            )
         }
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
@@ -142,6 +142,7 @@ class VedtakServiceTest(
             saksstatistikkEventPublisher,
             fagsakRepository,
             vedtakRepository,
+            andelTilkjentYtelseRepository,
             loggService,
             arbeidsfordelingService,
             infotrygdService,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Saksbehandler får ikke opprettet manuell migrering dersom det finnes en tidligere behandling og denne ikke har resultat `OPPHØRT`, `FORTSATT_OPPHØRT` eller `ENDRET_OG_OPPHØRT`. Det kan forekomme tilfeller av behandlinger som er opphørt men får ytterligere endringer i en behandling etter opphøret, med et resultat som ikke matcher et av opphør-resultatene. Dette til tross for at det ikke finnes noen løpende andeler i behandlingen.

Har derfor justert valideringen til å kun sjekke om andelene til siste vedtatte behandling er løpende: `tom` > dagens dato. Er den løpende kan man ikke opprette en manuell migreringsbehandling.

### ✅ Checklist
- [x] Jeg har skrevet tester.
