### PR TITLE
Klipp kompetanse til andelene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
@@ -128,14 +128,12 @@ class TilpassKompetanserTilEndretUtebetalingAndelerService(
                 barnasSkalIkkeUtbetalesTidslinjer,
                 annenForelderOmfattetAvNorskLovgivningTidslinje,
                 brukBarnetsRegelverkVedBlandetResultat = unleashNext.isEnabled(ENDRET_EØS_REGELVERKFILTER_FOR_BARN),
-                barnHarAndelTidslinjer = barnHarAndelTidslinjer
+                barnHarAndelTidslinjer = barnHarAndelTidslinjer,
             ).medBehandlingId(behandlingId)
 
         skjemaService.lagreDifferanseOgVarsleAbonnenter(behandlingId, gjeldendeKompetanser, oppdaterteKompetanser)
     }
 }
-
-
 
 fun tilpassKompetanserTilRegelverk(
     gjeldendeKompetanser: Collection<Kompetanse>,
@@ -143,7 +141,7 @@ fun tilpassKompetanserTilRegelverk(
     barnasSkalIkkeUtbetalesTidslinjer: Map<Aktør, Tidslinje<Boolean, Måned>>,
     annenForelderOmfattetAvNorskLovgivningTidslinje: Tidslinje<Boolean, Måned> = TomTidslinje<Boolean, Måned>(),
     brukBarnetsRegelverkVedBlandetResultat: Boolean = true,
-    barnHarAndelTidslinjer: Map<Aktør, Tidslinje<Boolean, Måned>>
+    barnHarAndelTidslinjer: Map<Aktør, Tidslinje<Boolean, Måned>>,
 ): Collection<Kompetanse> {
     val barnasEøsRegelverkTidslinjer =
         barnaRegelverkTidslinjer.tilBarnasEøsRegelverkTidslinjer(
@@ -222,9 +220,10 @@ private fun <I, T : Tidsenhet> Tidslinje<I, T>.flyttTilOgMed(tilTidspunkt: Tidsp
 }
 
 fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilBarnHarAndelTidslinjer(): Map<Aktør, Tidslinje<Boolean, Måned>> {
-    val andelerPerBarnTidslinje = filter { !it.erSøkersAndel() }.groupBy { it.aktør }
-        .mapValues { (_, andelerPåBarnet) ->
-            andelerPåBarnet.tilTidslinje().map { andelIPeriode -> if(andelIPeriode != null) true else null }
-        }
+    val andelerPerBarnTidslinje =
+        filter { !it.erSøkersAndel() }.groupBy { it.aktør }
+            .mapValues { (_, andelerPåBarnet) ->
+                andelerPåBarnet.tilTidslinje().map { andelIPeriode -> if (andelIPeriode != null) true else null }
+            }
     return andelerPerBarnTidslinje
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -289,11 +289,12 @@ internal class KompetanseServiceTest {
                         .tilPersonEnkelSøkerOgBarn(),
             )
 
-        val tilkjentYtelse = TilkjentYtelseUtils.beregnTilkjentYtelse(
-            vilkårsvurdering= vilkårsvurdering,
-            personopplysningGrunnlag= PersonopplysningGrunnlag(behandlingId= behandlingId.id, personer = mutableSetOf(søker, barn1, barn2)),
-            fagsakType = FagsakType.NORMAL
-        )
+        val tilkjentYtelse =
+            TilkjentYtelseUtils.beregnTilkjentYtelse(
+                vilkårsvurdering = vilkårsvurdering,
+                personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandlingId.id, personer = mutableSetOf(søker, barn1, barn2)),
+                fagsakType = FagsakType.NORMAL,
+            )
 
         every { vilkårsvurderingTidslinjeService.hentTidslinjerThrows(behandlingId) } returns vilkårsvurderingTidslinjer
         every { vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId) } returns TomTidslinje()
@@ -349,11 +350,12 @@ internal class KompetanseServiceTest {
                         .tilPersonEnkelSøkerOgBarn(),
             )
 
-        val tilkjentYtelse = TilkjentYtelseUtils.beregnTilkjentYtelse(
-            vilkårsvurdering= vilkårsvurdering,
-            personopplysningGrunnlag= PersonopplysningGrunnlag(behandlingId= behandlingId.id, personer = mutableSetOf(søker, barn1, barn2)),
-            fagsakType = FagsakType.NORMAL
-        )
+        val tilkjentYtelse =
+            TilkjentYtelseUtils.beregnTilkjentYtelse(
+                vilkårsvurdering = vilkårsvurdering,
+                personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandlingId.id, personer = mutableSetOf(søker, barn1, barn2)),
+                fagsakType = FagsakType.NORMAL,
+            )
 
         every { vilkårsvurderingTidslinjeService.hentTidslinjerThrows(behandlingId) } returns vilkårsvurderingTidslinjer
         every { endretUtbetalingAndelTidslinjeService.hentBarnasSkalIkkeUtbetalesTidslinjer(behandlingId) } returns emptyMap()
@@ -404,11 +406,12 @@ internal class KompetanseServiceTest {
                         .tilPersonEnkelSøkerOgBarn(),
             )
 
-        val tilkjentYtelse = TilkjentYtelseUtils.beregnTilkjentYtelse(
-            vilkårsvurdering= vilkårsvurdering,
-            personopplysningGrunnlag= PersonopplysningGrunnlag(behandlingId= behandlingId.id, personer = mutableSetOf(søker, barn1, barn2, barn3)),
-            fagsakType = FagsakType.NORMAL
-        )
+        val tilkjentYtelse =
+            TilkjentYtelseUtils.beregnTilkjentYtelse(
+                vilkårsvurdering = vilkårsvurdering,
+                personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandlingId.id, personer = mutableSetOf(søker, barn1, barn2, barn3)),
+                fagsakType = FagsakType.NORMAL,
+            )
 
         every { vilkårsvurderingTidslinjeService.hentTidslinjerThrows(behandlingId) } returns vilkårsvurderingTidslinjer
         every { vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId) } returns TomTidslinje()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -5,6 +5,9 @@ import io.mockk.mockk
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.tilPersonEnkelSøkerOgBarn
 import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseUtils
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassKompetanserTilRegelverkService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
@@ -14,8 +17,10 @@ import no.nav.familie.ba.sak.kjerne.eøs.util.mockPeriodeBarnSkjemaRepository
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.EndretUtbetalingAndelTidslinjeService
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjeService
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjer
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
@@ -36,6 +41,7 @@ internal class KompetanseServiceTest {
     val mockKompetanseRepository: PeriodeOgBarnSkjemaRepository<Kompetanse> = mockPeriodeBarnSkjemaRepository()
     val vilkårsvurderingTidslinjeService: VilkårsvurderingTidslinjeService = mockk()
     val endretUtbetalingAndelTidslinjeService: EndretUtbetalingAndelTidslinjeService = mockk()
+    val andelerTilkjentYtelseOgEndreteUtbetalingerService = mockk<AndelerTilkjentYtelseOgEndreteUtbetalingerService>()
     val unleashService: UnleashService = mockk()
 
     val kompetanseService =
@@ -46,11 +52,12 @@ internal class KompetanseServiceTest {
 
     val tilpassKompetanserTilRegelverkService =
         TilpassKompetanserTilRegelverkService(
-            vilkårsvurderingTidslinjeService,
-            endretUtbetalingAndelTidslinjeService,
-            unleashService,
-            mockKompetanseRepository,
-            emptyList(),
+            vilkårsvurderingTidslinjeService = vilkårsvurderingTidslinjeService,
+            endretUtbetalingAndelTidslinjeService = endretUtbetalingAndelTidslinjeService,
+            andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            unleashNext = unleashService,
+            kompetanseRepository = mockKompetanseRepository,
+            endringsabonnenter = emptyList(),
         )
 
     @BeforeEach
@@ -269,20 +276,29 @@ internal class KompetanseServiceTest {
 
         val forventedeKompetanser =
             KompetanseBuilder(treMånederSiden.neste(), behandlingId)
-                .medKompetanse("->", barn1, barn2)
+                .medKompetanse("------", barn1, barn2)
+                .medKompetanse("      ----", barn1)
                 .byggKompetanser()
 
+        val vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering()
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingTidslinjer(
-                vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
+                vilkårsvurdering = vilkårsvurdering,
                 søkerOgBarn =
                     lagTestPersonopplysningGrunnlag(behandlingId.id, søker, barn1, barn2)
                         .tilPersonEnkelSøkerOgBarn(),
             )
 
+        val tilkjentYtelse = TilkjentYtelseUtils.beregnTilkjentYtelse(
+            vilkårsvurdering= vilkårsvurdering,
+            personopplysningGrunnlag= PersonopplysningGrunnlag(behandlingId= behandlingId.id, personer = mutableSetOf(søker, barn1, barn2)),
+            fagsakType = FagsakType.NORMAL
+        )
+
         every { vilkårsvurderingTidslinjeService.hentTidslinjerThrows(behandlingId) } returns vilkårsvurderingTidslinjer
         every { vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId) } returns TomTidslinje()
         every { endretUtbetalingAndelTidslinjeService.hentBarnasSkalIkkeUtbetalesTidslinjer(behandlingId) } returns emptyMap()
+        every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
 
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 
@@ -321,20 +337,28 @@ internal class KompetanseServiceTest {
         val forventedeKompetanser =
             KompetanseBuilder(seksMånederSiden.neste(), behandlingId)
                 .medKompetanse("--", barn1, barn2) // Begge barna har 3 mnd EØS-regelverk før nå-tidspunktet
-                .medKompetanse("  ->", barn1) // Bare barn 1 har EØS-regelverk etter nå-tidspunktet
+                .medKompetanse("  --------", barn1) // Bare barn 1 har EØS-regelverk etter nå-tidspunktet
                 .byggKompetanser()
 
+        val vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering()
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingTidslinjer(
-                vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
+                vilkårsvurdering = vilkårsvurdering,
                 søkerOgBarn =
                     lagTestPersonopplysningGrunnlag(behandlingId.id, søker, barn1, barn2)
                         .tilPersonEnkelSøkerOgBarn(),
             )
 
+        val tilkjentYtelse = TilkjentYtelseUtils.beregnTilkjentYtelse(
+            vilkårsvurdering= vilkårsvurdering,
+            personopplysningGrunnlag= PersonopplysningGrunnlag(behandlingId= behandlingId.id, personer = mutableSetOf(søker, barn1, barn2)),
+            fagsakType = FagsakType.NORMAL
+        )
+
         every { vilkårsvurderingTidslinjeService.hentTidslinjerThrows(behandlingId) } returns vilkårsvurderingTidslinjer
         every { endretUtbetalingAndelTidslinjeService.hentBarnasSkalIkkeUtbetalesTidslinjer(behandlingId) } returns emptyMap()
         every { vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId) } returns TomTidslinje()
+        every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
 
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 
@@ -380,9 +404,16 @@ internal class KompetanseServiceTest {
                         .tilPersonEnkelSøkerOgBarn(),
             )
 
+        val tilkjentYtelse = TilkjentYtelseUtils.beregnTilkjentYtelse(
+            vilkårsvurdering= vilkårsvurdering,
+            personopplysningGrunnlag= PersonopplysningGrunnlag(behandlingId= behandlingId.id, personer = mutableSetOf(søker, barn1, barn2, barn3)),
+            fagsakType = FagsakType.NORMAL
+        )
+
         every { vilkårsvurderingTidslinjeService.hentTidslinjerThrows(behandlingId) } returns vilkårsvurderingTidslinjer
         every { vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId) } returns TomTidslinje()
         every { endretUtbetalingAndelTidslinjeService.hentBarnasSkalIkkeUtbetalesTidslinjer(behandlingId) } returns emptyMap()
+        every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
 
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.KompetanseBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.somBoolskTidslinje
@@ -52,7 +53,13 @@ class TilpassKompetanserTilRegelverkTest {
                 .byggKompetanser()
 
         val faktiskeKompetanser =
-            tilpassKompetanserTilRegelverk(kompetanser, eøsPerioder, emptyMap(), annenForelderOmfattetTidslinje)
+            tilpassKompetanserTilRegelverk(
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = eøsPerioder,
+                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+                annenForelderOmfattetAvNorskLovgivningTidslinje = annenForelderOmfattetTidslinje,
+                barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+            )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
@@ -68,7 +75,12 @@ class TilpassKompetanserTilRegelverkTest {
 
         val forventedeKompetanser = emptyList<Kompetanse>()
 
-        val faktiskeKompetanser = tilpassKompetanserTilRegelverk(kompetanser, eøsPerioder, emptyMap())
+        val faktiskeKompetanser = tilpassKompetanserTilRegelverk(
+            gjeldendeKompetanser = kompetanser,
+            barnaRegelverkTidslinjer = eøsPerioder,
+            barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+            barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+        )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
@@ -92,9 +104,10 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
-                kompetanser,
-                barnasRegelverkResultatTidslinjer,
-                emptyMap(),
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer,
+                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -122,9 +135,10 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
-                kompetanser,
-                barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
-                emptyMap(),
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
+                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -166,9 +180,10 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
-                kompetanser,
-                barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
-                emptyMap(),
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
+                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -192,9 +207,10 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
-                kompetanser,
-                barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
-                emptyMap(),
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
+                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -236,6 +252,7 @@ class TilpassKompetanserTilRegelverkTest {
                 kompetanser,
                 barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 emptyMap(),
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -268,9 +285,10 @@ class TilpassKompetanserTilRegelverkTest {
 
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
-                kompetanser,
-                barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
-                barnasHarEtterbetaling3År,
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
+                barnasSkalIkkeUtbetalesTidslinjer = barnasHarEtterbetaling3År,
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -58,7 +58,7 @@ class TilpassKompetanserTilRegelverkTest {
                 barnaRegelverkTidslinjer = eøsPerioder,
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
                 annenForelderOmfattetAvNorskLovgivningTidslinje = annenForelderOmfattetTidslinje,
-                barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -75,12 +75,13 @@ class TilpassKompetanserTilRegelverkTest {
 
         val forventedeKompetanser = emptyList<Kompetanse>()
 
-        val faktiskeKompetanser = tilpassKompetanserTilRegelverk(
-            gjeldendeKompetanser = kompetanser,
-            barnaRegelverkTidslinjer = eøsPerioder,
-            barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-            barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
-        )
+        val faktiskeKompetanser =
+            tilpassKompetanserTilRegelverk(
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = eøsPerioder,
+                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+                barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
+            )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
@@ -107,7 +108,7 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer,
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -138,7 +139,7 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -183,7 +184,7 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -210,7 +211,7 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -252,7 +253,7 @@ class TilpassKompetanserTilRegelverkTest {
                 kompetanser,
                 barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 emptyMap(),
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -288,7 +289,7 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = barnasHarEtterbetaling3År,
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -313,17 +314,18 @@ class TilpassKompetanserTilRegelverkTest {
                 .medKompetanse("   ---", barn1)
                 .byggKompetanser().sortedBy { it.fom }
 
-        val barnHarAndelTidslinjer = mapOf(
-            Pair(barn1.aktør, "tttttt".somBoolskTidslinje(jan2020)),
-            Pair(barn2.aktør, "ttt".somBoolskTidslinje(jan2020))
-        )
+        val barnHarAndelTidslinjer =
+            mapOf(
+                Pair(barn1.aktør, "tttttt".somBoolskTidslinje(jan2020)),
+                Pair(barn2.aktør, "ttt".somBoolskTidslinje(jan2020)),
+            )
 
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnHarAndelTidslinjer
+                barnHarAndelTidslinjer = barnHarAndelTidslinjer,
             ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -293,6 +293,41 @@ class TilpassKompetanserTilRegelverkTest {
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
+
+    @Test
+    fun `skal klippe kompetansen etter andelene slik at vi kun har kompetanse der vi har andeler på personen`() {
+        val kompetanser =
+            KompetanseBuilder(jan2020)
+                .medKompetanse("->", barn1, barn2)
+                .byggKompetanser()
+
+        val barnasRegelverkResultatTidslinjer =
+            mapOf(
+                barn1.aktør to "EEEEEEEEE".tilRegelverkResultatTidslinje(jan2020),
+                barn2.aktør to "EEEEEEEEE".tilRegelverkResultatTidslinje(jan2020),
+            )
+
+        val forventedeKompetanser =
+            KompetanseBuilder(jan2020)
+                .medKompetanse("---", barn1, barn2)
+                .medKompetanse("   ---", barn1)
+                .byggKompetanser().sortedBy { it.fom }
+
+        val barnHarAndelTidslinjer = mapOf(
+            Pair(barn1.aktør, "tttttt".somBoolskTidslinje(jan2020)),
+            Pair(barn2.aktør, "ttt".somBoolskTidslinje(jan2020))
+        )
+
+        val faktiskeKompetanser =
+            tilpassKompetanserTilRegelverk(
+                gjeldendeKompetanser = kompetanser,
+                barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
+                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
+                barnHarAndelTidslinjer = barnHarAndelTidslinjer
+            ).sortedBy { it.fom }
+
+        assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
+    }
 }
 
 private fun Tidslinje<RegelverkResultat, Måned>.kombinertSøkersResultatTidslinje(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
@@ -267,6 +267,7 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
+                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             )
 
         assertEquals(1, kompetanser.size)
@@ -318,6 +319,7 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
+                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             )
 
         val forventetRegelverkResultat =
@@ -373,6 +375,7 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
+                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
             )
 
         assertEquals(1, kompetanser.size)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
@@ -267,7 +267,7 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
-                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEquals(1, kompetanser.size)
@@ -319,7 +319,7 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
-                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         val forventetRegelverkResultat =
@@ -375,7 +375,7 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
-                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } }
+                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEquals(1, kompetanser.size)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17059

Del 1 av denne oppgaven ☝️ 
Når vi genererer kompetansene setter vi alltid siste periode til å være uendelig fram i tid. Dette skaper krøll når vi setter endret utbetaling til null kroner på grunn av endret mottaker ut behandlingen. Da vil vi få en kompetanse som starter etter at 18-årsdagen når den endrede utbetalingen avsluttes.  Se tegning.
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/261d3350-b6d3-4c5a-abbc-f4404bf3a192)

Endrer så vi fjerner kompetansen når vi ikke har noen andeler på personen, så slipper vi dette problemet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Dette fikser ikke at vi får feil farger i utbetalingstidslinjen på behandlingsresultatssiden når vi både har en nullutbetaling og endret utbetaling som er endret til null.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ]
