### PR TITLE
Legg til avslagIkkebosattINorgeSoker i Standardbegrunnelse.kt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -733,6 +733,10 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override val sanityApiNavn = "avslagBosattIRiket"
     },
+    AVSLAG_BOSATT_I_RIKET_SØKER {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
+        override val sanityApiNavn = "avslagIkkebosattINorgeSoker"
+    },
     AVSLAG_LOVLIG_OPPHOLD_TREDJELANDSBORGER {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override val sanityApiNavn = "avslagLovligOppholdTredjelandsborger"


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dersom man velger avslagBosattIRiket for søker vil man få en feil siden den begrunnelsen prøver å flette inn barn. Legger til en ny begrunnelse med en annen formulering for tilfellene der vi skal begrunne for søker. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
