### PR TITLE
Sørger for at vi ikke viser EØS praksisendring begrunnelser i prod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityService.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.sanity
 
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service
 @Service
 class SanityService(
     private val sanityKlient: SanityKlient,
+    private val featureToggleService: FeatureToggleService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -36,7 +39,17 @@ class SanityService(
 
     @Cacheable("sanityEØSBegrunnelser", cacheManager = "shortCache")
     fun hentSanityEØSBegrunnelser(): Map<EØSStandardbegrunnelse, SanityEØSBegrunnelse> {
-        val enumPåApiNavn = EØSStandardbegrunnelse.values().associateBy { it.sanityApiNavn }
+        val eøsPraksisEndringFeatureToggleErSlåttPå =
+            featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023)
+
+        // TODO: Fjern filtrering av begrunnelser etter at EØS praksisendringen er live i prod
+        val enumPåApiNavn = if (eøsPraksisEndringFeatureToggleErSlåttPå) {
+            EØSStandardbegrunnelse.values().associateBy { it.sanityApiNavn }
+        } else {
+            EØSStandardbegrunnelse.values().subtract(EØSStandardbegrunnelse.eøsPraksisendringBegrunnelser())
+                .associateBy { it.sanityApiNavn }
+        }
+
         val sanityEØSBegrunnelser = sanityKlient.hentEØSBegrunnelser()
         logManglerSanityBegrunnelseForEnum(enumPåApiNavn, sanityEØSBegrunnelser, "SanityEØSBegrunnelse")
         return sanityEØSBegrunnelser

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -511,4 +511,27 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
             sanityEØSBegrunnelse = sanityEØSBegrunnelse,
         )
     }
+
+    companion object {
+        fun eøsPraksisendringBegrunnelser(): Set<EØSStandardbegrunnelse> = setOf(
+            EØSStandardbegrunnelse.INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_STANDARD,
+            EØSStandardbegrunnelse.INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_UK_STANDARD,
+            EØSStandardbegrunnelse.INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_UK_OG_STANDARD,
+            EØSStandardbegrunnelse.INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_UTSENDT_ARBEIDSTAKER,
+            EØSStandardbegrunnelse.INNVILGET_SELVSTENDIG_RETT_SEKUNDÆRLAND_STANDARD,
+            EØSStandardbegrunnelse.INNVILGET_SELVSTENDIG_RETT_SEKUNDÆRLAND_UK_STANDARD,
+            EØSStandardbegrunnelse.INNVILGET_SELVSTENDIG_RETT_SEKUNDÆRLAND_UK_OG_UTLAND_STANDARD,
+            EØSStandardbegrunnelse.OPPHØR_SELVSTENDIG_RETT_OPPHØR,
+            EØSStandardbegrunnelse.OPPHØR_SELVSTENDIG_RETT_UTSENDT_ARBEIDSTAKER_FRA_ANNET_EØS_LAND,
+            EØSStandardbegrunnelse.AVSLAG_SELVSTENDIG_RETT_STANDARD_AVSLAG,
+            EØSStandardbegrunnelse.AVSLAG_SELVSTENDIG_RETT_UTSENDT_ARBEIDSTAKER_FRA_ANNET_EØS_LAND,
+            EØSStandardbegrunnelse.AVSLAG_SELVSTENDIG_RETT_BOR_IKKE_FAST_MED_BARNET,
+            EØSStandardbegrunnelse.FORTSATT_INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_STANDARD,
+            EØSStandardbegrunnelse.FORTSATT_INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_UK_STANDARD,
+            EØSStandardbegrunnelse.FORTSATT_INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_UK_OG_UTLAND_STANDARD,
+            EØSStandardbegrunnelse.FORTSATT_INNVILGET_SELVSTENDIG_RETT_SEKUNDÆRLAND_STANDARD,
+            EØSStandardbegrunnelse.FORTSATT_INNVILGET_SELVSTENDIG_RETT_SEKUNDÆRLAND_UK_STANDARD,
+            EØSStandardbegrunnelse.FORTSATT_INNVILGET_SELVSTENDIG_RETT_SEKUNDAERLAND_UK_OG_UTLAND_STANDARD,
+        )
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
@@ -1,0 +1,82 @@
+package no.nav.familie.ba.sak.integrasjoner.sanity
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class SanityServiceTest {
+
+    @MockK
+    private lateinit var sanityKlient: SanityKlient
+
+    @MockK
+    private lateinit var featureToggleService: FeatureToggleService
+
+    @InjectMockKs
+    private lateinit var sanityService: SanityService
+
+    @Test
+    fun `hentSanityEØSBegrunnelser - skal filtrere bort nye begrunnelser tilknyttet EØS praksisendring dersom toggel er av`() {
+        every { featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023) } returns false
+
+        every { sanityKlient.hentEØSBegrunnelser() } returns EØSStandardbegrunnelse.values().map {
+            SanityEØSBegrunnelse(
+                apiNavn = it.sanityApiNavn,
+                navnISystem = it.name,
+                fagsakType = null,
+                periodeType = null,
+                tema = null,
+                vilkår = emptySet(),
+                annenForeldersAktivitet = emptyList(),
+                barnetsBostedsland = emptyList(),
+                kompetanseResultat = emptyList(),
+                hjemler = emptyList(),
+                hjemlerFolketrygdloven = emptyList(),
+                hjemlerEØSForordningen883 = emptyList(),
+                hjemlerEØSForordningen987 = emptyList(),
+                hjemlerSeperasjonsavtalenStorbritannina = emptyList(),
+            )
+        }
+
+        val eøsBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
+
+        assertThat(eøsBegrunnelser.keys).doesNotContainAnyElementsOf(EØSStandardbegrunnelse.eøsPraksisendringBegrunnelser())
+    }
+
+    @Test
+    fun `hentSanityEØSBegrunnelser - skal ikke filtrere bort nye begrunnelser tilknyttet EØS praksisendring dersom toggel er på`() {
+        every { featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023) } returns true
+
+        every { sanityKlient.hentEØSBegrunnelser() } returns EØSStandardbegrunnelse.values().map {
+            SanityEØSBegrunnelse(
+                apiNavn = it.sanityApiNavn,
+                navnISystem = it.name,
+                fagsakType = null,
+                periodeType = null,
+                tema = null,
+                vilkår = emptySet(),
+                annenForeldersAktivitet = emptyList(),
+                barnetsBostedsland = emptyList(),
+                kompetanseResultat = emptyList(),
+                hjemler = emptyList(),
+                hjemlerFolketrygdloven = emptyList(),
+                hjemlerEØSForordningen883 = emptyList(),
+                hjemlerEØSForordningen987 = emptyList(),
+                hjemlerSeperasjonsavtalenStorbritannina = emptyList(),
+            )
+        }
+
+        val eøsBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
+
+        assertThat(eøsBegrunnelser.keys).isEqualTo(EØSStandardbegrunnelse.values().toSet())
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Bruker EØS-praksisendring toggle for å hindre at vi viser EØS-praksisendring begrunnelser før det er klart i prod.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

