### PR TITLE
Vi ønsker å kunne begrunne avslagsperiode for søker selvom det bare finnes uregistrert barn og ingen andre på søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
@@ -110,7 +110,7 @@ data class BehandlingsGrunnlagForVedtaksperioder(
                     ordinæreVilkårForSøkerTidslinje = ordinæreVilkårForSøkerForskjøvetTidslinje,
                     fagsakType = fagsakType,
                     vilkårRolle = vilkårRolle,
-                    bareSøkerOgUregistrertBarn = bareSøkerOgUregistrertBarn
+                    bareSøkerOgUregistrertBarn = bareSøkerOgUregistrertBarn,
                 )
 
             AktørOgRolleBegrunnelseGrunnlag(aktør, vilkårRolle) to

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
@@ -77,6 +77,23 @@ Egenskap: Vedtaksperioder for behandling med uregistrert barn
       | 01.12.2034 |            | Opphør             |           |                         |
       |            |            | Avslag             |           | AVSLAG_UREGISTRERT_BARN |
 
+  Scenario: Skal lage avslagsperiode som begrunner eksplisitt avslag i søkers vilkår dersom det bare finnes uregistrert barn
 
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |
 
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår         | Fra dato   | Til dato | Resultat     | Er eksplisitt avslag |
+      | 1234    | BOSATT_I_RIKET | 11.01.1970 |          | Oppfylt      |                      |
+      | 1234    | LOVLIG_OPPHOLD | 11.01.1970 |          | Ikke_oppfylt | Ja                   |
 
+    Og med uregistrerte barn
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 1
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar | Begrunnelser            |
+      | 01.02.1970 |          | Avslag             |           |                         |
+      |            |          | Avslag             |           | AVSLAG_UREGISTRERT_BARN |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14370
Vi har en feil der vi ikke kan begrunne avslag på de ordinære vilkårene til søker dersom det bare eksisterer uregistrert barn.

Før:
![førrrr](https://github.com/navikt/familie-ba-sak/assets/110383605/e7a46c90-57b6-4f65-8081-1b810e9b8a4b)

Etter:
![etterrr](https://github.com/navikt/familie-ba-sak/assets/110383605/a91c5d6f-50a4-42c9-9daa-465f15162979)
