### PR TITLE
Revert "Bump kotlin.version from 1.9.0 to 1.9.10"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <kotlin.version>1.9.10</kotlin.version>
+        <kotlin.version>1.9.0</kotlin.version>
         <revision>1</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>


### PR DESCRIPTION
Reverts navikt/familie-ba-sak#3846

CodeQL Støtter ikke Kotlin 1.9.10 enda. Se https://github.com/navikt/familie-ba-sak/actions/runs/5962112501