### PR TITLE
Finner og returnerer utbetalingsoppdrag med feil opphørsdato, sammen med korrigert utbetalingsoppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -111,7 +111,7 @@ class ForvalterController(
     }
 
     @PostMapping("/finnBehandlingerMedPotensieltFeilUtbetalingsoppdrag")
-    fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<List<ForvalterService.ValidertUtbetalingsoppdrag>> {
+    fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<BehandlingerMedFeilIUtbetalingsoppdrag> {
         logger.info("Starter identifiserBehandlingerSomKanKrevePatching")
         val validerteUtbetalingsoppdragMedFeil =
             forvalterService.identifiserPåvirkedeBehandlingerOgValiderOpphørsdatoIUtbetalingsoppdrag()
@@ -120,8 +120,8 @@ class ForvalterController(
     }
 
     @PostMapping("/sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato")
-    fun sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(@RequestBody behandlingListe: List<Long>): ResponseEntity<Set<ForvalterService.ValidertUtbetalingsoppdrag>> {
-        val set: Set<ForvalterService.ValidertUtbetalingsoppdrag> =
+    fun sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(@RequestBody behandlingListe: List<Long>): ResponseEntity<BehandlingerMedFeilIUtbetalingsoppdrag> {
+        val validerteUtbetalingsoppdragMedFeil: Set<ValidertUtbetalingsoppdrag> =
             behandlingListe.fold(LinkedHashSet()) { accumulator, behandlingId ->
                 val validertUtbetalingsoppdrag =
                     forvalterService.validerOpphørsdatoIUtbetalingsoppdragForBehandling(behandlingId)
@@ -131,6 +131,11 @@ class ForvalterController(
                 accumulator
             }
 
-        return ResponseEntity.ok(set)
+        return ResponseEntity.ok(
+            BehandlingerMedFeilIUtbetalingsoppdrag(
+                behandlinger = validerteUtbetalingsoppdragMedFeil.map { it.behandlingId },
+                validerteUtbetalingsoppdrag = validerteUtbetalingsoppdragMedFeil,
+            ),
+        )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -111,21 +111,24 @@ class ForvalterController(
     }
 
     @PostMapping("/finnBehandlingerMedPotensieltFeilUtbetalingsoppdrag")
-    fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<List<Long>> {
+    fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<List<ForvalterService.ValidertUtbetalingsoppdrag>> {
         logger.info("Starter identifiserBehandlingerSomKanKrevePatching")
-        val behandlingsIder = forvalterService.identifiserBehandlingerSomKanKrevePatching()
+        val behandlingsIder = forvalterService.identifiserPåvirkedeBehandlingerOgValiderOpphørsdatoIUtbetalingsoppdrag()
         logger.warn("Følgende behandlinger har ikke korrekte opphørsdatoer: [$behandlingsIder]")
         return ResponseEntity.ok(behandlingsIder)
     }
 
     @PostMapping("/sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato")
-    fun sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(@RequestBody behandlingListe: List<Long>): ResponseEntity<Set<Long>> {
-        val set: Set<Long> = behandlingListe.fold(LinkedHashSet()) { accumulator, behandlingId ->
-            if (!forvalterService.harTilkjentYtelseForBehandlingKorrektOpphørsdato(behandlingId)) {
-                accumulator.add(behandlingId)
+    fun sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato(@RequestBody behandlingListe: List<Long>): ResponseEntity<Set<ForvalterService.ValidertUtbetalingsoppdrag>> {
+        val set: Set<ForvalterService.ValidertUtbetalingsoppdrag> =
+            behandlingListe.fold(LinkedHashSet()) { accumulator, behandlingId ->
+                val validertUtbetalingsoppdrag =
+                    forvalterService.validerOpphørsdatoIUtbetalingsoppdragForBehandling(behandlingId)
+                if (!validertUtbetalingsoppdrag.harKorrekteOpphørsdatoer) {
+                    accumulator.add(validertUtbetalingsoppdrag)
+                }
+                accumulator
             }
-            accumulator
-        }
 
         return ResponseEntity.ok(set)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -113,9 +113,10 @@ class ForvalterController(
     @PostMapping("/finnBehandlingerMedPotensieltFeilUtbetalingsoppdrag")
     fun identifiserBehandlingerSomKanKrevePatching(): ResponseEntity<List<ForvalterService.ValidertUtbetalingsoppdrag>> {
         logger.info("Starter identifiserBehandlingerSomKanKrevePatching")
-        val behandlingsIder = forvalterService.identifiserPåvirkedeBehandlingerOgValiderOpphørsdatoIUtbetalingsoppdrag()
-        logger.warn("Følgende behandlinger har ikke korrekte opphørsdatoer: [$behandlingsIder]")
-        return ResponseEntity.ok(behandlingsIder)
+        val validerteUtbetalingsoppdragMedFeil =
+            forvalterService.identifiserPåvirkedeBehandlingerOgValiderOpphørsdatoIUtbetalingsoppdrag()
+        secureLogger.warn("Følgende behandlinger har ikke korrekte opphørsdatoer: [$validerteUtbetalingsoppdragMedFeil]")
+        return ResponseEntity.ok(validerteUtbetalingsoppdragMedFeil)
     }
 
     @PostMapping("/sjekkOmTilkjentYtelseForBehandlingHarUkorrektOpphørsdato")

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -41,6 +41,8 @@ import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import no.nav.familie.log.mdc.MDCConstants
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -200,23 +202,23 @@ class ForvalterService(
         }
     }
 
-    fun harTilkjentYtelseForBehandlingKorrektOpphørsdato(behandlingId: Long): Boolean {
+    fun validerOpphørsdatoIUtbetalingsoppdragForBehandling(behandlingId: Long): ValidertUtbetalingsoppdrag {
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandlingId)
-        return erOpphørsdatoKorrekt(tilkjentYtelse)
+        return validerOpphørsdatoIUtbetalingsoppdrag(tilkjentYtelse)
     }
 
-    fun identifiserBehandlingerSomKanKrevePatching(): List<Long> {
+    fun identifiserPåvirkedeBehandlingerOgValiderOpphørsdatoIUtbetalingsoppdrag(): List<ValidertUtbetalingsoppdrag> {
         val tilkjenteYtelserMedOpphørSomKanVæreFeil =
             tilkjentYtelseRepository.findTilkjentYtelseMedFeilUtbetalingsoppdrag()
         logger.info("Behandlinger som potensielt har feil: ${tilkjenteYtelserMedOpphørSomKanVæreFeil.map { it.behandling.id }}")
 
         return tilkjenteYtelserMedOpphørSomKanVæreFeil
-            .filter { !erOpphørsdatoKorrekt(it) }
-            .map { it.behandling.id }
+            .map { validerOpphørsdatoIUtbetalingsoppdrag(it) }
+            .filter { !it.harKorrekteOpphørsdatoer }
     }
 
-    private fun erOpphørsdatoKorrekt(tilkjentYtelse: TilkjentYtelse): Boolean {
-        val utbetalingsoppdrag = tilkjentYtelse.utbetalingsoppdrag() ?: return true
+    private fun validerOpphørsdatoIUtbetalingsoppdrag(tilkjentYtelse: TilkjentYtelse): ValidertUtbetalingsoppdrag {
+        val utbetalingsoppdrag = tilkjentYtelse.utbetalingsoppdrag() ?: return ValidertUtbetalingsoppdrag(true)
         logger.info("Sjekker behandling for korrekt opphørsdato ${tilkjentYtelse.behandling.id}")
         try {
             val grupperteNyeAndeler = grupperAndeler(
@@ -263,6 +265,9 @@ class ForvalterService(
             val utbetalingsperioderMedOpphør = utbetalingsoppdrag.utbetalingsperiode.filter { it.opphør != null }
             secureLogger.info("Utbetalingsperioder med opphør: $utbetalingsperioderMedOpphør for behandling ${tilkjentYtelse.behandling.id}")
 
+            val utbetalingsperioderMedFeilOpphørsdato = mutableListOf<Utbetalingsperiode>()
+            val korrigerteUtbetalingsperioder = mutableListOf<Utbetalingsperiode>()
+
             // Finner ut hvilken opphørsAndel som tilhører hvilken utbetalingsperiodeMedOpphør
             val alleUtbetalingsperioderMedOpphørHarKorrektOpphørsdato = utbetalingsperioderMedOpphør
                 .all { periodeMedOpphør ->
@@ -270,20 +275,52 @@ class ForvalterService(
                         andelerTilOpphør.filter { andelForPerson -> andelForPerson.first.periodeOffset == periodeMedOpphør.periodeId }
                     if (andelerTilPersonMedOpphør.size != 1) {
                         secureLogger.info("Mer enn 1 eller ingen andeler med samme periodeOffsett som opphørsperioden $periodeMedOpphør for behandling ${tilkjentYtelse.behandling.id}")
+                        utbetalingsperioderMedFeilOpphørsdato.add(periodeMedOpphør)
                         false
                     } else {
                         secureLogger.info("Andel fra forrige med korrekt opphørsdato: ${andelerTilPersonMedOpphør.first().second.førsteDagIInneværendeMåned()}. Opphørsperiode sendt til økonomi med opphørsdato: ${periodeMedOpphør.opphør!!.opphørDatoFom} for behandling ${tilkjentYtelse.behandling.id}")
-                        andelerTilPersonMedOpphør.first().second
-                            .førsteDagIInneværendeMåned() == periodeMedOpphør.opphør!!.opphørDatoFom
+                        if (andelerTilPersonMedOpphør.first().second
+                                .førsteDagIInneværendeMåned() != periodeMedOpphør.opphør!!.opphørDatoFom
+                        ) {
+                            utbetalingsperioderMedFeilOpphørsdato.add(periodeMedOpphør)
+                            korrigerteUtbetalingsperioder.add(
+                                periodeMedOpphør.copy(
+                                    opphør = periodeMedOpphør.opphør!!.copy(
+                                        opphørDatoFom = andelerTilPersonMedOpphør.first().second
+                                            .førsteDagIInneværendeMåned(),
+                                    ),
+                                ),
+                            )
+                            false
+                        } else {
+                            true
+                        }
                     }
                 }
-            return alleUtbetalingsperioderMedOpphørHarKorrektOpphørsdato
+            if (alleUtbetalingsperioderMedOpphørHarKorrektOpphørsdato) {
+                return ValidertUtbetalingsoppdrag(harKorrekteOpphørsdatoer = true)
+            }
+            return ValidertUtbetalingsoppdrag(
+                harKorrekteOpphørsdatoer = false,
+                utbetalingsperioderMedFeilOpphørsdato = utbetalingsperioderMedFeilOpphørsdato,
+                korrigerteUtbetalingsperioder = korrigerteUtbetalingsperioder,
+                gammeltUtbetalingsoppdrag = utbetalingsoppdrag,
+                nyttUtbetalingsoppdrag = utbetalingsoppdrag.copy(
+                    utbetalingsperiode = utbetalingsoppdrag.utbetalingsperiode.map { utbetalingsperiode ->
+                        korrigerteUtbetalingsperioder.find { it.periodeId == utbetalingsperiode.periodeId }
+                            ?: utbetalingsperiode
+                    },
+                ),
+
+            )
         } catch (e: Exception) {
             secureLogger.warn(
                 "opphørsdatoErKorrekt kaster feil: ${e.message} for behandling ${tilkjentYtelse.behandling.id}",
                 e,
             )
-            return false
+            return ValidertUtbetalingsoppdrag(
+                harKorrekteOpphørsdatoer = false,
+            )
         }
     }
 
@@ -309,4 +346,12 @@ class ForvalterService(
             null
         }
     }
+
+    data class ValidertUtbetalingsoppdrag(
+        val harKorrekteOpphørsdatoer: Boolean,
+        val utbetalingsperioderMedFeilOpphørsdato: List<Utbetalingsperiode>? = null,
+        val korrigerteUtbetalingsperioder: List<Utbetalingsperiode>? = null,
+        val gammeltUtbetalingsoppdrag: Utbetalingsoppdrag? = null,
+        val nyttUtbetalingsoppdrag: Utbetalingsoppdrag? = null,
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -218,7 +218,10 @@ class ForvalterService(
     }
 
     private fun validerOpphørsdatoIUtbetalingsoppdrag(tilkjentYtelse: TilkjentYtelse): ValidertUtbetalingsoppdrag {
-        val utbetalingsoppdrag = tilkjentYtelse.utbetalingsoppdrag() ?: return ValidertUtbetalingsoppdrag(true)
+        val utbetalingsoppdrag = tilkjentYtelse.utbetalingsoppdrag() ?: return ValidertUtbetalingsoppdrag(
+            harKorrekteOpphørsdatoer = true,
+            behandlingId = tilkjentYtelse.behandling.id,
+        )
         logger.info("Sjekker behandling for korrekt opphørsdato ${tilkjentYtelse.behandling.id}")
         try {
             val grupperteNyeAndeler = grupperAndeler(
@@ -298,10 +301,14 @@ class ForvalterService(
                     }
                 }
             if (alleUtbetalingsperioderMedOpphørHarKorrektOpphørsdato) {
-                return ValidertUtbetalingsoppdrag(harKorrekteOpphørsdatoer = true)
+                return ValidertUtbetalingsoppdrag(
+                    harKorrekteOpphørsdatoer = true,
+                    behandlingId = tilkjentYtelse.behandling.id,
+                )
             }
             return ValidertUtbetalingsoppdrag(
                 harKorrekteOpphørsdatoer = false,
+                behandlingId = tilkjentYtelse.behandling.id,
                 utbetalingsperioderMedFeilOpphørsdato = utbetalingsperioderMedFeilOpphørsdato,
                 korrigerteUtbetalingsperioder = korrigerteUtbetalingsperioder,
                 gammeltUtbetalingsoppdrag = utbetalingsoppdrag,
@@ -320,6 +327,7 @@ class ForvalterService(
             )
             return ValidertUtbetalingsoppdrag(
                 harKorrekteOpphørsdatoer = false,
+                behandlingId = tilkjentYtelse.behandling.id,
             )
         }
     }
@@ -349,6 +357,7 @@ class ForvalterService(
 
     data class ValidertUtbetalingsoppdrag(
         val harKorrekteOpphørsdatoer: Boolean,
+        val behandlingId: Long,
         val utbetalingsperioderMedFeilOpphørsdato: List<Utbetalingsperiode>? = null,
         val korrigerteUtbetalingsperioder: List<Utbetalingsperiode>? = null,
         val gammeltUtbetalingsoppdrag: Utbetalingsoppdrag? = null,


### PR DESCRIPTION
Returnerer alle utbetalingsoppdrag som har feil opphørsdato i perioden med bug i prod. I tillegg returneres informasjon om hvilke utbetalingsperioder som har feil, og hvordan det oppdaterte utbetalingsoppdrag vil se ut etter korrigering.