### PR TITLE
NAV-14467: Sammenligning av andeler fra fler enn 2 fagsaker skal være mulig

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -255,11 +255,11 @@ object TilkjentYtelseValidering {
             tidslinjePerBehandling.map { tidslinje -> tidslinje.map { it?.prosent } }
 
         val erOver100ProsentTidslinje =
-            prosenttidslinjerPerBehandling.fold(emptyList<Periode<BigDecimal, Måned>>().tilTidslinje()) { acc, neste ->
-                acc.kombinerMed(neste) { pAcc, pNeste ->
-                    (pAcc ?: BigDecimal.ZERO) + (pNeste ?: BigDecimal.ZERO)
+            prosenttidslinjerPerBehandling.fold(emptyList<Periode<BigDecimal, Måned>>().tilTidslinje()) { summertProsentTidslinje, prosentTidslinje ->
+                summertProsentTidslinje.kombinerMed(prosentTidslinje) { sumProsentForPeriode, prosentForAndel ->
+                    (sumProsentForPeriode ?: BigDecimal.ZERO) + (prosentForAndel ?: BigDecimal.ZERO)
                 }
-            }.map { (it ?: BigDecimal.ZERO) > BigDecimal.valueOf(100) }
+            }.map { sumProsentForPeriode -> (sumProsentForPeriode ?: BigDecimal.ZERO) > BigDecimal.valueOf(100) }
 
         return erOver100ProsentTidslinje
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
@@ -268,6 +268,61 @@ class TilkjentYtelseValideringTest {
         )
     }
 
+    @Test
+    fun `Skal håndtere overlappende tidligere andeler fra flere enn 1 behandling`() {
+        val barn = tilfeldigPerson()
+        val andeler = listOf(
+            lagAndelTilkjentYtelse(
+                fom = inneværendeMåned().minusYears(1),
+                tom = inneværendeMåned(),
+                beløp = 2108,
+                person = barn,
+            ),
+            lagAndelTilkjentYtelse(
+                fom = inneværendeMåned().plusMonths(1),
+                tom = inneværendeMåned().plusYears(1),
+                beløp = 2108,
+                person = barn,
+            ),
+        )
+
+        // 3 Behandlinger med identiske perioder.
+        val andelerFraTidligere = listOf(
+            lagAndelTilkjentYtelse(
+                fom = inneværendeMåned().minusYears(1).plusMonths(1),
+                tom = inneværendeMåned().plusMonths(2),
+                beløp = 2108,
+                person = barn,
+            ),
+            lagAndelTilkjentYtelse(
+                fom = inneværendeMåned().minusYears(1).plusMonths(1),
+                tom = inneværendeMåned().plusMonths(2),
+                beløp = 2108,
+                person = barn,
+            ),
+            lagAndelTilkjentYtelse(
+                fom = inneværendeMåned().minusYears(1).plusMonths(1),
+                tom = inneværendeMåned().plusMonths(2),
+                beløp = 2108,
+                person = barn,
+            ),
+        )
+
+        Assertions.assertEquals(
+            listOf(
+                MånedPeriode(
+                    inneværendeMåned().minusYears(1).plusMonths(1),
+                    inneværendeMåned().plusMonths(2),
+                ),
+            ),
+            TilkjentYtelseValidering.finnPeriodeMedOverlappAvAndeler(andeler, andelerFraTidligere),
+        )
+        Assertions.assertEquals(
+            TilkjentYtelseValidering.finnPeriodeMedOverlappAvAndeler(andeler, emptyList()),
+            emptyList<MånedPeriode>(),
+        )
+    }
+
     @Nested
     inner class `Valider at satsendring kun oppdaterer sats på eksisterende perioder` {
         @Test


### PR DESCRIPTION
Favro: [NAV-14467](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14467)

### 💰 Hva skal gjøres, og hvorfor?
Koden som validerer at en aktør ikke får utbetalinger som overstiger 100% feilet dersom en aktør hadde andeler i flere enn 2 fagsaker. Vi fikk en tidslinje-feil om etterfølgende overlappende perioder.

Har nå justert koden slik at den vil fungere uavhengig av hvor mange fagsaker en aktør har andeler i.


### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
