### PR TITLE
Oppretter satsendring hvis endre migreringsdato feiler pga manglende sats

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
@@ -63,7 +63,7 @@ class TestVerktøyController(
         @PathVariable fagsakId: Long,
     ): ResponseEntity<Ressurs<String>> {
         return if (envService.erPreprod() || envService.erDev()) {
-            opprettTaskService.opprettSatsendringTask(fagsakId, startSatsendring.hentAktivSatsendringstidspunkt())
+            opprettTaskService.opprettSatsendringTask(fagsakId, StartSatsendring.hentAktivSatsendringstidspunkt())
             ResponseEntity.ok(Ressurs.success("Trigget satsendring for fagsak $fagsakId"))
         } else {
             ResponseEntity.ok(Ressurs.success(ENDEPUNKTET_GJØR_IKKE_NOE_I_PROD_MELDING))

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringStatistikk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringStatistikk.kt
@@ -31,7 +31,7 @@ class SatsendringStatistikk(
         try {
             MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
             logger.info("Kjører statistikk satsendring")
-            val satsTidspunkt = startSatsendring.hentAktivSatsendringstidspunkt()
+            val satsTidspunkt = StartSatsendring.hentAktivSatsendringstidspunkt()
             val antallKjørt = satskjøringRepository.countByFerdigTidspunktIsNotNullAndSatsTidspunkt(satsTidspunkt)
             val antallTriggetTotalt = satskjøringRepository.countBySatsTidspunkt(satsTidspunkt)
             val antallLøpendeFagsakerTotalt = fagsakRepository.finnAntallFagsakerLøpende()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -167,15 +167,15 @@ class StartSatsendring(
         }
     }
 
-    fun hentAktivSatsendringstidspunkt(): YearMonth {
-        return SATSENDRINGMÅNED_JANUAR_2024
-    }
-
     fun opprettSatsendringForFagsak(fagsakId: Long) {
         opprettTaskService.opprettSatsendringTask(fagsakId, hentAktivSatsendringstidspunkt())
     }
 
     companion object {
+        fun hentAktivSatsendringstidspunkt(): YearMonth {
+            return SATSENDRINGMÅNED_JANUAR_2024
+        }
+
         val logger: Logger = LoggerFactory.getLogger(StartSatsendring::class.java)
         val SATSENDRINGMÅNED_MARS_2023: YearMonth = YearMonth.of(2023, 3)
         val SATSENDRINGMÅNED_JANUAR_2024: YearMonth = YearMonth.of(2024, 1)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.randomFnr
@@ -27,7 +28,7 @@ internal class StegServiceTest {
     private val behandlingService: BehandlingService = mockk()
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
     private val satsendringService: SatsendringService = mockk()
-    private val opprettTaskService: OpprettTaskService = mockk()
+    private val opprettTaskService: OpprettTaskService = mockk(relaxed = true)
 
     private val stegService =
         StegService(
@@ -42,7 +43,7 @@ internal class StegServiceTest {
             satsendringService = satsendringService,
             personopplysningerService = mockk(),
             automatiskBeslutningService = mockk(),
-            opprettTaskService = mockk(),
+            opprettTaskService = opprettTaskService,
         )
 
     @BeforeEach
@@ -116,6 +117,7 @@ internal class StegServiceTest {
             )
 
         assertThrows<FunksjonellFeil> { stegService.håndterNyBehandling(nyBehandling) }
+        verify(exactly = 1) { opprettTaskService.opprettSatsendringTask(any(), any()) }
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.task.OpprettTaskService
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -26,6 +27,7 @@ internal class StegServiceTest {
     private val behandlingService: BehandlingService = mockk()
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
     private val satsendringService: SatsendringService = mockk()
+    private val opprettTaskService: OpprettTaskService = mockk()
 
     private val stegService =
         StegService(
@@ -40,6 +42,7 @@ internal class StegServiceTest {
             satsendringService = satsendringService,
             personopplysningerService = mockk(),
             automatiskBeslutningService = mockk(),
+            opprettTaskService = mockk(),
         )
 
     @BeforeEach


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det er per nå ikke mulig å opprette en endre migreringsdato behandling dersom det finnes nye satser og forrige vedtatte behandling ikke har de nye satsene på plass. 

Denne endringen oppretter automatisk satsendring når man prøver å endre migreringsdato og satsen ikke er på plass.

https://nav-it.slack.com/archives/C01G9BA8JKZ/p1704456100569059

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
