### PR TITLE
Legg til filter på hendelser for begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.utledSegmenter
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -33,6 +34,7 @@ import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.fpsak.tidsserie.LocalDateInterval
 import no.nav.fpsak.tidsserie.LocalDateSegment
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.Objects
 
@@ -258,6 +260,17 @@ enum class YtelseType(val klassifisering: String) {
         ORDINÆR_BARNETRYGD -> listOf(SatsType.ORBA, SatsType.TILLEGG_ORBA)
         UTVIDET_BARNETRYGD -> listOf(SatsType.UTVIDET_BARNETRYGD)
         SMÅBARNSTILLEGG -> listOf(SatsType.SMA)
+    }
+
+    fun tilSatsType(person: Person, ytelseDato: LocalDate) = when (this) {
+        ORDINÆR_BARNETRYGD -> if (ytelseDato.toYearMonth() < person.hentSeksårsdag().toYearMonth()) {
+            SatsType.TILLEGG_ORBA
+        } else {
+            SatsType.ORBA
+        }
+
+        UTVIDET_BARNETRYGD -> SatsType.UTVIDET_BARNETRYGD
+        SMÅBARNSTILLEGG -> SatsType.SMA
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/Dødsfall.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/Dødsfall.kt
@@ -74,3 +74,20 @@ fun lagDødsfall(
         dødsfallPoststed = dødsfallAdresseFraPdl?.poststedsnavn,
     )
 }
+
+fun lagDødsfall(
+    person: Person,
+    dødsfallDato: LocalDate,
+    dødsfallAdresse: String? = null,
+    dødsfallPostnummer: String? = null,
+    dødsfallPoststed: String? = null,
+
+): Dødsfall {
+    return Dødsfall(
+        person = person,
+        dødsfallDato = dødsfallDato,
+        dødsfallAdresse = dødsfallAdresse,
+        dødsfallPostnummer = dødsfallPostnummer,
+        dødsfallPoststed = dødsfallPoststed,
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -110,7 +110,7 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåHendelser(
     } else if (begrunnelseGrunnlag.grunnlagForVedtaksperiode !is GrunnlagForPersonVilkårInnvilget) {
         val person = begrunnelseGrunnlag.grunnlagForVedtaksperiode.person
 
-        this.filtrerPåPersonDød(person, fomVedtaksperiode)
+        this.filtrerPåBarnDød(person, fomVedtaksperiode)
     } else {
         val person = begrunnelseGrunnlag.grunnlagForVedtaksperiode.person
 
@@ -132,7 +132,7 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåBarn6år(
     }
 }
 
-fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåPersonDød(
+fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåBarnDød(
     person: Person,
     fomVedtaksperiode: LocalDate?,
 ): Map<Standardbegrunnelse, SanityBegrunnelse> {
@@ -140,7 +140,7 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåPersonDød(
     val personDødeForrigeMåned =
         dødsfall != null && dødsfall.dødsfallDato.toYearMonth().plusMonths(1) == fomVedtaksperiode?.toYearMonth()
 
-    return if (personDødeForrigeMåned) {
+    return if (personDødeForrigeMåned && person.type == PersonType.BARN) {
         this.filterValues { it.ovrigeTriggere?.contains(ØvrigTrigger.BARN_DØD) == true }
     } else {
         emptyMap()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -167,9 +167,12 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåSatsendring(
 private fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåPeriodetype(
     begrunnelseGrunnlag: BegrunnelseGrunnlag,
 ) = this.filterValues {
+    val begrunnelseGjelderFraInnvilgelsestidspunkt =
+        it.ovrigeTriggere?.contains(ØvrigTrigger.GJELDER_FRA_INNVILGELSESTIDSPUNKT) == true
+
     when (begrunnelseGrunnlag) {
         is BegrunnelseGrunnlagMedVerdiIDennePerioden -> {
-            if (begrunnelseGrunnlag.grunnlagForVedtaksperiode.erInnvilget()) {
+            val resultater = if (begrunnelseGrunnlag.grunnlagForVedtaksperiode.erInnvilget()) {
                 it.resultat in listOf(
                     SanityVedtakResultat.INNVILGET_ELLER_ØKNING,
                     SanityVedtakResultat.REDUKSJON,
@@ -179,12 +182,15 @@ private fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåPeriodetype(
                     SanityVedtakResultat.REDUKSJON,
                     SanityVedtakResultat.IKKE_INNVILGET,
                 )
-            } && it.ovrigeTriggere?.contains(ØvrigTrigger.GJELDER_FRA_INNVILGELSESTIDSPUNKT) != true
+            }
+
+            !begrunnelseGjelderFraInnvilgelsestidspunkt && resultater
         }
 
         is BegrunnelseGrunnlagIngenVerdiIDennePerioden -> {
-            it.resultat in listOf(SanityVedtakResultat.REDUKSJON) &&
-                it.ovrigeTriggere?.contains(ØvrigTrigger.GJELDER_FRA_INNVILGELSESTIDSPUNKT) == true
+            begrunnelseGrunnlag.erInnvilgetForrigeBehandling &&
+                it.resultat in listOf(SanityVedtakResultat.REDUKSJON) &&
+                begrunnelseGjelderFraInnvilgelsestidspunkt
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -152,12 +152,14 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåSatsendring(
     andeler: Iterable<AndelForVedtaksperiode>,
     fomVedtaksperiode: LocalDate?,
 ): Map<Standardbegrunnelse, SanityBegrunnelse> {
-    val satstyper = andeler.map { it.type.tilSatsType(person, fomVedtaksperiode ?: TIDENES_MORGEN) }.toSet()
+    val satstyperPåAndelene = andeler.map { it.type.tilSatsType(person, fomVedtaksperiode ?: TIDENES_MORGEN) }.toSet()
 
-    val erSatsendringPåEnAvSatsene =
-        satstyper.any { satstype -> SatsService.finnAlleSatserFor(satstype).any { it.gyldigFom == fomVedtaksperiode } }
+    val erSatsendringIPeriodenForPerson =
+        satstyperPåAndelene.any { satstype ->
+            SatsService.finnAlleSatserFor(satstype).any { it.gyldigFom == fomVedtaksperiode }
+        }
 
-    return if (erSatsendringPåEnAvSatsene) {
+    return if (erSatsendringIPeriodenForPerson) {
         this.filterValues { it.ovrigeTriggere?.contains(ØvrigTrigger.SATSENDRING) == true }
     } else {
         emptyMap()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -1,13 +1,16 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.brevBegrunnelseProdusent
 
-import erReduksjonDelBostedBegrunnelse
 import filtrerPåVilkår
+import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
@@ -22,12 +25,14 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.AktørOgRolleBegrunnelseGrunnlag
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.AndelForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.EndretUtbetalingAndelForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForPersonVilkårInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForVedtaksperioder
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 
 fun UtvidetVedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserForPeriode(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -89,7 +89,7 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserPerPerso
                 endretUtbetalingForrigePeriode = hentEndretUtbetalingForrigePeriode(begrunnelseGrunnlag),
             )
 
-        val filtrertPåHendelse = begrunnelserFiltrertPåPeriodetype.filtrerPåHendelser(
+        val filtrertPåHendelser = begrunnelserFiltrertPåPeriodetype.filtrerPåHendelser(
             begrunnelseGrunnlag,
             this.fom,
         )
@@ -97,7 +97,7 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserPerPerso
         filtrertPåVilkår.keys.toSet() +
             filtrertPåEndretUtbetaling.keys.toSet() +
             filtrertPåEtterEndretUtbetaling.keys.toSet() +
-            filtrertPåHendelse.keys.toSet()
+            filtrertPåHendelser.keys.toSet()
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -138,10 +138,10 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåPersonDød(
 ): Map<Standardbegrunnelse, SanityBegrunnelse> {
     val dødsfall = person.dødsfall
     val personDødeForrigeMåned =
-        dødsfall != null && dødsfall.dødsfallDato.toYearMonth() == fomVedtaksperiode?.toYearMonth()?.plusMonths(1)
+        dødsfall != null && dødsfall.dødsfallDato.toYearMonth().plusMonths(1) == fomVedtaksperiode?.toYearMonth()
 
     return if (personDødeForrigeMåned) {
-        this.filterValues { it.ovrigeTriggere?.contains(ØvrigTrigger.BARN_MED_6_ÅRS_DAG) == true }
+        this.filterValues { it.ovrigeTriggere?.contains(ØvrigTrigger.BARN_DØD) == true }
     } else {
         emptyMap()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -152,7 +152,7 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåSatsendring(
     andeler: Iterable<AndelForVedtaksperiode>,
     fomVedtaksperiode: LocalDate?,
 ): Map<Standardbegrunnelse, SanityBegrunnelse> {
-    val satstyper = andeler.map { it.type }.map { it.tilSatsType(person, fomVedtaksperiode ?: TIDENES_MORGEN) }.toSet()
+    val satstyper = andeler.map { it.type.tilSatsType(person, fomVedtaksperiode ?: TIDENES_MORGEN) }.toSet()
 
     val erSatsendringPåEnAvSatsene =
         satstyper.any { satstype -> SatsService.finnAlleSatserFor(satstype).any { it.gyldigFom == fomVedtaksperiode } }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -105,13 +105,16 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåHendelser(
     begrunnelseGrunnlag: BegrunnelseGrunnlag,
     fomVedtaksperiode: LocalDate?,
 ): Map<Standardbegrunnelse, SanityBegrunnelse> {
-    return if (begrunnelseGrunnlag !is BegrunnelseGrunnlagMedVerdiIDennePerioden || begrunnelseGrunnlag.grunnlagForVedtaksperiode !is GrunnlagForPersonVilkårInnvilget) {
+    return if (begrunnelseGrunnlag !is BegrunnelseGrunnlagMedVerdiIDennePerioden) {
         emptyMap()
+    } else if (begrunnelseGrunnlag.grunnlagForVedtaksperiode !is GrunnlagForPersonVilkårInnvilget) {
+        val person = begrunnelseGrunnlag.grunnlagForVedtaksperiode.person
+
+        this.filtrerPåPersonDød(person, fomVedtaksperiode)
     } else {
         val person = begrunnelseGrunnlag.grunnlagForVedtaksperiode.person
 
         this.filtrerPåBarn6år(person, fomVedtaksperiode) +
-            this.filtrerPåPersonDød(person, fomVedtaksperiode) +
             this.filtrerPåSatsendring(person, begrunnelseGrunnlag.grunnlagForVedtaksperiode.andeler, fomVedtaksperiode)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -194,6 +194,7 @@ fun tilfeldigPerson(
     kjønn: Kjønn = Kjønn.MANN,
     aktør: Aktør = randomAktør(),
     personId: Long = nestePersonId(),
+    dødsfall: Dødsfall? = null,
 ) =
     Person(
         id = personId,
@@ -204,6 +205,7 @@ fun tilfeldigPerson(
         navn = "",
         kjønn = kjønn,
         målform = Målform.NB,
+        dødsfall = dødsfall,
     ).apply { sivilstander = mutableListOf(GrSivilstand(type = SIVILSTAND.UGIFT, person = this)) }
 
 fun Person.tilPersonEnkel() =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -38,6 +38,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.SøkersAktivitet
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.GrunnlagForVedtaksperioder
@@ -231,7 +232,12 @@ fun lagPersonGrunnlag(dataTable: DataTable): Map<Long, PersonopplysningGrunnlag>
                     rad,
                 ),
                 aktør = randomAktør().copy(aktørId = VedtaksperiodeMedBegrunnelserParser.parseAktørId(rad)),
-            )
+            ).also { person ->
+                parseValgfriDato(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.DØDSFALLDATO,
+                    rad,
+                )?.let { person.dødsfall = lagDødsfall(person = person, dødsfallDato = it) }
+            }
         }
     }.flatten()
         .groupBy({ it.first }, { it.second })

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -43,6 +43,7 @@ object VedtaksperiodeMedBegrunnelserParser {
     enum class DomenebegrepPersongrunnlag(override val nøkkel: String) : Domenenøkkel {
         PERSON_TYPE("Persontype"),
         FØDSELSDATO("Fødselsdato"),
+        DØDSFALLDATO("Dødsfalldato"),
         AKTØR_ID("AktørId"),
     }
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
@@ -1,7 +1,7 @@
 # language: no
 # encoding: UTF-8
 
-Egenskap: Vedtaksperioder med mor og et barn
+Egenskap: Begrunnelser ved endring av vilkår
 
   Bakgrunn:
     Gitt følgende behandling

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
@@ -1,0 +1,36 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Begrunnelser for hendelser
+
+  Bakgrunn:
+    Gitt følgende behandling
+      | BehandlingId |
+      | 1            |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |
+      | 1            | 3456    | BARN       | 13.04.2017  |
+
+  Scenario: Skal ta med 6-års begrunnelse når barn blir 6 år
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                                     | 13.04.2017 | 12.04.2035 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2017 |            | Oppfylt  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2017 | 31.03.2023 | 1354  | 1            |
+      | 3456    | 01.04.2023 | 31.03.2035 | 1054  | 1            |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser | Ekskluderte Begrunnelser |
+      | 01.05.2017 | 31.03.2023 | UTBETALING         |                         |                          |
+      | 01.04.2023 | 31.03.2035 | UTBETALING         | REDUKSJON_UNDER_6_ÅR    |                          |
+      | 01.04.2035 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR      |                          |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
@@ -8,12 +8,12 @@ Egenskap: Begrunnelser for hendelser
       | BehandlingId |
       | 1            |
 
+  Scenario: Skal ta med 6-års begrunnelse når barn blir 6 år
     Og følgende persongrunnlag for begrunnelse
       | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
       | 1            | 1234    | SØKER      | 11.01.1970  |              |
-      | 1            | 3456    | BARN       | 13.04.2017  | 02.03.2024   |
+      | 1            | 3456    | BARN       | 13.04.2017  |              |
 
-  Scenario: Skal ta med 6-års begrunnelse når barn blir 6 år
     Og lag personresultater for begrunnelse for behandling 1
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
@@ -36,18 +36,23 @@ Egenskap: Begrunnelser for hendelser
       | 01.04.2035 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR      |                          |
 
   Scenario: Skal ta med dødsfallbegrunnelse om baret er dødt
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |              |
+      | 1            | 5678    | BARN       | 13.04.2017  | 02.03.2024   |
+
     Og lag personresultater for begrunnelse for behandling 1
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |
       | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |
-      | 3456    | UNDER_18_ÅR                                                     | 13.04.2017 | 12.04.2035 | Oppfylt  |
-      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2017 | 02.03.2024 | Oppfylt  |
+      | 5678    | UNDER_18_ÅR                                                     | 13.04.2017 | 12.04.2035 | Oppfylt  |
+      | 5678    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2017 | 02.03.2024 | Oppfylt  |
 
     Og med andeler tilkjent ytelse for begrunnelse
       | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
-      | 3456    | 01.05.2017 | 31.03.2023 | 1354  | 1            |
-      | 3456    | 01.04.2023 | 31.03.2024 | 1054  | 1            |
+      | 5678    | 01.05.2017 | 31.03.2023 | 1354  | 1            |
+      | 5678    | 01.04.2023 | 31.03.2024 | 1054  | 1            |
 
     Når begrunnelsetekster genereres for behandling 1
 
@@ -56,3 +61,30 @@ Egenskap: Begrunnelser for hendelser
       | 01.05.2017 | 31.03.2023 | UTBETALING         |                         |                          |
       | 01.04.2023 | 31.03.2024 | UTBETALING         | REDUKSJON_UNDER_6_ÅR    |                          |
       | 01.04.2024 |            | OPPHØR             | REDUKSJON_BARN_DØD      |                          |
+
+  Scenario: Skal ta med satsendringbegrunnelse ved satsendring
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |              |
+      | 1            | 3456    | BARN       | 13.04.2017  |              |
+
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                                     | 13.04.2017 | 12.04.2035 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2017 |            | Oppfylt  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2017 | 28.02.2023 | 1676  | 1            |
+      | 3456    | 01.03.2023 | 31.03.2035 | 1083  | 1            |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                     | Ekskluderte Begrunnelser |
+      | 01.05.2017 | 28.02.2023 | UTBETALING         |                                             |                          |
+      | 01.03.2023 | 31.03.2035 | UTBETALING         | REDUKSJON_UNDER_6_ÅR, INNVILGET_SATSENDRING |                          |
+      | 01.04.2035 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR                          |                          |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
@@ -42,7 +42,7 @@ Egenskap: Begrunnelser for hendelser
       | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |
       | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |
       | 3456    | UNDER_18_ÅR                                                     | 13.04.2017 | 12.04.2035 | Oppfylt  |
-      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2017 | 31.03.2024 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2017 | 02.03.2024 | Oppfylt  |
 
     Og med andeler tilkjent ytelse for begrunnelse
       | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
@@ -35,7 +35,7 @@ Egenskap: Begrunnelser for hendelser
       | 01.04.2023 | 31.03.2035 | UTBETALING         | REDUKSJON_UNDER_6_ÅR    |                          |
       | 01.04.2035 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR      |                          |
 
-  Scenario: Skal ta med dødsfallbegrunnelse om baret er dødt
+  Scenario: Skal ta med dødsfallbegrunnelse om barnet er dødt
     Og følgende persongrunnlag for begrunnelse
       | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
       | 1            | 1234    | SØKER      | 11.01.1970  |              |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
@@ -9,9 +9,9 @@ Egenskap: Begrunnelser for hendelser
       | 1            |
 
     Og følgende persongrunnlag for begrunnelse
-      | BehandlingId | AktørId | Persontype | Fødselsdato |
-      | 1            | 1234    | SØKER      | 11.01.1970  |
-      | 1            | 3456    | BARN       | 13.04.2017  |
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |              |
+      | 1            | 3456    | BARN       | 13.04.2017  | 02.03.2024   |
 
   Scenario: Skal ta med 6-års begrunnelse når barn blir 6 år
     Og lag personresultater for begrunnelse for behandling 1
@@ -34,3 +34,25 @@ Egenskap: Begrunnelser for hendelser
       | 01.05.2017 | 31.03.2023 | UTBETALING         |                         |                          |
       | 01.04.2023 | 31.03.2035 | UTBETALING         | REDUKSJON_UNDER_6_ÅR    |                          |
       | 01.04.2035 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR      |                          |
+
+  Scenario: Skal ta med dødsfallbegrunnelse om baret er dødt
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                                  | 11.01.1970 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                                     | 13.04.2017 | 12.04.2035 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2017 | 31.03.2024 | Oppfylt  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2017 | 31.03.2023 | 1354  | 1            |
+      | 3456    | 01.04.2023 | 31.03.2024 | 1054  | 1            |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser | Ekskluderte Begrunnelser |
+      | 01.05.2017 | 31.03.2023 | UTBETALING         |                         |                          |
+      | 01.04.2023 | 31.03.2024 | UTBETALING         | REDUKSJON_UNDER_6_ÅR    |                          |
+      | 01.04.2024 |            | OPPHØR             | REDUKSJON_BARN_DØD      |                          |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-13721

Vi ønsker å filtrere begrunnelsene slik at satsendring-, dødsfall og seksårsbegrunnelsene kommer opp ved de hendelsene. 

Legger til filtreringsregler for satsendring, dødsfall og reduksjon 6 år.  

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
