### PR TITLE
Filtrer begrunnelser basert på tema og regelverk periode er vurdert etter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelse.kt
@@ -28,6 +28,7 @@ interface ISanityBegrunnelse {
     val lovligOppholdTriggere: List<VilkårTrigger>
     val utvidetBarnetrygdTriggere: List<UtvidetBarnetrygdTrigger>
     val fagsakType: FagsakType?
+    val tema: Tema?
 }
 
 data class SanityBegrunnelse(
@@ -41,6 +42,7 @@ data class SanityBegrunnelse(
     override val borMedSokerTriggere: List<VilkårTrigger> = emptyList(),
     override val utvidetBarnetrygdTriggere: List<UtvidetBarnetrygdTrigger> = emptyList(),
     override val fagsakType: FagsakType? = null,
+    override val tema: Tema? = null,
     @Deprecated("Bruk vilkår")
     val vilkaar: List<SanityVilkår> = emptyList(),
     val rolle: List<VilkårRolle> = emptyList(),
@@ -78,6 +80,7 @@ data class RestSanityBegrunnelse(
     val valgbarhet: String? = null,
     val vedtakResultat: String?,
     val fagsakType: String?,
+    val tema: String?,
 ) {
     fun tilSanityBegrunnelse(): SanityBegrunnelse? {
         if (apiNavn == null) return null
@@ -134,6 +137,10 @@ data class RestSanityBegrunnelse(
             fagsakType = fagsakType?.let {
                 finnEnumverdi(it, FagsakType.entries.toTypedArray(), apiNavn)
             },
+            tema = tema?.let {
+                finnEnumverdi(it, Tema.entries.toTypedArray(), apiNavn)
+            },
+
         )
     }
 }
@@ -239,6 +246,12 @@ enum class Valgbarhet {
     AUTOMATISK,
     TILLEGGSTEKST,
     SAKSPESIFIKK,
+}
+
+enum class Tema {
+    NASJONAL,
+    EØS,
+    FELLES,
 }
 
 private fun SanityBegrunnelse.tilTriggesAv(): TriggesAv {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser
 
 import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.Tema
 import no.nav.familie.ba.sak.kjerne.brev.domene.UtvidetBarnetrygdTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.finnEnumverdi
@@ -34,6 +35,7 @@ data class RestSanityEØSBegrunnelse(
     val eosVilkaar: List<String>? = null,
     val vedtakResultat: String?,
     val fagsakType: String?,
+    val tema: String?,
 ) {
     fun tilSanityEØSBegrunnelse(): SanityEØSBegrunnelse? {
         if (apiNavn == null || navnISystem == null) return null
@@ -61,6 +63,9 @@ data class RestSanityEØSBegrunnelse(
             fagsakType = fagsakType?.let {
                 finnEnumverdi(it, FagsakType.entries.toTypedArray(), apiNavn)
             },
+            tema = tema?.let {
+                finnEnumverdi(it, Tema.entries.toTypedArray(), apiNavn)
+            },
         )
     }
 
@@ -74,6 +79,7 @@ data class SanityEØSBegrunnelse(
     override val periodeResultat: SanityPeriodeResultat? = null,
     override val vilkår: Set<Vilkår>,
     override val fagsakType: FagsakType?,
+    override val tema: Tema?,
     val annenForeldersAktivitet: List<KompetanseAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,
     val kompetanseResultat: List<KompetanseResultat>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
+import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.Tema
@@ -76,12 +77,11 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserPerPerso
         return avslagsbegrunnelserPerPerson
     }
 
-    val begrunnelseGrunnlagPerPerson =
-        this.finnBegrunnelseGrunnlagPerPerson(
-            behandlingsGrunnlagForVedtaksperioder,
-            behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
-            nåDato,
-        )
+    val begrunnelseGrunnlagPerPerson = this.finnBegrunnelseGrunnlagPerPerson(
+        behandlingsGrunnlagForVedtaksperioder,
+        behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
+        nåDato,
+    )
 
     return begrunnelseGrunnlagPerPerson.mapValues { (person, begrunnelseGrunnlag) ->
         val relevantePeriodeResultater =
@@ -106,30 +106,39 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserPerPerso
 
         val temaSomPeriodeErVurdertEtter = hentTemaSomPeriodeErVurdertEtter(begrunnelseGrunnlag)
 
-        val standardOgEøsBegrunnelserFiltrertPåTema = (standardBegrunnelser + eøsBegrunnelser).filter {
-            val temaPåBegrunnelse = it.value.tema
+        val standardOgEøsBegrunnelser: Map<IVedtakBegrunnelse, ISanityBegrunnelse> =
+            (standardBegrunnelser + eøsBegrunnelser)
 
-            (temaSomPeriodeErVurdertEtter == temaPåBegrunnelse || temaPåBegrunnelse == Tema.FELLES)
-        }.keys.toSet()
+        val standardOgEøsBegrunnelserFiltrertPåTema =
+            standardOgEøsBegrunnelser.filtrerPåTema(temaSomPeriodeErVurdertEtter)
 
         standardOgEøsBegrunnelserFiltrertPåTema + avslagsbegrunnelser
     }
 }
 
+private fun Map<IVedtakBegrunnelse, ISanityBegrunnelse>.filtrerPåTema(
+    temaSomPeriodeErVurdertEtter: Tema,
+) = filter {
+    val temaPåBegrunnelse = it.value.tema
+
+    temaSomPeriodeErVurdertEtter == temaPåBegrunnelse || temaPåBegrunnelse == Tema.FELLES
+}.keys.toSet()
+
 fun hentTemaSomPeriodeErVurdertEtter(
-    begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode
-): Tema  {
+    begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode,
+): Tema {
     val harKompetanseDennePerioden = begrunnelseGrunnlag.dennePerioden.kompetanse != null
-    val harMistetKompetanseDennePerioden = !harKompetanseDennePerioden && begrunnelseGrunnlag.forrigePeriode?.kompetanse != null
-    val harGåttOverTilNasjonalFraEøs = harMistetKompetanseDennePerioden && begrunnelseGrunnlag.dennePerioden.andeler.any { it.nasjonaltPeriodebeløp != 0 }
+    val harMistetKompetanseDennePerioden =
+        !harKompetanseDennePerioden && begrunnelseGrunnlag.forrigePeriode?.kompetanse != null
+    val harGåttFraEøsTilNasjonal =
+        harMistetKompetanseDennePerioden && begrunnelseGrunnlag.dennePerioden.andeler.any { it.nasjonaltPeriodebeløp != 0 }
 
     return when {
-        harGåttOverTilNasjonalFraEøs -> Tema.NASJONAL
+        harGåttFraEøsTilNasjonal -> Tema.NASJONAL
         harKompetanseDennePerioden || harMistetKompetanseDennePerioden -> Tema.EØS
         else -> Tema.NASJONAL
     }
 }
-
 
 private fun UtvidetVedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerson(
     behandlingsGrunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
@@ -138,9 +147,7 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerso
 
     return behandlingsGrunnlagForVedtaksperioder.persongrunnlag.personer.associateWith { person ->
         val avslagsbegrunnelserTisdlinje =
-            behandlingsGrunnlagForVedtaksperioder.personResultater.single { it.aktør == person.aktør }
-                .vilkårResultater
-                .filter { it.erEksplisittAvslagPåSøknad == true }
+            behandlingsGrunnlagForVedtaksperioder.personResultater.single { it.aktør == person.aktør }.vilkårResultater.filter { it.erEksplisittAvslagPåSøknad == true }
                 .tilForskjøvedeVilkårTidslinjer(person.fødselsdato)
                 .kombiner { vilkårResultaterIPeriode -> vilkårResultaterIPeriode.flatMap { it.standardbegrunnelser } }
 
@@ -160,8 +167,7 @@ private fun hentStandardBegrunnelser(
 ): Map<Standardbegrunnelse, SanityBegrunnelse> {
     val endretUtbetalingDennePerioden = hentEndretUtbetalingDennePerioden(begrunnelseGrunnlag)
 
-    val relevantePeriodeResultaterForrigePeriode =
-        hentResultaterForForrigePeriode(begrunnelseGrunnlag.forrigePeriode)
+    val relevantePeriodeResultaterForrigePeriode = hentResultaterForForrigePeriode(begrunnelseGrunnlag.forrigePeriode)
 
     val filtrertPåRolle = sanityBegrunnelser.filterValues { begrunnelse ->
         begrunnelse.erGjeldendeForRolle(person, fagsakType)
@@ -209,25 +215,19 @@ private fun hentStandardBegrunnelser(
             begrunnelse.erGjeldendeForRolle(person, fagsakType)
         }
 
-    val filtrertPåEtterEndretUtbetaling =
-        filtrertPåRolleOgPeriodetypeForrigePeriode.filterValues {
-            it.erEtterEndretUtbetaling(
-                endretUtbetalingDennePerioden = endretUtbetalingDennePerioden,
-                endretUtbetalingForrigePeriode = hentEndretUtbetalingForrigePeriode(begrunnelseGrunnlag),
-            )
-        }
+    val filtrertPåEtterEndretUtbetaling = filtrertPåRolleOgPeriodetypeForrigePeriode.filterValues {
+        it.erEtterEndretUtbetaling(
+            endretUtbetalingDennePerioden = endretUtbetalingDennePerioden,
+            endretUtbetalingForrigePeriode = hentEndretUtbetalingForrigePeriode(begrunnelseGrunnlag),
+        )
+    }
 
     val filtrertPåHendelser = filtrertPåRolleFagsaktypeOgPeriodetype.filtrerPåHendelser(
         begrunnelseGrunnlag,
         vedtaksperiode.fom,
     )
 
-    return filtrertPåVilkårOgEndretUtbetaling +
-        filtrertPåReduksjonFraForrigeBehandling +
-        filtrertPåOpphørFraForrigeBehandling +
-        filtrertPåSmåbarnstillegg +
-        filtrertPåEtterEndretUtbetaling +
-        filtrertPåHendelser
+    return filtrertPåVilkårOgEndretUtbetaling + filtrertPåReduksjonFraForrigeBehandling + filtrertPåOpphørFraForrigeBehandling + filtrertPåSmåbarnstillegg + filtrertPåEtterEndretUtbetaling + filtrertPåHendelser
 }
 
 private fun SanityBegrunnelse.erGjeldendeForFagsakType(
@@ -246,8 +246,7 @@ private fun filtrerPåEndretUtbetaling(
 private fun filtrerPåVilkår(
     it: SanityBegrunnelse,
     begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode,
-) = !it.begrunnelseGjelderReduksjonFraForrigeBehandling() &&
-    it.erGjeldendeForUtgjørendeVilkår(begrunnelseGrunnlag)
+) = !it.begrunnelseGjelderReduksjonFraForrigeBehandling() && it.erGjeldendeForUtgjørendeVilkår(begrunnelseGrunnlag)
 
 private fun SanityBegrunnelse.erGjeldendeForReduksjonFraForrigeBehandling(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode): Boolean {
     if (begrunnelseGrunnlag !is BegrunnelseGrunnlagForPeriodeMedReduksjonPåTversAvBehandlinger) {
@@ -259,8 +258,7 @@ private fun SanityBegrunnelse.erGjeldendeForReduksjonFraForrigeBehandling(begrun
             .map { it.vilkårType }.toSet()
     val oppfylteVilkårForrigeBehandling =
         begrunnelseGrunnlag.sammePeriodeForrigeBehandling?.vilkårResultater?.filter { it.resultat == Resultat.OPPFYLT }
-            ?.map { it.vilkårType }?.toSet()
-            ?: emptySet()
+            ?.map { it.vilkårType }?.toSet() ?: emptySet()
 
     val vilkårMistetSidenForrigeBehandling = oppfylteVilkårForrigeBehandling - oppfylteVilkårDenneBehandlingen
 
@@ -284,17 +282,14 @@ private fun SanityBegrunnelse.erGjeldendeForOpphørFraForrigeBehandling(begrunne
     val oppfylteVilkårsresultaterForrigeBehandling =
         begrunnelseGrunnlag.sammePeriodeForrigeBehandling?.vilkårResultater?.filter { it.resultat == Resultat.OPPFYLT }
     val oppfylteVilkårForrigeBehandling =
-        oppfylteVilkårsresultaterForrigeBehandling
-            ?.map { it.vilkårType }?.toSet()
-            ?: emptySet()
+        oppfylteVilkårsresultaterForrigeBehandling?.map { it.vilkårType }?.toSet() ?: emptySet()
 
     val vilkårMistetSidenForrigeBehandling = oppfylteVilkårForrigeBehandling - oppfylteVilkårDenneBehandlingen
 
-    val begrunnelseGjelderMistedeVilkår =
-        this.erLikVilkårOgUtdypendeVilkårIPeriode(
-            oppfylteVilkårsresultaterForrigeBehandling?.filter { it.vilkårType in vilkårMistetSidenForrigeBehandling }
-                ?: emptyList(),
-        )
+    val begrunnelseGjelderMistedeVilkår = this.erLikVilkårOgUtdypendeVilkårIPeriode(
+        oppfylteVilkårsresultaterForrigeBehandling?.filter { it.vilkårType in vilkårMistetSidenForrigeBehandling }
+            ?: emptyList(),
+    )
 
     val dennePeriodenErFørsteVedtaksperiodePåFagsak = begrunnelseGrunnlag.forrigePeriode == null
 
@@ -321,8 +316,7 @@ private fun hentEØSStandardBegrunnelser(
         erEndringIKompetanse(begrunnelseGrunnlag) && begrunnelse.erLikKompetanseIPeriode(begrunnelseGrunnlag)
     }
 
-    return filtrertPåVilkår +
-        filtrertPåKompetanse
+    return filtrertPåVilkår + filtrertPåKompetanse
 }
 
 private fun SanityBegrunnelse.erGjeldendeForRolle(
@@ -353,9 +347,9 @@ fun SanityEØSBegrunnelse.erLikKompetanseIPeriode(
         -> return false
     }
 
-    return this.annenForeldersAktivitet.contains(kompetanse.annenForeldersAktivitet) &&
-        this.barnetsBostedsland.contains(landkodeTilBarnetsBostedsland(kompetanse.barnetsBostedsland)) &&
-        this.kompetanseResultat.contains(kompetanse.resultat)
+    return this.annenForeldersAktivitet.contains(kompetanse.annenForeldersAktivitet) && this.barnetsBostedsland.contains(
+        landkodeTilBarnetsBostedsland(kompetanse.barnetsBostedsland),
+    ) && this.kompetanseResultat.contains(kompetanse.resultat)
 }
 
 fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåHendelser(
@@ -368,8 +362,11 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåHendelser(
 } else {
     val person = begrunnelseGrunnlag.dennePerioden.person
 
-    this.filtrerPåBarn6år(person, fomVedtaksperiode) +
-        this.filtrerPåSatsendring(person, begrunnelseGrunnlag.dennePerioden.andeler, fomVedtaksperiode)
+    this.filtrerPåBarn6år(person, fomVedtaksperiode) + this.filtrerPåSatsendring(
+        person,
+        begrunnelseGrunnlag.dennePerioden.andeler,
+        fomVedtaksperiode,
+    )
 }
 
 fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåBarn6år(
@@ -407,10 +404,9 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåSatsendring(
 ): Map<Standardbegrunnelse, SanityBegrunnelse> {
     val satstyperPåAndelene = andeler.map { it.type.tilSatsType(person, fomVedtaksperiode ?: TIDENES_MORGEN) }.toSet()
 
-    val erSatsendringIPeriodenForPerson =
-        satstyperPåAndelene.any { satstype ->
-            SatsService.finnAlleSatserFor(satstype).any { it.gyldigFom == fomVedtaksperiode }
-        }
+    val erSatsendringIPeriodenForPerson = satstyperPåAndelene.any { satstype ->
+        SatsService.finnAlleSatserFor(satstype).any { it.gyldigFom == fomVedtaksperiode }
+    }
 
     return if (erSatsendringIPeriodenForPerson) {
         this.filterValues { it.ovrigeTriggere.contains(ØvrigTrigger.SATSENDRING) }
@@ -421,26 +417,26 @@ fun Map<Standardbegrunnelse, SanityBegrunnelse>.filtrerPåSatsendring(
 
 private fun hentResultaterForForrigePeriode(
     begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
-) = if (begrunnelseGrunnlagForrigePeriode?.erOrdinæreVilkårInnvilget() == true &&
-    begrunnelseGrunnlagForrigePeriode.erInnvilgetEtterEndretUtbetaling()
-) {
-    listOf(
-        SanityPeriodeResultat.REDUKSJON,
-        SanityPeriodeResultat.INNVILGET_ELLER_ØKNING,
-    )
-} else {
-    listOf(
-        SanityPeriodeResultat.REDUKSJON,
-        SanityPeriodeResultat.IKKE_INNVILGET,
-    )
-}
+) =
+    if (begrunnelseGrunnlagForrigePeriode?.erOrdinæreVilkårInnvilget() == true && begrunnelseGrunnlagForrigePeriode.erInnvilgetEtterEndretUtbetaling()) {
+        listOf(
+            SanityPeriodeResultat.REDUKSJON,
+            SanityPeriodeResultat.INNVILGET_ELLER_ØKNING,
+        )
+    } else {
+        listOf(
+            SanityPeriodeResultat.REDUKSJON,
+            SanityPeriodeResultat.IKKE_INNVILGET,
+        )
+    }
 
 private fun hentResultaterForPeriode(
     begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
     begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
 ): List<SanityPeriodeResultat> {
-    val erAndelerPåPersonHvisBarn = begrunnelseGrunnlagForPeriode.person.type != PersonType.BARN ||
-        begrunnelseGrunnlagForPeriode.andeler.toList().isNotEmpty()
+    val erAndelerPåPersonHvisBarn =
+        begrunnelseGrunnlagForPeriode.person.type != PersonType.BARN || begrunnelseGrunnlagForPeriode.andeler.toList()
+            .isNotEmpty()
 
     val erInnvilgetEtterVilkårOgEndretUtbetaling =
         begrunnelseGrunnlagForPeriode.erOrdinæreVilkårInnvilget() && begrunnelseGrunnlagForPeriode.erInnvilgetEtterEndretUtbetaling()
@@ -481,8 +477,7 @@ private fun erReduksjonIAndelMellomPerioder(
     val andelerDennePerioden = begrunnelseGrunnlagForPeriode?.andeler ?: emptyList()
 
     return andelerForrigePeriode.any { andelIForrigePeriode ->
-        val sammeAndelDennePerioden =
-            andelerDennePerioden.singleOrNull { andelIForrigePeriode.type == it.type }
+        val sammeAndelDennePerioden = andelerDennePerioden.singleOrNull { andelIForrigePeriode.type == it.type }
 
         val erAndelenMistet =
             sammeAndelDennePerioden == null && begrunnelseGrunnlagForrigePeriode?.erInnvilgetEtterEndretUtbetaling() == true
@@ -502,8 +497,7 @@ private fun erØkningIAndelMellomPerioder(
     val andelerDennePerioden = begrunnelseGrunnlagForPeriode.andeler
 
     return andelerDennePerioden.any { andelIPeriode ->
-        val sammeAndelForrigePeriode =
-            andelerForrigePeriode.singleOrNull { andelIPeriode.type == it.type }
+        val sammeAndelForrigePeriode = andelerForrigePeriode.singleOrNull { andelIPeriode.type == it.type }
 
         val erAndelenTjent =
             sammeAndelForrigePeriode == null && begrunnelseGrunnlagForPeriode.erInnvilgetEtterEndretUtbetaling()
@@ -585,12 +579,10 @@ private fun SanityBegrunnelse.erDeltBostedUtbetalingstype(
 }
 
 private fun hentEndretUtbetalingDennePerioden(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode) =
-    begrunnelseGrunnlag.dennePerioden.endretUtbetalingAndel
-        .takeIf { begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget() }
+    begrunnelseGrunnlag.dennePerioden.endretUtbetalingAndel.takeIf { begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget() }
 
 private fun hentEndretUtbetalingForrigePeriode(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode) =
-    begrunnelseGrunnlag.forrigePeriode?.endretUtbetalingAndel
-        .takeIf { begrunnelseGrunnlag.forrigePeriode?.erOrdinæreVilkårInnvilget() == true }
+    begrunnelseGrunnlag.forrigePeriode?.endretUtbetalingAndel.takeIf { begrunnelseGrunnlag.forrigePeriode?.erOrdinæreVilkårInnvilget() == true }
 
 private fun UtvidetVedtaksperiodeMedBegrunnelser.finnBegrunnelseGrunnlagPerPerson(
     behandlingsGrunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
@@ -637,8 +629,7 @@ private fun Tidslinje<UtvidetVedtaksperiodeMedBegrunnelser, Måned>.lagTidslinje
 ): Tidslinje<IBegrunnelseGrunnlagForPeriode, Måned> {
     val grunnlagMedForrigePeriodeTidslinje = grunnlagTidslinje.tilForrigeOgNåværendePeriodeTidslinje(this)
 
-    val grunnlagForrigeBehandlingTidslinje =
-        grunnlagTidslinjePerPersonForrigeBehandling?.get(person) ?: TomTidslinje()
+    val grunnlagForrigeBehandlingTidslinje = grunnlagTidslinjePerPersonForrigeBehandling?.get(person) ?: TomTidslinje()
 
     return this.kombinerMed(
         grunnlagMedForrigePeriodeTidslinje,
@@ -686,8 +677,8 @@ private fun Tidslinje<BegrunnelseGrunnlagForPersonIPeriode, Måned>.tilForrigeOg
             månedPeriodeAv(YearMonth.now(), YearMonth.now(), null),
         ) + grunnlagPerioderSplittetPåVedtaksperiode
         ).zipWithNext { forrige, denne ->
-            periodeAv(denne.fraOgMed, denne.tilOgMed, ForrigeOgDennePerioden(forrige.innhold, denne.innhold))
-        }.tilTidslinje()
+        periodeAv(denne.fraOgMed, denne.tilOgMed, ForrigeOgDennePerioden(forrige.innhold, denne.innhold))
+    }.tilTidslinje()
 }
 
 private fun SanityBegrunnelse.erGjeldendeForSmåbarnstillegg(
@@ -700,18 +691,16 @@ private fun SanityBegrunnelse.erGjeldendeForSmåbarnstillegg(
 
     val erSmåbarnstilleggIForrigeBehandlingPeriode = begrunnelseGrunnlag.erSmåbarnstilleggIForrigeBehandlingPeriode
 
-    val begrunnelseGjelderSmåbarnstillegg =
-        UtvidetBarnetrygdTrigger.SMÅBARNSTILLEGG in utvidetBarnetrygdTriggere
+    val begrunnelseGjelderSmåbarnstillegg = UtvidetBarnetrygdTrigger.SMÅBARNSTILLEGG in utvidetBarnetrygdTriggere
 
     val erEndringISmåbarnstilleggFraForrigeBehandling =
         erSmåbarnstilleggIForrigeBehandlingPeriode != erSmåbarnstilleggDennePerioden
 
-    val begrunnelseMatcherPeriodeResultat =
-        this.matcherPerioderesultat(
-            erSmåbarnstilleggForrigePeriode,
-            erSmåbarnstilleggDennePerioden,
-            erSmåbarnstilleggIForrigeBehandlingPeriode,
-        )
+    val begrunnelseMatcherPeriodeResultat = this.matcherPerioderesultat(
+        erSmåbarnstilleggForrigePeriode,
+        erSmåbarnstilleggDennePerioden,
+        erSmåbarnstilleggIForrigeBehandlingPeriode,
+    )
 
     val erEndringISmåbarnstillegg = erSmåbarnstilleggForrigePeriode != erSmåbarnstilleggDennePerioden
 
@@ -737,5 +726,4 @@ private fun SanityBegrunnelse.matcherPerioderesultat(
 }
 
 private fun erEndringIKompetanse(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode) =
-    begrunnelseGrunnlag.dennePerioden.kompetanse !=
-        begrunnelseGrunnlag.forrigePeriode?.kompetanse
+    begrunnelseGrunnlag.dennePerioden.kompetanse != begrunnelseGrunnlag.forrigePeriode?.kompetanse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/produsent/VedtaksperiodeGrunnlagForPerson.kt
@@ -106,12 +106,14 @@ data class EndretUtbetalingAndelForVedtaksperiode(
 
 data class AndelForVedtaksperiode(
     val kalkulertUtbetalingsbeløp: Int,
+    val nasjonaltPeriodebeløp: Int?,
     val type: YtelseType,
     val prosent: BigDecimal,
     val sats: Int,
 ) {
     constructor(andelTilkjentYtelse: AndelTilkjentYtelse) : this(
         kalkulertUtbetalingsbeløp = andelTilkjentYtelse.kalkulertUtbetalingsbeløp,
+        nasjonaltPeriodebeløp = andelTilkjentYtelse.nasjonaltPeriodebeløp,
         type = andelTilkjentYtelse.type,
         prosent = andelTilkjentYtelse.prosent,
         sats = andelTilkjentYtelse.sats,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -39,6 +39,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityVilkår
+import no.nav.familie.ba.sak.kjerne.brev.domene.Tema
 import no.nav.familie.ba.sak.kjerne.brev.domene.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårRolle
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
@@ -1194,6 +1195,7 @@ fun lagRestSanityBegrunnelse(
     endretUtbetalingsperiodeTriggere: List<String>? = emptyList(),
     vedtakResultat: String? = null,
     fagsakType: String? = null,
+    tema: String? = null,
 
 ): RestSanityBegrunnelse = RestSanityBegrunnelse(
     apiNavn = apiNavn,
@@ -1212,6 +1214,7 @@ fun lagRestSanityBegrunnelse(
     endretUtbetalingsperiodeTriggere = endretUtbetalingsperiodeTriggere,
     vedtakResultat = vedtakResultat,
     fagsakType = fagsakType,
+    tema = tema,
 )
 
 fun lagSanityBegrunnelse(
@@ -1263,6 +1266,7 @@ fun lagSanityEøsBegrunnelse(
     hjemlerSeperasjonsavtalenStorbritannina: List<String> = emptyList(),
     vilkår: List<Vilkår> = emptyList(),
     fagsakType: FagsakType? = null,
+    tema: Tema? = null,
 ): SanityEØSBegrunnelse = SanityEØSBegrunnelse(
     apiNavn = apiNavn,
     navnISystem = navnISystem,
@@ -1276,6 +1280,7 @@ fun lagSanityEøsBegrunnelse(
     hjemlerSeperasjonsavtalenStorbritannina = hjemlerSeperasjonsavtalenStorbritannina,
     vilkår = vilkår.toSet(),
     fagsakType = fagsakType,
+    tema = tema,
 )
 
 fun lagTriggesAv(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -223,7 +223,7 @@ class BegrunnelseTeksterStepDefinition {
     }
 
     /**
-     * Mulige verdier: | Fra dato | Til dato | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser | Ekskluderte Begrunnelser |
+     * Mulige verdier: | Fra dato | Til dato | VedtaksperiodeType | Regelverk Inkluderte Begrunnelser | Inkluderte Begrunnelser | Regelverk Ekskluderte Begrunnelser | Ekskluderte Begrunnelser |
      */
     @Så("forvent følgende standardBegrunnelser")
     fun `forvent følgende standardBegrunnelser`(dataTable: DataTable) {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BrevBegrunnelseParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BrevBegrunnelseParser.kt
@@ -11,20 +11,25 @@ object BrevBegrunnelseParser {
 
     fun mapStandardBegrunnelser(dataTable: DataTable): List<SammenlignbarBegrunnelse> {
         return dataTable.asMaps().map { rad ->
-            val vurderesEtter: Regelverk =
-                parseValgfriEnum<Regelverk>(DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.REGELVERK, rad)
+            val regelverkForInkluderteBegrunnelser =
+                parseValgfriEnum<Regelverk>(DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.REGELVERK_INKLUDERTE_BEGRUNNELSER, rad)
                     ?: Regelverk.NASJONALE_REGLER
 
+            val regelverkForEkskluderteBegrunnelser =
+                parseValgfriEnum<Regelverk>(DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.REGELVERK_EKSKLUDERTE_BEGRUNNELSER, rad)
+                    ?: regelverkForInkluderteBegrunnelser
+
             val inkluderteStandardBegrunnelser = hentForventedeBegrunnelser(
-                vurderesEtter,
+                regelverkForInkluderteBegrunnelser,
                 DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.INKLUDERTE_BEGRUNNELSER,
                 rad,
             )
             val ekskluderteStandardBegrunnelser = hentForventedeBegrunnelser(
-                vurderesEtter,
+                regelverkForEkskluderteBegrunnelser,
                 DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.EKSKLUDERTE_BEGRUNNELSER,
                 rad,
             )
+
             SammenlignbarBegrunnelse(
                 fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad),
                 tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad),
@@ -61,6 +66,7 @@ object BrevBegrunnelseParser {
         VEDTAKSPERIODE_TYPE("VedtaksperiodeType"),
         INKLUDERTE_BEGRUNNELSER("Inkluderte Begrunnelser"),
         EKSKLUDERTE_BEGRUNNELSER("Ekskluderte Begrunnelser"),
-        REGELVERK("Regelverk"),
+        REGELVERK_INKLUDERTE_BEGRUNNELSER("Regelverk Inkluderte Begrunnelser"),
+        REGELVERK_EKSKLUDERTE_BEGRUNNELSER("Regelverk Ekskluderte Begrunnelser"),
     }
 }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -35,10 +35,10 @@ Egenskap: Begrunnelser for kompetanser
     Når begrunnelsetekster genereres for behandling 1
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser                            | Ekskluderte Begrunnelser                              |
-      | 01.05.2020 | 30.04.2021 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE    |
-      | 01.05.2021 | 31.03.2038 | Utbetaling         | EØS_FORORDNINGEN | INNVILGET_SEKUNDÆRLAND_STANDARD                    | INNVILGET_SEKUNDÆRLAND_TO_ARBEIDSLAND_NORGE_UTBETALER |
-      | 01.04.2038 |            | Opphør             |                  |                                                    |                                                       |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Inkluderte Begrunnelser | Inkluderte Begrunnelser                            | Ekskluderte Begrunnelser                              |
+      | 01.05.2020 | 30.04.2021 | Utbetaling         | EØS_FORORDNINGEN                  | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_JOBBER_I_NORGE    |
+      | 01.05.2021 | 31.03.2038 | Utbetaling         | EØS_FORORDNINGEN                  | INNVILGET_SEKUNDÆRLAND_STANDARD                    | INNVILGET_SEKUNDÆRLAND_TO_ARBEIDSLAND_NORGE_UTBETALER |
+      | 01.04.2038 |            | Opphør             |                                   |                                                    |                                                       |
 
   Scenario: Ikke vis kompetansebegrunnelser dersom kompetansen ikke endrer seg
     Gitt følgende behandling
@@ -76,11 +76,11 @@ Egenskap: Begrunnelser for kompetanser
     Når begrunnelsetekster genereres for behandling 100173206
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser | Ekskluderte Begrunnelser      |
-      | 01.04.2023 | 30.06.2023 | UTBETALING         |                  |                         |                               |
-      | 01.07.2023 | 31.07.2023 | UTBETALING         | EØS_FORORDNINGEN |                         | INNVILGET_PRIMÆRLAND_STANDARD |
-      | 01.08.2023 | 31.01.2033 | UTBETALING         |                  |                         |                               |
-      | 01.02.2033 |            | OPPHØR             |                  |                         |                               |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Inkluderte Begrunnelser | Inkluderte Begrunnelser | Ekskluderte Begrunnelser      |
+      | 01.04.2023 | 30.06.2023 | UTBETALING         |                                   |                         |                               |
+      | 01.07.2023 | 31.07.2023 | UTBETALING         | EØS_FORORDNINGEN                  |                         | INNVILGET_PRIMÆRLAND_STANDARD |
+      | 01.08.2023 | 31.01.2033 | UTBETALING         |                                   |                         |                               |
+      | 01.02.2033 |            | OPPHØR             |                                   |                         |                               |
 
   Scenario: Skal gi riktig begrunnelse ved opphør av EØS-sak
     Gitt følgende behandling
@@ -116,10 +116,10 @@ Egenskap: Begrunnelser for kompetanser
     Når begrunnelsetekster genereres for behandling 100173207
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser            | Ekskluderte Begrunnelser |
-      | 01.04.2023 | 30.06.2023 | UTBETALING         |                  |                                    |                          |
-      | 01.07.2023 | 31.08.2023 | UTBETALING         |                  |                                    |                          |
-      | 01.09.2023 |            | OPPHØR             | EØS_FORORDNINGEN | OPPHØR_IKKE_STATSBORGER_I_EØS_LAND |                          |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Inkluderte Begrunnelser | Inkluderte Begrunnelser            | Ekskluderte Begrunnelser |
+      | 01.04.2023 | 30.06.2023 | UTBETALING         |                                   |                                    |                          |
+      | 01.07.2023 | 31.08.2023 | UTBETALING         |                                   |                                    |                          |
+      | 01.09.2023 |            | OPPHØR             | EØS_FORORDNINGEN                  | OPPHØR_IKKE_STATSBORGER_I_EØS_LAND |                          |
 
   Scenario: Skal begrunne endring i kompetanse, når resultat er fortsatt innvilget
     Gitt følgende fagsaker for begrunnelse
@@ -180,8 +180,8 @@ Egenskap: Begrunnelser for kompetanser
     Når begrunnelsetekster genereres for behandling 2
 
     Så forvent følgende standardBegrunnelser
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk        | Inkluderte Begrunnelser                | Ekskluderte Begrunnelser                              |
-      | 01.05.2023 | 30.06.2023 | UTBETALING         | EØS_FORORDNINGEN | FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD | REDUKSJON_BARN_DØD_EØS,REDUKSJON_IKKE_ANSVAR_FOR_BARN |
-      | 01.07.2023 | 31.01.2033 | UTBETALING         |                  |                                        |                                                       |
-      | 01.02.2033 |            | OPPHØR             |                  |                                        |                                                       |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Inkluderte Begrunnelser | Inkluderte Begrunnelser                | Ekskluderte Begrunnelser                              |
+      | 01.05.2023 | 30.06.2023 | UTBETALING         | EØS_FORORDNINGEN                  | FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD | REDUKSJON_BARN_DØD_EØS,REDUKSJON_IKKE_ANSVAR_FOR_BARN |
+      | 01.07.2023 | 31.01.2033 | UTBETALING         |                                   |                                        |                                                       |
+      | 01.02.2033 |            | OPPHØR             |                                   |                                        |                                                       |
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/tema.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/tema.feature
@@ -1,0 +1,96 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Tema
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId |
+      | 1            | 1        |                     |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 02.01.1985  |
+      | 1            | 4567    | BARN       | 07.09.2019  |
+
+  Scenario: Man skal ikke få nasjonale begrunnelser dersom vedtaksperiode overlapper med eøs perioder
+    Og følgende dagens dato 2023-09-13
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                          | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | LOVLIG_OPPHOLD                  |                              | 02.01.1985 |            | OPPFYLT  | Nei                  |
+      | 1234    | BOSATT_I_RIKET                  | OMFATTET_AV_NORSK_LOVGIVNING | 02.01.1985 |            | OPPFYLT  | Nei                  |
+
+      | 4567    | UNDER_18_ÅR                     |                              | 07.09.2019 | 06.09.2037 | OPPFYLT  | Nei                  |
+      | 4567    | LOVLIG_OPPHOLD,GIFT_PARTNERSKAP |                              | 07.09.2019 |            | OPPFYLT  | Nei                  |
+      | 4567    | BOSATT_I_RIKET                  | BARN_BOR_I_NORGE             | 07.09.2019 |            | OPPFYLT  | Nei                  |
+      | 4567    | BOR_MED_SØKER                   | BARN_BOR_I_EØS_MED_SØKER     | 07.09.2019 |            | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent |
+      | 4567    | 1            | 01.10.2019 | 31.08.2020 | 1054  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.09.2020 | 31.08.2021 | 1354  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.09.2021 | 31.12.2021 | 1654  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.01.2022 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.07.2023 | 31.08.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.09.2025 | 31.08.2037 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+
+    Og med kompetanser for begrunnelse
+      | AktørId | Fra dato   | Til dato | Resultat            | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 4567    | 01.10.2019 |          | NORGE_ER_PRIMÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | SE                             | SE                  |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Inkluderte Begrunnelser | Inkluderte Begrunnelser                           | Regelverk Ekskluderte Begrunnelser | Ekskluderte Begrunnelser     |
+      | 01.10.2019 | 31.08.2020 | UTBETALING         | EØS_FORORDNINGEN                  | INNVILGET_PRIMÆRLAND_BARNETRYGD_ALLEREDE_UTBETALT | NASJONALE_REGLER                   | INNVILGET_NYFØDT_BARN_FØRSTE |
+      | 01.09.2020 | 31.08.2021 | UTBETALING         |                                   |                                                   |                                    |                              |
+      | 01.09.2021 | 31.12.2021 | UTBETALING         |                                   |                                                   |                                    |                              |
+      | 01.01.2022 | 28.02.2023 | UTBETALING         |                                   |                                                   |                                    |                              |
+      | 01.03.2023 | 30.06.2023 | UTBETALING         |                                   |                                                   |                                    |                              |
+      | 01.07.2023 | 31.08.2025 | UTBETALING         |                                   |                                                   |                                    |                              |
+      | 01.09.2025 | 31.08.2037 | UTBETALING         |                                   |                                                   |                                    |                              |
+      | 01.09.2037 |            | OPPHØR             |                                   |                                                   |                                    |                              |
+
+  Scenario: Man skal ikke få eøs begrunnelser dersom vedtaksperiode ikke overlapper med nasjonale perioder
+    Og følgende dagens dato 2023-09-13
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                          | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1234    | LOVLIG_OPPHOLD                  |                              | 02.01.1985 |            | OPPFYLT  | Nei                  |
+      | 1234    | BOSATT_I_RIKET                  | OMFATTET_AV_NORSK_LOVGIVNING | 02.01.1985 |            | OPPFYLT  | Nei                  |
+
+      | 4567    | UNDER_18_ÅR                     |                              | 07.09.2019 | 06.09.2037 | OPPFYLT  | Nei                  |
+      | 4567    | LOVLIG_OPPHOLD,GIFT_PARTNERSKAP |                              | 07.09.2019 |            | OPPFYLT  | Nei                  |
+      | 4567    | BOSATT_I_RIKET                  | BARN_BOR_I_NORGE             | 07.09.2019 |            | OPPFYLT  | Nei                  |
+      | 4567    | BOR_MED_SØKER                   | BARN_BOR_I_EØS_MED_SØKER     | 07.09.2019 |            | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent |
+      | 4567    | 1            | 01.10.2019 | 31.08.2020 | 1054  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.09.2020 | 31.08.2021 | 1354  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.09.2021 | 31.12.2021 | 1654  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.01.2022 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.07.2023 | 31.08.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     |
+      | 4567    | 1            | 01.09.2025 | 31.08.2037 | 1310  | ORDINÆR_BARNETRYGD | 100     |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Inkluderte Begrunnelser | Inkluderte Begrunnelser                  | Regelverk Ekskluderte Begrunnelser | Ekskluderte Begrunnelser                          |
+      | 01.10.2019 | 31.08.2020 | UTBETALING         | NASJONALE_REGLER                  | INNVILGET_BOSATT_I_RIKTET_LOVLIG_OPPHOLD | EØS_FORORDNINGEN                   | INNVILGET_PRIMÆRLAND_BARNETRYGD_ALLEREDE_UTBETALT |
+      | 01.09.2020 | 31.08.2021 | UTBETALING         |                                   |                                          |                                    |                                                   |
+      | 01.09.2021 | 31.12.2021 | UTBETALING         |                                   |                                          |                                    |                                                   |
+      | 01.01.2022 | 28.02.2023 | UTBETALING         |                                   |                                          |                                    |                                                   |
+      | 01.03.2023 | 30.06.2023 | UTBETALING         |                                   |                                          |                                    |                                                   |
+      | 01.07.2023 | 31.08.2025 | UTBETALING         |                                   |                                          |                                    |                                                   |
+      | 01.09.2025 | 31.08.2037 | UTBETALING         |                                   |                                          |                                    |                                                   |
+      | 01.09.2037 |            | OPPHØR             |                                   |                                          |                                    |                                                   |


### PR DESCRIPTION
Favrokort: [NAV-13724](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13724)

Vi ønsker å kunne filtrere bort EØS begrunnelser for en periode (per person) dersom perioden er vurdert etter nasjonale regler, og vi ønsker å kunne filtrere bort nasjonale begrunnelser dersom en periode er vurdert etter EØS regler.
Dette er satt på feltet tema i sanity.
Dersom det er begrunnelser med tema felles som har blitt trigget i enten nasjonal eller eøs, så ønsker vi også å ta med disse.

Logikken er dersom som følges:

- Dersom man har en kompetanse i nåværende grunnlagperiode så sier man at perioden er vurdert etter eøs.
- Dersom man har hatt en kompetanse periode i forrige periode, men har mistet den, så må man se på nærmere på det:
 - Hvis det fortsatt eksisterer andeler som har høyere nasjonalt periode beløp enn 0, så har man bare gått over til nasjonal regelverk. Da setter man det vurdert etter nasjonale regler. (se bilde)
 - Hvis det ikke eksisterer andeler som har høyere nasjonalt periode beløp enn 0, så ønsker man å begrunne med eøs reduksjon og opphør tekster, så man setter vurdert etter til eøs.
 
 
![Screenshot 2023-09-14 at 10 15 23](https://github.com/navikt/familie-ba-sak/assets/110383605/08efb169-1b58-450d-bb39-ea8df1ab876f)

 
 I tillegg er det gjort noe utvidelser i test-rammeverket for å tillatte sammenligning av begrunnelser på tvers av regelverk.