### PR TITLE
Lagt til nytt endepunkt i ForvalterController og lagt til fnr i respons

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -220,11 +220,19 @@ class ForvalterController(
     }
 
     @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd")
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(): ResponseEntity<List<Long>> {
+    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(): ResponseEntity<List<Pair<Long, String>>> {
         val åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd =
             forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd()
         logger.info("Følgende fagsaker har flere migreringsbehandlinger og løpende sak i Infotrygd: $åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd")
         return ResponseEntity.ok(åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd)
+    }
+
+    @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlinger")
+    fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(): ResponseEntity<List<Pair<Long, String>>> {
+        val åpneFagsakerMedFlereMigreringsbehandlinger =
+            forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger()
+        logger.info("Følgende fagsaker har flere migreringsbehandlinger og løper i ba-sak: $åpneFagsakerMedFlereMigreringsbehandlinger")
+        return ResponseEntity.ok(åpneFagsakerMedFlereMigreringsbehandlinger)
     }
 
     data class SendUtbetalingsoppdragPåNyttResponse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -418,11 +418,16 @@ class ForvalterService(
         return false
     }
 
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(): List<Long> {
+    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(): List<Pair<Long, String>> {
         val løpendeFagsakerMedFlereMigreringsbehandlinger =
             fagsakRepository.finnFagsakerMedFlereMigreringsbehandlinger()
         return løpendeFagsakerMedFlereMigreringsbehandlinger.filter { infotrygdService.harLøpendeSakIInfotrygd(listOf(it.aktør.aktivFødselsnummer())) }
-            .map { it.id }
+            .map { Pair(it.id, it.aktør.aktivFødselsnummer()) }
+    }
+
+    fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(): List<Pair<Long, String>> {
+        return fagsakRepository.finnFagsakerMedFlereMigreringsbehandlinger()
+            .map { Pair(it.id, it.aktør.aktivFødselsnummer()) }
     }
 }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
* Lagt til nytt endepunkt for å hente ut alle fagsaker som er migrert flere ganger og som løper i ba-sak.
* For å enklere kunne finne igjen saker i Infotrygd og Oppdrag legger vi til fnr i respons på endepunktene `/finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd` og `/finnÅpneFagsakerMedFlereMigreringsbehandlinger`
