### PR TITLE
endepunkt for å endre periodeFom på vilkårResultat dersom det er før barns fødselsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -11,10 +11,10 @@ import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.ba.sak.task.GrensesnittavstemMotOppdrag
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.PatchFomPåVilkårTilFødselsdato
 import no.nav.familie.ba.sak.task.PatchIdentForBarnPåFagsak
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -262,8 +262,8 @@ class ForvalterController(
     )
     fun flyttVilkårFomDatoTilFødselsdato(
         @PathVariable behandlingId: Long,
-    ): ResponseEntity<Vilkårsvurdering> {
-        val endretVilkårsvurdering = forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandlingId)
-        return ResponseEntity.ok(endretVilkårsvurdering)
+    ): ResponseEntity<String> {
+        opprettTaskService.opprettTaskForÅPatcheVilkårFom(PatchFomPåVilkårTilFødselsdato(behandlingId))
+        return ResponseEntity.ok("Ok")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -253,7 +253,7 @@ class ForvalterController(
         return ResponseEntity.ok("Ok")
     }
 
-    @PatchMapping("/flytt-vilkaar-fom-dato-til-foedselsdato/behandling/{behandlingId}")
+    @PatchMapping("/flytt-vilkaar-fom-dato-til-foedselsdato")
     @Operation(
         summary = "Sett periodeFom på vilkårresultater i behandling som er tidligere enn personens fødselsdato til å være fødselsdato. ",
         description =
@@ -261,9 +261,9 @@ class ForvalterController(
                 "vilkårresultatet sin periodeFom < personens fødselsdato.",
     )
     fun flyttVilkårFomDatoTilFødselsdato(
-        @PathVariable behandlingId: Long,
+        @RequestBody behandlinger: Set<Long>,
     ): ResponseEntity<String> {
-        opprettTaskService.opprettTaskForÅPatcheVilkårFom(PatchFomPåVilkårTilFødselsdato(behandlingId))
+        opprettTaskService.opprettTaskForÅPatcheVilkårFom(PatchFomPåVilkårTilFødselsdato(behandlinger))
         return ResponseEntity.ok("Ok")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.ba.sak.task.GrensesnittavstemMotOppdrag
 import no.nav.familie.ba.sak.task.OpprettTaskService
@@ -250,5 +251,19 @@ class ForvalterController(
         if (task.type != GrensesnittavstemMotOppdrag.TASK_STEP_TYPE) error("sisteTaskId må være av typen ${GrensesnittavstemMotOppdrag.TASK_STEP_TYPE}")
         opprettTaskService.opprettGrensesnittavstemMotOppdragTask(GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(task.triggerTid.toLocalDate()))
         return ResponseEntity.ok("Ok")
+    }
+
+    @PatchMapping("/flytt-vilkaar-fom-dato-til-foedselsdato/behandling/{behandlingId}")
+    @Operation(
+        summary = "Sett periodeFom på vilkårresultater i behandling som er tidligere enn personens fødselsdato til å være fødselsdato. ",
+        description =
+            "Dette endepunktet henter alle vilkårresultater og setter periodefom = fødselsdato til personen vilkårresultatet tilhører dersom " +
+                "vilkårresultatet sin periodeFom < personens fødselsdato.",
+    )
+    fun flyttVilkårFomDatoTilFødselsdato(
+        @PathVariable behandlingId: Long,
+    ): ResponseEntity<Vilkårsvurdering> {
+        val endretVilkårsvurdering = forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandlingId)
+        return ResponseEntity.ok(endretVilkårsvurdering)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -265,7 +265,9 @@ class ForvalterController(
     fun flyttVilkårFomDatoTilFødselsdato(
         @RequestBody behandlinger: Set<Long>,
     ): ResponseEntity<String> {
-        opprettTaskService.opprettTaskForÅPatcheVilkårFom(PatchFomPåVilkårTilFødselsdato(behandlinger))
+        behandlinger.forEach {
+            opprettTaskService.opprettTaskForÅPatcheVilkårFom(PatchFomPåVilkårTilFødselsdato(it))
+        }
         return ResponseEntity.ok("Ok")
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -204,7 +204,7 @@ class OpprettTaskService(
                 payload = objectMapper.writeValueAsString(dto),
                 properties =
                     Properties().apply {
-                        this["behandlingId"] = dto.behandlingId.toString()
+                        this["behandlingId"] = dto.behandlinger.toString()
                     },
             ),
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -204,7 +204,7 @@ class OpprettTaskService(
                 payload = objectMapper.writeValueAsString(dto),
                 properties =
                     Properties().apply {
-                        this["behandlingId"] = dto.behandlinger.toString()
+                        this["behandlingId"] = dto.behandlingId.toString()
                     },
             ),
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -195,6 +195,22 @@ class OpprettTaskService(
     }
 
     @Transactional
+    fun opprettTaskForÅPatcheVilkårFom(
+        dto: PatchFomPåVilkårTilFødselsdato,
+    ) {
+        taskRepository.save(
+            Task(
+                type = PatchFomPåVilkårTilFødselsdatoTask.TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(dto),
+                properties =
+                    Properties().apply {
+                        this["behandlingId"] = dto.behandlingId.toString()
+                    },
+            ),
+        )
+    }
+
+    @Transactional
     fun opprettGrensesnittavstemMotOppdragTask(
         dto: GrensesnittavstemmingTaskDTO,
     ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PatchFomPåVilkårTilFødselsdato.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PatchFomPåVilkårTilFødselsdato.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.internal.ForvalterService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = PatchFomPåVilkårTilFødselsdatoTask.TASK_STEP_TYPE,
+    beskrivelse = "Patcher fom på vilkår til å bli satt til fødselsdato dersom fom er før fødselsdato.",
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = true,
+)
+class PatchFomPåVilkårTilFødselsdatoTask(
+    private val forvalterService: ForvalterService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val dto = objectMapper.readValue(task.payload, PatchFomPåVilkårTilFødselsdato::class.java)
+
+        forvalterService.settFomPåVilkårTilPersonsFødselsdato(dto.behandlingId)
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "PatchFomPaaVilkaar"
+    }
+}
+
+data class PatchFomPåVilkårTilFødselsdato(
+    val behandlingId: Long,
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PatchFomPåVilkårTilFødselsdato.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PatchFomPåVilkårTilFødselsdato.kt
@@ -20,9 +20,7 @@ class PatchFomPåVilkårTilFødselsdatoTask(
     override fun doTask(task: Task) {
         val dto = objectMapper.readValue(task.payload, PatchFomPåVilkårTilFødselsdato::class.java)
 
-        dto.behandlinger.forEach {
-            forvalterService.settFomPåVilkårTilPersonsFødselsdato(it)
-        }
+        forvalterService.settFomPåVilkårTilPersonsFødselsdato(dto.behandlingId)
     }
 
     companion object {
@@ -31,5 +29,5 @@ class PatchFomPåVilkårTilFødselsdatoTask(
 }
 
 data class PatchFomPåVilkårTilFødselsdato(
-    val behandlinger: Set<Long>,
+    val behandlingId: Long,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PatchFomPåVilkårTilFødselsdato.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PatchFomPåVilkårTilFødselsdato.kt
@@ -20,7 +20,9 @@ class PatchFomPåVilkårTilFødselsdatoTask(
     override fun doTask(task: Task) {
         val dto = objectMapper.readValue(task.payload, PatchFomPåVilkårTilFødselsdato::class.java)
 
-        forvalterService.settFomPåVilkårTilPersonsFødselsdato(dto.behandlingId)
+        dto.behandlinger.forEach {
+            forvalterService.settFomPåVilkårTilPersonsFødselsdato(it)
+        }
     }
 
     companion object {
@@ -29,5 +31,5 @@ class PatchFomPåVilkårTilFødselsdatoTask(
 }
 
 data class PatchFomPåVilkårTilFødselsdato(
-    val behandlingId: Long,
+    val behandlinger: Set<Long>,
 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -1,0 +1,303 @@
+package no.nav.familie.ba.sak.internal
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.isSameOrAfter
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
+import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
+import kotlin.random.Random
+
+@ExtendWith(MockKExtension::class)
+class ForvalterServiceTest {
+    @MockK
+    lateinit var persongrunnlagService: PersongrunnlagService
+
+    @MockK
+    lateinit var økonomiService: ØkonomiService
+
+    @MockK
+    lateinit var vedtakService: VedtakService
+
+    @MockK
+    lateinit var beregningService: BeregningService
+
+    @MockK
+    lateinit var behandlingHentOgPersisterService: BehandlingHentOgPersisterService
+
+    @MockK
+    lateinit var stegService: StegService
+
+    @MockK
+    lateinit var fagsakService: FagsakService
+
+    @MockK
+    lateinit var behandlingService: BehandlingService
+
+    @MockK
+    lateinit var taskRepository: TaskRepositoryWrapper
+
+    @MockK
+    lateinit var autovedtakService: AutovedtakService
+
+    @MockK
+    lateinit var vilkårsvurderingService: VilkårsvurderingService
+
+    @MockK
+    lateinit var fagsakRepository: FagsakRepository
+
+    @MockK
+    lateinit var behandlingRepository: BehandlingRepository
+
+    @MockK
+    lateinit var tilkjentYtelseValideringService: TilkjentYtelseValideringService
+
+    @MockK
+    lateinit var arbeidsfordelingService: ArbeidsfordelingService
+
+    @MockK
+    lateinit var infotrygdService: InfotrygdService
+
+    @InjectMockKs
+    lateinit var forvalterService: ForvalterService
+
+    @Test
+    fun `Skal endre periodeFom på vilkårresultat når den er før fødselsdato på person`() {
+        val behandling = lagBehandling()
+        behandling.status = BehandlingStatus.AVSLUTTET
+
+        val barnFødselsdato = LocalDate.now().minusYears(1).withDayOfMonth(15)
+        val søker = lagPerson()
+        val barn = lagPerson(fødselsdato = barnFødselsdato)
+
+        val vilkårsVurderingSomSkalFlushes = slot<Vilkårsvurdering>()
+        every { vilkårsvurderingService.oppdater(capture(vilkårsVurderingSomSkalFlushes)) } answers {
+            if (vilkårsVurderingSomSkalFlushes.isCaptured) {
+                vilkårsVurderingSomSkalFlushes.captured
+            } else {
+                throw Feil("Noe gikk feil ved capturing av vilkårsvurdring.")
+            }
+        }
+
+        every { persongrunnlagService.hentSøkerOgBarnPåBehandling(any()) } returns
+            listOf(
+                personTilPersonEnkel(barn),
+                personTilPersonEnkel(søker),
+            )
+
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
+
+        val vilkårsVurdering =
+            lagVilkårsvurdering(
+                behandling = behandling,
+                søkerAktør = søker.aktør,
+                resultat = Resultat.OPPFYLT,
+            )
+        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
+        barnResultat.setSortedVilkårResultater(
+            setOf(
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.førsteDagIInneværendeMåned(), vilkårType = Vilkår.BOSATT_I_RIKET),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.UNDER_18_ÅR),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, periodeTom = barnFødselsdato.plusMonths(2), vilkårType = Vilkår.BOR_MED_SØKER),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.plusMonths(3), vilkårType = Vilkår.BOR_MED_SØKER),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.LOVLIG_OPPHOLD),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.GIFT_PARTNERSKAP),
+            ),
+        )
+        vilkårsVurdering.personResultater += barnResultat
+
+        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsVurdering
+
+        val vilkårsvurderingEndret = forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandling.id)
+        vilkårsvurderingEndret.personResultater.singleOrNull { !it.erSøkersResultater() }
+            ?.vilkårResultater?.forEach { vilkårResultat ->
+                assertTrue(vilkårResultat.periodeFom?.isSameOrAfter(barn.fødselsdato) ?: false)
+            }
+
+        val vilkårResultaterMedFomEtterBarnsFødselsDato =
+            vilkårsvurderingEndret.personResultater.singleOrNull { !it.erSøkersResultater() }?.vilkårResultater
+                ?.filter { it.periodeFom?.isAfter(barn.fødselsdato) ?: false }
+        assertThat(vilkårResultaterMedFomEtterBarnsFødselsDato?.size).isEqualTo(1)
+            .`as`("Vilkårresultater med fom etter barns fødselsdato har også blitt endret: $vilkårResultaterMedFomEtterBarnsFødselsDato")
+    }
+
+    @Test
+    fun `Skal kaste feil når vi har etterfølgende perioder som begge begynner før fødselsdato`() {
+        val behandling = lagBehandling()
+        behandling.status = BehandlingStatus.AVSLUTTET
+
+        val barnFødselsdato = LocalDate.now().minusYears(1).withDayOfMonth(15)
+        val søker = lagPerson()
+        val barn = lagPerson(fødselsdato = barnFødselsdato)
+
+        val vilkårsVurderingSomSkalFlushes = slot<Vilkårsvurdering>()
+        every { vilkårsvurderingService.oppdater(capture(vilkårsVurderingSomSkalFlushes)) } answers {
+            if (vilkårsVurderingSomSkalFlushes.isCaptured) {
+                vilkårsVurderingSomSkalFlushes.captured
+            } else {
+                throw Feil("Noe gikk feil ved capturing av vilkårsvurdring.")
+            }
+        }
+
+        every { persongrunnlagService.hentSøkerOgBarnPåBehandling(any()) } returns
+            listOf(
+                personTilPersonEnkel(barn),
+                personTilPersonEnkel(søker),
+            )
+
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
+
+        val vilkårsVurdering =
+            lagVilkårsvurdering(
+                behandling = behandling,
+                søkerAktør = søker.aktør,
+                resultat = Resultat.OPPFYLT,
+            )
+        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
+        barnResultat.setSortedVilkårResultater(
+            setOf(
+                lagVilkårResultat(
+                    barnResultat = barnResultat,
+                    periodeFom = barn.fødselsdato.førsteDagIInneværendeMåned(),
+                    periodeTom = barn.fødselsdato.minusDays(5),
+                    vilkårType = Vilkår.BOSATT_I_RIKET,
+                ),
+                lagVilkårResultat(
+                    barnResultat = barnResultat,
+                    periodeFom = barn.fødselsdato.minusDays(4),
+                    vilkårType = Vilkår.BOSATT_I_RIKET,
+                ),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.UNDER_18_ÅR),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.BOR_MED_SØKER),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.LOVLIG_OPPHOLD),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.GIFT_PARTNERSKAP),
+            ),
+        )
+        vilkårsVurdering.personResultater += barnResultat
+
+        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsVurdering
+
+        assertThrows<Feil> {
+            forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandling.id)
+        }
+    }
+
+    @Test
+    fun `Skal kaste feil når vilkårResultat begynner tidligere måned enn fødselsdato`() {
+        val behandling = lagBehandling()
+        behandling.status = BehandlingStatus.AVSLUTTET
+
+        val barnFødselsdato = LocalDate.now().minusYears(1).withDayOfMonth(15)
+        val søker = lagPerson()
+        val barn = lagPerson(fødselsdato = barnFødselsdato)
+
+        val vilkårsVurderingSomSkalFlushes = slot<Vilkårsvurdering>()
+        every { vilkårsvurderingService.oppdater(capture(vilkårsVurderingSomSkalFlushes)) } answers {
+            if (vilkårsVurderingSomSkalFlushes.isCaptured) {
+                vilkårsVurderingSomSkalFlushes.captured
+            } else {
+                throw Feil("Noe gikk feil ved capturing av vilkårsvurdring.")
+            }
+        }
+
+        every { persongrunnlagService.hentSøkerOgBarnPåBehandling(any()) } returns
+            listOf(
+                personTilPersonEnkel(barn),
+                personTilPersonEnkel(søker),
+            )
+
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
+
+        val vilkårsVurdering =
+            lagVilkårsvurdering(
+                behandling = behandling,
+                søkerAktør = søker.aktør,
+                resultat = Resultat.OPPFYLT,
+            )
+        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
+        barnResultat.setSortedVilkårResultater(
+            setOf(
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.minusMonths(2), vilkårType = Vilkår.BOSATT_I_RIKET),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.UNDER_18_ÅR),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.BOR_MED_SØKER),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.LOVLIG_OPPHOLD),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.GIFT_PARTNERSKAP),
+            ),
+        )
+        vilkårsVurdering.personResultater += barnResultat
+
+        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsVurdering
+
+        assertThrows<Feil> {
+            forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandling.id)
+        }
+    }
+
+    private fun personTilPersonEnkel(barn: Person) =
+        PersonEnkel(
+            type = PersonType.BARN,
+            aktør = barn.aktør,
+            fødselsdato = barn.fødselsdato,
+            dødsfallDato = null,
+            målform = Målform.NB,
+        )
+
+    private fun lagVilkårResultat(
+        vilkårType: Vilkår,
+        barnResultat: PersonResultat,
+        periodeFom: LocalDate,
+        periodeTom: LocalDate? =
+            if (vilkårType == Vilkår.UNDER_18_ÅR) {
+                periodeFom.plusYears(18).minusMonths(1)
+            } else {
+                null
+            },
+    ): VilkårResultat {
+        return VilkårResultat(
+            personResultat = barnResultat,
+            vilkårType = vilkårType,
+            resultat = Resultat.OPPFYLT,
+            periodeFom = periodeFom,
+            periodeTom = periodeTom,
+            begrunnelse = "",
+            sistEndretIBehandlingId = Random.nextLong(),
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -164,8 +164,8 @@ class ForvalterServiceTest {
         behandling.status = BehandlingStatus.AVSLUTTET
 
         val barnFødselsdato = LocalDate.now().minusYears(1).withDayOfMonth(15)
-        val søker = lagPerson()
-        val barn = lagPerson(fødselsdato = barnFødselsdato)
+        val søker = lagPerson(type = PersonType.SØKER)
+        val barn = lagPerson(type = PersonType.BARN, fødselsdato = barnFødselsdato)
 
         val vilkårsvurderingSomSkalFlushes = slot<Vilkårsvurdering>()
         every { vilkårsvurderingService.oppdater(capture(vilkårsvurderingSomSkalFlushes)) } answers {
@@ -225,8 +225,8 @@ class ForvalterServiceTest {
         behandling.status = BehandlingStatus.AVSLUTTET
 
         val barnFødselsdato = LocalDate.now().minusYears(1).withDayOfMonth(15)
-        val søker = lagPerson()
-        val barn = lagPerson(fødselsdato = barnFødselsdato)
+        val søker = lagPerson(type = PersonType.SØKER)
+        val barn = lagPerson(type = PersonType.BARN, fødselsdato = barnFødselsdato)
 
         val vilkårsvurderingSomSkalFlushes = slot<Vilkårsvurdering>()
         every { vilkårsvurderingService.oppdater(capture(vilkårsvurderingSomSkalFlushes)) } answers {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -100,19 +100,18 @@ class ForvalterServiceTest {
 
     @Test
     fun `Skal endre periodeFom på vilkårresultat når den er før fødselsdato på person`() {
-        val behandling = lagBehandling()
-        behandling.status = BehandlingStatus.AVSLUTTET
+        val behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET)
 
         val barnFødselsdato = LocalDate.now().minusYears(1).withDayOfMonth(15)
-        val søker = lagPerson()
-        val barn = lagPerson(fødselsdato = barnFødselsdato)
+        val søker = lagPerson(type = PersonType.SØKER)
+        val barn = lagPerson(type = PersonType.BARN, fødselsdato = barnFødselsdato)
 
-        val vilkårsVurderingSomSkalFlushes = slot<Vilkårsvurdering>()
-        every { vilkårsvurderingService.oppdater(capture(vilkårsVurderingSomSkalFlushes)) } answers {
-            if (vilkårsVurderingSomSkalFlushes.isCaptured) {
-                vilkårsVurderingSomSkalFlushes.captured
+        val vilkårsvurderingSomSkalFlushes = slot<Vilkårsvurdering>()
+        every { vilkårsvurderingService.oppdater(capture(vilkårsvurderingSomSkalFlushes)) } answers {
+            if (vilkårsvurderingSomSkalFlushes.isCaptured) {
+                vilkårsvurderingSomSkalFlushes.captured
             } else {
-                throw Feil("Noe gikk feil ved capturing av vilkårsvurdring.")
+                throw Feil("Noe gikk feil ved capturing av vilkårsvurdering.")
             }
         }
 
@@ -133,7 +132,8 @@ class ForvalterServiceTest {
         val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
         barnResultat.setSortedVilkårResultater(
             setOf(
-                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.førsteDagIInneværendeMåned(), vilkårType = Vilkår.BOSATT_I_RIKET),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.førsteDagIInneværendeMåned(), periodeTom = barn.fødselsdato.plusMonths(3), vilkårType = Vilkår.BOSATT_I_RIKET),
+                lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.plusMonths(4), vilkårType = Vilkår.BOSATT_I_RIKET),
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.UNDER_18_ÅR),
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, periodeTom = barnFødselsdato.plusMonths(2), vilkårType = Vilkår.BOR_MED_SØKER),
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.plusMonths(3), vilkårType = Vilkår.BOR_MED_SØKER),
@@ -154,7 +154,7 @@ class ForvalterServiceTest {
         val vilkårResultaterMedFomEtterBarnsFødselsDato =
             vilkårsvurderingEndret.personResultater.singleOrNull { !it.erSøkersResultater() }?.vilkårResultater
                 ?.filter { it.periodeFom?.isAfter(barn.fødselsdato) ?: false }
-        assertThat(vilkårResultaterMedFomEtterBarnsFødselsDato?.size).isEqualTo(1)
+        assertThat(vilkårResultaterMedFomEtterBarnsFødselsDato?.size).isEqualTo(2)
             .`as`("Vilkårresultater med fom etter barns fødselsdato har også blitt endret: $vilkårResultaterMedFomEtterBarnsFødselsDato")
     }
 
@@ -167,10 +167,10 @@ class ForvalterServiceTest {
         val søker = lagPerson()
         val barn = lagPerson(fødselsdato = barnFødselsdato)
 
-        val vilkårsVurderingSomSkalFlushes = slot<Vilkårsvurdering>()
-        every { vilkårsvurderingService.oppdater(capture(vilkårsVurderingSomSkalFlushes)) } answers {
-            if (vilkårsVurderingSomSkalFlushes.isCaptured) {
-                vilkårsVurderingSomSkalFlushes.captured
+        val vilkårsvurderingSomSkalFlushes = slot<Vilkårsvurdering>()
+        every { vilkårsvurderingService.oppdater(capture(vilkårsvurderingSomSkalFlushes)) } answers {
+            if (vilkårsvurderingSomSkalFlushes.isCaptured) {
+                vilkårsvurderingSomSkalFlushes.captured
             } else {
                 throw Feil("Noe gikk feil ved capturing av vilkårsvurdring.")
             }
@@ -228,10 +228,10 @@ class ForvalterServiceTest {
         val søker = lagPerson()
         val barn = lagPerson(fødselsdato = barnFødselsdato)
 
-        val vilkårsVurderingSomSkalFlushes = slot<Vilkårsvurdering>()
-        every { vilkårsvurderingService.oppdater(capture(vilkårsVurderingSomSkalFlushes)) } answers {
-            if (vilkårsVurderingSomSkalFlushes.isCaptured) {
-                vilkårsVurderingSomSkalFlushes.captured
+        val vilkårsvurderingSomSkalFlushes = slot<Vilkårsvurdering>()
+        every { vilkårsvurderingService.oppdater(capture(vilkårsvurderingSomSkalFlushes)) } answers {
+            if (vilkårsvurderingSomSkalFlushes.isCaptured) {
+                vilkårsvurderingSomSkalFlushes.captured
             } else {
                 throw Feil("Noe gikk feil ved capturing av vilkårsvurdring.")
             }


### PR DESCRIPTION
legg til forvalterEndepunkt som endrer fomdato til vilkårResultat til persons fødselsdato dersom fomdato er før fødselsdato innenfor samme måned

### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17837)
Ønsker et forvalterendepunkt vi kan bruke for å rette opp vilkårresultater der periodefom er før barns fødselsdato. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

