### PR TITLE
Vi ønsker å bare se på fom dato på andelene når vi henter relevante utbetalingsperioder relevant for opphørsperiode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -182,7 +182,7 @@ fun VedtaksperiodeMedBegrunnelser.hentUtbetalingsperiodeDetaljer(
             "Finner ikke segment for vedtaksperiode (${this.fom}, ${this.tom}) blant segmenter ${andelerTilkjentYtelse.utledSegmenter()}",
         )
 
-        Vedtaksperiodetype.OPPHØR -> finnUtbetalingsperioderRelevantForVedtaksperiode(utbetalingsperiodeDetaljer)?.toList()
+        Vedtaksperiodetype.OPPHØR -> finnUtbetalingsperioderRelevantForOpphørVedtaksperiode(utbetalingsperiodeDetaljer)?.toList()
             ?: emptyList()
     }
 }
@@ -195,6 +195,16 @@ private fun VedtaksperiodeMedBegrunnelser.finnUtbetalingsperioderRelevantForVedt
         andelerVertikal.tilOgMed.tilSisteDagIMåneden().tilLocalDate()
             .isSameOrAfter(this.tom ?: TIDENES_ENDE)
 }?.innhold
+
+private fun VedtaksperiodeMedBegrunnelser.finnUtbetalingsperioderRelevantForOpphørVedtaksperiode(
+    utbetalingsperiodeDetaljer: Tidslinje<Iterable<UtbetalingsperiodeDetalj>, Måned>,
+): Iterable<UtbetalingsperiodeDetalj>? {
+    val innhold = utbetalingsperiodeDetaljer.perioder().find { andelerVertikal ->
+        andelerVertikal.fraOgMed.tilFørsteDagIMåneden().tilLocalDate() == this.fom
+    }?.innhold
+
+    return innhold
+}
 
 private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalingerTidslinje(
     personopplysningGrunnlag: PersonopplysningGrunnlag,


### PR DESCRIPTION
Denne oppgaven løser 2 favrokort:

Favrokort: 

- https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15512
- https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15077

Det er nå tillatt å begrunne opphørsperioder med endret utbetalingsbegrunnelser.
Eksisterende logikk som gjør dette bruker andelene for å gjøre det, men siden vi for opphørsperioder har tom som kan være uendelig, så fungerer ikke dette.
Jeg endrer det derfor til at for opphørsperioder, så er det bare relevant å se på fom i vedtaksperioden er lik fom i andel. 
Deretter vil overlapping av perioden + endretutbetaling og beløp bli gjort senere i løpet.