### PR TITLE
Filtrer begrunnelser på rolle

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
@@ -36,6 +37,7 @@ import java.time.LocalDate
 
 class BegrunnelseTeksterStepDefinition {
 
+    private var fagsaker: Map<Long, Fagsak> = emptyMap()
     private var behandlinger = mutableMapOf<Long, Behandling>()
     private var behandlingTilForrigeBehandling = mutableMapOf<Long, Long?>()
     private var vedtaksliste = mutableListOf<Vedtak>()
@@ -52,6 +54,14 @@ class BegrunnelseTeksterStepDefinition {
     private var utvidetVedtaksperiodeMedBegrunnelser = mutableListOf<UtvidetVedtaksperiodeMedBegrunnelser>()
 
     /**
+     * Mulige verdier: | FagsakId | Fagsaktype |
+     */
+    @Gitt("følgende fagsaker for begrunnelse")
+    fun `følgende fagsaker for begrunnelse`(dataTable: DataTable) {
+        fagsaker = lagFagsaker(dataTable)
+    }
+
+    /**
      * Mulige felter:
      * | BehandlingId | FagsakId | ForrigeBehandlingId |
      */
@@ -62,7 +72,7 @@ class BegrunnelseTeksterStepDefinition {
             behandlinger = behandlinger,
             behandlingTilForrigeBehandling = behandlingTilForrigeBehandling,
             vedtaksListe = vedtaksliste,
-            fagsaker = emptyMap(),
+            fagsaker = fagsaker,
         )
     }
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/rolle.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/rolle.feature
@@ -1,0 +1,90 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Begrunnelser ved endring av vilkår
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype             |
+      | 1        | NORMAL                 |
+      | 2        | BARN_ENSLIG_MINDREÅRIG |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId |
+      | 1            | 1        |
+      | 2            | 2        |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |
+      | 1            | 3456    | BARN       | 13.04.2020  |
+
+      | 2            | 4567    | BARN       | 13.04.2020  |
+
+  Scenario: Skal få med begrunnelse som kun gjelder søker når søker sine vilkår endrer seg
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
+      | 1234    | LOVLIG_OPPHOLD                                                  | 11.01.1970 |            | Oppfylt  |                              |
+      | 1234    | BOSATT_I_RIKET                                                  | 11.01.1970 | 10.05.2020 | Oppfylt  | OMFATTET_AV_NORSK_LOVGIVNING |
+      | 1234    | BOSATT_I_RIKET                                                  | 11.05.2020 |            | Oppfylt  |                              |
+      | 3456    | UNDER_18_ÅR                                                     | 13.04.2020 | 12.04.2038 | Oppfylt  |                              |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2020 |            | Oppfylt  |                              |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2020 | 31.03.2038 | 1354  | 1            |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                 | Ekskluderte Begrunnelser                |
+      | 01.05.2020 | 31.05.2020 | UTBETALING         |                                         | FORTSATT_INNVILGET_SØKER_BOSATT_I_RIKET |
+      | 01.06.2020 | 31.03.2038 | UTBETALING         | FORTSATT_INNVILGET_SØKER_BOSATT_I_RIKET |                                         |
+      | 01.04.2038 |            | OPPHØR             |                                         |                                         |
+
+  Scenario: Skal ikke få med begrunnelse som kun gjelder søker når barn sine vilkår endrer seg
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                          | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
+      | 1234    | LOVLIG_OPPHOLD,   BOSATT_I_RIKET                | 11.01.1970 |            | Oppfylt  |                              |
+      | 3456    | UNDER_18_ÅR                                     | 13.04.2020 | 12.04.2038 | Oppfylt  |                              |
+      | 3456    | GIFT_PARTNERSKAP, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2020 |            | Oppfylt  |                              |
+      | 3456    | BOSATT_I_RIKET                                  | 13.04.2020 | 10.05.2020 | Oppfylt  | OMFATTET_AV_NORSK_LOVGIVNING |
+      | 3456    | BOSATT_I_RIKET                                  | 11.05.2020 |            | Oppfylt  |                              |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2020 | 31.03.2038 | 1354  | 1            |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser | Ekskluderte Begrunnelser                |
+      | 01.05.2020 | 31.05.2020 | UTBETALING         |                         | FORTSATT_INNVILGET_SØKER_BOSATT_I_RIKET |
+      | 01.06.2020 | 31.03.2038 | UTBETALING         |                         | FORTSATT_INNVILGET_SØKER_BOSATT_I_RIKET |
+      | 01.04.2038 |            | OPPHØR             |                         |                                         |
+
+  Scenario: Skal få med begrunnelse som kun gjelder søker når barn sine vilkår endrer seg om barn er søker
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår                                          | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
+      | 4567    | UNDER_18_ÅR                                     | 13.04.2020 | 12.04.2038 | Oppfylt  |                              |
+      | 4567    | GIFT_PARTNERSKAP, LOVLIG_OPPHOLD, BOR_MED_SØKER | 13.04.2020 |            | Oppfylt  |                              |
+      | 4567    | BOSATT_I_RIKET                                  | 13.04.2020 | 10.05.2020 | Oppfylt  | OMFATTET_AV_NORSK_LOVGIVNING |
+      | 4567    | BOSATT_I_RIKET                                  | 11.05.2020 |            | Oppfylt  |                              |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 4567    | 01.05.2020 | 31.03.2038 | 1354  | 2            |
+
+    Når begrunnelsetekster genereres for behandling 2
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                 | Ekskluderte Begrunnelser                |
+      | 01.05.2020 | 31.05.2020 | UTBETALING         |                                         | FORTSATT_INNVILGET_SØKER_BOSATT_I_RIKET |
+      | 01.06.2020 | 31.03.2038 | UTBETALING         | FORTSATT_INNVILGET_SØKER_BOSATT_I_RIKET |                                         |
+      | 01.04.2038 |            | OPPHØR             |                                         |                                         |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utdypende_vilkårsvurdering_utbetaling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utdypende_vilkårsvurdering_utbetaling.feature
@@ -54,9 +54,9 @@ Egenskap: Begrunnelser for utdypende vilkårsvurdering med utbetaling
     Når begrunnelsetekster genereres for behandling 1
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                                                  | Ekskluderte Begrunnelser                    |
-      | 01.05.2020 | 31.03.2021 | UTBETALING         | INNVILGET_LOVLIG_OPPHOLD_SKJØNNSMESSIG_VURDERING_TREDJELANDSBORGER_SØKER | INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE |
-      | 01.04.2021 |            | OPPHØR             | OPPHØR_IKKE_OPPHOLDSTILLATELSE_MER_ENN_12_MÅNEDER                        |                                             |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                           | Ekskluderte Begrunnelser                    |
+      | 01.05.2020 | 31.03.2021 | UTBETALING         | INNVILGET_BOSATT_I_RIKTET                         | INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE |
+      | 01.04.2021 |            | OPPHØR             | OPPHØR_IKKE_OPPHOLDSTILLATELSE_MER_ENN_12_MÅNEDER |                                             |
 
   Scenario: Skal detektere endring i utdypende vilkår
     Og lag personresultater for begrunnelse for behandling 1
@@ -76,10 +76,10 @@ Egenskap: Begrunnelser for utdypende vilkårsvurdering med utbetaling
     Når begrunnelsetekster genereres for behandling 1
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                                                  | Ekskluderte Begrunnelser                                                                                              |
-      | 01.05.2020 | 31.03.2021 | UTBETALING         | INNVILGET_LOVLIG_OPPHOLD_SKJØNNSMESSIG_VURDERING_TREDJELANDSBORGER_SØKER | INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE                                                                           |
-      | 01.04.2021 | 31.03.2022 | UTBETALING         | FORTSATT_INNVILGET_BARN_OG_SØKER_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE       | INNVILGET_LOVLIG_OPPHOLD_SKJØNNSMESSIG_VURDERING_TREDJELANDSBORGER_SØKER, INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE |
-      | 01.04.2022 |            | OPPHØR             | OPPHØR_HAR_IKKE_OPPHOLDSTILLATELSE                                       | OPPHØR_IKKE_OPPHOLDSTILLATELSE_MER_ENN_12_MÅNEDER                                                                     |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Inkluderte Begrunnelser                                            | Ekskluderte Begrunnelser                                               |
+      | 01.05.2020 | 31.03.2021 | UTBETALING         | INNVILGET_BOSATT_I_RIKTET                                          | INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE                            |
+      | 01.04.2021 | 31.03.2022 | UTBETALING         | FORTSATT_INNVILGET_BARN_OG_SØKER_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE | INNVILGET_BOSATT_I_RIKTET, INNVILGET_LOVLIG_OPPHOLD_OPPHOLDSTILLATELSE |
+      | 01.04.2022 |            | OPPHØR             | OPPHØR_HAR_IKKE_OPPHOLDSTILLATELSE                                 | OPPHØR_IKKE_OPPHOLDSTILLATELSE_MER_ENN_12_MÅNEDER                      |
 
 
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14647)

Vi ønsker at begrunnelser knyttet til rolle kun skal dukke opp for den relevante rollen. 

Gjør så vi filtrerer bort begrunnelsen for personer som ikke er i rollelisten til behandlingen. NB: Tar alltid med begrunnelsen dersom den ikke er knyttet til noen rolle. Dersom rollelisten er tom blir begrunnelsen alltid tatt med i dette filteret. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

