### PR TITLE
Fiks uendelighetfeil i tidslinjene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
@@ -13,10 +13,22 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeTil
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom.rangeTo
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.fraOgMed() =
-    this.perioder().firstOrNull()?.fraOgMed
+    this.perioder().firstOrNull()?.let {
+        if (it.fraOgMed.erEndelig()) {
+            it.fraOgMed
+        } else {
+            minOf(it.fraOgMed.somEndelig(), it.tilOgMed.somEndelig()).somUendeligLengeSiden()
+        }
+    }
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.tilOgMed() =
-    this.perioder().lastOrNull()?.tilOgMed
+    this.perioder().lastOrNull()?.let {
+        if (it.tilOgMed.erEndelig()) {
+            it.tilOgMed
+        } else {
+            maxOf(it.fraOgMed.somEndelig(), it.tilOgMed.somEndelig()).somUendeligLengeTil()
+        }
+    }
 
 fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.fraOgMed() = this
     .map { it.fraOgMed() }
@@ -33,9 +45,10 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.tidsrom(): Collection<Tidspunkt<T>> = whe
     else -> (perioder().first().fraOgMed.rangeTo(perioder().last().tilOgMed)).toList()
 }
 
-fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): Collection<Tidspunkt<T>> = when {
-    fraOgMed() == null || tilOgMed() == null -> emptyList()
-    else -> (fraOgMed()!!..tilOgMed()!!).toList()
+fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): Collection<Tidspunkt<T>> {
+    val fraOgMed = fraOgMed() ?: return emptyList()
+    val tilOgMed = tilOgMed() ?: return emptyList()
+    return (fraOgMed..tilOgMed).toList()
 }
 
 fun <T : Tidsenhet> tidsrom(vararg tidslinjer: Tidslinje<*, T>) = tidslinjer.toList().tidsrom()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
@@ -31,13 +31,11 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.tilOgMed() =
     }
 
 fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.fraOgMed() = this
-    .map { it.fraOgMed() }
-    .filterNotNull()
+    .mapNotNull { it.fraOgMed() }
     .minsteEllerNull()
 
 fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tilOgMed() = this
-    .map { it.tilOgMed() }
-    .filterNotNull()
+    .mapNotNull { it.tilOgMed() }
     .størsteEllerNull()
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.tidsrom(): Collection<Tidspunkt<T>> = when {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidslinjeTest.kt
@@ -1,24 +1,27 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje
 
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje.Companion.TidslinjeFeilException
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeSiden
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeTil
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
-import org.junit.jupiter.api.Assertions
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 
 internal class TidslinjeTest {
 
     @Test
     fun `skal validere at perioder ikke kan ha fra-og-med etter til-og-med`() {
-        assertThrows<TidslinjeFeilException> {
+        assertThatExceptionOfType(TidslinjeFeilException::class.java).isThrownBy {
             TestTidslinje(
                 Periode(15.jan(2020), 14.jan(2020), 'A'),
             ).perioder()
@@ -27,7 +30,7 @@ internal class TidslinjeTest {
 
     @Test
     fun `skal validere at perioder som overlapper med kun én dag ikke er lov`() {
-        assertThrows<TidslinjeFeilException> {
+        assertThatExceptionOfType(TidslinjeFeilException::class.java).isThrownBy {
             TestTidslinje(
                 Periode(1.jan(2020), 31.mar(2020), 'A'),
                 Periode(31.mar(2020), 31.mai(2020), 'B'),
@@ -37,7 +40,7 @@ internal class TidslinjeTest {
 
     @Test
     fun `skal validere at periode som ligger inni en annen ikke er lov`() {
-        assertThrows<TidslinjeFeilException> {
+        assertThatExceptionOfType(TidslinjeFeilException::class.java).isThrownBy {
             TestTidslinje(
                 Periode(1.jan(2020), 31.mai(2020), 'A'),
                 Periode(1.mar(2020), 30.apr(2020), 'B'),
@@ -63,7 +66,7 @@ internal class TidslinjeTest {
 
     @Test
     fun `skal validere at uendelige perioder inni en tidslinje ikke er lov`() {
-        assertThrows<TidslinjeFeilException> {
+        assertThatExceptionOfType(TidslinjeFeilException::class.java).isThrownBy {
             TestTidslinje(
                 Periode(1.jan(2020), 31.jan(2020), 'A'),
                 Periode(1.feb(2020).somUendeligLengeSiden(), 29.feb(2020), 'A'),
@@ -71,7 +74,7 @@ internal class TidslinjeTest {
             ).perioder()
         }
 
-        assertThrows<TidslinjeFeilException> {
+        assertThatExceptionOfType(TidslinjeFeilException::class.java).isThrownBy {
             TestTidslinje(
                 Periode(1.jan(2020), 31.jan(2020), 'A'),
                 Periode(1.feb(2020), 29.feb(2020).somUendeligLengeTil(), 'A'),
@@ -82,17 +85,45 @@ internal class TidslinjeTest {
 
     @Test
     fun `skal presentere tidslinjefeil på et forstålig format`() {
-        val tidslinjeFeil = assertThrows<TidslinjeFeilException> {
+        assertThatExceptionOfType(TidslinjeFeilException::class.java).isThrownBy {
             TestTidslinje(
                 Periode(1.jan(2020), 31.jan(2020), 'A'),
                 Periode(1.feb(2020), 29.feb(2020).somUendeligLengeTil(), 'A'),
                 Periode(1.mar(2020), 30.apr(2020), 'B'),
             ).perioder()
+        }.withMessage(
+            "[TidslinjeFeil(type=UENDELIG_FREMTID_FØR_SISTE_PERIODE, periode=2020-02-01 - 2020-02-29-->: A, tidslinje=2020-01-01 - 2020-01-31: A | 2020-02-01 - 2020-02-29-->: A | 2020-03-01 - 2020-04-30: B)]",
+        )
+    }
+
+    @Test
+    fun `Skal kunne kombinere tidslinje med uendelighet der det uendelige tidspunktet er satt tilbake i tid`() {
+        val tidslinjeMedUendelighet = listOf(
+            Periode(jan(2020), des(2020), 'A'),
+            Periode(jan(2021), feb(1999).somUendeligLengeTil(), 'B'),
+        ).tilTidslinje()
+
+        val kombinertMedSegSelv = tidslinjeMedUendelighet.kombinerMed(tidslinjeMedUendelighet) { v, h ->
+            "$v$h"
         }
 
-        Assertions.assertEquals(
-            "[TidslinjeFeil(type=UENDELIG_FREMTID_FØR_SISTE_PERIODE, periode=2020-02-01 - 2020-02-29-->: A, tidslinje=2020-01-01 - 2020-01-31: A | 2020-02-01 - 2020-02-29-->: A | 2020-03-01 - 2020-04-30: B)]",
-            tidslinjeFeil.message,
+        Assertions.assertThat(kombinertMedSegSelv).isEqualTo(
+            listOf(
+                Periode(jan(2020), des(2020), "AA"),
+                Periode(jan(2021), feb(1999).somUendeligLengeTil(), "BB"),
+            ).tilTidslinje(),
+        )
+    }
+
+    @Test
+    fun `tidsrom skal lage liste med alle tidspunkter opp til uendelig tidspunk`() {
+        val tidslinjeMedUendelighet = listOf(
+            Periode(nov(2020), des(2020), 'A'),
+            Periode(jan(2021), jan(1999).somUendeligLengeTil(), 'B'),
+        ).tilTidslinje()
+
+        Assertions.assertThat(tidsrom(tidslinjeMedUendelighet).toList()).isEqualTo(
+            listOf(nov(2020), des(2020), jan(1999).somUendeligLengeTil()),
         )
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når vi skal kombinere to tidslinjer gjør vi lager i først en liste som inneholder alle tidspunktene i begge tidslinjene, før vi kjører kombineringsfunkjsonen på tidslinjene sine verdier i hvert av tidspunktene. 

Dersom en av periodene i tidslinjene er uendelig brukes fremdeles den endelige verdien. Dette skaper trøbbel når den endelige verdien kommer før andre tidspunkter i tidslinen fordi vi da ikke ser på periodene vi ville trodd at vi skulle se på. 

Endre så periodene vi henter ut til å kjøre kombineringsfunkjsonen på går fra det minste av fom og til til den første perioden og det største av fom og tom til den siste perioden. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Det av vi må mappe over alle verdiene som finnes mellom det første og det seneste tidspunktet i tidslinjene er i seg selv litt iffy. I framtiden burde vi vurdere om vi skal gå over til KS sine tidslinjer som sammenligner periode for periode og ikke alle tidspunktene i en periode. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
