### PR TITLE
legg til begrunnelseType i kontrakt for SanityBegrunnelse og legg til støtte for felter med nytt navn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 
 sealed interface ISanityBegrunnelse {
@@ -24,6 +25,7 @@ sealed interface ISanityBegrunnelse {
     val tema: Tema?
     val valgbarhet: Valgbarhet?
     val periodeType: BrevPeriodeType?
+    val begrunnelseTypeForPerson: VedtakBegrunnelseType? // TODO: Fjern når migrering av ny felter er ferdig
 
     val gjelderEtterEndretUtbetaling
         get() = this is SanityBegrunnelse &&
@@ -52,6 +54,7 @@ data class SanityBegrunnelse(
     override val tema: Tema? = null,
     override val valgbarhet: Valgbarhet? = null,
     override val periodeType: BrevPeriodeType? = null,
+    override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
     @Deprecated("Bruk vilkår")
     val vilkaar: List<SanityVilkår> = emptyList(),
     val rolle: List<VilkårRolle> = emptyList(),
@@ -77,6 +80,7 @@ data class SanityEØSBegrunnelse(
     override val fagsakType: FagsakType?,
     override val tema: Tema?,
     override val periodeType: BrevPeriodeType?,
+    override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
     val annenForeldersAktivitet: List<KompetanseAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,
     val kompetanseResultat: List<KompetanseResultat>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import org.slf4j.Logger
@@ -36,9 +37,13 @@ data class RestSanityBegrunnelse(
     val utvidetBarnetrygdTriggere: List<String>? = emptyList(),
     val valgbarhet: String? = null,
     val vedtakResultat: String?,
+    val periodeResultatForPerson: String?,
     val fagsakType: String?,
     val tema: String?,
+    val regelverk: String?,
     val periodeType: String?,
+    val brevPeriodeType: String?,
+    val begrunnelseTypeForPerson: String?,
 ) {
     fun tilSanityBegrunnelse(): SanityBegrunnelse? {
         if (apiNavn == null || apiNavn !in Standardbegrunnelse.entries.map { it.sanityApiNavn }) return null
@@ -83,10 +88,14 @@ data class RestSanityBegrunnelse(
                 it.finnEnumverdi<UtvidetBarnetrygdTrigger>(apiNavn)
             } ?: emptyList(),
             valgbarhet = valgbarhet.finnEnumverdi<Valgbarhet>(apiNavn),
-            periodeResultat = vedtakResultat.finnEnumverdi<SanityPeriodeResultat>(apiNavn),
+            periodeResultat = (
+                periodeResultatForPerson
+                    ?: vedtakResultat
+                ).finnEnumverdi<SanityPeriodeResultat>(apiNavn),
             fagsakType = fagsakType.finnEnumverdiNullable<FagsakType>(),
-            tema = tema.finnEnumverdi<Tema>(apiNavn),
-            periodeType = periodeType.finnEnumverdi<BrevPeriodeType>(apiNavn),
+            tema = (tema ?: regelverk).finnEnumverdi<Tema>(apiNavn),
+            periodeType = (brevPeriodeType ?: periodeType).finnEnumverdi<BrevPeriodeType>(apiNavn),
+            begrunnelseTypeForPerson = begrunnelseTypeForPerson.finnEnumverdi<VedtakBegrunnelseType>(apiNavn),
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
@@ -36,11 +36,14 @@ data class RestSanityBegrunnelse(
     val endretUtbetalingsperiodeTriggere: List<String>? = emptyList(),
     val utvidetBarnetrygdTriggere: List<String>? = emptyList(),
     val valgbarhet: String? = null,
+    @Deprecated("Erstattes av periodeResultatForPerson")
     val vedtakResultat: String?,
     val periodeResultatForPerson: String?,
     val fagsakType: String?,
+    @Deprecated("Erstattes av regelverk")
     val tema: String?,
     val regelverk: String?,
+    @Deprecated("Erstattes brevPeriodeType")
     val periodeType: String?,
     val brevPeriodeType: String?,
     val begrunnelseTypeForPerson: String?,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -83,6 +83,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksbegrunnelseFritekst
@@ -1203,9 +1204,13 @@ fun lagRestSanityBegrunnelse(
     endretUtbetalingsperiodeDeltBostedTriggere: String = "",
     endretUtbetalingsperiodeTriggere: List<String>? = emptyList(),
     vedtakResultat: String? = null,
+    periodeResultatForPerson: String? = null,
     fagsakType: String? = null,
     tema: String? = null,
+    regelverk: String? = null,
     periodeType: String? = null,
+    brevPeriodeType: String? = null,
+    begrunnelseTypeForPerson: String? = null,
 ): RestSanityBegrunnelse = RestSanityBegrunnelse(
     apiNavn = apiNavn,
     navnISystem = navnISystem,
@@ -1222,9 +1227,13 @@ fun lagRestSanityBegrunnelse(
     endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = endretUtbetalingsperiodeDeltBostedTriggere,
     endretUtbetalingsperiodeTriggere = endretUtbetalingsperiodeTriggere,
     vedtakResultat = vedtakResultat,
+    periodeResultatForPerson = periodeResultatForPerson,
     fagsakType = fagsakType,
     tema = tema,
+    regelverk = regelverk,
     periodeType = periodeType,
+    brevPeriodeType = brevPeriodeType,
+    begrunnelseTypeForPerson = begrunnelseTypeForPerson,
 )
 
 fun lagSanityBegrunnelse(
@@ -1245,6 +1254,7 @@ fun lagSanityBegrunnelse(
     resultat: SanityPeriodeResultat? = null,
     fagsakType: FagsakType? = null,
     periodeType: BrevPeriodeType? = null,
+    begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
 ): SanityBegrunnelse = SanityBegrunnelse(
     apiNavn = apiNavn,
     navnISystem = navnISystem,
@@ -1263,6 +1273,7 @@ fun lagSanityBegrunnelse(
     periodeResultat = resultat,
     fagsakType = fagsakType,
     periodeType = periodeType,
+    begrunnelseTypeForPerson = begrunnelseTypeForPerson,
 )
 
 fun lagSanityEøsBegrunnelse(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16222)
[Favro2](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16225)

Ønsker å rename en del av feltene i sanity. Legger derfor til navnet på de nye feltene slik at vi kan migrere til de, før vi sletter de gamle. 
Ønsker også å ta i bruk begrunnelseType så legger til navnet på det nye feltet i kontrakten (begrunnelseTypeForPerson)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er navnene bra nok?
Tema -> Regelverk: Er litt i tvil siden Tema strengt talt inneholder "Felles" for øyeblikket
begrunnelseType -> begrunnelseTypeForPerson : litt langt navn, burde vi heller kalle det noe annet? 

