### PR TITLE
Gi fortsatt innvilget-periode ved beh.res. endret og fortsatt innvilget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
@@ -50,7 +49,7 @@ fun genererVedtaksperioder(
         )
     }
 
-    if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET) {
+    if (vedtak.behandling.resultat.erFortsattInnvilget()) {
         return lagFortsattInnvilgetPeriode(vedtak = vedtak)
     }
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/fortsatt_innvilget.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/fortsatt_innvilget.feature
@@ -128,7 +128,6 @@ Egenskap: Gyldige begrunnelser for fortsatt innvilget
       | Fra dato | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                     | Ugyldige begrunnelser |
       |          |          | FORTSATT_INNVILGET | EØS_FORORDNINGEN               | FORTSETT_INNVILGET_SEKUNDÆRLAND_STANDARD |                       |
 
-
   Scenario: Skal få tekster tilhørende EØS primærland og sekundærland ved fortsatt innvilget EØS med ulik kompetanse for barna
     Gitt følgende fagsaker for begrunnelse
       | FagsakId | Fagsaktype |
@@ -234,3 +233,53 @@ Egenskap: Gyldige begrunnelser for fortsatt innvilget
       | Fra dato | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                                                             | Ugyldige begrunnelser |
       |          |          | FORTSATT_INNVILGET |                                | FORTSATT_INNVILGET_BOR_ALENE_MED_BARN                                            |                       |
       |          |          | FORTSATT_INNVILGET | EØS_FORORDNINGEN               | FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD, FORTSETT_INNVILGET_SEKUNDÆRLAND_STANDARD |                       |
+
+  Scenario: Revurdering endrer fom for søkers vilkår, men påvirker ikke andeler og resultat, skal begrunne fortsatt innvilget
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat          | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        |                     | INNVILGET                    | FØDSELSHENDELSE  | Ja                        | NASJONAL            |
+      | 2            | 1        | 1                   | ENDRET_OG_FORTSATT_INNVILGET | SØKNAD           | Nei                       | NASJONAL            |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | ANNENPART  | 14.08.1996  |
+      | 1            | 2       | SØKER      | 19.11.1997  |
+      | 1            | 3       | BARN       | 05.09.2023  |
+      | 2            | 2       | SØKER      | 19.11.1997  |
+      | 2            | 3       | BARN       | 05.09.2023  |
+    Og følgende dagens dato 22.10.2023
+    Og lag personresultater for begrunnelse for behandling 1
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 2       | BOSATT_I_RIKET,LOVLIG_OPPHOLD                                |                  | 05.09.2023 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | BOSATT_I_RIKET,LOVLIG_OPPHOLD,BOR_MED_SØKER,GIFT_PARTNERSKAP |                  | 05.09.2023 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | UNDER_18_ÅR                                                  |                  | 05.09.2023 | 04.09.2041 | OPPFYLT  | Nei                  |                      |
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 2       | BOSATT_I_RIKET                                               |                  | 01.02.2023 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | LOVLIG_OPPHOLD                                               |                  | 15.06.2023 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | UNDER_18_ÅR                                                  |                  | 05.09.2023 | 04.09.2041 | OPPFYLT  | Nei                  |                      |
+      | 3       | GIFT_PARTNERSKAP,BOSATT_I_RIKET,LOVLIG_OPPHOLD,BOR_MED_SØKER |                  | 05.09.2023 |            | OPPFYLT  | Nei                  |                      |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 3       | 1            | 01.10.2023 | 31.08.2029 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 1            | 01.09.2029 | 31.08.2041 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+
+      | 3       | 2            | 01.10.2023 | 31.08.2029 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 2            | 01.09.2029 | 31.08.2041 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser             | Ugyldige begrunnelser |
+      |          |          | FORTSATT_INNVILGET |                                | FORTSATT_INNVILGET_UENDRET_TRYGD |                       |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-16239
Søker har fått innvilget barnetrygd ved automatisk behandling av fødselshendelse, men sender også søknad kort tid etterpå. Revurdering med årsak søknad gir endring i mors vilkår (tidligere FOM-datoer) men påvirker ikke utfallet av behandlingen. Behandlingsresultatet blir `ENDRET_OG_FORTSATT_INNVILGET` pga endring i vilkår. Dette skal vi kunne begrunne med tekstene for fortsatt innvilget.

Tidligere har vi kun opprettet vedtaksperiode for fortsatt innvilget dersom behandlingsresultatet ble `FORTSATT_INNVILGET`. Tipper at vi har glemt at vi har flere varianter av fortsatt innvilget? Hører gjerne motargumenter om dere vet om noen grunn til å forskjellsbehandle disse

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. 
