### PR TITLE
Slå sammen andeler til rest ytelse perioder riktig

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestTilkjentYtelse.kt
@@ -3,9 +3,8 @@ package no.nav.familie.ba.sak.ekstern.restDomene
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.slåSammenBack2BackAndelsperioderMedSammeBeløp
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilRestYtelsePerioder
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
-import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -32,23 +31,13 @@ fun PersonopplysningGrunnlag.tilRestPersonerMedAndeler(andelerKnyttetTilPersoner
             val personId = andelerForPerson.key
             val andeler = andelerForPerson.value
 
-            val sammenslåtteAndeler =
-                andeler.groupBy { it.type }.flatMap { it.value.slåSammenBack2BackAndelsperioderMedSammeBeløp() }
+            val ytelsePerioder = andeler.tilRestYtelsePerioder()
 
             RestPersonMedAndeler(
                 personIdent = this.søkerOgBarn.find { person -> person.aktør == personId }?.aktør?.aktivFødselsnummer(),
-                beløp = sammenslåtteAndeler.sumOf { it.kalkulertUtbetalingsbeløp },
-                stønadFom = sammenslåtteAndeler.map { it.stønadFom }.minOrNull() ?: LocalDate.MIN.toYearMonth(),
-                stønadTom = sammenslåtteAndeler.map { it.stønadTom }.maxOrNull() ?: LocalDate.MAX.toYearMonth(),
-                ytelsePerioder =
-                    sammenslåtteAndeler.map { it1 ->
-                        RestYtelsePeriode(
-                            beløp = it1.kalkulertUtbetalingsbeløp,
-                            stønadFom = it1.stønadFom,
-                            stønadTom = it1.stønadTom,
-                            ytelseType = it1.type,
-                            skalUtbetales = it1.prosent > BigDecimal.ZERO,
-                        )
-                    },
+                beløp = ytelsePerioder.sumOf { it.beløp },
+                stønadFom = ytelsePerioder.minOfOrNull { it.stønadFom } ?: LocalDate.MIN.toYearMonth(),
+                stønadTom = ytelsePerioder.maxOfOrNull { it.stønadTom } ?: LocalDate.MAX.toYearMonth(),
+                ytelsePerioder = ytelsePerioder,
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestTilkjentYtelse.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.ekstern.restDomene
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilRestYtelsePerioder
+import no.nav.familie.ba.sak.kjerne.beregning.tilRestYtelsePerioder
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import java.time.LocalDate
 import java.time.YearMonth

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -13,7 +13,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
-import no.nav.familie.ba.sak.kjerne.beregning.domene.RestYtelsePeriodeUtenDatoer
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.medEndring
@@ -325,6 +324,12 @@ internal data class BeregnetAndel(
     val beløp: Int,
     val sats: Int,
     val prosent: BigDecimal,
+)
+
+data class RestYtelsePeriodeUtenDatoer(
+    val kalkulertUtbetalingsbeløp: Int,
+    val ytelseType: YtelseType,
+    val skalUtbetales: Boolean,
 )
 
 fun List<AndelTilkjentYtelse>.tilRestYtelsePerioder(): List<RestYtelsePeriode> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -7,11 +7,13 @@ import no.nav.familie.ba.sak.common.erDagenFør
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.inkluderer
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
+import no.nav.familie.ba.sak.ekstern.restDomene.RestYtelsePeriode
 import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.finnUtvidetVilkår
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
+import no.nav.familie.ba.sak.kjerne.beregning.domene.RestYtelsePeriodeUtenDatoer
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.medEndring
@@ -21,6 +23,10 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
+import no.nav.familie.ba.sak.kjerne.tidslinje.månedPeriodeAv
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -320,3 +326,37 @@ internal data class BeregnetAndel(
     val sats: Int,
     val prosent: BigDecimal,
 )
+
+fun List<AndelTilkjentYtelse>.tilRestYtelsePerioder(): List<RestYtelsePeriode> {
+    val restYtelsePeriodeTidslinjePerAktørOgTypeSlåttSammen =
+        this.groupBy { Pair(it.aktør, it.type) }
+            .mapValues { (_, andelerTilkjentYtelse) ->
+                andelerTilkjentYtelse
+                    .tilRestYtelsePeriodeUtenDatoerTidslinje()
+                    .slåSammenLike()
+            }
+
+    return restYtelsePeriodeTidslinjePerAktørOgTypeSlåttSammen
+        .flatMap { (_, andelerTidslinje) -> andelerTidslinje.perioder() }
+        .mapNotNull { periode ->
+            periode.innhold?.let { innhold ->
+                RestYtelsePeriode(
+                    beløp = innhold.kalkulertUtbetalingsbeløp,
+                    stønadFom = periode.fraOgMed.tilYearMonth(),
+                    stønadTom = periode.tilOgMed.tilYearMonth(),
+                    ytelseType = innhold.ytelseType,
+                    skalUtbetales = innhold.skalUtbetales,
+                )
+            }
+        }
+}
+
+private fun List<AndelTilkjentYtelse>.tilRestYtelsePeriodeUtenDatoerTidslinje() =
+    this.map {
+        månedPeriodeAv(
+            fraOgMed = it.stønadFom,
+            tilOgMed = it.stønadTom,
+            innhold = RestYtelsePeriodeUtenDatoer(kalkulertUtbetalingsbeløp = it.kalkulertUtbetalingsbeløp, it.type, it.prosent > BigDecimal.ZERO),
+        )
+    }
+        .tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -194,12 +194,6 @@ data class AndelTilkjentYtelse(
             }
 }
 
-data class RestYtelsePeriodeUtenDatoer(
-    val kalkulertUtbetalingsbeløp: Int,
-    val ytelseType: YtelseType,
-    val skalUtbetales: Boolean,
-)
-
 fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.lagVertikaleSegmenter(): Map<LocalDateSegment<Int>, List<AndelTilkjentYtelseMedEndreteUtbetalinger>> {
     return this.utledSegmenter()
         .fold(mutableMapOf()) { acc, segment ->

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsTest.kt
@@ -1295,6 +1295,8 @@ internal class TilkjentYtelseUtilsTest {
             listOf(
                 lagAndelTilkjentYtelse(fom = årMnd("2020-03"), tom = årMnd("2020-12"), ytelseType = YtelseType.SMÅBARNSTILLEGG, beløp = 1234, prosent = BigDecimal.valueOf(100), aktør = aktør),
                 lagAndelTilkjentYtelse(fom = årMnd("2021-01"), tom = årMnd("2021-12"), ytelseType = YtelseType.UTVIDET_BARNETRYGD, beløp = 1234, prosent = BigDecimal.valueOf(100), aktør = aktør),
+                lagAndelTilkjentYtelse(fom = årMnd("2022-01"), tom = årMnd("2022-12"), ytelseType = YtelseType.UTVIDET_BARNETRYGD, beløp = 0, prosent = BigDecimal.valueOf(100), aktør = aktør),
+                lagAndelTilkjentYtelse(fom = årMnd("2023-01"), tom = årMnd("2023-12"), ytelseType = YtelseType.UTVIDET_BARNETRYGD, beløp = 0, prosent = BigDecimal.valueOf(0), aktør = aktør),
             )
 
         val restYtelsePerioder = andeler.tilRestYtelsePerioder()
@@ -1302,6 +1304,8 @@ internal class TilkjentYtelseUtilsTest {
             listOf(
                 RestYtelsePeriode(beløp = 1234, stønadFom = årMnd("2020-03"), stønadTom = årMnd("2020-12"), ytelseType = YtelseType.SMÅBARNSTILLEGG, skalUtbetales = true),
                 RestYtelsePeriode(beløp = 1234, stønadFom = årMnd("2021-01"), stønadTom = årMnd("2021-12"), ytelseType = YtelseType.UTVIDET_BARNETRYGD, skalUtbetales = true),
+                RestYtelsePeriode(beløp = 0, stønadFom = årMnd("2022-01"), stønadTom = årMnd("2022-12"), ytelseType = YtelseType.UTVIDET_BARNETRYGD, skalUtbetales = true),
+                RestYtelsePeriode(beløp = 0, stønadFom = årMnd("2023-01"), stønadTom = årMnd("2023-12"), ytelseType = YtelseType.UTVIDET_BARNETRYGD, skalUtbetales = false),
             )
         Assertions.assertThat(restYtelsePerioder).containsAll(forventetRestYtelsePerioder).hasSize(forventetRestYtelsePerioder.size)
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17059

Vi har et case der andelene i behandlingsresultatet vises feil siden vi ikke slår sammen periodene riktig. 
Endrer til å bruke tidslinjerammeverket til å slå sammen like perioder, så slipper vi å deale med dette selv. 


Leses enklest commit for commit. 