### PR TITLE
Vi ønsker å slå sammen småbarnstillegg andeler og vedtaksperioder der…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -120,7 +120,6 @@ fun Tidslinje<AndelTilkjentYtelseForTidslinje, Måned>.tilAndelerTilkjentYtelse(
 
 /**
  * Lager tidslinje med AndelTilkjentYtelseForTidslinje-objekter, som derfor er "trygg" mtp DB-endringer
- * Ivaretar fom og tom i objektene, slik at ellers like andeler ikke blir slått sammen
  */
 fun Iterable<AndelTilkjentYtelse>.tilTryggTidslinjeForSøkersYtelse(ytelseType: YtelseType) = this
     .filter { it.erSøkersAndel() }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -99,12 +99,6 @@ fun AndelTilkjentYtelse.tilpassTilTidslinje() =
         differanseberegnetPeriodebeløp = this.differanseberegnetPeriodebeløp,
     )
 
-fun AndelTilkjentYtelse.tilpassTilTidslinjeOgBevarFomOgTom() =
-    tilpassTilTidslinje().copy(
-        stønadFom = this.stønadFom,
-        stønadTom = this.stønadTom,
-    )
-
 fun Tidslinje<AndelTilkjentYtelseForTidslinje, Måned>.tilAndelerTilkjentYtelse(tilkjentYtelse: TilkjentYtelse) =
     perioder()
         .filter { it.innhold != null }
@@ -137,7 +131,7 @@ fun Iterable<AndelTilkjentYtelse>.tilTryggTidslinjeForSøkersYtelse(ytelseType: 
                 Periode(
                     it.stønadFom.tilTidspunkt(),
                     it.stønadTom.tilTidspunkt(),
-                    it.tilpassTilTidslinjeOgBevarFomOgTom(),
+                    it.tilpassTilTidslinje(),
                 )
             }
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstøn
 import no.nav.familie.ba.sak.kjerne.beregning.domene.slåSammenTidligerePerioder
 import no.nav.familie.ba.sak.kjerne.beregning.domene.splitFramtidigePerioderFraForrigeBehandling
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
-import no.nav.familie.ba.sak.kjerne.grunnlag.småbarnstillegg.PeriodeOvergangsstønadGrunnlag
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
@@ -36,11 +35,13 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
-fun List<PeriodeOvergangsstønadGrunnlag>.splittOgSlåSammen(
+fun List<InternPeriodeOvergangsstønad>.splittOgSlåSammen(
     overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>,
-) = map { InternPeriodeOvergangsstønad(it) }
-    .slåSammenTidligerePerioder()
-    .splitFramtidigePerioderFraForrigeBehandling(overgangsstønadPerioderFraForrigeBehandling)
+    dagensDato: LocalDate,
+    skalBrukeNyBegrunnelseLogikk: Boolean,
+) = this
+    .slåSammenTidligerePerioder(dagensDato, skalBrukeNyBegrunnelseLogikk)
+    .splitFramtidigePerioderFraForrigeBehandling(overgangsstønadPerioderFraForrigeBehandling, LocalDate.now())
 
 class VedtaksperiodefinnerSmåbarnstilleggFeil(
     melding: String,
@@ -59,6 +60,7 @@ fun vedtakOmOvergangsstønadPåvirkerFagsak(
     nyePerioderMedFullOvergangsstønad: List<InternPeriodeOvergangsstønad>,
     forrigeAndelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
     barnasAktørerOgFødselsdatoer: List<Pair<Aktør, LocalDate>>,
+    skalBrukeNyBegrunnelseLogikk: Boolean,
 ): Boolean {
     val (forrigeSmåbarnstilleggAndeler, forrigeAndelerIkkeSmåbarnstillegg) = forrigeAndelerTilkjentYtelse.partition { it.erSmåbarnstillegg() }
 
@@ -69,6 +71,7 @@ fun vedtakOmOvergangsstønadPåvirkerFagsak(
         barnasAndeler = forrigeBarnasAndeler,
         utvidetAndeler = forrigeUtvidetAndeler,
         barnasAktørerOgFødselsdatoer = barnasAktørerOgFødselsdatoer,
+        skalBrukeNyBegrunnelseLogikk = skalBrukeNyBegrunnelseLogikk,
     )
 
     return nyeSmåbarnstilleggAndeler.førerTilEndringIUtbetalingFraForrigeBehandling(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -33,6 +33,7 @@ object TilkjentYtelseUtils {
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         endretUtbetalingAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse> = emptyList(),
         fagsakType: FagsakType,
+        skalBrukeNyBegrunnelseLogikk: Boolean,
         hentPerioderMedFullOvergangsstønad: (aktør: Aktør) -> List<InternPeriodeOvergangsstønad> = { _ -> emptyList() },
     ): TilkjentYtelse {
         val tilkjentYtelse = TilkjentYtelse(
@@ -93,6 +94,7 @@ object TilkjentYtelseUtils {
                     ),
                     utvidetAndeler = andelerTilkjentYtelseUtvidetMedAlleEndringer,
                     barnasAndeler = barnasAndelerInkludertEtterbetaling3ÅrEndringer,
+                    skalBrukeNyBegrunnelseLogikk = skalBrukeNyBegrunnelseLogikk,
                     barnasAktørerOgFødselsdatoer = personopplysningGrunnlag.barna.map {
                         Pair(
                             it.aktør,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/InternPeriodeOvergangsstønad.kt
@@ -26,8 +26,17 @@ fun EksternPeriode.tilInternPeriodeOvergangsstønad() = InternPeriodeOvergangsst
     tomDato = this.tomDato,
 )
 
-fun List<InternPeriodeOvergangsstønad>.slåSammenTidligerePerioder(): List<InternPeriodeOvergangsstønad> {
-    val tidligerePerioder = this.filter { it.tomDato.isSameOrBefore(LocalDate.now()) }
+fun List<InternPeriodeOvergangsstønad>.slåSammenTidligerePerioder(
+    dagensDato: LocalDate,
+    skalBrukeNyBegrunnelseLogikk: Boolean,
+): List<InternPeriodeOvergangsstønad> {
+    val tidligerePerioder =
+        if (skalBrukeNyBegrunnelseLogikk) {
+            this.filter { it.fomDato.isSameOrBefore(dagensDato) }
+        } else {
+            this.filter { it.tomDato.isSameOrBefore(dagensDato) }
+        }
+
     val nyePerioder = this.minus(tidligerePerioder)
     return tidligerePerioder.slåSammenSammenhengendePerioder() + nyePerioder
 }
@@ -59,8 +68,9 @@ fun List<InternPeriodeOvergangsstønad>.slåSammenSammenhengendePerioder(): List
  ***/
 fun List<InternPeriodeOvergangsstønad>.splitFramtidigePerioderFraForrigeBehandling(
     overgangsstønadPerioderFraForrigeBehandling: List<InternPeriodeOvergangsstønad>,
+    dagensDato: LocalDate,
 ): List<InternPeriodeOvergangsstønad> {
-    val tidligerePerioder = this.filter { it.tomDato.isSameOrBefore(LocalDate.now()) }
+    val tidligerePerioder = this.filter { it.tomDato.isSameOrBefore(dagensDato) }
     val framtidigePerioder = this.minus(tidligerePerioder)
     val nyeOvergangsstønadTidslinje = InternPeriodeOvergangsstønadTidslinje(framtidigePerioder)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BegrunnelseGrunnlagForPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BegrunnelseGrunnlagForPeriode.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.brevBegrunnelseProdusent
 
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 
 sealed interface IBegrunnelseGrunnlagForPeriode {
     val dennePerioden: BegrunnelseGrunnlagForPersonIPeriode
     val forrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?
+    val erSmåbarnstilleggIForrigeBehandlingPeriode: Boolean
 
     companion object {
         fun opprett(
@@ -21,7 +23,7 @@ sealed interface IBegrunnelseGrunnlagForPeriode {
                     sammePeriodeForrigeBehandling = sammePeriodeForrigeBehandling,
                 )
             } else {
-                BegrunnelseGrunnlagForPeriode(dennePerioden, forrigePeriode)
+                BegrunnelseGrunnlagForPeriode(dennePerioden, forrigePeriode, sammePeriodeForrigeBehandling?.andeler?.any { it.type == YtelseType.SMÅBARNSTILLEGG } == true)
             }
     }
 }
@@ -29,10 +31,16 @@ sealed interface IBegrunnelseGrunnlagForPeriode {
 data class BegrunnelseGrunnlagForPeriode(
     override val dennePerioden: BegrunnelseGrunnlagForPersonIPeriode,
     override val forrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
+    override val erSmåbarnstilleggIForrigeBehandlingPeriode: Boolean,
 ) : IBegrunnelseGrunnlagForPeriode
 
 data class BegrunnelseGrunnlagForPeriodeMedReduksjonPåTversAvBehandlinger(
     override val dennePerioden: BegrunnelseGrunnlagForPersonIPeriode,
     override val forrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
     val sammePeriodeForrigeBehandling: BegrunnelseGrunnlagForPersonIPeriode?,
-) : IBegrunnelseGrunnlagForPeriode
+) : IBegrunnelseGrunnlagForPeriode {
+    override val erSmåbarnstilleggIForrigeBehandlingPeriode: Boolean
+        get() = harPeriodeSmåbarnstillegg()
+
+    private fun harPeriodeSmåbarnstillegg() = sammePeriodeForrigeBehandling?.andeler?.any { it.type == YtelseType.SMÅBARNSTILLEGG } == true
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -564,23 +564,29 @@ private fun SanityBegrunnelse.erGjeldendeForSmåbarnstillegg(
     val erSmåbarnstilleggDennePerioden =
         begrunnelseGrunnlag.dennePerioden.andeler.any { it.type == YtelseType.SMÅBARNSTILLEGG }
 
+    val erSmåbarnstilleggIForrigeBehandlingPeriode = begrunnelseGrunnlag.erSmåbarnstilleggIForrigeBehandlingPeriode
+
     val begrunnelseGjelderSmåbarnstillegg =
         UtvidetBarnetrygdTrigger.SMÅBARNSTILLEGG in utvidetBarnetrygdTriggere
 
+    val erEndringISmåbarnstilleggFraForrigeBehandling =
+        erSmåbarnstilleggIForrigeBehandlingPeriode != erSmåbarnstilleggDennePerioden
+
     val begrunnelseMatcherPeriodeResultat =
-        this.matcherPerioderesultat(erSmåbarnstilleggForrigePeriode, erSmåbarnstilleggDennePerioden)
+        this.matcherPerioderesultat(erSmåbarnstilleggForrigePeriode, erSmåbarnstilleggDennePerioden, erSmåbarnstilleggIForrigeBehandlingPeriode)
 
     val erEndringISmåbarnstillegg = erSmåbarnstilleggForrigePeriode != erSmåbarnstilleggDennePerioden
 
-    return begrunnelseGjelderSmåbarnstillegg && begrunnelseMatcherPeriodeResultat && erEndringISmåbarnstillegg
+    return begrunnelseGjelderSmåbarnstillegg && begrunnelseMatcherPeriodeResultat && (erEndringISmåbarnstillegg || erEndringISmåbarnstilleggFraForrigeBehandling)
 }
 
 private fun SanityBegrunnelse.matcherPerioderesultat(
     erSmåbarnstilleggForrigePeriode: Boolean,
     erSmåbarnstilleggDennePerioden: Boolean,
+    erSmåbarnstilleggIForrigeBehandlingPeriode: Boolean,
 ): Boolean {
-    val erReduksjon = erSmåbarnstilleggForrigePeriode && !erSmåbarnstilleggDennePerioden
-    val erØkning = !erSmåbarnstilleggForrigePeriode && erSmåbarnstilleggDennePerioden
+    val erReduksjon = !erSmåbarnstilleggDennePerioden && (erSmåbarnstilleggForrigePeriode || erSmåbarnstilleggIForrigeBehandlingPeriode)
+    val erØkning = erSmåbarnstilleggDennePerioden && (!erSmåbarnstilleggForrigePeriode || !erSmåbarnstilleggIForrigeBehandlingPeriode)
 
     val erBegrunnelseReduksjon = periodeResultat == SanityPeriodeResultat.REDUKSJON
     val erBegrunnelseØkning = periodeResultat == SanityPeriodeResultat.INNVILGET_ELLER_ØKNING

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest.kt
@@ -338,6 +338,7 @@ private fun <T : Tidsenhet> VilkårsvurderingBuilder.PersonResultatBuilder<T>.be
         vilkårsvurdering = this.byggVilkårsvurdering(),
         personopplysningGrunnlag = personopplysningGrunnlag,
         fagsakType = FagsakType.NORMAL,
+        skalBrukeNyBegrunnelseLogikk = false,
     ).andelerTilkjentYtelse.map {
         BeregnetAndel(
             person = personopplysningGrunnlag.personer.first { person -> person.aktør == it.aktør },

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.nesteMåned
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestBaseFagsak
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestFagsak
@@ -110,6 +111,7 @@ class BeregningServiceTest {
             personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
             småbarnstilleggService = småbarnstilleggService,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            featureToggleService = featureToggleService,
         )
 
         every { tilkjentYtelseRepository.slettTilkjentYtelseFor(any()) } just Runs
@@ -123,6 +125,7 @@ class BeregningServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } answers { emptyList() }
         every { endretUtbetalingAndelRepository.saveAllAndFlush(any<Collection<EndretUtbetalingAndel>>()) } answers { emptyList() }
         every { andelTilkjentYtelseRepository.saveAllAndFlush(any<Collection<AndelTilkjentYtelse>>()) } answers { emptyList() }
+        every { featureToggleService.isEnabled(FeatureToggleConfig.BEGRUNNELSER_NY) } returns false
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGeneratorTest.kt
@@ -76,6 +76,7 @@ class SmåbarnstilleggBarnetrygdGeneratorTest {
                     utvidetAndeler = utvidetAndeler,
                     barnasAndeler = barnasAndeler,
                     barnasAktørerOgFødselsdatoer = listOf(Pair(barn3.aktør, barn3.fødselsdato)),
+                    skalBrukeNyBegrunnelseLogikk = false,
                 )
 
         Assertions.assertEquals(1, småbarnstilleggAndeler.size)
@@ -139,6 +140,7 @@ class SmåbarnstilleggBarnetrygdGeneratorTest {
                     utvidetAndeler = utvidetAndeler,
                     barnasAndeler = barnasAndeler,
                     barnasAktørerOgFødselsdatoer = listOf(Pair(barn3.aktør, barn3.fødselsdato)),
+                    skalBrukeNyBegrunnelseLogikk = false,
                 )
 
         Assertions.assertEquals(2, småbarnstilleggAndeler.size)
@@ -202,6 +204,7 @@ class SmåbarnstilleggBarnetrygdGeneratorTest {
                         Pair(barn1.aktør, barn1.fødselsdato),
                         Pair(barn2.aktør, barn2.fødselsdato),
                     ),
+                    skalBrukeNyBegrunnelseLogikk = false,
                 )
 
         Assertions.assertEquals(2, småbarnstilleggAndeler.size)
@@ -265,6 +268,7 @@ class SmåbarnstilleggBarnetrygdGeneratorTest {
                         Pair(barn1.aktør, barn1.fødselsdato),
                         Pair(barn2.aktør, barn2.fødselsdato),
                     ),
+                    skalBrukeNyBegrunnelseLogikk = false,
                 )
 
         Assertions.assertEquals(2, småbarnstilleggAndeler.size)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggServiceTest.kt
@@ -8,6 +8,8 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.ef.EfSakRestClient
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -34,6 +36,7 @@ class SmåbarnstilleggServiceTest {
     private val persongrunnlagService = mockk<PersongrunnlagService>()
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService =
         mockk<AndelerTilkjentYtelseOgEndreteUtbetalingerService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private lateinit var småbarnstilleggService: SmåbarnstilleggService
 
@@ -46,9 +49,11 @@ class SmåbarnstilleggServiceTest {
             tilkjentYtelseRepository = tilkjentYtelseRepository,
             persongrunnlagService = persongrunnlagService,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            featureToggleService = featureToggleService,
         )
 
         every { periodeOvergangsstønadGrunnlagRepository.deleteByBehandlingId(any()) } just Runs
+        every { featureToggleService.isEnabled(FeatureToggleConfig.BEGRUNNELSER_NY) } returns false
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
@@ -333,6 +333,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             ),
             barnasAktørerOgFødselsdatoer = listOf(Pair(barnAktør, LocalDate.now().minusYears(2))),
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertTrue(påvirkerFagsak)
@@ -379,6 +380,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             ),
             barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertFalse(påvirkerFagsak)
@@ -444,6 +446,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             ),
             barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertFalse(påvirkerFagsak)
@@ -495,6 +498,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             ),
             barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertFalse(påvirkerFagsak)
@@ -546,6 +550,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             ),
             barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertTrue(påvirkerFagsak)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
@@ -81,6 +81,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertEquals(1, tilkjentYtelse.andelerTilkjentYtelse.size)
@@ -114,6 +115,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertEquals(2, tilkjentYtelse.andelerTilkjentYtelse.size)
@@ -151,6 +153,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertEquals(2, tilkjentYtelse.andelerTilkjentYtelse.size)
@@ -183,6 +186,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         assertEquals(2, tilkjentYtelse.andelerTilkjentYtelse.size)
@@ -212,6 +216,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse
             .toList()
@@ -273,6 +278,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList()
             .sortedBy { it.stønadFom }
@@ -314,6 +320,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = oppdatertVilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList()
             .sortedBy { it.stønadFom }
@@ -346,6 +353,7 @@ internal class TilkjentYtelseUtilsTest {
             vilkårsvurdering = oppdatertVilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList()
             .sortedBy { it.stønadFom }
@@ -1258,6 +1266,7 @@ internal class TilkjentYtelseUtilsTest {
             ),
             endretUtbetalingAndeler = endretUtbetalingAndeler,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         ) { (_) ->
             lagOvergangsstønadPerioder(
                 perioder = overgangsstønadPerioder,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -106,6 +106,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList()
             .sortedWith(compareBy({ it.stønadFom }, { it.type }, { it.kalkulertUtbetalingsbeløp }))
@@ -196,6 +197,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList()
             .sortedWith(compareBy({ it.stønadFom }, { it.type }, { it.kalkulertUtbetalingsbeløp }))
@@ -278,6 +280,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 
@@ -357,6 +360,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 
@@ -436,6 +440,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 
@@ -524,6 +529,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         ).andelerTilkjentYtelse.toList().sortedBy { it.type }
 
         val vedtaksperioderMedBegrunnelser = hentPerioderMedUtbetaling(
@@ -654,6 +660,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 
@@ -764,6 +771,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 
@@ -873,6 +881,7 @@ internal class UtvidetBarnetrygdTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
             .andelerTilkjentYtelse.toList().sortedBy { it.type }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/VilkårTilTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/VilkårTilTilkjentYtelseTest.kt
@@ -93,6 +93,7 @@ class VilkårTilTilkjentYtelseTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         Assertions.assertEquals(
@@ -156,6 +157,7 @@ class VilkårTilTilkjentYtelseTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         ) { aktør ->
             if (småbarnstilleggTestPeriode != null) {
                 listOf(
@@ -233,6 +235,7 @@ class VilkårTilTilkjentYtelseTest {
             vilkårsvurdering = vilkårsvurdering,
             personopplysningGrunnlag = personopplysningGrunnlag,
             fagsakType = FagsakType.NORMAL,
+            skalBrukeNyBegrunnelseLogikk = false,
         )
 
         Assertions.assertEquals(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -126,6 +126,7 @@ fun <T : Tidsenhet> VilkårsvurderingBuilder<T>.byggTilkjentYtelse() =
         vilkårsvurdering = this.byggVilkårsvurdering(),
         personopplysningGrunnlag = this.byggPersonopplysningGrunnlag(),
         fagsakType = FagsakType.NORMAL,
+        skalBrukeNyBegrunnelseLogikk = false,
     )
 
 data class UtdypendeVilkårRegelverkResultat(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -8,9 +8,11 @@ import io.cucumber.java.no.Så
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.cucumber.domeneparser.BrevBegrunnelseParser.mapStandardBegrunnelser
 import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser
+import no.nav.familie.ba.sak.cucumber.domeneparser.parseDato
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
@@ -48,6 +50,8 @@ class BegrunnelseTeksterStepDefinition {
     private var endredeUtbetalinger = mutableMapOf<Long, List<EndretUtbetalingAndel>>()
     private var andelerTilkjentYtelse = mutableMapOf<Long, List<AndelTilkjentYtelse>>()
     private var overstyrteEndringstidspunkt = mutableMapOf<Long, LocalDate>()
+    private var overgangsstønadForVedtaksperiode = mapOf<Long, List<InternPeriodeOvergangsstønad>>()
+    private var dagensDato: LocalDate = LocalDate.now()
 
     private var gjeldendeBehandlingId: Long? = null
 
@@ -82,6 +86,14 @@ class BegrunnelseTeksterStepDefinition {
     @Og("følgende persongrunnlag for begrunnelse")
     fun `følgende persongrunnlag for begrunnelse`(dataTable: DataTable) {
         persongrunnlag.putAll(lagPersonGrunnlag(dataTable))
+    }
+
+    /**
+     * Mulige verdier: | Dato |
+     */
+    @Og("følgende dagens dato {}")
+    fun `følgende dagens dato`(dagensDatoString: String) {
+        dagensDato = parseDato(dagensDatoString)
     }
 
     @Og("lag personresultater for begrunnelse for behandling {}")
@@ -132,6 +144,19 @@ class BegrunnelseTeksterStepDefinition {
         andelerTilkjentYtelse = lagAndelerTilkjentYtelse(dataTable, behandlinger, persongrunnlag)
     }
 
+    /**
+     * Mulige verdier: | BehandlingId | AktørId | Fra dato | Til dato |
+     */
+    @Og("med overgangsstønad for begrunnelse")
+    fun `med overgangsstønad for begrunnelse`(dataTable: DataTable) {
+        overgangsstønadForVedtaksperiode = lagOvergangsstønad(
+            dataTable,
+            persongrunnlag,
+            behandlingTilForrigeBehandling,
+            dagensDato,
+        )
+    }
+
     @Når("begrunnelsetekster genereres for behandling {}")
     fun `generer begrunnelsetekst for `(behandlingId: Long) {
         gjeldendeBehandlingId = behandlingId
@@ -148,7 +173,7 @@ class BegrunnelseTeksterStepDefinition {
             kompetanser = kompetanser[behandlingId] ?: emptyList(),
             endredeUtbetalinger = endredeUtbetalinger[behandlingId] ?: emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse[behandlingId] ?: emptyList(),
-            perioderOvergangsstønad = emptyList(),
+            perioderOvergangsstønad = overgangsstønadForVedtaksperiode[behandlingId] ?: emptyList(),
             uregistrerteBarn = emptyList(),
         )
         val forrigeBehandlingId = behandlingTilForrigeBehandling[behandlingId]

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -150,10 +150,10 @@ class BegrunnelseTeksterStepDefinition {
     @Og("med overgangsstønad for begrunnelse")
     fun `med overgangsstønad for begrunnelse`(dataTable: DataTable) {
         overgangsstønadForVedtaksperiode = lagOvergangsstønad(
-            dataTable,
-            persongrunnlag,
-            behandlingTilForrigeBehandling,
-            dagensDato,
+            dataTable = dataTable,
+            persongrunnlag = persongrunnlag,
+            tidligereBehandlinger = behandlingTilForrigeBehandling,
+            dagensDato = dagensDato,
         )
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -88,9 +88,6 @@ class BegrunnelseTeksterStepDefinition {
         persongrunnlag.putAll(lagPersonGrunnlag(dataTable))
     }
 
-    /**
-     * Mulige verdier: | Dato |
-     */
     @Og("følgende dagens dato {}")
     fun `følgende dagens dato`(dagensDatoString: String) {
         dagensDato = parseDato(dagensDatoString)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -130,7 +130,7 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
      */
     @Og("med overgangsstønad")
     fun `med overgangsstønad`(dataTable: DataTable) {
-        overgangsstønad = lagOvergangsstønad(dataTable, persongrunnlag)
+        overgangsstønad = lagOvergangsstønad(dataTable, persongrunnlag, behandlingTilForrigeBehandling, LocalDate.now())
     }
 
     @Og("med uregistrerte barn")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeMedBegrunnelserStepDefinition.kt
@@ -130,7 +130,12 @@ class VedtaksperiodeMedBegrunnelserStepDefinition {
      */
     @Og("med overgangsstønad")
     fun `med overgangsstønad`(dataTable: DataTable) {
-        overgangsstønad = lagOvergangsstønad(dataTable, persongrunnlag, behandlingTilForrigeBehandling, LocalDate.now())
+        overgangsstønad = lagOvergangsstønad(
+            dataTable = dataTable,
+            persongrunnlag = persongrunnlag,
+            tidligereBehandlinger = behandlingTilForrigeBehandling,
+            dagensDato = LocalDate.now(),
+        )
     }
 
     @Og("med uregistrerte barn")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.common.nesteMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.EfSakRestClientMock
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.behandling.kjørStegprosessForBehandling
 import no.nav.familie.ba.sak.datagenerator.vilkårsvurdering.lagVilkårsvurderingFraRestScenario
@@ -124,6 +125,7 @@ class BehandleSmåbarnstilleggTest(
     fun førHverTest() {
         mockkObject(SatsTidspunkt)
         every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2022, 12, 31)
+        every { featureToggleService.isEnabled(FeatureToggleConfig.BEGRUNNELSER_NY) } returns false
     }
 
     @AfterEach

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/overgangsstønad_og_småbarnstillegg.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/overgangsstønad_og_småbarnstillegg.feature
@@ -1,0 +1,119 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Overgangsstønad og småbarnstillegg
+
+  Bakgrunn:
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId |
+      | 1            | 1        |                     |
+      | 2            | 2        | 1                   |
+
+    Og følgende dagens dato 05.09.2023
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 05.04.1985  |
+      | 1            | 4567    | BARN       | 22.08.2022  |
+      | 2            | 1234    | SØKER      | 05.04.1985  |
+      | 2            | 4567    | BARN       | 22.08.2022  |
+
+  Scenario: Skal slå sammen tidligere overgangsstønad dersom periodene er sammenhengende
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | LOVLIG_OPPHOLD,UTVIDET_BARNETRYGD,BOSATT_I_RIKET             |                  | 05.04.1985 |            | OPPFYLT  | Nei                  |
+
+      | 4567    | LOVLIG_OPPHOLD,BOR_MED_SØKER,BOSATT_I_RIKET,GIFT_PARTNERSKAP |                  | 22.08.2022 |            | OPPFYLT  | Nei                  |
+      | 4567    | UNDER_18_ÅR                                                  |                  | 22.08.2022 | 21.08.2040 | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent |
+      | 4567    | 1            | 01.09.2022 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.07.2023 | 31.07.2028 | 1766  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.08.2028 | 31.07.2040 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.09.2022 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.07.2023 | 31.07.2040 | 2516  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.02.2023 | 28.02.2023 | 660   | SMÅBARNSTILLEGG    | 100     |
+      | 1234    | 1            | 01.03.2023 | 30.06.2023 | 678   | SMÅBARNSTILLEGG    | 100     |
+      | 1234    | 1            | 01.07.2023 | 31.08.2024 | 696   | SMÅBARNSTILLEGG    | 100     |
+
+    Og med overgangsstønad for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   |
+      | 4567    | 1            | 01.02.2023 | 30.04.2023 |
+      | 4567    | 1            | 01.05.2023 | 31.08.2024 |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser   | Ekskluderte Begrunnelser  |
+      | 01.09.2022 | 31.01.2023 | UTBETALING         |           |                           | INNVILGET_SMÅBARNSTILLEGG |
+      | 01.02.2023 | 28.02.2023 | UTBETALING         |           | INNVILGET_SMÅBARNSTILLEGG |                           |
+      | 01.03.2023 | 30.06.2023 | UTBETALING         |           | INNVILGET_SMÅBARNSTILLEGG |                           |
+      | 01.07.2023 | 31.08.2024 | UTBETALING         |           | INNVILGET_SMÅBARNSTILLEGG |                           |
+      | 01.09.2024 | 31.07.2028 | UTBETALING         |           |                           | INNVILGET_SMÅBARNSTILLEGG |
+      | 01.08.2028 | 31.07.2040 | UTBETALING         |           |                           |                           |
+      | 01.08.2040 |            | OPPHØR             |           |                           |                           |
+
+  Scenario: Skal splitte på riktige tidspunkter dersom overgangsstønaden har blitt forlenget siden siste behandling
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | LOVLIG_OPPHOLD,UTVIDET_BARNETRYGD,BOSATT_I_RIKET             |                  | 05.04.1985 |            | OPPFYLT  | Nei                  |
+
+      | 4567    | LOVLIG_OPPHOLD,BOR_MED_SØKER,BOSATT_I_RIKET,GIFT_PARTNERSKAP |                  | 22.08.2022 |            | OPPFYLT  | Nei                  |
+      | 4567    | UNDER_18_ÅR                                                  |                  | 22.08.2022 | 21.08.2040 | OPPFYLT  | Nei                  |
+
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | LOVLIG_OPPHOLD,UTVIDET_BARNETRYGD,BOSATT_I_RIKET             |                  | 05.04.1985 |            | OPPFYLT  | Nei                  |
+
+      | 4567    | LOVLIG_OPPHOLD,BOR_MED_SØKER,BOSATT_I_RIKET,GIFT_PARTNERSKAP |                  | 22.08.2022 |            | OPPFYLT  | Nei                  |
+      | 4567    | UNDER_18_ÅR                                                  |                  | 22.08.2022 | 21.08.2040 | OPPFYLT  | Nei                  |
+
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent |
+      | 4567    | 1            | 01.09.2022 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.07.2023 | 31.07.2028 | 1766  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.08.2028 | 31.07.2040 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.09.2022 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.07.2023 | 31.07.2040 | 2516  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 1            | 01.02.2023 | 28.02.2023 | 660   | SMÅBARNSTILLEGG    | 100     |
+      | 1234    | 1            | 01.03.2023 | 30.06.2023 | 678   | SMÅBARNSTILLEGG    | 100     |
+      | 1234    | 1            | 01.07.2023 | 31.10.2023 | 696   | SMÅBARNSTILLEGG    | 100     |
+
+      | 4567    | 2            | 01.09.2022 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 2            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 2            | 01.07.2023 | 31.07.2028 | 1766  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 2            | 01.08.2028 | 31.07.2040 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+      | 1234    | 2            | 01.09.2022 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 2            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 2            | 01.07.2023 | 31.07.2040 | 2516  | UTVIDET_BARNETRYGD | 100     |
+      | 1234    | 2            | 01.02.2023 | 28.02.2023 | 660   | SMÅBARNSTILLEGG    | 100     |
+      | 1234    | 2            | 01.03.2023 | 30.06.2023 | 678   | SMÅBARNSTILLEGG    | 100     |
+      | 1234    | 2            | 01.07.2023 | 31.08.2024 | 696   | SMÅBARNSTILLEGG    | 100     |
+
+    Og med overgangsstønad for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   |
+      | 4567    | 1            | 01.02.2023 | 30.04.2023 |
+      | 4567    | 1            | 01.05.2023 | 31.10.2023 |
+      | 4567    | 2            | 01.02.2023 | 30.04.2023 |
+      | 4567    | 2            | 01.05.2023 | 31.08.2024 |
+
+    Når begrunnelsetekster genereres for behandling 2
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser   | Ekskluderte Begrunnelser  |
+      | 01.11.2023 | 31.08.2024 | UTBETALING         |           | INNVILGET_SMÅBARNSTILLEGG |                           |
+      | 01.09.2024 | 31.07.2028 | UTBETALING         |           |                           | INNVILGET_SMÅBARNSTILLEGG |
+      | 01.08.2028 | 31.07.2040 | UTBETALING         |           |                           |                           |
+      | 01.08.2040 |            | OPPHØR             |           |                           |                           |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15167

Vi ønsker å slå sammen småbarnstillegg andeler og vedtaksperioder dersom overgangsstønadsperiodene starter tidligere enn dagens dato. Dette gjøres ikke per i dag, og skaper noen unødvendige splitter i vedtaksperiodene.

Det legges bak en feature toggle fordi logikken som lager splitt og slår sammen splitt brukes av andelsgeneratoren for småbarnstillegg som ikke er kompatibel med denne endringen før vi får ut ny begrunnelse logikk.