### PR TITLE
Bugfix/ingen personresultater for person

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
@@ -181,8 +181,8 @@ private fun VedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerson(
             .tilForskjøvedeVilkårTidslinjer(person.fødselsdato)
             .kombiner { vilkårResultaterIPeriode -> vilkårResultaterIPeriode.flatMap { it.standardbegrunnelser } }
 
-        tidslinjeMedVedtaksperioden.kombinerMed(avslagsbegrunnelserTisdlinje) { h, v ->
-            v.takeIf { h != null }
+        tidslinjeMedVedtaksperioden.kombinerMed(avslagsbegrunnelserTisdlinje) { vedtaksperiode, avslagsbegrunnelser ->
+            avslagsbegrunnelser.takeIf { vedtaksperiode != null }
         }.perioder().mapNotNull { it.innhold }.flatten().toSet()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
@@ -173,10 +173,13 @@ private fun VedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerson(
     val tidslinjeMedVedtaksperioden = this.tilTidslinjeForAktuellPeriode()
 
     return behandlingsGrunnlagForVedtaksperioder.persongrunnlag.personer.associateWith { person ->
-        val avslagsbegrunnelserTisdlinje =
-            behandlingsGrunnlagForVedtaksperioder.personResultater.single { it.aktør == person.aktør }.vilkårResultater.filter { it.erEksplisittAvslagPåSøknad == true }
-                .tilForskjøvedeVilkårTidslinjer(person.fødselsdato)
-                .kombiner { vilkårResultaterIPeriode -> vilkårResultaterIPeriode.flatMap { it.standardbegrunnelser } }
+        val vilkårResultaterForPerson = behandlingsGrunnlagForVedtaksperioder
+            .personResultater.firstOrNull { it.aktør == person.aktør }?.vilkårResultater ?: emptyList()
+
+        val avslagsbegrunnelserTisdlinje = vilkårResultaterForPerson
+            .filter { it.erEksplisittAvslagPåSøknad == true }
+            .tilForskjøvedeVilkårTidslinjer(person.fødselsdato)
+            .kombiner { vilkårResultaterIPeriode -> vilkårResultaterIPeriode.flatMap { it.standardbegrunnelser } }
 
         tidslinjeMedVedtaksperioden.kombinerMed(avslagsbegrunnelserTisdlinje) { h, v ->
             v.takeIf { h != null }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi får feil [her](https://sentry.gc.nav.no/organizations/nav/issues/514136/?environment=prod&project=112&query=is:unresolved) fordi vi bruker `.single` når vi finner personresultater til personene og det er en uten personresultat

Endrer så vi bruker `.firstOrNull`
