### PR TITLE
Splitt opp integrasjonstestene og enhetstestene

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,30 +24,50 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Kjør ktlint
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mvn -B --no-transfer-progress antrun:run@ktlint
-  enhetstester-integrasjonstester:
-    name: Enhetstester og integrasjonstester
+
+  enhetstester:
+    name: Enhetstester
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-      - name: Kjør enhetstester og integrasjonstester
+
+      - name: Kjør enhetstester
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -DexcludedGroups=verdikjedetest
+          mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -DexcludedGroups=integration,verdikjedetest
+
+  integrasjonstester:
+    name: Integrasjonstester
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Kjør integrasjonstester
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -Dgroups=integration
+
   verdikjedetesterFeatureToggleOff:
     name: Verdikjedetester m/ feature toggles slått av
     runs-on: ubuntu-latest
@@ -58,12 +78,14 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Kjør verdikjedetester m/ feature toggles slått av
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -DargLine="-DmockFeatureToggleAnswer=false" -Dgroups=verdikjedetest
+
   verdikjedetesterFeatureToggleOn:
     name: Verdikjedetester m/ feature toggles slått på
     runs-on: ubuntu-latest
@@ -74,6 +96,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Kjør verdikjedetester m/ feature toggles slått på
         env:
           GITHUB_USERNAME: x-access-token


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Siden enhetstestene og integrasjonstestene noen ganger bruker lengst tid, kan vi tjene litt på å splitte dem opp.

![image](https://github.com/navikt/familie-ba-sak/assets/17828446/0aac66e3-8769-410d-aa16-66f7b6bda54d)
