### PR TITLE
Legg til logg av begrunnelsesutleding for feilende prodsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent
 
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
@@ -124,6 +125,10 @@ fun VedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserPerPerson(
                 utvidetVilkårPåSøkerIForrigePeriode = utvidetVilkårPåSøkerIForrigePeriode,
                 temaSomPeriodeErVurdertEtter = temaSomPeriodeErVurdertEtter,
             )
+
+        if (grunnlag.behandlingsGrunnlagForVedtaksperioder.behandling.fagsak.id == "2178816".toLong()) {
+            secureLogger.info("Henter EØS standardbegrunnelser for behandling=${grunnlag.behandlingsGrunnlagForVedtaksperioder.behandling.id} periode fom ${this.fom} med begrunnelsegrunnlag=$begrunnelseGrunnlag, relevantePeriodeResultater=$relevantePeriodeResultater, erUtbetalingEllerDeltBostedIPeriode=$erUtbetalingEllerDeltBostedIPeriode, utvidetVilkårPåSøkerIPeriode=$utvidetVilkårPåSøkerIPeriode, utvidetVilkårPåSøkerIForrigePeriode=$utvidetVilkårPåSøkerIForrigePeriode")
+        }
 
         val avslagsbegrunnelser = avslagsbegrunnelserPerPerson[person] ?: emptySet()
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro:  NAV-17336

Ønsker å legge til logg til securelog for denne spesifikke fagsaken slik at vi kan se de evaluerte verdiene og undersøke hvorfor de utledete gyldige EØS-begrunnelsene er ulike fra de vi finner når vi reproduserer saken i cucumber-test (se #4237)

Denne skal reverteres etter at vi får lest ut loggen fra gjeldende sak
