### PR TITLE
Flytt henting av vedtaksperioder til eget endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/EksternTjenesteKaller.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/EksternTjenesteKaller.kt
@@ -18,9 +18,15 @@ inline fun <reified Data> kallEksternTjeneste(
     loggEksternKall(tjeneste, uri, formål)
 
     return try {
-        eksterntKall().also {
-            eksternTjenesteKallerLogger.info("${lagEksternKallPreMelding(tjeneste, uri)} Kall ok")
-        }
+        val startTid = System.currentTimeMillis()
+        val data = eksterntKall()
+        val sluttTid = System.currentTimeMillis()
+
+        eksternTjenesteKallerLogger.info(
+            "${lagEksternKallPreMelding(tjeneste, uri)} Kall ok. Dette tok ${sluttTid - startTid} ms.",
+        )
+
+        data
     } catch (exception: Exception) {
         throw handleException(exception = exception, tjeneste = tjeneste, uri = uri, formål = formål)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.BegrunnelseData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.EØSBegrunnelseData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.FritekstBegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -133,6 +134,15 @@ class VedtaksperiodeMedBegrunnelserController(
 
         return ResponseEntity.ok(Ressurs.Companion.success(begrunnelser.toSet()))
     }
+
+    @GetMapping(path = ["/behandling/{behandlingId}/hent-vedtaksperioder"])
+    fun hentPersonerMedUgyldigEtterbetalingsperiode(
+        @PathVariable behandlingId: Long,
+    ): ResponseEntity<Ressurs<List<RestUtvidetVedtaksperiodeMedBegrunnelser>>> = ResponseEntity.ok(
+        Ressurs.success(
+            vedtaksperiodeService.hentRestUtvidetVedtaksperiodeMedBegrunnelser(behandlingId),
+        ),
+    )
 
     companion object {
         const val OPPDATERE_BEGRUNNELSER_HANDLING = "oppdatere vedtaksperiode med begrunnelser"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -62,7 +62,10 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilVedtaksbegrunnelseFritekst
 import no.nav.familie.ba.sak.kjerne.vedtak.feilutbetaltValuta.FeilutbetaltValutaRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.refusjonEøs.RefusjonEøsRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.brevBegrunnelseProdusent.hentGyldigeBegrunnelserForPeriode
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.sorter
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilRestUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.BehandlingsGrunnlagForVedtaksperioder
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.produsent.genererVedtaksperioder
@@ -454,6 +457,22 @@ class VedtaksperiodeService(
         return vedtaksperiodeHentOgPersisterService.finnVedtaksperioderFor(vedtakId = vedtak.id)
     }
 
+    fun hentRestUtvidetVedtaksperiodeMedBegrunnelser(behandlingId: Long): List<RestUtvidetVedtaksperiodeMedBegrunnelser> {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+
+        return if (behandling.status != BehandlingStatus.AVSLUTTET) {
+            val utvidetVedtaksperiodeMedBegrunnelser = hentUtvidetVedtaksperiodeMedBegrunnelser(
+                vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingId),
+                personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId),
+            )
+            utvidetVedtaksperiodeMedBegrunnelser
+                .sorter()
+                .map { it.tilRestUtvidetVedtaksperiodeMedBegrunnelser() }
+        } else {
+            emptyList()
+        }
+    }
+
     fun hentUtvidetVedtaksperiodeMedBegrunnelser(
         vedtak: Vedtak,
         personopplysningGrunnlag: PersonopplysningGrunnlag? = null,
@@ -504,6 +523,10 @@ class VedtaksperiodeService(
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
         val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
         val kompetanser = kompetanseRepository.finnFraBehandlingId(behandling.id)
+        val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+
+        val behandlingsGrunnlagForVedtaksperioder = behandling.hentGrunnlagForVedtaksperioder()
+        val behandlingsGrunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder()
 
         return utvidedeVedtaksperioderMedBegrunnelser.map { utvidetVedtaksperiodeMedBegrunnelser ->
             val kompetanserIPeriode = kompetanser.hentIPeriode(
@@ -521,12 +544,9 @@ class VedtaksperiodeService(
 
             utvidetVedtaksperiodeMedBegrunnelser.copy(
                 gyldigeBegrunnelser = if (featureToggleService.isEnabled(FeatureToggleConfig.BEGRUNNELSER_NY)) {
-                    val forrigeBehandling =
-                        behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
-
                     utvidetVedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserForPeriode(
-                        behandlingsGrunnlagForVedtaksperioder = behandling.hentGrunnlagForVedtaksperioder(),
-                        behandlingsGrunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
+                        behandlingsGrunnlagForVedtaksperioder = behandlingsGrunnlagForVedtaksperioder,
+                        behandlingsGrunnlagForVedtaksperioderForrigeBehandling = behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
                         sanityBegrunnelser = sanityBegrunnelser,
                         sanityEØSBegrunnelser = sanityEØSBegrunnelser,
                         behandlingUnderkategori = behandling.underkategori,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Denne behandlingen](https://barnetrygd.intern.nav.no/fagsak/1921845/3780399) stopper helt opp fordi vi ikke klarer å utlede vedtaksperiodene. Det er ikke mulig å se på noe annet data siden all data finnes på samme objekt som vi nå ikke klarer å lage. 

![image](https://github.com/navikt/familie-ba-sak/assets/17828446/2dafc883-e8c2-4f10-9da7-29e71b6dbc55)

Splitter hentingen av vedtaksperiodene på eget endepunkt slik at vi kan begrense feilmeldingen til der det feiler:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/7f2c000c-60b4-47e9-bd74-b76a0aacfc8b)

