### PR TITLE
Sørger for at vi sender alle kjedeelementer knyttet til kjeden med oppdatert opphørsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -353,13 +353,15 @@ class ForvalterService(
                     behandlingId = tilkjentYtelse.behandling.id,
                 )
             }
-            val kjederMedOppdatertOpphørsdato: Map<Long, List<Utbetalingsperiode>> =
-                korrigerteUtbetalingsperioder.associate { it.periodeId to listOf(it) }
+            val kjederMedOppdatertOpphørsdato: MutableMap<Long, List<Utbetalingsperiode>> =
+                korrigerteUtbetalingsperioder.associate { it.periodeId to listOf(it) }.toMutableMap()
             utbetalingsoppdrag.utbetalingsperiode.sortedBy { it.periodeId }.forEach { utbetalingsperiode ->
                 val kjedeMedOppdatertOpphørsdato =
                     kjederMedOppdatertOpphørsdato.entries.find { kjede -> kjede.value.any { it.periodeId == utbetalingsperiode.forrigePeriodeId } }
                 if (kjedeMedOppdatertOpphørsdato != null) {
-                    kjederMedOppdatertOpphørsdato[kjedeMedOppdatertOpphørsdato.key]!!.plus(utbetalingsperiode)
+                    val kjedeElementer = kjederMedOppdatertOpphørsdato[kjedeMedOppdatertOpphørsdato.key]!!
+                    kjederMedOppdatertOpphørsdato[kjedeMedOppdatertOpphørsdato.key] =
+                        kjedeElementer.plus(utbetalingsperiode)
                 }
             }
             return ValidertUtbetalingsoppdrag(


### PR DESCRIPTION
Fikser bug som førte til at vi kun sendte perioden med endringen og ikke alle periodene i samme kjede som kom etter. Noe usikkert om det har noe å si eller ikke, men her er ihvertfall endringen som sørger for at vi sender alle perioder i den endrede kjeden.