### PR TITLE
Fikser at behandleFødselsehendelseTask feiler med UnexpectedRollbackException

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -18,6 +18,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.prosessering.error.RekjørSenereException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 interface AutovedtakBehandlingService<Behandlingsdata : AutomatiskBehandlingData> {
@@ -74,6 +76,7 @@ class AutovedtakStegService(
         Metrics.counter("behandling.saksbehandling.autovedtak.aapen_behandling", "type", it.name)
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun kjørBehandlingFødselshendelse(mottakersAktør: Aktør, nyBehandlingHendelse: NyBehandlingHendelse): String {
         return kjørBehandling(
             mottakersAktør = mottakersAktør,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fikser at behandleFødselsehendelseTask feiler med UnexpectedRollbackException ved FunksjonellFeil

Når det kastes en FunksjonellFeil i kjørBehandling for AutovedtakBehandlingService, så vil behandlingen bli markert som rollback av transaksjonsmangeren, men siden vi catcher FunksjonellFeil i tasken for å opprette oppgave i stedet for å feile tasken, så vil det bli en conflikt når transaksjonsmanageren prøver å commite riktig status på tasken

Dette kan løses ved å kjøre  kjørBehandlingFødselshendelse i egen tråd. Da vil behandlingen rulles tilbake, men og tasken kan kjøres FERDIG.

Man kunne ha automatisk henlagt denne behandlingen i stedet, som man gjør når det slår ut ved filtreringsregler, men den behandlingen vil mest sannsynlig ikke være til hjel for saksbehandler. Så synes det er greit at den behandlingen rulles tilbake.

Jeg synes også at denne logikken som ligger i catchen på tasken er feil, og bør vurderes å skrive om. Hvis det er en løpende sak, så vil det alltid være en fagsak og en aktiv behandling, selv om behandlingen nødvendigvis ikke er den fødselshendelse-behandlingen, så der vil if alltid treffe i case 1. Selv om den aktive behandlingen kan være alt fra satsendring, førstegangsbehandling eller en tidligere fødselshendelse

```
val behandling = if (fagsak != null) { behandlingHentOgPersisterService.finnAktivForFagsak(fagsak.id) } else { null }

            if (fagsak != null && behandling != null && behandling.erSatsendring()) {
                // bruk den vanlige løypa for å opprette oppgave
                oppgaveService.opprettOppgaveForManuellBehandling(
                    behandling = behandling,
                    begrunnelse = ManuellOppgaveType.FØDSELSHENDELSE.toString(),
                    opprettLogginnslag = false,
                    manuellOppgaveType = ManuellOppgaveType.FØDSELSHENDELSE,
                )
            } else {
                taskRepositoryWrapper.save(
                    OpprettVurderFødselshendelseKonsekvensForYtelseOppgave.opprettTask(
                        ident = aktør.aktørId,
                        oppgavetype = Oppgavetype.VurderLivshendelse,
                        beskrivelse = "Saksbehandler må vurdere konsekvens for ytelse fordi fødselshendelsen ikke kunne håndteres automatisk",
                    ),
                )
            }
```
### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
