### PR TITLE
Fjern tester i byggesteg når for bygg som trigges av at en PR committes

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -72,7 +72,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    needs: [ bygg ]
+    needs: [ bygg, deploy-preprod ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,7 +83,7 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
-          IMAGE: ${{ needs.deploy-preprod.outputs.image }}
+          IMAGE: ${{ needs.bygg.outputs.image }}
 
   loggfeil:
     name: Send logg til slack ved feil

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -9,40 +9,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  integrasjonstester:
-    name: Kjører enhetstester og integrasjonstester
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Kjør integrasjonstester
-        env:
-          GITHUB_USERNAME: x-access-token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml -Dtest="!no/nav/familie/ba/sak/kjerne/verdikjedetester/**"
-  verdikjedetester:
-    name: Kjører verdikjedetester
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Kjør verdikjedetester
-        env:
-          GITHUB_USERNAME: x-access-token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml -Dtest="no/nav/familie/ba/sak/kjerne/verdikjedetester/**"
   bygg:
     name: Bygg app/image, push til github, deploy til preprod-gcp
     runs-on: ubuntu-latest
@@ -78,6 +44,7 @@ jobs:
         run: echo 'Docker-tag er ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }} ' >> $GITHUB_STEP_SUMMARY
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
+
   deploy-preprod:
     name: Deploy til dev-gcp
     runs-on: ubuntu-latest
@@ -98,13 +65,14 @@ jobs:
           IMAGE: ${{ needs.bygg.outputs.image }}
     outputs:
       image: ${{ needs.bygg.outputs.image }}
+
   deploy-to-prod:
     name: Deploy til prod-gcp
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"
-    needs: [ integrasjonstester,verdikjedetester,deploy-preprod ]
+    needs: [ bygg ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -63,8 +63,6 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
           IMAGE: ${{ needs.bygg.outputs.image }}
-    outputs:
-      image: ${{ needs.bygg.outputs.image }}
 
   deploy-to-prod:
     name: Deploy til prod-gcp


### PR DESCRIPTION
Ref [slacktråd](https://nav-it.slack.com/archives/C01G9BA8JKZ/p1697809402319029)

Nå som vi kjører testene som det siste vi gjør før vi merger en PR til main er det unødvendig å kjøre testene på nytt i deploy-steget.

Fjerner testene fra deploysteget

Merk dette er et forslag. Det er lov å være uenig i at dette er ok.