### PR TITLE
Hent kun inn kompetanser som gjelder for dagens dato for begrunnelser når periodetypen er fortsatt innvilget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -47,7 +47,7 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
     """
       
   Scenario: Plassholdertekst for scenario - ${RandomStringUtils.randomAlphanumeric(10)}
-    Og følgende dagens dato ${LocalDate.now()}""" +
+    Og følgende dagens dato ${LocalDate.now().tilddMMyyyy()}""" +
     lagPersonresultaterTekst(forrigeBehandling) +
     lagPersonresultaterTekst(behandling) +
     hentTekstForVilkårresultater(personResultaterForrigeBehandling, forrigeBehandling?.id) +
@@ -76,13 +76,13 @@ fun hentTekstForBehandlinger(behandling: Behandling, forrigeBehandling: Behandli
     """
 
     Gitt følgende behandling
-      | BehandlingId | FagsakId | ForrigeBehandlingId |${
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak |${
         forrigeBehandling?.let {
             """ 
-      | ${forrigeBehandling.id} | ${forrigeBehandling.fagsak.id} |           |"""
+      | ${it.id} | ${it.fagsak.id} |           | ${it.resultat} | ${it.opprettetÅrsak} |"""
         } ?: ""
     }
-      | ${behandling.id} | ${behandling.fagsak.id} | ${forrigeBehandling?.id ?: ""} |"""
+      | ${behandling.id} | ${behandling.fagsak.id} | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak} |"""
 
 fun hentTekstForPersongrunnlag(
     persongrunnlag: PersonopplysningGrunnlag,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -589,8 +589,8 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.finnBegrunnelseGrunnlagPerPerso
         when (this.type) {
             Vedtaksperiodetype.OPPHØR -> begrunnelseperioderIVedtaksperiode.first()
             Vedtaksperiodetype.FORTSATT_INNVILGET -> if (this.fom == null && this.tom == null) {
-                val perioder = grunnlagMedForrigePeriodeOgBehandlingTidslinje.perioder()
-                perioder.single { nåDato.toYearMonth() in it.fraOgMed.tilYearMonthEllerUendeligFortid()..it.tilOgMed.tilYearMonthEllerUendeligFramtid() }.innhold!!
+                grunnlagMedForrigePeriodeOgBehandlingTidslinje.perioder()
+                    .single { it.gjelderNesteMåned(nåDato) }.innhold!!
             } else {
                 begrunnelseperioderIVedtaksperiode.single()
             }
@@ -599,6 +599,11 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.finnBegrunnelseGrunnlagPerPerso
         }
     }
 }
+
+private fun Periode<IBegrunnelseGrunnlagForPeriode, Måned>.gjelderNesteMåned(
+    nåDato: LocalDate,
+) = nåDato.toYearMonth()
+    .plusMonths(1) in fraOgMed.tilYearMonthEllerUendeligFortid()..tilOgMed.tilYearMonthEllerUendeligFramtid()
 
 private fun Tidslinje<UtvidetVedtaksperiodeMedBegrunnelser, Måned>.lagTidslinjeGrunnlagDennePeriodenForrigePeriodeOgPeriodeForrigeBehandling(
     grunnlagTidslinje: Tidslinje<BegrunnelseGrunnlagForPersonIPeriode, Måned>,

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/behandlingsresultat.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/behandlingsresultat.feature
@@ -1,7 +1,7 @@
 # language: no
 # encoding: UTF-8
 
-Egenskap: Behandlingsresultat
+Egenskap: Begrunnelser for behandlingsresultat
 
   Bakgrunn:
     Gitt følgende fagsaker for begrunnelse
@@ -77,3 +77,70 @@ Egenskap: Behandlingsresultat
     Så forvent følgende standardBegrunnelser
       | Fra dato | Til dato | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser | Ekskluderte Begrunnelser |
       |          |          | FORTSATT_INNVILGET |           |                         |                          |
+
+  Scenario: Plassholdertekst for scenario - G2Gpn6sQDp
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId  | Fagsaktype |
+      | 200057431 | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId  | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak |
+      | 100175489    | 200057431 |                     | Innvilget           | SØKNAD           |
+      | 100175553    | 200057431 | 100175489           | FORTSATT_INNVILGET  | NYE_OPPLYSNINGER |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId       | Persontype | Fødselsdato |
+      | 100175489    | 2015561009263 | BARN       | 16.06.2010  |
+      | 100175489    | 2459059241282 | BARN       | 17.10.2005  |
+      | 100175489    | 2736409265911 | SØKER      | 11.02.1988  |
+      | 100175553    | 2015561009263 | BARN       | 16.06.2010  |
+      | 100175553    | 2459059241282 | BARN       | 17.10.2005  |
+      | 100175553    | 2736409265911 | SØKER      | 11.02.1988  |
+
+    Og følgende dagens dato 13.09.2023
+
+    Og lag personresultater for begrunnelse for behandling 100175489
+    Og lag personresultater for begrunnelse for behandling 100175553
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 100175489
+      | AktørId       | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 2736409265911 | LOVLIG_OPPHOLD                                               |                  | 11.02.1988 |            | OPPFYLT  | Nei                  |
+      | 2736409265911 | BOSATT_I_RIKET                                               |                  | 15.12.2022 |            | OPPFYLT  | Nei                  |
+
+      | 2015561009263 | BOSATT_I_RIKET,GIFT_PARTNERSKAP,LOVLIG_OPPHOLD,BOR_MED_SØKER |                  | 16.06.2010 |            | OPPFYLT  | Nei                  |
+      | 2015561009263 | UNDER_18_ÅR                                                  |                  | 16.06.2010 | 15.06.2028 | OPPFYLT  | Nei                  |
+
+      | 2459059241282 | UNDER_18_ÅR                                                  |                  | 17.10.2005 | 16.10.2023 | OPPFYLT  | Nei                  |
+      | 2459059241282 | GIFT_PARTNERSKAP,BOR_MED_SØKER,LOVLIG_OPPHOLD,BOSATT_I_RIKET |                  | 17.10.2005 |            | OPPFYLT  | Nei                  |
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 100175553
+      | AktørId       | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 2015561009263 | BOSATT_I_RIKET,BOR_MED_SØKER,GIFT_PARTNERSKAP,LOVLIG_OPPHOLD |                  | 16.06.2010 |            | OPPFYLT  | Nei                  |
+      | 2015561009263 | UNDER_18_ÅR                                                  |                  | 16.06.2010 | 15.06.2028 | OPPFYLT  | Nei                  |
+
+      | 2459059241282 | UNDER_18_ÅR                                                  |                  | 17.10.2005 | 16.10.2023 | OPPFYLT  | Nei                  |
+      | 2459059241282 | LOVLIG_OPPHOLD,GIFT_PARTNERSKAP,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.10.2005 |            | OPPFYLT  | Nei                  |
+
+      | 2736409265911 | LOVLIG_OPPHOLD                                               |                  | 11.02.1988 |            | OPPFYLT  | Nei                  |
+      | 2736409265911 | BOSATT_I_RIKET                                               |                  | 15.12.2022 |            | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId       | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent |
+      | 2459059241282 | 100175489    | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     |
+      | 2459059241282 | 100175489    | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     |
+      | 2459059241282 | 100175489    | 01.07.2023 | 30.09.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+      | 2015561009263 | 100175489    | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     |
+      | 2015561009263 | 100175489    | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     |
+      | 2015561009263 | 100175489    | 01.07.2023 | 31.05.2028 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+      | 2459059241282 | 100175553    | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     |
+      | 2459059241282 | 100175553    | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     |
+      | 2459059241282 | 100175553    | 01.07.2023 | 30.09.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+      | 2015561009263 | 100175553    | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     |
+      | 2015561009263 | 100175553    | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     |
+      | 2015561009263 | 100175553    | 01.07.2023 | 31.05.2028 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+
+    Når begrunnelsetekster genereres for behandling 100175553
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato | Til dato | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser | Ekskluderte Begrunnelser |
+      |          |          | FORTSATT_INNVILGET |           | REDUKSJON_UNDER_18_ÅR   |                          |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14458)

Når vi ser på kompetanser i begrunnelsestekstene henter vi inn alle kompetansene i vedtaksperioden. For uendelige perioder som fortsatt innvilget perioder henter henter derfor inn alle kompetansene på behandlingen. 

Endrer så vi kun henter inn kompetansene som er aktive for dagens dato til begrunnelsene når vedtaksperioden er uendelig. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
