### PR TITLE
Fix: Kombinasjon EØS og nasjonal sak med utvidet delt BA

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -123,7 +123,6 @@ spec:
       memory: 1024Mi
       cpu: 500m
   ingresses:
-    - https://familie-ba-sak.dev.intern.nav.no # Deprecated
     - https://familie-ba-sak.intern.dev.nav.no
   secureLogs:
     enabled: true

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -76,6 +76,7 @@ object TilkjentYtelseUtils {
             tilkjentYtelse = tilkjentYtelse,
             andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer = barnasAndelerInkludertEtterbetaling3ÅrEndringer,
             endretUtbetalingAndelerSøker = endretUtbetalingAndelerSøker,
+            personResultater = vilkårsvurdering.personResultater
         )
 
         val småbarnstilleggErMulig = erSmåbarnstilleggMulig(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -76,7 +76,7 @@ object TilkjentYtelseUtils {
             tilkjentYtelse = tilkjentYtelse,
             andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer = barnasAndelerInkludertEtterbetaling3ÅrEndringer,
             endretUtbetalingAndelerSøker = endretUtbetalingAndelerSøker,
-            personResultater = vilkårsvurdering.personResultater
+            personResultater = vilkårsvurdering.personResultater,
         )
 
         val småbarnstilleggErMulig = erSmåbarnstilleggMulig(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -6,8 +6,12 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMedKunVerdi
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullOgIkkeTom
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.leftJoin
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinjeForOppfyltVilkårForVoksenPerson
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
@@ -19,6 +23,7 @@ data class UtvidetBarnetrygdGenerator(
     fun lagUtvidetBarnetrygdAndeler(
         utvidetVilkår: List<VilkårResultat>,
         andelerBarna: List<AndelTilkjentYtelse>,
+        tidslinjerMedPerioderBarnaBorMedSøker: Map<Aktør, Tidslinje<Boolean, Måned>>
     ): List<AndelTilkjentYtelse> {
         if (utvidetVilkår.isEmpty() || andelerBarna.isEmpty()) return emptyList()
 
@@ -26,8 +31,14 @@ data class UtvidetBarnetrygdGenerator(
 
         val utvidetVilkårTidslinje = utvidetVilkår.tilForskjøvetTidslinjeForOppfyltVilkårForVoksenPerson(Vilkår.UTVIDET_BARNETRYGD)
 
-        val størsteProsentTidslinje = andelerBarna
-            .tilSeparateTidslinjerForBarna().values
+        val barnasAndelerFiltrertForPerioderBarnaBorMedSøker = andelerBarna.tilSeparateTidslinjerForBarna().leftJoin(tidslinjerMedPerioderBarnaBorMedSøker) { andelerBarna, barnBorMedSøker ->
+            when (barnBorMedSøker) {
+                true -> andelerBarna
+                else -> null
+            }
+        }
+
+        val størsteProsentTidslinje = barnasAndelerFiltrertForPerioderBarnaBorMedSøker.values
             .kombinerUtenNullOgIkkeTom { andeler -> andeler.maxOf { it.prosent } }
 
         val utvidetAndeler = utvidetVilkårTidslinje.kombinerMedKunVerdi(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -23,7 +23,7 @@ data class UtvidetBarnetrygdGenerator(
     fun lagUtvidetBarnetrygdAndeler(
         utvidetVilkår: List<VilkårResultat>,
         andelerBarna: List<AndelTilkjentYtelse>,
-        tidslinjerMedPerioderBarnaBorMedSøker: Map<Aktør, Tidslinje<Boolean, Måned>>
+        tidslinjerMedPerioderBarnaBorMedSøker: Map<Aktør, Tidslinje<Boolean, Måned>>,
     ): List<AndelTilkjentYtelse> {
         if (utvidetVilkår.isEmpty() || andelerBarna.isEmpty()) return emptyList()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
@@ -34,7 +34,7 @@ object UtvidetBarnetrygdUtil {
             .lagUtvidetBarnetrygdAndeler(
                 utvidetVilkår = utvidetVilkår,
                 andelerBarna = andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer.map { it.andel },
-                tidslinjerMedPerioderBarnaBorMedSøker = tidslinjerMedPerioderBarnaBorMedSøker
+                tidslinjerMedPerioderBarnaBorMedSøker = tidslinjerMedPerioderBarnaBorMedSøker,
             )
 
         return TilkjentYtelseUtils.oppdaterTilkjentYtelseMedEndretUtbetalingAndeler(
@@ -51,7 +51,7 @@ object UtvidetBarnetrygdUtil {
                     vilkårResultat?.utdypendeVilkårsvurderinger?.none {
                         it in listOf(
                             UtdypendeVilkårsvurdering.BARN_BOR_I_EØS_MED_ANNEN_FORELDER,
-                            UtdypendeVilkårsvurdering.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER
+                            UtdypendeVilkårsvurdering.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER,
                         )
                     }
                 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
@@ -9,6 +9,10 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.lagForskjøvetTidslinjeForOppfylteVilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
@@ -19,7 +23,10 @@ object UtvidetBarnetrygdUtil {
         andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
         tilkjentYtelse: TilkjentYtelse,
         endretUtbetalingAndelerSøker: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
+        personResultater: Set<PersonResultat>,
     ): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
+        val tidslinjerMedPerioderBarnaBorMedSøker = finnPerioderBarnaBorMedSøker(personResultater)
+
         val andelerTilkjentYtelseUtvidet = UtvidetBarnetrygdGenerator(
             behandlingId = tilkjentYtelse.behandling.id,
             tilkjentYtelse = tilkjentYtelse,
@@ -27,6 +34,7 @@ object UtvidetBarnetrygdUtil {
             .lagUtvidetBarnetrygdAndeler(
                 utvidetVilkår = utvidetVilkår,
                 andelerBarna = andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer.map { it.andel },
+                tidslinjerMedPerioderBarnaBorMedSøker = tidslinjerMedPerioderBarnaBorMedSøker
             )
 
         return TilkjentYtelseUtils.oppdaterTilkjentYtelseMedEndretUtbetalingAndeler(
@@ -34,6 +42,20 @@ object UtvidetBarnetrygdUtil {
             endretUtbetalingAndeler = endretUtbetalingAndelerSøker,
         )
     }
+
+    private fun finnPerioderBarnaBorMedSøker(personResultater: Set<PersonResultat>) =
+        personResultater.associate { personResultat ->
+            personResultat.aktør to personResultat.vilkårResultater
+                .lagForskjøvetTidslinjeForOppfylteVilkår(Vilkår.BOR_MED_SØKER)
+                .map { vilkårResultat ->
+                    vilkårResultat?.utdypendeVilkårsvurderinger?.none {
+                        it in listOf(
+                            UtdypendeVilkårsvurdering.BARN_BOR_I_EØS_MED_ANNEN_FORELDER,
+                            UtdypendeVilkårsvurdering.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER
+                        )
+                    }
+                }
+        }
 
     internal fun finnUtvidetVilkår(vilkårsvurdering: Vilkårsvurdering): List<VilkårResultat> {
         val utvidetVilkårResultater = vilkårsvurdering.personResultater

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -82,7 +82,7 @@ object VilkårsvurderingForskyvningUtils {
         return this.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår)
     }
 
-    private fun Collection<VilkårResultat>.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår: Vilkår): Tidslinje<VilkårResultat, Måned> {
+    fun Collection<VilkårResultat>.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår: Vilkår): Tidslinje<VilkårResultat, Måned> {
         return this
             .filter { it.vilkårType == vilkår && it.erOppfylt() }
             .tilTidslinje()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -258,7 +258,6 @@ internal class UtvidetBarnetrygdTest {
             ),
         )
 
-
         val utvidetAndelerNårBarnMed100ProsentBorMedSøker = UtvidetBarnetrygdGenerator(
             behandlingId = behandling.id,
             tilkjentYtelse = tilkjentYtelse,
@@ -266,7 +265,7 @@ internal class UtvidetBarnetrygdTest {
             utvidetVilkår = listOf(utvidetVilkår),
             andelerBarna = barnasAndeler,
             tidslinjerMedPerioderBarnaBorMedSøker = barnasAndeler
-                .tilSeparateTidslinjerForBarna().mapValues { it.value.map { true } }
+                .tilSeparateTidslinjerForBarna().mapValues { it.value.map { true } },
         )
 
         val utvidetAndelerNårKunBarnMed50ProsentBorMedSøker = UtvidetBarnetrygdGenerator(
@@ -276,7 +275,7 @@ internal class UtvidetBarnetrygdTest {
             utvidetVilkår = listOf(utvidetVilkår),
             andelerBarna = barnasAndeler,
             tidslinjerMedPerioderBarnaBorMedSøker = barnasAndeler
-                .tilSeparateTidslinjerForBarna().mapValues { it.value.map { andel -> andel?.prosent == BigDecimal(50) } }
+                .tilSeparateTidslinjerForBarna().mapValues { it.value.map { andel -> andel?.prosent == BigDecimal(50) } },
         )
 
         assertEquals(BigDecimal(100), utvidetAndelerNårBarnMed100ProsentBorMedSøker.minOf { it.prosent })
@@ -1013,7 +1012,7 @@ internal class UtvidetBarnetrygdTest {
                 utvidetVilkår = listOf(utvidetVilkår),
                 andelerBarna = barnasAndeler,
                 tidslinjerMedPerioderBarnaBorMedSøker =
-                barnasAndeler.tilSeparateTidslinjerForBarna().mapValues { it.value.map { true } }
+                barnasAndeler.tilSeparateTidslinjerForBarna().mapValues { it.value.map { true } },
             )
         }
     }
@@ -1056,7 +1055,7 @@ internal class UtvidetBarnetrygdTest {
             utvidetVilkår = listOf(utvidetVilkår),
             andelerBarna = barnasAndeler,
             tidslinjerMedPerioderBarnaBorMedSøker = barnasAndeler
-                .tilSeparateTidslinjerForBarna().mapValues { it.value.map { true } }
+                .tilSeparateTidslinjerForBarna().mapValues { it.value.map { true } },
         ).sortedBy { it.stønadFom }
 
         assertEquals(2, utvidetAndeler.size)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
@@ -1,16 +1,27 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.common.lagPersonResultat
 import no.nav.familie.ba.sak.common.lagVilkårResultat
+import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.validerUtvidetVilkårsresultat
+import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.beregnTilkjentYtelseUtvidet
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import java.time.LocalDate
+import java.time.YearMonth
 
 class UtvidetBarnetrygdUtilTest {
+
     @Test
     fun `Valider utvidet vilkår - skal kaste feil hvis fom og tom er i samme kalendermåned uten etterfølgende periode`() {
         val vilkårResultat = lagVilkårResultat(
@@ -20,8 +31,14 @@ class UtvidetBarnetrygdUtilTest {
             resultat = Resultat.OPPFYLT,
         )
 
-        assertThrows<FunksjonellFeil> { validerUtvidetVilkårsresultat(vilkårResultat = vilkårResultat, utvidetVilkårResultater = listOf(vilkårResultat)) }
+        assertThrows<FunksjonellFeil> {
+            validerUtvidetVilkårsresultat(
+                vilkårResultat = vilkårResultat,
+                utvidetVilkårResultater = listOf(vilkårResultat)
+            )
+        }
     }
+
 
     @Test
     fun `Valider utvidet vilkår - skal ikke kaste feil hvis fom og tom er i samme kalendermåned og har etterfølgende periode`() {
@@ -39,6 +56,82 @@ class UtvidetBarnetrygdUtilTest {
             resultat = Resultat.OPPFYLT,
         )
 
-        assertDoesNotThrow { validerUtvidetVilkårsresultat(vilkårResultat = vilkårResultat, utvidetVilkårResultater = listOf(vilkårResultat, etterfølgendeVilkårResultat)) }
+        assertDoesNotThrow {
+            validerUtvidetVilkårsresultat(
+                vilkårResultat = vilkårResultat,
+                utvidetVilkårResultater = listOf(
+                    vilkårResultat,
+                    etterfølgendeVilkårResultat
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Beregn utvidet - skal ikke gi rett til utvidet for perioder der barnet ikke bor med søker`() {
+        val testBeregnUtvidet = TestBeregnTilkjentYtelseUtvidet()
+
+        val feilmeldinger = assertThrows<FunksjonellFeil> {
+            testBeregnUtvidet.med(UtdypendeVilkårsvurdering.BARN_BOR_I_EØS_MED_ANNEN_FORELDER)
+        }.melding to assertThrows<FunksjonellFeil> {
+            testBeregnUtvidet.med(UtdypendeVilkårsvurdering.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER)
+        }.melding
+
+        val forventetFeilmelding = "Du har lagt til utvidet barnetrygd for en periode der det ikke er rett til barnetrygd"
+
+        assertTrue(forventetFeilmelding in feilmeldinger.first && forventetFeilmelding in feilmeldinger.second)
+
+        assertDoesNotThrow {
+            testBeregnUtvidet.med(UtdypendeVilkårsvurdering.BARN_BOR_I_EØS_MED_SØKER)
+        }
+    }
+
+    private class TestBeregnTilkjentYtelseUtvidet {
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+
+        val søker = tilfeldigPerson(personType = PersonType.SØKER)
+        val barn = tilfeldigPerson()
+
+        val personResultatSøker = lagPersonResultat(
+            vilkårsvurdering = Vilkårsvurdering(behandling = tilkjentYtelse.behandling),
+            person = søker,
+            resultat = Resultat.OPPFYLT,
+            periodeFom = LocalDate.of(2021, 10, 1),
+            periodeTom = LocalDate.of(2022, 2, 28),
+        )
+
+        val personResultatBarn = lagPersonResultat(
+            vilkårsvurdering = Vilkårsvurdering(behandling = tilkjentYtelse.behandling),
+            person = barn,
+            resultat = Resultat.OPPFYLT,
+            periodeFom = LocalDate.of(2021, 10, 1),
+            periodeTom = LocalDate.of(2022, 2, 28),
+            vilkårType = Vilkår.BOR_MED_SØKER
+        )
+
+        val utvidetVilkår = lagVilkårResultat(
+            vilkårType = Vilkår.UTVIDET_BARNETRYGD,
+            periodeFom = LocalDate.of(2021, 10, 1),
+            periodeTom = LocalDate.of(2022, 2, 28),
+            resultat = Resultat.OPPFYLT,
+            personResultat = personResultatSøker
+        )
+        fun med(utdypendeVilkårsvurdering: UtdypendeVilkårsvurdering) = utdypendeVilkårsvurdering.let {
+            personResultatBarn.vilkårResultater.first().utdypendeVilkårsvurderinger = listOf(utdypendeVilkårsvurdering)
+
+            beregnTilkjentYtelseUtvidet(
+                utvidetVilkår = listOf(utvidetVilkår),
+                tilkjentYtelse = tilkjentYtelse,
+                andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer = listOf(
+                    lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+                        person = barn,
+                        fom = YearMonth.of(2021, 10),
+                        tom = YearMonth.of(2022, 2)
+                    )
+                ),
+                endretUtbetalingAndelerSøker = emptyList(),
+                personResultater = setOf(personResultatBarn)
+            )
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
@@ -7,16 +7,16 @@ import no.nav.familie.ba.sak.common.lagPersonResultat
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.validerUtvidetVilkårsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.beregnTilkjentYtelseUtvidet
+import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.validerUtvidetVilkårsresultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -34,11 +34,10 @@ class UtvidetBarnetrygdUtilTest {
         assertThrows<FunksjonellFeil> {
             validerUtvidetVilkårsresultat(
                 vilkårResultat = vilkårResultat,
-                utvidetVilkårResultater = listOf(vilkårResultat)
+                utvidetVilkårResultater = listOf(vilkårResultat),
             )
         }
     }
-
 
     @Test
     fun `Valider utvidet vilkår - skal ikke kaste feil hvis fom og tom er i samme kalendermåned og har etterfølgende periode`() {
@@ -61,8 +60,8 @@ class UtvidetBarnetrygdUtilTest {
                 vilkårResultat = vilkårResultat,
                 utvidetVilkårResultater = listOf(
                     vilkårResultat,
-                    etterfølgendeVilkårResultat
-                )
+                    etterfølgendeVilkårResultat,
+                ),
             )
         }
     }
@@ -106,7 +105,7 @@ class UtvidetBarnetrygdUtilTest {
             resultat = Resultat.OPPFYLT,
             periodeFom = LocalDate.of(2021, 10, 1),
             periodeTom = LocalDate.of(2022, 2, 28),
-            vilkårType = Vilkår.BOR_MED_SØKER
+            vilkårType = Vilkår.BOR_MED_SØKER,
         )
 
         val utvidetVilkår = lagVilkårResultat(
@@ -114,8 +113,9 @@ class UtvidetBarnetrygdUtilTest {
             periodeFom = LocalDate.of(2021, 10, 1),
             periodeTom = LocalDate.of(2022, 2, 28),
             resultat = Resultat.OPPFYLT,
-            personResultat = personResultatSøker
+            personResultat = personResultatSøker,
         )
+
         fun med(utdypendeVilkårsvurdering: UtdypendeVilkårsvurdering) = utdypendeVilkårsvurdering.let {
             personResultatBarn.vilkårResultater.first().utdypendeVilkårsvurderinger = listOf(utdypendeVilkårsvurdering)
 
@@ -126,11 +126,11 @@ class UtvidetBarnetrygdUtilTest {
                     lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                         person = barn,
                         fom = YearMonth.of(2021, 10),
-                        tom = YearMonth.of(2022, 2)
-                    )
+                        tom = YearMonth.of(2022, 2),
+                    ),
                 ),
                 endretUtbetalingAndelerSøker = emptyList(),
-                personResultater = setOf(personResultatBarn)
+                personResultater = setOf(personResultatBarn),
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14453) 

Beregner prosenten utvidet andel søker skal ha ut i fra største prosent blant andelene til barna som har oppfylt "bor med søker", uten utdypende vilkårsvurdering som tilsier at de bor hos den andre forelderen.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
