### PR TITLE
Endre generic til sealed interface

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
@@ -76,7 +76,7 @@ class TestVerktøyController(
             val aktør = personidentService.hentAktør(personIdent.ident)
             val melding = autovedtakStegService.kjørBehandlingSmåbarnstillegg(
                 mottakersAktør = aktør,
-                behandlingsdata = aktør,
+                aktør = aktør,
             )
             ResponseEntity.ok(Ressurs.success(melding))
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -6,21 +6,22 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.AutovedtakFødselshendelseService
-import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevBehandlingsdata
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.AutovedtakSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.prosessering.error.RekjørSenereException
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
-interface AutovedtakBehandlingService<Behandlingsdata> {
-    fun skalAutovedtakBehandles(behandlingsdata: Behandlingsdata): Boolean = true
+interface AutovedtakBehandlingService<Behandlingsdata : AutomatiskBehandlingData> {
+    fun skalAutovedtakBehandles(behandlingsdata: Behandlingsdata): Boolean
 
     fun kjørBehandling(behandlingsdata: Behandlingsdata): String
 }
@@ -29,6 +30,31 @@ enum class Autovedtaktype(val displayName: String) {
     FØDSELSHENDELSE("Fødselshendelse"),
     SMÅBARNSTILLEGG("Småbarnstillegg"),
     OMREGNING_BREV("Omregning"),
+}
+
+sealed interface AutomatiskBehandlingData {
+    val type: Autovedtaktype
+}
+
+data class FødselshendelseData(
+    val nyBehandlingHendelse: NyBehandlingHendelse,
+) : AutomatiskBehandlingData {
+    override val type = Autovedtaktype.FØDSELSHENDELSE
+}
+
+data class SmåbarnstilleggData(
+    val aktør: Aktør,
+) : AutomatiskBehandlingData {
+    override val type = Autovedtaktype.SMÅBARNSTILLEGG
+}
+
+data class OmregningBrevData(
+    val aktør: Aktør,
+    val behandlingsårsak: BehandlingÅrsak,
+    val standardbegrunnelse: Standardbegrunnelse,
+    val fagsakId: Long,
+) : AutomatiskBehandlingData {
+    override val type = Autovedtaktype.OMREGNING_BREV
 }
 
 @Service
@@ -48,91 +74,71 @@ class AutovedtakStegService(
         Metrics.counter("behandling.saksbehandling.autovedtak.aapen_behandling", "type", it.name)
     }
 
-    fun kjørBehandlingFødselshendelse(mottakersAktør: Aktør, behandlingsdata: NyBehandlingHendelse): String {
+    fun kjørBehandlingFødselshendelse(mottakersAktør: Aktør, nyBehandlingHendelse: NyBehandlingHendelse): String {
         return kjørBehandling(
             mottakersAktør = mottakersAktør,
-            autovedtaktype = Autovedtaktype.FØDSELSHENDELSE,
-            behandlingsdata = behandlingsdata,
+            automatiskBehandlingData = FødselshendelseData(nyBehandlingHendelse),
         )
     }
 
-    fun kjørBehandlingOmregning(mottakersAktør: Aktør, behandlingsdata: AutovedtakBrevBehandlingsdata): String {
+    fun kjørBehandlingOmregning(mottakersAktør: Aktør, behandlingsdata: OmregningBrevData): String {
         return kjørBehandling(
             mottakersAktør = mottakersAktør,
-            autovedtaktype = Autovedtaktype.OMREGNING_BREV,
-            behandlingsdata = behandlingsdata,
+            automatiskBehandlingData = behandlingsdata,
         )
     }
 
-    fun kjørBehandlingSmåbarnstillegg(mottakersAktør: Aktør, behandlingsdata: Aktør): String {
+    fun kjørBehandlingSmåbarnstillegg(mottakersAktør: Aktør, aktør: Aktør): String {
         return kjørBehandling(
             mottakersAktør = mottakersAktør,
-            autovedtaktype = Autovedtaktype.SMÅBARNSTILLEGG,
-            behandlingsdata = behandlingsdata,
+            automatiskBehandlingData = SmåbarnstilleggData(aktør),
         )
     }
 
-    private fun <Behandlingsdata> kjørBehandling(
+    private fun kjørBehandling(
+        automatiskBehandlingData: AutomatiskBehandlingData,
         mottakersAktør: Aktør,
-        autovedtaktype: Autovedtaktype,
-        behandlingsdata: Behandlingsdata,
     ): String {
-        secureLoggAutovedtakBehandling(autovedtaktype, mottakersAktør, BEHANDLING_STARTER)
-        antallAutovedtak[autovedtaktype]?.increment()
+        secureLoggAutovedtakBehandling(automatiskBehandlingData.type, mottakersAktør, BEHANDLING_STARTER)
+        antallAutovedtak[automatiskBehandlingData.type]?.increment()
 
-        val skalAutovedtakBehandles = when (autovedtaktype) {
-            Autovedtaktype.FØDSELSHENDELSE -> {
-                autovedtakFødselshendelseService.skalAutovedtakBehandles(behandlingsdata as NyBehandlingHendelse)
-            }
-
-            Autovedtaktype.OMREGNING_BREV -> {
-                autovedtakBrevService.skalAutovedtakBehandles(behandlingsdata as AutovedtakBrevBehandlingsdata)
-            }
-
-            Autovedtaktype.SMÅBARNSTILLEGG -> {
-                autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(behandlingsdata as Aktør)
-            }
+        val skalAutovedtakBehandles = when (automatiskBehandlingData) {
+            is FødselshendelseData -> autovedtakFødselshendelseService.skalAutovedtakBehandles(automatiskBehandlingData)
+            is OmregningBrevData -> autovedtakBrevService.skalAutovedtakBehandles(automatiskBehandlingData)
+            is SmåbarnstilleggData -> autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(automatiskBehandlingData)
         }
 
         if (!skalAutovedtakBehandles) {
             secureLoggAutovedtakBehandling(
-                autovedtaktype,
+                automatiskBehandlingData.type,
                 mottakersAktør,
                 "Skal ikke behandles",
             )
-            return "${autovedtaktype.displayName}: Skal ikke behandles"
+            return "${automatiskBehandlingData.type.displayName}: Skal ikke behandles"
         }
 
         if (håndterÅpenBehandlingOgAvbrytAutovedtak(
                 aktør = mottakersAktør,
-                autovedtaktype = autovedtaktype,
-                fagsakId = hentFagsakIdFraBehandlingsdata(autovedtaktype, behandlingsdata),
+                autovedtaktype = automatiskBehandlingData.type,
+                fagsakId = hentFagsakIdFraBehandlingsdata(automatiskBehandlingData),
             )
         ) {
             secureLoggAutovedtakBehandling(
-                autovedtaktype,
+                automatiskBehandlingData.type,
                 mottakersAktør,
                 "Bruker har åpen behandling",
             )
-            return "${autovedtaktype.displayName}: Bruker har åpen behandling"
+            return "${automatiskBehandlingData.type.displayName}: Bruker har åpen behandling"
         }
 
-        val resultatAvKjøring = when (autovedtaktype) {
-            Autovedtaktype.FØDSELSHENDELSE -> {
-                autovedtakFødselshendelseService.kjørBehandling(behandlingsdata as NyBehandlingHendelse)
-            }
-
-            Autovedtaktype.OMREGNING_BREV -> {
-                autovedtakBrevService.kjørBehandling(behandlingsdata as AutovedtakBrevBehandlingsdata)
-            }
-
-            Autovedtaktype.SMÅBARNSTILLEGG -> {
-                autovedtakSmåbarnstilleggService.kjørBehandling(behandlingsdata as Aktør)
-            }
+        val resultatAvKjøring = when (automatiskBehandlingData) {
+            is FødselshendelseData -> autovedtakFødselshendelseService.kjørBehandling(automatiskBehandlingData)
+            is OmregningBrevData -> autovedtakBrevService.kjørBehandling(automatiskBehandlingData)
+            is SmåbarnstilleggData -> autovedtakSmåbarnstilleggService.kjørBehandling(automatiskBehandlingData)
         }
 
         secureLoggAutovedtakBehandling(
-            autovedtaktype,
+            automatiskBehandlingData.type,
             mottakersAktør,
             resultatAvKjøring,
         )
@@ -140,15 +146,13 @@ class AutovedtakStegService(
         return resultatAvKjøring
     }
 
-    private fun <Behandlingsdata> hentFagsakIdFraBehandlingsdata(
-        autovedtaktype: Autovedtaktype,
-        behandlingsdata: Behandlingsdata,
-    ): Long? {
-        return if (autovedtaktype == Autovedtaktype.OMREGNING_BREV) {
-            (behandlingsdata as AutovedtakBrevBehandlingsdata).fagsakId
-        } else {
-            null
-        }
+    private fun hentFagsakIdFraBehandlingsdata(
+        behandlingsdata: AutomatiskBehandlingData,
+    ): Long? = when (behandlingsdata) {
+        is OmregningBrevData -> behandlingsdata.fagsakId
+        is FødselshendelseData,
+        is SmåbarnstilleggData,
+        -> null
     }
 
     private fun håndterÅpenBehandlingOgAvbrytAutovedtak(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakBehandlingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.FødselshendelseData
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregler.FiltreringsreglerService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.vilkårsvurdering.utfall.VilkårIkkeOppfyltÅrsak
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.vilkårsvurdering.utfall.VilkårKanskjeOppfyltÅrsak
@@ -60,7 +61,7 @@ class AutovedtakFødselshendelseService(
     private val statsborgerskapService: StatsborgerskapService,
     private val opprettTaskService: OpprettTaskService,
     private val oppgaveService: OppgaveService,
-) : AutovedtakBehandlingService<NyBehandlingHendelse> {
+) : AutovedtakBehandlingService<FødselshendelseData> {
 
     val stansetIAutomatiskFiltreringCounter =
         Metrics.counter("familie.ba.sak.henvendelse.stanset", "steg", "filtrering")
@@ -68,10 +69,11 @@ class AutovedtakFødselshendelseService(
         Metrics.counter("familie.ba.sak.henvendelse.stanset", "steg", "vilkaarsvurdering")
     val passertFiltreringOgVilkårsvurderingCounter = Metrics.counter("familie.ba.sak.henvendelse.passert")
 
-    override fun skalAutovedtakBehandles(behandlingsdata: NyBehandlingHendelse): Boolean {
-        val morsAktør = personidentService.hentAktør(behandlingsdata.morsIdent)
+    override fun skalAutovedtakBehandles(behandlingsdata: FødselshendelseData): Boolean {
+        val nyBehandlingHendelse = behandlingsdata.nyBehandlingHendelse
+        val morsAktør = personidentService.hentAktør(nyBehandlingHendelse.morsIdent)
         val morsÅpneBehandling = hentÅpenNormalBehandling(aktør = morsAktør)
-        val barnsAktører = personidentService.hentAktørIder(behandlingsdata.barnasIdenter)
+        val barnsAktører = personidentService.hentAktørIder(nyBehandlingHendelse.barnasIdenter)
 
         if (morsÅpneBehandling != null) {
             val barnaPåÅpenBehandling =
@@ -85,7 +87,7 @@ class AutovedtakFødselshendelseService(
                 logger.info("Ignorerer fødselshendelse fordi åpen behandling inneholder alle barna i hendelsen.")
                 secureLogger.info(
                     "Ignorerer fødselshendelse fordi åpen behandling inneholder alle barna i hendelsen." +
-                        "Barn på hendelse=${behandlingsdata.barnasIdenter}, barn på åpen behandling=$barnaPåÅpenBehandling",
+                        "Barn på hendelse=${nyBehandlingHendelse.barnasIdenter}, barn på åpen behandling=$barnaPåÅpenBehandling",
                 )
                 return false
             }
@@ -93,7 +95,7 @@ class AutovedtakFødselshendelseService(
 
         val (barnSomSkalBehandlesForMor, alleBarnSomKanBehandles) = finnBarnSomSkalBehandlesForMor(
             fagsak = fagsakService.hentNormalFagsak(aktør = morsAktør),
-            nyBehandlingHendelse = behandlingsdata,
+            nyBehandlingHendelse = nyBehandlingHendelse,
         )
 
         if (barnSomSkalBehandlesForMor.isEmpty()) {
@@ -108,7 +110,8 @@ class AutovedtakFødselshendelseService(
         return true
     }
 
-    override fun kjørBehandling(nyBehandling: NyBehandlingHendelse): String {
+    override fun kjørBehandling(behandlingsdata: FødselshendelseData): String {
+        val nyBehandling = behandlingsdata.nyBehandlingHendelse
         val morsAktør = personidentService.hentAktør(nyBehandling.morsIdent)
 
         val (barnSomSkalBehandlesForMor, _) = finnBarnSomSkalBehandlesForMor(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.omregning
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.OmregningBrevData
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -90,7 +91,7 @@ class Autobrev6og18ÅrService(
 
         autovedtakStegService.kjørBehandlingOmregning(
             mottakersAktør = behandling.fagsak.aktør,
-            behandlingsdata = AutovedtakBrevBehandlingsdata(
+            behandlingsdata = OmregningBrevData(
                 aktør = behandling.fagsak.aktør,
                 behandlingsårsak = behandlingsårsak,
                 standardbegrunnelse = AutobrevUtils.hentGjeldendeVedtakbegrunnelseReduksjonForAlder(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.omregning
 
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.OmregningBrevData
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -71,7 +72,7 @@ class AutobrevOpphørSmåbarnstilleggService(
 
         autovedtakStegService.kjørBehandlingOmregning(
             mottakersAktør = behandling.fagsak.aktør,
-            behandlingsdata = AutovedtakBrevBehandlingsdata(
+            behandlingsdata = OmregningBrevData(
                 aktør = behandling.fagsak.aktør,
                 behandlingsårsak = behandlingsårsak,
                 standardbegrunnelse = standardbegrunnelse,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutovedtakBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutovedtakBrevService.kt
@@ -7,12 +7,12 @@ import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakBehandlingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.OmregningBrevData
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
@@ -24,13 +24,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 
-data class AutovedtakBrevBehandlingsdata(
-    val aktør: Aktør,
-    val behandlingsårsak: BehandlingÅrsak,
-    val standardbegrunnelse: Standardbegrunnelse,
-    val fagsakId: Long,
-)
-
 @Service
 class AutovedtakBrevService(
     private val fagsakService: FagsakService,
@@ -41,10 +34,10 @@ class AutovedtakBrevService(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val taskRepository: TaskRepositoryWrapper,
     private val infotrygdService: InfotrygdService,
-) : AutovedtakBehandlingService<AutovedtakBrevBehandlingsdata> {
+) : AutovedtakBehandlingService<OmregningBrevData> {
 
     override fun kjørBehandling(
-        behandlingsdata: AutovedtakBrevBehandlingsdata,
+        behandlingsdata: OmregningBrevData,
     ): String {
         val behandlingEtterBehandlingsresultat =
             autovedtakService.opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
@@ -148,6 +141,8 @@ class AutovedtakBrevService(
     companion object {
         val logger = LoggerFactory.getLogger(AutovedtakBrevService::class.java)
     }
+
+    override fun skalAutovedtakBehandles(behandlingsdata: OmregningBrevData): Boolean = true
 }
 
 private fun BehandlingÅrsak.tilBrevkoder(): List<InfotrygdBrevkode> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
@@ -71,7 +71,7 @@ class BehandleFødselshendelseTask(
                     mottakersAktør = personidentService.hentAktør(
                         nyBehandling.morsIdent,
                     ),
-                    behandlingsdata = nyBehandling,
+                    nyBehandlingHendelse = nyBehandling,
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/VedtakOmOvergangsstønadTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/VedtakOmOvergangsstønadTask.kt
@@ -30,7 +30,7 @@ class VedtakOmOvergangsstønadTask(
 
         val responseFraService = autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
-            behandlingsdata = aktør,
+            aktør = aktør,
         )
         secureLogger.info("Håndterte vedtak om overgangsstønad for person $personIdent:\n$responseFraService")
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
@@ -42,14 +42,14 @@ class AutobrevStegServiceTest {
             it.status = BehandlingStatus.UTREDES
         }
 
-        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
+        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
         every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
         every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
 
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
-            behandlingsdata = aktør,
+            aktør = aktør,
         )
 
         verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
@@ -63,14 +63,14 @@ class AutobrevStegServiceTest {
             it.status = BehandlingStatus.FATTER_VEDTAK
         }
 
-        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
+        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
         every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
         every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
 
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = aktør,
-            behandlingsdata = aktør,
+            aktør = aktør,
         )
 
         verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
@@ -84,7 +84,7 @@ class AutobrevStegServiceTest {
             it.status = BehandlingStatus.IVERKSETTER_VEDTAK
         }
 
-        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(aktør) } returns true
+        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
         every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
         every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
@@ -92,7 +92,7 @@ class AutobrevStegServiceTest {
         assertThrows<RekjørSenereException> {
             autovedtakStegService.kjørBehandlingSmåbarnstillegg(
                 mottakersAktør = aktør,
-                behandlingsdata = aktør,
+                aktør = aktør,
             )
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
+import no.nav.familie.ba.sak.kjerne.autovedtak.FødselshendelseData
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregler.FiltreringsreglerService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
@@ -235,7 +236,7 @@ class FødselshendelseServiceTest {
             ),
         )
 
-        autovedtakFødselshendelseService.kjørBehandling(nyBehandlingHendelse)
+        autovedtakFødselshendelseService.kjørBehandling(FødselshendelseData(nyBehandlingHendelse))
         verify(exactly = 0) {
             opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = any(),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -317,7 +317,7 @@ class BehandleSmåbarnstilleggTest(
         val søkersAktør = personidentService.hentAktør(søkersIdent)
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            behandlingsdata = søkersAktør,
+            aktør = søkersAktør,
         )
         val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør)
         val aktivBehandling = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId = fagsak!!.id)!!
@@ -346,7 +346,7 @@ class BehandleSmåbarnstilleggTest(
         )
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            behandlingsdata = søkersAktør,
+            aktør = søkersAktør,
         )
 
         val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør)
@@ -402,7 +402,7 @@ class BehandleSmåbarnstilleggTest(
         )
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            behandlingsdata = søkersAktør,
+            aktør = søkersAktør,
         )
 
         val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør)
@@ -467,7 +467,7 @@ class BehandleSmåbarnstilleggTest(
         )
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            behandlingsdata = søkersAktør,
+            aktør = søkersAktør,
         )
         val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør)
         val aktivBehandling = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId = fagsak!!.id)!!
@@ -533,7 +533,7 @@ class BehandleSmåbarnstilleggTest(
         )
         autovedtakStegService.kjørBehandlingSmåbarnstillegg(
             mottakersAktør = søkersAktør,
-            behandlingsdata = søkersAktør,
+            aktør = søkersAktør,
         )
 
         val fagsak = fagsakService.hentFagsakPåPerson(aktør = søkersAktør)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
For de automatiske behandlingene har vi `AutovedtakStegService` som har en felles funksjon `kjørBehandling` som gjør logging og annet diverse i tillegg til å kjøre gjennom de respektive behandlingene. Den har til nå hatt behandlingsdata som en generisk parameter, noe som er helt unødvendig ettersom vi vet typen på behandlingsdataene ved kompileringstid. 

Endrer så vi bruker et sealed interface i stedet for en generisk variabel. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ingen ny funksjonalitet 