### PR TITLE
Feat/legg til test på at vi får riktig periodetype

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPersonResultat
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.common.tilddMMyyyy
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.cucumber.domeneparser.Domenebegrep
@@ -407,7 +408,10 @@ fun leggBegrunnelserIVedtaksperiodene(
 
     val vedtaksperiode =
         vedtaksperioder.find { it.fom == fom && it.tom == tom }
-            ?: throw Feil("Ingen vedtaksperioder med Fom=$fom og Tom=$tom")
+            ?: throw Feil(
+                "Ingen vedtaksperioder med Fom=$fom og Tom=$tom. " +
+                    "Vedtaksperiodene var ${vedtaksperioder.map { "\n${it.fom?.tilddMMyyyy()} til ${it.tom?.tilddMMyyyy()}" }}",
+            )
     val vedtaksperiodeMedBegrunnelser = vedtaksperiode.tilVedtaksperiodeMedBegrunnelser(
         vedtak,
     )

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/test.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/test.feature
@@ -1,0 +1,51 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Brevperioder: Brev periode type
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak |
+      | 1            | 1        |                     | INNVILGET           | SØKNAD           |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | BARN       | 16.03.2022  |
+      | 1            | 2       | SØKER      | 28.07.1985  |
+
+  Scenario: Skal få brevperiode av typen utbetaling når vi har eøs nullutbetaling
+    Og følgende dagens dato 29.09.2023
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                          | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 2       | BOSATT_I_RIKET                  | OMFATTET_AV_NORSK_LOVGIVNING | 28.07.1985 |            | OPPFYLT  | Nei                  |
+      | 2       | LOVLIG_OPPHOLD                  |                              | 28.07.1985 |            | OPPFYLT  | Nei                  |
+
+      | 1       | UNDER_18_ÅR                     |                              | 16.03.2022 | 15.03.2040 | OPPFYLT  | Nei                  |
+      | 1       | BOR_MED_SØKER                   | BARN_BOR_I_EØS_MED_SØKER     | 16.03.2022 |            | OPPFYLT  | Nei                  |
+      | 1       | LOVLIG_OPPHOLD,GIFT_PARTNERSKAP |                              | 16.03.2022 |            | OPPFYLT  | Nei                  |
+      | 1       | BOSATT_I_RIKET                  | BARN_BOR_I_NORGE             | 16.03.2022 |            | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.04.2022 | 28.02.2023 | 0     | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 1       | 1            | 01.03.2023 | 30.06.2023 | 0     | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 1       | 1            | 01.07.2023 | 29.02.2028 | 23    | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 1       | 1            | 01.03.2028 | 29.02.2040 | 0     | ORDINÆR_BARNETRYGD | 100     | 1310 |
+
+    Og med kompetanser for begrunnelse
+      | AktørId | Fra dato   | Til dato | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 1       | 01.04.2022 |          | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | PL                             | PL                  |
+
+    Og med vedtaksperioder for behandling 1
+      | Fra dato   | Til dato   | Standardbegrunnelser | Eøsbegrunnelser                 | Fritekster |
+      | 01.04.2022 | 30.06.2023 |                      | INNVILGET_SEKUNDÆRLAND_STANDARD |            |
+
+    Så forvent følgende brevperioder for behandling 1
+      | Type       | Fra dato   | Til dato      | Beløp | Antall barn | Barnas fødselsdager | Du eller institusjonen |
+      | UTBETALING | april 2022 | til juni 2023 | 0     | 0           |                     | du                     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15803)

Dersom vi har nullutbetaling fordi norge er sekundærland og primærlandet betaler ut mer skal vi fremdeles få "utbetaling" som periodetype. Slik er det ikke i den gamle løsningen:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/1ee2e805-9278-40bf-89d3-495434764bc3)

Dette er allerede fiksa i den nye løsningen. Lager en test for det slik at vi har dokumentert det

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
