### PR TITLE
Legg til støtte for å bruke delmal duMåMeldeFraOmEndringerEøsSelvstendigRett eller duMåMeldeFraOmEndringer basert på vilkårsvurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -14,6 +14,8 @@ class FeatureToggleConfig {
         const val ER_MANUEL_POSTERING_TOGGLE_PÅ = "familie-ba-sak.manuell-postering"
         const val FEILUTBETALT_VALUTA_PR_MND = "familie-ba-sak.feilutbetalt-valuta-pr-mnd"
         const val BEGRUNNELSER_NY = "familie-ba-sak.begrunnelser-ny"
+        const val EØS_PRAKSISENDRING_SEPTEMBER2023 =
+            "familie-ba-sak.behandling.eos-annen-forelder-omfattet-av-norsk-lovgivning"
 
         // unleash toggles for satsendring, kan slettes etter at satsendring er skrudd på for alle satstyper
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -87,6 +87,10 @@ class BrevService(
         val vedtakFellesfelter = lagVedtaksbrevFellesfelter(vedtak)
         validerBrevdata(brevmal, vedtakFellesfelter)
 
+        val skalMeldeFraOmEndringerEøsSelvstendigRett by lazy {
+            vedtaksperiodeService.skalMeldeFraOmEndringerEøsSelvstendigRett(vedtak)
+        }
+
         return when (brevmal) {
             Brevmal.VEDTAK_FØRSTEGANGSVEDTAK -> Førstegangsvedtak(
                 vedtakFellesfelter = vedtakFellesfelter,
@@ -94,6 +98,8 @@ class BrevService(
                 informasjonOmAarligKontroll = vedtaksperiodeService.skalHaÅrligKontroll(vedtak),
                 refusjonEosAvklart = beskrivPerioderMedAvklartRefusjonEøs(vedtak),
                 refusjonEosUavklart = beskrivPerioderMedUavklartRefusjonEøs(vedtak),
+                duMåMeldeFraOmEndringer = !skalMeldeFraOmEndringerEøsSelvstendigRett,
+                duMåMeldeFraOmEndringerEøsSelvstendigRett = skalMeldeFraOmEndringerEøsSelvstendigRett,
             )
 
             Brevmal.VEDTAK_FØRSTEGANGSVEDTAK_INSTITUSJON -> Førstegangsvedtak(
@@ -113,6 +119,8 @@ class BrevService(
                 },
                 refusjonEosAvklart = beskrivPerioderMedAvklartRefusjonEøs(vedtak),
                 refusjonEosUavklart = beskrivPerioderMedUavklartRefusjonEøs(vedtak),
+                duMåMeldeFraOmEndringer = !skalMeldeFraOmEndringerEøsSelvstendigRett,
+                duMåMeldeFraOmEndringerEøsSelvstendigRett = skalMeldeFraOmEndringerEøsSelvstendigRett,
             )
 
             Brevmal.VEDTAK_ENDRING_INSTITUSJON -> VedtakEndring(
@@ -162,6 +170,8 @@ class BrevService(
                 informasjonOmAarligKontroll = vedtaksperiodeService.skalHaÅrligKontroll(vedtak),
                 refusjonEosAvklart = beskrivPerioderMedAvklartRefusjonEøs(vedtak),
                 refusjonEosUavklart = beskrivPerioderMedUavklartRefusjonEøs(vedtak),
+                duMåMeldeFraOmEndringer = !skalMeldeFraOmEndringerEøsSelvstendigRett,
+                duMåMeldeFraOmEndringerEøsSelvstendigRett = skalMeldeFraOmEndringerEøsSelvstendigRett,
             )
 
             Brevmal.VEDTAK_FORTSATT_INNVILGET_INSTITUSJON -> ForsattInnvilget(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForsattInnvilget.kt
@@ -15,6 +15,8 @@ data class ForsattInnvilget(
         informasjonOmAarligKontroll: Boolean = false,
         refusjonEosAvklart: RefusjonEøsAvklart? = null,
         refusjonEosUavklart: RefusjonEøsUavklart? = null,
+        duMåMeldeFraOmEndringer: Boolean = true,
+        duMåMeldeFraOmEndringerEøsSelvstendigRett: Boolean = false,
     ) :
         this(
             mal = mal,
@@ -32,6 +34,8 @@ data class ForsattInnvilget(
                     informasjonOmAarligKontroll = informasjonOmAarligKontroll,
                     refusjonEosAvklart = refusjonEosAvklart,
                     refusjonEosUavklart = refusjonEosUavklart,
+                    duMaaMeldeFraOmEndringer = duMåMeldeFraOmEndringer,
+                    duMaaMeldeFraOmEndringerEosSelvstendigRett = duMåMeldeFraOmEndringerEøsSelvstendigRett,
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     gjelder = flettefelt(vedtakFellesfelter.gjelder),
@@ -59,5 +63,7 @@ data class ForsattInnvilgetData(
         val informasjonOmAarligKontroll: Boolean,
         val refusjonEosAvklart: RefusjonEøsAvklart?,
         val refusjonEosUavklart: RefusjonEøsUavklart?,
+        val duMaaMeldeFraOmEndringerEosSelvstendigRett: Boolean,
+        val duMaaMeldeFraOmEndringer: Boolean,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Førstegangsvedtak.kt
@@ -15,6 +15,8 @@ data class Førstegangsvedtak(
         informasjonOmAarligKontroll: Boolean = false,
         refusjonEosAvklart: RefusjonEøsAvklart? = null,
         refusjonEosUavklart: RefusjonEøsUavklart? = null,
+        duMåMeldeFraOmEndringer: Boolean = true,
+        duMåMeldeFraOmEndringerEøsSelvstendigRett: Boolean = false,
     ) :
         this(
             mal = mal,
@@ -32,6 +34,8 @@ data class Førstegangsvedtak(
                     informasjonOmAarligKontroll = informasjonOmAarligKontroll,
                     refusjonEosAvklart = refusjonEosAvklart,
                     refusjonEosUavklart = refusjonEosUavklart,
+                    duMaaMeldeFraOmEndringerEosSelvstendigRett = duMåMeldeFraOmEndringerEøsSelvstendigRett,
+                    duMaaMeldeFraOmEndringer = duMåMeldeFraOmEndringer,
                 ),
                 perioder = vedtakFellesfelter.perioder,
                 flettefelter = FlettefelterForDokumentImpl(
@@ -59,5 +63,7 @@ data class FørstegangsvedtakData(
         val informasjonOmAarligKontroll: Boolean,
         val refusjonEosAvklart: RefusjonEøsAvklart?,
         val refusjonEosUavklart: RefusjonEøsUavklart?,
+        val duMaaMeldeFraOmEndringerEosSelvstendigRett: Boolean,
+        val duMaaMeldeFraOmEndringer: Boolean,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/VedtakEndring.kt
@@ -18,6 +18,8 @@ data class VedtakEndring(
         feilutbetaltValuta: FeilutbetaltValuta? = null,
         refusjonEosAvklart: RefusjonEøsAvklart? = null,
         refusjonEosUavklart: RefusjonEøsUavklart? = null,
+        duMåMeldeFraOmEndringer: Boolean = true,
+        duMåMeldeFraOmEndringerEøsSelvstendigRett: Boolean = false,
     ) :
         this(
             mal = mal,
@@ -39,6 +41,8 @@ data class VedtakEndring(
                     forMyeUtbetaltBarnetrygd = feilutbetaltValuta,
                     refusjonEosAvklart = refusjonEosAvklart,
                     refusjonEosUavklart = refusjonEosUavklart,
+                    duMaaMeldeFraOmEndringerEosSelvstendigRett = duMåMeldeFraOmEndringerEøsSelvstendigRett,
+                    duMaaMeldeFraOmEndringer = duMåMeldeFraOmEndringer,
                 ),
                 flettefelter = FlettefelterForDokumentImpl(
                     gjelder = flettefelt(vedtakFellesfelter.gjelder),
@@ -70,5 +74,7 @@ data class EndringVedtakData(
         val forMyeUtbetaltBarnetrygd: FeilutbetaltValuta?,
         val refusjonEosAvklart: RefusjonEøsAvklart?,
         val refusjonEosUavklart: RefusjonEøsUavklart?,
+        val duMaaMeldeFraOmEndringerEosSelvstendigRett: Boolean,
+        val duMaaMeldeFraOmEndringer: Boolean,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -67,6 +67,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdu
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.BehandlingsGrunnlagForVedtaksperioder
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.genererVedtaksperioder
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import utledEndringstidspunkt
@@ -621,6 +623,28 @@ class VedtaksperiodeService(
         }
         return vedtak.behandling.kategori == BehandlingKategori.EØS &&
             hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
+    }
+
+    fun skalMeldeFraOmEndringerEøsSelvstendigRett(vedtak: Vedtak): Boolean {
+        val vilkårsvurdering =
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = vedtak.behandling.id)
+
+        val annenForelderOmfattetAvNorskLovgivningErSattPåBosattIRiket = (
+            vilkårsvurdering?.personResultater?.flatMap { it.vilkårResultater }
+                ?.any { it.utdypendeVilkårsvurderinger.contains(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING) && it.vilkårType == Vilkår.BOSATT_I_RIKET }
+                ?: false
+            )
+
+        val passendeBehandlingsresultat = vedtak.behandling.resultat !in listOf(
+            Behandlingsresultat.AVSLÅTT,
+            Behandlingsresultat.ENDRET_OG_OPPHØRT,
+            Behandlingsresultat.OPPHØRT,
+        )
+
+        val eøsPraksisEndringFeatureToggleErSlåttPå =
+            featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023)
+
+        return annenForelderOmfattetAvNorskLovgivningErSattPåBosattIRiket && passendeBehandlingsresultat && eøsPraksisEndringFeatureToggleErSlåttPå
     }
 
     fun beskrivPerioderMedFeilutbetaltValuta(vedtak: Vedtak): Set<String>? {


### PR DESCRIPTION
Favrokort:  https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15665

Det er ønskelig å bruke erstatte bruken av delmalen "duMaaMeldeFraOmEndringer" med delmalen "duMaaMeldeFraOmEndringerEosSelvstendigRett" dersom det er satt ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING på bosatt i riket vilkåret.

For å støtte dette er følgende gjort:

- For vedtaksbrev som skal starte å benytte seg av duMaaMeldeFraOmEndringerEosSelvstendigRett så sender vi nå alltid med en booleansk verdi som sier om delmalen skal benyttes eller ikke.
- For vedtaksbrev som har benyttet seg av duMaaMeldeFraOmEndringer, så må vi nå alltid sende med booleansk verdi som sier om delmalen skal benyttes eller ikke. Dette fordi at i sanity, så har vi tidlig satt den til å alltid vises, men det er nå conditional. Verdien settes til omvendt av duMaaMeldeFraOmEndringerEosSelvstendigRett.
- Når denne PRn er merget så må man skru av "delmal skal alltid vises" på duMaaMeldeFraOmEndringer delmalen i sanity.

Demonstrasjon av logikk:

https://github.com/navikt/familie-ba-sak/assets/110383605/65a7315e-2844-4f22-98ac-06d72cda97c5

