### PR TITLE
Kun flett inn barna som hadde andeler forrige periode når vi opphører på søker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
@@ -103,6 +104,14 @@ data class VilkårResultatForVedtaksperiode(
 fun List<VilkårResultatForVedtaksperiode>.erLikUtenFomOgTom(other: List<VilkårResultatForVedtaksperiode>): Boolean {
     return this.map { it.copy(fom = null, tom = null) }.toSet() == other.map { it.copy(fom = null, tom = null) }.toSet()
 }
+
+fun Iterable<VilkårResultatForVedtaksperiode>.erOppfyltForBarn(): Boolean =
+    Vilkår.hentOrdinæreVilkårFor(PersonType.BARN)
+        .all { vilkår ->
+            val vilkårsresutlatet = this.find { it.vilkårType == vilkår }
+
+            vilkårsresutlatet?.resultat == Resultat.OPPFYLT
+        }
 
 data class EndretUtbetalingAndelForVedtaksperiode(
     val prosent: BigDecimal,

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
@@ -1,0 +1,50 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Brevbegrunnelser ved opphør
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId  | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId  | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Skal behandles automatisk |
+      | 1            | 1        |                     | INNVILGET_OG_OPPHØRT | SØKNAD           | Nei                       |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId       | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 10.07.1988  |
+      | 1            | 2       | BARN       | 17.04.2017  |
+      | 1            | 3       | BARN       | 11.07.2013  |
+
+  Scenario: Skal kun flette inn barna som hadde andeler forrige periode når vi opphører på søker.
+    Og følgende dagens dato 13.10.2023
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId       | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1       | LOVLIG_OPPHOLD                                               |                  | 10.07.1988 |            | OPPFYLT  | Nei                  |
+      | 1       | BOSATT_I_RIKET                                               |                  | 01.12.2022 | 01.02.2023 | OPPFYLT  | Nei                  |
+
+      | 3       | GIFT_PARTNERSKAP,BOR_MED_SØKER,LOVLIG_OPPHOLD                |                  | 11.07.2013 |            | OPPFYLT  | Nei                  |
+      | 3       | UNDER_18_ÅR                                                  |                  | 11.07.2013 | 10.07.2031 | OPPFYLT  | Nei                  |
+      | 3       | BOSATT_I_RIKET                                               |                  | 01.12.2022 | 01.01.2023 | OPPFYLT  | Nei                  |
+
+      | 2       | GIFT_PARTNERSKAP,LOVLIG_OPPHOLD,BOSATT_I_RIKET,BOR_MED_SØKER |                  | 17.04.2017 |            | OPPFYLT  | Nei                  |
+      | 2       | UNDER_18_ÅR                                                  |                  | 17.04.2017 | 16.04.2035 | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId       | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 3       | 1            | 01.01.2023 | 31.01.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+
+    Når vedtaksperiodene genereres for behandling 1
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato | Standardbegrunnelser | Eøsbegrunnelser | Fritekster |
+      | 01.03.2023 |          | OPPHØR_UTVANDRET     |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.03.2023 til -
+      | Begrunnelse      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp |
+      | OPPHØR_UTVANDRET | STANDARD | Ja            | 17.04.17             | 1           | februar 2023                         | NB      | 0     | 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
@@ -17,6 +17,7 @@ Egenskap: Brevbegrunnelser ved opphør
       | 1            | 1       | SØKER      | 10.07.1988  |
       | 1            | 2       | BARN       | 17.04.2017  |
       | 1            | 3       | BARN       | 11.07.2013  |
+      | 1            | 4       | BARN       | 16.04.2017  |
 
   Scenario: Skal kun flette inn barna som hadde andeler forrige periode når vi opphører på søker.
     Og følgende dagens dato 13.10.2023
@@ -47,4 +48,35 @@ Egenskap: Brevbegrunnelser ved opphør
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.03.2023 til -
       | Begrunnelse      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp |
-      | OPPHØR_UTVANDRET | STANDARD | Ja            | 17.04.17             | 1           | februar 2023                         | NB      | 0     | 
+      | OPPHØR_UTVANDRET | STANDARD | Ja            | 17.04.17             | 1           | februar 2023                         | NB      | 0     |
+
+  Scenario: Skal flette inn barn som har oppfylte vilkår og barn som hadde andeler i forrige periode når vi opphører for søker
+    Og følgende dagens dato 13.10.2023
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | 1       | LOVLIG_OPPHOLD                                               |                  | 10.07.1988 |            | OPPFYLT  | Nei                  |
+      | 1       | BOSATT_I_RIKET                                               |                  | 01.12.2022 | 01.02.2023 | OPPFYLT  | Nei                  |
+
+      | 2       | GIFT_PARTNERSKAP,LOVLIG_OPPHOLD,BOSATT_I_RIKET,BOR_MED_SØKER |                  | 17.04.2017 |            | OPPFYLT  | Nei                  |
+      | 2       | UNDER_18_ÅR                                                  |                  | 17.04.2017 | 16.04.2035 | OPPFYLT  | Nei                  |
+
+      | 4       | GIFT_PARTNERSKAP,LOVLIG_OPPHOLD,BOR_MED_SØKER                |                  | 17.04.2017 |            | OPPFYLT  | Nei                  |
+      | 4       | BOSATT_I_RIKET                                               |                  | 17.04.2017 | 01.02.2023 | OPPFYLT  | Nei                  |
+      | 4       | UNDER_18_ÅR                                                  |                  | 17.04.2017 | 16.04.2035 | OPPFYLT  | Nei                  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 4       | 1            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+
+    Når vedtaksperiodene genereres for behandling 1
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato | Standardbegrunnelser | Eøsbegrunnelser | Fritekster |
+      | 01.03.2023 |          | OPPHØR_UTVANDRET     |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.03.2023 til -
+      | Begrunnelse      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp |
+      | OPPHØR_UTVANDRET | STANDARD | Ja            | 16.04.17 og 17.04.17 | 2           | februar 2023                         | NB      | 0     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15352)

Når vi opphører på søker legger vi med alle barna som er på behandlingen i begrunnelsen. Det blir feil når vi har barn som er opphørt på et tidligere tidspunkt. 

Endrer så vi kun fletter inn barn som hadde andeler i forrige periode for begrunnelser som gjelder opphør for søker. 

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.