### PR TITLE
Opprett kun 1 rad i satsendring ved oppretting av task

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/Batch.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/Batch.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
@@ -10,10 +9,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
-import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import java.time.LocalDate
 
-@EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "Batch")
 @Table(name = "BATCH")
 data class Batch(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -139,11 +139,13 @@ class StegService(
         check(nyBehandling.behandlingÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO)
 
         if (!satsendringService.erFagsakOppdatertMedSisteSatser(fagsakId = nyBehandling.fagsakId)) {
-            if (satskjøringRepository.findByFagsakIdAndSatsTidspunkt(nyBehandling.fagsakId, StartSatsendring.hentAktivSatsendringstidspunkt()) == null) {
+            val satskjøring = satskjøringRepository.findByFagsakIdAndSatsTidspunkt(nyBehandling.fagsakId, StartSatsendring.hentAktivSatsendringstidspunkt())
+            if (satskjøring == null) {
+                opprettTaskService.opprettSatsendringTask(fagsakId = nyBehandling.fagsakId, satstidspunkt = StartSatsendring.hentAktivSatsendringstidspunkt())
+                throw FunksjonellFeil("Fagsaken har ikke siste sats. Det har automatisk blitt opprettet en behandling for satsendring. Vent til den er ferdig behandlet før du endrer migreringsdato.")
+            } else if (satskjøring.ferdigTidspunkt == null) {
                 throw FunksjonellFeil("Det kjøres satsendring på fagsaken. Vennligst prøv igjen senere")
             }
-            opprettTaskService.opprettSatsendringTask(fagsakId = nyBehandling.fagsakId, satstidspunkt = StartSatsendring.hentAktivSatsendringstidspunkt())
-            throw FunksjonellFeil("Fagsaken har ikke siste sats. Det har automatisk blitt opprettet en behandling for satsendring. Vent til den er ferdig behandlet før du endrer migreringsdato.")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdFeedService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.SatsendringService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
@@ -65,6 +66,7 @@ class StegService(
     private val personopplysningerService: PersonopplysningerService,
     private val automatiskBeslutningService: AutomatiskBeslutningService,
     private val opprettTaskService: OpprettTaskService,
+    private val satskjøringRepository: SatskjøringRepository,
 ) {
     private val stegSuksessMetrics: Map<StegType, Counter> = initStegMetrikker("suksess")
 
@@ -137,6 +139,9 @@ class StegService(
         check(nyBehandling.behandlingÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO)
 
         if (!satsendringService.erFagsakOppdatertMedSisteSatser(fagsakId = nyBehandling.fagsakId)) {
+            if (satskjøringRepository.findByFagsakIdAndSatsTidspunkt(nyBehandling.fagsakId, StartSatsendring.hentAktivSatsendringstidspunkt()) == null) {
+                throw FunksjonellFeil("Det kjøres satsendring på fagsaken. Vennligst prøv igjen senere")
+            }
             opprettTaskService.opprettSatsendringTask(fagsakId = nyBehandling.fagsakId, satstidspunkt = StartSatsendring.hentAktivSatsendringstidspunkt())
             throw FunksjonellFeil("Fagsaken har ikke siste sats. Det har automatisk blitt opprettet en behandling for satsendring. Vent til den er ferdig behandlet før du endrer migreringsdato.")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -131,7 +131,9 @@ class OpprettTaskService(
         fagsakId: Long,
         satstidspunkt: YearMonth,
     ) {
-        satskjøringRepository.save(Satskjøring(fagsakId = fagsakId, satsTidspunkt = satstidspunkt))
+        if (satskjøringRepository.findByFagsakIdAndSatsTidspunkt(fagsakId, satstidspunkt) == null) {
+            satskjøringRepository.save(Satskjøring(fagsakId = fagsakId, satsTidspunkt = satstidspunkt))
+        }
         overstyrTaskMedNyCallId(IdUtils.generateId()) {
             taskRepository.save(
                 Task(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -42,6 +42,7 @@ internal class StartSatsendringTest {
     fun setUp() {
         val satsSlot = slot<Satskjøring>()
         every { satskjøringRepository.save(capture(satsSlot)) } answers { satsSlot.captured }
+        every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(any(), any()) } returns null
         val taskSlot = slot<Task>()
         every { taskRepository.save(capture(taskSlot)) } answers { taskSlot.captured }
         val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -44,6 +44,7 @@ internal class StegServiceTest {
             personopplysningerService = mockk(),
             automatiskBeslutningService = mockk(),
             opprettTaskService = opprettTaskService,
+            satskjøringRepository = mockk(relaxed = true),
         )
 
     @BeforeEach

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -130,7 +130,7 @@ internal class StegServiceTest {
     }
 
     @Test
-    fun `Skal ikke trugge ny satsendring dersom vi har en gammel sats på forrige iverksatte behandling på endre migreringsdato behandling, og satsendring allerede er trigget`() {
+    fun `Skal ikke trigge ny satsendring dersom vi har en gammel sats på forrige iverksatte behandling på endre migreringsdato behandling, og satsendring allerede er trigget`() {
         every { satsendringService.erFagsakOppdatertMedSisteSatser(any()) } returns false
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(any(), any()) } returns Satskjøring(fagsakId = 1, startTidspunkt = LocalDateTime.now(), satsTidspunkt = YearMonth.now())
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner rollestyring fra batch for den blokker for å oppprette konsitensavstemming gjennom forvaltertjenesten som forvalter

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
