### PR TITLE
Bruk `personer` og ikke `søkerOgBarn` når vi ser på andeler på personer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Utbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Utbetalingsperiode.kt
@@ -109,7 +109,7 @@ fun Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>.lagUtbetalingsperiodeD
 ): List<UtbetalingsperiodeDetalj> =
     this.map { andel ->
         val personForAndel =
-            personopplysningGrunnlag.søkerOgBarn.find { person -> andel.aktør == person.aktør }
+            personopplysningGrunnlag.personer.find { person -> andel.aktør == person.aktør }
                 ?: throw IllegalStateException("Fant ikke personopplysningsgrunnlag for andel")
 
         UtbetalingsperiodeDetalj(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Feil](https://sentry.gc.nav.no/organizations/nav/issues/513217/?environment=prod&query=is:unresolved)

`søkerOgBarn` inneholder ikke alle personene. 
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/2dfc663c-a128-4109-985b-3f90c8ceb80c)
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/131184ce-ade2-499c-8565-ea1b23e11212)

Endrer til å se på `.personer`
