### PR TITLE
Sjekker om endret migreringsdato skal brukes som opphørsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForIverksettingFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForSimuleringFactory
@@ -47,6 +48,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import java.time.YearMonth
 
 @Service
 class ForvalterService(
@@ -235,6 +237,11 @@ class ForvalterService(
             val sisteBeståendeAndelPerKjede =
                 ØkonomiUtils.sisteBeståendeAndelPerKjede(grupperteForrigeAndeler, grupperteNyeAndeler)
 
+            val endretMigreringsdato = beregnOmMigreringsDatoErEndret(
+                tilkjentYtelse.behandling,
+                grupperteForrigeAndeler.values.flatten().minByOrNull { it.stønadFom }?.stønadFom,
+            )
+
             // Finner andeler som skal opphøres slik vi gjorde før
             val andelerTilOpphør = grupperteForrigeAndeler
                 .mapValues { (person, forrigeAndeler) ->
@@ -246,7 +253,10 @@ class ForvalterService(
                 .filter { (_, andelerSomOpphøres) -> andelerSomOpphøres.isNotEmpty() }
                 .mapValues { andelForKjede -> andelForKjede.value.sortedBy { it.stønadFom } }
                 .map { (_, kjedeEtterFørsteEndring) ->
-                    kjedeEtterFørsteEndring.last() to kjedeEtterFørsteEndring.minOf { it.stønadFom }
+                    kjedeEtterFørsteEndring.last() to (
+                        endretMigreringsdato
+                            ?: kjedeEtterFørsteEndring.minOf { it.stønadFom }
+                        )
                 }
 
             secureLogger.info("Andeler som som skal opphøres: ${andelerTilOpphør.map { "PeriodeId: ${it.first.periodeOffset} ForrigePeriodeId: ${it.first.forrigePeriodeOffset} Opphørsdato: ${it.second}" }} for behandling ${tilkjentYtelse.behandling.id}")
@@ -274,6 +284,29 @@ class ForvalterService(
                 e,
             )
             return false
+        }
+    }
+
+    private fun beregnOmMigreringsDatoErEndret(behandling: Behandling, forrigeTilstandFraDato: YearMonth?): YearMonth? {
+        val erMigrertSak =
+            behandlingHentOgPersisterService.hentBehandlinger(behandling.fagsak.id)
+                .any { it.type == BehandlingType.MIGRERING_FRA_INFOTRYGD }
+
+        if (!erMigrertSak) {
+            return null
+        }
+
+        val nyttTilstandFraDato = behandlingService.hentMigreringsdatoPåFagsak(fagsakId = behandling.fagsak.id)
+            ?.toYearMonth()
+            ?.plusMonths(1)
+
+        return if (forrigeTilstandFraDato != null &&
+            nyttTilstandFraDato != null &&
+            forrigeTilstandFraDato.isAfter(nyttTilstandFraDato)
+        ) {
+            nyttTilstandFraDato
+        } else {
+            null
         }
     }
 }


### PR DESCRIPTION
Filtrerer bort ytterligere behandlinger som ikke er påvirket av opphørsdatofeil. Behandlinger etter en ENDRET_MIGRERINGSDATO behandling bruker migreringsdato som opphørsdato.
