### PR TITLE
Kun vis kompetansebegrunnelser dersom det er endring i kompetanse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -22,6 +23,7 @@ class TestVerktøyService(
     private val endretUtbetalingRepository: EndretUtbetalingAndelRepository,
     private val vedtaksperiodeHentOgPersisterService: VedtaksperiodeHentOgPersisterService,
     private val vedtakService: VedtakService,
+    private val kompetanseRepository: KompetanseRepository,
 ) {
 
     @Transactional
@@ -63,6 +65,10 @@ class TestVerktøyService(
         val endredeUtbetalingerForrigeBehandling =
             forrigeBehandling?.let { endretUtbetalingRepository.findByBehandlingId(it.id) }
 
+        val kompetanse = kompetanseRepository.finnFraBehandlingId(behandlingId)
+        val kompetanseForrigeBehandling =
+            forrigeBehandling?.let { kompetanseRepository.finnFraBehandlingId(it.id) }
+
         val vedtaksperioder = vedtaksperiodeHentOgPersisterService.finnVedtaksperioderFor(
             vedtakService.hentAktivForBehandlingThrows(behandlingId).id,
         )
@@ -79,6 +85,8 @@ class TestVerktøyService(
             vedtaksperioder = vedtaksperioder,
             endredeUtbetalinger = endredeUtbetalinger,
             endredeUtbetalingerForrigeBehandling = endredeUtbetalingerForrigeBehandling,
+            kompetanse = kompetanse,
+            kompetanseForrigeBehandling = kompetanseForrigeBehandling,
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -215,10 +215,8 @@ private fun hentEØSStandardBegrunnelser(
         it.erGjeldendeForUtgjørendeVilkår(begrunnelseGrunnlag)
     }
 
-    val filtrertPåKompetanse = begrunnelserFiltrertPåPeriodetype.filterValues {
-        it.erLikKompetanseIPeriode(
-            begrunnelseGrunnlag,
-        )
+    val filtrertPåKompetanse = begrunnelserFiltrertPåPeriodetype.filterValues { begrunnelse ->
+        erEndringIKompetanse(begrunnelseGrunnlag) && begrunnelse.erLikKompetanseIPeriode(begrunnelseGrunnlag)
     }
 
     return filtrertPåVilkår.keys.toSet() +
@@ -591,3 +589,7 @@ private fun SanityBegrunnelse.matcherPerioderesultat(
     val økningMatcher = erØkning == erBegrunnelseØkning
     return reduksjonMatcher && økningMatcher
 }
+
+private fun erEndringIKompetanse(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode) =
+    begrunnelseGrunnlag.dennePerioden.kompetanse !=
+        begrunnelseGrunnlag.forrigePeriode?.kompetanse

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -40,4 +40,45 @@ Egenskap: Kompetanse-begrunnelser
       | 01.05.2021 | 31.03.2038 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_SEKUNDÆRLAND_STANDARD                    | INNVILGET_SEKUNDÆRLAND_TO_ARBEIDSLAND_NORGE_UTBETALER |
       | 01.04.2038 |            | Opphør             |                  |                                                    |                                                       |
 
+  Scenario: Vis innvilgetbegrunnelser når kompetanse endrer seg
+    Gitt følgende behandling
+      | BehandlingId | FagsakId  | ForrigeBehandlingId |
+      | 100173206    | 200055603 |                     |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId       | Persontype | Fødselsdato |
+      | 100173206    | 2013549321777 | BARN       | 02.02.2015  |
+      | 100173206    | 1448019142841 | SØKER      | 30.09.1984  |
+
+    Og lag personresultater for begrunnelse for behandling 100173206
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 100173206
+      | AktørId       | Vilkår                          | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1448019142841 | LOVLIG_OPPHOLD                  |                              | 30.09.1984 |            | OPPFYLT  | Nei                  |
+      | 1448019142841 | BOSATT_I_RIKET                  | OMFATTET_AV_NORSK_LOVGIVNING | 15.03.2023 |            | OPPFYLT  | Nei                  |
+
+      | 2013549321777 | BOR_MED_SØKER                   | BARN_BOR_I_EØS_MED_SØKER     | 02.02.2015 |            | OPPFYLT  | Nei                  |
+      | 2013549321777 | LOVLIG_OPPHOLD,GIFT_PARTNERSKAP |                              | 02.02.2015 |            | OPPFYLT  | Nei                  |
+      | 2013549321777 | UNDER_18_ÅR                     |                              | 02.02.2015 | 01.02.2033 | OPPFYLT  | Nei                  |
+      | 2013549321777 | BOSATT_I_RIKET                  | BARN_BOR_I_NORGE             | 02.02.2015 |            | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId       | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent |
+      | 2013549321777 | 100173206    | 01.04.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     |
+      | 2013549321777 | 100173206    | 01.07.2023 | 31.07.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+      | 2013549321777 | 100173206    | 01.08.2023 | 31.01.2033 | 167   | ORDINÆR_BARNETRYGD | 100     |
+
+    Og med kompetanser for begrunnelse
+      | AktørId       | Fra dato   | Til dato   | Resultat              | BehandlingId | Annen forelders aktivitet | Barnets bostedsland |
+      | 2013549321777 | 01.04.2023 | 01.07.2023 | NORGE_ER_PRIMÆRLAND   | 100173206    | INAKTIV                   | NO                  |
+      | 2013549321777 | 01.08.2023 |            | NORGE_ER_SEKUNDÆRLAND | 100173206    | I_ARBEID                  | GB                  |
+
+    Når begrunnelsetekster genereres for behandling 100173206
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser | Ekskluderte Begrunnelser      |
+      | 01.04.2023 | 30.06.2023 | UTBETALING         |                  |                         |                               |
+      | 01.07.2023 | 31.07.2023 | UTBETALING         | EØS_FORORDNINGEN |                         | INNVILGET_PRIMÆRLAND_STANDARD |
+      | 01.08.2023 | 31.01.2033 | UTBETALING         |                  |                         |                               |
+      | 01.02.2033 |            | OPPHØR             |                  |                         |                               |
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -40,7 +40,7 @@ Egenskap: Kompetanse-begrunnelser
       | 01.05.2021 | 31.03.2038 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_SEKUNDÆRLAND_STANDARD                    | INNVILGET_SEKUNDÆRLAND_TO_ARBEIDSLAND_NORGE_UTBETALER |
       | 01.04.2038 |            | Opphør             |                  |                                                    |                                                       |
 
-  Scenario: Vis innvilgetbegrunnelser når kompetanse endrer seg
+  Scenario: Ikke vis kompetansebegrunnelser dersom kompetansen ikke endrer seg
     Gitt følgende behandling
       | BehandlingId | FagsakId  | ForrigeBehandlingId |
       | 100173206    | 200055603 |                     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I saken beskrevet [i dette favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15079) viser vi kompetansebegrunnelser når alt som har skjedd er at det er en satsendring. 

Endrer så vi kun viser kompetansebegrunnelser dersom det er endring i kompetanse

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.