### PR TITLE
Identifisere behandlinger med feil opphørsdato i utbetalingsoppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -108,5 +109,16 @@ class ForvalterController(
             forvalterService.identifiserUtbetalingerOver100Prosent(callId)
         }
         return ResponseEntity.ok(Pair("callId", callId))
+    }
+
+    @GetMapping("/finnBehandlingerMedPotensieltFeilUtbetalingsoppdrag")
+    fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<List<Long>> {
+        val behandlingsIder = forvalterService.identifiserBehandlingerSomKanKrevePatching()
+        return ResponseEntity.ok(behandlingsIder)
+    }
+
+    @GetMapping("/sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato")
+    fun sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(@PathVariable behandlingId: Long): ResponseEntity<Boolean> {
+        return ResponseEntity.ok(forvalterService.sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(behandlingId))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -112,9 +112,13 @@ class ForvalterController(
     }
 
     @GetMapping("/finnBehandlingerMedPotensieltFeilUtbetalingsoppdrag")
-    fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<List<Long>> {
-        val behandlingsIder = forvalterService.identifiserBehandlingerSomKanKrevePatching()
-        return ResponseEntity.ok(behandlingsIder)
+    fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<Pair<String, String>> {
+        val callId = UUID.randomUUID().toString()
+        thread {
+            val behandlingsIder = forvalterService.identifiserBehandlingerSomKanKrevePatching()
+            logger.warn("Følgende behandlinger har ikke korrekte opphørsdatoer: [$behandlingsIder]")
+        }
+        return ResponseEntity.ok(Pair("callId", callId))
     }
 
     @GetMapping("/sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato")

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -121,7 +121,7 @@ class ForvalterController(
         return ResponseEntity.ok(Pair("callId", callId))
     }
 
-    @GetMapping("/sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato")
+    @GetMapping("/sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato/{behandlingId}")
     fun sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(@PathVariable behandlingId: Long): ResponseEntity<Boolean> {
         return ResponseEntity.ok(forvalterService.sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(behandlingId))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
@@ -18,4 +18,7 @@ interface TilkjentYtelseRepository : JpaRepository<TilkjentYtelse, Long> {
 
     @Query("SELECT ty FROM TilkjentYtelse ty JOIN ty.behandling b WHERE b.id = :behandlingId AND ty.utbetalingsoppdrag is not null")
     fun findByBehandlingAndHasUtbetalingsoppdrag(behandlingId: Long): TilkjentYtelse?
+
+    @Query("select ty from TilkjentYtelse ty JOIN Behandling b on b.id = ty.behandling.id where DATE(ty.endretDato) > '2023-06-07 00:00:00.000000' and Date(ty.endretDato) < '2023-08-15 00:00:00.000000' and ty.utbetalingsoppdrag is not null and b.resultat <> 'INNVILGET' and ty.opphørFom is not null")
+    fun findTilkjentYtelseMedFeilUtbetalingsoppdrag(): List<TilkjentYtelse>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
@@ -19,6 +19,6 @@ interface TilkjentYtelseRepository : JpaRepository<TilkjentYtelse, Long> {
     @Query("SELECT ty FROM TilkjentYtelse ty JOIN ty.behandling b WHERE b.id = :behandlingId AND ty.utbetalingsoppdrag is not null")
     fun findByBehandlingAndHasUtbetalingsoppdrag(behandlingId: Long): TilkjentYtelse?
 
-    @Query("select ty from TilkjentYtelse ty JOIN Behandling b on b.id = ty.behandling.id where DATE(ty.endretDato) > '2023-06-07 00:00:00.000000' and Date(ty.endretDato) < '2023-08-15 00:00:00.000000' and ty.utbetalingsoppdrag is not null and b.resultat <> 'INNVILGET' and ty.opphørFom is not null")
+    @Query("select ty from TilkjentYtelse ty JOIN Behandling b on b.id = ty.behandling.id where DATE(ty.endretDato) > '2023-08-22 00:00:00.000000' and Date(ty.endretDato) < '2023-08-25 00:00:00.000000' and ty.utbetalingsoppdrag is not null and ty.opphørFom is not null")
     fun findTilkjentYtelseMedFeilUtbetalingsoppdrag(): List<TilkjentYtelse>
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Etter at vi rullet ut kode knyttet til sisteAndelPerKjede (https://github.com/navikt/familie-ba-sak/commit/3a1992a2ae788eb20ef2ed7cef1fd6ab2b6e0703) så ble også kode knyttet til opphør noe endret. Det vi ikke innså var at vi der var avhengig av en sortering av andelTilkjentYtelse på `stønadFom` for å fungere. Sorteringen ble fjernet og vi har kjørt ett døgn i prod med denne feilen. Feilen skal nå være rettet, men vil mest sannsynlig kreve litt opprydningsarbeid for å fikse saker som er iverksatt mot økonomi med feil opphørsdato.

Med denne PR'en ønsker jeg å få ut kode som kan hjelpe oss med å se hvor mange behandlinger som har blitt påvirket av feilen. Forsøker her å sammenligne opphørsdato vi har brukt i utbetalingsoppdraget mot det som burde ha blitt sendt. 

Jeg har ikke skrevet tester fordi det haster å få litt oversikt over omfanget av feilen.

