### PR TITLE
Korrigerer periodene hvor vi innvilger selvstendig rett

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -1,12 +1,13 @@
 package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
 
+import no.nav.familie.ba.sak.common.førsteDagINesteMåned
+import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.periodeAv
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.forskyv
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.tilMåned
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
@@ -45,11 +46,11 @@ class VilkårsvurderingTidslinjeService(
             .personResultater.single { it.aktør == søker.aktør }
 
         val erAnnenForelderOmfattetAvNorskLovgivingTidslinje = søkerPersonresultater.vilkårResultater
-            .filter { it.vilkårType === Vilkår.BOSATT_I_RIKET }
+            .filter { it.vilkårType === Vilkår.BOSATT_I_RIKET && it.erOppfylt() }
             .map {
                 periodeAv(
-                    it.periodeFom,
-                    it.periodeTom,
+                    it.periodeFom!!.førsteDagINesteMåned(),
+                    it.periodeTom?.sisteDagIMåned(),
                     it.utdypendeVilkårsvurderinger.contains(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
                 )
             }
@@ -57,6 +58,6 @@ class VilkårsvurderingTidslinjeService(
 
         val månedsbasertTidslinje =
             erAnnenForelderOmfattetAvNorskLovgivingTidslinje.tilMåned { it.contains(element = true) }
-        return månedsbasertTidslinje.forskyv(1)
+        return månedsbasertTidslinje
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -40,7 +40,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
     }
 
     @Test
-    fun `skal forskyve tidslinje for erAnnenForelderOmfattetAvNorskLovgivning med 1 måned`() {
+    fun `skal forskyve fom med 1 mnd for periode med erAnnenForelderOmfattetAvNorskLovgivning`() {
         val søker = lagPerson(type = PersonType.SØKER)
         val barn = lagPerson(type = PersonType.BARN)
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -74,7 +74,54 @@ internal class VilkårsvurderingTidslinjeServiceTest {
         val faktiskTidslinje = vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(
             behandlingId = BehandlingId(behandling.id),
         )
-        val forventetTidslinje = "+++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023))
+        val forventetTidslinje = "++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023))
+        assertEquals(forventetTidslinje, faktiskTidslinje)
+    }
+
+    @Test
+    fun `skal forskyve fom med 1 mnd for perioder med erAnnenForelderOmfattetAvNorskLovgivning`() {
+        val søker = lagPerson(type = PersonType.SØKER)
+        val barn = lagPerson(type = PersonType.BARN)
+        val fagsak = Fagsak(aktør = søker.aktør)
+        val behandling = lagBehandling(fagsak = fagsak, behandlingKategori = BehandlingKategori.EØS)
+        val vilkårsvurdering = lagVilkårsvurderingMedOverstyrendeResultater(
+            søker = søker,
+            barna = listOf(barn),
+            overstyrendeVilkårResultater = mapOf(
+                Pair(
+                    søker.aktør.aktørId,
+                    listOf(
+                        lagVilkårResultat(
+                            vilkårType = Vilkår.BOSATT_I_RIKET,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = LocalDate.of(2023, 1, 2),
+                            periodeTom = LocalDate.of(2023, 3, 4),
+                            behandlingId = behandling.id,
+                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
+                        ),
+                        lagVilkårResultat(
+                            vilkårType = Vilkår.BOSATT_I_RIKET,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = LocalDate.of(2023, 4, 30),
+                            periodeTom = LocalDate.of(2023, 7, 1),
+                            behandlingId = behandling.id,
+                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns lagTestPersonopplysningGrunnlag(
+            behandlingId = behandling.id,
+            søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+            barnasIdenter = listOf(barn.aktør.aktivFødselsnummer()),
+        )
+        every { vilkårsvurderingService.hentAktivForBehandlingThrows(behandlingId = behandling.id) } returns vilkårsvurdering
+
+        val faktiskTidslinje = vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(
+            behandlingId = BehandlingId(behandling.id),
+        )
+        val forventetTidslinje = "++-+++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023))
         assertEquals(forventetTidslinje, faktiskTidslinje)
     }
 }


### PR DESCRIPTION
Favro: [NAV-15579](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15579)

### 💰 Hva skal gjøres, og hvorfor?
Periodene i tidslinja "AnnenForelderOmfattetAvNorskLovgivningTidslinje" blir 1 mnd for lange. `fom` blir satt korrekt til neste mnd, men `tom` blir også satt til neste mnd og det blir feil. 

Sørger her for at `fom` blir satt til neste mnd og `tom` til inneværende mnd.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
