### PR TITLE
Ta høyde for nye andeler når vi skal finne tom-dato for vedtaksperiode ved omregning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -457,8 +457,10 @@ fun lagPeriodeForOmregningsbehandling(
     andelTilkjentYtelser: List<AndelTilkjentYtelse>,
     nåDato: LocalDate,
 ): List<VedtaksperiodeMedBegrunnelser> {
-    val nesteEndringITilkjentYtelse = andelTilkjentYtelser.tilTidslinjerPerAktørOgType().values
-        .kombiner { it.toList() }.perioder()
+    val andelerTidslinje: Tidslinje<List<AndelForVedtaksperiode>, Måned> =
+        andelTilkjentYtelser.tilTidslinjerPerAktørOgType().values.kombiner { it.toList() }
+
+    val nesteEndringITilkjentYtelse = andelerTidslinje.perioder()
         .singleOrNull { it.periodeInneholder(nåDato) }
         ?.tilOgMed?.tilYearMonth()?.sisteDagIInneværendeMåned()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
@@ -22,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilDagEllerFørsteDagIPerioden
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilLocalDateEllerNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.ZipPadding
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
@@ -455,9 +457,10 @@ fun lagPeriodeForOmregningsbehandling(
     andelTilkjentYtelseer: List<AndelTilkjentYtelse>,
     nåDato: LocalDate,
 ): List<VedtaksperiodeMedBegrunnelser> {
-    val nesteEndringITilkjentYtelse = andelTilkjentYtelseer
-        .filter { it.periodeInneholder(nåDato) }
-        .minByOrNull { it.stønadTom }?.stønadTom?.sisteDagIInneværendeMåned()
+    val nesteEndringITilkjentYtelse = andelTilkjentYtelseer.tilTidslinjerPerAktørOgType().values
+        .kombiner { it.toList() }.perioder()
+        .singleOrNull { it.periodeInneholder(nåDato) }
+        ?.tilOgMed?.tilYearMonth()?.sisteDagIInneværendeMåned()
 
     return listOf(
         VedtaksperiodeMedBegrunnelser(
@@ -470,6 +473,6 @@ fun lagPeriodeForOmregningsbehandling(
     )
 }
 
-private fun AndelTilkjentYtelse.periodeInneholder(
+private fun <T> Periode<T, Måned>.periodeInneholder(
     nåDato: LocalDate,
-) = stønadFom <= nåDato.toYearMonth() && stønadTom >= nåDato.toYearMonth()
+) = this.fraOgMed.tilYearMonth() <= nåDato.toYearMonth() && this.tilOgMed.tilYearMonth() >= nåDato.toYearMonth()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -48,7 +48,7 @@ fun genererVedtaksperioder(
         return lagPeriodeForOmregningsbehandling(
             vedtak = vedtak,
             nåDato = nåDato,
-            andelTilkjentYtelseer = grunnlagForVedtakPerioder.andelerTilkjentYtelse,
+            andelTilkjentYtelser = grunnlagForVedtakPerioder.andelerTilkjentYtelse,
         )
     }
 
@@ -454,10 +454,10 @@ fun lagFortsattInnvilgetPeriode(
 
 fun lagPeriodeForOmregningsbehandling(
     vedtak: Vedtak,
-    andelTilkjentYtelseer: List<AndelTilkjentYtelse>,
+    andelTilkjentYtelser: List<AndelTilkjentYtelse>,
     nåDato: LocalDate,
 ): List<VedtaksperiodeMedBegrunnelser> {
-    val nesteEndringITilkjentYtelse = andelTilkjentYtelseer.tilTidslinjerPerAktørOgType().values
+    val nesteEndringITilkjentYtelse = andelTilkjentYtelser.tilTidslinjerPerAktørOgType().values
         .kombiner { it.toList() }.perioder()
         .singleOrNull { it.periodeInneholder(nåDato) }
         ?.tilOgMed?.tilYearMonth()?.sisteDagIInneværendeMåned()

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/automatisk_behandling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/automatisk_behandling.feature
@@ -1,0 +1,83 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Vedtaksperioder ved automatisk behandling
+
+  Bakgrunn:
+
+  Scenario: Skal splitte vedtaksperiode på opphold i småbarnstillegg
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende vedtak
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | SMÅBARNSTILLEGG  |
+      | 2            | 1        | 1                   | FORTSATT_INNVILGET  | OMREGNING_6ÅR    |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 30.09.1995  |
+      | 1            | 2       | BARN       | 30.11.2017  |
+      | 1            | 3       | BARN       | 12.10.2021  |
+      | 2            | 1       | SØKER      | 30.09.1995  |
+      | 2            | 2       | BARN       | 30.11.2017  |
+      | 2            | 3       | BARN       | 12.10.2021  |
+
+    Og følgende dagens dato 08.11.2023
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 15.09.2023 | 15.02.2024 | OPPFYLT  | Nei                  |                      |
+      | 1       | UTVIDET_BARNETRYGD            |                             | 17.11.2022 |            | OPPFYLT  | Nei                  |                      |
+
+      | 2       | GIFT_PARTNERSKAP              |                             | 30.11.2017 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | UNDER_18_ÅR                   |                             | 30.11.2017 | 29.11.2035 | OPPFYLT  | Nei                  |                      |
+      | 2       | LOVLIG_OPPHOLD,BOSATT_I_RIKET |                             | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER                 |                             | 01.04.2022 | 16.11.2022 | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER                 | DELT_BOSTED_SKAL_IKKE_DELES | 17.11.2022 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | GIFT_PARTNERSKAP              |                             | 12.10.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | UNDER_18_ÅR                   |                             | 12.10.2021 | 11.10.2039 | OPPFYLT  | Nei                  |                      |
+      | 3       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER                 |                             | 01.04.2022 | 16.11.2022 | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER                 | DELT_BOSTED_SKAL_IKKE_DELES | 17.11.2022 |            | OPPFYLT  | Nei                  |                      |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 15.09.2023 | 15.02.2024 | OPPFYLT  | Nei                  |                      |
+      | 1       | UTVIDET_BARNETRYGD            |                             | 17.11.2022 |            | OPPFYLT  | Nei                  |                      |
+
+      | 2       | GIFT_PARTNERSKAP              |                             | 30.11.2017 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | UNDER_18_ÅR                   |                             | 30.11.2017 | 29.11.2035 | OPPFYLT  | Nei                  |                      |
+      | 2       | LOVLIG_OPPHOLD,BOSATT_I_RIKET |                             | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER                 |                             | 01.04.2022 | 16.11.2022 | OPPFYLT  | Nei                  |                      |
+      | 2       | BOR_MED_SØKER                 | DELT_BOSTED_SKAL_IKKE_DELES | 17.11.2022 |            | OPPFYLT  | Nei                  |                      |
+
+      | 3       | GIFT_PARTNERSKAP              |                             | 12.10.2021 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | UNDER_18_ÅR                   |                             | 12.10.2021 | 11.10.2039 | OPPFYLT  | Nei                  |                      |
+      | 3       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER                 |                             | 01.04.2022 | 16.11.2022 | OPPFYLT  | Nei                  |                      |
+      | 3       | BOR_MED_SØKER                 | DELT_BOSTED_SKAL_IKKE_DELES | 17.11.2022 |            | OPPFYLT  | Nei                  |                      |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.10.2023 | 31.10.2023 | 696   | SMÅBARNSTILLEGG    | 100     | 696  |
+      | 1       | 1            | 01.12.2023 | 28.02.2024 | 696   | SMÅBARNSTILLEGG    | 100     | 696  |
+      | 2       | 1            | 01.10.2023 | 31.10.2023 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.11.2023 | 28.02.2024 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 3       | 1            | 01.10.2023 | 28.02.2024 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+
+      | 1       | 2            | 01.10.2023 | 31.10.2023 | 696   | SMÅBARNSTILLEGG    | 100     | 696  |
+      | 1       | 2            | 01.12.2023 | 28.02.2024 | 696   | SMÅBARNSTILLEGG    | 100     | 696  |
+      | 2       | 2            | 01.10.2023 | 31.10.2023 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.11.2023 | 28.02.2024 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 3       | 2            | 01.10.2023 | 28.02.2024 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 2
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.11.2023 | 30.11.2023 | UTBETALING         |           |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/automatisk_behandling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/automatisk_behandling.feature
@@ -5,7 +5,7 @@ Egenskap: Vedtaksperioder ved automatisk behandling
 
   Bakgrunn:
 
-  Scenario: Skal splitte vedtaksperiode på opphold i småbarnstillegg
+  Scenario: Skal splitte vedtaksperiode på oppstart av ny andel ved omregningsoppgave
     Gitt følgende fagsaker
       | FagsakId | Fagsaktype |
       | 1        | NORMAL     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16984)

Når vi skal finne stopptidspunktet for vedtakseperioden til omregning  6- og 18år-behandlinger ser vi bruker vi neste endring i tilkjent ytelse. 

Vi har en bug der vi ikke tar høyde for nye andeler som starter, bare andeler som slutter. 

Endrer så vi også tar høyde for andelene som starter

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

