### PR TITLE
Fix: Riktig opphørsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiUtils.kt
@@ -160,7 +160,7 @@ object ØkonomiUtils {
             .map { (identOgYtelse, kjedeEtterFørsteEndring) ->
                 val sisteAndel =
                     sisteAndelPerIdent[identOgYtelse] ?: error("Finner ikke siste andel for $identOgYtelse")
-                sisteAndel to (endretMigreringsDato ?: kjedeEtterFørsteEndring.first().stønadFom)
+                sisteAndel to (endretMigreringsDato ?: kjedeEtterFørsteEndring.minOf { it.stønadFom })
             }
 
     private fun altIKjedeOpphøres(


### PR DESCRIPTION
Det virker som om vi tar utgangspunkt i at en liste er sortert etter stonadFom dato, og bruker `first()` for å hente den laveste datoen. Listen vil ikke alltid væres sortert så her må vi sørge for å hente den laveste fom'en med `.minOf { it.stønadFom }`
