### PR TITLE
rename SanityEØSBegrunnelse.kt -> RestSanityEØSBegrunnelse.kt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityKlient.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ba.sak.common.kallEksternTjeneste
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.RestSanityEØSBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.eøs.RestSanityEØSBegrunnelse
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.retry.annotation.Backoff

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevPeriodeService.kt
@@ -155,35 +155,35 @@ class BrevPeriodeService(
                 uregistrerteBarn = minimerteUregistrerteBarn,
                 brevMålform = personopplysningGrunnlag.søker.målform,
                 erFørsteVedtaksperiodePåFagsak =
-                    erFørsteVedtaksperiodePåFagsak(
-                        andelerTilkjentYtelse = andelerTilkjentYtelse,
-                        periodeFom = utvidetVedtaksperiodeMedBegrunnelse.fom,
-                    ),
+                erFørsteVedtaksperiodePåFagsak(
+                    andelerTilkjentYtelse = andelerTilkjentYtelse,
+                    periodeFom = utvidetVedtaksperiodeMedBegrunnelse.fom,
+                ),
                 barnMedReduksjonFraForrigeBehandlingIdent =
-                    hentBarnsPersonIdentMedRedusertPeriode(
-                        vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
-                        andelerTilkjentYtelse = andelerTilkjentYtelse,
-                    ),
+                hentBarnsPersonIdentMedRedusertPeriode(
+                    vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+                    andelerTilkjentYtelse = andelerTilkjentYtelse,
+                ),
                 minimerteKompetanserForPeriode =
-                    hentMinimerteKompetanserForPeriode(
-                        kompetanser = kompetanser,
-                        fom = vedtaksperiodeMedBegrunnelser.fom?.toYearMonth(),
-                        tom = vedtaksperiodeMedBegrunnelser.tom?.toYearMonth(),
+                hentMinimerteKompetanserForPeriode(
+                    kompetanser = kompetanser,
+                    fom = vedtaksperiodeMedBegrunnelser.fom?.toYearMonth(),
+                    tom = vedtaksperiodeMedBegrunnelser.tom?.toYearMonth(),
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    landkoderISO2 = landkoderISO2,
+                ),
+                minimerteKompetanserSomStopperRettFørPeriode =
+                hentKompetanserSomStopperRettFørPeriode(
+                    kompetanser = kompetanser,
+                    periodeFom = minimertVedtaksperiode.fom?.toYearMonth(),
+                ).filter {
+                    it.erObligatoriskeFelterSatt()
+                }.map {
+                    it.tilMinimertKompetanse(
                         personopplysningGrunnlag = personopplysningGrunnlag,
                         landkoderISO2 = landkoderISO2,
-                    ),
-                minimerteKompetanserSomStopperRettFørPeriode =
-                    hentKompetanserSomStopperRettFørPeriode(
-                        kompetanser = kompetanser,
-                        periodeFom = minimertVedtaksperiode.fom?.toYearMonth(),
-                    ).filter {
-                        it.erObligatoriskeFelterSatt()
-                    }.map {
-                        it.tilMinimertKompetanse(
-                            personopplysningGrunnlag = personopplysningGrunnlag,
-                            landkoderISO2 = landkoderISO2,
-                        )
-                    },
+                    )
+                },
                 dødeBarnForrigePeriode = dødeBarnForrigePeriode,
             )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -104,8 +104,8 @@ fun hentHjemmeltekst(
     val ordinæreHjemler =
         hentOrdinæreHjemler(
             hjemler =
-                (sanityStandardbegrunnelser.flatMap { it.hjemler } + sanityEøsBegrunnelser.flatMap { it.hjemler })
-                    .toMutableSet(),
+            (sanityStandardbegrunnelser.flatMap { it.hjemler } + sanityEøsBegrunnelser.flatMap { it.hjemler })
+                .toMutableSet(),
             opplysningspliktHjemlerSkalMedIBrev = opplysningspliktHjemlerSkalMedIBrev,
             finnesVedtaksperiodeMedFritekst = minimerteVedtaksperioder.flatMap { it.fritekster }.isNotEmpty(),
         )
@@ -115,12 +115,12 @@ fun hentHjemmeltekst(
     val alleHjemlerForBegrunnelser =
         hentAlleTyperHjemler(
             hjemlerSeparasjonsavtaleStorbritannia =
-                sanityEøsBegrunnelser.flatMap { it.hjemlerSeperasjonsavtalenStorbritannina }
-                    .distinct(),
+            sanityEøsBegrunnelser.flatMap { it.hjemlerSeperasjonsavtalenStorbritannina }
+                .distinct(),
             ordinæreHjemler = ordinæreHjemler.distinct(),
             hjemlerFraFolketrygdloven =
-                (sanityStandardbegrunnelser.flatMap { it.hjemlerFolketrygdloven } + sanityEøsBegrunnelser.flatMap { it.hjemlerFolketrygdloven })
-                    .distinct(),
+            (sanityStandardbegrunnelser.flatMap { it.hjemlerFolketrygdloven } + sanityEøsBegrunnelser.flatMap { it.hjemlerFolketrygdloven })
+                .distinct(),
             hjemlerEØSForordningen883 = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen883 }.distinct(),
             hjemlerEØSForordningen987 = hentHjemlerForEøsForordningen987(sanityEøsBegrunnelser, refusjonEøsHjemmelSkalMedIBrev),
             målform = målform,
@@ -265,7 +265,7 @@ fun hentVirkningstidspunkt(
         .maxOfOrNull { it.periodeFom }
         ?.tilMånedÅr()
         ?: throw Feil("Fant ikke opphørdato ved generering av dødsfallbrev på behandling $behandlingId")
-)
+    )
 
 fun hentForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev: Boolean): List<String> {
     return if (vedtakKorrigertHjemmelSkalMedIBrev) listOf("35") else emptyList()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -135,12 +135,12 @@ private fun Standardbegrunnelse.lagEnkeltBegrunnelse(
             soknadstidspunkt = søknadstidspunktEndretUtbetaling?.tilKortString() ?: "",
             avtaletidspunktDeltBosted = "",
             sokersRettTilUtvidet =
-                hentSøkersRettTilUtvidet(
-                    utvidetUtbetalingsdetaljer =
-                        hentUtvidetAndelerIPeriode(
-                            begrunnelsesGrunnlagPerPerson,
-                        ),
-                ).tilSanityFormat(),
+            hentSøkersRettTilUtvidet(
+                utvidetUtbetalingsdetaljer =
+                hentUtvidetAndelerIPeriode(
+                    begrunnelsesGrunnlagPerPerson,
+                ),
+            ).tilSanityFormat(),
             vedtakBegrunnelseType = this.vedtakBegrunnelseType,
         ),
     )
@@ -203,12 +203,12 @@ private fun Standardbegrunnelse.delOppBegrunnelsenPåAvtaletidspunkt(
             soknadstidspunkt = søknadstidspunkt?.tilKortString() ?: "",
             avtaletidspunktDeltBosted = avtaletidspunktDeltBosted.tilKortString(),
             sokersRettTilUtvidet =
-                hentSøkersRettTilUtvidet(
-                    utvidetUtbetalingsdetaljer =
-                        hentUtvidetAndelerIPeriode(
-                            begrunnelseGrunnlagPerPerson,
-                        ),
-                ).tilSanityFormat(),
+            hentSøkersRettTilUtvidet(
+                utvidetUtbetalingsdetaljer =
+                hentUtvidetAndelerIPeriode(
+                    begrunnelseGrunnlagPerPerson,
+                ),
+            ).tilSanityFormat(),
             vedtakBegrunnelseType = this.vedtakBegrunnelseType,
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.ba.sak.kjerne.brev.domene
 
+import no.nav.familie.ba.sak.kjerne.brev.domene.eøs.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -26,6 +26,7 @@ sealed interface ISanityBegrunnelse {
     val valgbarhet: Valgbarhet?
     val periodeType: BrevPeriodeType?
     val begrunnelseTypeForPerson: VedtakBegrunnelseType? // TODO: Fjern når migrering av ny felter er ferdig
+    val ovrigeTriggere: List<ØvrigTrigger>
 
     val gjelderEtterEndretUtbetaling
         get() =
@@ -58,10 +59,10 @@ data class SanityBegrunnelse(
     override val valgbarhet: Valgbarhet? = null,
     override val periodeType: BrevPeriodeType? = null,
     override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
+    override val ovrigeTriggere: List<ØvrigTrigger> = emptyList(),
     @Deprecated("Bruk vilkår")
     val vilkaar: List<SanityVilkår> = emptyList(),
     val rolle: List<VilkårRolle> = emptyList(),
-    val ovrigeTriggere: List<ØvrigTrigger> = emptyList(),
     val hjemler: List<String> = emptyList(),
     val hjemlerFolketrygdloven: List<String> = emptyList(),
     val endringsaarsaker: List<Årsak> = emptyList(),
@@ -74,6 +75,25 @@ data class SanityBegrunnelse(
         this.endretUtbetalingsperiodeTriggere.contains(EndretUtbetalingsperiodeTrigger.ETTER_ENDRET_UTBETALINGSPERIODE)
 }
 
+enum class ØvrigTrigger {
+    MANGLER_OPPLYSNINGER,
+    SATSENDRING,
+    BARN_MED_6_ÅRS_DAG,
+    ALLTID_AUTOMATISK,
+    ETTER_ENDRET_UTBETALING,
+    ENDRET_UTBETALING,
+    OPPHØR_FRA_FORRIGE_BEHANDLING,
+    REDUKSJON_FRA_FORRIGE_BEHANDLING,
+    BARN_DØD,
+    SKAL_VISES_SELV_OM_IKKE_ENDRING,
+
+    @Deprecated("Skal erstattes med OPPHØR_FRA_FORRIGE_BEHANDLING, må endres i sanity")
+    GJELDER_FØRSTE_PERIODE,
+
+    @Deprecated("Skal erstattes med REDUKSJON_FRA_FORRIGE_BEHANDLING, må endres i sanity")
+    GJELDER_FRA_INNVILGELSESTIDSPUNKT,
+}
+
 data class SanityEØSBegrunnelse(
     override val apiNavn: String,
     override val navnISystem: String,
@@ -84,6 +104,7 @@ data class SanityEØSBegrunnelse(
     override val periodeType: BrevPeriodeType?,
     override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
     override val valgbarhet: Valgbarhet?,
+    override val ovrigeTriggere: List<ØvrigTrigger>,
     val annenForeldersAktivitet: List<KompetanseAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,
     val kompetanseResultat: List<KompetanseResultat>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
@@ -175,25 +175,6 @@ enum class SanityPeriodeResultat {
     REDUKSJON,
 }
 
-enum class ØvrigTrigger {
-    MANGLER_OPPLYSNINGER,
-    SATSENDRING,
-    BARN_MED_6_ÅRS_DAG,
-    ALLTID_AUTOMATISK,
-    ETTER_ENDRET_UTBETALING,
-    ENDRET_UTBETALING,
-    OPPHØR_FRA_FORRIGE_BEHANDLING,
-    REDUKSJON_FRA_FORRIGE_BEHANDLING,
-    BARN_DØD,
-    SKAL_VISES_SELV_OM_IKKE_ENDRING,
-
-    @Deprecated("Skal erstattes med OPPHØR_FRA_FORRIGE_BEHANDLING, må endres i sanity")
-    GJELDER_FØRSTE_PERIODE,
-
-    @Deprecated("Skal erstattes med REDUKSJON_FRA_FORRIGE_BEHANDLING, må endres i sanity")
-    GJELDER_FRA_INNVILGELSESTIDSPUNKT,
-}
-
 enum class EndretUtbetalingsperiodeTrigger {
     ETTER_ENDRET_UTBETALINGSPERIODE,
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/EØSBegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/EØSBegrunnelseUtil.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.brev.domene.eøs
 import no.nav.familie.ba.sak.kjerne.brev.domene.MinimertKompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
 
 fun hentKompetanserForEØSBegrunnelse(
     eøsBegrunnelseMedTriggere: EØSBegrunnelseMedTriggere,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/RestSanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/RestSanityEØSBegrunnelse.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser
+package no.nav.familie.ba.sak.kjerne.brev.domene.eøs
 
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
@@ -7,21 +7,11 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.brev.domene.finnEnumverdi
 import no.nav.familie.ba.sak.kjerne.brev.domene.finnEnumverdiNullable
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
+import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
-
-enum class BarnetsBostedsland {
-    NORGE,
-    IKKE_NORGE,
-}
-
-fun landkodeTilBarnetsBostedsland(landkode: String): BarnetsBostedsland =
-    when (landkode) {
-        "NO" -> BarnetsBostedsland.NORGE
-        else -> BarnetsBostedsland.IKKE_NORGE
-    }
 
 data class RestSanityEØSBegrunnelse(
     val apiNavn: String?,
@@ -35,6 +25,7 @@ data class RestSanityEØSBegrunnelse(
     val hjemlerEOSForordningen987: List<String>?,
     val hjemlerSeperasjonsavtalenStorbritannina: List<String>?,
     val eosVilkaar: List<String>? = null,
+    val ovrigeTriggere: List<String>? = emptyList(),
     @Deprecated("Skal bruke periodeResultatForPerson i stedet")
     val vedtakResultat: String?,
     val periodeResultatForPerson: String?,
@@ -80,9 +71,24 @@ data class RestSanityEØSBegrunnelse(
             tema = (regelverk ?: tema).finnEnumverdi<Tema>(apiNavn),
             periodeType = (brevPeriodeType ?: periodeType).finnEnumverdi<BrevPeriodeType>(apiNavn),
             valgbarhet = valgbarhet?.finnEnumverdi<Valgbarhet>(apiNavn),
+            ovrigeTriggere =
+                ovrigeTriggere?.mapNotNull {
+                    it.finnEnumverdi<ØvrigTrigger>(apiNavn)
+                } ?: emptyList(),
         )
     }
 
     private inline fun <reified T> konverterTilEnumverdi(it: String): T? where T : Enum<T> =
         enumValues<T>().find { enum -> enum.name == it }
 }
+
+enum class BarnetsBostedsland {
+    NORGE,
+    IKKE_NORGE,
+}
+
+fun landkodeTilBarnetsBostedsland(landkode: String): BarnetsBostedsland =
+    when (landkode) {
+        "NO" -> BarnetsBostedsland.NORGE
+        else -> BarnetsBostedsland.IKKE_NORGE
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseUtils.kt
@@ -57,10 +57,10 @@ fun Standardbegrunnelse.triggesForPeriode(
         hentPersonerForAlleUtgjørendeVilkår(
             minimertePersonResultater = minimertePersonResultater,
             vedtaksperiode =
-                Periode(
-                    fom = minimertVedtaksperiode.fom ?: TIDENES_MORGEN,
-                    tom = minimertVedtaksperiode.tom ?: TIDENES_ENDE,
-                ),
+            Periode(
+                fom = minimertVedtaksperiode.fom ?: TIDENES_MORGEN,
+                tom = minimertVedtaksperiode.tom ?: TIDENES_ENDE,
+            ),
             oppdatertBegrunnelseType = this.vedtakBegrunnelseType,
             aktuellePersonerForVedtaksperiode = aktuellePersoner.map { it.tilMinimertRestPerson() },
             triggesAv = triggesAv,
@@ -146,8 +146,8 @@ private fun erEndretTriggerErOppfylt(
         triggesAv.erTriggereOppfyltForEndretUtbetaling(
             minimertEndretAndel = minimertEndretAndel,
             minimerteUtbetalingsperiodeDetaljer =
-                minimertVedtaksperiode
-                    .utbetalingsperioder.map { it.tilMinimertUtbetalingsperiodeDetalj() },
+            minimertVedtaksperiode
+                .utbetalingsperioder.map { it.tilMinimertUtbetalingsperiodeDetalj() },
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
 import no.nav.familie.ba.sak.kjerne.brev.domene.Tema
 import no.nav.familie.ba.sak.kjerne.brev.domene.UtvidetBarnetrygdTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.Valgbarhet
+import no.nav.familie.ba.sak.kjerne.brev.domene.eøs.landkodeTilBarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilPersonType
 import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
@@ -36,7 +37,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.landkodeTilBarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.hentBrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
@@ -872,7 +872,7 @@ private fun Tidslinje<BegrunnelseGrunnlagForPersonIPeriode, Måned>.tilForrigeOg
         listOf(
             månedPeriodeAv(YearMonth.now(), YearMonth.now(), null),
         ) + grunnlagPerioderSplittetPåVedtaksperiode
-    ).zipWithNext { forrige, denne ->
+        ).zipWithNext { forrige, denne ->
         periodeAv(denne.fraOgMed, denne.tilOgMed, ForrigeOgDennePerioden(forrige.innhold, denne.innhold))
     }.tilTidslinje()
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -44,6 +44,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.Tema
 import no.nav.familie.ba.sak.kjerne.brev.domene.Valgbarhet
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårRolle
 import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
+import no.nav.familie.ba.sak.kjerne.brev.domene.eøs.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
@@ -79,7 +80,6 @@ import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.steg.domene.JournalførVedtaksbrevDTO
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.TriggesAv
@@ -500,15 +500,15 @@ fun lagSøknadDTO(
     return SøknadDTO(
         underkategori = underkategori.tilDto(),
         søkerMedOpplysninger =
-            SøkerMedOpplysninger(
-                ident = søkerIdent,
-            ),
+        SøkerMedOpplysninger(
+            ident = søkerIdent,
+        ),
         barnaMedOpplysninger =
-            barnasIdenter.map {
-                BarnMedOpplysninger(
-                    ident = it,
-                )
-            },
+        barnasIdenter.map {
+            BarnMedOpplysninger(
+                ident = it,
+            )
+        },
         endringAvOpplysningerBegrunnelse = "",
     )
 }
@@ -535,11 +535,11 @@ fun lagPersonResultaterForSøkerOgToBarn(
         lagPersonResultat(
             vilkårsvurdering = vilkårsvurdering,
             person =
-                lagPerson(
-                    type = PersonType.BARN,
-                    aktør = barn1Aktør,
-                    fødselsdato = stønadFom,
-                ),
+            lagPerson(
+                type = PersonType.BARN,
+                aktør = barn1Aktør,
+                fødselsdato = stønadFom,
+            ),
             resultat = Resultat.OPPFYLT,
             periodeFom = stønadFom,
             periodeTom = stønadTom,
@@ -595,13 +595,13 @@ fun lagPersonResultat(
                     begrunnelse = "",
                     sistEndretIBehandlingId = vilkårsvurdering.behandling.id,
                     utdypendeVilkårsvurderinger =
-                        listOfNotNull(
-                            when {
-                                erDeltBosted && it == Vilkår.BOR_MED_SØKER -> UtdypendeVilkårsvurdering.DELT_BOSTED
-                                erDeltBostedSkalIkkeDeles && it == Vilkår.BOR_MED_SØKER -> UtdypendeVilkårsvurdering.DELT_BOSTED_SKAL_IKKE_DELES
-                                else -> null
-                            },
-                        ),
+                    listOfNotNull(
+                        when {
+                            erDeltBosted && it == Vilkår.BOR_MED_SØKER -> UtdypendeVilkårsvurdering.DELT_BOSTED
+                            erDeltBostedSkalIkkeDeles && it == Vilkår.BOR_MED_SØKER -> UtdypendeVilkårsvurdering.DELT_BOSTED_SKAL_IKKE_DELES
+                            else -> null
+                        },
+                    ),
                     erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
                 )
             }.toSet(),
@@ -747,15 +747,15 @@ fun kjørStegprosessForFGB(
         stegService.håndterSøknad(
             behandling = behandling,
             restRegistrerSøknad =
-                RestRegistrerSøknad(
-                    søknad =
-                        lagSøknadDTO(
-                            søkerIdent = søkerFnr,
-                            barnasIdenter = barnasIdenter,
-                            underkategori = behandlingUnderkategori,
-                        ),
-                    bekreftEndringerViaFrontend = true,
+            RestRegistrerSøknad(
+                søknad =
+                lagSøknadDTO(
+                    søkerIdent = søkerFnr,
+                    barnasIdenter = barnasIdenter,
+                    underkategori = behandlingUnderkategori,
                 ),
+                bekreftEndringerViaFrontend = true,
+            ),
         )
 
     if (tilSteg == StegType.REGISTRERE_PERSONGRUNNLAG || tilSteg == StegType.REGISTRERE_SØKNAD) {
@@ -822,13 +822,13 @@ fun kjørStegprosessForFGB(
             behandlingEtterIverksetteVedtak,
             StatusFraOppdragMedTask(
                 statusFraOppdragDTO =
-                    StatusFraOppdragDTO(
-                        fagsystem = FAGSYSTEM,
-                        personIdent = søkerFnr,
-                        aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktivFødselsnummer(),
-                        behandlingsId = behandlingEtterIverksetteVedtak.id,
-                        vedtaksId = vedtak.id,
-                    ),
+                StatusFraOppdragDTO(
+                    fagsystem = FAGSYSTEM,
+                    personIdent = søkerFnr,
+                    aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktivFødselsnummer(),
+                    behandlingsId = behandlingEtterIverksetteVedtak.id,
+                    vedtaksId = vedtak.id,
+                ),
                 task = Task(type = StatusFraOppdragTask.TASK_STEP_TYPE, payload = ""),
             ),
         )
@@ -856,9 +856,9 @@ fun kjørStegprosessForFGB(
                 journalpostId = "1234",
                 personEllerInstitusjonIdent = søkerFnr,
                 brevmal =
-                    brevmalService.hentBrevmal(
-                        behandlingEtterJournalførtVedtak,
-                    ),
+                brevmalService.hentBrevmal(
+                    behandlingEtterJournalførtVedtak,
+                ),
                 erManueltSendt = false,
             ),
         )
@@ -957,13 +957,13 @@ fun kjørStegprosessForRevurderingÅrligKontroll(
             behandlingEtterIverksetteVedtak,
             StatusFraOppdragMedTask(
                 statusFraOppdragDTO =
-                    StatusFraOppdragDTO(
-                        fagsystem = FAGSYSTEM,
-                        personIdent = søkerFnr,
-                        aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktørId,
-                        behandlingsId = behandlingEtterIverksetteVedtak.id,
-                        vedtaksId = vedtak.id,
-                    ),
+                StatusFraOppdragDTO(
+                    fagsystem = FAGSYSTEM,
+                    personIdent = søkerFnr,
+                    aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktørId,
+                    behandlingsId = behandlingEtterIverksetteVedtak.id,
+                    vedtaksId = vedtak.id,
+                ),
                 task = Task(type = StatusFraOppdragTask.TASK_STEP_TYPE, payload = ""),
             ),
         )
@@ -1087,9 +1087,9 @@ fun leggTilBegrunnelsePåVedtaksperiodeIBehandling(
     vedtaksperiodeService.oppdaterVedtaksperiodeMedStandardbegrunnelser(
         vedtaksperiodeId = perisisterteVedtaksperioder.first { it.type == Vedtaksperiodetype.UTBETALING }.id,
         standardbegrunnelserFraFrontend =
-            listOf(
-                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
-            ),
+        listOf(
+            Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+        ),
         eøsStandardbegrunnelserFraFrontend = emptyList(),
     )
 }
@@ -1341,6 +1341,7 @@ fun lagSanityEøsBegrunnelse(
     tema: Tema? = null,
     periodeType: BrevPeriodeType? = null,
     valgbarhet: Valgbarhet? = null,
+    ovrigeTriggere: List<ØvrigTrigger>,
 ): SanityEØSBegrunnelse =
     SanityEØSBegrunnelse(
         apiNavn = apiNavn,
@@ -1358,6 +1359,7 @@ fun lagSanityEøsBegrunnelse(
         tema = tema,
         periodeType = periodeType,
         valgbarhet = valgbarhet,
+        ovrigeTriggere = ovrigeTriggere,
     )
 
 fun lagTriggesAv(
@@ -1404,11 +1406,11 @@ fun oppfyltVilkår(
     VilkårRegelverkResultat(
         vilkår = vilkår,
         regelverkResultat =
-            when (regelverk) {
-                Regelverk.NASJONALE_REGLER -> RegelverkResultat.OPPFYLT_NASJONALE_REGLER
-                Regelverk.EØS_FORORDNINGEN -> RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN
-                else -> RegelverkResultat.OPPFYLT_REGELVERK_IKKE_SATT
-            },
+        when (regelverk) {
+            Regelverk.NASJONALE_REGLER -> RegelverkResultat.OPPFYLT_NASJONALE_REGLER
+            Regelverk.EØS_FORORDNINGEN -> RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN
+            else -> RegelverkResultat.OPPFYLT_REGELVERK_IKKE_SATT
+        },
     )
 
 fun ikkeOppfyltVilkår(vilkår: Vilkår) =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/datagenerator/behandling/KjørRevurdering.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/datagenerator/behandling/KjørRevurdering.kt
@@ -167,15 +167,15 @@ private fun håndterSøknadSteg(
 ) = stegService.håndterSøknad(
     behandling = behandling,
     restRegistrerSøknad =
-        RestRegistrerSøknad(
-            søknad =
-                lagSøknadDTO(
-                    søkerIdent = søkerFnr,
-                    barnasIdenter = barnasIdenter,
-                    underkategori = behandlingUnderkategori,
-                ),
-            bekreftEndringerViaFrontend = true,
+    RestRegistrerSøknad(
+        søknad =
+        lagSøknadDTO(
+            søkerIdent = søkerFnr,
+            barnasIdenter = barnasIdenter,
+            underkategori = behandlingUnderkategori,
         ),
+        bekreftEndringerViaFrontend = true,
+    ),
 )
 
 private fun håndterSendtTilBeslutterSteg(
@@ -262,13 +262,13 @@ private fun håndterStatusFraOppdragSteg(
         behandlingEtterIverksetteVedtak,
         StatusFraOppdragMedTask(
             statusFraOppdragDTO =
-                StatusFraOppdragDTO(
-                    fagsystem = FAGSYSTEM,
-                    personIdent = søkerFnr,
-                    aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktørId,
-                    behandlingsId = behandlingEtterIverksetteVedtak.id,
-                    vedtaksId = vedtak!!.id,
-                ),
+            StatusFraOppdragDTO(
+                fagsystem = FAGSYSTEM,
+                personIdent = søkerFnr,
+                aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktørId,
+                behandlingsId = behandlingEtterIverksetteVedtak.id,
+                vedtaksId = vedtak!!.id,
+            ),
             task = Task(type = StatusFraOppdragTask.TASK_STEP_TYPE, payload = ""),
         ),
     )
@@ -405,29 +405,29 @@ fun leggTilAlleGyldigeBegrunnelserPåVedtaksperiodeIBehandling(
                 sanityBegrunnelser = sanityBegrunnelser,
                 minimertePersoner = personopplysningGrunnlag.tilMinimertePersoner(),
                 minimertePersonresultater =
-                    vilkårsvurdering.personResultater
-                        .map { it.tilMinimertPersonResultat() },
+                vilkårsvurdering.personResultater
+                    .map { it.tilMinimertPersonResultat() },
                 aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                 minimerteEndredeUtbetalingAndeler =
-                    endredeUtbetalingAndeler
-                        .map { it.tilMinimertEndretUtbetalingAndel() },
+                endredeUtbetalingAndeler
+                    .map { it.tilMinimertEndretUtbetalingAndel() },
                 erFørsteVedtaksperiodePåFagsak =
-                    erFørsteVedtaksperiodePåFagsak(
-                        andelerTilkjentYtelse,
-                        utvidetVedtaksperiodeMedBegrunnelser.fom,
-                    ),
+                erFørsteVedtaksperiodePåFagsak(
+                    andelerTilkjentYtelse,
+                    utvidetVedtaksperiodeMedBegrunnelser.fom,
+                ),
                 ytelserForSøkerForrigeMåned =
-                    hentYtelserForSøkerForrigeMåned(
-                        andelerTilkjentYtelse,
-                        utvidetVedtaksperiodeMedBegrunnelser,
-                    ),
+                hentYtelserForSøkerForrigeMåned(
+                    andelerTilkjentYtelse,
+                    utvidetVedtaksperiodeMedBegrunnelser,
+                ),
                 ytelserForrigePerioder =
-                    andelerTilkjentYtelse.filter {
-                        ytelseErFraForrigePeriode(
-                            it,
-                            utvidetVedtaksperiodeMedBegrunnelser,
-                        )
-                    },
+                andelerTilkjentYtelse.filter {
+                    ytelseErFraForrigePeriode(
+                        it,
+                        utvidetVedtaksperiodeMedBegrunnelser,
+                    )
+                },
             )
         vedtaksperiodeService.oppdaterVedtaksperiodeMedStandardbegrunnelser(
             vedtaksperiodeId = vedtaksperiode.id,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevperiodeTest.kt
@@ -52,20 +52,20 @@ class BrevperiodeTest {
                         tom = behandlingsresultatPersonTestConfig.tom,
                         type = behandlingsresultatPersonTestConfig.vedtaksperiodetype,
                         begrunnelser =
-                            behandlingsresultatPersonTestConfig
-                                .begrunnelser.map { it.tilBrevBegrunnelseGrunnlag(sanityBegrunnelser) },
+                        behandlingsresultatPersonTestConfig
+                            .begrunnelser.map { it.tilBrevBegrunnelseGrunnlag(sanityBegrunnelser) },
                         fritekster = behandlingsresultatPersonTestConfig.fritekster,
                         minimerteUtbetalingsperiodeDetaljer =
-                            behandlingsresultatPersonTestConfig
-                                .personerPåBehandling
-                                .flatMap { it.tilUtbetalingsperiodeDetaljer() },
+                        behandlingsresultatPersonTestConfig
+                            .personerPåBehandling
+                            .flatMap { it.tilUtbetalingsperiodeDetaljer() },
                         eøsBegrunnelser =
-                            behandlingsresultatPersonTestConfig.eøsBegrunnelser?.map {
-                                EØSBegrunnelseMedTriggere(
-                                    eøsBegrunnelse = it,
-                                    sanityEØSBegrunnelse = sanityEØSBegrunnelser[it]!!,
-                                )
-                            } ?: emptyList(),
+                        behandlingsresultatPersonTestConfig.eøsBegrunnelser?.map {
+                            EØSBegrunnelseMedTriggere(
+                                eøsBegrunnelse = it,
+                                sanityEØSBegrunnelse = sanityEØSBegrunnelser[it]!!,
+                            )
+                        } ?: emptyList(),
                     )
 
                 val restBehandlingsgrunnlagForBrev =
@@ -85,20 +85,20 @@ class BrevperiodeTest {
                             erFørsteVedtaksperiodePåFagsak = behandlingsresultatPersonTestConfig.erFørsteVedtaksperiodePåFagsak,
                             brevMålform = behandlingsresultatPersonTestConfig.brevMålform,
                             barnMedReduksjonFraForrigeBehandlingIdent =
-                                behandlingsresultatPersonTestConfig.hentBarnMedReduksjonFraForrigeBehandling()
-                                    .map { it.personIdent },
+                            behandlingsresultatPersonTestConfig.hentBarnMedReduksjonFraForrigeBehandling()
+                                .map { it.personIdent },
                             minimerteKompetanserForPeriode =
-                                behandlingsresultatPersonTestConfig.kompetanser?.map {
-                                    it.tilMinimertKompetanse(
-                                        behandlingsresultatPersonTestConfig.personerPåBehandling,
-                                    )
-                                } ?: emptyList(),
+                            behandlingsresultatPersonTestConfig.kompetanser?.map {
+                                it.tilMinimertKompetanse(
+                                    behandlingsresultatPersonTestConfig.personerPåBehandling,
+                                )
+                            } ?: emptyList(),
                             minimerteKompetanserSomStopperRettFørPeriode =
-                                behandlingsresultatPersonTestConfig.kompetanserSomStopperRettFørPeriode?.map {
-                                    it.tilMinimertKompetanse(
-                                        behandlingsresultatPersonTestConfig.personerPåBehandling,
-                                    )
-                                } ?: emptyList(),
+                            behandlingsresultatPersonTestConfig.kompetanserSomStopperRettFørPeriode?.map {
+                                it.tilMinimertKompetanse(
+                                    behandlingsresultatPersonTestConfig.personerPåBehandling,
+                                )
+                            } ?: emptyList(),
                             dødeBarnForrigePeriode = emptyList(),
                         ).genererBrevPeriode()
                     } catch (e: Exception) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/StandardbegrunnelseTest.kt
@@ -226,22 +226,22 @@ internal class StandardbegrunnelseTest {
                     minimertePersonResultater = vilkårsvurdering.personResultater.map { it.tilMinimertPersonResultat() },
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     minimertVedtaksperiode =
-                        lagUtvidetVedtaksperiodeMedBegrunnelser(
-                            type = Vedtaksperiodetype.UTBETALING,
-                            fom = LocalDate.of(2021, 10, 1),
-                            tom = LocalDate.of(2021, 10, 31),
-                        ).tilMinimertVedtaksperiode(),
+                    lagUtvidetVedtaksperiodeMedBegrunnelser(
+                        type = Vedtaksperiodetype.UTBETALING,
+                        fom = LocalDate.of(2021, 10, 1),
+                        tom = LocalDate.of(2021, 10, 31),
+                    ).tilMinimertVedtaksperiode(),
                     minimerteEndredeUtbetalingAndeler =
-                        listOf(
-                            lagEndretUtbetalingAndel(
-                                prosent = BigDecimal.ZERO,
-                                behandlingId = behandling.id,
-                                person = barn,
-                                fom = YearMonth.of(2021, 6),
-                                tom = YearMonth.of(2021, 9),
-                                årsak = Årsak.DELT_BOSTED,
-                            ),
-                        ).map { it.tilMinimertEndretUtbetalingAndel() },
+                    listOf(
+                        lagEndretUtbetalingAndel(
+                            prosent = BigDecimal.ZERO,
+                            behandlingId = behandling.id,
+                            person = barn,
+                            fom = YearMonth.of(2021, 6),
+                            tom = YearMonth.of(2021, 9),
+                            årsak = Årsak.DELT_BOSTED,
+                        ),
+                    ).map { it.tilMinimertEndretUtbetalingAndel() },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
                     ytelserForrigePeriode = emptyList(),
@@ -261,22 +261,22 @@ internal class StandardbegrunnelseTest {
                     minimertePersonResultater = vilkårsvurdering.personResultater.map { it.tilMinimertPersonResultat() },
                     aktørIderMedUtbetaling = aktørerMedUtbetaling.map { it.aktørId },
                     minimertVedtaksperiode =
-                        lagUtvidetVedtaksperiodeMedBegrunnelser(
-                            type = Vedtaksperiodetype.UTBETALING,
-                            fom = LocalDate.of(2021, 10, 1),
-                            tom = LocalDate.of(2021, 10, 31),
-                        ).tilMinimertVedtaksperiode(),
+                    lagUtvidetVedtaksperiodeMedBegrunnelser(
+                        type = Vedtaksperiodetype.UTBETALING,
+                        fom = LocalDate.of(2021, 10, 1),
+                        tom = LocalDate.of(2021, 10, 31),
+                    ).tilMinimertVedtaksperiode(),
                     minimerteEndredeUtbetalingAndeler =
-                        listOf(
-                            lagEndretUtbetalingAndel(
-                                prosent = BigDecimal.ZERO,
-                                behandlingId = behandling.id,
-                                person = barn,
-                                fom = YearMonth.of(2021, 10),
-                                tom = YearMonth.of(2021, 10),
-                                årsak = Årsak.DELT_BOSTED,
-                            ),
-                        ).map { it.tilMinimertEndretUtbetalingAndel() },
+                    listOf(
+                        lagEndretUtbetalingAndel(
+                            prosent = BigDecimal.ZERO,
+                            behandlingId = behandling.id,
+                            person = barn,
+                            fom = YearMonth.of(2021, 10),
+                            tom = YearMonth.of(2021, 10),
+                            årsak = Årsak.DELT_BOSTED,
+                        ),
+                    ).map { it.tilMinimertEndretUtbetalingAndel() },
                     erFørsteVedtaksperiodePåFagsak = false,
                     ytelserForSøkerForrigeMåned = emptyList(),
                     ytelserForrigePeriode = emptyList(),
@@ -358,10 +358,10 @@ internal class StandardbegrunnelseTest {
             listOf(
                 lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                     fom =
-                        YearMonth.of(
-                            LocalDate.now().minusMonths(1).year,
-                            LocalDate.now().minusMonths(1).month,
-                        ),
+                    YearMonth.of(
+                        LocalDate.now().minusMonths(1).year,
+                        LocalDate.now().minusMonths(1).month,
+                    ),
                     tom = YearMonth.of(LocalDate.now().year, LocalDate.now().month),
                     aktør = Aktør(fnr + "00").also { it.personidenter.add(Personident(fnr, it)) },
                 ),
@@ -405,10 +405,10 @@ internal class StandardbegrunnelseTest {
             listOf(
                 lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                     fom =
-                        YearMonth.of(
-                            dødsfallDato.minusMonths(5).year,
-                            dødsfallDato.minusMonths(5).month,
-                        ),
+                    YearMonth.of(
+                        dødsfallDato.minusMonths(5).year,
+                        dødsfallDato.minusMonths(5).month,
+                    ),
                     tom = YearMonth.of(dødsfallDato.minusMonths(1).year, dødsfallDato.minusMonths(1).month),
                     aktør = Aktør(fnr + "00").also { it.personidenter.add(Personident(fnr, it)) },
                 ),
@@ -452,10 +452,10 @@ internal class StandardbegrunnelseTest {
             listOf(
                 lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                     fom =
-                        YearMonth.of(
-                            dødsfallDato.plusMonths(5).year,
-                            dødsfallDato.plusMonths(5).month,
-                        ),
+                    YearMonth.of(
+                        dødsfallDato.plusMonths(5).year,
+                        dødsfallDato.plusMonths(5).month,
+                    ),
                     tom = YearMonth.of(dødsfallDato.plusMonths(6).year, dødsfallDato.plusMonths(6).month),
                     aktør = Aktør(fnr + "00").also { it.personidenter.add(Personident(fnr, it)) },
                 ),
@@ -493,10 +493,10 @@ internal class StandardbegrunnelseTest {
             listOf(
                 lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                     fom =
-                        YearMonth.of(
-                            dødsfallDatoBarn1.minusMonths(1).year,
-                            dødsfallDatoBarn1.minusMonths(1).month,
-                        ),
+                    YearMonth.of(
+                        dødsfallDatoBarn1.minusMonths(1).year,
+                        dødsfallDatoBarn1.minusMonths(1).month,
+                    ),
                     tom = YearMonth.of(dødsfallDatoBarn1.year, dødsfallDatoBarn1.month),
                     aktør = Aktør(barn1Fnr + "00").also { it.personidenter.add(Personident(barn1Fnr, it)) },
                 ),
@@ -516,10 +516,10 @@ internal class StandardbegrunnelseTest {
             listOf(
                 lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                     fom =
-                        YearMonth.of(
-                            dødsfallDatoBarn1.minusMonths(1).year,
-                            dødsfallDatoBarn1.minusMonths(1).month,
-                        ),
+                    YearMonth.of(
+                        dødsfallDatoBarn1.minusMonths(1).year,
+                        dødsfallDatoBarn1.minusMonths(1).month,
+                    ),
                     tom = YearMonth.of(dødsfallDatoBarn2.year, dødsfallDatoBarn2.month),
                     aktør = Aktør(barn2Fnr + "00").also { it.personidenter.add(Personident(barn2Fnr, it)) },
                 ),
@@ -549,10 +549,10 @@ internal class StandardbegrunnelseTest {
             listOf(
                 lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                     fom =
-                        YearMonth.of(
-                            dødsfallDatoBarn1.minusMonths(1).year,
-                            dødsfallDatoBarn1.minusMonths(1).month,
-                        ),
+                    YearMonth.of(
+                        dødsfallDatoBarn1.minusMonths(1).year,
+                        dødsfallDatoBarn1.minusMonths(1).month,
+                    ),
                     tom = YearMonth.of(dødsfallDatoBarn1.year, dødsfallDatoBarn1.month),
                     aktør = Aktør(barn1Fnr + "00").also { it.personidenter.add(Personident(barn1Fnr, it)) },
                 ),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -18,8 +18,8 @@ import no.nav.familie.ba.sak.kjerne.brev.LANDKODER
 import no.nav.familie.ba.sak.kjerne.brev.brevBegrunnelseProdusent.GrunnlagForBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.lagBrevPeriode
 import no.nav.familie.ba.sak.kjerne.brev.domene.RestSanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.eøs.RestSanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriode
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
@@ -31,7 +31,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Personopplysning
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.RestSanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.BegrunnelseMedData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseUtfyltTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseUtfyltTest.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ba.sak.kjerne.eøs.kompetanse
 
 import no.nav.familie.ba.sak.ekstern.restDomene.UtfyltStatus
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestKompetanse
+import no.nav.familie.ba.sak.kjerne.brev.domene.eøs.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagKompetanse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.BarnetsBostedsland
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
Flyttet RestSanityEØSBegrunnelse til brev/domene/eos 
Legg til ovrigeTriggere i RestSanityEØSBegrunnelse

### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16995)
Ønsker å ha øvrige triggere for eøsbegrunnelser også. Har lagt til I sanity [her](https://github.com/navikt/familie-sanity-brev/pull/488)

Les commit for commit 😊 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
