### PR TITLE
endre SanityQueries.kt slik at vi bruker regelverk og ikke tema

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityQueries.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityQueries.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.sanity
 
 const val hentBegrunnelser =
-    "*[_type == \"begrunnelse\" && tema != \"EØS\" && apiNavn != null && navnISystem != null]"
+    "*[_type == \"begrunnelse\" && regelverk != \"EØS\" && apiNavn != null && navnISystem != null]"
 
 const val hentEØSBegrunnelser =
-    "*[_type == \"begrunnelse\" && tema == \"EØS\" && apiNavn != null && navnISystem != null]"
+    "*[_type == \"begrunnelse\" && regelverk == \"EØS\" && apiNavn != null && navnISystem != null]"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
@@ -33,10 +33,17 @@ data class RestSanityEØSBegrunnelse(
     val hjemlerEOSForordningen987: List<String>?,
     val hjemlerSeperasjonsavtalenStorbritannina: List<String>?,
     val eosVilkaar: List<String>? = null,
+    @Deprecated("Skal bruke periodeResultatForPerson i stedet")
     val vedtakResultat: String?,
+    val periodeResultatForPerson: String?,
     val fagsakType: String?,
+    @Deprecated("Skal bruke regelverk i stedet")
     val tema: String?,
+    val regelverk: String?,
+    @Deprecated("Skal bruke periodeResultatForPerson i stedet")
     val periodeType: String?,
+    val brevPeriodeType: BrevPeriodeType,
+    val begrunnelseTypeForPerson: String?,
 ) {
     fun tilSanityEØSBegrunnelse(): SanityEØSBegrunnelse? {
         if (apiNavn == null || navnISystem == null) return null
@@ -58,10 +65,13 @@ data class RestSanityEØSBegrunnelse(
             hjemlerEØSForordningen987 = hjemlerEOSForordningen987 ?: emptyList(),
             hjemlerSeperasjonsavtalenStorbritannina = hjemlerSeperasjonsavtalenStorbritannina ?: emptyList(),
             vilkår = eosVilkaar?.mapNotNull { konverterTilEnumverdi<Vilkår>(it) }?.toSet() ?: emptySet(),
-            periodeResultat = vedtakResultat.finnEnumverdi<SanityPeriodeResultat>(apiNavn),
+            periodeResultat = (
+                periodeResultatForPerson
+                    ?: vedtakResultat
+                ).finnEnumverdi<SanityPeriodeResultat>(apiNavn),
             fagsakType = fagsakType.finnEnumverdiNullable<FagsakType>(),
-            tema = tema.finnEnumverdi<Tema>(apiNavn),
-            periodeType = periodeType.finnEnumverdi<BrevPeriodeType>(apiNavn),
+            tema = (regelverk ?: tema).finnEnumverdi<Tema>(apiNavn),
+            periodeType = (periodeType).finnEnumverdi<BrevPeriodeType>(apiNavn),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/SanityEØSBegrunnelse.kt
@@ -42,7 +42,7 @@ data class RestSanityEØSBegrunnelse(
     val regelverk: String?,
     @Deprecated("Skal bruke periodeResultatForPerson i stedet")
     val periodeType: String?,
-    val brevPeriodeType: BrevPeriodeType,
+    val brevPeriodeType: String?,
     val begrunnelseTypeForPerson: String?,
 ) {
     fun tilSanityEØSBegrunnelse(): SanityEØSBegrunnelse? {
@@ -71,7 +71,7 @@ data class RestSanityEØSBegrunnelse(
                 ).finnEnumverdi<SanityPeriodeResultat>(apiNavn),
             fagsakType = fagsakType.finnEnumverdiNullable<FagsakType>(),
             tema = (regelverk ?: tema).finnEnumverdi<Tema>(apiNavn),
-            periodeType = (periodeType).finnEnumverdi<BrevPeriodeType>(apiNavn),
+            periodeType = (brevPeriodeType ?: periodeType).finnEnumverdi<BrevPeriodeType>(apiNavn),
         )
     }
 


### PR DESCRIPTION
oppdatere RestSanityEØSBegrunnelse til å ta i bruk nye felter

### 💰 Hva skal gjøres, og hvorfor?
Får feil fordi vi ikke får hentet ut begrunnelser som har eøs i regelverk etter at vi har slettet 'tema'-feltet fra sanity.
La også til bruk av nye felter i restSanityEØSBegrunnelser siden det også vil gi feil dersom de nye ikke blir tatt i bruk. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
