### PR TITLE
Legg til pre så vi kan lese testen rett ut fra nettleseren

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -34,6 +34,7 @@ fun lagGyldigeBegrunnelserTest(
     kompetanse: Collection<Kompetanse>,
     kompetanseForrigeBehandling: Collection<Kompetanse>?,
 ) = """
+<pre>
 # language: no
 # encoding: UTF-8
 
@@ -54,7 +55,9 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
     hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) + """
     
     Når begrunnelsetekster genereres for behandling ${behandling.id}""" +
-    hentTekstForVedtaksperioder(vedtaksperioder)
+    hentTekstForVedtaksperioder(vedtaksperioder) + """
+</pre> 
+    """
 
 private fun lagPersonresultaterTekst(behandling: Behandling?) = behandling?.let {
     """


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Legger til \<pre>-tag rundt testene som vi genererer fra endepunkt slik at nettleseren skjønner at den ikke skal formatere teksten.  

<img width="995" alt="image" src="https://github.com/navikt/familie-ba-sak/assets/17828446/e925a72d-39c7-42dc-aa65-bc11667bae87">
