### PR TITLE
Skru på test igjen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -141,7 +141,7 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")
                 }|${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""}|${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""}| ${vilkårResultatRad.resultat} | ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"} | ${
                     vilkårResultatRad.standardbegrunnelser.joinToString(",")
-                }"""
+                } |"""
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
@@ -40,7 +40,15 @@ fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tilOgMed() = this
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.tidsrom(): Collection<Tidspunkt<T>> = when {
     this.perioder().isEmpty() -> emptyList()
-    else -> (perioder().first().fraOgMed.rangeTo(perioder().last().tilOgMed)).toList()
+    else -> {
+        val fraOgMed = this.fraOgMed()
+        val tilOgMed = this.tilOgMed()
+        if (fraOgMed == null || tilOgMed == null) {
+            emptyList()
+        } else {
+            (fraOgMed..tilOgMed).toList()
+        }
+    }
 }
 
 fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): Collection<Tidspunkt<T>> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/TidslinjeTest.kt
@@ -116,7 +116,7 @@ internal class TidslinjeTest {
     }
 
     @Test
-    fun `tidsrom skal lage liste med alle tidspunkter opp til uendelig tidspunk`() {
+    fun `tidsrom på liste av tidslinjer skal lage liste med alle tidspunkter opp til uendelig tidspunkt`() {
         val tidslinjeMedUendelighet = listOf(
             Periode(nov(2020), des(2020), 'A'),
             Periode(jan(2021), jan(1999).somUendeligLengeTil(), 'B'),
@@ -124,6 +124,18 @@ internal class TidslinjeTest {
 
         Assertions.assertThat(tidsrom(tidslinjeMedUendelighet).toList()).isEqualTo(
             listOf(nov(2020), des(2020), jan(1999).somUendeligLengeTil()),
+        )
+    }
+
+    @Test
+    fun `tidsrom på tidslinje skal lage liste med alle tidspunkter opp til uendelig tidspunkt`() {
+        val tidslinjeMedUendelighet = listOf(
+            Periode(feb(2023), apr(2023), 'A'),
+            Periode(mai(2023), mai(2022).somUendeligLengeTil(), 'B'),
+        ).tilTidslinje()
+
+        Assertions.assertThat(tidslinjeMedUendelighet.tidsrom().toList()).isEqualTo(
+            listOf(feb(2023), mar(2023), apr(2023), mai(2023).somUendeligLengeTil()),
         )
     }
 }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -135,7 +135,7 @@ Egenskap: Gyldige begrunnelser for kompetanser
       | 2            | 1234    | BARN       | 02.02.2015  |
       | 2            | 5678    | SØKER      | 10.05.1985  |
 
-    Og følgende dagens dato 2023-09-12
+    Og følgende dagens dato 12.09.2023
     Og lag personresultater for begrunnelse for behandling 1
     Og lag personresultater for begrunnelse for behandling 2
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -117,8 +117,7 @@ Egenskap: Gyldige begrunnelser for kompetanser
       | 01.04.2023 | 30.06.2023 | UTBETALING         |                                |                                    |                       |
       | 01.07.2023 | 31.08.2023 | UTBETALING         |                                |                                    |                       |
       | 01.09.2023 |            | OPPHØR             | EØS_FORORDNINGEN               | OPPHØR_IKKE_STATSBORGER_I_EØS_LAND |                       |
-
-  @Disabled
+    
   Scenario: Skal begrunne endring i kompetanse når det ikke er noen endringer i resten av behandlingen
     Gitt følgende fagsaker for begrunnelse
       | FagsakId | Fagsaktype |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/selvstendig_rett.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/selvstendig_rett.feature
@@ -18,7 +18,6 @@ Egenskap: Brevperioder: Selvstendig rett
       | 1            | 2       | BARN       | 26.01.2010  |
       | 1            | 3       | BARN       | 21.04.2023  |
 
-  @Disabled
   Scenario: Skal få brevperiode og brevbegrunnelse med eldste barn flettet inn og korrekt kompetansedata
     Og følgende dagens dato 19.10.2023
     Og lag personresultater for begrunnelse for behandling 1


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16908)

Vi har hatt feil som kun dukker opp i når testene kjøres i github actions. Grunnen til dette er todelt.
### Feil 1:
`YearMonth.now()` gir annet svar i GA.  I localhost får vi nov 2023, mens i github actions gir det nov 2022. Hvorfor dette skjer vet jeg ikke, men det burde egentlig ikke ha noe å si for testene. De burde fungere uavhengig av dagens dato, men på grunn av den andre feilen beskrevet under gjorde de ikke de. 

### Feil 2: 
`Tidslinje.tidsrom()` ga feil ved uendelige datoer. Når vi har en periode med uendelig fom- eller tomdato setter vi likevel en skjult dato som ikke brude brukes som selve datoen til tidspunktet. Vanligvis settes dette bare til dagens dato/måned. 
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/66852461-0d4a-42ff-9d91-8be76a73577a)
Når vi skulle finne tidsrommet som gjalt for en tidslinje brukte vi selve datoen, selv tidspunktet var uendelig. 

Eksempel: 
Ta tidslinjen som Har verdien `A` fra februar 2022 til april 2023 og verdien `B` fra mai 2023 og ut i uendeligheten
```2022.02 - 2023.04: A | 2023.05 - 2022.11->: B```
Når vi hentet månedene denne tidslinjen gjalt for fikk vi bare 2022.02 - 2022.11 siden vi brukte tidspunktet til den uendelige datoen når vi prøvde å finne til-og-med-datoen til siste periode. 

Endrer så vi ser på fom-datoen dersom tom-datoen er uendelig når vi prøver å finne tom-dato for en periode. 
Altså dersom vi prøver å finne tom-datoen for perioden `2023.05 - 2022.11->: B` så blir tom=`2023.05->`, april 2023 med uendelighet framover.