### PR TITLE
Skiller på perioderesultatet er innvilget, redukjson og ingen endring i begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory
 interface ISanityBegrunnelse {
     val apiNavn: String
     val navnISystem: String
-    val resultat: SanityVedtakResultat?
+    val resultat: SanityPeriodeResultat?
     val vilkår: Set<Vilkår>
     val borMedSokerTriggere: List<VilkårTrigger>
     val giftPartnerskapTriggere: List<VilkårTrigger>
@@ -30,7 +30,7 @@ interface ISanityBegrunnelse {
 data class SanityBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
-    override val resultat: SanityVedtakResultat? = null,
+    override val resultat: SanityPeriodeResultat? = null,
     override val vilkår: Set<Vilkår> = emptySet(),
     override val lovligOppholdTriggere: List<VilkårTrigger> = emptyList(),
     override val bosattIRiketTriggere: List<VilkårTrigger> = emptyList(),
@@ -124,7 +124,7 @@ data class RestSanityBegrunnelse(
             } ?: emptyList(),
             valgbarhet = valgbarhet?.let { finnEnumverdi(valgbarhet, Valgbarhet.entries.toTypedArray(), apiNavn) },
             resultat = vedtakResultat?.let {
-                finnEnumverdi(it, SanityVedtakResultat.entries.toTypedArray(), apiNavn)
+                finnEnumverdi(it, SanityPeriodeResultat.entries.toTypedArray(), apiNavn)
             },
         )
     }
@@ -187,7 +187,7 @@ fun List<VilkårTrigger>.tilUtdypendeVilkårsvurderinger() = this.map {
     }
 }
 
-enum class SanityVedtakResultat {
+enum class SanityPeriodeResultat {
     INNVILGET_ELLER_ØKNING,
     INGEN_ENDRING,
     IKKE_INNVILGET,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser
 
 import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.AnnenForeldersAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
@@ -60,7 +60,7 @@ data class RestSanityEØSBegrunnelse(
 data class SanityEØSBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
-    override val resultat: SanityVedtakResultat? = null,
+    override val resultat: SanityPeriodeResultat? = null,
     override val vilkår: Set<Vilkår>,
     val annenForeldersAktivitet: List<AnnenForeldersAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -245,11 +245,11 @@ private fun hentResultaterForPeriode(
 ) = if (begrunnelseGrunnlagForPeriode?.erOrdinæreVilkårInnvilget() == true &&
     begrunnelseGrunnlagForPeriode.erInnvilgetEtterEndretUtbetaling()
 ) {
-    val erReduksjonIAndel = erReduksjon(
+    val erReduksjonIAndel = erReduksjonIAndelMellomPerioder(
         begrunnelseGrunnlagForPeriode,
         begrunnelseGrunnlagForrigePeriode,
     )
-    val erØkingIAndel = erØking(
+    val erØkingIAndel = erØkningIAndelMellomPerioder(
         begrunnelseGrunnlagForPeriode,
         begrunnelseGrunnlagForrigePeriode,
     )
@@ -270,7 +270,7 @@ private fun hentResultaterForPeriode(
     )
 }
 
-private fun erReduksjon(
+private fun erReduksjonIAndelMellomPerioder(
     begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode?,
     begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
 ): Boolean {
@@ -291,7 +291,7 @@ private fun erReduksjon(
     }
 }
 
-private fun erØking(
+private fun erØkningIAndelMellomPerioder(
     begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
     begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
 ): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -94,7 +94,7 @@ private fun hentStandardBegrunnelser(
     val endretUtbetalingDennePerioden = hentEndretUtbetalingDennePerioden(begrunnelseGrunnlag)
 
     val relevanteResultater =
-        hentRelevanteBegrunnelseTyperForPeriode(begrunnelseGrunnlag.dennePerioden, begrunnelseGrunnlag.forrigePeriode)
+        hentResultaterForPeriode(begrunnelseGrunnlag.dennePerioden, begrunnelseGrunnlag.forrigePeriode)
 
     val begrunnelserFiltrertPåPeriodetype = sanityBegrunnelser.filterValues {
         it.resultat in relevanteResultater
@@ -109,7 +109,7 @@ private fun hentStandardBegrunnelser(
     }
 
     val relevanteResultaterForrigePeriode =
-        hentRelevanteBegrunnelseTyperForrigePeriode(begrunnelseGrunnlag.forrigePeriode)
+        hentResultaterForForrigePeriode(begrunnelseGrunnlag.forrigePeriode)
 
     val begrunnelserFiltrertPåPeriodetypeForrigePeriode = sanityBegrunnelser.filterValues {
         it.resultat in relevanteResultaterForrigePeriode
@@ -145,7 +145,7 @@ private fun hentEØSStandardBegrunnelser(
     behandlingUnderkategori: BehandlingUnderkategori,
 ): Set<EØSStandardbegrunnelse> {
     val relevanteResultater =
-        hentRelevanteBegrunnelseTyperForPeriode(begrunnelseGrunnlag.dennePerioden, begrunnelseGrunnlag.forrigePeriode)
+        hentResultaterForPeriode(begrunnelseGrunnlag.dennePerioden, begrunnelseGrunnlag.forrigePeriode)
 
     val begrunnelserFiltrertPåPeriodetype = sanityEØSBegrunnelser.filterValues {
         it.resultat in relevanteResultater
@@ -223,23 +223,23 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåSatsendring(
     }
 }
 
-private fun hentRelevanteBegrunnelseTyperForrigePeriode(
+private fun hentResultaterForForrigePeriode(
     begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
 ) = if (begrunnelseGrunnlagForrigePeriode?.erOrdinæreVilkårInnvilget() == true &&
     begrunnelseGrunnlagForrigePeriode.erInnvilgetEtterEndretUtbetaling()
 ) {
     listOf(
-        SanityVedtakResultat.REDUKSJON,
-        SanityVedtakResultat.INNVILGET_ELLER_ØKNING,
+        SanityPeriodeResultat.REDUKSJON,
+        SanityPeriodeResultat.INNVILGET_ELLER_ØKNING,
     )
 } else {
     listOf(
-        SanityVedtakResultat.REDUKSJON,
-        SanityVedtakResultat.IKKE_INNVILGET,
+        SanityPeriodeResultat.REDUKSJON,
+        SanityPeriodeResultat.IKKE_INNVILGET,
     )
 }
 
-private fun hentRelevanteBegrunnelseTyperForPeriode(
+private fun hentResultaterForPeriode(
     begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode?,
     begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
 ) = if (begrunnelseGrunnlagForPeriode?.erOrdinæreVilkårInnvilget() == true &&
@@ -259,14 +259,14 @@ private fun hentRelevanteBegrunnelseTyperForPeriode(
         begrunnelseGrunnlagForrigePeriode?.erOrdinæreVilkårInnvilget() == true
 
     listOfNotNull(
-        if (erØkingIAndel || erSøker) SanityVedtakResultat.INNVILGET_ELLER_ØKNING else null,
-        if (erReduksjonIAndel) SanityVedtakResultat.REDUKSJON else null,
-        if (!erØkingIAndel && !erReduksjonIAndel && erOrdinæreVilkårOppfyltIForrigePeriode) SanityVedtakResultat.INGEN_ENDRING else null,
+        if (erØkingIAndel || erSøker) SanityPeriodeResultat.INNVILGET_ELLER_ØKNING else null,
+        if (erReduksjonIAndel) SanityPeriodeResultat.REDUKSJON else null,
+        if (!erØkingIAndel && !erReduksjonIAndel && erOrdinæreVilkårOppfyltIForrigePeriode) SanityPeriodeResultat.INGEN_ENDRING else null,
     )
 } else {
     listOf(
-        SanityVedtakResultat.REDUKSJON,
-        SanityVedtakResultat.IKKE_INNVILGET,
+        SanityPeriodeResultat.REDUKSJON,
+        SanityPeriodeResultat.IKKE_INNVILGET,
     )
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -93,11 +93,11 @@ private fun hentStandardBegrunnelser(
 ): Set<Standardbegrunnelse> {
     val endretUtbetalingDennePerioden = hentEndretUtbetalingDennePerioden(begrunnelseGrunnlag)
 
-    val relevanteResultater =
+    val relevantePeriodeResultater =
         hentResultaterForPeriode(begrunnelseGrunnlag.dennePerioden, begrunnelseGrunnlag.forrigePeriode)
 
     val begrunnelserFiltrertPåPeriodetype = sanityBegrunnelser.filterValues {
-        it.resultat in relevanteResultater
+        it.resultat in relevantePeriodeResultater
     }
 
     val filtrertPåVilkår = begrunnelserFiltrertPåPeriodetype.filterValues {
@@ -108,11 +108,11 @@ private fun hentStandardBegrunnelser(
         )
     }
 
-    val relevanteResultaterForrigePeriode =
+    val relevantePeriodeResultaterForrigePeriode =
         hentResultaterForForrigePeriode(begrunnelseGrunnlag.forrigePeriode)
 
     val begrunnelserFiltrertPåPeriodetypeForrigePeriode = sanityBegrunnelser.filterValues {
-        it.resultat in relevanteResultaterForrigePeriode
+        it.resultat in relevantePeriodeResultaterForrigePeriode
     }
 
     val filtrertPåEndretUtbetaling = begrunnelserFiltrertPåPeriodetype.filterValues {
@@ -144,11 +144,11 @@ private fun hentEØSStandardBegrunnelser(
     person: Person,
     behandlingUnderkategori: BehandlingUnderkategori,
 ): Set<EØSStandardbegrunnelse> {
-    val relevanteResultater =
+    val relevantePeriodeResultater =
         hentResultaterForPeriode(begrunnelseGrunnlag.dennePerioden, begrunnelseGrunnlag.forrigePeriode)
 
     val begrunnelserFiltrertPåPeriodetype = sanityEØSBegrunnelser.filterValues {
-        it.resultat in relevanteResultater
+        it.resultat in relevantePeriodeResultater
     }
 
     val filtrertPåVilkår = begrunnelserFiltrertPåPeriodetype.filterValues {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeGrunnlagForPerson.kt
@@ -111,11 +111,13 @@ data class AndelForVedtaksperiode(
     val kalkulertUtbetalingsbeløp: Int,
     val type: YtelseType,
     val prosent: BigDecimal,
+    val sats: Int,
 ) {
     constructor(andelTilkjentYtelse: AndelTilkjentYtelse) : this(
         kalkulertUtbetalingsbeløp = andelTilkjentYtelse.kalkulertUtbetalingsbeløp,
         type = andelTilkjentYtelse.type,
         prosent = andelTilkjentYtelse.prosent,
+        sats = andelTilkjentYtelse.sats,
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -37,7 +37,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBost
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVedtakResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVilkår
 import no.nav.familie.ba.sak.kjerne.brev.domene.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårRolle
@@ -1229,7 +1229,7 @@ fun lagSanityBegrunnelse(
     endretUtbetalingsperiodeDeltBostedTriggere: EndretUtbetalingsperiodeDeltBostedTriggere? = null,
     endretUtbetalingsperiodeTriggere: List<EndretUtbetalingsperiodeTrigger> = emptyList(),
     valgbarhet: Valgbarhet? = null,
-    resultat: SanityVedtakResultat? = null,
+    resultat: SanityPeriodeResultat? = null,
 ): SanityBegrunnelse = SanityBegrunnelse(
     apiNavn = apiNavn,
     navnISystem = navnISystem,

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
@@ -75,4 +75,24 @@ Egenskap: Begrunnelser ved endring av vilkår
       | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser       | Ekskluderte Begrunnelser      |
       | 01.05.2021 | 31.03.2022 | UTBETALING         | INNVILGET_BOR_HOS_SØKER       | REDUKSJON_IKKE_BOSATT_I_NORGE |
       | 01.04.2022 |            | OPPHØR             | OPPHØR_BARN_FLYTTET_FRA_SØKER |                               |
+    
+  Scenario: Skal ikke gi redukjsonsbegrunnelse når det er innvilgelse
+    Og lag personresultater for begrunnelse for behandling 1
 
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                           | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                   | 15.01.1990 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                      | 13.04.2020 | 12.04.2038 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 13.04.2020 |            | Oppfylt  |
+      | 3456    | BOR_MED_SØKER                                    | 13.04.2021 | 10.03.2022 | Oppfylt  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2021 | 31.03.2022 | 1354  | 1            |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser       | Ekskluderte Begrunnelser |
+      | 01.05.2021 | 31.03.2022 | UTBETALING         | INNVILGET_BOR_HOS_SØKER       | REDUKSJON_FLYTTET_BARN   |
+      | 01.04.2022 |            | OPPHØR             | OPPHØR_BARN_FLYTTET_FRA_SØKER |                          |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/brevbegrunnelse_vilkår.feature
@@ -76,7 +76,7 @@ Egenskap: Begrunnelser ved endring av vilkår
       | 01.05.2021 | 31.03.2022 | UTBETALING         | INNVILGET_BOR_HOS_SØKER       | REDUKSJON_IKKE_BOSATT_I_NORGE |
       | 01.04.2022 |            | OPPHØR             | OPPHØR_BARN_FLYTTET_FRA_SØKER |                               |
     
-  Scenario: Skal ikke gi redukjsonsbegrunnelse når det er innvilgelse
+  Scenario: Skal ikke gi reduksjonsbegrunnelse når det er innvilgelse
     Og lag personresultater for begrunnelse for behandling 1
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 1

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/hendelser.feature
@@ -86,5 +86,5 @@ Egenskap: Begrunnelser for hendelser
     Så forvent følgende standardBegrunnelser
       | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                     | Ekskluderte Begrunnelser |
       | 01.05.2017 | 28.02.2023 | UTBETALING         |                                             |                          |
-      | 01.03.2023 | 31.03.2035 | UTBETALING         | REDUKSJON_UNDER_6_ÅR, INNVILGET_SATSENDRING |                          |
+      | 01.03.2023 | 31.03.2035 | UTBETALING         | REDUKSJON_UNDER_6_ÅR, REDUKSJON_SATSENDRING |                          |
       | 01.04.2035 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR                          |                          |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/restSanityBegrunnelser.json
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/restSanityBegrunnelser.json
@@ -36219,6 +36219,9 @@
     "_rev": "NDfx9S957IRtMdNtplloIf",
     "vedtakResultat": "REDUKSJON",
     "navnISystem": "Satsendring",
+    "ovrigeTriggere": [
+      "SATSENDRING"
+    ],
     "hjemler": [
       "2",
       "10"

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utdypende_vilkårsvurdering_utbetaling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utdypende_vilkårsvurdering_utbetaling.feature
@@ -26,7 +26,8 @@ Egenskap: Begrunnelser for utdypende vilkårsvurdering med utbetaling
 
     Og med andeler tilkjent ytelse for begrunnelse
       | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
-      | 3456    | 01.05.2020 | 31.05.2022 | 1354  | 1            |
+      | 3456    | 01.05.2020 | 31.03.2021 | 500   | 1            |
+      | 3456    | 01.04.2021 | 31.05.2022 | 1354  | 1            |
 
     Når begrunnelsetekster genereres for behandling 1
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13718)

Slik koden er nå skiller vi ikke mellom begrunnelsene som er knyttet til de forskjellige perioderesultatene innvilget, redukjson og ingen endring. 

Gjør så reduksjonsbegrunnelsene kun kommer om det er reduksjon, innvilgetbegrunnelsene kommer når det er økning og "ingen endring"-begrunnelsene kommer når det ikke er noen endring. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester
