### PR TITLE
Månedlig uttrekk av saker som er migrert til BA-sak flere ganger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
 import java.util.UUID
 import kotlin.concurrent.thread
 
@@ -121,18 +122,18 @@ class ForvalterController(
         return ResponseEntity.ok(ecbService.hentValutakurs(valuta, dato))
     }
 
-    @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd")
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(): ResponseEntity<List<Pair<Long, String>>> {
+    @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd/{fraÅrMåned}")
+    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(@PathVariable fraÅrMåned: YearMonth): ResponseEntity<List<Pair<Long, String>>> {
         val åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd =
-            forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd()
+            forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(fraÅrMåned)
         logger.info("Følgende fagsaker har flere migreringsbehandlinger og løpende sak i Infotrygd: $åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd")
         return ResponseEntity.ok(åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd)
     }
 
-    @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlinger")
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(): ResponseEntity<List<Pair<Long, String>>> {
+    @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlinger/{fraÅrMåned}")
+    fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(@PathVariable fraÅrMåned: YearMonth): ResponseEntity<List<Pair<Long, String>>> {
         val åpneFagsakerMedFlereMigreringsbehandlinger =
-            forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger()
+            forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger(fraÅrMåned)
         logger.info("Følgende fagsaker har flere migreringsbehandlinger og løper i ba-sak: $åpneFagsakerMedFlereMigreringsbehandlinger")
         return ResponseEntity.ok(åpneFagsakerMedFlereMigreringsbehandlinger)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterScheduler.kt
@@ -1,0 +1,44 @@
+package no.nav.familie.ba.sak.internal
+
+import no.nav.familie.ba.sak.common.EnvService
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.task.FinnSakerMedFlereMigreringsbehandlingerTask
+import no.nav.familie.leader.LeaderClient
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.YearMonth
+
+@Component
+class ForvalterScheduler(
+    private val taskRepository: TaskRepositoryWrapper,
+    private val envService: EnvService,
+) {
+
+    /*
+     * Oppretter task månedlig for å identifisere løpende fagsaker som har flere migreringer sist måned
+     */
+    @Scheduled(cron = "0 0 7 1 * *")
+    fun opprettFinnSakerMedFlereMigreringsbehandlingerTask() {
+        when (LeaderClient.isLeader() == true || envService.erDev()) {
+            true -> {
+                val finnSakerMedFlereMigreringsbehandlingerTask =
+                    Task(
+                        type = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE,
+                        payload = "${YearMonth.now().minusMonths(1)}",
+                    )
+                taskRepository.save(finnSakerMedFlereMigreringsbehandlingerTask)
+                logger.info("Opprettet FinnSakerMedFlereMigreringsbehandlingerTask")
+            }
+
+            false -> {
+                logger.info("Ikke opprettet FinnSakerMedFlereMigreringsbehandlingerTask på denne poden")
+            }
+        }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(ForvalterScheduler::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.fagsak
 import io.micrometer.core.annotation.Timed
 import jakarta.persistence.LockModeType
 import no.nav.familie.ba.sak.ekstern.skatteetaten.UtvidetSkatt
+import no.nav.familie.ba.sak.internal.FagsakMedFlereMigreringer
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -184,12 +185,38 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
 
     @Query(
         """
-        SELECT distinct f FROM Fagsak f
-            JOIN Behandling b ON f.id = b.fagsak.id
-            WHERE f.status = 'LØPENDE' AND b.opprettetÅrsak in ('HELMANUELL_MIGRERING', 'MIGRERING') AND b.resultat NOT IN ('HENLAGT_FEILAKTIG_OPPRETTET', 'HENLAGT_SØKNAD_TRUKKET', 'HENLAGT_AUTOMATISK_FØDSELSHENDELSE', 'HENLAGT_TEKNISK_VEDLIKEHOLD')
-        GROUP BY f.id
-        HAVING COUNT(*) >= 2
+        WITH fagsakerMigrertFlereGanger AS (SELECT f.id
+                                    FROM Fagsak f
+                                             JOIN Behandling b ON f.id = b.fk_fagsak_id
+                                             join aktoer a on f.fk_aktoer_id = a.aktoer_id
+                                    WHERE f.status = 'LØPENDE'
+                                      AND b.opprettet_aarsak in ('HELMANUELL_MIGRERING', 'MIGRERING')
+                                      AND b.resultat NOT IN (
+                                                             'HENLAGT_FEILAKTIG_OPPRETTET',
+                                                             'HENLAGT_SØKNAD_TRUKKET',
+                                                             'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+                                                             'HENLAGT_TEKNISK_VEDLIKEHOLD'
+                                        )
+                                      AND b.status = 'AVSLUTTET'
+                                    GROUP BY f.id
+                                    HAVING COUNT(*) >= 2)
+
+        SELECT b.fk_fagsak_id as fagsakId, p.foedselsnummer as fødselsnummer
+        FROM Behandling b
+                 JOIN fagsakerMigrertFlereGanger fmfg ON b.fk_fagsak_id = fmfg.id
+                 JOIN vedtak v ON b.id = v.fk_behandling_id
+                 JOIN fagsak f ON f.id = b.fk_fagsak_id
+                 join personident p ON p.fk_aktoer_id = f.fk_aktoer_id
+        WHERE b.opprettet_aarsak in ('HELMANUELL_MIGRERING', 'MIGRERING')
+          AND b.resultat NOT IN (
+                                 'HENLAGT_FEILAKTIG_OPPRETTET',
+                                 'HENLAGT_SØKNAD_TRUKKET',
+                                 'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+                                 'HENLAGT_TEKNISK_VEDLIKEHOLD'
+            )
+          AND vedtaksdato > :month
         """,
+        nativeQuery = true,
     )
-    fun finnFagsakerMedFlereMigreringsbehandlinger(): List<Fagsak>
+    fun finnFagsakerMedFlereMigreringsbehandlinger(month: LocalDateTime): List<FagsakMedFlereMigreringer>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTask.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.internal.ForvalterService
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE,
+    beskrivelse = "Finn fagsaker med flere migreringersbehandlinger",
+    maxAntallFeil = 1,
+)
+class FinnSakerMedFlereMigreringsbehandlingerTask(val forvalterService: ForvalterService) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val fraOgMedÅrMåned = YearMonth.parse(task.payload)
+
+        val sakerMedFlereMigreringsbehandlinger = forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger(fraOgMedÅrMåned)
+
+        if (sakerMedFlereMigreringsbehandlinger.isNotEmpty()) {
+            error("$FEILMELDING fraOgMedÅrMåned=$fraOgMedÅrMåned \n${sakerMedFlereMigreringsbehandlinger.joinToString("\n")}")
+        }
+    }
+
+    companion object {
+        private const val FEILMELDING = "Det er nye fagsaker som har har flere enn 1 migrering fra Infotrygd. Send liste til fag og avvikshåndter tasken."
+
+        const val TASK_STEP_TYPE = "finnSakerMedFlereMigreringsbehandlinger"
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ba.sak.internal
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import no.nav.familie.ba.sak.common.EnvService
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.task.FinnSakerMedFlereMigreringsbehandlingerTask
+import no.nav.familie.prosessering.domene.Task
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class ForvalterSchedulerTest {
+
+    private val taskRepository = mockk<TaskRepositoryWrapper>()
+    private val envService = mockk<EnvService>()
+    private val service = ForvalterScheduler(taskRepository, envService)
+    private val slot = slot<Task>()
+
+    @BeforeEach
+    fun initTest() {
+        mockkStatic(YearMonth::class)
+        every { YearMonth.now() }.returns(YearMonth.of(2022, 5))
+        every { envService.erDev() } returns true
+        every { taskRepository.save(capture(slot)) } returns Task(type = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE, payload = "")
+    }
+
+    @Test
+    fun `Skal opprette task av type finnSakerMedFlereMigreringsbehandlinger`() {
+        service.opprettFinnSakerMedFlereMigreringsbehandlingerTask()
+
+        assertThat(slot.captured.payload).isEqualTo("2022-04")
+        assertThat(slot.captured.type).isEqualTo("finnSakerMedFlereMigreringsbehandlinger")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTaskTest.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.internal.ForvalterService
+import no.nav.familie.prosessering.domene.Task
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class FinnSakerMedFlereMigreringsbehandlingerTaskTest {
+    private val forvalterService = mockk<ForvalterService>()
+    private val task = FinnSakerMedFlereMigreringsbehandlingerTask(forvalterService)
+
+    @Test
+    fun `Skal kaste feil hvis man finner åpne saker med flere migreringsbehandlinger fra sist måned`() {
+        every { forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger(any()) } returns
+            listOf(Pair(1, "fnr1"), Pair(2, "fnr2"))
+
+        val exception = assertThrows<IllegalStateException> {
+            task.doTask(Task(type = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE, payload = "2023-10"))
+        }
+
+        assertThat(exception.message).isEqualTo(
+            """
+            Det er nye fagsaker som har har flere enn 1 migrering fra Infotrygd. Send liste til fag og avvikshåndter tasken. fraOgMedÅrMåned=2023-10 
+            (1, fnr1)
+            (2, fnr2)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `Skal ikke kaste feil hvis man ikke finner nye åpne saker som har flere enn 1 migrering`() {
+        every { forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger(any()) } returns emptyList()
+
+        task.doTask(Task(type = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE, payload = "2023-10"))
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Månedlig uttrekk av saker som er migrert til BA-sak flere ganger

En schedulert jobb som kjører hver måned, som oppretter en task som leter etter løpende fagsaker med flere enn 1 migrering. Hvis den finner slike saker, så feiler tasken og må avvikhåndteres etter at listen er sendt til Anna.

NAV-16095

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
