### PR TITLE
Fjern deprecated ingress som ikke lenger er støttet

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -123,7 +123,6 @@ spec:
       memory: 1024Mi
       cpu: 500m
   ingresses:
-    - https://familie-ba-sak.dev.intern.nav.no # Deprecated
     - https://familie-ba-sak.intern.dev.nav.no
   secureLogs:
     enabled: true


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner deprecated ingress som nå førte til feil ved deploy:
![image](https://github.com/navikt/familie-ba-sak/assets/25459913/0de04446-c3a7-4812-bd5a-d6abc7536afc)


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei
