### PR TITLE
Gjør så vi stopper tidligere prodbygg som kjører dersom vi starter flere deploys samtidig

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   integrasjonstester:
     name: Kjører enhetstester og integrasjonstester


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dersom vi starter to deploys til prod samtidig ønsker vi kun at det siste skal deployes. 

Endrer så vi stopper alle tidligere deploys dersom de ikke har kjørt ferdig når vi starter en ny deploy

