### PR TITLE
Sletter ubrukt kode og bytter ut assert med check

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -2,19 +2,8 @@ package no.nav.familie.ba.sak.internal
 
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
-import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
-import no.nav.familie.ba.sak.kjerne.steg.StegType
-import no.nav.familie.kontrakter.felles.Tema
-import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
-import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
-import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
-import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -26,9 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlin.concurrent.thread
 
@@ -40,9 +26,6 @@ class ForvalterController(
     private val integrasjonClient: IntegrasjonClient,
     private val restartAvSmåbarnstilleggService: RestartAvSmåbarnstilleggService,
     private val forvalterService: ForvalterService,
-    private val oppgaveService: OppgaveService,
-    private val behandlingRepository: BehandlingRepository,
-    private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ForvalterController::class.java)
 
@@ -65,171 +48,6 @@ class ForvalterController(
             )
         }
         return ResponseEntity.ok("Ferdigstill oppgaver kjørt. Antall som ikke ble ferdigstilt: $antallFeil")
-    }
-
-    data class KopiertFagsakInfo(
-        val fagsakId: Long,
-        val feil: String = "",
-        val trengerNyBehandling: Boolean = true,
-    )
-
-    data class KopierteEUAFagsakerRespons(
-        val feilet: List<Long>,
-        val kopierte: List<Long>,
-        val fagsakerSomIkkeTrengerNyBehandling: List<Long>,
-        val kopierteFagsakerInfo: List<KopiertFagsakInfo>,
-    )
-
-    @PostMapping(
-        path = ["/kopier-eua-satsendring/{skalKopiere}"],
-        consumes = [MediaType.APPLICATION_JSON_VALUE],
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-    )
-    fun kopierEndretUtbetalingAndelerFraForrigeBehandling(
-        @RequestBody fagsakListe: List<Long>,
-        @PathVariable skalKopiere: Boolean = false,
-    ): ResponseEntity<KopierteEUAFagsakerRespons> {
-        val kopierteFagsakerInfo = mutableListOf<KopiertFagsakInfo>()
-        fagsakListe.parallelStream().forEach { fagsakId ->
-            try {
-                val behandlinger = behandlingRepository.finnBehandlinger(fagsakId)
-                val sorterteVedtatteBehandlinger = behandlinger
-                    .filter { it.steg == StegType.BEHANDLING_AVSLUTTET && !it.erHenlagt() }
-                    .sortedByDescending { it.aktivertTidspunkt }
-
-                val sisteVedtatteBehandling = sorterteVedtatteBehandlinger[0]
-                val nestSisteVedtatteBehandling = sorterteVedtatteBehandlinger[1]
-
-                if (!sisteVedtatteBehandling.erSatsendring() && sisteVedtatteBehandling.opprettetTidspunkt > LocalDate.of(
-                        2023,
-                        6,
-                        19,
-                    ).atStartOfDay()
-                ) {
-                    throw Exception("Det er gjennomført en ny behandling etter satsendring som har tatt med seg feilen videre. Fagsak $fagsakId, Behandling $sisteVedtatteBehandling.")
-                }
-
-                val sisteEndreteUtbetalingsAndeler =
-                    endretUtbetalingAndelRepository.findByBehandlingId(sisteVedtatteBehandling.id)
-
-                val nestSisteEndreteUtbetalingsAndeler =
-                    endretUtbetalingAndelRepository.findByBehandlingId(nestSisteVedtatteBehandling.id)
-
-                if (sisteEndreteUtbetalingsAndeler.isNotEmpty() || nestSisteEndreteUtbetalingsAndeler.isEmpty()) {
-                    logger.info("Siste behandling har allerede EUA eller nest siste har ingen EUA og vi trenger ikke å kopiere. Fagsak $fagsakId")
-                    kopierteFagsakerInfo.add(KopiertFagsakInfo(fagsakId = fagsakId, trengerNyBehandling = false))
-                } else {
-                    logger.info("Kopierer EndretUtbetalingAndel fra behandling $nestSisteVedtatteBehandling til $sisteVedtatteBehandling.")
-
-                    if (skalKopiere) {
-                        forvalterService.kopierEndretUtbetalingFraForrigeBehandling(
-                            sisteVedtatteBehandling = sisteVedtatteBehandling,
-                            nestSisteVedtatteBehandling = nestSisteVedtatteBehandling,
-                        )
-                    }
-                    kopierteFagsakerInfo.add(KopiertFagsakInfo(fagsakId = fagsakId))
-                }
-            } catch (exception: Exception) {
-                logger.warn(exception.message)
-                logger.warn("Feil ved kopiering av EndretUtbetalingAndel fra nest siste behandling. Fagsak $fagsakId.")
-                kopierteFagsakerInfo.add(
-                    KopiertFagsakInfo(
-                        fagsakId = fagsakId,
-                        exception.message
-                            ?: "Feil ved kopiering av EndretUtbetalingAndel fra nest siste behandling. Fagsak $fagsakId.",
-                    ),
-                )
-            }
-        }
-
-        return ResponseEntity.ok(
-            KopierteEUAFagsakerRespons(
-                feilet = kopierteFagsakerInfo.filter { it.feil.isNotEmpty() }.map { it.fagsakId },
-                kopierte = kopierteFagsakerInfo.filter { it.feil.isEmpty() && it.trengerNyBehandling }
-                    .map { it.fagsakId },
-                fagsakerSomIkkeTrengerNyBehandling = kopierteFagsakerInfo.filter { !it.trengerNyBehandling }
-                    .map { it.fagsakId },
-                kopierteFagsakerInfo = kopierteFagsakerInfo,
-            ),
-        )
-    }
-
-    @PostMapping(
-        path = ["/gjenåpne-oppgaver"],
-        consumes = [MediaType.APPLICATION_JSON_VALUE],
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-    )
-    fun gjenåpneFeilaktigLukketOppgave(@RequestBody request: GjenåpneOppgaverRequest): ResponseEntity<Map<String, Set<Long>>> {
-        val result = mutableSetOf<Long>()
-
-        request.behandlinger.forEach { behandlingId ->
-            val lagretDbOppgave = oppgaveRepository.findByBehandlingAndTypeAndErFerdigstilt(
-                behandlingId,
-                request.oppgavetype,
-            ).maxBy { it.opprettetTidspunkt }
-
-            if (lagretDbOppgave == null) {
-                logger.info("Finner ikke oppgave for behandlingId=$behandlingId")
-            } else {
-                val eksisterendeOppgave =
-                    oppgaveService.hentOppgave(lagretDbOppgave.gsakId.toLong()) // Sikre med å sjekke oppgavetype er det som er i input
-
-                val ferdigstiltTid =
-                    LocalDateTime.parse(
-                        eksisterendeOppgave.ferdigstiltTidspunkt,
-                        DateTimeFormatter.ISO_DATE_TIME,
-                    ) // format "ferdigstiltTidspunkt": "2023-03-28T11:13:16.79+02:00",
-                if (eksisterendeOppgave.status == StatusEnum.FERDIGSTILT &&
-                    ferdigstiltTid.isAfter(request.ferdigstiltFom) &&
-                    ferdigstiltTid.isBefore(
-                        request.ferdigstiltTom,
-                    ) &&
-                    eksisterendeOppgave.tema == Tema.BAR &&
-                    eksisterendeOppgave.oppgavetype == request.oppgavetype.value
-                ) {
-                    val klonetOppgave = OpprettOppgaveRequest(
-                        ident = OppgaveIdentV2(
-                            ident = lagretDbOppgave.behandling.fagsak.aktør.aktørId,
-                            gruppe = IdentGruppe.AKTOERID,
-                        ),
-                        saksId = eksisterendeOppgave.saksreferanse,
-                        tema = Tema.BAR,
-                        oppgavetype = request.oppgavetype,
-                        fristFerdigstillelse = if (eksisterendeOppgave.fristFerdigstillelse != null) { // "fristFerdigstillelse": "2023-03-28",
-                            LocalDate.parse(
-                                eksisterendeOppgave.fristFerdigstillelse,
-                                DateTimeFormatter.ISO_DATE,
-                            )
-                        } else {
-                            LocalDate.now()
-                        },
-                        beskrivelse = "--- Gjenåpnet ferdigstilt oppgave med id ${eksisterendeOppgave.id} ---\n" + eksisterendeOppgave.beskrivelse,
-                        enhetsnummer = eksisterendeOppgave.tildeltEnhetsnr,
-                        behandlingstema = eksisterendeOppgave.behandlingstema,
-                        behandlingstype = eksisterendeOppgave.behandlingstype,
-                        tilordnetRessurs = eksisterendeOppgave.tilordnetRessurs,
-                        mappeId = eksisterendeOppgave.mappeId,
-                        prioritet = eksisterendeOppgave.prioritet ?: OppgavePrioritet.NORM,
-                    )
-
-                    val oppgaveOpprettet = integrasjonClient.opprettOppgave(klonetOppgave)
-                    logger.info("Gjenåpnet oppgave med id=${eksisterendeOppgave.id}. Ny oppgave har oppgaveId=${oppgaveOpprettet.oppgaveId}")
-                    secureLogger.info("Gjenåpnet oppgave med id=${eksisterendeOppgave.id}. Ny oppgave har oppgaveId==$oppgaveOpprettet oppgave=$klonetOppgave")
-                    result.add(behandlingId)
-                } else {
-                    logger.info(
-                        "Ignorerer gjenoppretting av eksisterende oppgave: " +
-                            "request=${request.oppgavetype}, oppgavetype=${request.oppgavetype}, behandlingId=$behandlingId, fom=${request.ferdigstiltFom}, tom=${request.ferdigstiltTom} \n" +
-                            "eksisterendeOppgave=${eksisterendeOppgave.id}, ${eksisterendeOppgave.tema}, ${eksisterendeOppgave.oppgavetype}, ${eksisterendeOppgave.ferdigstiltTidspunkt}, ${eksisterendeOppgave.status}",
-                    )
-                }
-            }
-        }
-
-        val returnValue = mutableMapOf<String, Set<Long>>()
-        returnValue.put("oppprettet", result)
-        returnValue.put("ignorert", request.behandlinger.toSet() - result)
-        return ResponseEntity.ok(returnValue)
     }
 
     @PostMapping(
@@ -292,10 +110,3 @@ class ForvalterController(
         return ResponseEntity.ok(Pair("callId", callId))
     }
 }
-
-data class GjenåpneOppgaverRequest(
-    val behandlinger: List<Long>,
-    val oppgavetype: Oppgavetype,
-    val ferdigstiltFom: LocalDateTime,
-    val ferdigstiltTom: LocalDateTime,
-)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -113,7 +113,7 @@ data class AndelTilkjentYtelseMedEndreteUtbetalinger internal constructor(
     fun slåSammenMed(naboAndel: AndelTilkjentYtelseMedEndreteUtbetalinger): AndelTilkjentYtelseMedEndreteUtbetalinger {
         // Skal allerede være sjekket at disse er naboer som kan slås sammen, bla. at de eventuelt har samme endringsperiode
         // Dermed skal en en enkel utvidelse med stønadTom fra naboen fungere
-        assert(skalAndelerSlåsSammen(this, naboAndel))
+        check(skalAndelerSlåsSammen(this, naboAndel))
         return AndelTilkjentYtelseMedEndreteUtbetalinger(
             andelTilkjentYtelse.copy(stønadTom = naboAndel.stønadTom),
             endreteUtbetalinger,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- Rydder vekk et par metoder i forvalter som man ikke lenger trenger.

- assert funker kun når man starter familie-ba-sak med -ea, så å ha dette i koden gjør ingenting uten denne kompiler-parameteren. Endrer til check, som funker uten kompilerparameter
