### PR TITLE
Valgfelt du og barna: tell antall barn med opphør på samme vilkår som søker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -314,9 +314,6 @@ fun hentAntallBarnForBegrunnelse(
     }
 }
 
-fun IVedtakBegrunnelse.erAvslagUregistrerteBarnBegrunnelse() =
-    this in setOf(Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN, EØSStandardbegrunnelse.AVSLAG_EØS_UREGISTRERT_BARN)
-
 fun VedtaksperiodeMedBegrunnelser.hentMånedOgÅrForBegrunnelse(): String? {
     return if (this.fom == null || fom == TIDENES_MORGEN) {
         null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -109,6 +109,7 @@ private fun Standardbegrunnelse.lagEnkeltBegrunnelse(
         grunnlag = grunnlag,
         barnasFødselsdatoer = barnasFødselsdatoer,
         gjelderSøker = gjelderSøker,
+        antallBarnGjeldendeForBegrunnelse = personerGjeldeneForBegrunnelse.filter { it.type == PersonType.BARN }.size,
     )
 
     sanityBegrunnelse.validerBrevbegrunnelse(
@@ -299,6 +300,7 @@ fun hentAntallBarnForBegrunnelse(
     grunnlag: GrunnlagForBegrunnelse,
     gjelderSøker: Boolean,
     barnasFødselsdatoer: List<LocalDate>,
+    antallBarnGjeldendeForBegrunnelse: Int,
 ): Int {
     val uregistrerteBarnPåBehandlingen = grunnlag.behandlingsGrunnlagForVedtaksperioder.uregistrerteBarn
     val erAvslagUregistrerteBarn = begrunnelse.erAvslagUregistrerteBarnBegrunnelse()
@@ -306,6 +308,8 @@ fun hentAntallBarnForBegrunnelse(
     return when {
         erAvslagUregistrerteBarn -> uregistrerteBarnPåBehandlingen.size
         gjelderSøker && begrunnelse.vedtakBegrunnelseType == VedtakBegrunnelseType.AVSLAG -> 0
+        gjelderSøker && begrunnelse.vedtakBegrunnelseType == VedtakBegrunnelseType.OPPHØR ->
+            antallBarnGjeldendeForBegrunnelse
         else -> barnasFødselsdatoer.size
     }
 }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
@@ -79,5 +79,84 @@ Egenskap: Brevbegrunnelser ved opphør
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.03.2023 til -
       | Begrunnelse      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp |
-      | OPPHØR_UTVANDRET | STANDARD | Ja            | 16.04.17 og 17.04.17 | 2           | februar 2023                         | NB      | 0     |
       | OPPHØR_UTVANDRET | STANDARD | Ja            | 16.04.17 og 17.04.17 | 1           | februar 2023                         | NB      | 0     |
+
+  Scenario: Skal flette inn barnas fødselsdatoer men ikke "du og barna" når vi begrunner opphør på søkers vilkår
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | SATSENDRING      | Ja                        | NASJONAL            |
+      | 2            | 1        | 1                   | OPPHØRT             | NYE_OPPLYSNINGER | Nei                       | NASJONAL            |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 15.01.1988  |
+      | 1            | 2       | BARN       | 06.03.2012  |
+      | 1            | 3       | BARN       | 21.12.2016  |
+      | 2            | 1       | SØKER      | 15.01.1988  |
+      | 2            | 2       | BARN       | 06.03.2012  |
+      | 2            | 3       | BARN       | 21.12.2016  |
+    Og følgende dagens dato 30.10.2023
+    Og lag personresultater for begrunnelse for behandling 1
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD               |                  | 01.01.2022 |            | OPPFYLT  | Nei                  |                      |
+
+      | 2       | GIFT_PARTNERSKAP                            |                  | 06.03.2012 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | UNDER_18_ÅR                                 |                  | 06.03.2012 | 05.03.2030 | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,LOVLIG_OPPHOLD |                  | 01.01.2022 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | GIFT_PARTNERSKAP                            |                  | 21.12.2016 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | UNDER_18_ÅR                                 |                  | 21.12.2016 | 20.12.2034 | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER,LOVLIG_OPPHOLD,BOSATT_I_RIKET |                  | 25.02.2022 |            | OPPFYLT  | Nei                  |                      |
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | BOSATT_I_RIKET                              |                  | 01.01.2022 | 16.07.2023 | OPPFYLT      | Nei                  |                      |
+      | 1       | LOVLIG_OPPHOLD                              |                  | 01.01.2022 |            | OPPFYLT      | Nei                  |                      |
+      | 1       | BOSATT_I_RIKET                              |                  | 17.07.2023 |            | IKKE_OPPFYLT | Nei                  |                      |
+
+      | 2       | GIFT_PARTNERSKAP                            |                  | 06.03.2012 |            | OPPFYLT      | Nei                  |                      |
+      | 2       | UNDER_18_ÅR                                 |                  | 06.03.2012 | 05.03.2030 | OPPFYLT      | Nei                  |                      |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,LOVLIG_OPPHOLD |                  | 01.01.2022 |            | OPPFYLT      | Nei                  |                      |
+
+      | 3       | GIFT_PARTNERSKAP                            |                  | 21.12.2016 |            | OPPFYLT      | Nei                  |                      |
+      | 3       | UNDER_18_ÅR                                 |                  | 21.12.2016 | 20.12.2034 | OPPFYLT      | Nei                  |                      |
+      | 3       | BOR_MED_SØKER,LOVLIG_OPPHOLD,BOSATT_I_RIKET |                  | 25.02.2022 |            | OPPFYLT      | Nei                  |                      |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.02.2022 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 1            | 01.07.2023 | 28.02.2030 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 3       | 1            | 01.03.2022 | 30.11.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 3       | 1            | 01.12.2022 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 3       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 3       | 1            | 01.07.2023 | 30.11.2034 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+
+      | 2       | 2            | 01.02.2022 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 2            | 01.07.2023 | 31.07.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 3       | 2            | 01.03.2022 | 30.11.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 3       | 2            | 01.12.2022 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 3       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 3       | 2            | 01.07.2023 | 31.07.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser | Ugyldige begrunnelser |
+      | 01.08.2023 |          | OPPHØR             |                                | OPPHØR_UTVANDRET     |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato | Standardbegrunnelser | Eøsbegrunnelser | Fritekster |
+      | 01.08.2023 |          | OPPHØR_UTVANDRET     |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.08.2023 til -
+      | Begrunnelse      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp |
+      | OPPHØR_UTVANDRET | STANDARD | Ja            | 06.03.12 og 21.12.16 | 0           | juli 2023                            | NB      | 0     |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
@@ -48,7 +48,7 @@ Egenskap: Brevbegrunnelser ved opphør
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.03.2023 til -
       | Begrunnelse      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp |
-      | OPPHØR_UTVANDRET | STANDARD | Ja            | 17.04.17             | 1           | februar 2023                         | NB      | 0     |
+      | OPPHØR_UTVANDRET | STANDARD | Ja            | 17.04.17             | 0           | februar 2023                         | NB      | 0     |
 
   Scenario: Skal flette inn barn som har oppfylte vilkår og barn som hadde andeler i forrige periode når vi opphører for søker
     Og følgende dagens dato 13.10.2023
@@ -80,3 +80,4 @@ Egenskap: Brevbegrunnelser ved opphør
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.03.2023 til -
       | Begrunnelse      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp |
       | OPPHØR_UTVANDRET | STANDARD | Ja            | 16.04.17 og 17.04.17 | 2           | februar 2023                         | NB      | 0     |
+      | OPPHØR_UTVANDRET | STANDARD | Ja            | 16.04.17 og 17.04.17 | 1           | februar 2023                         | NB      | 0     |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør_samme_måned.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør_samme_måned.feature
@@ -71,5 +71,5 @@ Egenskap: Brevbegrunnelser ved opphør der vilkår blir innvilget og opphørt in
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2020 til -
       | Begrunnelse                | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
-      | OPPHØR_IKKE_BOSATT_I_NORGE | Ja            | 16.06.15 og 30.11.16 | 2           | august 2020                          | NB      | 0     |                  | SØKER_HAR_IKKE_RETT     |
+      | OPPHØR_IKKE_BOSATT_I_NORGE | Ja            | 16.06.15 og 30.11.16 | 0           | august 2020                          | NB      | 0     |                  | SØKER_HAR_IKKE_RETT     |
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-14024

Når vi opphører og begrunnelsen gjelder søker må vi ta stilling til **antall barn som også har opphør på samme vilkår** i perioden når vi skal bestemme om vi skal si "du"/"du og barnet"/"du og barna". I dag teller vi med alle barna som har andeler i forrige periode, men om det kun er søker som har opphørende vilkår blir det feil å begrunne med at "du og barna ikke lenger er bosatt i Norge".

Har prøvd å stykke det opp så det gir mening å lese commit for commit.

Fjerner også en funksjon som ikke var i bruk - den er en duplikat av en metode som ligger i `IVedtakBegrunnelse.kt`, og det er den andre metoden som kalles på.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
