### PR TITLE
Splitt opp begrunnelsegrunnlag på vedtaksperiode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/Periode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/Periode.kt
@@ -37,3 +37,6 @@ fun <I, T : Tidsenhet> periodeAv(
 fun <I, T : Tidsenhet> Tidspunkt<T>.tilPeriodeMedInnhold(innhold: I?) = Periode(this, this, innhold)
 
 fun <I, T : Tidsenhet> Tidspunkt<T>.tilPeriodeUtenInnhold() = tilPeriodeMedInnhold(null as I)
+
+fun <I, T : Tidsenhet, R> Collection<Periode<I, T>>.mapInnhold(mapper: (I?) -> R?): Collection<Periode<R, T>> =
+    this.map { Periode(it.fraOgMed, it.tilOgMed, mapper(it.innhold)) }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
@@ -55,5 +55,24 @@ Egenskap: Begrunnelser ved endring av vilkår
       | 01.02.2021 | 31.03.2021 | UTBETALING         | INNVILGET_BOSATT_I_RIKTET_LOVLIG_OPPHOLD |                          |
       | 01.04.2021 |            | OPPHØR             | OPPHØR_BARN_FLYTTET_FRA_SØKER            |                          |
 
+  Scenario: Bor med søker for barn er eneste utgjørende vilkår skal kun gi bor med søker begrunnelser
+    Og lag personresultater for begrunnelse for behandling 1
 
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                           | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                   | 15.01.1990 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                      | 13.04.2020 | 12.04.2038 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 13.04.2020 |            | Oppfylt  |
+      | 3456    | BOR_MED_SØKER                                    | 13.04.2021 | 10.03.2022 | Oppfylt  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2021 | 31.03.2022 | 1354  | 1            |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser       | Ekskluderte Begrunnelser      |
+      | 01.05.2021 | 31.03.2022 | UTBETALING         | INNVILGET_BOR_HOS_SØKER       | REDUKSJON_IKKE_BOSATT_I_NORGE |
+      | 01.04.2022 |            | OPPHØR             | OPPHØR_BARN_FLYTTET_FRA_SØKER |                               |
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Personene sine begrunnelse-grunnlag er ikke nødvendigvis splittet opp samtidig som vedtaksperiodene. 

For eksempel er det i testen som blir lagt til i PRen kun én periode for søker siden søker ikke har noen endringer. 

Denne PRen sørger for å lage en splitt samtidig som vedtaksperioden slik at vi kan sammenligne hva vi hadde rettfør vedtaksperioden og det vi har i vedtaksperioden. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇