### PR TITLE
Validering: søker kan ikke vurderes etter nasjonal om det finnes barn vurdert etter EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -130,8 +130,17 @@ class VilkårsvurderingTidslinjer(
 }
 
 fun VilkårsvurderingTidslinjer.harBlandetRegelverk(): Boolean {
-    return søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
+    return søkerHarNasjonalOgFinnesBarnMedEøs() ||
+        søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
         barnasTidslinjer().values.any { it.egetRegelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) }
+}
+
+private fun VilkårsvurderingTidslinjer.søkerHarNasjonalOgFinnesBarnMedEøs(): Boolean {
+    return søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_NASJONALE_REGLER) && barnasTidslinjer().values.any {
+        it.egetRegelverkResultatTidslinje.inneholder(
+            RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN
+        )
+    }
 }
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.inneholder(innhold: I): Boolean =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -136,11 +136,12 @@ fun VilkårsvurderingTidslinjer.harBlandetRegelverk(): Boolean {
 }
 
 private fun VilkårsvurderingTidslinjer.søkerHarNasjonalOgFinnesBarnMedEøs(): Boolean {
-    return søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_NASJONALE_REGLER) && barnasTidslinjer().values.any {
-        it.egetRegelverkResultatTidslinje.inneholder(
-            RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN
-        )
-    }
+    return søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_NASJONALE_REGLER) &&
+        barnasTidslinjer().values.any {
+            it.egetRegelverkResultatTidslinje.inneholder(
+                RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN,
+            )
+        }
 }
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.inneholder(innhold: I): Boolean =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17560

Hvis søkers vilkår vurderes etter nasjonale regler, og det finnes minst ett barn som har vilkår vurdert etter eøs-regler skal validering feile. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har testet manuelt. Usikker på om det er verdt å lage en testrigg rundt dette 🤷 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
