### PR TITLE
oppdater vedtak med vedtakperiode ved omregning FORTSATT_OPPHØRT

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -14,7 +14,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForP
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonIkkeInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForVedtaksperioder
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.sammenlignUtenFomOgTom
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.erLikUtenFomOgTom
 import java.time.LocalDate
 
 fun utledEndringstidspunkt(
@@ -66,22 +66,22 @@ private fun loggEndringstidspunktOgEndringer(
     when (grunnlagIPeriodeMedEndring) {
         is GrunnlagForPersonInnvilget -> {
             if (grunnlagIPeriodeMedEndringForrigeBehanlding is GrunnlagForPersonInnvilget) {
-                if (grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.sammenlignUtenFomOgTom(
+                if (!grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.erLikUtenFomOgTom(
                         grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode,
                     )
                 ) {
                     endringer.add("Endring i vilkårene")
                 }
-                if (grunnlagIPeriodeMedEndring.kompetanse == grunnlagIPeriodeMedEndringForrigeBehanlding.kompetanse) {
+                if (grunnlagIPeriodeMedEndring.kompetanse != grunnlagIPeriodeMedEndringForrigeBehanlding.kompetanse) {
                     endringer.add("Endring i kompetansen")
                 }
-                if (grunnlagIPeriodeMedEndring.endretUtbetalingAndel == grunnlagIPeriodeMedEndringForrigeBehanlding.endretUtbetalingAndel) {
+                if (grunnlagIPeriodeMedEndring.endretUtbetalingAndel != grunnlagIPeriodeMedEndringForrigeBehanlding.endretUtbetalingAndel) {
                     endringer.add("Endring i de endrede utbetalingene")
                 }
-                if (grunnlagIPeriodeMedEndring.overgangsstønad == grunnlagIPeriodeMedEndringForrigeBehanlding.overgangsstønad) {
+                if (grunnlagIPeriodeMedEndring.overgangsstønad != grunnlagIPeriodeMedEndringForrigeBehanlding.overgangsstønad) {
                     endringer.add("Endring i overgangsstønaden")
                 }
-                if (grunnlagIPeriodeMedEndring.andeler.toSet() == grunnlagIPeriodeMedEndringForrigeBehanlding.andeler.toSet()) {
+                if (grunnlagIPeriodeMedEndring.andeler.toSet() != grunnlagIPeriodeMedEndringForrigeBehanlding.andeler.toSet()) {
                     endringer.add("Endring i andelene")
                 }
             } else {
@@ -91,7 +91,7 @@ private fun loggEndringstidspunktOgEndringer(
 
         is GrunnlagForPersonIkkeInnvilget ->
             if (grunnlagIPeriodeMedEndringForrigeBehanlding is GrunnlagForPersonIkkeInnvilget) {
-                if (grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.sammenlignUtenFomOgTom(
+                if (!grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.erLikUtenFomOgTom(
                         grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode,
                     )
                 ) {
@@ -126,7 +126,7 @@ private fun GrunnlagForPerson?.erLik(
 ): Boolean = when (this) {
     is GrunnlagForPersonInnvilget ->
         grunnlagForVedtaksperiodeForrigeBehandling is GrunnlagForPersonInnvilget &&
-            this.vilkårResultaterForVedtaksperiode.sammenlignUtenFomOgTom(
+            this.vilkårResultaterForVedtaksperiode.erLikUtenFomOgTom(
                 grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode,
             ) &&
             this.kompetanse == grunnlagForVedtaksperiodeForrigeBehandling.kompetanse &&

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -295,8 +295,7 @@ class VedtaksperiodeService(
         vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(vedtak)
         val behandling = vedtak.behandling
 
-        // Rent fortsatt innvilget-resultat er det eneste som kun skal gi én vedtaksperiode
-        if (behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET) {
+        if (behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET || behandling.opprettetÅrsak.erOmregningsårsak()) {
             val vedtaksbrevmal = brevmalService.hentVedtaksbrevmal(
                 behandling,
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/GrunnlagForPerson.kt
@@ -84,7 +84,7 @@ data class VilkårResultatForVedtaksperiode(
     )
 }
 
-fun List<VilkårResultatForVedtaksperiode>.sammenlignUtenFomOgTom(other: List<VilkårResultatForVedtaksperiode>): Boolean {
+fun List<VilkårResultatForVedtaksperiode>.erLikUtenFomOgTom(other: List<VilkårResultatForVedtaksperiode>): Boolean {
     return this.map { it.copy(fom = null, tom = null) }.toSet() == other.map { it.copy(fom = null, tom = null) }.toSet()
 }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14321)
Vi begrunner feil barn når vi har et barn som allerede er opphørt ved omregning. Dette kommer at vi går inn i feil if-branch i VedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(). 
Lagt til test så vi ikke brekker dette på et senere tidspunkt. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇