### PR TITLE
Fjern vedtaksperioder fra RestUtvidetBehandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVedtak.kt
@@ -1,14 +1,12 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import java.time.LocalDateTime
 
 data class RestVedtak(
     val aktiv: Boolean,
     val vedtaksdato: LocalDateTime?,
-    val vedtaksperioderMedBegrunnelser: List<RestUtvidetVedtaksperiodeMedBegrunnelser>,
     val id: Long,
 )
 
@@ -18,19 +16,9 @@ data class RestVedtakBegrunnelseTilknyttetVilkår(
     val vilkår: Vilkår?,
 )
 
-fun Vedtak.tilRestVedtak(
-    vedtaksperioderMedBegrunnelser: List<RestUtvidetVedtaksperiodeMedBegrunnelser>,
-    skalMinimeres: Boolean,
-) =
+fun Vedtak.tilRestVedtak() =
     RestVedtak(
         aktiv = this.aktiv,
         vedtaksdato = this.vedtaksdato,
         id = this.id,
-        vedtaksperioderMedBegrunnelser = if (skalMinimeres) {
-            vedtaksperioderMedBegrunnelser
-                .filter { it.begrunnelser.isNotEmpty() }
-                .map { it.copy(gyldigeBegrunnelser = emptyList()) }
-        } else {
-            vedtaksperioderMedBegrunnelser
-        },
     )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -18,7 +18,6 @@ import no.nav.familie.ba.sak.ekstern.restDomene.tilRestValutakurs
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestVedtak
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregler.domene.FødselshendelsefiltreringResultatRepository
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -38,8 +37,6 @@ import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.feilutbetaltValuta.FeilutbetaltValutaService
 import no.nav.familie.ba.sak.kjerne.vedtak.refusjonEøs.RefusjonEøsService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.sorter
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilRestUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import org.springframework.stereotype.Service
 
@@ -131,20 +128,7 @@ class UtvidetBehandlingService(
             endretUtbetalingAndeler = endreteUtbetalingerMedAndeler
                 .map { it.tilRestEndretUtbetalingAndel() },
             tilbakekreving = tilbakekreving?.tilRestTilbakekreving(),
-            vedtak = vedtak?.tilRestVedtak(
-                vedtaksperioderMedBegrunnelser = if (behandling.status != BehandlingStatus.AVSLUTTET) {
-                    vedtaksperiodeService.hentUtvidetVedtaksperiodeMedBegrunnelser(
-                        vedtak = vedtak,
-                        personopplysningGrunnlag = personopplysningGrunnlag
-                            ?: error("Mangler persongrunnlag på behandling=$behandlingId"),
-                    )
-                        .sorter()
-                        .map { it.tilRestUtvidetVedtaksperiodeMedBegrunnelser() }
-                } else {
-                    emptyList()
-                },
-                skalMinimeres = behandling.status != BehandlingStatus.UTREDES,
-            ),
+            vedtak = vedtak?.tilRestVedtak(),
             kompetanser = kompetanser.map { it.tilRestKompetanse() }.sortedByDescending { it.fom },
             totrinnskontroll = totrinnskontroll?.tilRestTotrinnskontroll(),
             aktivSettPåVent = settPåVentService.finnAktivSettPåVentPåBehandling(behandlingId = behandlingId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -459,7 +459,7 @@ class VedtaksperiodeService(
     fun hentRestUtvidetVedtaksperiodeMedBegrunnelser(behandlingId: Long): List<RestUtvidetVedtaksperiodeMedBegrunnelser> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
 
-        return if (behandling.status != BehandlingStatus.AVSLUTTET) {
+        val vedtaksperioder = if (behandling.status != BehandlingStatus.AVSLUTTET) {
             val utvidetVedtaksperiodeMedBegrunnelser = hentUtvidetVedtaksperiodeMedBegrunnelser(
                 vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingId),
                 personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId),
@@ -469,6 +469,16 @@ class VedtaksperiodeService(
                 .map { it.tilRestUtvidetVedtaksperiodeMedBegrunnelser() }
         } else {
             emptyList()
+        }
+
+        val skalMinimeres = behandling.status != BehandlingStatus.UTREDES
+
+        return if (skalMinimeres) {
+            vedtaksperioder
+                .filter { it.begrunnelser.isNotEmpty() }
+                .map { it.copy(gyldigeBegrunnelser = emptyList()) }
+        } else {
+            vedtaksperioder
         }
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AndelTilkjentYtelseOffsetTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AndelTilkjentYtelseOffsetTest.kt
@@ -18,11 +18,11 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.SatsTidspunkt
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.brev.BrevmalService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenarioPerson
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -40,10 +40,10 @@ class AndelTilkjentYtelseOffsetTest(
     @Autowired private val fagsakService: FagsakService,
     @Autowired private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     @Autowired private val vedtakService: VedtakService,
+    @Autowired private val vedtaksperiodeService: VedtaksperiodeService,
     @Autowired private val stegService: StegService,
     @Autowired private val efSakRestClient: EfSakRestClient,
     @Autowired private val beregningService: BeregningService,
-    @Autowired private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     @Autowired private val brevmalService: BrevmalService,
     @Autowired private val featureToggleService: FeatureToggleService,
 ) : AbstractVerdikjedetest() {
@@ -156,6 +156,7 @@ class AndelTilkjentYtelseOffsetTest(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             lagToken = ::token,
             brevmalService = brevmalService,
+            vedtaksperiodeService = vedtaksperiodeService,
 
         )
     }
@@ -199,7 +200,7 @@ class AndelTilkjentYtelseOffsetTest(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             lagToken = ::token,
             brevmalService = brevmalService,
-
+            vedtaksperiodeService = vedtaksperiodeService,
         )
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenarioPerson
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -39,6 +40,7 @@ class AutobrevSmåbarnstilleggOpphørTest(
     @Autowired private val fagsakRepository: FagsakRepository,
     @Autowired private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     @Autowired private val vedtakService: VedtakService,
+    @Autowired private val vedtaksperiodeService: VedtaksperiodeService,
     @Autowired private val stegService: StegService,
     @Autowired private val efSakRestClient: EfSakRestClient,
     @Autowired private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
@@ -164,7 +166,7 @@ class AutobrevSmåbarnstilleggOpphørTest(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             lagToken = ::token,
             brevmalService = brevmalService,
-
+            vedtaksperiodeService = vedtaksperiodeService,
         )
     }
 
@@ -207,7 +209,7 @@ class AutobrevSmåbarnstilleggOpphørTest(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             lagToken = ::token,
             brevmalService = brevmalService,
-
+            vedtaksperiodeService = vedtaksperiodeService,
         )
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -250,11 +250,13 @@ class BehandleSmåbarnstilleggTest(
             behandlingStegType = StegType.SEND_TIL_BESLUTTER,
         )
 
-        val vedtaksperiodeId =
-            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.vedtak!!.vedtaksperioderMedBegrunnelser.sortedBy { it.fom }
-                .first()
+        val vedtaksperioderMedBegrunnelser = vedtaksperiodeService.hentRestUtvidetVedtaksperiodeMedBegrunnelser(
+            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.behandlingId,
+        )
+
+        val vedtaksperiode = vedtaksperioderMedBegrunnelser.sortedBy { it.fom }.first()
         familieBaSakKlient().oppdaterVedtaksperiodeMedStandardbegrunnelser(
-            vedtaksperiodeId = vedtaksperiodeId.id,
+            vedtaksperiodeId = vedtaksperiode.id,
             restPutVedtaksperiodeMedStandardbegrunnelser = RestPutVedtaksperiodeMedStandardbegrunnelser(
                 standardbegrunnelser = listOf(
                     Standardbegrunnelse.INNVILGET_BOR_HOS_SØKER.enumnavnTilString(),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Datagenerator.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Datagenerator.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
 import no.nav.familie.kontrakter.ba.infotrygd.Barn
 import no.nav.familie.kontrakter.ba.infotrygd.Delytelse
@@ -101,6 +102,7 @@ fun fullførBehandlingFraVilkårsvurderingAlleVilkårOppfylt(
     vedtakService: VedtakService,
     stegService: StegService,
     brevmalService: BrevmalService,
+    vedtaksperiodeService: VedtaksperiodeService,
 ): Behandling {
     settAlleVilkårTilOppfylt(
         restUtvidetBehandling = restUtvidetBehandling,
@@ -123,9 +125,12 @@ fun fullførBehandlingFraVilkårsvurderingAlleVilkårOppfylt(
             RestTilbakekreving(Tilbakekrevingsvalg.IGNORER_TILBAKEKREVING, begrunnelse = "begrunnelse"),
         )
 
+    val vedtaksperioderMedBegrunnelser = vedtaksperiodeService.hentRestUtvidetVedtaksperiodeMedBegrunnelser(
+        restUtvidetBehandlingEtterVurderTilbakekreving.data!!.behandlingId,
+    )
+
     val utvidetVedtaksperiodeMedBegrunnelser =
-        restUtvidetBehandlingEtterVurderTilbakekreving.data!!.vedtak!!.vedtaksperioderMedBegrunnelser.sortedBy { it.fom }
-            .first()
+        vedtaksperioderMedBegrunnelser.sortedBy { it.fom }.first()
 
     familieBaSakKlient.oppdaterVedtaksperiodeMedStandardbegrunnelser(
         vedtaksperiodeId = utvidetVedtaksperiodeMedBegrunnelser.id,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FamilieBaSakKlient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FamilieBaSakKlient.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRequest
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.logg.Logg
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.http.HttpHeaders
@@ -161,7 +162,7 @@ class FamilieBaSakKlient(
     fun oppdaterVedtaksperiodeMedStandardbegrunnelser(
         vedtaksperiodeId: Long,
         restPutVedtaksperiodeMedStandardbegrunnelser: RestPutVedtaksperiodeMedStandardbegrunnelser,
-    ): Ressurs<RestUtvidetBehandling> {
+    ): Ressurs<List<RestUtvidetVedtaksperiodeMedBegrunnelser>> {
         val uri = URI.create("$baSakUrl/api/vedtaksperioder/standardbegrunnelser/$vedtaksperiodeId")
 
         return putForEntity(uri, restPutVedtaksperiodeMedStandardbegrunnelser, headers)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenarioPerson
 import no.nav.familie.ba.sak.util.sisteUtvidetSatsTilTester
@@ -48,6 +49,7 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
     @Autowired private val stegService: StegService,
     @Autowired private val featureToggleService: FeatureToggleService,
     @Autowired private val brevmalService: BrevmalService,
+    @Autowired private val vedtaksperiodeService: VedtaksperiodeService,
 ) : AbstractVerdikjedetest() {
 
     @BeforeEach
@@ -171,11 +173,13 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
             behandlingStegType = StegType.SEND_TIL_BESLUTTER,
         )
 
-        val vedtaksperiodeId =
-            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.vedtak!!.vedtaksperioderMedBegrunnelser.sortedBy { it.fom }
-                .first()
+        val vedtaksperioderMedBegrunnelser = vedtaksperiodeService.hentRestUtvidetVedtaksperiodeMedBegrunnelser(
+            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.behandlingId,
+        )
+
+        val vedtaksperiode = vedtaksperioderMedBegrunnelser.sortedBy { it.fom }.first()
         familieBaSakKlient().oppdaterVedtaksperiodeMedStandardbegrunnelser(
-            vedtaksperiodeId = vedtaksperiodeId.id,
+            vedtaksperiodeId = vedtaksperiode.id,
             restPutVedtaksperiodeMedStandardbegrunnelser = RestPutVedtaksperiodeMedStandardbegrunnelser(
                 standardbegrunnelser = listOf(
                     Standardbegrunnelse.INNVILGET_BOR_HOS_SØKER.enumnavnTilString(),
@@ -352,12 +356,14 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
             behandlingStegType = StegType.SEND_TIL_BESLUTTER,
         )
 
-        val vedtaksperiodeId =
-            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.vedtak!!.vedtaksperioderMedBegrunnelser.sortedBy { it.fom }
-                .first()
+        val vedtaksperioderMedBegrunnelser = vedtaksperiodeService.hentRestUtvidetVedtaksperiodeMedBegrunnelser(
+            restUtvidetBehandlingEtterVurderTilbakekreving.data!!.behandlingId,
+        )
+
+        val vedtaksperiode = vedtaksperioderMedBegrunnelser.sortedBy { it.fom }.first()
 
         familieBaSakKlient().oppdaterVedtaksperiodeMedStandardbegrunnelser(
-            vedtaksperiodeId = vedtaksperiodeId.id,
+            vedtaksperiodeId = vedtaksperiode.id,
             restPutVedtaksperiodeMedStandardbegrunnelser = RestPutVedtaksperiodeMedStandardbegrunnelser(
                 standardbegrunnelser = listOf(
                     Standardbegrunnelse.INNVILGET_BOR_HOS_SØKER.enumnavnTilString(),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/OpplysningspliktTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/OpplysningspliktTest.kt
@@ -120,9 +120,11 @@ class OpplysningspliktTest(
                 RestTilbakekreving(Tilbakekrevingsvalg.IGNORER_TILBAKEKREVING, begrunnelse = "begrunnelse"),
             )
 
-        val vedtaksperiode =
-            behandlingEtterVurderTilbakekreving.data!!.vedtak!!.vedtaksperioderMedBegrunnelser.sortedBy { it.fom }
-                .first()
+        val vedtaksperioderMedBegrunnelser = vedtaksperiodeService.hentRestUtvidetVedtaksperiodeMedBegrunnelser(
+            behandlingEtterVurderTilbakekreving.data!!.behandlingId,
+        )
+
+        val vedtaksperiode = vedtaksperioderMedBegrunnelser.sortedBy { it.fom }.first()
         familieBaSakKlient().oppdaterVedtaksperiodeMedStandardbegrunnelser(
             vedtaksperiodeId = vedtaksperiode.id,
             restPutVedtaksperiodeMedStandardbegrunnelser = RestPutVedtaksperiodeMedStandardbegrunnelser(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
@@ -179,7 +179,7 @@ class ReduksjonFraForrigeIverksatteBehandlingTest(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             lagToken = ::token,
             brevmalService = brevmalService,
-
+            vedtaksperiodeService = vedtaksperiodeService,
         )
     }
 
@@ -215,7 +215,7 @@ class ReduksjonFraForrigeIverksatteBehandlingTest(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             lagToken = ::token,
             brevmalService = brevmalService,
-
+            vedtaksperiodeService = vedtaksperiodeService,
         )
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Hører til https://github.com/navikt/familie-ba-sak/pull/3869 og https://github.com/navikt/familie-ba-sak-frontend/pull/2751 og må bli merget etter dem.

[Denne behandlingen](https://barnetrygd.intern.nav.no/fagsak/1921845/3780399) stopper helt opp fordi vi ikke klarer å utlede vedtaksperiodene. Det er ikke mulig å se på noe annet data siden all data i behandlingen som sendes til frontend finnes på samme objekt som vi nå ikke klarer å lage. 

Gjør så vi splitter ut vedtaksperiodene fra `IBehandling` (`RestUtvidetBehandling` backend). 
* Første steg er å gi med vedtaksperiodene i både `RestUtvidetBehandling` og eget endtepunkt. https://github.com/navikt/familie-ba-sak/pull/3869
* Så må frontend gå over til å ta imot fra det nye endepunktet. https://github.com/navikt/familie-ba-sak-frontend/pull/2751
* Til slutt kan vi fjerne vedtaksperiodene fra `RestUtvidetBehandling`. (Denne PRen)

![image](https://github.com/navikt/familie-ba-sak/assets/17828446/2dafc883-e8c2-4f10-9da7-29e71b6dbc55)

Splitter hentingen av vedtaksperiodene på eget endepunkt slik at vi kan begrense feilmeldingen til der det feiler:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/077220fe-1659-4f65-88ab-fee987957f25)
