### PR TITLE
Fjern ubrukte begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -1349,22 +1349,6 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override val sanityApiNavn = "fortsattInnvilgetGenerellBorSammenMedBarn"
     },
-    ENDRET_UTBETALING_DELT_BOSTED_FULL_UTBETALING {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
-        override val sanityApiNavn = "endretUtbetalingDeltBostedFullUtbetalingForSoknad"
-    },
-    ENDRET_UTBETALING_DELT_BOSTED_INGEN_UTBETALING {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
-        override val sanityApiNavn = "endretUtbetalingDeltBostedIngenUtbetalingForSoknad"
-    },
-    ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_KUN_ETTERBETALING_UTVIDET {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
-        override val sanityApiNavn = "endretUtbetalingDeltBostedKunEtterbetalingUtvidet"
-    },
-    ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_FULL_ORDINÆR_OG_ETTERBETALING_UTVIDET {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
-        override val sanityApiNavn = "endretUtbetalingDeltBostedFullOrdinarOgEtterbetalingUtvidet"
-    },
     ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
         override val sanityApiNavn = "endretUtbetalingDeltBostedIngenUtbetaling"

--- a/src/test/resources/brevperiodeCaser/ENDRET_UTBETALING.json
+++ b/src/test/resources/brevperiodeCaser/ENDRET_UTBETALING.json
@@ -4,7 +4,7 @@
   "tom": "2021-12-31",
   "vedtaksperiodetype": "UTBETALING",
   "begrunnelser": [
-    "Standardbegrunnelse$ENDRET_UTBETALING_DELT_BOSTED_INGEN_UTBETALING"
+    "Standardbegrunnelse$ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY"
   ],
   "fritekster": [],
   "uregistrerteBarn": [],
@@ -73,7 +73,7 @@
         "antallBarnOppfyllerTriggereOgHarNullutbetaling": 1,
         "maanedOgAarBegrunnelsenGjelderFor": "august 2021",
         "maalform": "bokmaal",
-        "apiNavn": "endretUtbetalingDeltBostedIngenUtbetalingForSoknad",
+        "apiNavn": "endretUtbetalingDeltBostedIngenUtbetaling",
         "belop": 0,
         "soknadstidspunkt": "31.01.21"
       }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12311)
Fjerner begrunnelser som ikke skal brukes lenger.

Jeg har kjørt
```
select *
from vedtaksbegrunnelse vb
         join vedtaksperiode vp on vb.fk_vedtaksperiode_id = vp.id
         join vedtak v on vp.fk_vedtak_id = v.id
         join behandling b on v.fk_behandling_id = b.id
where b.status != 'AVSLUTTET'
  and vb.vedtak_begrunnelse_spesifikasjon = 'ENDRET_UTBETALING_DELT_BOSTED_INGEN_UTBETALING';
```

For hver av begrunnelsene og det er ingen slike rader i databasen. begrunnelsene er altså ikke i bruk.

