### PR TITLE
Ikke send med kompetansedata for opphør og avslag eøs

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -330,7 +330,7 @@ fun hentTekstValgteBegrunnelser(
 fun hentValgteBegrunnelserRader(vedtaksperioder: List<VedtaksperiodeMedBegrunnelser>) =
     vedtaksperioder.joinToString("") { vedtaksperiode ->
         """
-        | ${vedtaksperiode.fom?.tilddMMyyyy() ?: ""} |${vedtaksperiode.tom?.tilddMMyyyy() ?: ""} | ${vedtaksperiode.begrunnelser.joinToString { it.standardbegrunnelse.name }} | ${vedtaksperiode.eøsBegrunnelser.joinToString { it.begrunnelse.name }} | ${vedtaksperiode.fritekster.joinToString()} |"""
+        | ${vedtaksperiode.fom?.tilddMMyyyy() ?: ""} |${vedtaksperiode.tom?.tilddMMyyyy() ?: ""} | ${vedtaksperiode.begrunnelser.joinToString { it.standardbegrunnelse.name }} | ${vedtaksperiode.eøsBegrunnelser.joinToString { it.begrunnelse.name }} | |"""
     }
 
 fun hentTekstBrevPerioder(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
@@ -48,7 +48,7 @@ fun EØSStandardbegrunnelse.lagBrevBegrunnelse(
     val barnPåBehandling = grunnlag.behandlingsGrunnlagForVedtaksperioder.persongrunnlag.barna
     val barnIBegrunnelse = personerGjeldeneForBegrunnelse.filter { it.type == PersonType.BARN }
 
-    return if (kompetanser.isEmpty() && sanityBegrunnelse.periodeResultat == SanityPeriodeResultat.IKKE_INNVILGET) {
+    return if (sanityBegrunnelse.periodeResultat == SanityPeriodeResultat.IKKE_INNVILGET) {
         val gjelderSøker = personerIBegrunnelse.any { it.type == PersonType.SØKER }
 
         val barnasFødselsdatoer = hentBarnasFødselsdatoerForAvslagsbegrunnelse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.norskDatoFormatter
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseBoolean
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseEnum
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseInt
-import no.nav.familie.ba.sak.cucumber.domeneparser.parseString
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriBoolean
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriEnum
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriString
@@ -73,7 +72,7 @@ fun parseStandardBegrunnelse(rad: Tabellrad) =
             rad,
         ) ?: "",
         maalform = parseEnum<Målform>(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅLFORM, rad).tilSanityFormat(),
-        belop = parseString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BELØP, rad).replace(' ', ' '),
+        belop = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BELØP, rad)?.replace(' ', ' ') ?: "",
         soknadstidspunkt = parseValgfriString(
             BrevPeriodeParser.DomenebegrepBrevBegrunnelse.SØKNADSTIDSPUNKT,
             rad,
@@ -119,14 +118,16 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
         rad,
     ).sanityApiNavn
 
-    val barnasFodselsdatoer = parseString(
+    val barnasFodselsdatoer = parseValgfriString(
         BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BARNAS_FØDSELSDATOER,
         rad,
-    )
+    ) ?: ""
 
     val antallBarn = parseInt(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_BARN, rad)
 
-    val målform = parseEnum<Målform>(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅLFORM, rad).tilSanityFormat()
+    val målform = parseValgfriEnum<Målform>(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅLFORM, rad) ?: Målform.NB
+
+    val målformSaniytFormat = målform.tilSanityFormat()
 
     return if (gjelderSoker == null) {
         if (annenForeldersAktivitet == null ||
@@ -143,7 +144,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             apiNavn = apiNavn,
             barnasFodselsdatoer = barnasFodselsdatoer,
             antallBarn = antallBarn,
-            maalform = målform,
+            maalform = målformSaniytFormat,
 
             annenForeldersAktivitet = annenForeldersAktivitet,
             annenForeldersAktivitetsland = annenForeldersAktivitetsland,
@@ -158,7 +159,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             barnasFodselsdatoer = barnasFodselsdatoer,
 
             antallBarn = antallBarn,
-            maalform = målform,
+            maalform = målformSaniytFormat,
             gjelderSoker = gjelderSoker,
         )
     }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør_eøs.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør_eøs.feature
@@ -1,0 +1,95 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Brevbegrunnelser for opphør av eøs sak
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | ÅRLIG_KONTROLL   | Nei                       | EØS                 |
+      | 2            | 1        | 1                   | OPPHØRT             | NYE_OPPLYSNINGER | Nei                       | EØS                 |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 21.07.1982  |
+      | 1            | 2       | BARN       | 22.01.2006  |
+      | 1            | 3       | BARN       | 16.09.2020  |
+      | 2            | 1       | SØKER      | 21.07.1982  |
+      | 2            | 2       | BARN       | 22.01.2006  |
+      | 2            | 3       | BARN       | 16.09.2020  |
+
+  Scenario: Skal flette in alle barna selv om de har forskjellig kompetanse når det er opphør
+    Og følgende dagens dato 23.10.2023
+    Og lag personresultater for begrunnelse for behandling 1
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | LOVLIG_OPPHOLD   |                              | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 15.05.2023 |            | OPPFYLT  | Nei                  |                      |
+
+      | 2       | UNDER_18_ÅR      |                              | 22.01.2006 | 21.01.2024 | OPPFYLT  | Nei                  |                      |
+      | 2       | GIFT_PARTNERSKAP |                              | 22.01.2006 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | LOVLIG_OPPHOLD   |                              | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | GIFT_PARTNERSKAP |                              | 16.09.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | UNDER_18_ÅR      |                              | 16.09.2020 | 15.09.2038 | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | LOVLIG_OPPHOLD   |                              | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | LOVLIG_OPPHOLD   |                              | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 15.05.2023 | 30.06.2023 | OPPFYLT  | Nei                  |                      |
+
+      | 2       | GIFT_PARTNERSKAP |                              | 22.01.2006 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | UNDER_18_ÅR      |                              | 22.01.2006 | 21.01.2024 | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | LOVLIG_OPPHOLD   |                              | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | UNDER_18_ÅR      |                              | 16.09.2020 | 15.09.2038 | OPPFYLT  | Nei                  |                      |
+      | 3       | GIFT_PARTNERSKAP |                              | 16.09.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | LOVLIG_OPPHOLD   |                              | 01.12.2020 |            | OPPFYLT  | Nei                  |                      |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.06.2023 | 30.06.2023 | 182   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 1            | 01.07.2023 | 31.12.2023 | 409   | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 3       | 1            | 01.06.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 3       | 1            | 01.07.2023 | 31.08.2026 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 1            | 01.09.2026 | 31.08.2038 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+
+      | 2       | 2            | 01.06.2023 | 30.06.2023 | 182   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 3       | 2            | 01.06.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
+
+    Og med kompetanser for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.06.2023 |            | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | LT                             | LT                  |
+      | 3       | 01.06.2023 |            | NORGE_ER_PRIMÆRLAND   | 1            | ARBEIDER         | INAKTIV                   | NO                    | LT                             | LT                  |
+      | 2       | 01.06.2023 | 30.06.2023 | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | LT                             | LT                  |
+      | 3       | 01.06.2023 | 30.06.2023 | NORGE_ER_PRIMÆRLAND   | 2            | ARBEIDER         | INAKTIV                   | NO                    | LT                             | LT                  |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser | Ugyldige begrunnelser |
+      | 01.07.2023 |          | OPPHØR             | EØS_FORORDNINGEN               | OPPHØR_EØS_STANDARD  |                       |
+
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato | Standardbegrunnelser | Eøsbegrunnelser     | Fritekster |
+      | 01.07.2023 |          |                      | OPPHØR_EØS_STANDARD |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.07.2023 til -
+      | Begrunnelse         | Type | Barnas fødselsdatoer | Antall barn | Målform | Gjelder søker |
+      | OPPHØR_EØS_STANDARD | EØS  | 22.01.06 og 16.09.20 | 2           | NB      | Nei           | 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16128)

Opphørs- og avslagstekstene for eøs bruker ikke noe av dataene fra kompetansen og skal derfor ikke splittes opp per kompetanse, slik som innvilget-tekstene skal. 

Endrer så vi ignorerer kompetansene når man lager begrunnelsene ved opphør og avslag i en eøs-sak.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester
