### PR TITLE
Anonymiser aktørid, behandling og fagsak ved henting av begrunnelsestester

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -77,7 +77,7 @@ fun hentTekstForFagsak(behandling: Behandling) =
     """
     Gitt følgende fagsaker for begrunnelse
       | FagsakId | Fagsaktype |
-      | ${behandling.fagsak.id} | ${behandling.fagsak.type} |"""
+      | 1 | ${behandling.fagsak.type} |"""
 
 fun hentTekstForBehandlinger(behandling: Behandling, forrigeBehandling: Behandling?) =
     """
@@ -86,10 +86,10 @@ fun hentTekstForBehandlinger(behandling: Behandling, forrigeBehandling: Behandli
       | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk |${
         forrigeBehandling?.let {
             """ 
-      | ${it.id} | ${it.fagsak.id} |           | ${it.resultat} | ${it.opprettetÅrsak} | ${if (it.skalBehandlesAutomatisk) "Ja" else "Nei"} |"""
+      | ${it.id} | 1 |           | ${it.resultat} | ${it.opprettetÅrsak} | ${if (it.skalBehandlesAutomatisk) "Ja" else "Nei"} |"""
         } ?: ""
     }
-      | ${behandling.id} | ${behandling.fagsak.id} | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak} | ${if (behandling.skalBehandlesAutomatisk) "Ja" else "Nei"} |"""
+      | ${behandling.id} | 1 | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak} | ${if (behandling.skalBehandlesAutomatisk) "Ja" else "Nei"} |"""
 
 fun hentTekstForPersongrunnlag(
     persongrunnlag: PersonopplysningGrunnlag,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -74,6 +74,10 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
     val indekserteAktørIder =
         personerSomTestes.sortedBy { it.fødselsdato }.mapIndexed { i, p -> Pair(p.aktør.aktørId, i + 1) }.toMap()
 
+    val behandlinger: Map<Long, Int> =
+        listOf(forrigeBehandling?.id, behandling.id).filterNotNull().mapIndexed { i, bi -> Pair(bi, i + 1) }.toMap()
+
+    behandlinger.forEach { test = test.replace(it.key.toString(), it.value.toString()) }
     indekserteAktørIder.forEach { test = test.replace(it.key, it.value.toString()) }
     return test
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -178,6 +178,7 @@ fun hentTekstForTilkjentYtelse(
     Og med andeler tilkjent ytelse for begrunnelse
       | AktørId | BehandlingId | Fra dato | Til dato | Beløp | Ytelse type | Prosent | Sats | """ +
         hentAndelRader(andelerForrigeBehandling, persongrunnlagForrigeBehandling) +
+        "\n" +
         hentAndelRader(andeler, persongrunnlag)
 
 private fun hentAndelRader(andeler: List<AndelTilkjentYtelse>?, persongrunnlag: PersonopplysningGrunnlag?): String =

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -53,10 +53,10 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
         lagPersonresultaterTekst(forrigeBehandling) +
         lagPersonresultaterTekst(behandling) +
         hentTekstForVilkårresultater(
-            personResultaterForrigeBehandling?.sorterPåFøselsdato(persongrunnlagForrigeBehandling!!),
+            personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),
             forrigeBehandling?.id,
         ) +
-        hentTekstForVilkårresultater(personResultater.sorterPåFøselsdato(persongrunnlag), behandling.id) +
+        hentTekstForVilkårresultater(personResultater.sorterPåFødselsdato(persongrunnlag), behandling.id) +
         hentTekstForTilkjentYtelse(andeler, persongrunnlag, andelerForrigeBehandling, persongrunnlagForrigeBehandling) +
         hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
         hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) + """
@@ -300,7 +300,7 @@ fun hentVedtaksperiodeRaderForGyldigeBegrunnelser(vedtaksperioder: List<Vedtaksp
             }
     }
 
-private fun Set<PersonResultat>.sorterPåFøselsdato(persongrunnlag: PersonopplysningGrunnlag) =
+private fun Set<PersonResultat>.sorterPåFødselsdato(persongrunnlag: PersonopplysningGrunnlag) =
     this.sortedBy { personresultat -> persongrunnlag.personer.single { personresultat.aktør == it.aktør }.fødselsdato }
 
 fun hentTekstValgteBegrunnelser(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Nå er det en manuell jobb å anonymisere aktørid, behandling og fagsak ved henting av begrunnelsestester. Vi ønsker å automatisere dette for å unngå å hente ned og lagre disse dataene i testene våre

<details>
<summary>Før</summary>
<pre>
# language: no
# encoding: UTF-8

Egenskap: Plassholdertekst for egenskap - xQWffRfg80

  Bakgrunn:
    Gitt følgende fagsaker for begrunnelse
      | FagsakId | Fagsaktype |
      | 999952   | NORMAL     |

    Gitt følgende behandling
      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Skal behandles automatisk |
      | 999952       | 999952   |                     | INNVILGET_OG_OPPHØRT | SØKNAD           | Nei                       |
      | 1000001      | 999952   | 999952              | ENDRET_UTBETALING    | NYE_OPPLYSNINGER | Nei                       |

    Og følgende persongrunnlag for begrunnelse
      | BehandlingId | AktørId       | Persontype | Fødselsdato |
      | 999952       | 2217097330768 | SØKER      | 09.07.1986  |
      | 999952       | 2765766368213 | BARN       | 06.11.2010  |
      | 999952       | 2253105480524 | BARN       | 13.02.2005  |
      | 1000001      | 2217097330768 | SØKER      | 09.07.1986  |
      | 1000001      | 2765766368213 | BARN       | 06.11.2010  |
      | 1000001      | 2253105480524 | BARN       | 13.02.2005  |

  Scenario: Plassholdertekst for scenario - dEtZMPyWKT
    Og følgende dagens dato 13.10.2023
    Og lag personresultater for begrunnelse for behandling 999952
    Og lag personresultater for begrunnelse for behandling 1000001

    Og legg til nye vilkårresultater for begrunnelse for behandling 999952
      | AktørId       | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
      | 2217097330768 | UTVIDET_BARNETRYGD,LOVLIG_OPPHOLD                            |                  | 09.07.1986 |            | OPPFYLT  | Nei                  |
      | 2217097330768 | BOSATT_I_RIKET                                               |                  | 09.07.1986 | 01.06.2023 | OPPFYLT  | Nei                  |

      | 2253105480524 | GIFT_PARTNERSKAP,BOR_MED_SØKER,BOSATT_I_RIKET,LOVLIG_OPPHOLD |                  | 13.02.2005 |            | OPPFYLT  | Nei                  |
      | 2253105480524 | UNDER_18_ÅR                                                  |                  | 13.02.2005 | 12.02.2023 | OPPFYLT  | Nei                  |

      | 2765766368213 | UNDER_18_ÅR                                                  |                  | 06.11.2010 | 05.11.2028 | OPPFYLT  | Nei                  |
      | 2765766368213 | BOR_MED_SØKER,GIFT_PARTNERSKAP,LOVLIG_OPPHOLD,BOSATT_I_RIKET |                  | 06.11.2010 |            | OPPFYLT  | Nei                  |

    Og legg til nye vilkårresultater for begrunnelse for behandling 1000001
      | AktørId       | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
      | 2217097330768 | LOVLIG_OPPHOLD,UTVIDET_BARNETRYGD,BOSATT_I_RIKET             |                  | 09.07.1986 |            | OPPFYLT  | Nei                  |

      | 2253105480524 | BOSATT_I_RIKET,BOR_MED_SØKER,LOVLIG_OPPHOLD,GIFT_PARTNERSKAP |                  | 13.02.2005 |            | OPPFYLT  | Nei                  |
      | 2253105480524 | UNDER_18_ÅR                                                  |                  | 13.02.2005 | 12.02.2023 | OPPFYLT  | Nei                  |

      | 2765766368213 | GIFT_PARTNERSKAP,LOVLIG_OPPHOLD,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 06.11.2010 |            | OPPFYLT  | Nei                  |
      | 2765766368213 | UNDER_18_ÅR                                                  |                  | 06.11.2010 | 05.11.2028 | OPPFYLT  | Nei                  |

    Og med andeler tilkjent ytelse for begrunnelse
      | AktørId       | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
      | 2765766368213 | 999952       | 01.12.2010 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 2765766368213 | 999952       | 01.03.2019 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
      | 2765766368213 | 999952       | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
      | 2217097330768 | 999952       | 01.03.2005 | 28.02.2019 | 970   | UTVIDET_BARNETRYGD | 100     | 970  |
      | 2217097330768 | 999952       | 01.03.2019 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     | 1054 |
      | 2217097330768 | 999952       | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
      | 2253105480524 | 999952       | 01.03.2005 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 2253105480524 | 999952       | 01.03.2019 | 31.01.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
      | 2765766368213 | 1000001      | 01.12.2010 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 2765766368213 | 1000001      | 01.03.2019 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
      | 2765766368213 | 1000001      | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
      | 2765766368213 | 1000001      | 01.07.2023 | 31.10.2028 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
      | 2217097330768 | 1000001      | 01.03.2005 | 28.02.2019 | 970   | UTVIDET_BARNETRYGD | 100     | 970  |
      | 2217097330768 | 1000001      | 01.03.2019 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     | 1054 |
      | 2217097330768 | 1000001      | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
      | 2217097330768 | 1000001      | 01.07.2023 | 31.10.2028 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
      | 2253105480524 | 1000001      | 01.03.2005 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 2253105480524 | 1000001      | 01.03.2019 | 31.01.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |

    Når vedtaksperiodene genereres for behandling 1000001

    Så forvent at følgende begrunnelser er gyldige
      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk | Gyldige begrunnelser  | Ugyldige begrunnelser |
      | 01.02.2023 | 28.02.2023 | UTBETALING         |           | REDUKSJON_UNDER_18_ÅR |                       |
      | 01.03.2023 | 30.06.2023 | UTBETALING         |           | INNVILGET_SATSENDRING |                       |
      | 01.07.2023 | 31.10.2028 | UTBETALING         |           | INNVILGET_SATSENDRING |                       |
      | 01.11.2028 |            | OPPHØR             |           |                       |                       |

    Og når disse begrunnelsene er valgt for behandling 1000001
      | Fra dato   | Til dato   | Standardbegrunnelser  | Eøsbegrunnelser | Fritekster |
      | 01.02.2023 | 28.02.2023 | REDUKSJON_UNDER_18_ÅR |                 |            |
      | 01.03.2023 | 30.06.2023 | INNVILGET_SATSENDRING |                 |            |
      | 01.07.2023 | 31.10.2028 | INNVILGET_SATSENDRING |                 |            |
      | 01.11.2028 |            |                       |                 |            |

    Så forvent følgende brevperioder for behandling 1000001
      | Brevperiodetype | Fra dato   | Til dato   | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
      |                 | 01.02.2023 | 28.02.2023 |       |                            |                     |                        |
      |                 | 01.03.2023 | 30.06.2023 |       |                            |                     |                        |
      |                 | 01.07.2023 | 31.10.2028 |       |                            |                     |                        |
      |                 | 01.11.2028 |            |       |                            |                     |                        |

    Så forvent følgende brevbegrunnelser for behandling 1000001 i periode 01.02.2023 til 28.02.2023
      | Begrunnelse           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
      | REDUKSJON_UNDER_18_ÅR | STANDARD |               |                      |             |                                      |         |       |                  |                         |

    Så forvent følgende brevbegrunnelser for behandling 1000001 i periode 01.03.2023 til 30.06.2023
      | Begrunnelse           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
      | INNVILGET_SATSENDRING | STANDARD |               |                      |             |                                      |         |       |                  |                         |

    Så forvent følgende brevbegrunnelser for behandling 1000001 i periode 01.07.2023 til 31.10.2028
      | Begrunnelse           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
      | INNVILGET_SATSENDRING | STANDARD |               |                      |             |                                      |         |       |                  |                         |

</pre>
</details>

<details>
<summary>Etter</summary>
<pre>
# language: no
# encoding: UTF-8

Egenskap: Plassholdertekst for egenskap - sGJKS3BC0j

  Bakgrunn:
    Gitt følgende fagsaker for begrunnelse
      | FagsakId | Fagsaktype |
      | 1        | NORMAL     |

    Gitt følgende behandling
      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Skal behandles automatisk |
      | 1            | 1        |                     | INNVILGET_OG_OPPHØRT | SØKNAD           | Nei                       |
      | 2            | 1        | 1                   | ENDRET_UTBETALING    | NYE_OPPLYSNINGER | Nei                       |

    Og følgende persongrunnlag for begrunnelse
      | BehandlingId | AktørId | Persontype | Fødselsdato |
      | 1            | 1       | SØKER      | 09.07.1986  |
      | 1            | 2       | BARN       | 13.02.2005  |
      | 1            | 3       | BARN       | 06.11.2010  |
      | 2            | 1       | SØKER      | 09.07.1986  |
      | 2            | 2       | BARN       | 13.02.2005  |
      | 2            | 3       | BARN       | 06.11.2010  |

  Scenario: Plassholdertekst for scenario - vee75fPuhY
    Og følgende dagens dato 13.10.2023
    Og lag personresultater for begrunnelse for behandling 1
    Og lag personresultater for begrunnelse for behandling 2

    Og legg til nye vilkårresultater for begrunnelse for behandling 1
      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
      | 1       | LOVLIG_OPPHOLD,UTVIDET_BARNETRYGD                            |                  | 09.07.1986 |            | OPPFYLT  | Nei                  |
      | 1       | BOSATT_I_RIKET                                               |                  | 09.07.1986 | 01.06.2023 | OPPFYLT  | Nei                  |

      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,GIFT_PARTNERSKAP,LOVLIG_OPPHOLD |                  | 13.02.2005 |            | OPPFYLT  | Nei                  |
      | 2       | UNDER_18_ÅR                                                  |                  | 13.02.2005 | 12.02.2023 | OPPFYLT  | Nei                  |

      | 3       | BOSATT_I_RIKET,BOR_MED_SØKER,LOVLIG_OPPHOLD,GIFT_PARTNERSKAP |                  | 06.11.2010 |            | OPPFYLT  | Nei                  |
      | 3       | UNDER_18_ÅR                                                  |                  | 06.11.2010 | 05.11.2028 | OPPFYLT  | Nei                  |

    Og legg til nye vilkårresultater for begrunnelse for behandling 2
      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
      | 1       | LOVLIG_OPPHOLD,UTVIDET_BARNETRYGD,BOSATT_I_RIKET             |                  | 09.07.1986 |            | OPPFYLT  | Nei                  |

      | 2       | GIFT_PARTNERSKAP,LOVLIG_OPPHOLD,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 13.02.2005 |            | OPPFYLT  | Nei                  |
      | 2       | UNDER_18_ÅR                                                  |                  | 13.02.2005 | 12.02.2023 | OPPFYLT  | Nei                  |

      | 3       | GIFT_PARTNERSKAP,BOR_MED_SØKER,BOSATT_I_RIKET,LOVLIG_OPPHOLD |                  | 06.11.2010 |            | OPPFYLT  | Nei                  |
      | 3       | UNDER_18_ÅR                                                  |                  | 06.11.2010 | 05.11.2028 | OPPFYLT  | Nei                  |

    Og med andeler tilkjent ytelse for begrunnelse
      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
      | 1       | 1            | 01.03.2005 | 28.02.2019 | 970   | UTVIDET_BARNETRYGD | 100     | 970  |
      | 1       | 1            | 01.03.2019 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     | 1054 |
      | 1       | 1            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
      | 2       | 1            | 01.03.2005 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 2       | 1            | 01.03.2019 | 31.01.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
      | 3       | 1            | 01.12.2010 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 3       | 1            | 01.03.2019 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
      | 3       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |

      | 1       | 2            | 01.03.2005 | 28.02.2019 | 970   | UTVIDET_BARNETRYGD | 100     | 970  |
      | 1       | 2            | 01.03.2019 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     | 1054 |
      | 1       | 2            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
      | 1       | 2            | 01.07.2023 | 31.10.2028 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
      | 2       | 2            | 01.03.2005 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 2       | 2            | 01.03.2019 | 31.01.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
      | 3       | 2            | 01.12.2010 | 28.02.2019 | 970   | ORDINÆR_BARNETRYGD | 100     | 970  |
      | 3       | 2            | 01.03.2019 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
      | 3       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
      | 3       | 2            | 01.07.2023 | 31.10.2028 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |

    Når vedtaksperiodene genereres for behandling 2

    Så forvent at følgende begrunnelser er gyldige
      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk | Gyldige begrunnelser  | Ugyldige begrunnelser |
      | 01.02.2023 | 28.02.2023 | UTBETALING         |           | REDUKSJON_UNDER_18_ÅR |                       |
      | 01.03.2023 | 30.06.2023 | UTBETALING         |           | INNVILGET_SATSENDRING |                       |
      | 01.07.2023 | 31.10.2028 | UTBETALING         |           | INNVILGET_SATSENDRING |                       |
      | 01.11.2028 |            | OPPHØR             |           |                       |                       |

    Og når disse begrunnelsene er valgt for behandling 2
      | Fra dato   | Til dato   | Standardbegrunnelser  | Eøsbegrunnelser | Fritekster |
      | 01.02.2023 | 28.02.2023 | REDUKSJON_UNDER_18_ÅR |                 |            |
      | 01.03.2023 | 30.06.2023 | INNVILGET_SATSENDRING |                 |            |
      | 01.07.2023 | 31.10.2028 | INNVILGET_SATSENDRING |                 |            |
      | 01.11.2028 |            |                       |                 |            |

    Så forvent følgende brevperioder for behandling 2
      | Brevperiodetype | Fra dato   | Til dato   | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
      |                 | 01.02.2023 | 28.02.2023 |       |                            |                     |                        |
      |                 | 01.03.2023 | 30.06.2023 |       |                            |                     |                        |
      |                 | 01.07.2023 | 31.10.2028 |       |                            |                     |                        |
      |                 | 01.11.2028 |            |       |                            |                     |                        |

    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.02.2023 til 28.02.2023
      | Begrunnelse           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
      | REDUKSJON_UNDER_18_ÅR | STANDARD |               |                      |             |                                      |         |       |                  |                         |

    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.03.2023 til 30.06.2023
      | Begrunnelse           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
      | INNVILGET_SATSENDRING | STANDARD |               |                      |             |                                      |         |       |                  |                         |

    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.07.2023 til 31.10.2028
      | Begrunnelse           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
      | INNVILGET_SATSENDRING | STANDARD |               |                      |             |                                      |         |       |                  |                         |

</pre>
</details>

