### PR TITLE
Bumpet familie-utbetalingsgenerator og justert noen metodenavn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <felles-kontrakter.version>3.0_20230911102049_85cefe7</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20230912090318_2267c05</familie.kontrakter.stønadsstatistikk>
-        <utbetalingsgenerator.version>1.0_20230921152358_e73110f</utbetalingsgenerator.version>
+        <utbetalingsgenerator.version>1.0_20230927085000_900743f</utbetalingsgenerator.version>
         <familie.kontrakter.skatteetaten>2.0_20230214104704_706e9c0</familie.kontrakter.skatteetaten>
         <cucumber.version>7.14.0</cucumber.version>
         <mockk.version>1.13.5</mockk.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGenerator.kt
@@ -50,7 +50,7 @@ class UtbetalingsoppdragGenerator(
                 fagsystem = FagsystemBA.BARNETRYGD,
                 personIdent = vedtak.behandling.fagsak.aktør.aktivFødselsnummer(),
                 vedtaksdato = vedtak.vedtaksdato?.toLocalDate() ?: LocalDate.now(),
-                opphørFra = opphørFra(
+                opphørAlleKjederFra = finnOpphørsdatoForAlleKjeder(
                     forrigeTilkjentYtelse = forrigeTilkjentYtelse,
                     sisteAndelPerKjede = sisteAndelPerKjede,
                     endretMigreringsDato = endretMigreringsDato,
@@ -80,7 +80,7 @@ class UtbetalingsoppdragGenerator(
             kildeBehandlingId = kildeBehandlingId,
         )
 
-    private fun opphørFra(
+    private fun finnOpphørsdatoForAlleKjeder(
         forrigeTilkjentYtelse: TilkjentYtelse?,
         sisteAndelPerKjede: Map<IdentOgType, AndelTilkjentYtelse>,
         endretMigreringsDato: YearMonth?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
@@ -49,7 +49,7 @@ class UtbetalingsoppdragGeneratorService(
         val nyTilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandlingId = vedtak.behandling.id)
         val endretMigreringsDato = beregnOmMigreringsDatoErEndret(
             vedtak.behandling,
-            forrigeTilkjentYtelse?.andelerTilkjentYtelse?.minByOrNull { it.stønadFom }?.stønadFom,
+            forrigeTilkjentYtelse?.andelerTilkjentYtelse?.minOfOrNull { it.stønadFom },
         )
         val sisteAndelPerKjede = hentSisteAndelTilkjentYtelse(vedtak.behandling.fagsak)
         val beregnetUtbetalingsoppdrag = utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
@@ -95,7 +95,7 @@ class UtbetalingsoppdragGeneratorService(
             ?.let { tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(behandlingId = it.id) }
 
     private fun hentSisteAndelTilkjentYtelse(fagsak: Fagsak) =
-        andelTilkjentYtelseRepository.hentSisteAndelPerIdent(fagsakId = fagsak.id)
+        andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(fagsakId = fagsak.id)
             .associateBy { IdentOgType(it.aktør.aktivFødselsnummer(), it.type.tilYtelseType()) }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -80,7 +80,7 @@ class BeregningService(
         tilkjentYtelseRepository.findByBehandlingOptional(behandlingId)
 
     fun hentSisteAndelPerIdent(fagsakId: Long): Map<IdentOgYtelse, AndelTilkjentYtelseForUtbetalingsoppdrag> {
-        return andelTilkjentYtelseRepository.hentSisteAndelPerIdent(fagsakId)
+        return andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(fagsakId)
             .groupBy { IdentOgYtelse(it.aktør.aktivFødselsnummer(), it.type) }
             .mapValues { AndelTilkjentYtelseForSimuleringFactory().pakkInnForUtbetaling(it.value).single() }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -103,5 +103,5 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
     """,
         nativeQuery = true,
     )
-    fun hentSisteAndelPerIdent(fagsakId: Long): List<AndelTilkjentYtelse>
+    fun hentSisteAndelPerIdentOgType(fagsakId: Long): List<AndelTilkjentYtelse>
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorServiceTest.kt
@@ -738,13 +738,13 @@ class UtbetalingsoppdragGeneratorServiceTest {
     ) {
         if (forrigeTilkjentYtelse == null) {
             every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling) } returns null
-            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdent(behandling.fagsak.id) } returns emptyList()
+            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(behandling.fagsak.id) } returns emptyList()
         } else {
             every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling) } returns forrigeTilkjentYtelse.behandling
 
             every { tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(forrigeTilkjentYtelse.behandling.id) } returns forrigeTilkjentYtelse
 
-            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdent(behandling.fagsak.id) } returns
+            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(behandling.fagsak.id) } returns
                 forrigeTilkjentYtelse.andelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() }
                     .groupBy { it.aktør.aktivFødselsnummer() }
                     .mapValues { it.value.maxBy { it.periodeOffset!! } }.values.toList()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Etter gjennomgang av implementasjon mot `familie-utbetalingsgenerator` ble det foreslått noen små endringer av metodenavn og feltnavn.

Har bumpet versjonen til `familie-utbetalingsgenerator` for å få et mer presist feltnavn enn `opphørFra`. I ny versjon er `opphørFra` endret til `opphørAlleKjederFra`.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Jeg har ikke skrevet tester fordi:
Ikke gjort noen endringer som påvirker logikk

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
