### PR TITLE
Begrunn første innvilgede periode etter at utvidet ble oppfylt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VilkårFilterUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VilkårFilterUtil.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.UtvidetBarnetrygdTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilUtdypendeVilkårsvurderinger
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.IBegrunnelseGrunnlagForPeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VilkårResultatForVedtaksperiode
@@ -79,6 +80,7 @@ private fun finnUtgjørendeVilkår(
 
     return if (begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget()) {
         val utvidetTriggetAvInnvilgelse = hentUtvidetTriggetAvInnvilgelse(
+            sanityBegrunnelse = sanityBegrunnelse,
             andelerForrigePeriode = begrunnelseGrunnlag.forrigePeriode?.andeler,
             oppfylteVilkårResultaterDennePerioden = oppfylteVilkårResultaterDennePerioden,
         )
@@ -138,9 +140,13 @@ private fun hentVilkårResultaterTapt(
 }
 
 private fun hentUtvidetTriggetAvInnvilgelse(
+    sanityBegrunnelse: ISanityBegrunnelse,
     andelerForrigePeriode: Iterable<AndelForVedtaksperiode>?,
     oppfylteVilkårResultaterDennePerioden: List<VilkårResultatForVedtaksperiode>,
 ): List<VilkårResultatForVedtaksperiode> {
+    if (sanityBegrunnelse.apiNavn != Standardbegrunnelse.INNVILGET_BOR_ALENE_MED_BARN.sanityApiNavn) {
+        return emptyList()
+    }
     val ingenAndelerForrigePeriode = andelerForrigePeriode == null || !andelerForrigePeriode.any()
     val utvidetOppfyltDennePerioden =
         oppfylteVilkårResultaterDennePerioden.filter { it.vilkårType == Vilkår.UTVIDET_BARNETRYGD }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VilkårFilterUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VilkårFilterUtil.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.UtvidetBarnetrygdTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilUtdypendeVilkårsvurderinger
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.IBegrunnelseGrunnlagForPeriode
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VilkårResultatForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -77,8 +78,12 @@ private fun finnUtgjørendeVilkår(
     )
 
     return if (begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget()) {
+        val utvidetTriggetAvInnvilgelse = hentUtvidetTriggetAvInnvilgelse(
+            andelerForrigePeriode = begrunnelseGrunnlag.forrigePeriode?.andeler,
+            oppfylteVilkårResultaterDennePerioden = oppfylteVilkårResultaterDennePerioden,
+        )
         when (sanityBegrunnelse.periodeResultat) {
-            SanityPeriodeResultat.INNVILGET_ELLER_ØKNING -> vilkårTjent + vilkårEndret
+            SanityPeriodeResultat.INNVILGET_ELLER_ØKNING -> vilkårTjent + vilkårEndret + utvidetTriggetAvInnvilgelse
             SanityPeriodeResultat.INGEN_ENDRING -> vilkårEndret
             SanityPeriodeResultat.IKKE_INNVILGET,
             SanityPeriodeResultat.REDUKSJON,
@@ -130,4 +135,14 @@ private fun hentVilkårResultaterTapt(
     val vilkårTapt = oppfyltForrigePeriode - oppfyltDennePerioden
 
     return oppfylteVilkårResultaterForrigePeriode.filter { it.vilkårType in vilkårTapt }
+}
+
+private fun hentUtvidetTriggetAvInnvilgelse(
+    andelerForrigePeriode: Iterable<AndelForVedtaksperiode>?,
+    oppfylteVilkårResultaterDennePerioden: List<VilkårResultatForVedtaksperiode>,
+): List<VilkårResultatForVedtaksperiode> {
+    val ingenAndelerForrigePeriode = andelerForrigePeriode == null || !andelerForrigePeriode.any()
+    val utvidetOppfyltDennePerioden =
+        oppfylteVilkårResultaterDennePerioden.filter { it.vilkårType == Vilkår.UTVIDET_BARNETRYGD }
+    return if (ingenAndelerForrigePeriode) utvidetOppfyltDennePerioden else emptyList()
 }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utvidet.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utvidet.feature
@@ -1,0 +1,44 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Begrunnelser for utvidet barnetrygd
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak |
+      | 1            | 1        |                     | INNVILGET           | SØKNAD           |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 26.04.1985  |
+      | 1            | 2       | BARN       | 12.01.2022  |
+
+  Scenario: Skal gi innvilgelsesbegrunnelse for utvidet i første utbetalingsperiode etter at utvidet er oppfylt
+    Og følgende dagens dato 28.09.2023
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                        | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                  | 26.04.1985 |            | OPPFYLT  | Nei                  |
+      | 1       | UTVIDET_BARNETRYGD            |                  | 13.02.2023 |            | OPPFYLT  | Nei                  |
+
+      | 2       | GIFT_PARTNERSKAP              |                  | 12.01.2022 |            | OPPFYLT  | Nei                  |
+      | 2       | UNDER_18_ÅR                   |                  | 12.01.2022 | 11.01.2040 | OPPFYLT  | Nei                  |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER  |                  | 13.02.2023 |            | OPPFYLT  | Nei                  |
+      | 2       | LOVLIG_OPPHOLD                |                  | 23.04.2023 | 30.06.2023 | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.05.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
+      | 2       | 1            | 01.05.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
+
+    Når begrunnelsetekster genereres for behandling 1
+
+    Så forvent følgende standardBegrunnelser
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser      | Ekskluderte Begrunnelser |
+      | 01.05.2023 | 30.06.2023 | UTBETALING         |           | INNVILGET_BOR_ALENE_MED_BARN |                          |
+      | 01.07.2023 |            | OPPHØR             |           |                              |                          |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utvidet.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/utvidet.feature
@@ -17,7 +17,7 @@ Egenskap: Begrunnelser for utvidet barnetrygd
       | 1            | 1       | SØKER      | 26.04.1985  |
       | 1            | 2       | BARN       | 12.01.2022  |
 
-  Scenario: Skal gi innvilgelsesbegrunnelse for utvidet i første utbetalingsperiode etter at utvidet er oppfylt
+  Scenario: Skal gi innvilgelsesbegrunnelse INNVILGET_BOR_ALENE_MED_BARN for utvidet i første utbetalingsperiode etter at utvidet er oppfylt
     Og følgende dagens dato 28.09.2023
     Og lag personresultater for begrunnelse for behandling 1
 
@@ -40,5 +40,5 @@ Egenskap: Begrunnelser for utvidet barnetrygd
 
     Så forvent følgende standardBegrunnelser
       | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk | Inkluderte Begrunnelser      | Ekskluderte Begrunnelser |
-      | 01.05.2023 | 30.06.2023 | UTBETALING         |           | INNVILGET_BOR_ALENE_MED_BARN |                          |
+      | 01.05.2023 | 30.06.2023 | UTBETALING         |           | INNVILGET_BOR_ALENE_MED_BARN | INNVILGET_SKILT          |
       | 01.07.2023 |            | OPPHØR             |           |                              |                          |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-15813

Vi har en begrunnelsestekst `innvilgetBorAleneMedBarn` som skal være tilgjengelig i den første innvilgede vedtaksperioden  etter at utvidet blir oppfylt. Utvidet kan være oppfylt flere måneder før behandlingen gir innvilgede perioder, så vilkåret vil ikke nødvendigvis bli oppdaget som utgjørende med den eksisterende logikken vi har.

Begrunnelsen skiller seg fra andre utvidet-begrunnelser ved at den ikke fletter inn måned og år for når utvidet ble oppfylt. Vi ønsker ikke at triggeret for denne begrunnelsen også skal trigge andre utvidet-begrunnelser.

Vi har kun én begrunnelse som skal opptre på denne måten. Vi har diskutert om vi bør skrive logikk som takler at flere tekster skal opptre likt, men prioriterer det ned nå. Hvis man allikevel i fremtiden vil gjøre det er mitt forslag å opprette et nytt "Øvrig trigger" for at begrunnelsen alltid skal være tilgjengelig gitt at vilkårene og periodetype etc matcher, uavhengig av hvorvidt vilkåret er _utgjørende_ i perioden

---
**Vi ønsker å få med oss denne begrunnelsen:**
![image](https://github.com/navikt/familie-ba-sak/assets/2379098/e3145a07-aca2-4c27-a221-78cbad1a8f2a)
![image](https://github.com/navikt/familie-ba-sak/assets/2379098/243e446e-6c39-479a-bd4b-fb848fabf589)

---
**Ikke f.eks. denne:**
![image](https://github.com/navikt/familie-ba-sak/assets/2379098/1c7d4568-0424-4ad0-89b6-ec3f7a140c09)
![image](https://github.com/navikt/familie-ba-sak/assets/2379098/b03e5930-35e9-4a34-99e3-853381e2ea9f)


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. 
### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
