### PR TITLE
Wrappet kontrollerNyUtbetalingsgenerator i try-catch

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
@@ -61,70 +61,78 @@ class KontrollerNyUtbetalingsgeneratorService(
         gammeltUtbetalingsoppdrag: Utbetalingsoppdrag,
         erSimulering: Boolean = false,
     ): List<DiffFeilType> {
-        if (!skalKontrollereOppMotNyUtbetalingsgenerator()) return emptyList()
+        try {
+            if (!skalKontrollereOppMotNyUtbetalingsgenerator()) return emptyList()
 
-        val diffFeilTyper = mutableListOf<DiffFeilType>()
+            val diffFeilTyper = mutableListOf<DiffFeilType>()
 
-        val behandling = vedtak.behandling
+            val behandling = vedtak.behandling
 
-        val beregnetUtbetalingsoppdrag = utbetalingsoppdragGeneratorService.genererUtbetalingsoppdrag(
-            vedtak = vedtak,
-            saksbehandlerId = SikkerhetContext.hentSaksbehandler().take(8),
-            erSimulering = erSimulering,
-        )
-
-        if (!beregnetUtbetalingsoppdrag.utbetalingsoppdrag.skalIverksettesMotOppdrag()) return emptyList()
-
-        secureLogger.info("Behandling ${behandling.id} har følgende oppdaterte andeler: ${beregnetUtbetalingsoppdrag.andeler}")
-
-        secureLogger.info("Behandling ${behandling.id} får følgende utbetalingsoppdrag med gammel generator: $gammeltUtbetalingsoppdrag")
-        secureLogger.info("Behandling ${behandling.id} får følgende utbetalingsoppdrag med ny generator: ${beregnetUtbetalingsoppdrag.utbetalingsoppdrag}")
-
-        val nyttSimuleringResultat =
-            økonomiKlient.hentSimulering(beregnetUtbetalingsoppdrag.utbetalingsoppdrag)
-
-        if (nyttSimuleringResultat.simuleringMottaker.isEmpty() && gammeltSimuleringResultat.simuleringMottaker.isEmpty()) return emptyList()
-
-        if (!bådeNyOgGammelGirEtResultat(
-                nyttSimuleringResultat = nyttSimuleringResultat,
-                gammeltSimuleringResultat = gammeltSimuleringResultat,
-                behandling = behandling,
+            val beregnetUtbetalingsoppdrag = utbetalingsoppdragGeneratorService.genererUtbetalingsoppdrag(
+                vedtak = vedtak,
+                saksbehandlerId = SikkerhetContext.hentSaksbehandler().take(8),
+                erSimulering = erSimulering,
             )
-        ) {
-            diffFeilTyper.add(DiffFeilType.DetEneSimuleringsresultatetErTomt)
+
+            if (!beregnetUtbetalingsoppdrag.utbetalingsoppdrag.skalIverksettesMotOppdrag()) return emptyList()
+
+            secureLogger.info("Behandling ${behandling.id} har følgende oppdaterte andeler: ${beregnetUtbetalingsoppdrag.andeler}")
+
+            secureLogger.info("Behandling ${behandling.id} får følgende utbetalingsoppdrag med gammel generator: $gammeltUtbetalingsoppdrag")
+            secureLogger.info("Behandling ${behandling.id} får følgende utbetalingsoppdrag med ny generator: ${beregnetUtbetalingsoppdrag.utbetalingsoppdrag}")
+
+            val nyttSimuleringResultat =
+                økonomiKlient.hentSimulering(beregnetUtbetalingsoppdrag.utbetalingsoppdrag)
+
+            if (nyttSimuleringResultat.simuleringMottaker.isEmpty() && gammeltSimuleringResultat.simuleringMottaker.isEmpty()) return emptyList()
+
+            if (!bådeNyOgGammelGirEtResultat(
+                    nyttSimuleringResultat = nyttSimuleringResultat,
+                    gammeltSimuleringResultat = gammeltSimuleringResultat,
+                    behandling = behandling,
+                )
+            ) {
+                diffFeilTyper.add(DiffFeilType.DetEneSimuleringsresultatetErTomt)
+                return diffFeilTyper
+            }
+
+            val simuleringsPerioderGammel = gammeltSimuleringResultat.tilSorterteSimuleringsPerioder(behandling)
+
+            val simuleringsPerioderNy = nyttSimuleringResultat.tilSorterteSimuleringsPerioder(behandling)
+
+            val simuleringsPerioderGammelTidslinje: Tidslinje<SimuleringsPeriode, Måned> =
+                simuleringsPerioderGammel.tilTidslinje()
+
+            val simuleringsPerioderNyTidslinje: Tidslinje<SimuleringsPeriode, Måned> =
+                simuleringsPerioderNy.tilTidslinje()
+
+            validerAtSimuleringsPerioderGammelHarResultatLik0ForPerioderFørSimuleringsPerioderNy(
+                simuleringsPerioderGammelTidslinje = simuleringsPerioderGammelTidslinje,
+                simuleringsPerioderNyTidslinje = simuleringsPerioderNyTidslinje,
+                behandling = behandling,
+            )?.let {
+                diffFeilTyper.add(it)
+            }
+            validerAtSimuleringsPerioderGammelHarResultatLikSimuleringsPerioderNyEtterFomTilNy(
+                simuleringsPerioderGammelTidslinje = simuleringsPerioderGammelTidslinje,
+                simuleringsPerioderNyTidslinje = simuleringsPerioderNyTidslinje,
+                behandling = behandling,
+            )?.let {
+                diffFeilTyper.add(it)
+            }
+
+            if (diffFeilTyper.isNotEmpty()) {
+                loggSimuleringsPerioderMedDiff(simuleringsPerioderGammel, simuleringsPerioderNy)
+            }
+
             return diffFeilTyper
+        } catch (e: Exception) {
+            secureLogger.warn(
+                "En uventet feil har oppstått ved kontroll av ny utbetalingsoppdrag-generator for behandling ${vedtak.behandling.id}",
+                e,
+            )
+            return listOf(DiffFeilType.UventetFeil)
         }
-
-        val simuleringsPerioderGammel = gammeltSimuleringResultat.tilSorterteSimuleringsPerioder(behandling)
-
-        val simuleringsPerioderNy = nyttSimuleringResultat.tilSorterteSimuleringsPerioder(behandling)
-
-        val simuleringsPerioderGammelTidslinje: Tidslinje<SimuleringsPeriode, Måned> =
-            simuleringsPerioderGammel.tilTidslinje()
-
-        val simuleringsPerioderNyTidslinje: Tidslinje<SimuleringsPeriode, Måned> =
-            simuleringsPerioderNy.tilTidslinje()
-
-        validerAtSimuleringsPerioderGammelHarResultatLik0ForPerioderFørSimuleringsPerioderNy(
-            simuleringsPerioderGammelTidslinje = simuleringsPerioderGammelTidslinje,
-            simuleringsPerioderNyTidslinje = simuleringsPerioderNyTidslinje,
-            behandling = behandling,
-        )?.let {
-            diffFeilTyper.add(it)
-        }
-        validerAtSimuleringsPerioderGammelHarResultatLikSimuleringsPerioderNyEtterFomTilNy(
-            simuleringsPerioderGammelTidslinje = simuleringsPerioderGammelTidslinje,
-            simuleringsPerioderNyTidslinje = simuleringsPerioderNyTidslinje,
-            behandling = behandling,
-        )?.let {
-            diffFeilTyper.add(it)
-        }
-
-        if (diffFeilTyper.isNotEmpty()) {
-            loggSimuleringsPerioderMedDiff(simuleringsPerioderGammel, simuleringsPerioderNy)
-        }
-
-        return diffFeilTyper
     }
 
     private fun bådeNyOgGammelGirEtResultat(
@@ -223,4 +231,5 @@ enum class DiffFeilType {
     TidligerePerioderIGammelUlik0,
     UliktResultatISammePeriode,
     DetEneSimuleringsresultatetErTomt,
+    UventetFeil,
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
@@ -334,6 +334,24 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
         assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(0)
     }
 
+    @Test
+    fun `kontrollerNyUtbetalingsgenerator - skal fange opp feil som kastes`() {
+        every {
+            økonomiKlient.hentSimulering(any())
+        } throws Exception("Test")
+
+        val simuleringsPeriodeDiffFeil = kontrollerNyUtbetalingsgeneratorService.kontrollerNyUtbetalingsgenerator(
+            vedtak = lagVedtak(),
+            gammeltSimuleringResultat = mockk(),
+            gammeltUtbetalingsoppdrag = mockk(),
+        )
+
+        assertThat(simuleringsPeriodeDiffFeil.size).isEqualTo(1)
+        assertThat(
+            simuleringsPeriodeDiffFeil.first(),
+        ).isEqualTo(DiffFeilType.UventetFeil)
+    }
+
     fun lagDetaljertSimuleringsResultat(perioder: List<Periode<Int, Måned>>) =
         if (perioder.isEmpty()) {
             DetaljertSimuleringResultat(emptyList())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det hender at det kastes en feil i metoden `kontrollerNyUtbetalingsgenerator` som hindrer saksbehandling. Wrapper derfor hele metoden i en try-catch slik at vi fanger opp feilen.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
