### PR TITLE
Fiks kompetanseperioder ved stans av ytelse pga endret utbetaling

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -35,7 +35,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 internal class KompetanseServiceTest {
@@ -55,7 +54,6 @@ internal class KompetanseServiceTest {
         TilpassKompetanserTilRegelverkService(
             vilkårsvurderingTidslinjeService = vilkårsvurderingTidslinjeService,
             endretUtbetalingAndelTidslinjeService = endretUtbetalingAndelTidslinjeService,
-            andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
             unleashNext = unleashService,
             kompetanseRepository = mockKompetanseRepository,
             endringsabonnenter = emptyList(),
@@ -248,7 +246,6 @@ internal class KompetanseServiceTest {
     }
 
     @Test
-    @Disabled
     fun `kompetanse skal vare uendelig når til regelverk-tidslinjer fortsetter etter nåtidspunktet`() {
         val behandlingId = BehandlingId(10L)
 
@@ -278,8 +275,7 @@ internal class KompetanseServiceTest {
 
         val forventedeKompetanser =
             KompetanseBuilder(treMånederSiden.neste(), behandlingId)
-                .medKompetanse("------", barn1, barn2)
-                .medKompetanse("      ----", barn1)
+                .medKompetanse("->", barn1, barn2)
                 .byggKompetanser()
 
         val vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering()
@@ -310,7 +306,6 @@ internal class KompetanseServiceTest {
     }
 
     @Test
-    @Disabled
     fun `kompetanse skal ha sluttdato når til regelverk-tidslinjer avsluttes før nåtidspunktet`() {
         val behandlingId = BehandlingId(10L)
 
@@ -341,7 +336,7 @@ internal class KompetanseServiceTest {
         val forventedeKompetanser =
             KompetanseBuilder(seksMånederSiden.neste(), behandlingId)
                 .medKompetanse("--", barn1, barn2) // Begge barna har 3 mnd EØS-regelverk før nå-tidspunktet
-                .medKompetanse("  --------", barn1) // Bare barn 1 har EØS-regelverk etter nå-tidspunktet
+                .medKompetanse("  ->", barn1) // Bare barn 1 har EØS-regelverk etter nå-tidspunktet
                 .byggKompetanser()
 
         val vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -287,8 +287,7 @@ class TilpassKompetanserTilRegelverkTest {
     }
 
     @Test
-    @Disabled
-    fun `skal klippe kompetansen etter andelene slik at vi kun har kompetanse der vi har andeler på personen`() {
+    fun `skal klippe kompetansene basert på endret utbetaling som fører til stans av utbetaling`() {
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("->", barn1, barn2)
@@ -300,25 +299,23 @@ class TilpassKompetanserTilRegelverkTest {
                 barn2.aktør to "EEEEEEEEE".tilRegelverkResultatTidslinje(jan2020),
             )
 
-        val forventedeKompetanser =
-            KompetanseBuilder(jan2020)
-                .medKompetanse("---", barn1, barn2)
-                .medKompetanse("   ---", barn1)
-                .byggKompetanser().sortedBy { it.fom }
-
-        val barnHarAndelTidslinjer =
+        val barnasSkalIkkeUtbetalesTidslinjer =
             mapOf(
-                Pair(barn1.aktør, "tttttt".somBoolskTidslinje(jan2020)),
-                Pair(barn2.aktør, "ttt".somBoolskTidslinje(jan2020)),
+                Pair(barn1.aktør, "     tttt".somBoolskTidslinje(jan2020)),
             )
 
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
-                barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnHarAndelTidslinjer,
+                barnasSkalIkkeUtbetalesTidslinjer = barnasSkalIkkeUtbetalesTidslinjer,
             ).sortedBy { it.fom }
+
+        val forventedeKompetanser =
+            KompetanseBuilder(jan2020)
+                .medKompetanse("-----", barn1, barn2)
+                .medKompetanse("     ----", barn2)
+                .byggKompetanser().sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -10,14 +10,12 @@ import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.KompetanseBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.somBoolskTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.tilAnnenForelderOmfattetAvNorskLovgivningTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.tilRegelverkResultatTidslinje
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class TilpassKompetanserTilRegelverkTest {
@@ -59,7 +57,6 @@ class TilpassKompetanserTilRegelverkTest {
                 barnaRegelverkTidslinjer = eøsPerioder,
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
                 annenForelderOmfattetAvNorskLovgivningTidslinje = annenForelderOmfattetTidslinje,
-                barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -81,7 +78,6 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = eøsPerioder,
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = eøsPerioder.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -109,7 +105,6 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer,
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -140,7 +135,6 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
@@ -185,7 +179,6 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasEgneRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -212,7 +205,6 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = emptyMap(),
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -254,7 +246,6 @@ class TilpassKompetanserTilRegelverkTest {
                 kompetanser,
                 barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 emptyMap(),
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
@@ -290,7 +281,6 @@ class TilpassKompetanserTilRegelverkTest {
                 gjeldendeKompetanser = kompetanser,
                 barnaRegelverkTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { it.value.kombinertSøkersResultatTidslinje() },
                 barnasSkalIkkeUtbetalesTidslinjer = barnasHarEtterbetaling3År,
-                barnHarAndelTidslinjer = barnasRegelverkResultatTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             ).sortedBy { it.fom }
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
@@ -267,7 +267,6 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
-                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEquals(1, kompetanser.size)
@@ -319,7 +318,6 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
-                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         val forventetRegelverkResultat =
@@ -375,7 +373,6 @@ internal class TidslinjerTest {
                 emptyList(),
                 barnaRegelverkTidslinjer,
                 emptyMap(),
-                barnHarAndelTidslinjer = barnaRegelverkTidslinjer.mapValues { (_, regelverkTilBarnet) -> regelverkTilBarnet.map { it != null } },
             )
 
         assertEquals(1, kompetanser.size)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17059
Oppfølging for: https://github.com/navikt/familie-ba-sak/pull/4281

Når vi genererer kompetansene setter vi alltid siste periode til å være uendelig fram i tid dersom til-og-med-datoen er etter dagens dato. Når vi setter en endret utbetalingsperiode som stanser utbetalingen fjerner vi kompetansen i den perioden. 

Tidligere har vi satt kompetansene til å være uendelige før vi har fjernet kompetansene for endrede utbetalingsperioder som stanser utbetalingen. Da får vi problemet som er vist i bildet under, at den uendelige kompetansene starter opp etter de endrede utbetalingsperiodene. 
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/2ff9e264-7a3d-4c79-b810-38dc3cd66793)

Endrer så vi fjerner kompetansene i periodene med endret utbetalingsperiode som stanser utbetalingen før vi gjør kompetansene uendelige. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester
