### PR TITLE
Lag ikke-utbetalings-perioder når det andelene er endret til 0% og det ikke er delt bosted

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
@@ -44,7 +44,10 @@ data class GrunnlagForPersonInnvilget(
     val kompetanse: KompetanseForVedtaksperiode? = null,
     val endretUtbetalingAndel: EndretUtbetalingAndelForVedtaksperiode? = null,
     val overgangsstønad: OvergangsstønadForVedtaksperiode? = null,
-) : GrunnlagForPerson
+) : GrunnlagForPerson {
+    fun erEndretTilIngenUtbetalingIkkeDeltBosted() =
+        andeler.all { it.prosent == BigDecimal.ZERO } && endretUtbetalingAndel?.årsak != Årsak.DELT_BOSTED == true
+}
 
 data class GrunnlagForPersonIkkeInnvilget(
     override val person: Person,
@@ -100,10 +103,12 @@ data class EndretUtbetalingAndelForVedtaksperiode(
 data class AndelForVedtaksperiode(
     val kalkulertUtbetalingsbeløp: Int,
     val type: YtelseType,
+    val prosent: BigDecimal,
 ) {
     constructor(andelTilkjentYtelse: AndelTilkjentYtelse) : this(
         kalkulertUtbetalingsbeløp = andelTilkjentYtelse.kalkulertUtbetalingsbeløp,
         type = andelTilkjentYtelse.type,
+        prosent = andelTilkjentYtelse.prosent,
     )
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
@@ -271,7 +271,11 @@ fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksper
 }
 
 private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeType(): Vedtaksperiodetype {
-    val erUtbetalingsperiode = this.innhold != null && this.innhold.any { it.gjeldende is GrunnlagForPersonInnvilget }
+    val erUtbetalingsperiode =
+        this.innhold != null && this.innhold.any {
+            it.gjeldende is GrunnlagForPersonInnvilget &&
+                !it.gjeldende.erEndretTilIngenUtbetalingIkkeDeltBosted()
+        }
     val erAvslagsperiode = this.innhold != null && this.innhold.all { it.gjeldende?.erEksplisittAvslag() == true }
 
     return when {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -197,10 +197,11 @@ fun lagEndredeUtbetalinger(
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             person = persongrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer.find { aktørId == it.aktør.aktørId },
-            prosent = BigDecimal.ZERO,
-            årsak = Årsak.ALLEREDE_UTBETALT,
+            prosent = parseValgfriLong(VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT, rad)?.toBigDecimal() ?: BigDecimal.ZERO,
+            årsak = parseValgfriEnum<Årsak>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.ÅRSAK, rad) ?: Årsak.ALLEREDE_UTBETALT,
             søknadstidspunkt = LocalDate.now(),
             begrunnelse = "Fordi at...",
+            avtaletidspunktDeltBosted = LocalDate.now(),
         )
     }.groupBy { it.behandlingId }
         .toMutableMap()
@@ -248,6 +249,7 @@ fun lagAndelerTilkjentYtelse(
             VedtaksperiodeMedBegrunnelserParser.DomenebegrepAndelTilkjentYtelse.YTELSE_TYPE,
             rad,
         ) ?: YtelseType.ORDINÆR_BARNETRYGD,
+        prosent = parseValgfriLong(VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT, rad)?.toBigDecimal() ?: BigDecimal(100),
     )
 }.groupBy { it.behandlingId }
     .toMutableMap()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -65,6 +65,11 @@ object VedtaksperiodeMedBegrunnelserParser {
         RESULTAT("Resultat"),
     }
 
+    enum class DomenebegrepEndretUtbetaling(override val nøkkel: String) : Domenenøkkel {
+        PROSENT("Prosent"),
+        ÅRSAK("Årsak"),
+    }
+
     enum class DomenebegrepAndelTilkjentYtelse(override val nøkkel: String) : Domenenøkkel {
         YTELSE_TYPE("Ytelse type"),
     }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endret_utbetaling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endret_utbetaling.feature
@@ -1,0 +1,65 @@
+# language: no
+# encoding: UTF-8
+
+
+Egenskap: Endringstidspunkt påvirker periodene
+
+  Bakgrunn:
+    Gitt følgende vedtak
+      | BehandlingId |
+      | 1            |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 24.12.1987  |
+      | 1            | 3456    | BARN       | 02.12.2016  |
+
+  Scenario: Skal lage ikke utbetalingsperiode når andelene er endret til 0% og det ikke er delt bosted
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |                      |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 02.12.2016 |            | Oppfylt  |                      |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt  |                      |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId | Prosent |
+      | 3456    | 01.01.2017 | 30.11.2034 | 1234  | 1            | 0       |
+
+    Og med endrede utbetalinger
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Årsak             | prosent |
+      | 3456    | 01.01.2017 | 30.11.2034 | 1            | ETTERBETALING_3ÅR | 0       |
+
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar            |
+      | 01.01.2017 | 30.11.2034 | Opphør             | Endret utbetaling 0% |
+      | 01.12.2034 |            | Opphør             | Barn over 18         |
+
+  Scenario:  Skal lage utbetalingsperiode når andelene er endret til 0% og det er delt bosted
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |                      |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 02.12.2016 |            | Oppfylt  |                      |
+      | 3456    | UNDER_18_ÅR                                                     | 02.12.2016 | 01.12.2034 | Oppfylt  |                      |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId | Prosent |
+      | 3456    | 01.01.2017 | 30.11.2034 | 1234  | 1            | 0       |
+
+    Og med endrede utbetalinger
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Årsak       | prosent |
+      | 3456    | 01.01.2017 | 30.11.2034 | 1            | DELT_BOSTED | 0       |
+
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar       |
+      | 01.01.2017 | 30.11.2034 | Utbetaling         | Delt bosted     |
+      | 01.12.2034 |            | Opphør             | Barn er over 18 |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13242)

Hvorfor:
Vi har enkelte scenarier som i dag blir rare. Dette gjelder f.eks saker der bruker kun oppfyller vilkårene tilbake i tid for en periode som var mer enn 3 år tilbake i tid. I dag får vi vedtaksbrevet "Du får barnetrygd", men ønsket er at vi her skal avslå ytelsen fordi de i realiteten ikke får barnetrygd. 

Hva: 
Endrer så perioder med endret utbetaling 0% med alle årsaker utenom "Delt bosted", skal gi vedtakperiode av typen "Ingen utbetaling"

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

