### PR TITLE
Revert "Fjern ubrukte begrunnelser (#3910)"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -1349,6 +1349,22 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override val sanityApiNavn = "fortsattInnvilgetGenerellBorSammenMedBarn"
     },
+    ENDRET_UTBETALING_DELT_BOSTED_FULL_UTBETALING {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
+        override val sanityApiNavn = "endretUtbetalingDeltBostedFullUtbetalingForSoknad"
+    },
+    ENDRET_UTBETALING_DELT_BOSTED_INGEN_UTBETALING {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
+        override val sanityApiNavn = "endretUtbetalingDeltBostedIngenUtbetalingForSoknad"
+    },
+    ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_KUN_ETTERBETALING_UTVIDET {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
+        override val sanityApiNavn = "endretUtbetalingDeltBostedKunEtterbetalingUtvidet"
+    },
+    ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_FULL_ORDINÆR_OG_ETTERBETALING_UTVIDET {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
+        override val sanityApiNavn = "endretUtbetalingDeltBostedFullOrdinarOgEtterbetalingUtvidet"
+    },
     ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
         override val sanityApiNavn = "endretUtbetalingDeltBostedIngenUtbetaling"

--- a/src/test/resources/brevperiodeCaser/ENDRET_UTBETALING.json
+++ b/src/test/resources/brevperiodeCaser/ENDRET_UTBETALING.json
@@ -4,7 +4,7 @@
   "tom": "2021-12-31",
   "vedtaksperiodetype": "UTBETALING",
   "begrunnelser": [
-    "Standardbegrunnelse$ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY"
+    "Standardbegrunnelse$ENDRET_UTBETALING_DELT_BOSTED_INGEN_UTBETALING"
   ],
   "fritekster": [],
   "uregistrerteBarn": [],
@@ -73,7 +73,7 @@
         "antallBarnOppfyllerTriggereOgHarNullutbetaling": 1,
         "maanedOgAarBegrunnelsenGjelderFor": "august 2021",
         "maalform": "bokmaal",
-        "apiNavn": "endretUtbetalingDeltBostedIngenUtbetaling",
+        "apiNavn": "endretUtbetalingDeltBostedIngenUtbetalingForSoknad",
         "belop": 0,
         "soknadstidspunkt": "31.01.21"
       }


### PR DESCRIPTION
This reverts commit 2e51aa257a5714ca54c306de80ca0fc72e94da01.

Kontekst: 
https://nav-it.slack.com/archives/C036C6VAWH3/p1693866881601519