### PR TITLE
Alltid auditlogg tilgang på behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -103,15 +103,6 @@ class TilgangService(
         event: AuditLoggerEvent,
     ) {
         val aktør = fagsakService.hentAktør(fagsakId)
-        aktør.personidenter.forEach {
-            auditLogger.log(
-                Sporingsdata(
-                    event = event,
-                    personIdent = it.fødselsnummer,
-                    custom1 = CustomKeyValue("fagsak", fagsakId.toString()),
-                ),
-            )
-        }
         val personIdenterIFagsak =
             (
                 persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsakId)
@@ -119,6 +110,16 @@ class TilgangService(
                     ?: emptyList()
             )
                 .ifEmpty { listOf(aktør.aktivFødselsnummer()) }
+
+        personIdenterIFagsak.forEach { fnr ->
+            auditLogger.log(
+                Sporingsdata(
+                    event = event,
+                    personIdent = fnr,
+                    custom1 = CustomKeyValue("fagsak", fagsakId.toString()),
+                ),
+            )
+        }
         val harTilgang = harTilgangTilPersoner(personIdenterIFagsak)
         if (!harTilgang) {
             throw RolleTilgangskontrollFeil(

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -78,14 +78,16 @@ class TilgangService(
                 ?.map { it.aktør.aktivFødselsnummer() }
                 ?: listOf(behandlingHentOgPersisterService.hent(behandlingId).fagsak.aktør.aktivFødselsnummer())
 
-        personIdenter.forEach {
-            auditLogger.log(
-                Sporingsdata(
-                    event = event,
-                    personIdent = it,
-                    custom1 = CustomKeyValue("behandling", behandlingId.toString()),
-                ),
-            )
+        if (!SikkerhetContext.erSystemKontekst()) {
+            personIdenter.forEach {
+                auditLogger.log(
+                    Sporingsdata(
+                        event = event,
+                        personIdent = it,
+                        custom1 = CustomKeyValue("behandling", behandlingId.toString()),
+                    ),
+                )
+            }
         }
 
         if (!harTilgangTilPersoner(personIdenter)) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -73,24 +73,22 @@ class TilgangService(
         behandlingId: Long,
         event: AuditLoggerEvent,
     ) {
-        val harTilgang =
-            harSaksbehandlerTilgang("validerTilgangTilBehandling", behandlingId) {
-                val personIdenter =
-                    persongrunnlagService.hentSøkerOgBarnPåBehandling(behandlingId)
-                        ?.map { it.aktør.aktivFødselsnummer() }
-                        ?: listOf(behandlingHentOgPersisterService.hent(behandlingId).fagsak.aktør.aktivFødselsnummer())
-                personIdenter.forEach {
-                    auditLogger.log(
-                        Sporingsdata(
-                            event = event,
-                            personIdent = it,
-                            custom1 = CustomKeyValue("behandling", behandlingId.toString()),
-                        ),
-                    )
-                }
-                harTilgangTilPersoner(personIdenter)
-            }
-        if (!harTilgang) {
+        val personIdenter =
+            persongrunnlagService.hentSøkerOgBarnPåBehandling(behandlingId)
+                ?.map { it.aktør.aktivFødselsnummer() }
+                ?: listOf(behandlingHentOgPersisterService.hent(behandlingId).fagsak.aktør.aktivFødselsnummer())
+
+        personIdenter.forEach {
+            auditLogger.log(
+                Sporingsdata(
+                    event = event,
+                    personIdent = it,
+                    custom1 = CustomKeyValue("behandling", behandlingId.toString()),
+                ),
+            )
+        }
+
+        if (!harTilgangTilPersoner(personIdenter)) {
             throw RolleTilgangskontrollFeil(
                 "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
                     "har ikke tilgang til behandling=$behandlingId",

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -104,10 +104,12 @@ class TilgangService(
     ) {
         val aktør = fagsakService.hentAktør(fagsakId)
         aktør.personidenter.forEach {
-            Sporingsdata(
-                event = event,
-                personIdent = it.fødselsnummer,
-                custom1 = CustomKeyValue("fagsak", fagsakId.toString()),
+            auditLogger.log(
+                Sporingsdata(
+                    event = event,
+                    personIdent = it.fødselsnummer,
+                    custom1 = CustomKeyValue("fagsak", fagsakId.toString()),
+                ),
             )
         }
         val personIdenterIFagsak =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-12516 
Auditlogging skjer inne i en cachet metode, så man får dermed ikke med auditlogging ved endring av event. 
Skrur av caching for validerTilgangTilBehandling slik at man alltid auditlogger

Selve tilgangsjekken er cachet inne i harTilgangTilPersoner()

Fikser bug med manglende auditlogg i fagsak-metoden

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Dette vil gi mer auditlogging, men mener dette er bedre enn manglende auditlogging som det er nå.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
