### PR TITLE
Tar i bruk sisteVedtatteBehandlig for å sjekke og utføre satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringService.kt
@@ -19,14 +19,12 @@ class SatsendringService(
 ) {
     private val logger = LoggerFactory.getLogger(SatsendringService::class.java)
     fun erFagsakOppdatertMedSisteSatser(fagsakId: Long): Boolean {
-        // Må se på siste iverksatte og ikke siste vedtatte siden vi ønsker å se på
-        // den forrige behandlingen som sendte noe til økonomi
-        val sisteIverksatteEllerVedtatteBehandling =
-            behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId) ?: behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId)
+        val sisteVedtatteBehandling =
+            behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId)
 
-        return sisteIverksatteEllerVedtatteBehandling == null ||
+        return sisteVedtatteBehandling == null ||
             andelerTilkjentYtelseOgEndreteUtbetalingerService
-                .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(sisteIverksatteEllerVedtatteBehandling.id)
+                .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(sisteVedtatteBehandling.id)
                 .erOppdatertMedSisteSatser()
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Satssjekken bør alltid bruke sisteVedtatteBehandling for å sjekke om saken har siste sats. Dette for å få korrekt satssjekk der hvor behandling har en iverksatt med gammel sats, men har vedtatte etterpå som ikke gjør en iverksett mot oppdrag. Samme gjelder også ved satskjøring. Den burde bruke vedtatte, siden den er mest rett.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
