### PR TITLE
Legg til logikk for nye brevperiode typer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -7,6 +7,8 @@ import no.nav.familie.ba.sak.common.erSenereEnnInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.tilKortString
+import no.nav.familie.ba.sak.common.tilMånedÅr
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.brev.domene.BrevBegrunnelseGrunnlagMedPersoner
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertKompetanse
@@ -59,19 +61,11 @@ class BrevPeriodeGenerator(
 
         if (begrunnelserOgFritekster.isEmpty()) return null
 
-        val tomDato =
-            if (minimertVedtaksperiode.tom?.erSenereEnnInneværendeMåned() == false) {
-                minimertVedtaksperiode.tom.tilDagMånedÅr()
-            } else {
-                null
-            }
-
         val identerIBegrunnelene = begrunnelseGrunnlagMedPersoner
             .filter { it.vedtakBegrunnelseType.erInnvilget() }
             .flatMap { it.personIdenter }
 
         return byggBrevPeriode(
-            tomDato = tomDato,
             begrunnelserOgFritekster = begrunnelserOgFritekster,
             identerIBegrunnelene = identerIBegrunnelene,
         )
@@ -202,13 +196,21 @@ class BrevPeriodeGenerator(
     }
 
     private fun byggBrevPeriode(
-        tomDato: String?,
         begrunnelserOgFritekster: List<BrevBegrunnelse>,
         identerIBegrunnelene: List<String>,
     ): BrevPeriode {
         val (utbetalingerBarn, nullutbetalingerBarn) = minimertVedtaksperiode.minimerteUtbetalingsperiodeDetaljer
             .filter { it.person.type == PersonType.BARN }
             .partition { it.utbetaltPerMnd != 0 }
+
+        val skalBrukeNyBegrunnelseLogikk = featureToggleService.isEnabled(FeatureToggleConfig.BEGRUNNELSER_NY)
+
+        val tomDato =
+            if (minimertVedtaksperiode.tom?.erSenereEnnInneværendeMåned() == false) {
+                if (skalBrukeNyBegrunnelseLogikk) minimertVedtaksperiode.tom.tilMånedÅr() else minimertVedtaksperiode.tom.tilDagMånedÅr()
+            } else {
+                null
+            }
 
         val barnMedUtbetaling = utbetalingerBarn.map { it.person }
         val barnMedNullutbetaling = nullutbetalingerBarn.map { it.person }
@@ -225,11 +227,19 @@ class BrevPeriodeGenerator(
         }
 
         val utbetalingsbeløp = minimertVedtaksperiode.minimerteUtbetalingsperiodeDetaljer.totaltUtbetalt()
-        val brevPeriodeType = hentPeriodetype(minimertVedtaksperiode.fom, barnMedUtbetaling, utbetalingsbeløp)
+        val brevPeriodeType = if (skalBrukeNyBegrunnelseLogikk) {
+            hentPeriodeType(utbetalingsbeløp, minimertVedtaksperiode.fom)
+        } else {
+            hentPeriodeTypeGammel(utbetalingsbeløp, minimertVedtaksperiode.fom, barnMedUtbetaling)
+        }
+
+        val duEllerInstitusjon = hentDuEllerInstitusjonTekst(brevPeriodeType)
+
         return BrevPeriode(
 
-            fom = this.hentFomTekst(),
+            fom = if (skalBrukeNyBegrunnelseLogikk) this.hentFomTekst() else this.hentFomTekstGammel(),
             tom = when {
+                minimertVedtaksperiode.type == Vedtaksperiodetype.AVSLAG && skalBrukeNyBegrunnelseLogikk -> "til og med $tomDato"
                 minimertVedtaksperiode.type == Vedtaksperiodetype.FORTSATT_INNVILGET -> ""
                 tomDato.isNullOrBlank() -> ""
                 brevPeriodeType == BrevPeriodeType.INNVILGELSE_INGEN_UTBETALING -> " til $tomDato"
@@ -244,10 +254,14 @@ class BrevPeriodeGenerator(
             antallBarnMedNullutbetaling = barnMedNullutbetaling.size.toString(),
             fodselsdagerBarnMedUtbetaling = barnMedUtbetaling.tilBarnasFødselsdatoer(),
             fodselsdagerBarnMedNullutbetaling = barnMedNullutbetaling.tilBarnasFødselsdatoer(),
+            duEllerInstitusjon = duEllerInstitusjon,
         )
     }
 
-    private fun hentFomTekst(): String = when (minimertVedtaksperiode.type) {
+    private fun hentFomTekst(): String = minimertVedtaksperiode.fom!!.tilMånedÅr()
+
+    @Deprecated("Erstattes av hentFomTekst når nye begrunnelse logikk går live")
+    private fun hentFomTekstGammel(): String = when (minimertVedtaksperiode.type) {
         Vedtaksperiodetype.FORTSATT_INNVILGET -> hentFomtekstFortsattInnvilget(
             brevMålform,
             minimertVedtaksperiode.fom,
@@ -261,10 +275,45 @@ class BrevPeriodeGenerator(
         Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
     }
 
-    private fun hentPeriodetype(
+    private fun hentDuEllerInstitusjonTekst(brevPeriodeType: BrevPeriodeType): String =
+        when (restBehandlingsgrunnlagForBrev.fagsakType) {
+            FagsakType.INSTITUSJON -> {
+                when (brevPeriodeType) {
+                    BrevPeriodeType.UTBETALING, BrevPeriodeType.INGEN_UTBETALING -> "institusjon"
+                    else -> "Institusjon"
+                }
+            }
+
+            FagsakType.NORMAL, FagsakType.BARN_ENSLIG_MINDREÅRIG -> {
+                when (brevPeriodeType) {
+                    BrevPeriodeType.UTBETALING, BrevPeriodeType.INGEN_UTBETALING -> "du"
+                    else -> "Du"
+                }
+            }
+        }
+
+    private fun hentPeriodeType(
+        utbetalingsbeløp: Int,
+        fom: LocalDate?,
+    ): BrevPeriodeType =
+        when (minimertVedtaksperiode.type) {
+            Vedtaksperiodetype.FORTSATT_INNVILGET -> BrevPeriodeType.FORTSATT_INNVILGET_NY
+            Vedtaksperiodetype.UTBETALING -> when {
+                utbetalingsbeløp == 0 -> BrevPeriodeType.INGEN_UTBETALING
+                else -> BrevPeriodeType.UTBETALING
+            }
+
+            Vedtaksperiodetype.AVSLAG -> if (fom != null) BrevPeriodeType.INGEN_UTBETALING else BrevPeriodeType.INGEN_UTBETALING_UTEN_PERIODE
+            Vedtaksperiodetype.OPPHØR -> BrevPeriodeType.INGEN_UTBETALING
+            Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING -> BrevPeriodeType.UTBETALING
+            Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
+        }
+
+    @Deprecated("Erstattes av hentPeriodeType etter at ny begrunnelse logikk er produksjonsatt")
+    private fun hentPeriodeTypeGammel(
+        utbetalingsbeløp: Int,
         fom: LocalDate?,
         barnMedUtbetaling: List<MinimertRestPerson>,
-        utbetalingsbeløp: Int,
     ) = if (restBehandlingsgrunnlagForBrev.fagsakType == FagsakType.INSTITUSJON) {
         when (minimertVedtaksperiode.type) {
             Vedtaksperiodetype.FORTSATT_INNVILGET -> BrevPeriodeType.FORTSATT_INNVILGET_INSTITUSJON

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeGenerator.kt
@@ -233,7 +233,7 @@ class BrevPeriodeGenerator(
             hentPeriodeTypeGammel(utbetalingsbeløp, minimertVedtaksperiode.fom, barnMedUtbetaling)
         }
 
-        val duEllerInstitusjon = hentDuEllerInstitusjonTekst(brevPeriodeType)
+        val duEllerInstitusjonen = hentDuEllerInstitusjonenTekst(brevPeriodeType)
 
         return BrevPeriode(
 
@@ -254,7 +254,7 @@ class BrevPeriodeGenerator(
             antallBarnMedNullutbetaling = barnMedNullutbetaling.size.toString(),
             fodselsdagerBarnMedUtbetaling = barnMedUtbetaling.tilBarnasFødselsdatoer(),
             fodselsdagerBarnMedNullutbetaling = barnMedNullutbetaling.tilBarnasFødselsdatoer(),
-            duEllerInstitusjon = duEllerInstitusjon,
+            duEllerInstitusjonen = duEllerInstitusjonen,
         )
     }
 
@@ -275,12 +275,12 @@ class BrevPeriodeGenerator(
         Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
     }
 
-    private fun hentDuEllerInstitusjonTekst(brevPeriodeType: BrevPeriodeType): String =
+    private fun hentDuEllerInstitusjonenTekst(brevPeriodeType: BrevPeriodeType): String =
         when (restBehandlingsgrunnlagForBrev.fagsakType) {
             FagsakType.INSTITUSJON -> {
                 when (brevPeriodeType) {
-                    BrevPeriodeType.UTBETALING, BrevPeriodeType.INGEN_UTBETALING -> "institusjon"
-                    else -> "Institusjon"
+                    BrevPeriodeType.UTBETALING, BrevPeriodeType.INGEN_UTBETALING -> "institusjonen"
+                    else -> "Institusjonen"
                 }
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
@@ -43,6 +43,6 @@ private fun VedtaksperiodeMedBegrunnelser.byggBrevPeriode(
         antallBarnMedNullutbetaling = "",
         fodselsdagerBarnMedUtbetaling = "",
         fodselsdagerBarnMedNullutbetaling = "",
-        duEllerInstitusjon = "",
+        duEllerInstitusjonen = "",
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
@@ -43,5 +43,6 @@ private fun VedtaksperiodeMedBegrunnelser.byggBrevPeriode(
         antallBarnMedNullutbetaling = "",
         fodselsdagerBarnMedUtbetaling = "",
         fodselsdagerBarnMedNullutbetaling = "",
+        duEllerInstitusjon = "",
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Vedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Vedtaksbrev.kt
@@ -26,6 +26,10 @@ enum class BrevPeriodeType(val apiNavn: String) {
     AVSLAG_INSTITUSJON("avslagInstitusjon"),
     AVSLAG_UTEN_PERIODE_INSTITUSJON("avslagUtenPeriodeInstitusjon"),
     FORTSATT_INNVILGET_INSTITUSJON("fortsattInnvilgetInstitusjon"),
+    UTBETALING("utbetaling"),
+    FORTSATT_INNVILGET_NY("fortsattInnvilgetNy"),
+    INGEN_UTBETALING("ingenUtbetaling"),
+    INGEN_UTBETALING_UTEN_PERIODE("ingenUtbetalingUtenPeriode"),
 }
 
 enum class EndretUtbetalingBrevPeriodeType(val apiNavn: String) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/brevperioder/BrevPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/brevperioder/BrevPeriode.kt
@@ -18,7 +18,7 @@ data class BrevPeriode(
     val antallBarnMedNullutbetaling: Flettefelt,
     val fodselsdagerBarnMedUtbetaling: Flettefelt,
     val fodselsdagerBarnMedNullutbetaling: Flettefelt,
-    val duEllerInstitusjon: Flettefelt,
+    val duEllerInstitusjonen: Flettefelt,
 ) {
 
     constructor(
@@ -33,7 +33,7 @@ data class BrevPeriode(
         antallBarnMedNullutbetaling: String,
         fodselsdagerBarnMedUtbetaling: String,
         fodselsdagerBarnMedNullutbetaling: String,
-        duEllerInstitusjon: String,
+        duEllerInstitusjonen: String,
     ) : this(
         fom = flettefelt(fom),
         tom = flettefelt(tom),
@@ -46,6 +46,6 @@ data class BrevPeriode(
         fodselsdagerBarnMedNullutbetaling = flettefelt(fodselsdagerBarnMedNullutbetaling),
         begrunnelser = begrunnelser,
         type = flettefelt(brevPeriodeType.apiNavn),
-        duEllerInstitusjon = flettefelt(duEllerInstitusjon),
+        duEllerInstitusjonen = flettefelt(duEllerInstitusjonen),
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/brevperioder/BrevPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/brevperioder/BrevPeriode.kt
@@ -18,6 +18,7 @@ data class BrevPeriode(
     val antallBarnMedNullutbetaling: Flettefelt,
     val fodselsdagerBarnMedUtbetaling: Flettefelt,
     val fodselsdagerBarnMedNullutbetaling: Flettefelt,
+    val duEllerInstitusjon: Flettefelt,
 ) {
 
     constructor(
@@ -32,6 +33,7 @@ data class BrevPeriode(
         antallBarnMedNullutbetaling: String,
         fodselsdagerBarnMedUtbetaling: String,
         fodselsdagerBarnMedNullutbetaling: String,
+        duEllerInstitusjon: String,
     ) : this(
         fom = flettefelt(fom),
         tom = flettefelt(tom),
@@ -44,5 +46,6 @@ data class BrevPeriode(
         fodselsdagerBarnMedNullutbetaling = flettefelt(fodselsdagerBarnMedNullutbetaling),
         begrunnelser = begrunnelser,
         type = flettefelt(brevPeriodeType.apiNavn),
+        duEllerInstitusjon = flettefelt(duEllerInstitusjon),
     )
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15513

Vi oppretter 4 nye brevperiodetyper som erstatter de gamle.
Vi sender også mer data nå til familie-sanity-brev, slik at vi kan skille mellom institusjon og du istedenfor å ha egen brevperiodetype for hver av dem.

PR i familie-sanity-brev: https://github.com/navikt/familie-sanity-brev/pull/442
Nye brevperioder: https://familie-brev.sanity.studio/ba-brev/desk/periode;523a9377-af63-4192-892c-ea31706da7ee