### PR TITLE
Default til tomstreng istedenfor null

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -137,7 +137,7 @@ fun hentTekstForPersongrunnlag(
 private fun hentPersongrunnlagRader(persongrunnlag: PersonopplysningGrunnlag?): String =
     persongrunnlag?.personer?.sortedBy { it.fødselsdato }?.joinToString("") {
         """
-      | ${persongrunnlag.behandlingId} |${it.aktør.aktørId}|${it.type}|${it.fødselsdato.tilddMMyyyy()}|${it.dødsfall?.dødsfallDato?.tilddMMyyyy()}|"""
+      | ${persongrunnlag.behandlingId} |${it.aktør.aktørId}|${it.type}|${it.fødselsdato.tilddMMyyyy()}|${it.dødsfall?.dødsfallDato?.tilddMMyyyy() ?: ""}|"""
     } ?: ""
 
 fun hentTekstForVilkårresultater(


### PR DESCRIPTION

![Screenshot 2024-01-08 at 09 28 05](https://github.com/navikt/familie-ba-sak/assets/110383605/5776807f-fc02-47aa-9ec2-50ed280fe7e0)

Vi må defaulte til tomstreng istedenfor å ha det som null hvis dødsfall dato ikke finnes.