### PR TITLE
Kun se på vilkår som beholdes mellom behandlinger når vi utleder endringstidspunktet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -25,13 +25,13 @@ fun utledEndringstidspunkt(
     val grunnlagTidslinjePerPerson =
         behandlingsGrunnlagForVedtaksperioder.copy(
             personResultater = behandlingsGrunnlagForVedtaksperioder
-                .personResultater.filtrerVilkårBeholdesMellomBehandlinger(),
+                .personResultater.beholdKunOppfylteVilkår(),
         ).utledGrunnlagTidslinjePerPerson()
             .mapValues { it.value.vedtaksperiodeGrunnlagForPerson }
     val grunnlagTidslinjePerPersonForrigeBehandling =
         behandlingsGrunnlagForVedtaksperioderForrigeBehandling?.copy(
             personResultater = behandlingsGrunnlagForVedtaksperioderForrigeBehandling
-                .personResultater.filtrerVilkårBeholdesMellomBehandlinger(),
+                .personResultater.beholdKunOppfylteVilkår(),
         )?.utledGrunnlagTidslinjePerPerson()
             ?.mapValues { it.value.vedtaksperiodeGrunnlagForPerson } ?: emptyMap()
 
@@ -53,7 +53,7 @@ fun utledEndringstidspunkt(
     return datoTidligsteForskjell
 }
 
-private fun Set<PersonResultat>.filtrerVilkårBeholdesMellomBehandlinger(): Set<PersonResultat> = map {
+private fun Set<PersonResultat>.beholdKunOppfylteVilkår(): Set<PersonResultat> = map {
     it.tilKopiForNyVilkårsvurdering(it.vilkårsvurdering)
 }.toSet()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -23,12 +23,15 @@ fun utledEndringstidspunkt(
     behandlingsGrunnlagForVedtaksperioderForrigeBehandling: BehandlingsGrunnlagForVedtaksperioder?,
 ): LocalDate {
     val grunnlagTidslinjePerPerson =
-        behandlingsGrunnlagForVedtaksperioder.utledGrunnlagTidslinjePerPerson()
+        behandlingsGrunnlagForVedtaksperioder.copy(
+            personResultater = behandlingsGrunnlagForVedtaksperioder
+                .personResultater.filtrerVilkårBeholdesMellomBehandlinger(),
+        ).utledGrunnlagTidslinjePerPerson()
             .mapValues { it.value.vedtaksperiodeGrunnlagForPerson }
     val grunnlagTidslinjePerPersonForrigeBehandling =
         behandlingsGrunnlagForVedtaksperioderForrigeBehandling?.copy(
             personResultater = behandlingsGrunnlagForVedtaksperioderForrigeBehandling
-                .personResultater.filtrerVilkårErKopiertTilNesteBehandling(),
+                .personResultater.filtrerVilkårBeholdesMellomBehandlinger(),
         )?.utledGrunnlagTidslinjePerPerson()
             ?.mapValues { it.value.vedtaksperiodeGrunnlagForPerson } ?: emptyMap()
 
@@ -50,7 +53,7 @@ fun utledEndringstidspunkt(
     return datoTidligsteForskjell
 }
 
-private fun Set<PersonResultat>.filtrerVilkårErKopiertTilNesteBehandling(): Set<PersonResultat> = map {
+private fun Set<PersonResultat>.filtrerVilkårBeholdesMellomBehandlinger(): Set<PersonResultat> = map {
     it.tilKopiForNyVilkårsvurdering(it.vilkårsvurdering)
 }.toSet()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -25,13 +25,13 @@ fun utledEndringstidspunkt(
     val grunnlagTidslinjePerPerson =
         behandlingsGrunnlagForVedtaksperioder.copy(
             personResultater = behandlingsGrunnlagForVedtaksperioder
-                .personResultater.beholdKunOppfylteVilkår(),
+                .personResultater.beholdKunOppfylteVilkårResultater(),
         ).utledGrunnlagTidslinjePerPerson()
             .mapValues { it.value.vedtaksperiodeGrunnlagForPerson }
     val grunnlagTidslinjePerPersonForrigeBehandling =
         behandlingsGrunnlagForVedtaksperioderForrigeBehandling?.copy(
             personResultater = behandlingsGrunnlagForVedtaksperioderForrigeBehandling
-                .personResultater.beholdKunOppfylteVilkår(),
+                .personResultater.beholdKunOppfylteVilkårResultater(),
         )?.utledGrunnlagTidslinjePerPerson()
             ?.mapValues { it.value.vedtaksperiodeGrunnlagForPerson } ?: emptyMap()
 
@@ -53,7 +53,7 @@ fun utledEndringstidspunkt(
     return datoTidligsteForskjell
 }
 
-private fun Set<PersonResultat>.beholdKunOppfylteVilkår(): Set<PersonResultat> = map {
+private fun Set<PersonResultat>.beholdKunOppfylteVilkårResultater(): Set<PersonResultat> = map {
     it.tilKopiForNyVilkårsvurdering(it.vilkårsvurdering)
 }.toSet()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
@@ -280,7 +280,7 @@ private fun hentErMinstEttBarnMedUtbetalingTidslinje(
 ): Tidslinje<Boolean, Måned> {
     val søker = persongrunnlag.søker
     val søkerSinerOrdinæreVilkårErOppfyltTidslinje =
-        personResultater.single { it.erSøkersResultater() }.tilTidslinjeForSplittForPerson(
+        personResultater.single { it.aktør == søker.aktør }.tilTidslinjeForSplittForPerson(
             person = søker,
             fagsakType = fagsakType,
         ).map { it != null }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
@@ -178,3 +178,63 @@ Egenskap: Vedtaksperioder - Endringstidspunkt
       | Fra dato   | Til dato   | Vedtaksperiodetype |
       | 2023-02-01 | 2023-02-28 | UTBETALING         |
       | 2023-03-01 |            | OPPHØR             |
+
+  Scenario: Avslag i denne behandlingen skal ikke påvirke endringstidspunktet
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende vedtak
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat          | Behandlingsårsak |
+      | 1            | 1        |                     | ENDRET_OG_FORTSATT_INNVILGET | SØKNAD           |
+      | 2            | 1        | 1                   | AVSLÅTT                      | SØKNAD           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 25.11.1987  |
+      | 1            | 2       | BARN       | 19.06.2017  |
+      | 2            | 1       | SØKER      | 25.11.1987  |
+      | 2            | 2       | BARN       | 19.06.2017  |
+
+    Og følgende dagens dato 20.09.2023
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                         | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1       | LOVLIG_OPPHOLD,BOSATT_I_RIKET                  |                  | 01.09.2020 | 15.05.2035 | OPPFYLT  | Nei                  |
+
+      | 2       | UNDER_18_ÅR                                    |                  | 19.06.2017 | 18.06.2035 | OPPFYLT  | Nei                  |
+      | 2       | BOSATT_I_RIKET,LOVLIG_OPPHOLD,GIFT_PARTNERSKAP |                  | 19.06.2017 |            | OPPFYLT  | Nei                  |
+      | 2       | BOR_MED_SØKER                                  |                  | 19.06.2017 | 31.08.2020 | OPPFYLT  | Nei                  |
+      | 2       | BOR_MED_SØKER                                  | DELT_BOSTED      | 01.09.2020 |            | OPPFYLT  | Nei                  |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                                         | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
+      | 1       | UTVIDET_BARNETRYGD                             |                  |            |            | IKKE_OPPFYLT | Ja                   |
+      | 1       | LOVLIG_OPPHOLD,BOSATT_I_RIKET                  |                  | 01.09.2020 | 15.05.2035 | OPPFYLT      | Nei                  |
+
+      | 2       | BOR_MED_SØKER                                  |                  | 19.06.2017 | 31.08.2020 | OPPFYLT      | Nei                  |
+      | 2       | LOVLIG_OPPHOLD,GIFT_PARTNERSKAP,BOSATT_I_RIKET |                  | 19.06.2017 |            | OPPFYLT      | Nei                  |
+      | 2       | UNDER_18_ÅR                                    |                  | 19.06.2017 | 18.06.2035 | OPPFYLT      | Nei                  |
+      | 2       | BOR_MED_SØKER                                  | DELT_BOSTED      | 01.09.2020 |            | OPPFYLT      | Nei                  |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.09.2020 | 30.09.2020 | 1354  | ORDINÆR_BARNETRYGD | 100     | 1354 |
+      | 2       | 1            | 01.10.2020 | 31.05.2035 | 0     | ORDINÆR_BARNETRYGD | 0       | 1354 |
+
+      | 2       | 2            | 01.09.2020 | 30.09.2020 | 1354  | ORDINÆR_BARNETRYGD | 100     | 1354 |
+      | 2       | 2            | 01.10.2020 | 31.05.2035 | 0     | ORDINÆR_BARNETRYGD | 0       | 1354 |
+
+    Og med endrede utbetalinger
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak       | Prosent |
+      | 2       | 1            | 01.10.2020 | 01.05.2035 | DELT_BOSTED | 0       |
+      | 2       | 2            | 01.10.2020 | 01.05.2035 | DELT_BOSTED | 0       |
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 2
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato | Vedtaksperiodetype |
+      | 01.06.2035 |          | OPPHØR             |
+      |            |          | AVSLAG             |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
@@ -179,7 +179,7 @@ Egenskap: Vedtaksperioder - Endringstidspunkt
       | 2023-02-01 | 2023-02-28 | UTBETALING         |
       | 2023-03-01 |            | OPPHØR             |
 
-  Scenario: Avslag i denne behandlingen skal ikke påvirke endringstidspunktet
+  Scenario: Avslag i behandlingen skal ikke påvirke endringstidspunktet
     Gitt følgende fagsaker
       | FagsakId | Fagsaktype |
       | 1        | NORMAL     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fiks etter muntlig prat rundt [denne behandlingen](https://barnetrygd.intern.dev.nav.no/fagsak/200058751/100177351/vedtak). 

### Bakgrunn
I behandlingen ovenfor ☝️ er det ingen endringer, men det er lagt inn et avslag på utvidet barnetrygd. Da ønsker vi ikke at alle perioder skal dukke opp. Det skjer nå siden avslagsvilkåret påvirker endringstidspunktet som settes til starten av avslagsvilkåret (tidenes morgen). 

Før:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/ca92c2ee-d9f4-4a1f-8e20-c9bcdfa98a2a)

### Endring
Endrer så vi kun ser på vilkår som beholdes mellom behandlinger når vi utleder endringstidspunktet. 

Etter endring:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/13cd127f-e31a-4429-86a6-0191252c5387)


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester
