### PR TITLE
Støtt mulighet for at person ikke er med i behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -42,7 +42,7 @@ object EndringIVilkårsvurderingUtil {
             (nåværendePersonResultater.map { it.aktør } + forrigePersonResultater.map { it.aktør }).distinct()
 
         val tidslinjerPerPersonOgVilkår = allePersonerMedPersonResultat.flatMap { aktør ->
-            val personIBehandling = personerIBehandling.single { it.aktør == aktør }
+            val personIBehandling = personerIBehandling.singleOrNull { it.aktør == aktør }
             val personIForrigeBehandling = personerIForrigeBehandling.singleOrNull { it.aktør == aktør }
 
             Vilkår.values().map { vilkår ->
@@ -77,11 +77,11 @@ object EndringIVilkårsvurderingUtil {
         nåværendeOppfylteVilkårResultater: List<VilkårResultat>,
         forrigeOppfylteVilkårResultater: List<VilkårResultat>,
         vilkår: Vilkår,
-        personIBehandling: Person,
+        personIBehandling: Person?,
         personIForrigeBehandling: Person?,
     ): Tidslinje<Boolean, Måned> {
         val nåværendeVilkårResultatTidslinje = nåværendeOppfylteVilkårResultater
-            .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIBehandling.fødselsdato)
+            .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIBehandling?.fødselsdato)
 
         val tidligereVilkårResultatTidslinje = forrigeOppfylteVilkårResultater
             .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIForrigeBehandling?.fødselsdato)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Feilmelding i sentry](https://sentry.gc.nav.no/organizations/nav/issues/487793/events/9133addae4664f369e99f63299fbd8b8/?project=112&referrer=events-table%2F%3Fproject%3D112#exception)

Dersom vi har en person som var i forrige behandling, men som ikke er med i denne får vi nå en feil ved en `.single{}`. 
Endrer den til `.singleOrNull`

