### PR TITLE
Fjern spesiallogikk for å begrunne utvidet som nå dekkes av eget trigger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VilkårFilterUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VilkårFilterUtil.kt
@@ -6,8 +6,6 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.UtvidetBarnetrygdTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilUtdypendeVilkårsvurderinger
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VilkårResultatForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -92,13 +90,8 @@ private fun finnUtgjørendeVilkår(
     )
 
     return if (begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget()) {
-        val utvidetTriggetAvInnvilgelse = hentUtvidetTriggetAvInnvilgelse(
-            sanityBegrunnelse = sanityBegrunnelse,
-            andelerForrigePeriode = begrunnelseGrunnlag.forrigePeriode?.andeler,
-            oppfylteVilkårResultaterDennePerioden = oppfylteVilkårResultaterDennePerioden,
-        )
         when (sanityBegrunnelse.periodeResultat) {
-            SanityPeriodeResultat.INNVILGET_ELLER_ØKNING -> vilkårTjent + vilkårEndret + utvidetTriggetAvInnvilgelse
+            SanityPeriodeResultat.INNVILGET_ELLER_ØKNING -> vilkårTjent + vilkårEndret
             SanityPeriodeResultat.INGEN_ENDRING -> vilkårEndret
             SanityPeriodeResultat.IKKE_INNVILGET,
             SanityPeriodeResultat.REDUKSJON,
@@ -150,18 +143,4 @@ private fun hentVilkårResultaterTapt(
     val vilkårTapt = oppfyltForrigePeriode - oppfyltDennePerioden
 
     return oppfylteVilkårResultaterForrigePeriode.filter { it.vilkårType in vilkårTapt }
-}
-
-private fun hentUtvidetTriggetAvInnvilgelse(
-    sanityBegrunnelse: ISanityBegrunnelse,
-    andelerForrigePeriode: Iterable<AndelForVedtaksperiode>?,
-    oppfylteVilkårResultaterDennePerioden: List<VilkårResultatForVedtaksperiode>,
-): List<VilkårResultatForVedtaksperiode> {
-    if (sanityBegrunnelse.apiNavn != Standardbegrunnelse.INNVILGET_BOR_ALENE_MED_BARN.sanityApiNavn) {
-        return emptyList()
-    }
-    val ingenAndelerForrigePeriode = andelerForrigePeriode == null || !andelerForrigePeriode.any()
-    val utvidetOppfyltDennePerioden =
-        oppfylteVilkårResultaterDennePerioden.filter { it.vilkårType == Vilkår.UTVIDET_BARNETRYGD }
-    return if (ingenAndelerForrigePeriode) utvidetOppfyltDennePerioden else emptyList()
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Denne logikken ble lagt til i #4026 for å kunne begrunne utvidet i alle tilfeller der søker begynner å få utvidet-andeler, uavhengig av om det var utvidet-vilkåret som var utgjørende for at andelen begynte. 

I #4104 ble det lagt til et eget trigger som gjør denne begrunnelsen tilgjengelig i alle perioder der utvidet er innvilget. Dette gjør at vi ikke trenger logikken fra #4026 lengre.

Fjerner logikken men beholder testen som bekrefter ønsket oppførsel


