### PR TITLE
bumpet token-validation-spring-versjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <cucumber.version>7.14.0</cucumber.version>
         <mockk.version>1.13.5</mockk.version>
         <wiremock.version>3.3.1</wiremock.version>
-        <token-validation-spring.version>3.1.7</token-validation-spring.version>
+        <token-validation-spring.version>3.1.8</token-validation-spring.version>
         <nav-foedselsnummer.version>1.0-SNAPSHOT.6</nav-foedselsnummer.version>
         <springdoc.version>2.2.0</springdoc.version>
         <sentry.version>6.33.1</sentry.version>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dependabot greier ikke å oppdatere versjonen for denne ene pakken så oppdaterer den manuelt. 
