### PR TITLE
Gjør så vi ikke får feil når vi henter begrunnelser på vedtaksperioder begrunnet med utgåtte begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 interface BehandlingRepository : JpaRepository<Behandling, Long> {
@@ -169,4 +170,17 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
         nativeQuery = true,
     )
     fun finnAktiveBehandlingerSomManglerStønadTom(limit: Int): List<Long>
+
+    @Query(
+        """
+        select vb.vedtak_begrunnelse_spesifikasjon
+        from behandling b
+                 join vedtak v on v.fk_behandling_id = b.id
+                 join vedtaksperiode vp on vp.fk_vedtak_id = v.id
+                 join vedtaksbegrunnelse vb on vb.fk_vedtaksperiode_id = vp.id
+        where b.id = :behandlingId and vp.fom = :fomVedtaksperiode
+            """,
+        nativeQuery = true,
+    )
+    fun hentBegrunnelserPåBehandlingIPeriode(behandlingId: Long, fomVedtaksperiode: LocalDate): List<String>
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -55,6 +56,7 @@ internal class Autobrev6og18ÅrServiceTest {
     private val endretUtbetalingAndelRepository = mockk<EndretUtbetalingAndelRepository>(relaxed = true)
     private val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
     private val startSatsendring = mockk<StartSatsendring>(relaxed = true)
+    private val behandlingRepository = mockk<BehandlingRepository>(relaxed = true)
 
     private val autovedtakBrevService = AutovedtakBrevService(
         behandlingService = behandlingService,
@@ -65,6 +67,7 @@ internal class Autobrev6og18ÅrServiceTest {
         infotrygdService = infotrygdService,
         vedtaksperiodeService = vedtaksperiodeService,
         taskRepository = taskRepository,
+        behandlingRepository = behandlingRepository,
     )
 
     private val autobrev6og18ÅrService = Autobrev6og18ÅrService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -52,6 +53,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
     private val vedtaksperiodeService = mockk<VedtaksperiodeService>()
     private val periodeOvergangsstønadGrunnlagRepository = mockk<PeriodeOvergangsstønadGrunnlagRepository>()
     private val startSatsendring = mockk<StartSatsendring>(relaxed = true)
+    private val behandlingRepository = mockk<BehandlingRepository>(relaxed = true)
 
     private val autovedtakBrevService = AutovedtakBrevService(
         fagsakService = fagsakService,
@@ -62,6 +64,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
         vedtakService = vedtakService,
         vedtaksperiodeService = vedtaksperiodeService,
         taskRepository = taskRepository,
+        behandlingRepository = behandlingRepository,
     )
 
     private val autobrevOpphørSmåbarnstilleggService = AutobrevOpphørSmåbarnstilleggService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
@@ -142,6 +142,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
         every { periodeOvergangsstønadGrunnlagRepository.findByBehandlingId(any()) } returns listOf(
             lagPeriodeOvergangsstønadGrunnlag(LocalDate.now().minusYears(1), LocalDate.now().plusYears(1)),
         )
+        every { behandlingRepository.hentBegrunnelserPåBehandlingIPeriode(behandling.id, any()) } returns listOf("REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_BARN_UNDER_TRE_ÅR")
 
         autobrevOpphørSmåbarnstilleggService
             .kjørBehandlingOgSendBrevForOpphørAvSmåbarnstillegg(fagsakId = behandling.fagsak.id)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16314

Når vi kjører autobehandling ved 6 og 18 år sjekker vi om vi ikke allerede har begrunnet reduksjonen allerede. Måten vi gjør det på er at vi henter alle begrunnelsene i fagsaken og sjekker om én av dem er samme begrunnelse som vi ønsker å bruke og at den ble begrunnet denne måneden. Dersom vi har brukt en begrunnelse som vi har fjernet, vil dette feile. 

Endrer så vi kun henter begrunnelsene som strenger først og ignorerer dem dersom de ikke finnes i kodebasen lenger. 
