### PR TITLE
Vi ønsker å sette behandlingsresultat tilbake til IKKE_VURDERT dersom det skjer endringer i vilkårsvurderingen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
@@ -82,14 +83,17 @@ class TilbakestillBehandlingService(
      */
     @Transactional
     fun resettStegVedEndringPåVilkår(behandlingId: Long): Behandling {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+
         vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(
             vedtak = vedtakRepository.findByBehandlingAndAktiv(
-                behandlingId,
+                behandling.id,
             ),
         )
-        tilbakekrevingService.slettTilbakekrevingPåBehandling(behandlingId)
+        tilbakekrevingService.slettTilbakekrevingPåBehandling(behandling.id)
+        behandlingHentOgPersisterService.lagreEllerOppdater(behandling.apply { resultat = Behandlingsresultat.IKKE_VURDERT })
         return behandlingService.leggTilStegPåBehandlingOgSettTidligereStegSomUtført(
-            behandlingId = behandlingId,
+            behandlingId = behandling.id,
             steg = StegType.VILKÅRSVURDERING,
         )
     }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12477

Når vi har fått en behandlingsresultat, og gjør endringer i vilkårsvurderingen så resettes steget tilbake til vilkårsvurdering, og data som har blitt generert senere i løypa slettes (vedtaksperioder og tilbakekreving). Vi setter derimot ikke behandlingsresultatet tilbake til Ikke Vurdert, noe som forvirrer saksbehandler da det ikke er umiddelbart forståelig at man må videre til simuleringssteget igjen for å få oppdatert behandlingsresultatet.

Vi setter derfor resultatet til ikke vurdert når steget settes tilbake til vilkårsvurderingen.

