### PR TITLE
Valider at søker ikke har nasjonal i en periode minst ett barn har eøs

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -130,8 +130,17 @@ class VilkårsvurderingTidslinjer(
 }
 
 fun VilkårsvurderingTidslinjer.harBlandetRegelverk(): Boolean {
-    return søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
+    return this.søkerHarNasjonalOgFinnesBarnMedEøs() ||
+        søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
         barnasTidslinjer().values.any { it.egetRegelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) }
+}
+
+private fun VilkårsvurderingTidslinjer.søkerHarNasjonalOgFinnesBarnMedEøs(): Boolean {
+    return barnasTidslinjer().values.any {
+        it.egetRegelverkResultatTidslinje.kombinerMed(søkersTidslinjer().regelverkResultatTidslinje) { barnRegelverk, søkerRegelverk ->
+            barnRegelverk == RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN && søkerRegelverk == RegelverkResultat.OPPFYLT_NASJONALE_REGLER
+        }.inneholder(true)
+    }
 }
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.inneholder(innhold: I): Boolean =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1122,7 +1122,6 @@ fun lagVilkårResultat(
     utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = emptyList(),
     erEksplisittAvslagPåSøknad: Boolean = false,
     standardbegrunnelser: List<IVedtakBegrunnelse> = emptyList(),
-    vurderesEtter: Regelverk = Regelverk.NASJONALE_REGLER,
 ) = VilkårResultat(
     personResultat = personResultat,
     vilkårType = vilkårType,
@@ -1134,7 +1133,6 @@ fun lagVilkårResultat(
     utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
     erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
     standardbegrunnelser = standardbegrunnelser,
-    vurderesEtter = vurderesEtter,
 )
 
 val guttenBarnesenFødselsdato = LocalDate.now().withDayOfMonth(10).minusYears(6)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -570,6 +570,7 @@ fun lagPersonResultat(
     erDeltBosted: Boolean = false,
     erDeltBostedSkalIkkeDeles: Boolean = false,
     erEksplisittAvslagPåSøknad: Boolean? = null,
+    vurderesEtter: Regelverk = Regelverk.NASJONALE_REGLER
 ): PersonResultat {
     val personResultat =
         PersonResultat(
@@ -601,6 +602,7 @@ fun lagPersonResultat(
                             },
                         ),
                     erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
+                    vurderesEtter = vurderesEtter
                 )
             }.toSet(),
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1122,7 +1122,7 @@ fun lagVilkårResultat(
     utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = emptyList(),
     erEksplisittAvslagPåSøknad: Boolean = false,
     standardbegrunnelser: List<IVedtakBegrunnelse> = emptyList(),
-    vurderesEtter: Regelverk = Regelverk.NASJONALE_REGLER
+    vurderesEtter: Regelverk = Regelverk.NASJONALE_REGLER,
 ) = VilkårResultat(
     personResultat = personResultat,
     vilkårType = vilkårType,
@@ -1134,7 +1134,7 @@ fun lagVilkårResultat(
     utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
     erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
     standardbegrunnelser = standardbegrunnelser,
-    vurderesEtter = vurderesEtter
+    vurderesEtter = vurderesEtter,
 )
 
 val guttenBarnesenFødselsdato = LocalDate.now().withDayOfMonth(10).minusYears(6)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1124,6 +1124,7 @@ fun lagVilkårResultat(
     utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = emptyList(),
     erEksplisittAvslagPåSøknad: Boolean = false,
     standardbegrunnelser: List<IVedtakBegrunnelse> = emptyList(),
+    vurderesEtter: Regelverk = Regelverk.NASJONALE_REGLER
 ) = VilkårResultat(
     personResultat = personResultat,
     vilkårType = vilkårType,
@@ -1135,6 +1136,7 @@ fun lagVilkårResultat(
     utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
     erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
     standardbegrunnelser = standardbegrunnelser,
+    vurderesEtter = vurderesEtter
 )
 
 val guttenBarnesenFødselsdato = LocalDate.now().withDayOfMonth(10).minusYears(6)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -570,7 +570,6 @@ fun lagPersonResultat(
     erDeltBosted: Boolean = false,
     erDeltBostedSkalIkkeDeles: Boolean = false,
     erEksplisittAvslagPåSøknad: Boolean? = null,
-    vurderesEtter: Regelverk = Regelverk.NASJONALE_REGLER
 ): PersonResultat {
     val personResultat =
         PersonResultat(
@@ -602,7 +601,6 @@ fun lagPersonResultat(
                             },
                         ),
                     erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
-                    vurderesEtter = vurderesEtter
                 )
             }.toSet(),
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
@@ -3,16 +3,18 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
-import no.nav.familie.ba.sak.common.lagPersonResultat
-import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -27,9 +29,9 @@ class VilkårsvurderingValideringTest {
         val søker = lagPersonEnkel(PersonType.SØKER)
         val barn1 = lagPersonEnkel(PersonType.BARN)
         val barn2 = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPerson(søker, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
-        val personResultatBarn1 = byggPersonResultatForPerson(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn2 = byggPersonResultatForPerson(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+        val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+        val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        val personResultatBarn2 = byggPersonResultatForPersonEnkel(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
 
         vilkårsvurdering.personResultater = setOf(
             personResultatSøker,
@@ -37,7 +39,12 @@ class VilkårsvurderingValideringTest {
             personResultatBarn2
         )
 
-        assertThrows<FunksjonellFeil> { validerIkkeBlandetRegelverk(vilkårsvurdering = vilkårsvurdering, søkerOgBarn = listOf(søker, barn1, barn2)) }
+        assertThrows<FunksjonellFeil> {
+            validerIkkeBlandetRegelverk(
+                vilkårsvurdering = vilkårsvurdering,
+                søkerOgBarn = listOf(søker, barn1, barn2)
+            )
+        }
     }
 
     @Test
@@ -45,15 +52,20 @@ class VilkårsvurderingValideringTest {
         val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
         val søker = lagPersonEnkel(PersonType.SØKER)
         val barn1 = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPerson(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn1 = byggPersonResultatForPerson(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
 
         vilkårsvurdering.personResultater = setOf(
             personResultatSøker,
             personResultatBarn1
         )
 
-        assertDoesNotThrow { validerIkkeBlandetRegelverk(vilkårsvurdering = vilkårsvurdering, søkerOgBarn = listOf(søker, barn1)) }
+        assertDoesNotThrow {
+            validerIkkeBlandetRegelverk(
+                vilkårsvurdering = vilkårsvurdering,
+                søkerOgBarn = listOf(søker, barn1)
+            )
+        }
     }
 
     @Test
@@ -61,8 +73,8 @@ class VilkårsvurderingValideringTest {
         val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
         val søker = lagPersonEnkel(PersonType.SØKER)
         val barn1 = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPerson(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn1 = byggPersonResultatForPerson(barn1, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+        val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
 
         vilkårsvurdering.personResultater = setOf(
             personResultatSøker,
@@ -82,29 +94,23 @@ class VilkårsvurderingValideringTest {
         val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
         val søker = lagPersonEnkel(PersonType.SØKER)
         val barn = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPerson(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn = byggPersonResultatForPerson(barn, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
 
-        val ekstraPeriodeSøker = lagVilkårResultat(
-            personResultat = personResultatSøker,
-            vilkårType = Vilkår.BOSATT_I_RIKET,
-            periodeFom = LocalDate.now().minusMonths(1).plusDays(1),
-            periodeTom = null,
-            resultat = Resultat.OPPFYLT,
-            vurderesEtter = Regelverk.NASJONALE_REGLER
+        val vilkårPerioder = listOf(
+            VilkårPeriode(
+                regelverk = Regelverk.EØS_FORORDNINGEN,
+                fom = LocalDate.now().minusMonths(9),
+                tom = LocalDate.now().minusMonths(1)
+            ),
+            VilkårPeriode(
+                regelverk = Regelverk.NASJONALE_REGLER,
+                fom = LocalDate.now().minusMonths(1).plusMonths(1),
+                tom = null
+            )
         )
 
-        val ekstraPeriodeBarn = lagVilkårResultat(
-            personResultat = personResultatBarn,
-            vilkårType = Vilkår.BOSATT_I_RIKET,
-            periodeFom = LocalDate.now().minusMonths(1).plusDays(1),
-            periodeTom = null,
-            resultat = Resultat.OPPFYLT,
-            vurderesEtter = Regelverk.NASJONALE_REGLER
-        )
+        val personResultatSøker = byggPersonResultatForPersonIPerioder(søker, vilkårPerioder, vilkårsvurdering)
+        val personResultatBarn = byggPersonResultatForPersonIPerioder(barn, vilkårPerioder, vilkårsvurdering)
 
-        personResultatSøker.addVilkårResultat(ekstraPeriodeSøker)
-        personResultatBarn.addVilkårResultat(ekstraPeriodeBarn)
 
         vilkårsvurdering.personResultater = setOf(
             personResultatSøker,
@@ -119,28 +125,87 @@ class VilkårsvurderingValideringTest {
         }
     }
 
-    private fun byggPersonResultatForPerson(
+    private fun byggPersonResultatForPersonEnkel(
         person: PersonEnkel,
         regelverk: Regelverk,
         vilkårsvurdering: Vilkårsvurdering
     ): PersonResultat {
-        return lagPersonResultat(
+        val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = person.aktør)
+        val vilkårResultater = lagVilkårResultatForPersonIPeriode(
             vilkårsvurdering = vilkårsvurdering,
             person = lagPerson(type = person.type, aktør = person.aktør),
             periodeFom = LocalDate.now().minusMonths(2),
             periodeTom = LocalDate.now().minusMonths(1),
-            resultat = Resultat.OPPFYLT,
             vurderesEtter = regelverk,
-            lagFullstendigVilkårResultat = true
+            personResultat = personResultat
         )
+
+        personResultat.setSortedVilkårResultater(vilkårResultater)
+
+        return personResultat
     }
 
-    private fun lagPersonEnkel(personType: PersonType): PersonEnkel{
+    private data class VilkårPeriode(
+        val fom: LocalDate,
+        val tom: LocalDate?,
+        val regelverk: Regelverk
+    )
+
+    private fun byggPersonResultatForPersonIPerioder(
+        person: PersonEnkel,
+        perioder: List<VilkårPeriode>,
+        vilkårsvurdering: Vilkårsvurdering
+    ): PersonResultat {
+        val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = person.aktør)
+        val vilkårResultater = perioder.flatMap {
+            lagVilkårResultatForPersonIPeriode(
+                vilkårsvurdering = vilkårsvurdering,
+                person = lagPerson(type = person.type, aktør = person.aktør),
+                periodeFom = it.fom,
+                periodeTom = it.tom,
+                vurderesEtter = it.regelverk,
+                personResultat = personResultat
+            )
+        }.toSet()
+
+        personResultat.setSortedVilkårResultater(vilkårResultater)
+
+        return personResultat
+    }
+
+    private fun lagVilkårResultatForPersonIPeriode(
+        person: Person,
+        personResultat: PersonResultat,
+        vilkårsvurdering: Vilkårsvurdering,
+        periodeFom: LocalDate,
+        periodeTom: LocalDate?,
+        vurderesEtter: Regelverk
+    ): Set<VilkårResultat> {
+        return Vilkår.hentVilkårFor(
+            personType = person.type,
+            fagsakType = FagsakType.NORMAL,
+            behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
+        ).map {
+            VilkårResultat(
+                personResultat = personResultat,
+                periodeFom = if (it.gjelderAlltidFraBarnetsFødselsdato()) person.fødselsdato else periodeFom,
+                periodeTom = periodeTom,
+                vilkårType = it,
+                resultat = Resultat.OPPFYLT,
+                begrunnelse = "",
+                sistEndretIBehandlingId = vilkårsvurdering.behandling.id,
+                vurderesEtter = vurderesEtter
+            )
+        }.toSet()
+    }
+
+    private fun lagPersonEnkel(personType: PersonType): PersonEnkel {
         return PersonEnkel(
             type = personType,
             aktør = randomAktør(),
             dødsfallDato = null,
-            fødselsdato = if (personType == PersonType.SØKER) LocalDate.now().minusYears(34) else LocalDate.now().minusYears(4),
+            fødselsdato = if (personType == PersonType.SØKER) LocalDate.now().minusYears(34) else LocalDate.now()
+                .minusYears(4),
             målform = Målform.NB
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 
 class VilkårsvurderingValideringTest {
-
     @Test
     fun `skal kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS`() {
         val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
@@ -33,16 +32,17 @@ class VilkårsvurderingValideringTest {
         val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
         val personResultatBarn2 = byggPersonResultatForPersonEnkel(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
 
-        vilkårsvurdering.personResultater = setOf(
-            personResultatSøker,
-            personResultatBarn1,
-            personResultatBarn2
-        )
+        vilkårsvurdering.personResultater =
+            setOf(
+                personResultatSøker,
+                personResultatBarn1,
+                personResultatBarn2,
+            )
 
         assertThrows<FunksjonellFeil> {
             validerIkkeBlandetRegelverk(
                 vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn1, barn2)
+                søkerOgBarn = listOf(søker, barn1, barn2),
             )
         }
     }
@@ -55,15 +55,16 @@ class VilkårsvurderingValideringTest {
         val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
         val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
 
-        vilkårsvurdering.personResultater = setOf(
-            personResultatSøker,
-            personResultatBarn1
-        )
+        vilkårsvurdering.personResultater =
+            setOf(
+                personResultatSøker,
+                personResultatBarn1,
+            )
 
         assertDoesNotThrow {
             validerIkkeBlandetRegelverk(
                 vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn1)
+                søkerOgBarn = listOf(søker, barn1),
             )
         }
     }
@@ -76,15 +77,16 @@ class VilkårsvurderingValideringTest {
         val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
         val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
 
-        vilkårsvurdering.personResultater = setOf(
-            personResultatSøker,
-            personResultatBarn1
-        )
+        vilkårsvurdering.personResultater =
+            setOf(
+                personResultatSøker,
+                personResultatBarn1,
+            )
 
         assertDoesNotThrow {
             validerIkkeBlandetRegelverk(
                 vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn1)
+                søkerOgBarn = listOf(søker, barn1),
             )
         }
     }
@@ -95,32 +97,33 @@ class VilkårsvurderingValideringTest {
         val søker = lagPersonEnkel(PersonType.SØKER)
         val barn = lagPersonEnkel(PersonType.BARN)
 
-        val vilkårPerioder = listOf(
-            VilkårPeriode(
-                regelverk = Regelverk.EØS_FORORDNINGEN,
-                fom = LocalDate.now().minusMonths(9),
-                tom = LocalDate.now().minusMonths(1)
-            ),
-            VilkårPeriode(
-                regelverk = Regelverk.NASJONALE_REGLER,
-                fom = LocalDate.now().minusMonths(1).plusMonths(1),
-                tom = null
+        val vilkårPerioder =
+            listOf(
+                VilkårPeriode(
+                    regelverk = Regelverk.EØS_FORORDNINGEN,
+                    fom = LocalDate.now().minusMonths(9),
+                    tom = LocalDate.now().minusMonths(1),
+                ),
+                VilkårPeriode(
+                    regelverk = Regelverk.NASJONALE_REGLER,
+                    fom = LocalDate.now().minusMonths(1).plusMonths(1),
+                    tom = null,
+                ),
             )
-        )
 
         val personResultatSøker = byggPersonResultatForPersonIPerioder(søker, vilkårPerioder, vilkårsvurdering)
         val personResultatBarn = byggPersonResultatForPersonIPerioder(barn, vilkårPerioder, vilkårsvurdering)
 
-
-        vilkårsvurdering.personResultater = setOf(
-            personResultatSøker,
-            personResultatBarn,
-        )
+        vilkårsvurdering.personResultater =
+            setOf(
+                personResultatSøker,
+                personResultatBarn,
+            )
 
         assertDoesNotThrow {
             validerIkkeBlandetRegelverk(
                 vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn)
+                søkerOgBarn = listOf(søker, barn),
             )
         }
     }
@@ -128,17 +131,18 @@ class VilkårsvurderingValideringTest {
     private fun byggPersonResultatForPersonEnkel(
         person: PersonEnkel,
         regelverk: Regelverk,
-        vilkårsvurdering: Vilkårsvurdering
+        vilkårsvurdering: Vilkårsvurdering,
     ): PersonResultat {
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = person.aktør)
-        val vilkårResultater = lagVilkårResultatForPersonIPeriode(
-            vilkårsvurdering = vilkårsvurdering,
-            person = lagPerson(type = person.type, aktør = person.aktør),
-            periodeFom = LocalDate.now().minusMonths(2),
-            periodeTom = LocalDate.now().minusMonths(1),
-            vurderesEtter = regelverk,
-            personResultat = personResultat
-        )
+        val vilkårResultater =
+            lagVilkårResultatForPersonIPeriode(
+                vilkårsvurdering = vilkårsvurdering,
+                person = lagPerson(type = person.type, aktør = person.aktør),
+                periodeFom = LocalDate.now().minusMonths(2),
+                periodeTom = LocalDate.now().minusMonths(1),
+                vurderesEtter = regelverk,
+                personResultat = personResultat,
+            )
 
         personResultat.setSortedVilkårResultater(vilkårResultater)
 
@@ -148,25 +152,26 @@ class VilkårsvurderingValideringTest {
     private data class VilkårPeriode(
         val fom: LocalDate,
         val tom: LocalDate?,
-        val regelverk: Regelverk
+        val regelverk: Regelverk,
     )
 
     private fun byggPersonResultatForPersonIPerioder(
         person: PersonEnkel,
         perioder: List<VilkårPeriode>,
-        vilkårsvurdering: Vilkårsvurdering
+        vilkårsvurdering: Vilkårsvurdering,
     ): PersonResultat {
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = person.aktør)
-        val vilkårResultater = perioder.flatMap {
-            lagVilkårResultatForPersonIPeriode(
-                vilkårsvurdering = vilkårsvurdering,
-                person = lagPerson(type = person.type, aktør = person.aktør),
-                periodeFom = it.fom,
-                periodeTom = it.tom,
-                vurderesEtter = it.regelverk,
-                personResultat = personResultat
-            )
-        }.toSet()
+        val vilkårResultater =
+            perioder.flatMap {
+                lagVilkårResultatForPersonIPeriode(
+                    vilkårsvurdering = vilkårsvurdering,
+                    person = lagPerson(type = person.type, aktør = person.aktør),
+                    periodeFom = it.fom,
+                    periodeTom = it.tom,
+                    vurderesEtter = it.regelverk,
+                    personResultat = personResultat,
+                )
+            }.toSet()
 
         personResultat.setSortedVilkårResultater(vilkårResultater)
 
@@ -179,7 +184,7 @@ class VilkårsvurderingValideringTest {
         vilkårsvurdering: Vilkårsvurdering,
         periodeFom: LocalDate,
         periodeTom: LocalDate?,
-        vurderesEtter: Regelverk
+        vurderesEtter: Regelverk,
     ): Set<VilkårResultat> {
         return Vilkår.hentVilkårFor(
             personType = person.type,
@@ -194,7 +199,7 @@ class VilkårsvurderingValideringTest {
                 resultat = Resultat.OPPFYLT,
                 begrunnelse = "",
                 sistEndretIBehandlingId = vilkårsvurdering.behandling.id,
-                vurderesEtter = vurderesEtter
+                vurderesEtter = vurderesEtter,
             )
         }.toSet()
     }
@@ -204,9 +209,14 @@ class VilkårsvurderingValideringTest {
             type = personType,
             aktør = randomAktør(),
             dødsfallDato = null,
-            fødselsdato = if (personType == PersonType.SØKER) LocalDate.now().minusYears(34) else LocalDate.now()
-                .minusYears(4),
-            målform = Målform.NB
+            fødselsdato =
+                if (personType == PersonType.SØKER) {
+                    LocalDate.now().minusYears(34)
+                } else {
+                    LocalDate.now()
+                        .minusYears(4)
+                },
+            målform = Målform.NB,
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
@@ -1,0 +1,94 @@
+package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
+
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.common.lagPersonResultat
+import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class VilkårsvurderingValideringTest {
+
+    @Test
+    fun `skal kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS`() {
+        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+        val søker = lagPersonEnkel(PersonType.SØKER)
+        val barn1 = lagPersonEnkel(PersonType.BARN)
+        val barn2 = lagPersonEnkel(PersonType.BARN)
+        val personResultatSøker = byggPersonResultatForPerson(søker, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+        val personResultatBarn1 = byggPersonResultatForPerson(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        val personResultatBarn2 = byggPersonResultatForPerson(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+
+        vilkårsvurdering.personResultater = setOf(
+            personResultatSøker,
+            personResultatBarn1,
+            personResultatBarn2
+        )
+
+        assertThrows<FunksjonellFeil> { validerIkkeBlandetRegelverk(vilkårsvurdering = vilkårsvurdering, søkerOgBarn = listOf(søker, barn1, barn2)) }
+    }
+
+    @Test
+    fun `skal ikke kaste feil hvis både søker og barn vurderes etter eøs`() {
+        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+        val søker = lagPersonEnkel(PersonType.SØKER)
+        val barn1 = lagPersonEnkel(PersonType.BARN)
+        val personResultatSøker = byggPersonResultatForPerson(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        val personResultatBarn1 = byggPersonResultatForPerson(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+
+        vilkårsvurdering.personResultater = setOf(
+            personResultatSøker,
+            personResultatBarn1
+        )
+
+        assertDoesNotThrow { validerIkkeBlandetRegelverk(vilkårsvurdering = vilkårsvurdering, søkerOgBarn = listOf(søker, barn1)) }
+    }
+
+    @Test
+    fun `skal ikke kaste feil hvis søker vurderes etter eøs, men barn vurderes etter nasjonal`() {
+        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+        val søker = lagPersonEnkel(PersonType.SØKER)
+        val barn1 = lagPersonEnkel(PersonType.BARN)
+        val personResultatSøker = byggPersonResultatForPerson(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        val personResultatBarn1 = byggPersonResultatForPerson(barn1, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+
+        vilkårsvurdering.personResultater = setOf(
+            personResultatSøker,
+            personResultatBarn1
+        )
+
+        assertDoesNotThrow { validerIkkeBlandetRegelverk(vilkårsvurdering = vilkårsvurdering, søkerOgBarn = listOf(søker, barn1)) }
+    }
+
+    private fun byggPersonResultatForPerson(person: PersonEnkel, regelverk: Regelverk, vilkårsvurdering: Vilkårsvurdering): PersonResultat{
+        return lagPersonResultat(
+            vilkårsvurdering = vilkårsvurdering,
+            person = lagPerson(type = person.type, aktør = person.aktør),
+            periodeFom = LocalDate.now().minusMonths(2),
+            periodeTom = null,
+            resultat = Resultat.OPPFYLT,
+            vurderesEtter = regelverk,
+            lagFullstendigVilkårResultat = true
+        )
+    }
+
+    private fun lagPersonEnkel(personType: PersonType): PersonEnkel{
+        return PersonEnkel(
+            type = personType,
+            aktør = randomAktør(),
+            dødsfallDato = null,
+            fødselsdato = if (personType == PersonType.SØKER) LocalDate.now().minusYears(34) else LocalDate.now().minusYears(4),
+            målform = Målform.NB
+        )
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17560

Ny fiks som sørger for at validering kicker inn hvis søker har nasjonal i en periode minst ett barn har EØS. Hadde tidligere en fiks på problemet, som skapte feil, fordi jeg sjekket om søker hadde nasjonal og det fantes barn med EØS. Problemet var at jeg ikke sjekket I EN PERIODE, men generelt 😅 revertet endringene for å sørge for at det ikke var feil i produksjon så lenge, men denne PRen er egentlig bare en bugfix på det

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har testet manuelt at det funker og at det ikke brekker det som ble feil sist

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
