### PR TITLE
Feat/filtrer begrunnelser på kompetanser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory
 interface ISanityBegrunnelse {
     val apiNavn: String
     val navnISystem: String
-    val resultat: SanityVedtakResultat?
+    val vedtakResultat: SanityVedtakResultat?
     val vilkår: Set<Vilkår>
     val borMedSokerTriggere: List<VilkårTrigger>
     val giftPartnerskapTriggere: List<VilkårTrigger>
@@ -30,7 +30,7 @@ interface ISanityBegrunnelse {
 data class SanityBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
-    override val resultat: SanityVedtakResultat? = null,
+    override val vedtakResultat: SanityVedtakResultat? = null,
     override val vilkår: Set<Vilkår> = emptySet(),
     override val lovligOppholdTriggere: List<VilkårTrigger> = emptyList(),
     override val bosattIRiketTriggere: List<VilkårTrigger> = emptyList(),
@@ -123,7 +123,7 @@ data class RestSanityBegrunnelse(
                 finnEnumverdi(it, UtvidetBarnetrygdTrigger.entries.toTypedArray(), apiNavn)
             } ?: emptyList(),
             valgbarhet = valgbarhet?.let { finnEnumverdi(valgbarhet, Valgbarhet.entries.toTypedArray(), apiNavn) },
-            resultat = vedtakResultat?.let {
+            vedtakResultat = vedtakResultat?.let {
                 finnEnumverdi(it, SanityVedtakResultat.entries.toTypedArray(), apiNavn)
             },
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory
 interface ISanityBegrunnelse {
     val apiNavn: String
     val navnISystem: String
-    val vedtakResultat: SanityVedtakResultat?
+    val periodeResultat: SanityPeriodeResultat?
     val vilkår: Set<Vilkår>
     val borMedSokerTriggere: List<VilkårTrigger>
     val giftPartnerskapTriggere: List<VilkårTrigger>
@@ -30,7 +30,7 @@ interface ISanityBegrunnelse {
 data class SanityBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
-    override val vedtakResultat: SanityVedtakResultat? = null,
+    override val periodeResultat: SanityPeriodeResultat? = null,
     override val vilkår: Set<Vilkår> = emptySet(),
     override val lovligOppholdTriggere: List<VilkårTrigger> = emptyList(),
     override val bosattIRiketTriggere: List<VilkårTrigger> = emptyList(),
@@ -123,8 +123,8 @@ data class RestSanityBegrunnelse(
                 finnEnumverdi(it, UtvidetBarnetrygdTrigger.entries.toTypedArray(), apiNavn)
             } ?: emptyList(),
             valgbarhet = valgbarhet?.let { finnEnumverdi(valgbarhet, Valgbarhet.entries.toTypedArray(), apiNavn) },
-            vedtakResultat = vedtakResultat?.let {
-                finnEnumverdi(it, SanityVedtakResultat.entries.toTypedArray(), apiNavn)
+            periodeResultat = vedtakResultat?.let {
+                finnEnumverdi(it, SanityPeriodeResultat.entries.toTypedArray(), apiNavn)
             },
         )
     }
@@ -187,7 +187,7 @@ fun List<VilkårTrigger>.tilUtdypendeVilkårsvurderinger() = this.map {
     }
 }
 
-enum class SanityVedtakResultat {
+enum class SanityPeriodeResultat {
     INNVILGET_ELLER_ØKNING,
     INGEN_ENDRING,
     IKKE_INNVILGET,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
@@ -65,7 +65,7 @@ data class RestSanityEØSBegrunnelse(
 data class SanityEØSBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
-    override val resultat: SanityPeriodeResultat? = null,
+    override val periodeResultat: SanityPeriodeResultat? = null,
     override val vilkår: Set<Vilkår>,
     val annenForeldersAktivitet: List<AnnenForeldersAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser
 import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
+import no.nav.familie.ba.sak.kjerne.brev.domene.finnEnumverdi
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -29,6 +30,7 @@ data class RestSanityEØSBegrunnelse(
     val hjemlerEOSForordningen987: List<String>?,
     val hjemlerSeperasjonsavtalenStorbritannina: List<String>?,
     val eosVilkaar: List<String>? = null,
+    val vedtakResultat: String?,
 ) {
     fun tilSanityEØSBegrunnelse(): SanityEØSBegrunnelse? {
         if (apiNavn == null || navnISystem == null) return null
@@ -50,6 +52,9 @@ data class RestSanityEØSBegrunnelse(
             hjemlerEØSForordningen987 = hjemlerEOSForordningen987 ?: emptyList(),
             hjemlerSeperasjonsavtalenStorbritannina = hjemlerSeperasjonsavtalenStorbritannina ?: emptyList(),
             vilkår = eosVilkaar?.mapNotNull { konverterTilEnumverdi<Vilkår>(it) }?.toSet() ?: emptySet(),
+            vedtakResultat = vedtakResultat?.let {
+                finnEnumverdi(it, SanityVedtakResultat.entries.toTypedArray(), apiNavn)
+            },
         )
     }
 
@@ -60,7 +65,7 @@ data class RestSanityEØSBegrunnelse(
 data class SanityEØSBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
-    override val resultat: SanityVedtakResultat? = null,
+    override val vedtakResultat: SanityVedtakResultat? = null,
     override val vilkår: Set<Vilkår>,
     val annenForeldersAktivitet: List<AnnenForeldersAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser
 
 import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.finnEnumverdi
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
@@ -52,8 +52,8 @@ data class RestSanityEØSBegrunnelse(
             hjemlerEØSForordningen987 = hjemlerEOSForordningen987 ?: emptyList(),
             hjemlerSeperasjonsavtalenStorbritannina = hjemlerSeperasjonsavtalenStorbritannina ?: emptyList(),
             vilkår = eosVilkaar?.mapNotNull { konverterTilEnumverdi<Vilkår>(it) }?.toSet() ?: emptySet(),
-            vedtakResultat = vedtakResultat?.let {
-                finnEnumverdi(it, SanityVedtakResultat.entries.toTypedArray(), apiNavn)
+            periodeResultat = vedtakResultat?.let {
+                finnEnumverdi(it, SanityPeriodeResultat.entries.toTypedArray(), apiNavn)
             },
         )
     }
@@ -65,7 +65,7 @@ data class RestSanityEØSBegrunnelse(
 data class SanityEØSBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
-    override val vedtakResultat: SanityVedtakResultat? = null,
+    override val periodeResultat: SanityPeriodeResultat? = null,
     override val vilkår: Set<Vilkår>,
     val annenForeldersAktivitet: List<AnnenForeldersAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.brevBegrunnelseProdusent
 
 import erGjeldendeForUtgjørendeVilkår
+import erGjeldendeForUtgjørendeVilkårInkluderHvisIkkeVilkår
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.toYearMonth
@@ -145,7 +146,7 @@ private fun hentEØSStandardBegrunnelser(
     }
 
     val filtrertPåVilkår = begrunnelserFiltrertPåPeriodetype.filterValues {
-        it.erGjeldendeForUtgjørendeVilkår(
+        it.erGjeldendeForUtgjørendeVilkårInkluderHvisIkkeVilkår(
             begrunnelseGrunnlag,
             person,
             behandlingUnderkategori,
@@ -192,7 +193,7 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåBarn6år(
     val blirPerson6DennePerioden = person.hentSeksårsdag().toYearMonth() == fomVedtaksperiode?.toYearMonth()
 
     return if (blirPerson6DennePerioden) {
-        this.filterValues { it.ovrigeTriggere?.contains(ØvrigTrigger.BARN_MED_6_ÅRS_DAG) == true }
+        this.filterValues { it.ovrigeTriggere.contains(ØvrigTrigger.BARN_MED_6_ÅRS_DAG) }
     } else {
         emptyMap()
     }
@@ -207,7 +208,7 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåBarnDød(
         dødsfall != null && dødsfall.dødsfallDato.toYearMonth().plusMonths(1) == fomVedtaksperiode?.toYearMonth()
 
     return if (personDødeForrigeMåned && person.type == PersonType.BARN) {
-        this.filterValues { it.ovrigeTriggere?.contains(ØvrigTrigger.BARN_DØD) == true }
+        this.filterValues { it.ovrigeTriggere.contains(ØvrigTrigger.BARN_DØD) }
     } else {
         emptyMap()
     }
@@ -226,7 +227,7 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåSatsendring(
         }
 
     return if (erSatsendringIPeriodenForPerson) {
-        this.filterValues { it.ovrigeTriggere?.contains(ØvrigTrigger.SATSENDRING) == true }
+        this.filterValues { it.ovrigeTriggere.contains(ØvrigTrigger.SATSENDRING) }
     } else {
         emptyMap()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.brevBegrunnelseProdusent
 
 import erGjeldendeForUtgjørendeVilkår
-import erGjeldendeForUtgjørendeVilkårInkluderHvisIkkeVilkår
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.toYearMonth
@@ -10,7 +9,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -146,20 +145,21 @@ private fun hentEØSStandardBegrunnelser(
     }
 
     val filtrertPåVilkår = begrunnelserFiltrertPåPeriodetype.filterValues {
-        it.erGjeldendeForUtgjørendeVilkårInkluderHvisIkkeVilkår(
+        it.erGjeldendeForUtgjørendeVilkår(
             begrunnelseGrunnlag,
             person,
             behandlingUnderkategori,
         )
     }
 
-    val filtrertPåKompetanse = filtrertPåVilkår.filterValues {
+    val filtrertPåKompetanse = begrunnelserFiltrertPåPeriodetype.filterValues {
         it.erLikKompetanseIPeriode(
             begrunnelseGrunnlag,
         )
     }
 
-    return filtrertPåKompetanse.keys.toSet()
+    return filtrertPåVilkår.keys.toSet() +
+        filtrertPåKompetanse.keys.toSet()
 }
 
 fun SanityEØSBegrunnelse.erLikKompetanseIPeriode(
@@ -239,14 +239,14 @@ private fun ISanityBegrunnelse.harPeriodeTypeSomSkalBegrunnes(
     val dennePerioden = begrunnelseGrunnlag.dennePerioden
 
     return if (dennePerioden.erOrdinæreVilkårInnvilget() && dennePerioden.erInnvilgetEtterEndretUtbetaling()) {
-        this.vedtakResultat in listOf(
-            SanityVedtakResultat.INNVILGET_ELLER_ØKNING,
-            SanityVedtakResultat.REDUKSJON,
+        this.periodeResultat in listOf(
+            SanityPeriodeResultat.INNVILGET_ELLER_ØKNING,
+            SanityPeriodeResultat.REDUKSJON,
         )
     } else {
-        this.vedtakResultat in listOf(
-            SanityVedtakResultat.REDUKSJON,
-            SanityVedtakResultat.IKKE_INNVILGET,
+        this.periodeResultat in listOf(
+            SanityPeriodeResultat.REDUKSJON,
+            SanityPeriodeResultat.IKKE_INNVILGET,
         )
     }
 }
@@ -256,14 +256,14 @@ private fun ISanityBegrunnelse.harPeriodeTypeSomSkalBegrunnesForrigePeriode(
 ): Boolean {
     val forrigePeriode = begrunnelseGrunnlag.forrigePeriode
     return if (forrigePeriode?.erOrdinæreVilkårInnvilget() == true && forrigePeriode.erInnvilgetEtterEndretUtbetaling()) {
-        this.vedtakResultat in listOf(
-            SanityVedtakResultat.INNVILGET_ELLER_ØKNING,
-            SanityVedtakResultat.REDUKSJON,
+        this.periodeResultat in listOf(
+            SanityPeriodeResultat.INNVILGET_ELLER_ØKNING,
+            SanityPeriodeResultat.REDUKSJON,
         )
     } else {
-        this.vedtakResultat in listOf(
-            SanityVedtakResultat.REDUKSJON,
-            SanityVedtakResultat.IKKE_INNVILGET,
+        this.periodeResultat in listOf(
+            SanityPeriodeResultat.REDUKSJON,
+            SanityPeriodeResultat.IKKE_INNVILGET,
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -149,7 +149,7 @@ private fun hentEØSStandardBegrunnelser(
         hentResultaterForPeriode(begrunnelseGrunnlag.dennePerioden, begrunnelseGrunnlag.forrigePeriode)
 
     val begrunnelserFiltrertPåPeriodetype = sanityEØSBegrunnelser.filterValues {
-        it.resultat in relevantePeriodeResultater
+        it.periodeResultat in relevantePeriodeResultater
     }
 
     val filtrertPåVilkår = begrunnelserFiltrertPåPeriodetype.filterValues {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -26,6 +26,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.landkodeTilBarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.AndelForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.BehandlingsGrunnlagForVedtaksperioder
@@ -151,7 +152,23 @@ private fun hentEØSStandardBegrunnelser(
         )
     }
 
-    return filtrertPåVilkår.keys.toSet()
+    val filtrertPåKompetanse = filtrertPåVilkår.filterValues {
+        it.erLikKompetanseIPeriode(
+            begrunnelseGrunnlag,
+        )
+    }
+
+    return filtrertPåKompetanse.keys.toSet()
+}
+
+fun SanityEØSBegrunnelse.erLikKompetanseIPeriode(
+    begrunnelseGrunnlag: BegrunnelseGrunnlagForPeriode,
+): Boolean {
+    val kompetanseIPeriode = begrunnelseGrunnlag.dennePerioden.kompetanse ?: return false
+
+    return this.annenForeldersAktivitet.contains(kompetanseIPeriode.annenForeldersAktivitet) &&
+        this.barnetsBostedsland.contains(landkodeTilBarnetsBostedsland(kompetanseIPeriode.barnetsBostedsland)) &&
+        this.kompetanseResultat.contains(kompetanseIPeriode.resultat)
 }
 
 fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåHendelser(
@@ -221,12 +238,12 @@ private fun ISanityBegrunnelse.harPeriodeTypeSomSkalBegrunnes(
     val dennePerioden = begrunnelseGrunnlag.dennePerioden
 
     return if (dennePerioden.erOrdinæreVilkårInnvilget() && dennePerioden.erInnvilgetEtterEndretUtbetaling()) {
-        this.resultat in listOf(
+        this.vedtakResultat in listOf(
             SanityVedtakResultat.INNVILGET_ELLER_ØKNING,
             SanityVedtakResultat.REDUKSJON,
         )
     } else {
-        this.resultat in listOf(
+        this.vedtakResultat in listOf(
             SanityVedtakResultat.REDUKSJON,
             SanityVedtakResultat.IKKE_INNVILGET,
         )
@@ -238,12 +255,12 @@ private fun ISanityBegrunnelse.harPeriodeTypeSomSkalBegrunnesForrigePeriode(
 ): Boolean {
     val forrigePeriode = begrunnelseGrunnlag.forrigePeriode
     return if (forrigePeriode?.erOrdinæreVilkårInnvilget() == true && forrigePeriode.erInnvilgetEtterEndretUtbetaling()) {
-        this.resultat in listOf(
+        this.vedtakResultat in listOf(
             SanityVedtakResultat.INNVILGET_ELLER_ØKNING,
             SanityVedtakResultat.REDUKSJON,
         )
     } else {
-        this.resultat in listOf(
+        this.vedtakResultat in listOf(
             SanityVedtakResultat.REDUKSJON,
             SanityVedtakResultat.IKKE_INNVILGET,
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/VilkårFilterUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/VilkårFilterUtil.kt
@@ -34,6 +34,27 @@ fun ISanityBegrunnelse.erGjeldendeForUtgjørendeVilkår(
     )
 }
 
+fun ISanityBegrunnelse.erGjeldendeForUtgjørendeVilkårInkluderHvisIkkeVilkår(
+    begrunnelseGrunnlag: BegrunnelseGrunnlagForPeriode,
+    person: Person,
+    behandlingUnderkategori: BehandlingUnderkategori,
+): Boolean {
+    val vilkårForPerson = Vilkår.hentVilkårFor(
+        personType = person.type,
+        fagsakType = FagsakType.NORMAL,
+        behandlingUnderkategori = behandlingUnderkategori,
+    )
+
+    val utgjørendeVilkårResultater = finnUtgjørendeVilkår(
+        begrunnelseGrunnlag = begrunnelseGrunnlag,
+        vilkårForPerson = vilkårForPerson,
+    )
+
+    return this.erLikVilkårOgUtdypendeVilkårIPeriode(
+        utgjørendeVilkårResultater,
+    )
+}
+
 private fun ISanityBegrunnelse.erLikVilkårOgUtdypendeVilkårIPeriode(
     vilkårResultaterForPerson: Collection<VilkårResultatForVedtaksperiode>,
 ): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/VilkårFilterUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/VilkårFilterUtil.kt
@@ -34,27 +34,6 @@ fun ISanityBegrunnelse.erGjeldendeForUtgjørendeVilkår(
     )
 }
 
-fun ISanityBegrunnelse.erGjeldendeForUtgjørendeVilkårInkluderHvisIkkeVilkår(
-    begrunnelseGrunnlag: BegrunnelseGrunnlagForPeriode,
-    person: Person,
-    behandlingUnderkategori: BehandlingUnderkategori,
-): Boolean {
-    val vilkårForPerson = Vilkår.hentVilkårFor(
-        personType = person.type,
-        fagsakType = FagsakType.NORMAL,
-        behandlingUnderkategori = behandlingUnderkategori,
-    )
-
-    val utgjørendeVilkårResultater = finnUtgjørendeVilkår(
-        begrunnelseGrunnlag = begrunnelseGrunnlag,
-        vilkårForPerson = vilkårForPerson,
-    )
-
-    return this.erLikVilkårOgUtdypendeVilkårIPeriode(
-        utgjørendeVilkårResultater,
-    )
-}
-
 private fun ISanityBegrunnelse.erLikVilkårOgUtdypendeVilkårIPeriode(
     vilkårResultaterForPerson: Collection<VilkårResultatForVedtaksperiode>,
 ): Boolean {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -37,7 +37,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBost
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVilkår
 import no.nav.familie.ba.sak.kjerne.brev.domene.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårRolle
@@ -1229,7 +1229,7 @@ fun lagSanityBegrunnelse(
     endretUtbetalingsperiodeDeltBostedTriggere: EndretUtbetalingsperiodeDeltBostedTriggere? = null,
     endretUtbetalingsperiodeTriggere: List<EndretUtbetalingsperiodeTrigger> = emptyList(),
     valgbarhet: Valgbarhet? = null,
-    resultat: SanityVedtakResultat? = null,
+    resultat: SanityPeriodeResultat? = null,
 ): SanityBegrunnelse = SanityBegrunnelse(
     apiNavn = apiNavn,
     navnISystem = navnISystem,
@@ -1245,7 +1245,7 @@ fun lagSanityBegrunnelse(
     hjemlerFolketrygdloven = hjemlerFolketrygdloven,
     endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = endretUtbetalingsperiodeDeltBostedTriggere,
     endretUtbetalingsperiodeTriggere = endretUtbetalingsperiodeTriggere,
-    vedtakResultat = resultat,
+    periodeResultat = resultat,
 )
 
 fun lagSanityEøsBegrunnelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1245,7 +1245,7 @@ fun lagSanityBegrunnelse(
     hjemlerFolketrygdloven = hjemlerFolketrygdloven,
     endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = endretUtbetalingsperiodeDeltBostedTriggere,
     endretUtbetalingsperiodeTriggere = endretUtbetalingsperiodeTriggere,
-    resultat = resultat,
+    vedtakResultat = resultat,
 )
 
 fun lagSanityEøsBegrunnelse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BrevBegrunnelseParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BrevBegrunnelseParser.kt
@@ -50,7 +50,7 @@ object BrevBegrunnelseParser {
 
             Regelverk.EØS_FORORDNINGEN -> {
                 parseEnumListe<EØSStandardbegrunnelse>(
-                    DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.INKLUDERTE_BEGRUNNELSER,
+                    inkludertEllerEkskludert,
                     rad,
                 ).toSet()
             }
@@ -59,8 +59,8 @@ object BrevBegrunnelseParser {
 
     enum class DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser(override val nøkkel: String) : Domenenøkkel {
         VEDTAKSPERIODE_TYPE("VedtaksperiodeType"),
-        INKLUDERTE_BEGRUNNELSER("Inkluderte Begrunnelser"), EKSKLUDERTE_BEGRUNNELSER("Ekskluderte Begrunnelser"), REGELVERK(
-            "Regelverk",
-        ),
+        INKLUDERTE_BEGRUNNELSER("Inkluderte Begrunnelser"),
+        EKSKLUDERTE_BEGRUNNELSER("Ekskluderte Begrunnelser"),
+        REGELVERK("Regelverk"),
     }
 }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -13,7 +13,6 @@ Egenskap: Kompetanse-begrunnelser
       | 1            | 1234    | SØKER      | 11.01.1970  |
       | 1            | 3456    | BARN       | 13.04.2020  |
 
-    #TODO: Legg til forventede inkluderte begrunnelser
   Scenario: Skal gi innvilget primærland begrunnelse basert på kompetanse
     Og lag personresultater for begrunnelse for behandling 1
 
@@ -36,9 +35,9 @@ Egenskap: Kompetanse-begrunnelser
     Når begrunnelsetekster genereres for behandling 1
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser | Ekskluderte Begrunnelser                           |
-      | 01.05.2020 | 30.04.2021 | Utbetaling         | EØS_FORORDNINGEN |                         | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE |
-      | 01.05.2021 | 31.03.2038 | Utbetaling         |                  |                         |                                                    |
-      | 01.04.2038 |            | Opphør             |                  |                         |                                                    |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser                            | Ekskluderte Begrunnelser                           |
+      | 01.05.2020 | 30.04.2021 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE |
+      | 01.05.2021 | 31.03.2038 | Utbetaling         |                  |                                                    |                                                    |
+      | 01.04.2038 |            | Opphør             |                  |                                                    |                                                    |
 
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -30,14 +30,14 @@ Egenskap: Kompetanse-begrunnelser
     Og med kompetanser for begrunnelse
       | AktørId | Fra dato   | Til dato   | Resultat              | BehandlingId | Annen forelders aktivitet | Barnets bostedsland |
       | 3456    | 01.05.2020 | 30.04.2021 | NORGE_ER_PRIMÆRLAND   | 1            | IKKE_AKTUELT              | NORGE               |
-      | 3456    | 01.05.2021 | 31.03.2038 | NORGE_ER_SEKUNDÆRLAND | 1            |                           |                     |
+      | 3456    | 01.05.2021 | 31.03.2038 | NORGE_ER_SEKUNDÆRLAND | 1            | I_ARBEID                  | IKKE_NORGE          |
 
     Når begrunnelsetekster genereres for behandling 1
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser                            | Ekskluderte Begrunnelser                           |
-      | 01.05.2020 | 30.04.2021 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE |
-      | 01.05.2021 | 31.03.2038 | Utbetaling         |                  |                                                    |                                                    |
-      | 01.04.2038 |            | Opphør             |                  |                                                    |                                                    |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser                            | Ekskluderte Begrunnelser                              |
+      | 01.05.2020 | 30.04.2021 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE    |
+      | 01.05.2021 | 31.03.2038 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_SEKUNDÆRLAND_STANDARD                    | INNVILGET_SEKUNDÆRLAND_TO_ARBEIDSLAND_NORGE_UTBETALER |
+      | 01.04.2038 |            | Opphør             |                  |                                                    |                                                       |
 
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
EØS-begrunnelser må filtreres på kompetanse.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Har nå lagt inn en ekstra metode for å filtrere på vilkår som tar med begrunnelser som ikke skal vurderes på vilkår. Denne brukes foreløpig kun for EØS-begrunnelser. Gjorde det slik siden EØS-begrunnelser sjeldent vurderes på vilkår.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇