### PR TITLE
Send med riktige barn når det er flere kompetanser som gjelder for en begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -374,7 +374,7 @@ fun hentEØSBrevBegrunnelseTekster(
         """
 
     Så forvent følgende brevbegrunnelser for behandling $behandlingId i periode ${vedtaksperiode.fom?.tilddMMyyyy() ?: "-"} til ${vedtaksperiode.tom?.tilddMMyyyy() ?: "-"}
-        | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet | """ +
+        | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland | """ +
             vedtaksperiode.eøsBegrunnelser.map { it.begrunnelse }.joinToString("") {
                 """
         | $it | EØS | | | | | | | | |"""

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
@@ -69,19 +69,26 @@ fun EØSStandardbegrunnelse.lagBrevBegrunnelse(
             ),
         )
     } else {
-        kompetanser.map { kompetanse ->
-            EØSBegrunnelseDataMedKompetanse(
-                vedtakBegrunnelseType = this.vedtakBegrunnelseType,
-                apiNavn = sanityBegrunnelse.apiNavn,
-                annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
-                annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland?.tilLandNavn(landkoder)?.navn,
-                barnetsBostedsland = kompetanse.barnetsBostedsland.tilLandNavn(landkoder).navn,
-                barnasFodselsdatoer = Utils.slåSammen(barnIBegrunnelse.map { it.fødselsdato.tilKortString() }),
-                antallBarn = barnIBegrunnelse.size,
-                maalform = grunnlag.behandlingsGrunnlagForVedtaksperioder.persongrunnlag.søker.målform.tilSanityFormat(),
-                sokersAktivitet = kompetanse.søkersAktivitet,
-                sokersAktivitetsland = kompetanse.søkersAktivitetsland.tilLandNavn(landkoder).navn,
-            )
+        kompetanser.mapNotNull { kompetanse ->
+            val barnIBegrunnelseOgIKompetanse =
+                kompetanse.barnAktører.mapNotNull { barnAktør -> personerGjeldeneForBegrunnelse.find { it.aktør == barnAktør } }
+
+            if (barnIBegrunnelseOgIKompetanse.isNotEmpty()) {
+                EØSBegrunnelseDataMedKompetanse(
+                    vedtakBegrunnelseType = vedtakBegrunnelseType,
+                    apiNavn = sanityBegrunnelse.apiNavn,
+                    annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
+                    annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland?.tilLandNavn(landkoder)?.navn,
+                    barnetsBostedsland = kompetanse.barnetsBostedsland.tilLandNavn(landkoder).navn,
+                    barnasFodselsdatoer = Utils.slåSammen(barnIBegrunnelseOgIKompetanse.map { it.fødselsdato.tilKortString() }),
+                    antallBarn = barnIBegrunnelseOgIKompetanse.size,
+                    maalform = grunnlag.behandlingsGrunnlagForVedtaksperioder.persongrunnlag.søker.målform.tilSanityFormat(),
+                    sokersAktivitet = kompetanse.søkersAktivitet,
+                    sokersAktivitetsland = kompetanse.søkersAktivitetsland.tilLandNavn(landkoder).navn,
+                )
+            } else {
+                null
+            }
         }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.cucumber.domeneparser.norskDatoFormatter
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseEnum
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseInt
-import no.nav.familie.ba.sak.cucumber.domeneparser.parseString
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriBoolean
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriEnum
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriInt
@@ -114,10 +113,10 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
         rad,
     ).sanityApiNavn
 
-    val barnasFodselsdatoer = parseString(
+    val barnasFodselsdatoer = parseValgfriString(
         BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BARNAS_FØDSELSDATOER,
         rad,
-    )
+    ) ?: ""
 
     val antallBarn = parseInt(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_BARN, rad)
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/begrunnelsetekster/kompetanser.feature
@@ -76,7 +76,7 @@ Egenskap: Gyldige begrunnelser for kompetanser
     Når vedtaksperiodene genereres for behandling 1
 
     Så forvent at følgende begrunnelser er gyldige
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser | Regelverk Ugyldige begrunnelser | Ugyldige begrunnelser         |
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser | Regelverk Ugyldige begrunnelser | Ugyldige begrunnelser          |
       | 01.10.2023 | 30.09.2035 | UTBETALING         |                                | REDUKSJON_UNDER_6_ÅR | EØS_FORORDNINGEN                | REDUKSJON_IKKE_ANSVAR_FOR_BARN |
 
   Scenario: Skal gi riktig begrunnelse ved opphør av EØS-sak
@@ -117,7 +117,7 @@ Egenskap: Gyldige begrunnelser for kompetanser
       | 01.04.2023 | 30.06.2023 | UTBETALING         |                                |                                    |                       |
       | 01.07.2023 | 31.08.2023 | UTBETALING         |                                |                                    |                       |
       | 01.09.2023 |            | OPPHØR             | EØS_FORORDNINGEN               | OPPHØR_IKKE_STATSBORGER_I_EØS_LAND |                       |
-    
+
   Scenario: Skal begrunne endring i kompetanse når det ikke er noen endringer i resten av behandlingen
     Gitt følgende fagsaker for begrunnelse
       | FagsakId | Fagsaktype |
@@ -289,4 +289,84 @@ Egenskap: Gyldige begrunnelser for kompetanser
       | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                    | Ugyldige begrunnelser |
       | 01.05.2023 | 30.06.2023 | UTBETALING         |                                | REDUKSJON_UNDER_6_ÅR                    |                       |
       | 01.05.2023 | 30.06.2023 | UTBETALING         | EØS_FORORDNINGEN               | REDUKSJON_TILLEGGSTEKST_VALUTAJUSTERING |                       |
+
+  Scenario: Skal dele opp begrunnelse etter antall kompetanser og skal kun dra med riktige barn per kompetanse
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | SATSENDRING      | Ja                        | EØS                 |
+      | 2            | 1        | 1                   | ENDRET_UTBETALING   | NYE_OPPLYSNINGER | Nei                       | EØS                 |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 17.12.1976  |
+      | 1            | 2       | BARN       | 10.08.2009  |
+      | 1            | 3       | BARN       | 07.05.2014  |
+      | 2            | 1       | SØKER      | 17.12.1976  |
+      | 2            | 2       | BARN       | 10.08.2009  |
+      | 2            | 3       | BARN       | 07.05.2014  |
+
+    Og følgende dagens dato 07.11.2023
+    Og lag personresultater for begrunnelse for behandling 1
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | LOVLIG_OPPHOLD   |                              | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 15.12.2021 | 15.03.2022 | OPPFYLT  | Nei                  |                      |
+
+      | 2       | UNDER_18_ÅR      |                              | 10.08.2009 | 09.08.2027 | OPPFYLT  | Nei                  |                      |
+      | 2       | GIFT_PARTNERSKAP |                              | 10.08.2009 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | LOVLIG_OPPHOLD   |                              | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_NORGE             | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_NORGE_MED_SØKER   | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | UNDER_18_ÅR      |                              | 07.05.2014 | 06.05.2032 | OPPFYLT  | Nei                  |                      |
+      | 3       | GIFT_PARTNERSKAP |                              | 07.05.2014 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOSATT_I_RIKET   | BARN_BOR_I_NORGE             | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER    | BARN_BOR_I_NORGE_MED_SØKER   | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | LOVLIG_OPPHOLD   |                              | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | LOVLIG_OPPHOLD   |                              | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 15.12.2021 | 15.03.2022 | OPPFYLT  | Nei                  |                      |
+
+      | 2       | UNDER_18_ÅR      |                              | 10.08.2009 | 09.08.2027 | OPPFYLT  | Nei                  |                      |
+      | 2       | GIFT_PARTNERSKAP |                              | 10.08.2009 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_NORGE             | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | LOVLIG_OPPHOLD   |                              | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_NORGE_MED_SØKER   | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | GIFT_PARTNERSKAP |                              | 07.05.2014 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | UNDER_18_ÅR      |                              | 07.05.2014 | 06.05.2032 | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER    | BARN_BOR_I_NORGE_MED_SØKER   | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | LOVLIG_OPPHOLD   |                              | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOSATT_I_RIKET   | BARN_BOR_I_NORGE             | 09.08.2021 |            | OPPFYLT  | Nei                  |                      |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.01.2022 | 31.03.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 3       | 1            | 01.01.2022 | 31.03.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.01.2022 | 31.03.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 3       | 2            | 01.01.2022 | 31.03.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+
+    Og med kompetanser for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Resultat            | BehandlingId | Søkers aktivitet                     | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.01.2022 | 31.03.2022 | NORGE_ER_PRIMÆRLAND | 2            | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | INAKTIV                   | NO                    | PL                             | NO                  |
+      | 3       | 01.01.2022 | 31.03.2022 | NORGE_ER_PRIMÆRLAND | 2            | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | I_ARBEID                  | NO                    | PL                             | NO                  |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser | Eøsbegrunnelser               | Fritekster |
+      | 01.01.2022 | 31.03.2022 |                      | INNVILGET_PRIMÆRLAND_STANDARD |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.01.2022 til 31.03.2022
+      | Begrunnelse                   | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet                     | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | INNVILGET_PRIMÆRLAND_STANDARD | EØS  | 10.08.09             | 1           | NB      | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | INAKTIV                   | Norge                 | Polen                          | Norge               |
+      | INNVILGET_PRIMÆRLAND_STANDARD | EØS  | 07.05.14             | 1           | NB      | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | I_ARBEID                  | Norge                 | Polen                          | Norge               |
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16824)

Når vi har flere kompetanser i samme tidsrom som gjelder for samme begrunnelse skal begrunnelsen deles opp etter kompetansene. Da skal dataene fra de respektive kompetansene komme med i begrunnelsene.

Vi har hatt et problem med at barna fra alle kompetansene kom med i alle begrunnelsene. For eksempel hadde vi et case der en begrunnelse som ble dekket av to kompetanser med ett barn hver ble begrunnelsen delt i to, men begge barna kom med i begge begrunnelsene, selv om bare ett barn skulle med. 

Fikser så kun barna fra den respektive kompetansen kommer med i begrunnelsene

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇