### PR TITLE
Vi beskjærer bare fom dato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -1,16 +1,13 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
-import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilMånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjær
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinjeForOppfyltVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
@@ -42,7 +39,7 @@ object EndringIVilkårsvurderingUtil {
                         personIBehandling = personIBehandling,
                         personIForrigeBehandling = personIForrigeBehandling,
                     )
-                vilkårTidslinje.fjernPerioderFørRelevantFomDato(tidligsteRelevanteFomDatoForPersonIVilkårsvurdering, personIBehandling)
+                vilkårTidslinje.beskjærFraOgMed(fraOgMed = tidligsteRelevanteFomDatoForPersonIVilkårsvurdering.tilTidspunkt())
             }
 
         return tidslinjePerVilkår.kombiner { finnesMinstEnEndringIPeriode(it) }
@@ -108,10 +105,4 @@ object EndringIVilkårsvurderingUtil {
             }
         }
     }
-
-    private fun Tidslinje<Boolean, Måned>.fjernPerioderFørRelevantFomDato(
-        relevantFomDato: YearMonth,
-        person: Person?,
-    ) =
-        this.beskjær(fraOgMed = relevantFomDato.tilTidspunkt(), tilOgMed = person?.fødselsdato?.til18ÅrsVilkårsdato()?.tilMånedTidspunkt() ?: throw Feil("Mangler fødselsdato, men prøver å beskjære på 18-år vilkåret"))
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
@@ -77,3 +77,15 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.beskjær(
 
     return (fom..tom).tidslinjeFraTidspunkt { tidspunkt -> innholdForTidspunkt(tidspunkt) }
 }
+
+/**
+ * Extension-metode for å beskjære fom dato på en tidslinje
+ * Etter beskjæringen vil tidslinjen maksimalt strekke seg fra innsendt [fraOgMed] og til eksisterende tilOgMed
+ */
+fun <I, T : Tidsenhet> Tidslinje<I, T>.beskjærFraOgMed(
+    fraOgMed: Tidspunkt<T>,
+): Tidslinje<I, T> =
+    when {
+        this.tidsrom().isEmpty() -> TomTidslinje()
+        else -> beskjær(fraOgMed, this.tilOgMed()!!)
+    }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
@@ -255,8 +254,7 @@ class EndringIVilkårsvurderingUtilTest {
 
         Assertions.assertEquals(1, perioderMedEndring.size)
         Assertions.assertEquals(jun22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        Assertions.assertEquals(person.fødselsdato.til18ÅrsVilkårsdato().toYearMonth(), perioderMedEndring.single().tilOgMed.tilYearMonth())
-        Assertions.assertEquals(Uendelighet.INGEN, perioderMedEndring.single().tilOgMed.uendelighet)
+        Assertions.assertEquals(Uendelighet.FREMTID, perioderMedEndring.single().tilOgMed.uendelighet)
     }
 
     @Test


### PR DESCRIPTION
Fikser en bug i prod som oppstår fordi vi forsøker å beskjære tidslinje sin tom på 18 års vilkår.
Dette ble opprinnelig gjort fordi det å sette TIDENES_ENDE førte til en evig lang tidslinje som tok evigheter å prosessere i ba-sak.

Lager derfor en extension metode for tidslinje som bare beskjærer fomdato og lar tomdato være as-is.