### PR TITLE
Ta med barn med nullutbetaling pga sekundærland i periodetekst

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.IBegrunnelseGrunnlagForPeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.erUtbetalingEllerDeltBostedIPeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.finnBegrunnelseGrunnlagPerPerson
+import java.math.BigDecimal
 
 fun VedtaksperiodeMedBegrunnelser.lagBrevPeriode(
     grunnlagForBegrunnelse: GrunnlagForBegrunnelse,
@@ -110,12 +111,13 @@ private fun Map<Person, IBegrunnelseGrunnlagForPeriode>.hentTotaltUtbetaltIPerio
 
 private fun Map<Person, IBegrunnelseGrunnlagForPeriode>.finnBarnMedUtbetaling() =
     filterKeys { it.type == PersonType.BARN }
-        .filterValues {
+        .filterValues { grunnlag ->
             val endretUtbetalingAndelIPeriodeErDeltBosted =
-                it.dennePerioden.endretUtbetalingAndel?.årsak == Årsak.DELT_BOSTED
-            val utbetalingssumIPeriode = it.dennePerioden.andeler.sumOf { andel -> andel.kalkulertUtbetalingsbeløp }
+                grunnlag.dennePerioden.endretUtbetalingAndel?.årsak == Årsak.DELT_BOSTED
+            val harAndelerSomIkkeErPåNullProsent =
+                grunnlag.dennePerioden.andeler.filter { it.prosent != BigDecimal.ZERO }.toList().isNotEmpty()
 
-            utbetalingssumIPeriode != 0 || endretUtbetalingAndelIPeriodeErDeltBosted
+            harAndelerSomIkkeErPåNullProsent || endretUtbetalingAndelIPeriodeErDeltBosted
         }
 
 fun Set<Person>.tilBarnasFødselsdatoer(): String {

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/brevperiodetype.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/brevperiodetype.feature
@@ -48,4 +48,4 @@ Egenskap: Brevperioder: Brevperiodetype
 
     Så forvent følgende brevperioder for behandling 1
       | Brevperiodetype | Fra dato   | Til dato      | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
-      | UTBETALING      | april 2022 | til juni 2023 | 0     | 0                          |                     | du                     |
+      | UTBETALING      | april 2022 | til juni 2023 | 0     | 1                          | 16.03.22            | du                     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Der vi ikke fletter inn barn med nullutbetaling EØS i periodeteksten. 
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/fdc7f04a-517f-4309-9f72-07e4a051b4d2)
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/c9e4e146-82ae-4810-9a8d-5745d4c9dd59)
☝️ Her skulle vi fått "Du får 0 kroner for 1 barn født ..."

Fikser så vi ikke filtrerer ut barn med 0 kroner pga sekundærland

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester
