### PR TITLE
Sender kun andeler med utbetaling til ny utbetalingsgenerator

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
@@ -52,15 +52,14 @@ class UtbetalingsoppdragGenerator(
                 opphørFra = opphørFra(forrigeTilkjentYtelse, erSimulering, endretMigreringsDato),
                 utbetalesTil = hentUtebetalesTil(vedtak.behandling.fagsak),
             ),
-            forrigeAndeler = forrigeTilkjentYtelse?.andelerTilkjentYtelse?.map {
-                it.tilAndelDataLongId()
-            } ?: emptyList(),
-            nyeAndeler = nyTilkjentYtelse.andelerTilkjentYtelse.map {
-                it.tilAndelDataLongId()
-            },
+            forrigeAndeler = forrigeTilkjentYtelse?.tilAndelDataMedUtbetaling() ?: emptyList(),
+            nyeAndeler = nyTilkjentYtelse.tilAndelDataMedUtbetaling(),
             sisteAndelPerKjede = sisteAndelPerKjede.mapValues { it.value.tilAndelDataLongId() },
         )
     }
+
+    private fun TilkjentYtelse.tilAndelDataMedUtbetaling(): List<AndelDataLongId> =
+        this.andelerTilkjentYtelse.map { it.tilAndelDataLongId() }.filter { it.beløp > 0 }
 
     private fun AndelTilkjentYtelse.tilAndelDataLongId(): AndelDataLongId =
         AndelDataLongId(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi får feilen "Kan ikke sende med opphørFra når det ikke finnes noen kjede fra tidligere" når vi sender andeler med 0 kr i `kalkulertUtbetalingsbeløp` til ny utbetalingsoppdrag-generator. Dette er typisk EØS saker i årlig kontroll behandlinger hvor man har gått fra ingen utbetaling til utbetaling.

Feilen er rettet ved å filtrere bort alle andeler med 0 kr i beløp før den sendes inn i ny utbetalingsoppdrag-generator. Da vil man kun sende nye linjer for periodene med beløp > 0 kr og ikke sende opphør for perioder med 0 kr.
