### PR TITLE
Pensjon: Fikser overlapp-exception som oppstod i preprod, og for ikke-ordinære perioder i prod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -255,7 +255,7 @@ class PensjonService(
                                 it.kildesystem == "Infotrygd" && opprinneligeInfotrygdPerioder.fomDatoer().contains(it.stønadFom)
                             }
                         } catch (e: Exception) {
-                            logger.error("PensjonService: Klarte ikke kombinere BA og IT-perioder for fjerning av evt. overlapp")
+                            logger.error("Klarte ikke kombinere BA og IT-perioder for fjerning av eventuelle overlapp")
                             secureLogger.warn("Klarte ikke kombinere $baSakPerioder\n og \n$opprinneligeInfotrygdPerioder", e)
 
                             throw EksternTjenesteFeilException(

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -231,14 +231,20 @@ class PensjonService(
                         perioderTilhørendePerson.partition { it.kildesystem == "BA" }
 
                     val infotrygdperioderMinusOverlappMedBA =
-                        baSakPerioder.tidslinje().crossJoin(opprinneligeInfotrygdPerioder.tidslinje()).toSegments().map {
-                            it.value.copy(
-                                stønadFom = it.fom.toYearMonth(),
-                                stønadTom = it.tom.toYearMonth(),
-                            )
-                        }.filter {
-                            it.kildesystem == "Infotrygd" && opprinneligeInfotrygdPerioder.fomDatoer().contains(it.stønadFom)
+                        try {
+                            baSakPerioder.tidslinje().crossJoin(opprinneligeInfotrygdPerioder.tidslinje()).toSegments().map {
+                                it.value.copy(
+                                    stønadFom = it.fom.toYearMonth(),
+                                    stønadTom = it.tom.toYearMonth(),
+                                )
+                            }.filter {
+                                it.kildesystem == "Infotrygd" && opprinneligeInfotrygdPerioder.fomDatoer().contains(it.stønadFom)
+                            }
+                        } catch (e: Exception) {
+                            secureLogger.warn("Klarte ikke kombinere $baSakPerioder\nog\n$opprinneligeInfotrygdPerioder")
+                            opprinneligeInfotrygdPerioder
                         }
+
                     sjekkOgLoggOmDetFinnesOverlapp(baSakPerioder, opprinneligeInfotrygdPerioder, infotrygdperioderMinusOverlappMedBA)
                     perioderUtenOverlappMellomFagsystemene.addAll(baSakPerioder + infotrygdperioderMinusOverlappMedBA)
                 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -157,6 +157,7 @@ class PensjonService(
                 ?: error("Finner ikke tilkjent ytelse for behandling=${behandling.id}")
         return tilkjentYtelse.andelerTilkjentYtelse
             .filter { it.stønadTom.isSameOrAfter(fraDato.toYearMonth()) }
+            .filter { it.type == YtelseType.ORDINÆR_BARNETRYGD } // Pensjon trenger kun forholde seg til periodene med Ordinær BA
             .map { andel ->
                 BarnetrygdPeriode(
                     ytelseTypeEkstern = andel.type.tilPensjonYtelsesType(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -204,12 +204,16 @@ class PensjonService(
     private fun List<BarnetrygdPeriode>.maskerPersonidenteneIPreprod(barnFnr: List<String>?) =
         when {
             envService.erPreprod() -> {
-                groupBy { it.personIdent }.values.flatMapIndexed { i, iendePeriode ->
-                    barnFnr?.elementAtOrNull(i)?.let { ident ->
-                        iendePeriode.map { it.copy(personIdent = ident) }
-                    } ?: emptyList()
+                val barnetrygdperioerPerPerson = this.groupBy { it.personIdent }.values
+                if (barnFnr != null) {
+                    barnetrygdperioerPerPerson.zip(barnFnr) { barnetrydperioder, barn ->
+                        barnetrydperioder.map { it.copy(personIdent = barn) }
+                    }.flatten()
+                } else {
+                    emptyList()
                 }
             }
+
             else -> this
         }
 


### PR DESCRIPTION
Filtrerer vekk periodene med småbarnstillegg og utvidet barnetrygd for å unngå problemene med IllegalArgumentException ved håndtering av overlapp, etter avklaring med Pensjon, da de uansett kun trenger å forholde seg til periodene med ordinær barnetrygd.

Fikser feilene som oppstod i preprod ved å bruke barnas identer til å maskere personidentene fra infotrygd-Q, istedenfor bare aktør.aktivtFødseslnummer på tvers av alle periodene tilhørerende ulike barn.
