### PR TITLE
Bug: Fjern validering som jeg la til feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -130,18 +130,8 @@ class VilkårsvurderingTidslinjer(
 }
 
 fun VilkårsvurderingTidslinjer.harBlandetRegelverk(): Boolean {
-    return søkerHarNasjonalOgFinnesBarnMedEøs() ||
-        søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
+    return søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
         barnasTidslinjer().values.any { it.egetRegelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) }
-}
-
-private fun VilkårsvurderingTidslinjer.søkerHarNasjonalOgFinnesBarnMedEøs(): Boolean {
-    return søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_NASJONALE_REGLER) &&
-        barnasTidslinjer().values.any {
-            it.egetRegelverkResultatTidslinje.inneholder(
-                RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN,
-            )
-        }
 }
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.inneholder(innhold: I): Boolean =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Valideringen sjekker om det finnes nasjonal på søker og eøs på barn generelt, men skulle ha vært i en spesifikk periode. Har en fiks på det andre klart, men fjerne fordi det tar litt tid å teste at det andre er riktig. Stopper opp noen saker.

Revert av #4279 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
