### PR TITLE
Flytter/Rydder i noen toggles jeg kjenner til

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -15,10 +15,6 @@ class FeatureToggleConfig {
         const val EØS_PRAKSISENDRING_SEPTEMBER2023 =
             "familie-ba-sak.behandling.eos-annen-forelder-omfattet-av-norsk-lovgivning"
 
-        // unleash toggles for satsendring, kan slettes etter at satsendring er skrudd på for alle satstyper
-
-        const val SATSENDRING_SNIKE_I_KØEN = "familie-ba-sak.satsendring-snike-i-koen"
-
         // Ny utbetalingsgenerator
         const val KONTROLLER_NY_UTBETALINGSGENERATOR = "familie.ba.sak.kontroller-ny-utbetalingsgenerator"
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -15,17 +15,15 @@ class FeatureToggleConfig {
         const val EØS_PRAKSISENDRING_SEPTEMBER2023 =
             "familie-ba-sak.behandling.eos-annen-forelder-omfattet-av-norsk-lovgivning"
 
-        // Ny utbetalingsgenerator
-        const val KONTROLLER_NY_UTBETALINGSGENERATOR = "familie.ba.sak.kontroller-ny-utbetalingsgenerator"
 
         // Unleash Next toggles
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"
         const val NY_GENERERING_AV_BREVOBJEKTER = "familie-ba-sak.ny-generering-av-brevobjekter"
-
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"
 
         // Ny utbetalingsgenerator
         const val BRUK_NY_UTBETALINGSGENERATOR = "familie.ba.sak.bruk-ny-utbetalingsgenerator"
+        const val KONTROLLER_NY_UTBETALINGSGENERATOR = "familie-ba-sak.kontroller-ny-utbetalingsgenerator"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -15,7 +15,6 @@ class FeatureToggleConfig {
         const val EØS_PRAKSISENDRING_SEPTEMBER2023 =
             "familie-ba-sak.behandling.eos-annen-forelder-omfattet-av-norsk-lovgivning"
 
-
         // Unleash Next toggles
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"
         const val NY_GENERERING_AV_BREVOBJEKTER = "familie-ba-sak.ny-generering-av-brevobjekter"

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -4,7 +4,6 @@ class FeatureToggleConfig {
     companion object {
         // Operasjonelle
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"
-        const val SKATTEETATEN_API_EKTE_DATA = "familie-ba-sak.skatteetaten-api-ekte-data-i-respons"
         const val IKKE_STOPP_MIGRERINGSBEHANDLING = "familie-ba-sak.ikke.stopp.migeringsbehandling"
         const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
         const val TEKNISK_ENDRING = "familie-ba-sak.behandling.teknisk-endring"

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -16,16 +16,20 @@ class FeatureToggleConfig {
             "familie-ba-sak.behandling.eos-annen-forelder-omfattet-av-norsk-lovgivning"
 
         // unleash toggles for satsendring, kan slettes etter at satsendring er skrudd på for alle satstyper
-        const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"
+
         const val SATSENDRING_SNIKE_I_KØEN = "familie-ba-sak.satsendring-snike-i-koen"
 
         // Ny utbetalingsgenerator
         const val KONTROLLER_NY_UTBETALINGSGENERATOR = "familie.ba.sak.kontroller-ny-utbetalingsgenerator"
-        const val BRUK_NY_UTBETALINGSGENERATOR = "familie.ba.sak.bruk-ny-utbetalingsgenerator"
 
         // Unleash Next toggles
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"
         const val NY_GENERERING_AV_BREVOBJEKTER = "familie-ba-sak.ny-generering-av-brevobjekter"
+
+        const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"
+
+        // Ny utbetalingsgenerator
+        const val BRUK_NY_UTBETALINGSGENERATOR = "familie.ba.sak.bruk-ny-utbetalingsgenerator"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/skatteetaten/SkatteetatenController.kt
@@ -2,8 +2,7 @@ package no.nav.familie.ba.sak.ekstern.skatteetaten
 
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotNull
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
+import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.eksterne.kontrakter.skatteetaten.SkatteetatenPeriode
 import no.nav.familie.eksterne.kontrakter.skatteetaten.SkatteetatenPeriode.Delingsprosent
 import no.nav.familie.eksterne.kontrakter.skatteetaten.SkatteetatenPerioder
@@ -29,7 +28,7 @@ import java.time.LocalDateTime
 @ProtectedWithClaims(issuer = "azuread")
 class SkatteetatenController(
     private val skatteetatenService: SkatteetatenService,
-    private val featureToggleService: FeatureToggleService,
+    private val envService: EnvService,
 ) {
 
     @GetMapping(
@@ -42,7 +41,7 @@ class SkatteetatenController(
         aar: String,
     ): ResponseEntity<Ressurs<SkatteetatenPersonerResponse>> {
         logger.info("Treff på finnPersonerMedUtvidetBarnetrygd")
-        val respons = if (featureToggleService.isEnabled(FeatureToggleConfig.SKATTEETATEN_API_EKTE_DATA)) {
+        val respons = if (envService.erProd()) {
             skatteetatenService.finnPersonerMedUtvidetBarnetrygd(aar)
         } else {
             SkatteetatenPersonerResponse(
@@ -77,7 +76,7 @@ class SkatteetatenController(
         perioderRequest: SkatteetatenPerioderRequest,
     ): ResponseEntity<Ressurs<SkatteetatenPerioderResponse>> {
         logger.info("Treff på hentPerioderMedUtvidetBarnetrygd")
-        val response = if (featureToggleService.isEnabled(FeatureToggleConfig.SKATTEETATEN_API_EKTE_DATA)) {
+        val response = if (envService.erProd()) {
             skatteetatenService.finnPerioderMedUtvidetBarnetrygd(perioderRequest.identer, perioderRequest.aar)
         } else {
             SkatteetatenPerioderResponse(listeMedTestdataPerioder().filter { it.sisteVedtakPaaIdent.year == perioderRequest.aar.toInt() && it.ident in perioderRequest.identer })

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringService.kt
@@ -4,8 +4,6 @@ import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
 import no.nav.familie.ba.sak.common.secureLogger
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.SATSENDRING_SNIKE_I_KØEN
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
@@ -41,7 +39,6 @@ class AutovedtakSatsendringService(
     private val behandlingService: BehandlingService,
     private val satsendringService: SatsendringService,
     private val loggService: LoggService,
-    private val featureToggleService: FeatureToggleService,
     private val snikeIKøenService: SnikeIKøenService,
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
@@ -84,9 +81,7 @@ class AutovedtakSatsendringService(
 
         if (aktivOgÅpenBehandling != null) {
             val brukerHarÅpenBehandlingSvar = hentBrukerHarÅpenBehandlingSvar(aktivOgÅpenBehandling)
-            if (brukerHarÅpenBehandlingSvar == SatsendringSvar.BEHANDLING_KAN_SNIKES_FORBI &&
-                featureToggleService.isEnabled(SATSENDRING_SNIKE_I_KØEN)
-            ) {
+            if (brukerHarÅpenBehandlingSvar == SatsendringSvar.BEHANDLING_KAN_SNIKES_FORBI) {
                 snikeIKøenService.settAktivBehandlingTilPåMaskinellVent(
                     aktivOgÅpenBehandling.id,
                     SettPåMaskinellVentÅrsak.SATSENDRING,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
@@ -11,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.SatsendringTaskDto
+import no.nav.familie.unleash.UnleashService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
@@ -24,7 +24,7 @@ class StartSatsendring(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val opprettTaskService: OpprettTaskService,
     private val satskjøringRepository: SatskjøringRepository,
-    private val featureToggleService: FeatureToggleService,
+    private val unleashService: UnleashService,
     private val personidentService: PersonidentService,
     private val autovedtakSatsendringService: AutovedtakSatsendringService,
     private val satsendringService: SatsendringService,
@@ -36,7 +36,7 @@ class StartSatsendring(
     fun startSatsendring(
         antallFagsaker: Int,
     ) {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET, false)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET, false)) {
             logger.info("Skipper satsendring da toggle er skrudd av.")
             return
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.simulering
 
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForSimuleringFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGeneratorService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.skalIverksettesMotOppdrag
@@ -24,13 +23,14 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
+import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.time.YearMonth
 
 @Service
 class KontrollerNyUtbetalingsgeneratorService(
-    private val featureToggleService: FeatureToggleService,
+    private val unleashService: UnleashService,
     private val økonomiKlient: ØkonomiKlient,
     private val utbetalingsoppdragGeneratorService: UtbetalingsoppdragGeneratorService,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
@@ -203,7 +203,7 @@ class KontrollerNyUtbetalingsgeneratorService(
     }
 
     private fun skalKontrollereOppMotNyUtbetalingsgenerator(): Boolean =
-        featureToggleService.isEnabled(FeatureToggleConfig.KONTROLLER_NY_UTBETALINGSGENERATOR, false)
+        unleashService.isEnabled(FeatureToggleConfig.KONTROLLER_NY_UTBETALINGSGENERATOR, true)
 
     private fun validerAtSimuleringsPerioderGammelHarResultatLikSimuleringsPerioderNyEtterFomTilNy(
         simuleringsPerioderGammelTidslinje: Tidslinje<SimuleringsPeriode, Måned>,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -7,7 +7,6 @@ import io.mockk.spyk
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring.Companion.SATSENDRINGMÅNED_MARS_2023
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
@@ -17,6 +16,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -31,7 +31,7 @@ internal class StartSatsendringTest {
     private val fagsakRepository: FagsakRepository = mockk()
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
     private val satskjøringRepository: SatskjøringRepository = mockk()
-    private val featureToggleService: FeatureToggleService = mockk()
+    private val unleashService: UnleashService = mockk()
     private val personidentService: PersonidentService = mockk()
     private val autovedtakSatsendringService: AutovedtakSatsendringService = mockk()
     private val satsendringService: SatsendringService = mockk()
@@ -55,7 +55,7 @@ internal class StartSatsendringTest {
                 behandlingHentOgPersisterService = behandlingHentOgPersisterService,
                 opprettTaskService = opprettTaskService,
                 satskjøringRepository = satskjøringRepository,
-                featureToggleService = featureToggleService,
+                unleashService = unleashService,
                 personidentService = personidentService,
                 autovedtakSatsendringService = autovedtakSatsendringService,
                 satsendringService = satsendringService,
@@ -65,7 +65,7 @@ internal class StartSatsendringTest {
 
     @Test
     fun `start satsendring og opprett satsendringtask på sak hvis toggler er på `() {
-        every { featureToggleService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET, false) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET, false) } returns true
 
         val behandling = lagBehandling()
 
@@ -84,8 +84,8 @@ internal class StartSatsendringTest {
 
     @Test
     fun `finnLøpendeFagsaker har totalt antall sider 3, så den skal kalle finnLøpendeFagsaker 3 ganger for å få 5 satsendringer`() {
-        every { featureToggleService.isEnabled(any(), any()) } returns true
-        every { featureToggleService.isEnabled(any()) } returns true
+        every { unleashService.isEnabled(any(), false) } returns true
+        every { unleashService.isEnabled(any()) } returns true
 
         val behandling = lagBehandling()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGeneratorService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.lagUtbetalingsoppdrag
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiKlient

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorServiceTest.kt
@@ -39,6 +39,7 @@ import no.nav.familie.kontrakter.felles.simulering.MottakerType
 import no.nav.familie.kontrakter.felles.simulering.PosteringType
 import no.nav.familie.kontrakter.felles.simulering.SimuleringMottaker
 import no.nav.familie.kontrakter.felles.simulering.SimulertPostering
+import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -48,7 +49,7 @@ import java.math.BigDecimal
 class KontrollerNyUtbetalingsgeneratorServiceTest {
 
     @MockK
-    private lateinit var featureToggleService: FeatureToggleService
+    private lateinit var unleashService: UnleashService
 
     @MockK
     private lateinit var utbetalingsoppdragGeneratorService: UtbetalingsoppdragGeneratorService
@@ -483,9 +484,9 @@ class KontrollerNyUtbetalingsgeneratorServiceTest {
         overstyrteAndeler: List<AndelTilkjentYtelse>? = null,
     ) {
         every {
-            featureToggleService.isEnabled(
+            unleashService.isEnabled(
                 FeatureToggleConfig.KONTROLLER_NY_UTBETALINGSGENERATOR,
-                false,
+                true,
             )
         } returns true
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Flytter/Rydder i noen toggles jeg kjenner til
- Sletter skatt-toggle. Trenger forhåpentligvis ikke den lenger
- Flytter satsendring-toggle til unleash next
- Fjerner toggle for å snike i køen ved satsendring. Slik at den er alltid på.
- Flyttet kontroller-ny-utbetalingsgenerator til unleash-next
