### PR TITLE
Bruk 'StandardBegrunnelser' når vi parser begrunnelser valg i vilkårsvurderingen slik at eøs-begrunnelser kommer med

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
@@ -1,4 +1,3 @@
-
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.Utils.storForbokstav

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -205,7 +205,7 @@ private fun hentStandardBegrunnelser(rad: MutableMap<String, String>): List<IVed
             )
         } catch (_: Exception) {
             parseEnumListe<EØSStandardbegrunnelse>(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.EØSBEGRUNNELSER,
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.STANDARDBEGRUNNELSER,
                 rad,
             )
         }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/kompetanser.feature
@@ -403,15 +403,15 @@ Egenskap: Gyldige begrunnelser for kompetanser
       | 2       | LOVLIG_OPPHOLD   |                                     | 01.04.2022 |            | OPPFYLT  | Nei                  |                  |
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 2
-      | AktørId | Vilkår           | Utdypende vilkår                    | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser |
-      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING_UTLAND | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |
-      | 1       | LOVLIG_OPPHOLD   |                                     | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |
+      | AktørId | Vilkår           | Utdypende vilkår                    | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING_UTLAND | 01.04.2022 |            | OPPFYLT  | Nei                  |                  |
+      | 1       | LOVLIG_OPPHOLD   |                                     | 01.04.2022 |            | OPPFYLT  | Nei                  |                  |
 
-      | 2       | UNDER_18_ÅR      |                                     | 20.05.2017 | 19.05.2035 | OPPFYLT  | Nei                  |                      |
-      | 2       | GIFT_PARTNERSKAP |                                     | 20.05.2017 |            | OPPFYLT  | Nei                  |                      |
-      | 2       | LOVLIG_OPPHOLD   |                                     | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |
-      | 2       | BOR_MED_SØKER    | BARN_BOR_I_STORBRITANNIA_MED_SØKER  | 01.04.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN     |
-      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_STORBRITANNIA            | 01.04.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN     |
+      | 2       | UNDER_18_ÅR      |                                     | 20.05.2017 | 19.05.2035 | OPPFYLT  | Nei                  |                  |
+      | 2       | GIFT_PARTNERSKAP |                                     | 20.05.2017 |            | OPPFYLT  | Nei                  |                  |
+      | 2       | LOVLIG_OPPHOLD   |                                     | 01.04.2022 |            | OPPFYLT  | Nei                  |                  |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_STORBRITANNIA_MED_SØKER  | 01.04.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_STORBRITANNIA            | 01.04.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
 
     Og med andeler tilkjent ytelse for begrunnelse
       | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når man velger en standardbegrunnelse for vilkår som gjelder eøs, f.eks. avslagSelvstendigRettStandardAvslag vil ikke begrunnelsen dukke opp og føre til at man får feil flettefelt. Endrer slik at vi faktisk parser riktig felt. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
