### PR TITLE
Endre feil til funksjonell feil når SB har begrunnet flere perioder ved opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -197,13 +197,13 @@ class BrevService(
         brevmal: Brevmal,
         vedtakFellesfelter: VedtakFellesfelter,
     ) {
-        if (listOf(
+        if (brevmal in listOf(
                 Brevmal.VEDTAK_OPPHØRT,
                 Brevmal.VEDTAK_OPPHØRT_INSTITUSJON,
-            ).contains(brevmal) && vedtakFellesfelter.perioder.size > 1
+            ) && vedtakFellesfelter.perioder.size > 1
         ) {
-            throw Feil(
-                "Brevtypen er \"opphørt\", men mer enn én periode ble sendt med. Brev av typen opphørt skal kun ha én " + "periode.",
+            throw FunksjonellFeil(
+                "Behandlingsstatusen er \"Opphørt\", men mer enn én periode er begrunnet. Du skal kun begrunne perioden uten utbetaling.",
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Saker som har vært migrert kan mangle kompetanse fordi vi ikke har data om det fra Infotrygd. Når man da revurderer saken må vi legge til kompetansen. Dette fører til at systemet tror det er en endring og endringstidspunktet blir satt til starten av kompetansen. Dermed kommer det med flere vedtaksperioder enn det egentlig skal. 

Vi har en validering på at det kun er én periode som skal begrunnes for opphørsbrev. Siden det er mange vedtaksperioder som kommer med har saksbehandler mulighet til å begrunne flere. Dette gjelder for revurderinger som kommer etter migreringer og vil ikke skje når vi ikke har migreringssaker lenger. 

En workaround er at saksbehandlerene ikke begrunner periodene som ikke er opphørsperiodene. Legger ved en feilmelding som gjør det lettere for saksbehandlerene å forstå hva de skal gjøre i tillegg til at vi slipper alarmer.
