### PR TITLE
legg til vurderes etter i testendepunkter for begrunnelse- og vedtaksperiodetester

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -182,17 +182,25 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.vurderesEtter,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
-                """
-      | ${vilkårResultatRad.aktørId}  
-      | ${vilkårResultater.map { it.vilkårType }.joinToString(",")} 
-      | ${vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")} 
-      | ${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""} 
-      | ${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""} 
-      | ${vilkårResultatRad.resultat}  
-      | ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"}  
-      | ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}
-      | ${vilkårResultatRad.vurderesEtter}  
-      |"""
+                """| ${
+                    vilkårResultatRad.aktørId
+                }  | ${
+                    vilkårResultater.map { it.vilkårType }.joinToString(",")
+                } | ${
+                    vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")
+                } | ${
+                    vilkårResultatRad.fom?.tilddMMyyyy() ?: ""
+                } | ${
+                    vilkårResultatRad.tom?.tilddMMyyyy() ?: ""
+                } | ${
+                    vilkårResultatRad.resultat
+                }  | ${
+                    if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"
+                }  | ${
+                    vilkårResultatRad.standardbegrunnelser.joinToString(",")
+                }| ${
+                    vilkårResultatRad.vurderesEtter
+                } |"""
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -182,7 +182,7 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.vurderesEtter,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
-                "| ${vilkårResultatRad.aktørId} " +
+                "\n | ${vilkårResultatRad.aktørId} " +
                     "| ${vilkårResultater.map { it.vilkårType }.joinToString(",")} " +
                     "| ${vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")} " +
                     "| ${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""} " +
@@ -190,8 +190,8 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     "| ${vilkårResultatRad.resultat} " +
                     "| ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"} " +
                     "| ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}" +
-                    "| ${vilkårResultatRad.vurderesEtter} " +
-                    "|"
+                    "| ${vilkårResultatRad.vurderesEtter ?: ""} " +
+                    "| "
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -182,25 +182,16 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.vurderesEtter,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
-                """| ${
-                    vilkårResultatRad.aktørId
-                }  | ${
-                    vilkårResultater.map { it.vilkårType }.joinToString(",")
-                } | ${
-                    vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")
-                } | ${
-                    vilkårResultatRad.fom?.tilddMMyyyy() ?: ""
-                } | ${
-                    vilkårResultatRad.tom?.tilddMMyyyy() ?: ""
-                } | ${
-                    vilkårResultatRad.resultat
-                }  | ${
-                    if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"
-                }  | ${
-                    vilkårResultatRad.standardbegrunnelser.joinToString(",")
-                }| ${
-                    vilkårResultatRad.vurderesEtter
-                } |"""
+                "| ${vilkårResultatRad.aktørId} " +
+                    "| ${vilkårResultater.map { it.vilkårType }.joinToString(",")} " +
+                    "| ${vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")} " +
+                    "| ${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""} " +
+                    "| ${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""} " +
+                    "| ${vilkårResultatRad.resultat} " +
+                    "| ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"} " +
+                    "| ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}" +
+                    "| ${vilkårResultatRad.vurderesEtter} " +
+                    "|"
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Personopplysning
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import org.apache.commons.lang3.RandomStringUtils
 import java.time.LocalDate
@@ -150,7 +151,7 @@ fun hentTekstForVilkårresultater(
     return """
         
     Og legg til nye vilkårresultater for begrunnelse for behandling $behandlingId
-      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser |""" +
+      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter |""" +
         tilVilkårResultatRader(personResultater)
 }
 
@@ -162,6 +163,7 @@ data class VilkårResultatRad(
     val resultat: Resultat,
     val erEksplisittAvslagPåSøknad: Boolean?,
     val standardbegrunnelser: List<IVedtakBegrunnelse>,
+    val vurderesEtter: Regelverk?,
 )
 
 private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
@@ -177,14 +179,20 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.resultat,
                     it.erEksplisittAvslagPåSøknad,
                     it.standardbegrunnelser,
+                    it.vurderesEtter,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
                 """
-      | ${vilkårResultatRad.aktørId} |${vilkårResultater.map { it.vilkårType }.joinToString(",")}|${
-                    vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")
-                }|${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""}|${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""}| ${vilkårResultatRad.resultat} | ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"} | ${
-                    vilkårResultatRad.standardbegrunnelser.joinToString(",")
-                } |"""
+      | ${vilkårResultatRad.aktørId}  
+      | ${vilkårResultater.map { it.vilkårType }.joinToString(",")} 
+      | ${vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")} 
+      | ${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""} 
+      | ${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""} 
+      | ${vilkårResultatRad.resultat}  
+      | ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"}  
+      | ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}
+      | ${vilkårResultatRad.vurderesEtter}  
+      |"""
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -122,7 +122,7 @@ private fun hentTekstForVilkårresultater(
     return """
         
     Og legg til nye vilkårresultater for behandling $behandlingId
-      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser |""" +
+      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter |""" +
         tilVilkårResultatRader(personResultater)
 }
 
@@ -139,14 +139,20 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.resultat,
                     it.erEksplisittAvslagPåSøknad,
                     it.standardbegrunnelser,
+                    it.vurderesEtter,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
                 """
-      | ${vilkårResultatRad.aktørId} |${vilkårResultater.map { it.vilkårType }.joinToString(",")}|${
-                    vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")
-                }|${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""}|${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""}| ${vilkårResultatRad.resultat} | ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"} | ${
-                    vilkårResultatRad.standardbegrunnelser.joinToString(",")
-                } |"""
+      | ${vilkårResultatRad.aktørId}  
+      | ${vilkårResultater.map { it.vilkårType }.joinToString(",")} 
+      | ${vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")} 
+      | ${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""} 
+      | ${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""} 
+      | ${vilkårResultatRad.resultat}  
+      | ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"}  
+      | ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}
+      | ${vilkårResultatRad.vurderesEtter}  
+      |"""
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -142,17 +142,25 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.vurderesEtter,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
-                """
-      | ${vilkårResultatRad.aktørId}  
-      | ${vilkårResultater.map { it.vilkårType }.joinToString(",")} 
-      | ${vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")} 
-      | ${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""} 
-      | ${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""} 
-      | ${vilkårResultatRad.resultat}  
-      | ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"}  
-      | ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}
-      | ${vilkårResultatRad.vurderesEtter}  
-      |"""
+                """| ${
+                    vilkårResultatRad.aktørId
+                }  | ${
+                    vilkårResultater.map { it.vilkårType }.joinToString(",")
+                } | ${
+                    vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")
+                } | ${
+                    vilkårResultatRad.fom?.tilddMMyyyy() ?: ""
+                } | ${
+                    vilkårResultatRad.tom?.tilddMMyyyy() ?: ""
+                } | ${
+                    vilkårResultatRad.resultat
+                }  | ${
+                    if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"
+                }  | ${
+                    vilkårResultatRad.standardbegrunnelser.joinToString(",")
+                }| ${
+                    vilkårResultatRad.vurderesEtter
+                }|"""
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -151,7 +151,7 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     "| ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"}" +
                     "| ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}" +
                     "| ${vilkårResultatRad.vurderesEtter}" +
-                    "|"
+                    "| \n"
             }
     } ?: ""
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -142,25 +142,16 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.vurderesEtter,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
-                """| ${
-                    vilkårResultatRad.aktørId
-                }  | ${
-                    vilkårResultater.map { it.vilkårType }.joinToString(",")
-                } | ${
-                    vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")
-                } | ${
-                    vilkårResultatRad.fom?.tilddMMyyyy() ?: ""
-                } | ${
-                    vilkårResultatRad.tom?.tilddMMyyyy() ?: ""
-                } | ${
-                    vilkårResultatRad.resultat
-                }  | ${
-                    if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"
-                }  | ${
-                    vilkårResultatRad.standardbegrunnelser.joinToString(",")
-                }| ${
-                    vilkårResultatRad.vurderesEtter
-                }|"""
+                "| ${vilkårResultatRad.aktørId} " +
+                    "| ${vilkårResultater.map { it.vilkårType }.joinToString(",")} " +
+                    "| ${vilkårResultatRad.utdypendeVilkårsvurderinger.joinToString(",")} " +
+                    "| ${vilkårResultatRad.fom?.tilddMMyyyy() ?: ""} " +
+                    "| ${vilkårResultatRad.tom?.tilddMMyyyy() ?: ""} " +
+                    "| ${vilkårResultatRad.resultat} " +
+                    "| ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"}" +
+                    "| ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}" +
+                    "| ${vilkårResultatRad.vurderesEtter}" +
+                    "|"
             }
     } ?: ""
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vurderes etter kommer ikke automatisk med når vi generer tester for begrunnelser og vedtaksperioder. Med endringene som kommer i https://github.com/navikt/familie-ba-sak/pull/4192 blir vi mer avhengige av å ha riktig regelverk for at testene ikke skal feile. Må derfor ta med vurderes etter i testgeneratoren
