### PR TITLE
Fix: ikke kjøre simulering uten utbetalingsperioder og ikke sammenligne dersom resultat er tomt for ny og gammel

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiService.kt
@@ -90,7 +90,7 @@ class ØkonomiService(
     }
 }
 
-private fun Utbetalingsoppdrag.skalIverksettesMotOppdrag(): Boolean = utbetalingsperiode.isNotEmpty()
+fun Utbetalingsoppdrag.skalIverksettesMotOppdrag(): Boolean = utbetalingsperiode.isNotEmpty()
 
 private fun TilkjentYtelse.skalIverksettesMotOppdrag(): Boolean =
     this.utbetalingsoppdrag()?.skalIverksettesMotOppdrag() ?: false

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
@@ -19,7 +19,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjær
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
-import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
 import org.springframework.stereotype.Service
@@ -74,7 +73,7 @@ class KontrollerNyUtbetalingsgeneratorService(
             erSimulering = erSimulering,
         )
 
-        if (!beregnetUtbetalingsoppdrag.kanSimuleres()) return emptyList()
+        if (!beregnetUtbetalingsoppdrag.utbetalingsoppdrag.skalIverksettesMotOppdrag()) return emptyList()
 
         secureLogger.info("Behandling ${behandling.id} har følgende oppdaterte andeler: ${beregnetUtbetalingsoppdrag.andeler}")
 
@@ -192,9 +191,6 @@ class KontrollerNyUtbetalingsgeneratorService(
         }
         return null
     }
-
-    private fun BeregnetUtbetalingsoppdragLongId.kanSimuleres(): Boolean =
-        this.utbetalingsoppdrag.utbetalingsperiode.isNotEmpty()
 
     private fun loggSimuleringsPerioderMedDiff(
         simuleringsPerioderGammel: List<SimuleringsPeriode>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
@@ -187,10 +187,11 @@ class KontrollerNyUtbetalingsgeneratorService(
                 simuleringsPerioderGammelTidslinje.fraOgMed()!!,
                 simuleringsPerioderNyTidslinje.fraOgMed()!!.tilForrigeMåned(),
             ).perioder()
-            .filter { it.innhold!!.resultat != BigDecimal.ZERO }
+            // Bruker compareTo for å ignorere scale. 0 == 0.00 gir false, mens 0.compareTo(0.00) gir 0 som betyr at de er like.
+            .filter { it.innhold!!.resultat.compareTo(BigDecimal.ZERO) != 0 }
 
         if (perioderFraGammelFørNyMedResultatUlik0.isNotEmpty()) {
-            secureLogger.warn("Behandling ${behandling.id}  har diff i simuleringsresultat ved bruk av ny utbetalingsgenerator - simuleringsperioder før simuleringsperioder fra ny generator gir resultat ulik 0. [${perioderFraGammelFørNyMedResultatUlik0.joinToString() { it.toString() }}]")
+            secureLogger.warn("Behandling ${behandling.id}  har diff i simuleringsresultat ved bruk av ny utbetalingsgenerator - simuleringsperioder før simuleringsperioder fra gammel generator gir resultat ulik 0. [${perioderFraGammelFørNyMedResultatUlik0.joinToString() { it.toString() }}]")
             return DiffFeilType.TidligerePerioderIGammelUlik0
         }
         return null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
@@ -85,11 +85,15 @@ class KontrollerNyUtbetalingsgeneratorService(
 
         if (nyttSimuleringResultat.simuleringMottaker.isEmpty() && gammeltSimuleringResultat.simuleringMottaker.isEmpty()) return emptyList()
 
-        validerAtBådeNyOgGammelGirEtResultat(
-            nyttSimuleringResultat = nyttSimuleringResultat,
-            gammeltSimuleringResultat = gammeltSimuleringResultat,
-            behandling = behandling,
-        )?.let { diffFeilTyper.add(it) }
+        if (!bådeNyOgGammelGirEtResultat(
+                nyttSimuleringResultat = nyttSimuleringResultat,
+                gammeltSimuleringResultat = gammeltSimuleringResultat,
+                behandling = behandling,
+            )
+        ) {
+            diffFeilTyper.add(DiffFeilType.DetEneSimuleringsresultatetErTomt)
+            return diffFeilTyper
+        }
 
         val simuleringsPerioderGammel = gammeltSimuleringResultat.tilSorterteSimuleringsPerioder(behandling)
 
@@ -123,16 +127,16 @@ class KontrollerNyUtbetalingsgeneratorService(
         return diffFeilTyper
     }
 
-    private fun validerAtBådeNyOgGammelGirEtResultat(
+    private fun bådeNyOgGammelGirEtResultat(
         nyttSimuleringResultat: DetaljertSimuleringResultat,
         gammeltSimuleringResultat: DetaljertSimuleringResultat,
         behandling: Behandling,
-    ): DiffFeilType? {
-        if ((nyttSimuleringResultat.simuleringMottaker.isNotEmpty() && gammeltSimuleringResultat.simuleringMottaker.isEmpty()) || (nyttSimuleringResultat.simuleringMottaker.isEmpty() && gammeltSimuleringResultat.simuleringMottaker.isNotEmpty())) {
+    ): Boolean {
+        if (!(nyttSimuleringResultat.simuleringMottaker.isNotEmpty() && gammeltSimuleringResultat.simuleringMottaker.isNotEmpty())) {
             secureLogger.warn("Behandling ${behandling.id} får tomt simuleringsresultat med ny eller gammel generator. Ny er tom: ${nyttSimuleringResultat.simuleringMottaker.isEmpty()}, Gammel er tom: ${gammeltSimuleringResultat.simuleringMottaker.isEmpty()}")
-            return DiffFeilType.DetEneSimuleringsresultatetErTomt
+            return false
         }
-        return null
+        return true
     }
 
     private fun skalKontrollereOppMotNyUtbetalingsgenerator(): Boolean =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -70,8 +70,8 @@ class SimuleringService(
 
         kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
             vedtak = vedtak,
-            simuleringResultatGammel = detaljertSimuleringResultat,
-            utbetalingsoppdragGammel = utbetalingsoppdrag,
+            gammeltSimuleringResultat = detaljertSimuleringResultat,
+            gammeltUtbetalingsoppdrag = utbetalingsoppdrag,
             erSimulering = true,
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
@@ -93,8 +93,8 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
 
         val simuleringsPeriodeDiffFeil = kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
             vedtak = lagVedtak(),
-            simuleringResultatGammel = simuleringBasertPåGammelGenerator,
-            utbetalingsoppdragGammel = mockk(),
+            gammeltSimuleringResultat = simuleringBasertPåGammelGenerator,
+            gammeltUtbetalingsoppdrag = mockk(),
         )
 
         assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(2)
@@ -125,8 +125,8 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
 
         val simuleringsPeriodeDiffFeil = kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
             vedtak = lagVedtak(),
-            simuleringResultatGammel = simuleringBasertPåGammelGenerator,
-            utbetalingsoppdragGammel = mockk(),
+            gammeltSimuleringResultat = simuleringBasertPåGammelGenerator,
+            gammeltUtbetalingsoppdrag = mockk(),
         )
 
         assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(0)
@@ -150,8 +150,8 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
 
         val simuleringsPeriodeDiffFeil = kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
             vedtak = lagVedtak(),
-            simuleringResultatGammel = simuleringBasertPåGammelGenerator,
-            utbetalingsoppdragGammel = mockk(),
+            gammeltSimuleringResultat = simuleringBasertPåGammelGenerator,
+            gammeltUtbetalingsoppdrag = mockk(),
         )
 
         assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(0)
@@ -179,8 +179,8 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
 
         val simuleringsPeriodeDiffFeil = kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
             vedtak = lagVedtak(),
-            simuleringResultatGammel = simuleringBasertPåGammelGenerator,
-            utbetalingsoppdragGammel = mockk(),
+            gammeltSimuleringResultat = simuleringBasertPåGammelGenerator,
+            gammeltUtbetalingsoppdrag = mockk(),
         )
 
         assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(1)
@@ -210,8 +210,8 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
 
         val simuleringsPeriodeDiffFeil = kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
             vedtak = lagVedtak(),
-            simuleringResultatGammel = simuleringBasertPåGammelGenerator,
-            utbetalingsoppdragGammel = mockk(),
+            gammeltSimuleringResultat = simuleringBasertPåGammelGenerator,
+            gammeltUtbetalingsoppdrag = mockk(),
         )
 
         assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(1)
@@ -240,8 +240,8 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
 
         val simuleringsPeriodeDiffFeil = kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
             vedtak = lagVedtak(),
-            simuleringResultatGammel = simuleringBasertPåGammelGenerator,
-            utbetalingsoppdragGammel = mockk(),
+            gammeltSimuleringResultat = simuleringBasertPåGammelGenerator,
+            gammeltUtbetalingsoppdrag = mockk(),
         )
 
         assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(0)


### PR DESCRIPTION
Sammenligning mellom gammel og ny utbetalingsgenerator feiler i de tilfellene vi ikke har noen utbetalingsperioder. Typisk EØS-saker med 0 kr i `kalkulertUtbetalingsbeløp`.

Feiler også med `nullPointerException` i saker hvor alt opphører og vi får et tomt resultat tilbake fra Oppdrag.

* Legger inn sjekk før simulering, som sørger for at vi kun kjører simulering dersom det finnes utbetalingsperioder i utbetalingsoppdraget.
* Legger inn sjekk etter simulering som validere at resultatet ikke er tomt før vi går videre til sammenligning.