### PR TITLE
Utled endringsperiode i vedtaksperiodeprodusenten

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -415,16 +415,6 @@ class VedtaksperiodeService(
         lagreNedOverstyrtEndringstidspunkt(vedtak.behandling.id, overstyrtEndringstidspunkt)
     }
 
-    @Transactional
-    fun oppdaterEndringstidspunktOgGenererVedtaksperioderPåNytt(restGenererVedtaksperioder: RestGenererVedtaksperioderForOverstyrtEndringstidspunkt): LocalDate? {
-        val vedtak = vedtakRepository.findByBehandlingAndAktiv(restGenererVedtaksperioder.behandlingId)
-
-        val oppdatertBehandling = lagreNedOverstyrtEndringstidspunkt(vedtak.behandling.id, restGenererVedtaksperioder.overstyrtEndringstidspunkt)
-        oppdaterVedtakMedVedtaksperioder(vedtak)
-
-        return oppdatertBehandling.overstyrtEndringstidspunkt
-    }
-
     private fun lagreNedOverstyrtEndringstidspunkt(behandlingId: Long, overstyrtEndringstidspunkt: LocalDate): Behandling {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId)
         behandling.overstyrtEndringstidspunkt = overstyrtEndringstidspunkt

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -415,10 +415,10 @@ class VedtaksperiodeService(
         lagreNedOverstyrtEndringstidspunkt(vedtak.behandling.id, overstyrtEndringstidspunkt)
     }
 
-    private fun lagreNedOverstyrtEndringstidspunkt(behandlingId: Long, overstyrtEndringstidspunkt: LocalDate): Behandling {
+    private fun lagreNedOverstyrtEndringstidspunkt(behandlingId: Long, overstyrtEndringstidspunkt: LocalDate) {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId)
         behandling.overstyrtEndringstidspunkt = overstyrtEndringstidspunkt
-        return behandlingHentOgPersisterService.lagreEllerOppdater(behandling = behandling, sendTilDvh = false)
+        behandlingHentOgPersisterService.lagreEllerOppdater(behandling = behandling, sendTilDvh = false)
     }
 
     fun kopierOverVedtaksperioder(deaktivertVedtak: Vedtak, aktivtVedtak: Vedtak) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeProdusent.kt
@@ -24,13 +24,13 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import utledEndringstidspunkt
 import java.time.LocalDate
 
 fun genererVedtaksperioder(
     grunnlagForVedtakPerioder: GrunnlagForVedtaksperioder,
     grunnlagForVedtakPerioderForrigeBehandling: GrunnlagForVedtaksperioder?,
     vedtak: Vedtak,
-    endringstidspunkt: LocalDate,
 ): List<VedtaksperiodeMedBegrunnelser> {
     val grunnlagTidslinjePerPerson = grunnlagForVedtakPerioder.utledGrunnlagTidslinjePerPerson()
 
@@ -43,7 +43,10 @@ fun genererVedtaksperioder(
         finnPerioderSomSkalBegrunnes(
             grunnlagTidslinjePerPerson = grunnlagTidslinjePerPerson,
             grunnlagTidslinjePerPersonForrigeBehandling = grunnlagTidslinjePerPersonForrigeBehandling,
-            endringstidspunkt = endringstidspunkt,
+            endringstidspunkt = vedtak.behandling.overstyrtEndringstidspunkt ?: utledEndringstidspunkt(
+                grunnlagForVedtaksperioder = grunnlagForVedtakPerioder,
+                grunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtakPerioderForrigeBehandling,
+            ),
         )
 
     val vedtaksperioder =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -6,7 +6,6 @@ import io.cucumber.java.no.Når
 import io.cucumber.java.no.Og
 import io.cucumber.java.no.Så
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.cucumber.domeneparser.BrevBegrunnelseParser.mapStandardBegrunnelser
 import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -43,7 +42,7 @@ class BegrunnelseTeksterStepDefinition {
     private var kompetanser = mutableMapOf<Long, List<Kompetanse>>()
     private var endredeUtbetalinger = mutableMapOf<Long, List<EndretUtbetalingAndel>>()
     private var andelerTilkjentYtelse = mutableMapOf<Long, List<AndelTilkjentYtelse>>()
-    private var endringstidspunkt = mutableMapOf<Long, LocalDate>()
+    private var overstyrteEndringstidspunkt = mutableMapOf<Long, LocalDate>()
 
     private var gjeldendeBehandlingId: Long? = null
 
@@ -107,6 +106,8 @@ class BegrunnelseTeksterStepDefinition {
 
         val vedtak = vedtaksliste.find { it.behandling.id == behandlingId && it.aktiv } ?: error("Finner ikke vedtak")
 
+        vedtak.behandling.overstyrtEndringstidspunkt = overstyrteEndringstidspunkt[behandlingId]
+
         val grunnlagForVedtaksperiode = GrunnlagForVedtaksperioder(
             persongrunnlag = persongrunnlag.finnPersonGrunnlagForBehandling(behandlingId),
             personResultater = personResultater[behandlingId] ?: error("Finner ikke personresultater"),
@@ -138,7 +139,6 @@ class BegrunnelseTeksterStepDefinition {
             vedtak = vedtak,
             grunnlagForVedtakPerioder = grunnlagForVedtaksperiode,
             grunnlagForVedtakPerioderForrigeBehandling = grunnlagForVedtaksperiodeForrigeBehandling,
-            endringstidspunkt = endringstidspunkt[behandlingId] ?: TIDENES_MORGEN,
         )
 
         val utvidedeVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser.map {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -38,7 +38,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
     private var kompetanser = mutableMapOf<Long, List<Kompetanse>>()
     private var endredeUtbetalinger = mutableMapOf<Long, List<EndretUtbetalingAndel>>()
     private var andelerTilkjentYtelse = mutableMapOf<Long, List<AndelTilkjentYtelse>>()
-    private var overstyrtEndringstidspunkt = mapOf<Long, LocalDate>()
+    private var overstyrteEndringstidspunkt = mapOf<Long, LocalDate>()
     private var overgangsstønad = mapOf<Long, List<InternPeriodeOvergangsstønad>>()
     private var uregistrerteBarn = listOf<BarnMedOpplysninger>()
 
@@ -78,7 +78,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
 
     @Og("med overstyrt endringstidspunkt")
     fun settEndringstidspunkt(dataTable: DataTable) {
-        overstyrtEndringstidspunkt = dataTable.asMaps().associate { rad ->
+        overstyrteEndringstidspunkt = dataTable.asMaps().associate { rad ->
             parseLong(Domenebegrep.BEHANDLING_ID, rad) to
                 parseDato(DomenebegrepVedtaksperiodeMedBegrunnelser.ENDRINGSTIDSPUNKT, rad)
         }
@@ -124,25 +124,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
             kompetanser = kompetanser,
             endredeUtbetalinger = endredeUtbetalinger,
             andelerTilkjentYtelse = andelerTilkjentYtelse,
-            endringstidspunkt = overstyrtEndringstidspunkt,
-            overgangsstønad = overgangsstønad,
-            uregistrerteBarn = uregistrerteBarn,
-        )
-    }
-
-    @Når("vedtaksperioder med begrunnelser genereres der forrige behandling allerede er vedtatt for behandling {}")
-    fun `generer vedtaksperiode med begrunnelse med utledet endringstidspunkt`(behandlingId: Long) {
-        gjeldendeBehandlingId = behandlingId
-
-        vedtaksperioderMedBegrunnelser = lagVedtaksPerioderMedUtledetEndringsTidspunkt(
-            behandlingId = behandlingId,
-            vedtaksListe = vedtaksliste,
-            behandlingTilForrigeBehandling = behandlingTilForrigeBehandling,
-            personGrunnlag = persongrunnlag,
-            personResultater = personResultater,
-            kompetanser = kompetanser,
-            endredeUtbetalinger = endredeUtbetalinger,
-            andelerTilkjentYtelse = andelerTilkjentYtelse,
+            overstyrteEndringstidspunkt = overstyrteEndringstidspunkt,
             overgangsstønad = overgangsstønad,
             uregistrerteBarn = uregistrerteBarn,
         )

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
@@ -68,7 +68,6 @@ Egenskap: Endringstidspunkt påvirker periodene
       | Endringstidspunkt | BehandlingId |
       | 01.11.2021        | 1            |
 
-
     Og lag personresultater for behandling 2
     Og legg til nye vilkårresultater for behandling 2
       | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_endrede_utbetalinger.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_endrede_utbetalinger.feature
@@ -83,7 +83,7 @@ Egenskap: Vedtaksperioder med endrede utbetalinger
       | 5678    | 08.12.2021 | 31.10.2031 | 1354  | 1            |
       | 5678    | 08.12.2021 | 31.10.2031 | 1354  | 2            |
 
-    Når vedtaksperioder med begrunnelser genereres der forrige behandling allerede er vedtatt for behandling 2
+    Når vedtaksperioder med begrunnelser genereres for behandling 2
 
     Så forvent følgende vedtaksperioder med begrunnelser
       | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
@@ -125,7 +125,7 @@ Egenskap: Vedtaksperioder med endrede utbetalinger
       | 3456    | 31.05.2021 | 30.10.2033 | 1354  | 1            |
       | 3456    | 31.04.2023 | 30.10.2033 | 1354  | 2            |
 
-    Når vedtaksperioder med begrunnelser genereres der forrige behandling allerede er vedtatt for behandling 2
+    Når vedtaksperioder med begrunnelser genereres for behandling 2
 
     Så forvent følgende vedtaksperioder med begrunnelser
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar                                              |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_sammenlign_mot_forrige_behandling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_sammenlign_mot_forrige_behandling.feature
@@ -78,6 +78,10 @@ Egenskap: Vedtaksperiode for behandling som opphører perioder fra forrige behan
       | 5678    | 01.05.2021 | 31.03.2039 | 1354  | 1            |
       | 5678    | 01.02.2022 | 31.03.2039 | 1354  | 2            |
 
+    Og med overstyrt endringstidspunkt
+      | Endringstidspunkt | BehandlingId |
+      | 01.01.2021        | 2            |
+
     Når vedtaksperioder med begrunnelser genereres for behandling 2
 
     Så forvent følgende vedtaksperioder med begrunnelser

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_sammenlign_mot_forrige_behandling_etterfølgende_ikke_oppfylt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_sammenlign_mot_forrige_behandling_etterfølgende_ikke_oppfylt.feature
@@ -47,6 +47,10 @@ Egenskap: Vedtaksperiode for behandling som opphører perioder fra forrige behan
       | 3456    | 01.05.2020 | 31.12.2020 | 1354  | 2            |
       | 3456    | 01.02.2022 | 31.03.2038 | 1354  | 2            |
 
+    Og med overstyrt endringstidspunkt
+      | Endringstidspunkt | BehandlingId |
+      | 01.01.2020        | 2            |
+
     Når vedtaksperioder med begrunnelser genereres for behandling 2
 
     Så forvent følgende vedtaksperioder med begrunnelser

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vedtaksperiode_vilkår.feature
@@ -340,7 +340,9 @@ Egenskap: Vedtaksperioder med mor og et barn
       | 3456    | 01.01.2022 | 31.03.2023 | 1676  | 2            |
       | 3456    | 01.01.2030 | 30.02.2039 | 1676  | 2            |
 
-
+    Og med overstyrt endringstidspunkt
+      | Endringstidspunkt | BehandlingId |
+      | 01.01.2021        | 2            |
 
     Når vedtaksperioder med begrunnelser genereres for behandling 2
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Nå som vi bruker samme data for å generere vedtaksperiode og endringstidspunkt kan vi ha det i samme utledning slik at vi enklere kan teste på det
