### PR TITLE
håndter fom == null i finnForeliggende()

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/UtgjørendeVilkårUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/UtgjørendeVilkårUtils.kt
@@ -109,8 +109,9 @@ private fun List<MinimertVilkårResultat>.finnForeliggende(
 ): MinimertVilkårResultat? =
     minimertVilkårResultat.let { vilkårResultat ->
         this.find {
+            if (vilkårResultat.periodeFom == null) return@find false
             it.periodeTom?.isEqual(
-                vilkårResultat.periodeFom?.minusDays(
+                vilkårResultat.periodeFom.minusDays(
                     1,
                 ),
             ) == true && it.vilkårType == vilkårResultat.vilkårType


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Får feil i finnForeliggende() hvis periodeFom == null

Setter til å returnere false siden det ikke skal finnes noen foreliggende periode hvis fom == null