### PR TITLE
Legg til støtte for avslag

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -177,12 +177,12 @@ class BegrunnelseTeksterStepDefinition {
         val utvidedeVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser.map {
             it.tilUtvidetVedtaksperiodeMedBegrunnelser(
                 personopplysningGrunnlag = persongrunnlag.finnPersonGrunnlagForBehandling(behandlingId),
-                andelerTilkjentYtelse = andelerTilkjentYtelse[behandlingId]!!.map {
+                andelerTilkjentYtelse = andelerTilkjentYtelse[behandlingId]?.map {
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
                         it,
                         endredeUtbetalinger[behandlingId] ?: emptySet(),
                     )
-                },
+                } ?: emptyList(),
                 skalBrukeNyVedtaksperiodeLøsning = true,
             )
         }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/avslag.feature
@@ -1,0 +1,39 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Avslag
+
+  Bakgrunn:
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId |
+      | 1            | 1        |                     |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 03.01.1978  |
+      | 1            | 2       | BARN       | 16.02.2007  |
+
+  Scenario: Skal ikke krasje ved avslag uten fom- eller tomdato
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                            | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
+      | 1       | LOVLIG_OPPHOLD                    |                  |            |            | IKKE_OPPFYLT | Ja                   |
+      | 1       | UTVIDET_BARNETRYGD,BOSATT_I_RIKET |                  | 22.09.2022 |            | OPPFYLT      | Nei                  |
+
+      | 2       | LOVLIG_OPPHOLD                    |                  |            |            | IKKE_OPPFYLT | Ja                   |
+      | 2       | GIFT_PARTNERSKAP                  |                  | 16.02.2007 |            | OPPFYLT      | Nei                  |
+      | 2       | UNDER_18_ÅR                       |                  | 16.02.2007 | 15.02.2025 | OPPFYLT      | Nei                  |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET      |                  | 22.09.2022 |            | OPPFYLT      | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato | Til dato | Beløp | Ytelse type | Prosent |
+
+    Og med endrede utbetalinger for begrunnelse
+      | AktørId | Fra dato | Til dato | BehandlingId | Årsak | Prosent |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato | Til dato | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser | Ekskluderte Begrunnelser |
+      |          |          | AVSLAG             |           |                         |                          |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14518)

Dersom vi får en avslagsperiode uten datoer kan den strekke seg over flere splitter i personene sine data. Dette skapte litt krøll da får forskjellige perioder med data på person.

Lager en egen løype for avslagsperioder som kun tar med begrunnelsene fra vilkårsvurderingen. Legger også til begrunnelsene fra vilkårsvurderingen for de andre periodetypene

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
