### PR TITLE
Separer domenebegrepene for testing av brevperioder og brevbegrunnelser

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -296,7 +296,7 @@ class BegrunnelseTeksterStepDefinition {
     }
 
     /**
-     * Mulige verdier: | Begrunnelse | Type | Gjelder søker | Barnas fødselsdager | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Avtale tidspunkt delt bosted | Søkers rett til utvidet |
+     * Mulige verdier: | Begrunnelse | Type | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Avtale tidspunkt delt bosted | Søkers rett til utvidet |
      */
     @Så("forvent følgende brevbegrunnelser for behandling {} i periode {} til {}")
     fun `forvent følgende brevbegrunnelser for behandling i periode`(
@@ -324,7 +324,7 @@ class BegrunnelseTeksterStepDefinition {
     }
 
     /**
-     * Mulige verdier: | Type | Fra dato | Til dato | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
+     * Mulige verdier: | Brevperiodetype | Fra dato | Til dato | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
      */
     @Så("forvent følgende brevperioder for behandling {}")
     fun `forvent følgende brevperioder for behandling i periode`(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevperiodeUtil.kt
@@ -13,14 +13,14 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.BrevBegrunnelse
 fun parseBrevPerioder(dataTable: DataTable): List<BrevPeriode> {
     return dataTable.asMaps().map { rad: Tabellrad ->
 
-        val beløp = parseString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BELØP, rad)
-        val antallBarn = parseInt(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_BARN, rad)
-        val barnasFodselsdatoer = parseValgfriString(
-            BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BARNAS_FØDSELSDAGER,
+        val beløp = parseString(BrevPeriodeParser.DomenebegrepBrevPeriode.BELØP, rad)
+        val antallBarn = parseInt(BrevPeriodeParser.DomenebegrepBrevPeriode.ANTALL_BARN, rad)
+        val barnasFodselsdager = parseValgfriString(
+            BrevPeriodeParser.DomenebegrepBrevPeriode.BARNAS_FØDSELSDAGER,
             rad,
         ) ?: ""
         val duEllerInstitusjonen =
-            parseString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.DU_ELLER_INSTITUSJONEN, rad)
+            parseString(BrevPeriodeParser.DomenebegrepBrevPeriode.DU_ELLER_INSTITUSJONEN, rad)
 
         BrevPeriode(
             fom = parseValgfriString(Domenebegrep.FRA_DATO, rad) ?: "",
@@ -28,9 +28,9 @@ fun parseBrevPerioder(dataTable: DataTable): List<BrevPeriode> {
             beløp = beløp,
             // egen test for dette. Se `forvent følgende brevbegrunnelser for behandling i periode`()
             begrunnelser = emptyList<BrevBegrunnelse>(),
-            brevPeriodeType = parseEnum(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.TYPE, rad),
+            brevPeriodeType = parseEnum(BrevPeriodeParser.DomenebegrepBrevPeriode.TYPE, rad),
             antallBarn = antallBarn.toString(),
-            barnasFodselsdager = barnasFodselsdatoer,
+            barnasFodselsdager = barnasFodselsdager,
             duEllerInstitusjonen = duEllerInstitusjonen,
         )
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BrevPeriodeParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BrevPeriodeParser.kt
@@ -5,9 +5,8 @@ object BrevPeriodeParser {
     enum class DomenebegrepBrevBegrunnelse(override val nøkkel: String) : Domenenøkkel {
         BEGRUNNELSE("Begrunnelse"),
         GJELDER_SØKER("Gjelder søker"),
-        BARNAS_FØDSELSDATOER("Barnas fødselsdatoer"), // brevbegrunnelser
-        BARNAS_FØDSELSDAGER("Barnas fødselsdager"), // brevperioder
-        ANTALL_BARN("Antall barn med utbetaling"),
+        BARNAS_FØDSELSDATOER("Barnas fødselsdatoer"),
+        ANTALL_BARN("Antall barn"),
         MÅNED_OG_ÅR_BEGRUNNELSEN_GJELDER_FOR("Måned og år begrunnelsen gjelder for"),
         MÅLFORM("Målform"),
         BELØP("Beløp"),
@@ -15,6 +14,13 @@ object BrevPeriodeParser {
         AVTALETIDSPUNKT_DELT_BOSTED("Avtaletidspunkt delt bosted"),
         SØKERS_RETT_TIL_UTVIDET("Søkers rett til utvidet"),
         TYPE("Type"),
+    }
+
+    enum class DomenebegrepBrevPeriode(override val nøkkel: String) : Domenenøkkel {
+        BARNAS_FØDSELSDAGER("Barnas fødselsdager"),
+        ANTALL_BARN("Antall barn med utbetaling"),
+        TYPE("Brevperiodetype"),
+        BELØP("Beløp"),
         DU_ELLER_INSTITUSJONEN("Du eller institusjonen"),
     }
 }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/innvilgete-vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/innvilgete-vilkår.feature
@@ -50,8 +50,8 @@ Egenskap: Brevbegrunnelser med riktig fletting av personer med innvilgede vilkå
       | 01.12.2022 | 28.02.2023 | INNVILGET_BOSATT_I_RIKTET |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.12.2022 til 28.02.2023
-      | Begrunnelse               | Gjelder søker | Barnas fødselsdatoer | Antall barn med utbetaling | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
-      | INNVILGET_BOSATT_I_RIKTET | Ja            | 02.02.15 og 07.09.19 | 2                          | november 2022                        | NB      | 2 730 |                  | SØKER_HAR_IKKE_RETT     |
+      | Begrunnelse               | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
+      | INNVILGET_BOSATT_I_RIKTET | Ja            | 02.02.15 og 07.09.19 | 2           | november 2022                        | NB      | 2 730 |                  | SØKER_HAR_IKKE_RETT     |
 
 
   Scenario: barnet - skal kun ta med et barn når det bare er et barn som har endring i vilkår
@@ -85,8 +85,8 @@ Egenskap: Brevbegrunnelser med riktig fletting av personer med innvilgede vilkå
       | 01.12.2022 | 28.02.2023 | INNVILGET_BOSATT_I_RIKTET |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.12.2022 til 28.02.2023
-      | Begrunnelse               | Gjelder søker | Barnas fødselsdatoer | Antall barn med utbetaling | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
-      | INNVILGET_BOSATT_I_RIKTET | Nei           | 07.09.19             | 1                          | november 2022                        | NB      | 1 676 |                  | SØKER_HAR_IKKE_RETT     |
+      | Begrunnelse               | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
+      | INNVILGET_BOSATT_I_RIKTET | Nei           | 07.09.19             | 1           | november 2022                        | NB      | 1 676 |                  | SØKER_HAR_IKKE_RETT     |
 
 
   Scenario: Back to back perioder - ønsker kun å begrunne barnet som har flyttet til søker i INNVILGET_BOR_HOS_SØKER
@@ -122,13 +122,13 @@ Egenskap: Brevbegrunnelser med riktig fletting av personer med innvilgede vilkå
       | 01.06.2023 | 30.06.2023 | INNVILGET_BOR_HOS_SØKER, REDUKSJON_AVTALE_FAST_BOSTED |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.12.2022 til 28.02.2023
-      | Begrunnelse             | Gjelder søker | Barnas fødselsdatoer | Antall barn med utbetaling | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
-      | INNVILGET_BOR_HOS_SØKER | Nei           | 07.09.19             | 1                          | november 2022                        | NB      | 1 676 |                  | SØKER_HAR_IKKE_RETT     |
+      | Begrunnelse             | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
+      | INNVILGET_BOR_HOS_SØKER | Nei           | 07.09.19             | 1           | november 2022                        | NB      | 1 676 |                  | SØKER_HAR_IKKE_RETT     |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.06.2023 til 30.06.2023
-      | Begrunnelse                  | Gjelder søker | Barnas fødselsdatoer | Antall barn med utbetaling | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
-      | INNVILGET_BOR_HOS_SØKER      | Nei           | 02.02.15             | 1                          | mai 2023                             | NB      | 1 083 |                  | SØKER_HAR_IKKE_RETT     |
-      | REDUKSJON_AVTALE_FAST_BOSTED | Nei           | 07.09.19             | 1                          | mai 2023                             | NB      | 862   |                  | SØKER_HAR_IKKE_RETT     |
+      | Begrunnelse                  | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
+      | INNVILGET_BOR_HOS_SØKER      | Nei           | 02.02.15             | 1           | mai 2023                             | NB      | 1 083 |                  | SØKER_HAR_IKKE_RETT     |
+      | REDUKSJON_AVTALE_FAST_BOSTED | Nei           | 07.09.19             | 1           | mai 2023                             | NB      | 862   |                  | SØKER_HAR_IKKE_RETT     |
 
 
   Scenario:Endret for 1 av 2 - Skal kun flette inn barnet som det er utbetaling for når det andre barnet etterbetales
@@ -170,7 +170,7 @@ Egenskap: Brevbegrunnelser med riktig fletting av personer med innvilgede vilkå
       | 01.10.2019 | 31.08.2020 | INNVILGET_BOR_HOS_SØKER |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.10.2019 til 31.08.2020
-      | Begrunnelse             | Gjelder søker | Barnas fødselsdatoer | Antall barn med utbetaling | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
-      | INNVILGET_BOR_HOS_SØKER | Nei           | 07.09.19             | 1                          | september 2019                       | NB      | 1 054 |                  | SØKER_HAR_IKKE_RETT     |
+      | Begrunnelse             | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
+      | INNVILGET_BOR_HOS_SØKER | Nei           | 07.09.19             | 1           | september 2019                       | NB      | 1 054 |                  | SØKER_HAR_IKKE_RETT     |
 
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/kompetanser.feature
@@ -46,10 +46,10 @@ Egenskap: Brevbegrunnelser ved endring av kompetanse
       | 01.05.2021 | 31.03.2038 |                      | INNVILGET_SEKUNDÆRLAND_STANDARD                    |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.05.2020 til 30.04.2021
-      | Begrunnelse                                        | Type | Barnas fødselsdatoer | Antall barn med utbetaling | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
-      | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE | EØS  | 13.04.20             | 1                          | NB      | Norge                          | Norge               | Polen                 | IKKE_AKTUELT              | ARBEIDER         |
+      | Begrunnelse                                        | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
+      | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE | EØS  | 13.04.20             | 1           | NB      | Norge                          | Norge               | Polen                 | IKKE_AKTUELT              | ARBEIDER         |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.05.2021 til 31.03.2038
-      | Begrunnelse                     | Type | Barnas fødselsdatoer | Antall barn med utbetaling | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
-      | INNVILGET_SEKUNDÆRLAND_STANDARD | EØS  | 13.04.20             | 1                          | NB      | Norge                          | Polen               | Polen                 | I_ARBEID                  | ARBEIDER         |
+      | Begrunnelse                     | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
+      | INNVILGET_SEKUNDÆRLAND_STANDARD | EØS  | 13.04.20             | 1           | NB      | Norge                          | Polen               | Polen                 | I_ARBEID                  | ARBEIDER         |
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/vilkår.feature
@@ -32,6 +32,6 @@ Egenskap: Brevbegrunnelser ved endring av vilkår
       | 01.04.2021 |          | OPPHØR_BARN_FLYTTET_FRA_SØKER |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.04.2021 til -
-      | Begrunnelse                   | Gjelder søker | Barnas fødselsdatoer | Antall barn med utbetaling | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
-      | OPPHØR_BARN_FLYTTET_FRA_SØKER | Nei           | 13.04.20             | 1                          | mars 2021                            | NB      | 0     |                  | SØKER_HAR_IKKE_RETT     |
+      | Begrunnelse                   | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
+      | OPPHØR_BARN_FLYTTET_FRA_SØKER | Nei           | 13.04.20             | 1           | mars 2021                            | NB      | 0     |                  | SØKER_HAR_IKKE_RETT     |
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/brevperiodetype.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/brevperiodetype.feature
@@ -47,5 +47,5 @@ Egenskap: Brevperioder: Brevperiodetype
       | 01.04.2022 | 30.06.2023 |                      | INNVILGET_SEKUNDÆRLAND_STANDARD |            |
 
     Så forvent følgende brevperioder for behandling 1
-      | Type       | Fra dato   | Til dato      | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
-      | UTBETALING | april 2022 | til juni 2023 | 0     | 0                          |                     | du                     |
+      | Brevperiodetype | Fra dato   | Til dato      | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
+      | UTBETALING      | april 2022 | til juni 2023 | 0     | 0                          |                     | du                     |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/vilkår.feature
@@ -32,6 +32,6 @@ Egenskap: Brevperioder ved endring av vilkår
       | 01.04.2021 |          | OPPHØR_BARN_FLYTTET_FRA_SØKER |                 |            |
 
     Så forvent følgende brevperioder for behandling 1
-      | Type             | Fra dato   | Til dato | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
-      | INGEN_UTBETALING | april 2021 |          | 0     | 0                          |                      | du                     |
+      | Brevperiodetype  | Fra dato   | Til dato | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
+      | INGEN_UTBETALING | april 2021 |          | 0     | 0                          |                     | du                     |
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Oppfølging av #4028 
Brevperioder og brevbegrunnelser har begrepsbruk som er nesten lik men har ulik betydning eller bruksområde.
For å unngå forvirring når vi skriver og leser tester bør vi adskille dem slik at hvert begrep kan bli korrekt for sitt bruksområde

- **Antall barn**: i brevperiodene ønsker vi kun å ta inn dataen for antall barn med utbetaling, men i brevbegrunnelsene trenger vi å vite antall barn begrunnelsen gjelder
- **Barnas fødselsdager/fødselsdatoer**: restobjektene vi sender til familie-brev er ulike for brevperioder og brevbegrunnelser, de bruker hver sin variant av denne verdien
