### PR TITLE
Tilrettelegging for å kjøre satsendring januar 2024

### DIFF
--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -113,8 +113,8 @@ spec:
         - host: data-api.ecb.europa.eu
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
   replicas:
-    min: 2
-    max: 4
+    min: 3
+    max: 5
   resources:
     limits:
       memory: 4096Mi

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -4,7 +4,6 @@ class FeatureToggleConfig {
     companion object {
         // Release
         const val ENDRET_EØS_REGELVERKFILTER_FOR_BARN = "familie-ba-sak.endret-eos-regelverkfilter-for-barn"
-        const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"
 
         // Ny utbetalingsgenerator
         const val BRUK_NY_UTBETALINGSGENERATOR = "familie.ba.sak.bruk-ny-utbetalingsgenerator"
@@ -15,5 +14,18 @@ class FeatureToggleConfig {
         const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
         const val TEKNISK_ENDRING = "familie-ba-sak.behandling.teknisk-endring"
         const val HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD = "familie-ba-sak.hent-identer-til-psys-fra-infotrygd"
+
+        // satsendring
+        // Oppretter satsendring-tasker for de som ikke har fått ny task
+        const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"
+
+        // kjører satsendring i arbeidstid med lavt eller høyt volum
+        const val SATSENDRING_HØYT_VOLUM: String = "familie-ba-sak.satsendring-hoyt-volum"
+
+        // Kjører satsendring i utenfor arbeidstid
+        const val SATSENDRING_KVELD: String = "familie-ba-sak.satsendring-kveld"
+
+        // Kjører satsendring lørdag
+        const val SATSENDRING_LØRDAG: String = "familie-ba-sak.satsendring-lordag"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -168,7 +168,7 @@ class StartSatsendring(
     }
 
     fun hentAktivSatsendringstidspunkt(): YearMonth {
-        return SATSENDRINGMÅNED_JULI_2023
+        return SATSENDRINGMÅNED_JANUAR_2024
     }
 
     fun opprettSatsendringForFagsak(fagsakId: Long) {
@@ -178,6 +178,6 @@ class StartSatsendring(
     companion object {
         val logger: Logger = LoggerFactory.getLogger(StartSatsendring::class.java)
         val SATSENDRINGMÅNED_MARS_2023: YearMonth = YearMonth.of(2023, 3)
-        val SATSENDRINGMÅNED_JULI_2023: YearMonth = YearMonth.of(2023, 7)
+        val SATSENDRINGMÅNED_JANUAR_2024: YearMonth = YearMonth.of(2024, 1)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Endringer i scheduler jobben for å kjøre satsendring januar 2024

- Lagt tilbake scheduler-jobbene vi brukte for juni 2023 satsendring, men togglet de, slik at man kan starte med lavt volum, ikke utenom arbeidstid og helg. Alle toggler av for tidspunktet
- Endret søk etter ikke utførte satsendringer til å søke etter satstidspunkt 2024-01

PR kan gå inn før, men ikke testbar før https://github.com/navikt/familie-ba-sak/pull/4267 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
