### PR TITLE
Fjerner rollestyring fra batch-tabellen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/Batch.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/Batch.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
@@ -10,10 +9,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
-import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import java.time.LocalDate
 
-@EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "Batch")
 @Table(name = "BATCH")
 data class Batch(


### PR DESCRIPTION
Fjerner rollestyring fra batch-tabellen. Siden den blokker for å opprette konsistensavstemming gjennom forvaltertjenesten med forvalter som rolle, og tabellen ikke er i bruk i saksbehandlerkontext.
