### PR TITLE
Reduser feillogging til sentry

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
@@ -27,6 +27,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import java.io.PrintWriter
 import java.io.StringWriter
 
@@ -55,6 +56,16 @@ class ApiExceptionHandler {
     @ExceptionHandler(RessursException::class)
     fun handleRessursException(ressursException: RessursException): ResponseEntity<Ressurs<Any>> {
         return ResponseEntity.status(ressursException.httpStatus).body(ressursException.ressurs)
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<Ressurs<Nothing>> {
+        logger.info("Ikke forventet verdi på property= ${e.propertyName} med verdi=${e.value} for metode=${e.parameter}")
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            Ressurs.failure(
+                frontendFeilmelding = "Klarer ikke å tyde verdi på ${e.propertyName}. Sjekk at url er riktig",
+            ),
+        )
     }
 
     @ExceptionHandler(HttpClientErrorException.Forbidden::class)

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.core.NestedExceptionUtils
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -30,6 +31,7 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.time.format.DateTimeParseException
 
 @ControllerAdvice
 class ApiExceptionHandler {
@@ -61,11 +63,27 @@ class ApiExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
     fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<Ressurs<Nothing>> {
         logger.info("Ikke forventet verdi på property= ${e.propertyName} med verdi=${e.value} for metode=${e.parameter}")
+
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
             Ressurs.failure(
                 frontendFeilmelding = "Klarer ikke å tyde verdi på ${e.propertyName}. Sjekk at url er riktig",
             ),
         )
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<Ressurs<Nothing>> {
+        val mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(e)
+
+        return if (mostSpecificCause is DateTimeParseException) {
+            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                Ressurs.failure(
+                    frontendFeilmelding = "Ugyldig datoformat ${mostSpecificCause.parsedString}",
+                ),
+            )
+        } else {
+            illegalState(mostSpecificCause.message.toString(), mostSpecificCause)
+        }
     }
 
     @ExceptionHandler(HttpClientErrorException.Forbidden::class)

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
@@ -44,7 +44,6 @@ class TestVerktøyController(
     private val opprettTaskService: OpprettTaskService,
     private val taskService: TaskService,
     private val startSatsendring: StartSatsendring,
-    private val testVerktøyService: TestVerktøyService,
     private val behandlingRepository: BehandlingRepository,
 ) {
 
@@ -140,9 +139,13 @@ class TestVerktøyController(
         } else {
             error("Klarer ikke å utlede miljø for redirect til fagsak")
         }
-        val behandling = behandlingRepository.finnBehandling(behandlingId)
-        return ResponseEntity.status(302)
-            .location(URI.create("$hostname/fagsak/${behandling.fagsak.id}/$behandlingId/")).build()
+        val behandling = behandlingRepository.finnBehandlingNullable(behandlingId)
+        return if (behandling == null) {
+            ResponseEntity.status(200).body("Fant ikke behandling med id $behandlingId")
+        } else {
+            ResponseEntity.status(302)
+                .location(URI.create("$hostname/fagsak/${behandling.fagsak.id}/$behandlingId/")).build()
+        }
     }
 
     companion object {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- Exceptionhåndtering for NumberFormatException. Som skjer ofte når noen vil til fagsak/1000151/saksoversikt men skriver fagsak/1000151saksoversikt
![Screenshot 2023-11-03 at 12 56 13](https://github.com/navikt/familie-ba-sak/assets/1121978/5c5eab98-b102-4fed-97ec-19da8f5097be)

- Ikke logge feil ved redirect av behandling når behandling ikke finnes
- Bedre feilmelding til frontend for datetimeparse exception
![Screenshot 2023-11-03 at 14 13 16](https://github.com/navikt/familie-ba-sak/assets/1121978/b0684dea-bb25-4bea-b1b9-019816df26c9)

