### PR TITLE
Fix: Kompetanse ble ikke korrekt når bruker gikk fra EØS til nasjonal på 2 av 3 barn.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
@@ -12,7 +12,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.medBehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.replaceLast
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.EndretUtbetalingAndelTidslinjeService
-import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.RegelverkResultat
+import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.KombinertRegelverkResultat
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjeService
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.tilBarnasHarEtterbetaling3ÅrTidslinjer
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -102,7 +102,7 @@ class TilpassKompetanserTilEndretUtebetalingAndelerService(
 
 fun tilpassKompetanserTilRegelverk(
     gjeldendeKompetanser: Collection<Kompetanse>,
-    barnaRegelverkTidslinjer: Map<Aktør, Tidslinje<RegelverkResultat, Måned>>,
+    barnaRegelverkTidslinjer: Map<Aktør, Tidslinje<KombinertRegelverkResultat, Måned>>,
     barnasHarEtterbetaling3ÅrTidslinjer: Map<Aktør, Tidslinje<Boolean, Måned>>,
 ): Collection<Kompetanse> {
     val barnasEøsRegelverkTidslinjer = barnaRegelverkTidslinjer.tilBarnasEøsRegelverkTidslinjer()
@@ -120,15 +120,15 @@ fun tilpassKompetanserTilRegelverk(
         .tilSkjemaer()
 }
 
-fun VilkårsvurderingTidslinjeService.hentBarnasRegelverkResultatTidslinjer(behandlingId: BehandlingId): Map<Aktør, Tidslinje<RegelverkResultat, Måned>> =
+fun VilkårsvurderingTidslinjeService.hentBarnasRegelverkResultatTidslinjer(behandlingId: BehandlingId) =
     this.hentTidslinjerThrows(behandlingId).barnasTidslinjer()
         .mapValues { (_, tidslinjer) ->
             tidslinjer.regelverkResultatTidslinje
         }
 
-private fun Map<Aktør, Tidslinje<RegelverkResultat, Måned>>.tilBarnasEøsRegelverkTidslinjer() =
+private fun Map<Aktør, Tidslinje<KombinertRegelverkResultat, Måned>>.tilBarnasEøsRegelverkTidslinjer() =
     this.mapValues { (_, tidslinjer) ->
-        tidslinjer.map { it?.regelverk }
+        tidslinjer.map { it?.barnetsResultat?.regelverk }
             .filtrer { it == Regelverk.EØS_FORORDNINGEN }
             .filtrerIkkeNull()
             .forlengFremtidTilUendelig(MånedTidspunkt.nå())

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/VilkårRegelverkResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/VilkårRegelverkResultat.kt
@@ -90,3 +90,14 @@ fun RegelverkResultat?.kombinerMed(resultat: RegelverkResultat?) = when (this) {
 }
 
 fun VilkårRegelverkResultat?.erOppfylt() = this?.resultat == Resultat.OPPFYLT
+
+data class KombinertRegelverkResultat(
+    val barnetsResultat: RegelverkResultat?,
+    val søkersResultat: RegelverkResultat?,
+) {
+    val kombinertResultat get() = barnetsResultat.kombinerMed(søkersResultat)
+
+    override fun toString(): String {
+        return kombinertResultat.toString()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -59,8 +59,7 @@ class VilkårsvurderingTidslinjer(
 
     fun forBarn(barn: Person) = barnasTidslinjer[barn.aktør]!!
 
-    fun barnasTidslinjer(): Map<Aktør, BarnetsTidslinjer> =
-        barnasTidslinjer.entries.associate { it.key to it.value }
+    fun barnasTidslinjer(): Map<Aktør, BarnetsTidslinjer> = barnasTidslinjer
 
     class SøkersTidslinjer(
         tidslinjer: VilkårsvurderingTidslinjer,
@@ -114,7 +113,10 @@ class VilkårsvurderingTidslinjer(
 
         val regelverkResultatTidslinje = egetRegelverkResultatTidslinje
             .kombinerMed(søkersTidslinje.regelverkResultatTidslinje) { barnetsResultat, søkersResultat ->
-                barnetsResultat.kombinerMed(søkersResultat)
+                KombinertRegelverkResultat(
+                    barnetsResultat = barnetsResultat,
+                    søkersResultat = søkersResultat
+                )
             }
             // Barnets egne tidslinjer kan på dette tidspunktet strekke seg 18 år frem i tid,
             // og mye lenger enn søkers regelverk-tidslinje, som skal være begrensningen. Derfor besjærer vi mot den

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/RestTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/RestTidslinjer.kt
@@ -35,11 +35,11 @@ fun VilkårsvurderingTidslinjer.tilRestTidslinjer(): RestTidslinjer {
                 },
                 oppfyllerEgneVilkårIKombinasjonMedSøkerTidslinje = it.value
                     .regelverkResultatTidslinje
-                    .map { it?.resultat }
+                    .map { it?.kombinertResultat?.resultat }
                     .beskjærEtter(erUnder18årTidslinje)
                     .tilRestTidslinje(),
                 regelverkTidslinje = it.value.regelverkResultatTidslinje
-                    .map { it?.regelverk }
+                    .map { it?.kombinertResultat?.regelverk }
                     .beskjærEtter(erUnder18årTidslinje)
                     .tilRestTidslinje(),
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -4,9 +4,11 @@ import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.tilpassKompetanserTilRegelverk
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.KombinertRegelverkResultat
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.RegelverkResultat
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.KompetanseBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
@@ -26,7 +28,7 @@ class TilpassKompetanserTilRegelverkTest {
         val kompetanser: List<Kompetanse> = emptyList()
 
         val eøsPerioder = mapOf(
-            barn1.aktør to "EEENNEEEE".tilRegelverkResultatTidslinje(jan2020),
+            barn1.aktør to "EEENNEEEE".tilRegelverkResultatTidslinje(jan2020).kombinertSøkersTidslinjeResultat(),
         )
 
         val forventedeKompetanser = KompetanseBuilder(jan2020)
@@ -44,7 +46,7 @@ class TilpassKompetanserTilRegelverkTest {
             .medKompetanse("SSSSSSS", barn1)
             .byggKompetanser()
 
-        val eøsPerioder = emptyMap<Aktør, Tidslinje<RegelverkResultat, Måned>>()
+        val eøsPerioder = emptyMap<Aktør, Tidslinje<KombinertRegelverkResultat, Måned>>()
 
         val forventedeKompetanser = emptyList<Kompetanse>()
 
@@ -60,7 +62,7 @@ class TilpassKompetanserTilRegelverkTest {
             .byggKompetanser()
 
         val barnasRegelverkResultatTidslinjer = mapOf(
-            barn1.aktør to "EEENNEEEE".tilRegelverkResultatTidslinje(jan2020),
+            barn1.aktør to "EEENNEEEE".tilRegelverkResultatTidslinje(jan2020).kombinertSøkersTidslinjeResultat(),
         )
 
         val forventedeKompetanser = KompetanseBuilder(jan2020)
@@ -82,7 +84,7 @@ class TilpassKompetanserTilRegelverkTest {
             .medKompetanse("SS--SSSS", barn1, barn2)
             .byggKompetanser()
 
-        val barnasRegelverkResultatTidslinjer = mapOf(
+        val barnasEgneRegelverkResultatTidslinjer = mapOf(
             barn1.aktør to "EEENNEEEE".tilRegelverkResultatTidslinje(jan2020),
             barn2.aktør to "EEEENNEEE".tilRegelverkResultatTidslinje(jan2020),
         )
@@ -95,7 +97,7 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser = tilpassKompetanserTilRegelverk(
             kompetanser,
-            barnasRegelverkResultatTidslinjer,
+            barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersTidslinjeResultat() },
             emptyMap(),
         ).sortedBy { it.fom }
 
@@ -116,7 +118,7 @@ class TilpassKompetanserTilRegelverkTest {
             .medKompetanse("-      ", barn3)
             .byggKompetanser()
 
-        val barnasRegelverkResultatTidslinjer = mapOf(
+        val barnasEgneRegelverkResultatTidslinjer = mapOf(
             barn1.aktør to "EEENNEEEE".tilRegelverkResultatTidslinje(jan2020),
             barn2.aktør to "EEE--NNNN".tilRegelverkResultatTidslinje(jan2020),
             barn3.aktør to "EEEEEEEEE".tilRegelverkResultatTidslinje(jan2020),
@@ -135,7 +137,7 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser = tilpassKompetanserTilRegelverk(
             kompetanser,
-            barnasRegelverkResultatTidslinjer,
+            barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersTidslinjeResultat() },
             emptyMap(),
         ).sortedBy { it.fom }
 
@@ -158,7 +160,7 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser = tilpassKompetanserTilRegelverk(
             kompetanser,
-            barnasRegelverkResultatTidslinjer,
+            barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersTidslinjeResultat() },
             emptyMap(),
         ).sortedBy { it.fom }
 
@@ -195,7 +197,7 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser = tilpassKompetanserTilRegelverk(
             kompetanser,
-            barnasRegelverkResultatTidslinjer,
+            barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersTidslinjeResultat() },
             emptyMap(),
         ).sortedBy { it.fom }
 
@@ -225,10 +227,18 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser = tilpassKompetanserTilRegelverk(
             kompetanser,
-            barnasRegelverkResultatTidslinjer,
+            barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersTidslinjeResultat() },
             barnasHarEtterbetaling3År,
         ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
+    }
+}
+
+private fun Tidslinje<RegelverkResultat, Måned>.kombinertSøkersTidslinjeResultat(
+    søkersTidslinje: Tidslinje<RegelverkResultat, Måned>? = null
+): Tidslinje<KombinertRegelverkResultat, Måned> {
+    return this.kombinerMed(søkersTidslinje ?: this) {barnetsResultat: RegelverkResultat?, søkersResultat: RegelverkResultat? ->
+        KombinertRegelverkResultat(barnetsResultat, søkersResultat)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.tilpassKompetanserTilRegelverk
 import no.nav.familie.ba.sak.kjerne.eøs.util.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.konkatenerTidslinjer
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.ogSenere
@@ -18,6 +19,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom.rangeTo
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.VilkårsvurderingBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.byggVilkårsvurderingTidslinjer
@@ -83,8 +85,8 @@ internal class TidslinjerTest {
         )
 
         assertEquals(søkerResult, vilkårsvurderingTidslinjer.søkersTidslinjer().regelverkResultatTidslinje)
-        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
-        assertEquals(barn2Result, vilkårsvurderingTidslinjer.forBarn(barn2).regelverkResultatTidslinje)
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje.kombinertResultat)
+        assertEquals(barn2Result, vilkårsvurderingTidslinjer.forBarn(barn2).regelverkResultatTidslinje.kombinertResultat)
     }
 
     @Test
@@ -119,7 +121,7 @@ internal class TidslinjerTest {
         )
 
         assertEquals(søkerResult, vilkårsvurderingTidslinjer.søkersTidslinjer().regelverkResultatTidslinje)
-        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje.kombinertResultat)
     }
 
     @Test
@@ -169,7 +171,7 @@ internal class TidslinjerTest {
 
         val barn1Result = "E".tilRegelverkResultatTidslinje(mai(2020))
 
-        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje.kombinertResultat)
     }
 
     @Test
@@ -187,7 +189,7 @@ internal class TidslinjerTest {
 
         val barn1Result = "N".tilRegelverkResultatTidslinje(mai(2020))
 
-        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje.kombinertResultat)
     }
 
     @Test
@@ -207,7 +209,7 @@ internal class TidslinjerTest {
 
         val barn1Result = "!".tilRegelverkResultatTidslinje(mai(2020))
 
-        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
+        assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje.kombinertResultat)
     }
 
     @Test
@@ -300,7 +302,7 @@ internal class TidslinjerTest {
         val forventetRegelverkResultat =
             "NNNNNNNNNNNNNNNNEEEEEE".tilRegelverkResultatTidslinje(feb(2020))
 
-        assertEquals(forventetRegelverkResultat, barnaRegelverkTidslinjer[barn.aktør])
+        assertEquals(forventetRegelverkResultat, barnaRegelverkTidslinjer[barn.aktør]?.kombinertResultat)
         assertEquals(1, kompetanser.size)
         assertEquals(YearMonth.of(2021, 6), kompetanser.first().fom)
         assertEquals(YearMonth.of(2021, 11), kompetanser.first().tom)
@@ -355,3 +357,7 @@ internal class TidslinjerTest {
 
 fun VilkårsvurderingTidslinjer.barnasRegelverkResultatTidslinjer() = this.barnasTidslinjer()
     .mapValues { (_, barnetsTidslinjer) -> barnetsTidslinjer.regelverkResultatTidslinje }
+
+
+private val Tidslinje<KombinertRegelverkResultat, Måned>.kombinertResultat: Tidslinje<RegelverkResultat, Måned>
+    get() = map { it?.kombinertResultat }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro
](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12319)
Utsetter kombineringen av barns RegelverkResultat med søkers regelverkResultat. Oppretter instans av ny klasse som tar vare på resultatene til evaluering senere istedenfor. Får dermed filtrert etter regelverkene spesifikt gjeldende barna, istedenfor regelverket definert av det kombinerte resultatet (som var null for OPPFYLT_BLANDET_REGELVERK), ved henting av "barnasEøsRegelverkTidslinjer"

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
