### PR TITLE
Chore: optional andel tilkjent ytelse for å unngå mange logginnslag i sentry

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -86,11 +86,13 @@ class TilkjentYtelseValideringService(
     fun finnAktørerMedUgyldigEtterbetalingsperiode(
         behandlingId: Long,
     ): List<Aktør> {
-        val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandlingId)
+        val tilkjentYtelse = beregningService.hentOptionalTilkjentYtelseForBehandling(behandlingId = behandlingId)
+
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
 
         val forrigeBehandling =
             behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(
-                behandling = behandlingHentOgPersisterService.hent(behandlingId),
+                behandling = behandling,
             )
         val forrigeAndelerTilkjentYtelse =
             forrigeBehandling?.let { beregningService.hentOptionalTilkjentYtelseForBehandling(behandlingId = it.id) }
@@ -98,8 +100,8 @@ class TilkjentYtelseValideringService(
 
         return finnAktørIderMedUgyldigEtterbetalingsperiode(
             forrigeAndelerTilkjentYtelse = forrigeAndelerTilkjentYtelse ?: emptyList(),
-            andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.toList(),
-            kravDato = tilkjentYtelse.behandling.opprettetTidspunkt,
+            andelerTilkjentYtelse = tilkjentYtelse?.andelerTilkjentYtelse?.toList() ?: emptyList(),
+            kravDato = behandling.opprettetTidspunkt,
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringServiceTest.kt
@@ -135,7 +135,7 @@ class TilkjentYtelseValideringServiceTest {
                     ),
             )
 
-        every { beregningServiceMock.hentTilkjentYtelseForBehandling(behandlingId = behandling.id) } answers { tilkjentYtelse }
+        every { beregningServiceMock.hentOptionalTilkjentYtelseForBehandling(behandlingId = behandling.id) } answers { tilkjentYtelse }
         every { behandlingHentOgPersisterService.hent(behandlingId = behandling.id) } answers { behandling }
         every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling = behandling) } answers { forrigeBehandling }
         every { beregningServiceMock.hentOptionalTilkjentYtelseForBehandling(behandlingId = forrigeBehandling.id) } answers { forrigeTilkjentYtelse }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Får mange av [denne](https://sentry.gc.nav.no/organizations/nav/issues/520499/?project=112) feilen i Sentry. Skyldes at saksbehandler kommer inn på behandlingsresultat-siden når det ikke finnes tilkjent ytelse - feks ved henlagt behandling. Sørger for at tilkjent ytelse kan være optional. Hvis det ikke finnes tilkjent ytelse så sender vi bare inn en tom liste med andeler.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tenker det er unødvendig

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
