### PR TITLE
Bug: praksisendring EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -1,14 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
 
-import no.nav.familie.ba.sak.common.førsteDagINesteMåned
-import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.periodeAv
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.tilMåned
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.lagForskjøvetTidslinjeForOppfylteVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -46,18 +43,9 @@ class VilkårsvurderingTidslinjeService(
             .personResultater.single { it.aktør == søker.aktør }
 
         val erAnnenForelderOmfattetAvNorskLovgivingTidslinje = søkerPersonresultater.vilkårResultater
-            .filter { it.vilkårType === Vilkår.BOSATT_I_RIKET && it.erOppfylt() }
-            .map {
-                periodeAv(
-                    it.periodeFom!!.førsteDagINesteMåned(),
-                    it.periodeTom?.sisteDagIMåned(),
-                    it.utdypendeVilkårsvurderinger.contains(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
-                )
-            }
-            .tilTidslinje()
+            .lagForskjøvetTidslinjeForOppfylteVilkår(Vilkår.BOSATT_I_RIKET)
+            .map { it?.utdypendeVilkårsvurderinger?.contains(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING) }
 
-        val månedsbasertTidslinje =
-            erAnnenForelderOmfattetAvNorskLovgivingTidslinje.tilMåned { it.contains(element = true) }
-        return månedsbasertTidslinje
+        return erAnnenForelderOmfattetAvNorskLovgivingTidslinje
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -12,13 +12,15 @@ import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.simulering.lagBehandling
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.erTom
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.tilAnnenForelderOmfattetAvNorskLovgivningTidslinje
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -75,11 +77,50 @@ internal class VilkårsvurderingTidslinjeServiceTest {
             behandlingId = BehandlingId(behandling.id),
         )
         val forventetTidslinje = "++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023))
-        assertEquals(forventetTidslinje, faktiskTidslinje)
+        assertThat(faktiskTidslinje).isEqualTo(forventetTidslinje)
     }
 
     @Test
-    fun `skal forskyve fom med 1 mnd for perioder med erAnnenForelderOmfattetAvNorskLovgivning`() {
+    fun `skal ikke gi noen oppfylte perioder hvis vilkår kun oppfylt innenfor én måned`() {
+        val søker = lagPerson(type = PersonType.SØKER)
+        val barn = lagPerson(type = PersonType.BARN)
+        val fagsak = Fagsak(aktør = søker.aktør)
+        val behandling = lagBehandling(fagsak = fagsak, behandlingKategori = BehandlingKategori.EØS)
+        val vilkårsvurdering = lagVilkårsvurderingMedOverstyrendeResultater(
+            søker = søker,
+            barna = listOf(barn),
+            overstyrendeVilkårResultater = mapOf(
+                Pair(
+                    søker.aktør.aktørId,
+                    listOf(
+                        lagVilkårResultat(
+                            vilkårType = Vilkår.BOSATT_I_RIKET,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = LocalDate.of(2021, 12, 1),
+                            periodeTom = LocalDate.of(2021, 12, 31),
+                            behandlingId = behandling.id,
+                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns lagTestPersonopplysningGrunnlag(
+            behandlingId = behandling.id,
+            søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+            barnasIdenter = listOf(barn.aktør.aktivFødselsnummer()),
+        )
+        every { vilkårsvurderingService.hentAktivForBehandlingThrows(behandlingId = behandling.id) } returns vilkårsvurdering
+
+        val faktiskTidslinje = vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(
+            behandlingId = BehandlingId(behandling.id),
+        )
+
+        assertThat(faktiskTidslinje.erTom()).isTrue
+    }
+
+    @Test
+    fun `skal forskyve fom med 1 mnd for flere perioder med erAnnenForelderOmfattetAvNorskLovgivning`() {
         val søker = lagPerson(type = PersonType.SØKER)
         val barn = lagPerson(type = PersonType.BARN)
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -121,7 +162,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
         val faktiskTidslinje = vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(
             behandlingId = BehandlingId(behandling.id),
         )
-        val forventetTidslinje = "++-+++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023))
-        assertEquals(forventetTidslinje, faktiskTidslinje)
+        val forventetTidslinje = "++ +++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023)).filtrerIkkeNull()
+        assertThat(faktiskTidslinje).isEqualTo(forventetTidslinje)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Hadde en bug i koden hvor man fikk tidslinje-feil hvis vilkår kun var oppfylt innenfor en måned, feks 01.12-31.12. Dette gir ingen rett til utbetaling. Koden i prod nå forskjøv dette feil så man fikk fom=01.01 og tom=31.12. Retter opp dette i denne PRen ved å bruke metoden for forskyvning som også brukes ved generering av andeler.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
