### PR TITLE
Bedre logging brevbegrunnelsefeil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAnde
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
-import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
 import org.springframework.stereotype.Service
@@ -23,7 +23,7 @@ class TestVerktøyService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingRepository: EndretUtbetalingAndelRepository,
     private val vedtaksperiodeHentOgPersisterService: VedtaksperiodeHentOgPersisterService,
-    private val vedtakService: VedtakService,
+    private val vedtakRepository: VedtakRepository,
     private val kompetanseRepository: KompetanseRepository,
 ) {
     @Transactional
@@ -71,7 +71,7 @@ class TestVerktøyService(
 
         val vedtaksperioder =
             vedtaksperiodeHentOgPersisterService.finnVedtaksperioderFor(
-                vedtakService.hentAktivForBehandlingThrows(behandlingId).id,
+                vedtakRepository.findByBehandlingAndAktiv(behandlingId).id,
             )
 
         return lagGyldigeBegrunnelserTest(
@@ -112,7 +112,7 @@ class TestVerktøyService(
             forrigeBehandling?.let { kompetanseRepository.finnFraBehandlingId(it.id) }
         val vedtaksperioder =
             vedtaksperiodeHentOgPersisterService.finnVedtaksperioderFor(
-                vedtakService.hentAktivForBehandlingThrows(behandlingId).id,
+                vedtakRepository.findByBehandlingAndAktiv(behandlingId).id,
             )
 
         return lagVedtaksperioderTest(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevKlient.kt
@@ -48,7 +48,7 @@ class BrevKlient(
                 postForEntity(uri, begrunnelseData)
             }
         } catch (e: Exception) {
-            logger.info("Kall for å hente begrunnelsetest feilet. Autogenerert test:\"" + testVerktøyService.hentBegrunnelsetest(vedtaksperiode.vedtak.behandling.id))
+            secureLogger.info("Kall for å hente begrunnelsetest feilet. Autogenerert test:\"" + testVerktøyService.hentBegrunnelsetest(vedtaksperiode.vedtak.behandling.id))
             throw e
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.Utils.storForbokstavIAlleNavn
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
@@ -317,12 +318,13 @@ class BrevService(
                         landkoder = integrasjonClient.hentLandkoderISO2(),
                     )
                 } catch (e: BrevBegrunnelseFeil) {
-                    throw IllegalStateException(
-                        "${e.message} For behandling $behandlingId, " +
+                    secureLogger.info(
+                        "Brevbegrunnelsefeil for behandling $behandlingId, " +
                             "fagsak ${vedtak.behandling.fagsak.id} " +
                             "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +
                             "\nAutogenerert test:\n" + testVerktøyService.hentBegrunnelsetest(behandlingId),
                     )
+                    throw IllegalStateException(e.message, cause = e)
                 }
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -324,7 +324,7 @@ class BrevService(
                             "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +
                             "\nAutogenerert test:\n" + testVerktøyService.hentBegrunnelsetest(behandlingId),
                     )
-                    throw IllegalStateException(e.message, cause = e)
+                    throw IllegalStateException(e.message, e)
                 }
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -8,9 +8,11 @@ import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
+import no.nav.familie.ba.sak.internal.TestVerktøyService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.brev.brevBegrunnelseProdusent.BrevBegrunnelseFeil
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.lagBrevPeriode
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Autovedtak6og18årOgSmåbarnstillegg
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.AutovedtakNyfødtBarnFraFør
@@ -71,6 +73,7 @@ class BrevService(
     private val brevmalService: BrevmalService,
     private val refusjonEøsRepository: RefusjonEøsRepository,
     private val integrasjonClient: IntegrasjonClient,
+    private val testVerktøyService: TestVerktøyService,
 ) {
     fun hentVedtaksbrevData(vedtak: Vedtak): Vedtaksbrev {
         val behandling = vedtak.behandling
@@ -302,23 +305,33 @@ class BrevService(
 
         val grunnlagOgSignaturData = hentGrunnlagOgSignaturData(vedtak)
 
-        val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = vedtak.behandling.id)
+        val behandlingId = vedtak.behandling.id
+        val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandlingId)
 
         val grunnlagForBegrunnelser = vedtaksperiodeService.hentGrunnlagForBegrunnelse(vedtak.behandling)
         val brevperioder =
-            vedtaksperioder.mapNotNull {
-                it.lagBrevPeriode(
-                    grunnlagForBegrunnelse = grunnlagForBegrunnelser,
-                    landkoder = integrasjonClient.hentLandkoderISO2(),
-                )
+            vedtaksperioder.mapNotNull { vedtaksperiode ->
+                try {
+                    vedtaksperiode.lagBrevPeriode(
+                        grunnlagForBegrunnelse = grunnlagForBegrunnelser,
+                        landkoder = integrasjonClient.hentLandkoderISO2(),
+                    )
+                } catch (e: BrevBegrunnelseFeil) {
+                    throw IllegalStateException(
+                        "${e.message} For behandling $behandlingId, " +
+                            "fagsak ${vedtak.behandling.fagsak.id} " +
+                            "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +
+                            "\nAutogenerert test:\n" + testVerktøyService.hentBegrunnelsetest(behandlingId),
+                    )
+                }
             }
 
-        val korrigertVedtak = korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(vedtak.behandling.id)
-        val refusjonEøs = refusjonEøsRepository.finnRefusjonEøsForBehandling(vedtak.behandling.id)
+        val korrigertVedtak = korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(behandlingId)
+        val refusjonEøs = refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId)
 
         val hjemler =
             hentHjemler(
-                behandlingId = vedtak.behandling.id,
+                behandlingId = behandlingId,
                 erFritekstIBrev = vedtaksperioder.any { it.fritekster.isNotEmpty() },
                 vedtaksperioder = vedtaksperioder,
                 målform = personopplysningGrunnlag.søker.målform,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -386,7 +386,7 @@ private fun ISanityBegrunnelse.validerBrevbegrunnelse(
     barnasFødselsdatoer: List<LocalDate>,
 ) {
     if (!gjelderSøker && barnasFødselsdatoer.isEmpty() && !this.gjelderSatsendring && !this.erAvslagUregistrerteBarnBegrunnelse()) {
-        throw IllegalStateException("Ingen personer på brevbegrunnelse ${this.apiNavn}")
+        throw BrevBegrunnelseFeil("Ingen personer på brevbegrunnelse ${this.apiNavn}")
     }
 }
 
@@ -418,3 +418,7 @@ fun ISanityBegrunnelse.erAvslagUregistrerteBarnBegrunnelse() =
             Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN.sanityApiNavn,
             EØSStandardbegrunnelse.AVSLAG_EØS_UREGISTRERT_BARN.sanityApiNavn,
         )
+
+class BrevBegrunnelseFeil(
+    melding: String,
+) : IllegalStateException(melding)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.ekstern.restDomene.RestGenererVedtaksperioderForOverstyrtEndringstidspunkt
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedFritekster
@@ -153,12 +154,13 @@ class VedtaksperiodeMedBegrunnelserController(
                     landkoder = integrasjonClient.hentLandkoderISO2(),
                 )
             } catch (e: BrevBegrunnelseFeil) {
-                throw IllegalStateException(
-                    "${e.message}. På behandling $behandlingId, " +
+                secureLogger.info(
+                    "Brevbegrunnelsefeil for behandling $behandlingId, " +
                         "fagsak ${vedtaksperiode.vedtak.behandling.fagsak.id} " +
                         "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +
                         "\nAutogenerert test:\n" + testVerktøyService.hentBegrunnelsetest(behandlingId),
                 )
+                throw IllegalStateException(e.message, cause = e)
             }
 
         val begrunnelser =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -160,7 +160,7 @@ class VedtaksperiodeMedBegrunnelserController(
                         "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +
                         "\nAutogenerert test:\n" + testVerktøyService.hentBegrunnelsetest(behandlingId),
                 )
-                throw IllegalStateException(e.message, cause = e)
+                throw IllegalStateException(e.message, e)
             }
 
         val begrunnelser =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/BrevKlientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/BrevKlientMock.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.config
 
+import io.mockk.mockk
 import io.mockk.spyk
 import no.nav.familie.ba.sak.kjerne.brev.BrevKlient
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brev
@@ -17,6 +18,7 @@ class BrevKlientMock : BrevKlient(
     familieBrevUri = "brev_uri_mock",
     restTemplate = RestTemplate(),
     sanityDataset = "",
+    testVerktøyService = mockk(),
 ) {
     override fun genererBrev(
         målform: String,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -29,6 +29,7 @@ class BrevServiceTest {
             brevmalService = brevmalService,
             refusjonEøsRepository = mockk(),
             integrasjonClient = mockk(),
+            testVerktøyService = mockk(),
         )
 
     @BeforeEach


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ønsker bedre logging slik at det er lettere å håndtere feil rundt brevbegrunnelser. 
Legger til autogenererte tester i loggene slik at vi kan se staten til behandlingen i det feilen inntreffer. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Burde testene logges i securelogger? Dataene er obfuskerte, men datoene og antall barn vil fortsatt være til stede

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
