### PR TITLE
Bug/Oppdater spørring for å hente behandlinger som ligger til godkjenning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -95,12 +95,22 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     )
     fun finnBehandlingerSomHolderPåÅIverksettes(fagsakId: Long): List<Behandling>
 
+    /**
+     *  Finner behandlinger som ligger til godkjenning.
+     *  Dvs. behandlingen er på 'beslutte vedtak'-steget ('beslutte vedtak' er det siste steget på behandlingen) og dette steget er ikke utført enda
+     */
     @Query(
         """select b from Behandling b
-                           inner join BehandlingStegTilstand bst on b.id = bst.behandling.id
-                        where b.fagsak.id = :fagsakId AND bst.behandlingSteg = 'BESLUTTE_VEDTAK' AND bst.behandlingStegStatus = 'IKKE_UTFØRT'""",
+                inner join BehandlingStegTilstand bst on b.id = bst.behandling.id
+                where b.fagsak.id = :fagsakId AND bst.behandlingSteg = 'BESLUTTE_VEDTAK' AND bst.behandlingStegStatus = 'IKKE_UTFØRT' 
+                    AND bst.id = (
+                        select bst2.id
+                        from BehandlingStegTilstand bst2 
+                        where bst2.behandling.id = b.id 
+                        ORDER BY bst2.opprettetTidspunkt DESC LIMIT 1
+                    )""",
     )
-    fun finnBehandlingerSentTilGodkjenning(fagsakId: Long): List<Behandling>
+    fun finnBehandlingerSomLiggerTilGodkjenning(fagsakId: Long): List<Behandling>
 
     @Query("SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id = :fagsakId AND b.status = 'AVSLUTTET' AND f.arkivert = false")
     fun findByFagsakAndAvsluttet(fagsakId: Long): List<Behandling>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -107,12 +107,12 @@ class BeregningService(
             .filter { it.id != fagsakId }
 
         return andreFagsaker.mapNotNull { fagsak ->
-            val behandlingSomErSendtTilGodkjenning = behandlingRepository.finnBehandlingerSentTilGodkjenning(
+            val behandlingSomLiggerTilGodkjenning = behandlingRepository.finnBehandlingerSomLiggerTilGodkjenning(
                 fagsakId = fagsak.id,
             ).singleOrNull()
 
-            if (behandlingSomErSendtTilGodkjenning != null) {
-                behandlingSomErSendtTilGodkjenning
+            if (behandlingSomLiggerTilGodkjenning != null) {
+                behandlingSomLiggerTilGodkjenning
             } else {
                 val godkjenteBehandlingerSomIkkeErIverksattEnda =
                     behandlingRepository.finnBehandlingerSomHolderPåÅIverksettes(fagsakId = fagsak.id).singleOrNull()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.common.KONTAKT_TEAMET_SUFFIX
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
 import no.nav.familie.ba.sak.common.Utils
-import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.maksBeløp
@@ -187,12 +186,6 @@ object TilkjentYtelseValidering {
             }
         }
         if (barnMedUtbetalingsikkerhetFeil.isNotEmpty()) {
-            secureLogger.info(
-                "${barnMedAndreRelevanteTilkjentYtelser
-                    .filter { barnMedUtbetalingsikkerhetFeil.contains(it.first) }
-                    .map { "Andeler for barn ${it.first.fødselsdato}: ${it.second.map { tilkjentYtelse -> "[Fagsak ${tilkjentYtelse.behandling.fagsak}: ${tilkjentYtelse.andelerTilkjentYtelse}], " }}" }}",
-            )
-
             throw UtbetalingsikkerhetFeil(
                 melding = "Vi finner utbetalinger som overstiger 100% på hvert av barna: ${
                     barnMedUtbetalingsikkerhetFeil.tilFeilmeldingTekst()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-14060

Oppdaterer spørring så man kun henter ut behandlinger hvor beslutte vedtak-steget er **steget behandlingen er på (dvs. siste steg i behandling-steg-listen)** og dette steget ikke er utført. Vi hadde en bug hvor beslutte vedtak-steget kunne ligge i steg-listen som "ikke utført" hvis behandlingen hadde blitt henlagt når den sto på beslutte vedtak-steget, og da fanget denne spørringen opp det som en relevant behandling. Vi er kun på jakt etter behandlinger hvor dette er **siste/aktivt** steg.

Fjerner også logging som ikke er nødvendig lenger (det samme logges i funksjonen ett hakk ut).

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei ikke egentlig.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Jeg har testet manuelt i konsollen med prodsaken, og da får vi opp forventet resultat med den nye spørringen. Kan skrive test hvis det er ønskelig, men jeg føler ikke behovet i denne saken.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
