### PR TITLE
Ignorerer behandlinger med AVSLÅTT i query for å finne fagsaker som skal avsluttes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -71,6 +71,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
                              INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
                     WHERE f.status = 'LØPENDE'
                       AND f.arkivert = FALSE
+                      AND b.resultat != 'AVSLÅTT'
                     ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC)
                 
                 SELECT silp.fk_fagsak_id

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
@@ -44,9 +44,10 @@ class FerdigstillBehandling(
         }
 
         behandlingMetrikker.oppdaterBehandlingMetrikker(behandling)
+
         if (behandling.status == BehandlingStatus.IVERKSETTER_VEDTAK && behandling.resultat != Behandlingsresultat.AVSLÅTT) {
             oppdaterFagsakStatus(behandling = behandling)
-        } else { // Dette betyr henleggelse.
+        } else { // Dette betyr henleggelse eller avslag
             if (behandlingHentOgPersisterService.hentBehandlinger(behandling.fagsak.id).size == 1) {
                 fagsakService.oppdaterStatus(behandling.fagsak, FagsakStatus.AVSLUTTET)
             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
En fortsettelse på oppdatering av løpende flagg for fagsaker, der hvor 0-utbetalinger ikke ble avsluttet. Der fjernet man sjekken om behandling skulle ha utbetalingsoppdrag, og populerte stønad_tom for disse behandlingene, slik at de skulle bli avsluttet riktig. 

Dette støttet ikke tilfeller med løpende fagsaker hvor siste vedtak var AVSLÅTT, men hvor de hadde iverksette behandlinger. De har heller ingen stønad_fom eller stønad_tom populert.

Ved å filterere bort AVSLÅTT bort disse behandlingene så vil man få plukket ut disse slik at de får oppdatert flagg.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Jeg har testet query. Den plukker opp 3 saker som ikke er avsluttet, men som skulle vært avsluttet
