### PR TITLE
Bug: årlig kontroll delmal

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.Utils.storForbokstav
-import no.nav.familie.ba.sak.common.erSenereEnnInneværendeMåned
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.tilMånedÅr
@@ -18,7 +17,6 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClien
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.SmåbarnstilleggService
@@ -589,8 +587,8 @@ class VedtaksperiodeService(
     }
 
     fun skalHaÅrligKontroll(vedtak: Vedtak): Boolean {
-        return vedtak.behandling.kategori == BehandlingKategori.EØS &&
-            hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
+        return kompetanseRepository.finnFraBehandlingId(vedtak.behandling.id)
+            .any { it.tom == null || it.tom.isAfter(YearMonth.now()) }
     }
 
     fun skalMeldeFraOmEndringerEøsSelvstendigRett(vedtak: Vedtak): Boolean {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -128,12 +128,13 @@ class VedtaksperiodeServiceTest {
     fun `EØS med periode med utløpt tom skal ikke ha årlig kontroll`() {
         val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
 
-        every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns listOf(
-            lagKompetanse(
-                fom = YearMonth.now().minusMonths(2),
-                tom = YearMonth.now()
+        every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns
+            listOf(
+                lagKompetanse(
+                    fom = YearMonth.now().minusMonths(2),
+                    tom = YearMonth.now(),
+                ),
             )
-        )
 
         assertFalse { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }
@@ -142,12 +143,13 @@ class VedtaksperiodeServiceTest {
     fun `EØS med periode med løpende tom skal ha årlig kontroll`() {
         val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
 
-        every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns listOf(
-            lagKompetanse(
-                fom = YearMonth.now().minusMonths(1),
-                tom = YearMonth.now().plusMonths(5)
+        every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns
+            listOf(
+                lagKompetanse(
+                    fom = YearMonth.now().minusMonths(1),
+                    tom = YearMonth.now().plusMonths(5),
+                ),
             )
-        )
 
         assertTrue { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }
@@ -156,12 +158,13 @@ class VedtaksperiodeServiceTest {
     fun `EØS med periode uten tom skal ha årlig kontroll`() {
         val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
 
-        every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns listOf(
-            lagKompetanse(
-                fom = YearMonth.now().minusMonths(1),
-                tom = null
+        every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns
+            listOf(
+                lagKompetanse(
+                    fom = YearMonth.now().minusMonths(1),
+                    tom = null,
+                ),
             )
-        )
 
         assertTrue { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17453

Delmalen om årlig kontroll dukker opp i flere saker enn den skal. Dette er fordi eksisterende kode ser på om behandlingstema er EØS og om det finnes noen løpende vedtaksperioder. Dette gjør at saker som har hatt EØS i fortiden, men nå er nasjonale, også får med seg delmalen, fordi man ikke sjekker om det er løpende EØS. Jeg mener at vi kan endre til å kun sjekke om det finnes kompetanser i fremtiden, fordi det finnes alltid kompetanser i perioder som er vurdert etter EØS. Og man ønsker delmalen i EØS-perioder uansett om de fører til utbetaling eller nullutbetaling.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Egentlig ikke

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
