### PR TITLE
Fjern toggler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -9,8 +9,6 @@ class FeatureToggleConfig {
         const val TEKNISK_ENDRING = "familie-ba-sak.behandling.teknisk-endring"
 
         // Release
-        const val EØS_INFORMASJON_OM_ÅRLIG_KONTROLL = "familie-ba-sak.eos-informasjon-om-aarlig-kontroll"
-
         // Unleash Next toggles
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"
         const val NY_GENERERING_AV_BREVOBJEKTER = "familie-ba-sak.ny-generering-av-brevobjekter"

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -12,8 +12,6 @@ class FeatureToggleConfig {
         const val EØS_INFORMASJON_OM_ÅRLIG_KONTROLL = "familie-ba-sak.eos-informasjon-om-aarlig-kontroll"
         const val ER_MANUEL_POSTERING_TOGGLE_PÅ = "familie-ba-sak.manuell-postering"
         const val FEILUTBETALT_VALUTA_PR_MND = "familie-ba-sak.feilutbetalt-valuta-pr-mnd"
-        const val EØS_PRAKSISENDRING_SEPTEMBER2023 =
-            "familie-ba-sak.behandling.eos-annen-forelder-omfattet-av-norsk-lovgivning"
 
         // Unleash Next toggles
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -10,7 +10,6 @@ class FeatureToggleConfig {
 
         // Release
         const val EØS_INFORMASJON_OM_ÅRLIG_KONTROLL = "familie-ba-sak.eos-informasjon-om-aarlig-kontroll"
-        const val ER_MANUEL_POSTERING_TOGGLE_PÅ = "familie-ba-sak.manuell-postering"
 
         // Unleash Next toggles
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -11,7 +11,6 @@ class FeatureToggleConfig {
         // Release
         const val EØS_INFORMASJON_OM_ÅRLIG_KONTROLL = "familie-ba-sak.eos-informasjon-om-aarlig-kontroll"
         const val ER_MANUEL_POSTERING_TOGGLE_PÅ = "familie-ba-sak.manuell-postering"
-        const val FEILUTBETALT_VALUTA_PR_MND = "familie-ba-sak.feilutbetalt-valuta-pr-mnd"
 
         // Unleash Next toggles
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFeilutbetaltValuta.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFeilutbetaltValuta.kt
@@ -7,5 +7,4 @@ data class RestFeilutbetaltValuta(
     val fom: LocalDate,
     val tom: LocalDate,
     val feilutbetaltBeløp: Int,
-    val erPerMåned: Boolean? = null,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityService.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ba.sak.integrasjoner.sanity
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
@@ -15,7 +13,6 @@ import org.springframework.stereotype.Service
 @Service
 class SanityService(
     private val sanityKlient: SanityKlient,
-    private val featureToggleService: FeatureToggleService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -39,16 +36,7 @@ class SanityService(
 
     @Cacheable("sanityEØSBegrunnelser", cacheManager = "shortCache")
     fun hentSanityEØSBegrunnelser(): Map<EØSStandardbegrunnelse, SanityEØSBegrunnelse> {
-        val eøsPraksisEndringFeatureToggleErSlåttPå =
-            featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023)
-
-        // TODO: Fjern filtrering av begrunnelser etter at EØS praksisendringen er live i prod
-        val enumPåApiNavn = if (eøsPraksisEndringFeatureToggleErSlåttPå) {
-            EØSStandardbegrunnelse.values().associateBy { it.sanityApiNavn }
-        } else {
-            EØSStandardbegrunnelse.values().subtract(EØSStandardbegrunnelse.eøsPraksisendringBegrunnelser())
-                .associateBy { it.sanityApiNavn }
-        }
+        val enumPåApiNavn = EØSStandardbegrunnelse.entries.associateBy { it.sanityApiNavn }
 
         val sanityEØSBegrunnelser = sanityKlient.hentEØSBegrunnelser()
         logManglerSanityBegrunnelseForEnum(enumPåApiNavn, sanityEØSBegrunnelser, "SanityEØSBegrunnelse")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/KontrollerNyUtbetalingsgeneratorService.kt
@@ -272,7 +272,6 @@ class KontrollerNyUtbetalingsgeneratorService(
             this.simuleringMottaker.map {
                 it.tilBehandlingSimuleringMottaker(behandling)
             },
-            true,
         ).sortedBy { it.fom }
 
     data class KombinertSimuleringsResultat(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.simulering
 
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.simulering.domene.RestSimulering
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -19,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController
 class SimuleringController(
     private val simuleringService: SimuleringService,
     private val tilgangService: TilgangService,
-    private val featureToggleService: FeatureToggleService,
 ) {
 
     @GetMapping(path = ["/{behandlingId}/simulering"])
@@ -30,7 +27,6 @@ class SimuleringController(
         val vedtakSimuleringMottaker = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId)
         val restSimulering = vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = vedtakSimuleringMottaker,
-            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
         )
         return ResponseEntity.ok(Ressurs.success(restSimulering))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -5,7 +5,6 @@ import jakarta.transaction.Transactional
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForSimuleringFactory
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGeneratorService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.tilRestUtbetalingsoppdrag
@@ -41,7 +40,6 @@ class SimuleringService(
     private val beregningService: BeregningService,
     private val økonomiSimuleringMottakerRepository: ØkonomiSimuleringMottakerRepository,
     private val tilgangService: TilgangService,
-    private val featureToggleService: FeatureToggleService,
     private val unleashService: UnleashService,
     private val vedtakRepository: VedtakRepository,
     private val utbetalingsoppdragGeneratorService: UtbetalingsoppdragGeneratorService,
@@ -128,7 +126,6 @@ class SimuleringService(
         val simulering = hentSimuleringPåBehandling(behandlingId)
         val restSimulering = vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = simulering,
-            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
         )
 
         return if (!behandlingErFerdigBesluttet && simuleringErUtdatert(restSimulering)) {
@@ -175,14 +172,12 @@ class SimuleringService(
     fun hentEtterbetaling(økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>): BigDecimal {
         return vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = økonomiSimuleringMottakere,
-            erManuellPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
         ).etterbetaling
     }
 
     fun hentFeilutbetaling(økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>): BigDecimal {
         return vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere,
-            featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
         ).feilutbetaling
     }
 
@@ -246,7 +241,6 @@ class SimuleringService(
 
         return vedtakSimuleringMottakereTilSimuleringPerioder(
             økonomiSimuleringMottakere = hentSimuleringPåBehandling(behandlingId),
-            erManuelPosteringTogglePå = featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
         ).filter {
             it.fom.isSameOrBefore(februar2023)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
@@ -24,12 +24,10 @@ fun filterBortUrelevanteVedtakSimuleringPosteringer(
 
 fun vedtakSimuleringMottakereTilRestSimulering(
     økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>,
-    erManuellPosteringTogglePå: Boolean,
 ): RestSimulering {
     val perioder =
         vedtakSimuleringMottakereTilSimuleringPerioder(
             økonomiSimuleringMottakere,
-            erManuellPosteringTogglePå,
         )
     val tidSimuleringHentet = økonomiSimuleringMottakere.firstOrNull()?.opprettetTidspunkt?.toLocalDate()
 
@@ -59,7 +57,6 @@ fun vedtakSimuleringMottakereTilRestSimulering(
 
 fun vedtakSimuleringMottakereTilSimuleringPerioder(
     økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>,
-    erManuelPosteringTogglePå: Boolean,
 ): List<SimuleringsPeriode> {
     if (økonomiSimuleringMottakere.isEmpty()) {
         return emptyList()
@@ -76,43 +73,14 @@ fun vedtakSimuleringMottakereTilSimuleringPerioder(
             fom = fom,
             tom = posteringListe[0].tom,
             forfallsdato = posteringListe[0].forfallsdato,
-            nyttBeløp = if (erManuelPosteringTogglePå) {
-                hentNyttBeløpIPeriode(posteringListe)
-            } else {
-                hentNyttBeløpIPeriodeGammel(posteringListe)
-            },
-            tidligereUtbetalt = if (erManuelPosteringTogglePå) {
-                hentTidligereUtbetaltIPeriode(posteringListe)
-            } else {
-                hentTidligereUtbetaltIPeriodeGammel(posteringListe)
-            },
-            resultat = if (erManuelPosteringTogglePå) {
-                hentResultatIPeriode(posteringListe)
-            } else {
-                hentResultatIPeriodeGammel(posteringListe)
-            },
-            manuellPostering = if (erManuelPosteringTogglePå) {
-                hentManuellPosteringIPeriode(posteringListe)
-            } else {
-                BigDecimal.ZERO
-            },
+            nyttBeløp = hentNyttBeløpIPeriode(posteringListe),
+            tidligereUtbetalt = hentTidligereUtbetaltIPeriode(posteringListe),
+            resultat = hentResultatIPeriode(posteringListe),
+            manuellPostering = hentManuellPosteringIPeriode(posteringListe),
             feilutbetaling = hentPositivFeilbetalingIPeriode(posteringListe),
-            etterbetaling = if (erManuelPosteringTogglePå) {
-                hentEtterbetalingIPeriode(posteringListe, tidSimuleringHentet)
-            } else {
-                hentEtterbetalingIPeriodeGammel(posteringListe, tidSimuleringHentet)
-            },
+            etterbetaling = hentEtterbetalingIPeriode(posteringListe, tidSimuleringHentet),
         )
     }
-}
-
-@Deprecated("Skal bruke hentNyttBeløpIPeriode når manuelle posteringer er tester ferdig")
-fun hentNyttBeløpIPeriodeGammel(periode: List<ØkonomiSimuleringPostering>): BigDecimal {
-    val sumPositiveYtelser = periode.filter { postering ->
-        postering.posteringType == PosteringType.YTELSE && postering.beløp > BigDecimal.ZERO
-    }.sumOf { it.beløp }
-    val feilutbetaling = hentFeilbetalingIPeriodeGammel(periode)
-    return if (feilutbetaling > BigDecimal.ZERO) sumPositiveYtelser - feilutbetaling else sumPositiveYtelser
 }
 
 fun hentNyttBeløpIPeriode(periode: List<ØkonomiSimuleringPostering>): BigDecimal {
@@ -142,27 +110,11 @@ fun hentNegativFeilutbetalingIPeriode(periode: List<ØkonomiSimuleringPostering>
             postering.beløp < BigDecimal.ZERO
     }.sumOf { it.beløp }
 
-@Deprecated("Skal bruke hentFeilutbetalingIPeriode når manuelle posteringer er tester ferdig")
-fun hentFeilbetalingIPeriodeGammel(periode: List<ØkonomiSimuleringPostering>) =
-    periode.filter { postering ->
-        postering.posteringType == PosteringType.FEILUTBETALING &&
-            !postering.erManuellPostering
-    }.sumOf { it.beløp }
-
 fun hentFeilutbetalingIPeriode(periode: List<ØkonomiSimuleringPostering>, inkluderManuellePosteringer: Boolean) =
     periode
         .filter { it.posteringType == PosteringType.FEILUTBETALING }
         .filter { inkluderManuellePosteringer || !it.erManuellPostering }
         .sumOf { it.beløp }
-
-@Deprecated("Skal bruke hentTidligereUtbetaltIPeriode når manuelle posteringer er tester ferdig")
-fun hentTidligereUtbetaltIPeriodeGammel(periode: List<ØkonomiSimuleringPostering>): BigDecimal {
-    val sumNegativeYtelser = periode.filter { postering ->
-        (postering.posteringType == PosteringType.YTELSE && postering.beløp < BigDecimal.ZERO)
-    }.sumOf { it.beløp }
-    val feilutbetaling = hentFeilbetalingIPeriodeGammel(periode)
-    return if (feilutbetaling < BigDecimal.ZERO) -(sumNegativeYtelser - feilutbetaling) else -sumNegativeYtelser
-}
 
 fun hentTidligereUtbetaltIPeriode(periode: List<ØkonomiSimuleringPostering>): BigDecimal {
     val sumNegativeYtelser = periode
@@ -201,17 +153,6 @@ private fun hentManuellFeilutbetalingIPeriode(periode: List<ØkonomiSimuleringPo
         .filter { it.erManuellPostering }
         .sumOf { it.beløp }
 
-@Deprecated("Skal bruke hentResultatIPeriode når manuelle posteringer er tester ferdig")
-fun hentResultatIPeriodeGammel(periode: List<ØkonomiSimuleringPostering>): BigDecimal {
-    val feilutbetaling = hentFeilbetalingIPeriodeGammel(periode)
-
-    return if (feilutbetaling > BigDecimal.ZERO) {
-        -feilutbetaling
-    } else {
-        hentNyttBeløpIPeriode(periode) - hentTidligereUtbetaltIPeriodeGammel(periode)
-    }
-}
-
 fun hentResultatIPeriode(periode: List<ØkonomiSimuleringPostering>): BigDecimal {
     val feilutbetaling = hentFeilutbetalingIPeriode(periode, true)
 
@@ -220,22 +161,6 @@ fun hentResultatIPeriode(periode: List<ØkonomiSimuleringPostering>): BigDecimal
     } else {
         hentNyttBeløpIPeriode(periode) -
             hentTidligereUtbetaltIPeriode(periode)
-    }
-}
-
-@Deprecated("Skal bruke hentEtterbetalingIPeriode når manuelle posteringer er testet ferdig")
-fun hentEtterbetalingIPeriodeGammel(
-    periode: List<ØkonomiSimuleringPostering>,
-    tidSimuleringHentet: LocalDate,
-): BigDecimal {
-    val periodeHarPositivFeilutbetaling =
-        periode.any { it.posteringType == PosteringType.FEILUTBETALING && it.beløp > BigDecimal.ZERO }
-    val sumYtelser =
-        periode.filter { it.posteringType == PosteringType.YTELSE && it.forfallsdato <= tidSimuleringHentet }
-            .sumOf { it.beløp }
-    return when {
-        periodeHarPositivFeilutbetaling -> BigDecimal.ZERO
-        else -> maxOf(BigDecimal.ZERO, sumYtelser)
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.tilbakekreving
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
@@ -110,7 +109,6 @@ class TilbakekrevingService(
                     sumFeilutbetaling = simuleringService.hentFeilutbetaling(behandlingId).toLong(),
                     perioder = hentTilbakekrevingsperioderISimulering(
                         simuleringService.hentSimuleringPåBehandling(behandlingId),
-                        featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
                     ),
                 ),
                 fagsystem = Fagsystem.BA,
@@ -191,7 +189,6 @@ class TilbakekrevingService(
             varsel = opprettVarsel(
                 tilbakekreving,
                 simuleringService.hentSimuleringPåBehandling(behandling.id),
-                featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ),
             ),
             revurderingsvedtaksdato = revurderingsvedtaksdato,
             // Verge er per nå ikke støttet i familie-ba-sak.

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtil.kt
@@ -55,25 +55,21 @@ fun slåsammenNærliggendeFeilutbtalingPerioder(simuleringsPerioder: List<Simule
 
 fun hentTilbakekrevingsperioderISimulering(
     simulering: List<ØkonomiSimuleringMottaker>,
-    erManuelPosteringTogglePå: Boolean,
 ): List<Periode> =
     slåsammenNærliggendeFeilutbtalingPerioder(
         vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = simulering,
-            erManuellPosteringTogglePå = erManuelPosteringTogglePå,
         ).perioder,
     )
 
 fun opprettVarsel(
     tilbakekreving: Tilbakekreving?,
     simulering: List<ØkonomiSimuleringMottaker>,
-    erManuelPosteringTogglePå: Boolean,
 ): Varsel? =
     if (tilbakekreving?.valg == Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL) {
         val varseltekst = tilbakekreving.varsel ?: throw Feil("Varseltekst er ikke satt")
         val restSimulering = vedtakSimuleringMottakereTilRestSimulering(
             økonomiSimuleringMottakere = simulering,
-            erManuellPosteringTogglePå = erManuelPosteringTogglePå,
         )
 
         Varsel(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.feilutbetaltValuta
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.FEILUTBETALT_VALUTA_PR_MND
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestFeilutbetaltValuta
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
@@ -34,7 +33,7 @@ class FeilutbetaltValutaService(
                 fom = feilutbetaltValuta.fom,
                 tom = feilutbetaltValuta.tom,
                 feilutbetaltBeløp = feilutbetaltValuta.feilutbetaltBeløp,
-                erPerMåned = feilutbetaltValuta.erPerMåned ?: featureToggleService.isEnabled(FEILUTBETALT_VALUTA_PR_MND),
+                erPerMåned = feilutbetaltValuta.erPerMåned ?: true,
             ),
         )
         loggService.loggFeilutbetaltValutaPeriodeLagtTil(behandlingId = behandlingId, feilutbetaltValuta = lagret)
@@ -69,6 +68,6 @@ class FeilutbetaltValutaService(
         periode.fom = feilutbetaltValuta.fom
         periode.tom = feilutbetaltValuta.tom
         periode.feilutbetaltBeløp = feilutbetaltValuta.feilutbetaltBeløp
-        periode.erPerMåned = feilutbetaltValuta.erPerMåned ?: featureToggleService.isEnabled(FEILUTBETALT_VALUTA_PR_MND)
+        periode.erPerMåned = feilutbetaltValuta.erPerMåned ?: true
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.feilutbetaltValuta
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestFeilutbetaltValuta
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import org.springframework.beans.factory.annotation.Autowired
@@ -15,10 +14,6 @@ class FeilutbetaltValutaService(
 
     @Autowired
     private val loggService: LoggService,
-
-    @Autowired
-    private val featureToggleService: FeatureToggleService,
-
 ) {
 
     private fun finnFeilutbetaltValutaThrows(id: Long): FeilutbetaltValuta {
@@ -33,7 +28,7 @@ class FeilutbetaltValutaService(
                 fom = feilutbetaltValuta.fom,
                 tom = feilutbetaltValuta.tom,
                 feilutbetaltBeløp = feilutbetaltValuta.feilutbetaltBeløp,
-                erPerMåned = feilutbetaltValuta.erPerMåned ?: true,
+                erPerMåned = true,
             ),
         )
         loggService.loggFeilutbetaltValutaPeriodeLagtTil(behandlingId = behandlingId, feilutbetaltValuta = lagret)
@@ -58,7 +53,6 @@ class FeilutbetaltValutaService(
             fom = it.fom,
             tom = it.tom,
             feilutbetaltBeløp = it.feilutbetaltBeløp,
-            erPerMåned = it.erPerMåned,
         )
 
     @Transactional
@@ -68,6 +62,6 @@ class FeilutbetaltValutaService(
         periode.fom = feilutbetaltValuta.fom
         periode.tom = feilutbetaltValuta.tom
         periode.feilutbetaltBeløp = feilutbetaltValuta.feilutbetaltBeløp
-        periode.erPerMåned = feilutbetaltValuta.erPerMåned ?: true
+        periode.erPerMåned = true
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestGenererVedtaksperioderForOverstyrtEndringstidspunkt
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedFritekster
@@ -566,9 +565,6 @@ class VedtaksperiodeService(
     }
 
     fun skalHaÅrligKontroll(vedtak: Vedtak): Boolean {
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.EØS_INFORMASJON_OM_ÅRLIG_KONTROLL, false)) {
-            return false
-        }
         return vedtak.behandling.kategori == BehandlingKategori.EØS &&
             hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -589,10 +589,7 @@ class VedtaksperiodeService(
             Behandlingsresultat.OPPHØRT,
         )
 
-        val eøsPraksisEndringFeatureToggleErSlåttPå =
-            featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023)
-
-        return annenForelderOmfattetAvNorskLovgivningErSattPåBosattIRiket && passendeBehandlingsresultat && eøsPraksisEndringFeatureToggleErSlåttPå
+        return annenForelderOmfattetAvNorskLovgivningErSattPåBosattIRiket && passendeBehandlingsresultat
     }
 
     fun beskrivPerioderMedFeilutbetaltValuta(vedtak: Vedtak): Set<String>? {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
@@ -4,8 +4,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import org.assertj.core.api.Assertions.assertThat
@@ -18,16 +16,11 @@ class SanityServiceTest {
     @MockK
     private lateinit var sanityKlient: SanityKlient
 
-    @MockK
-    private lateinit var featureToggleService: FeatureToggleService
-
     @InjectMockKs
     private lateinit var sanityService: SanityService
 
     @Test
-    fun `hentSanityEØSBegrunnelser - skal filtrere bort nye begrunnelser tilknyttet EØS praksisendring dersom toggel er av`() {
-        every { featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023) } returns false
-
+    fun `hentSanityEØSBegrunnelser - skal ikke filtrere bort nye begrunnelser tilknyttet EØS praksisendring`() {
         every { sanityKlient.hentEØSBegrunnelser() } returns EØSStandardbegrunnelse.values().map {
             SanityEØSBegrunnelse(
                 apiNavn = it.sanityApiNavn,
@@ -49,34 +42,6 @@ class SanityServiceTest {
 
         val eøsBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
 
-        assertThat(eøsBegrunnelser.keys).doesNotContainAnyElementsOf(EØSStandardbegrunnelse.eøsPraksisendringBegrunnelser())
-    }
-
-    @Test
-    fun `hentSanityEØSBegrunnelser - skal ikke filtrere bort nye begrunnelser tilknyttet EØS praksisendring dersom toggel er på`() {
-        every { featureToggleService.isEnabled(FeatureToggleConfig.EØS_PRAKSISENDRING_SEPTEMBER2023) } returns true
-
-        every { sanityKlient.hentEØSBegrunnelser() } returns EØSStandardbegrunnelse.values().map {
-            SanityEØSBegrunnelse(
-                apiNavn = it.sanityApiNavn,
-                navnISystem = it.name,
-                fagsakType = null,
-                periodeType = null,
-                tema = null,
-                vilkår = emptySet(),
-                annenForeldersAktivitet = emptyList(),
-                barnetsBostedsland = emptyList(),
-                kompetanseResultat = emptyList(),
-                hjemler = emptyList(),
-                hjemlerFolketrygdloven = emptyList(),
-                hjemlerEØSForordningen883 = emptyList(),
-                hjemlerEØSForordningen987 = emptyList(),
-                hjemlerSeperasjonsavtalenStorbritannina = emptyList(),
-            )
-        }
-
-        val eøsBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
-
-        assertThat(eøsBegrunnelser.keys).isEqualTo(EØSStandardbegrunnelse.values().toSet())
+        assertThat(eøsBegrunnelser.keys).isEqualTo(EØSStandardbegrunnelse.entries.toSet())
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -17,7 +17,6 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGeneratorS
 import no.nav.familie.ba.sak.integrasjoner.økonomi.lagUtbetalingsoppdrag
 import no.nav.familie.ba.sak.integrasjoner.økonomi.tilRestUtbetalingsoppdrag
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiKlient
-import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -50,7 +49,6 @@ import org.hamcrest.CoreMatchers.`is` as Is
 internal class SimuleringServiceEnhetTest {
 
     private val økonomiKlient: ØkonomiKlient = mockk()
-    private val økonomiService: ØkonomiService = mockk()
     private val beregningService: BeregningService = mockk()
     private val økonomiSimuleringMottakerRepository: ØkonomiSimuleringMottakerRepository = mockk()
     private val tilgangService: TilgangService = mockk()
@@ -63,17 +61,16 @@ internal class SimuleringServiceEnhetTest {
     private val unleashService: UnleashService = mockk()
 
     private val simuleringService: SimuleringService = SimuleringService(
-        økonomiKlient,
-        beregningService,
-        økonomiSimuleringMottakerRepository,
-        tilgangService,
-        featureToggleService,
-        unleashService,
-        vedtakRepository,
-        utbetalingsoppdragGeneratorService,
-        behandlingHentOgPersisterService,
-        persongrunnlagService,
-        kontrollerNyUtbetalingsgeneratorService,
+        økonomiKlient = økonomiKlient,
+        beregningService = beregningService,
+        økonomiSimuleringMottakerRepository = økonomiSimuleringMottakerRepository,
+        tilgangService = tilgangService,
+        unleashService = unleashService,
+        vedtakRepository = vedtakRepository,
+        utbetalingsoppdragGeneratorService = utbetalingsoppdragGeneratorService,
+        behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+        persongrunnlagService = persongrunnlagService,
+        kontrollerNyUtbetalingsgeneratorService = kontrollerNyUtbetalingsgeneratorService,
     )
 
     val februar2023 = LocalDate.of(2023, 2, 1)
@@ -106,7 +103,6 @@ internal class SimuleringServiceEnhetTest {
             lagPerson(type = PersonType.BARN).tilPersonEnkel(),
             lagPerson(type = PersonType.BARN).tilPersonEnkel(),
         )
-        every { featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ) } returns true
 
         val behandlingHarAvvikInnenforBeløpsgrenser =
             simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
@@ -156,7 +152,6 @@ internal class SimuleringServiceEnhetTest {
             lagPerson(type = PersonType.BARN).tilPersonEnkel(),
             lagPerson(type = PersonType.BARN).tilPersonEnkel(),
         )
-        every { featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ) } returns true
 
         val behandlingHarAvvikInnenforBeløpsgrenser =
             simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
@@ -191,7 +186,6 @@ internal class SimuleringServiceEnhetTest {
             lagPerson(type = PersonType.BARN).tilPersonEnkel(),
             lagPerson(type = PersonType.BARN).tilPersonEnkel(),
         )
-        every { featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ) } returns true
 
         val behandlingHarAvvikInnenforBeløpsgrenser =
             simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtilTest.kt
@@ -144,7 +144,7 @@ class SimuleringUtilTest {
     fun `Total etterbetaling skal bli summen av ytelsene i periode med negativ feilutbetaling`() {
         val økonomiSimuleringMottaker =
             mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = økonomiSimuleringPosteringerMedNegativFeilutbetaling)
-        val restSimulering = vedtakSimuleringMottakereTilRestSimulering(listOf(økonomiSimuleringMottaker), false)
+        val restSimulering = vedtakSimuleringMottakereTilRestSimulering(listOf(økonomiSimuleringMottaker))
 
         Assertions.assertEquals(BigDecimal.valueOf(500), restSimulering.etterbetaling)
     }
@@ -153,7 +153,7 @@ class SimuleringUtilTest {
     fun `Total feilutbetaling skal bli 0 i periode med negativ feilutbetaling`() {
         val økonomiSimuleringMottaker =
             mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = økonomiSimuleringPosteringerMedNegativFeilutbetaling)
-        val restSimulering = vedtakSimuleringMottakereTilRestSimulering(listOf(økonomiSimuleringMottaker), false)
+        val restSimulering = vedtakSimuleringMottakereTilRestSimulering(listOf(økonomiSimuleringMottaker))
 
         Assertions.assertEquals(BigDecimal.valueOf(0), restSimulering.feilutbetaling)
     }
@@ -169,7 +169,7 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottaker =
             mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = økonomiSimuleringPosteringerMedPositivFeilutbetaling)
-        val restSimulering = vedtakSimuleringMottakereTilRestSimulering(listOf(økonomiSimuleringMottaker), false)
+        val restSimulering = vedtakSimuleringMottakereTilRestSimulering(listOf(økonomiSimuleringMottaker))
 
         Assertions.assertEquals(BigDecimal.valueOf(0), restSimulering.etterbetaling)
         Assertions.assertEquals(BigDecimal.valueOf(500), restSimulering.feilutbetaling)
@@ -238,8 +238,8 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = redusertYtelseTil2_000))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, true)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(10_000.toBigDecimal())
@@ -264,8 +264,8 @@ class SimuleringUtilTest {
             )
         }
 
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(vedtakSimuleringMottakere, true)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(vedtakSimuleringMottakere, true)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(vedtakSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(vedtakSimuleringMottakere)
 
         val simuleringJanuar22 = simuleringsperioder.single { it.fom == LocalDate.of(2022, 1, 1) }
         val simuleringFebruar22 = simuleringsperioder.single { it.fom == LocalDate.of(2022, 2, 1) }
@@ -324,8 +324,8 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = øktYtelseFra2_000Til3_000))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, false)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, false)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(2_000.toBigDecimal())
@@ -371,8 +371,8 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = YtelsefraBA))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, true)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(305.toBigDecimal())
@@ -419,8 +419,8 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = YtelsefraBA))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, true)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(305.toBigDecimal())
@@ -468,8 +468,8 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = YtelsefraBA))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, true)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         val simuleringsperiode = simuleringsperioder.single()
 
@@ -513,8 +513,8 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = øktYtelseFra3_000Til12_000))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, true)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(3_000.toBigDecimal())
@@ -540,7 +540,7 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = førstegangsbehandling_18_nov))
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, false)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         assertThat(oppsummering.feilutbetaling).isEqualTo(0.toBigDecimal())
         assertThat(oppsummering.etterbetaling).isEqualTo(160_629.toBigDecimal())
@@ -565,7 +565,7 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = revurering_22_nov))
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, false)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         assertThat(oppsummering.feilutbetaling).isEqualTo(3_752.toBigDecimal())
         assertThat(oppsummering.etterbetaling).isEqualTo(0.toBigDecimal())
@@ -590,8 +590,8 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = revurdering_23_nov))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, false)
-        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere, false)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
+        val oppsummering = vedtakSimuleringMottakereTilRestSimulering(økonomiSimuleringMottakere)
 
         (3..6).forEach {
             assertThat(simuleringsperioder[it].tidligereUtbetalt).isEqualTo(17_257.toBigDecimal())
@@ -656,7 +656,7 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = ytelseMetMotposteringerOgManuellePosteringer))
-        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere, true)
+        val simuleringsperioder = vedtakSimuleringMottakereTilSimuleringPerioder(økonomiSimuleringMottakere)
 
         val simuleringsperiode = simuleringsperioder.single()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -43,7 +42,6 @@ class VurderTilbakekrevingStegTest {
         every { tilbakekrevingService.søkerHarÅpenTilbakekreving(any()) } returns false
         every { tilbakekrevingService.validerRestTilbakekreving(any(), any()) } returns Unit
         every { tilbakekrevingService.lagreTilbakekreving(any(), any()) } returns null
-        every { featureToggleService.isEnabled(FeatureToggleConfig.ER_MANUEL_POSTERING_TOGGLE_PÅ) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.common.lagVedtaksperiodeMedBegrunnelser
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -107,12 +106,6 @@ class VedtaksperiodeServiceTest {
         every {
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
         } returns listOf(ytelseOpphørtFørEndringstidspunkt)
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.EØS_INFORMASJON_OM_ÅRLIG_KONTROLL,
-                any(),
-            )
-        } returns true
         every { feilutbetaltValutaRepository.finnFeilutbetaltValutaForBehandling(any()) } returns emptyList()
         every { småbarnstilleggService.hentPerioderMedFullOvergangsstønad(any()) } returns emptyList()
         every { refusjonEøsRepository.finnRefusjonEøsForBehandling(any()) } returns emptyList()
@@ -151,19 +144,6 @@ class VedtaksperiodeServiceTest {
             lagVedtaksperiodeMedBegrunnelser(vedtak = vedtak, tom = null),
         )
         assertTrue { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
-    }
-
-    @Test
-    fun `EØS skal ikke ha årlig kontroll når feature toggle er skrudd av`() {
-        every {
-            featureToggleService.isEnabled(FeatureToggleConfig.EØS_INFORMASJON_OM_ÅRLIG_KONTROLL, any())
-        } returns false
-
-        val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
-        every { vedtaksperiodeHentOgPersisterService.finnVedtaksperioderFor(any()) } returns listOf(
-            lagVedtaksperiodeMedBegrunnelser(vedtak = vedtak, tom = null),
-        )
-        assertFalse { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -113,12 +113,6 @@ class VedtaksperiodeServiceTest {
                 any(),
             )
         } returns true
-        every {
-            featureToggleService.isEnabled(
-                FeatureToggleConfig.FEILUTBETALT_VALUTA_PR_MND,
-                any(),
-            )
-        } returns true
         every { feilutbetaltValutaRepository.finnFeilutbetaltValutaForBehandling(any()) } returns emptyList()
         every { småbarnstilleggService.hentPerioderMedFullOvergangsstønad(any()) } returns emptyList()
         every { refusjonEøsRepository.finnRefusjonEøsForBehandling(any()) } returns emptyList()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner toggler som har vært på lenge: 

EØS_PRAKSISENDRING_SEPTEMBER2023 har vært på siden 01.10.2023
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/1f366b6a-b98f-419a-81f2-b354190b9cf9)

FEILUTBETALT_VALUTA_PR_MND har vært på siden 22.06.2023
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/6c251908-f338-4bfc-b529-671b1bad7a58)

ER_MANUEL_POSTERING_TOGGLE_PÅ har vært på siden 05.06.2023:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/c5b6853c-8b1b-41c3-9c1f-08c55a788443)

EØS_INFORMASJON_OM_ÅRLIG_KONTROLL har vært på siden 13.01.2023:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/88e38a79-1f6d-40e7-8989-a51ecbd08444)

