### PR TITLE
Lagt til validering av andeler returnert fra ny generator

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
@@ -154,12 +154,12 @@ class KontrollerNyUtbetalingsgeneratorService(
         val andelerMedUtbetaling = tilkjentYtelse.andelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() }
 
         if (andeler.size != andelerMedUtbetaling.size) {
-            secureLogger.warn("Antallet andeler fra ny generator matcher ikke antallet andeler med utbetaling i behandling ${behandling.id}.")
+            secureLogger.warn("Antallet andeler fra ny generator matcher ikke antallet andeler med utbetaling i behandling ${behandling.id}. Andeler fra ny generator: ${andeler.map { it.id }}, andeler med utbetaling: ${andelerMedUtbetaling.map { it.id }}.")
             return DiffFeilType.FeilAntallAndeler
         }
 
         if (!andelerMedUtbetaling.all { andelerMedUtbetaling -> andeler.any { it.id == andelerMedUtbetaling.id } }) {
-            secureLogger.warn("Finner ikke match for alle andeler med utbetaling i behandling ${behandling.id} blandt andelene returnert fra ny generator.")
+            secureLogger.warn("Finner ikke match for alle andeler med utbetaling i behandling ${behandling.id} blandt andelene returnert fra ny generator. Andeler fra ny generator: ${andeler.map { it.id }}, andeler med utbetaling: ${andelerMedUtbetaling.map { it.id }}.")
             return DiffFeilType.AndelerMatcherIkke
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -250,8 +250,10 @@ fun lagAndelTilkjentYtelse(
     prosent: BigDecimal = BigDecimal(100),
     kildeBehandlingId: Long? = behandling.id,
     differanseberegnetPeriodebeløp: Int? = null,
+    id: Long = 0,
 ): AndelTilkjentYtelse {
     return AndelTilkjentYtelse(
+        id = id,
         aktør = aktør,
         behandlingId = behandling.id,
         tilkjentYtelse = tilkjentYtelse ?: lagInitiellTilkjentYtelse(behandling),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det er viktig at andelene som returneres av ny utbetalingsgenerator inneholder alle andeler med `kalkulertUtbetalingsbeløp > 0`, slik at vi får oppdatert alle relevante andeler med korrekt `periodeId` og `forrigePeriodeId`.

Legger her inn validering av andelene i `KontrollerNyUtbetalingsgeneratorService`

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
