### PR TITLE
Ikke nedskaler podder ved satsendring, feil grensesnittavstemming på første forsøk og forvalterendepunkt for å oppprette ny grensesnitt-task

### DIFF
--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -113,7 +113,7 @@ spec:
         - host: data-api.ecb.europa.eu
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
   replicas:
-    min: 3
+    min: 5
     max: 5
   resources:
     limits:

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -12,8 +12,10 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.ba.sak.task.GrensesnittavstemMotOppdrag
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.PatchIdentForBarnPåFagsak
+import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -47,6 +49,7 @@ class ForvalterController(
     private val tilgangService: TilgangService,
     private val økonomiService: ØkonomiService,
     private val opprettTaskService: OpprettTaskService,
+    private val taskService: TaskService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ForvalterController::class.java)
 
@@ -230,5 +233,22 @@ class ForvalterController(
         økonomiService.opprettManuellKvitteringPåOppdrag(behandlingId = behandlingId)
 
         return ResponseEntity.ok("ok")
+    }
+
+    @PostMapping("/opprett-grensesnittavstemmingtask/sisteTaskId/{taskId}")
+    @Operation(
+        summary = "Opprett neste grensesnittavstemming basert på taskId av type avstemMotOppdrag ",
+        description =
+            "Dette endepunktet oppretter en ny task for å trigge grensesnittavstemming. Man må sende " +
+                "taskId fra sist avstemMotOppdrag-tasl som har kjørt ok mot oppdrag. Dette endepunktet kan brukes for å opprette neste " +
+                "task hvis man må avvikshåndtere en avstemMotOppdrag task",
+    )
+    fun opprettGrensesnittavstemmingtask(
+        @PathVariable taskId: Long,
+    ): ResponseEntity<String> {
+        val task = taskService.findById(taskId)
+        if (task.type != GrensesnittavstemMotOppdrag.TASK_STEP_TYPE) error("sisteTaskId må være av typen ${GrensesnittavstemMotOppdrag.TASK_STEP_TYPE}")
+        opprettTaskService.opprettGrensesnittavstemMotOppdragTask(GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(task.triggerTid.toLocalDate()))
+        return ResponseEntity.ok("Ok")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.task.dto.Autobrev6og18ÅrDTO
 import no.nav.familie.ba.sak.task.dto.AutobrevOpphørSmåbarnstilleggDTO
+import no.nav.familie.ba.sak.task.dto.GrensesnittavstemmingTaskDTO
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.ba.sak.task.dto.OpprettOppgaveTaskDTO
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -189,6 +190,25 @@ class OpprettTaskService(
                         this["gammelIdent"] = dto.gammelIdent.ident
                         this["nyIdent"] = dto.nyIdent.ident
                     },
+            ),
+        )
+    }
+
+    @Transactional
+    fun opprettGrensesnittavstemMotOppdragTask(
+        dto: GrensesnittavstemmingTaskDTO,
+    ) {
+        taskRepository.save(
+            Task(
+                type = GrensesnittavstemMotOppdrag.TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(dto),
+                properties =
+                    Properties().apply {
+                        this["fomDato"] = dto.fomDato.toString()
+                        this["tomDato"] = dto.tomDato.toString()
+                    },
+            ).medTriggerTid(
+                dto.tomDato.toLocalDate().atTime(8, 0),
             ),
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
@@ -25,7 +25,7 @@ class GrensesnittavstemMotOppdragTest {
     fun setUp() {
         val avstemmingServiceMock = mockk<AvstemmingService>()
         taskRepositoryMock = mockk()
-        grensesnittavstemMotOppdrag = GrensesnittavstemMotOppdrag(avstemmingServiceMock, taskRepositoryMock)
+        grensesnittavstemMotOppdrag = GrensesnittavstemMotOppdrag(avstemmingServiceMock, OpprettTaskService(taskRepositoryMock, mockk()))
     }
 
     @ParameterizedTest
@@ -69,7 +69,7 @@ class GrensesnittavstemMotOppdragTest {
     fun skalBeregneNesteAvstemmingForSammenhengendeHelligdag() {
         val juledagen = LocalDate.of(2019, 12, 24)
 
-        val testDto = grensesnittavstemMotOppdrag.nesteAvstemmingDTO(juledagen)
+        val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(juledagen)
 
         assertEquals(LocalDate.of(2019, 12, 27).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2019, 12, 24).atStartOfDay(), testDto.fomDato)
@@ -79,7 +79,7 @@ class GrensesnittavstemMotOppdragTest {
     fun skalBeregneNesteAvstemmingForEnkeltHelligdag() {
         val nyttårsdag = LocalDate.of(2019, 12, 31)
 
-        val testDto = grensesnittavstemMotOppdrag.nesteAvstemmingDTO(nyttårsdag)
+        val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(nyttårsdag)
 
         assertEquals(LocalDate.of(2020, 1, 2).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2019, 12, 31).atStartOfDay(), testDto.fomDato)
@@ -89,7 +89,7 @@ class GrensesnittavstemMotOppdragTest {
     fun skalBeregneNesteAvstemmingForLanghelg() {
         val valborg = LocalDate.of(2020, 4, 30)
 
-        val testDto = grensesnittavstemMotOppdrag.nesteAvstemmingDTO(valborg)
+        val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(valborg)
 
         assertEquals(LocalDate.of(2020, 5, 4).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2020, 4, 30).atStartOfDay(), testDto.fomDato)
@@ -99,7 +99,7 @@ class GrensesnittavstemMotOppdragTest {
     fun skalBeregneNesteAvstemmingForUkedag() {
         val enTirsdag = LocalDate.of(2020, 1, 14)
 
-        val testDto = grensesnittavstemMotOppdrag.nesteAvstemmingDTO(enTirsdag)
+        val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(enTirsdag)
 
         assertEquals(LocalDate.of(2020, 1, 15).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2020, 1, 14).atStartOfDay(), testDto.fomDato)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Huritgtiltak for å få bedre grensesnittavstemming ved satsendring.

- Sørger for at man kjører fast med 5 podder. Her skal man skalere ned til 2/4 når satsendring er ferdig
- Ikke automatisk rekjør tasken 3 ganger ved feil for å forhindre at man trigger flere grensesnittavstemminger ved nettverksfeil o.l.
- endepunkt for å opprette neste grensesnittavstemming som kan brukes når man må avvikhåndtere en avstemMotOppdrag task

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
