### PR TITLE
Kast feil hvis journalføringsoppgave ikke har en journalpost knyttet til seg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.oppgave
 
 import jakarta.validation.Valid
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.RessursUtils.illegalState
 import no.nav.familie.ba.sak.ekstern.restDomene.RestFerdigstillOppgaveKnyttJournalpost
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestPersonInfo
@@ -14,7 +15,6 @@ import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -98,10 +98,12 @@ class OppgaveController(
     fun hentDataForManuellJournalføring(@PathVariable(name = "oppgaveId") oppgaveId: Long): ResponseEntity<Ressurs<DataForManuellJournalføring>> {
         val oppgave = oppgaveService.hentOppgave(oppgaveId)
         val aktør = oppgave.aktoerId?.let { personidentService.hentAktør(it) }
+        
+        val journalpost = if (oppgave.journalpostId != null) integrasjonClient.hentJournalpost(oppgave.journalpostId!!) else throw Feil("Oppgave har ingen journalpost knyttet til seg")
 
         val dataForManuellJournalføring = DataForManuellJournalføring(
             oppgave = oppgave,
-            journalpost = null,
+            journalpost = journalpost,
             person = aktør?.let {
                 personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(it)
                     .tilRestPersonInfo(it.aktivFødselsnummer())
@@ -109,22 +111,11 @@ class OppgaveController(
             minimalFagsak = if (aktør != null) fagsakService.hentMinimalFagsakForPerson(aktør).data else null,
         )
 
-        val journalpost: Journalpost? =
-            if (oppgave.journalpostId == null) null else integrasjonClient.hentJournalpost(oppgave.journalpostId!!)
-
-        return when (journalpost) {
-            null -> {
-                ResponseEntity.ok(Ressurs.success(dataForManuellJournalføring))
-            }
-
-            else -> ResponseEntity.ok(
-                Ressurs.success(
-                    dataForManuellJournalføring.copy(
-                        journalpost = journalpost,
-                    ),
-                ),
-            )
-        }
+        return ResponseEntity.ok(
+            Ressurs.success(
+                dataForManuellJournalføring
+            ),
+        )
     }
 
     @GetMapping("/{oppgaveId}/ferdigstill")

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
@@ -98,7 +98,7 @@ class OppgaveController(
     fun hentDataForManuellJournalføring(@PathVariable(name = "oppgaveId") oppgaveId: Long): ResponseEntity<Ressurs<DataForManuellJournalføring>> {
         val oppgave = oppgaveService.hentOppgave(oppgaveId)
         val aktør = oppgave.aktoerId?.let { personidentService.hentAktør(it) }
-        
+
         val journalpost = if (oppgave.journalpostId != null) integrasjonClient.hentJournalpost(oppgave.journalpostId!!) else throw Feil("Oppgave har ingen journalpost knyttet til seg")
 
         val dataForManuellJournalføring = DataForManuellJournalføring(
@@ -113,7 +113,7 @@ class OppgaveController(
 
         return ResponseEntity.ok(
             Ressurs.success(
-                dataForManuellJournalføring
+                dataForManuellJournalføring,
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/domene/DataForManuellJournalføring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/domene/DataForManuellJournalføring.kt
@@ -8,6 +8,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 data class DataForManuellJournalføring(
     val oppgave: Oppgave,
     val person: RestPersonInfo?,
-    val journalpost: Journalpost?,
+    val journalpost: Journalpost,
     val minimalFagsak: RestMinimalFagsak?,
 )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16037

Det skal ikke være mulig at en journalføringsoppgave ikke har en journalpost knyttet til seg. I dag er det en mismatch fordi frontend forventer at journalpost alltid eksisterer på journalføringsoppgave, men backend håndterer at den er null. Sørger derfor for at det blir kastet en feil backend hvis det ikke er knyttet en journalpost til oppgaven.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tenker det gir lite verdi her

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
