### PR TITLE
Gå bort fra å returnere hele behandlingen ved oppdatering av fritekster

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -84,7 +84,7 @@ class VedtaksperiodeMedBegrunnelserController(
         vedtaksperiodeId: Long,
         @RequestBody
         restPutVedtaksperiodeMedFritekster: RestPutVedtaksperiodeMedFritekster,
-    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
+    ): ResponseEntity<Ressurs<List<RestUtvidetVedtaksperiodeMedBegrunnelser>>> {
         val behandlingId = vedtaksperiodeHentOgPersisterService.finnBehandlingIdFor(vedtaksperiodeId)
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.UPDATE)
         tilgangService.verifiserHarTilgangTilHandling(
@@ -92,12 +92,18 @@ class VedtaksperiodeMedBegrunnelserController(
             handling = OPPDATERE_BEGRUNNELSER_HANDLING,
         )
 
-        val vedtak = vedtaksperiodeService.oppdaterVedtaksperiodeMedFritekster(
+        vedtaksperiodeService.oppdaterVedtaksperiodeMedFritekster(
             vedtaksperiodeId,
             restPutVedtaksperiodeMedFritekster,
         )
 
-        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = vedtak.behandling.id)))
+        return ResponseEntity.ok(
+            Ressurs.success(
+                vedtaksperiodeService.hentRestUtvidetVedtaksperiodeMedBegrunnelser(
+                    behandlingId,
+                ),
+            ),
+        )
     }
 
     @PutMapping("/endringstidspunkt")


### PR DESCRIPTION
Favrokort: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543

Vi har en bug der vi ikke oppdaterer state korrekt etter at vi splittet ut vedtaksperioder fra behandling responsen.


Endrer til at i returnerer bare det relevante ved oppdatering av fritekst og oppdater state i henhold til dette i frontend.
Frontend PR: https://github.com/navikt/familie-ba-sak-frontend/pull/2769

