### PR TITLE
Ikke valider andeler på endret utbetaling ved satsendring 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -29,14 +29,14 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
 
     @Transactional
     fun finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandlingId: Long): List<EndretUtbetalingAndelMedAndelerTilkjentYtelse> {
-        // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
-        // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
-        // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt
         val vilkårsvurdering = vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId)
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val endreteUtbetalingerMedAndeler = lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
 
         return if (behandling.opprettetÅrsak != BehandlingÅrsak.SATSENDRING) {
+            // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
+            // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
+            // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt
             endreteUtbetalingerMedAndeler.filterBortAndelerMedValideringsfeil(vilkårsvurdering)
         } else {
             endreteUtbetalingerMedAndeler

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -3,11 +3,14 @@ package no.nav.familie.ba.sak.kjerne.beregning.domene
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.overlapperHeltEllerDelvisMed
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseUtils.skalAndelerSlåsSammen
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidering.validerPeriodeInnenforTilkjentytelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidering.validerÅrsak
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +20,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
 ) {
     @Transactional
     fun finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId: Long): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
@@ -29,20 +33,14 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
         // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt
         val vilkårsvurdering = vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId)
-        return lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
-            .map {
-                it.utenAndelerVedValideringsfeil {
-                    validerPeriodeInnenforTilkjentytelse(
-                        endretUtbetalingAndel = it.endretUtbetalingAndel,
-                        andelTilkjentYtelser = it.andelerTilkjentYtelse,
-                    )
-                }.utenAndelerVedValideringsfeil {
-                    validerÅrsak(
-                        endretUtbetalingAndel = it.endretUtbetalingAndel,
-                        vilkårsvurdering = vilkårsvurdering,
-                    )
-                }
-            }
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        val endreteUtbetalingerMedAndeler = lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
+
+        return if (behandling.opprettetÅrsak != BehandlingÅrsak.SATSENDRING) {
+            endreteUtbetalingerMedAndeler.filterBortAndelerMedValideringsfeil(vilkårsvurdering)
+        } else {
+            endreteUtbetalingerMedAndeler
+        }
     }
 
     private fun lagKombinator(behandlingId: Long) =
@@ -51,6 +49,21 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
             endretUtbetalingAndelRepository.findByBehandlingId(behandlingId),
         )
 }
+
+fun List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>.filterBortAndelerMedValideringsfeil(vilkårsvurdering: Vilkårsvurdering?): List<EndretUtbetalingAndelMedAndelerTilkjentYtelse> =
+    this.map {
+        it.utenAndelerVedValideringsfeil {
+            validerPeriodeInnenforTilkjentytelse(
+                it.endretUtbetalingAndel,
+                it.andelerTilkjentYtelse,
+            )
+        }.utenAndelerVedValideringsfeil {
+            validerÅrsak(
+                it.endretUtbetalingAndel,
+                vilkårsvurdering,
+            )
+        }
+    }
 
 private class AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(
     private val andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -28,17 +28,18 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
         // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
         // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt
+        val vilkårsvurdering = vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId)
         return lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
             .map {
                 it.utenAndelerVedValideringsfeil {
                     validerPeriodeInnenforTilkjentytelse(
-                        it.endretUtbetalingAndel,
-                        it.andelerTilkjentYtelse,
+                        endretUtbetalingAndel = it.endretUtbetalingAndel,
+                        andelTilkjentYtelser = it.andelerTilkjentYtelse,
                     )
                 }.utenAndelerVedValideringsfeil {
                     validerÅrsak(
-                        it.endretUtbetalingAndel,
-                        vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId),
+                        endretUtbetalingAndel = it.endretUtbetalingAndel,
+                        vilkårsvurdering = vilkårsvurdering,
                     )
                 }
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/Autobrev6og18ÅrServiceTest.kt
@@ -79,6 +79,7 @@ internal class Autobrev6og18ÅrServiceTest {
                     andelTilkjentYtelseRepository,
                     endretUtbetalingAndelRepository,
                     mockk(),
+                    mockk(),
                 ),
             startSatsendring = startSatsendring,
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -75,6 +75,7 @@ class BeregningServiceTest {
             andelTilkjentYtelseRepository,
             endretUtbetalingAndelRepository,
             vilkårsvurderingRepository,
+            behandlingHentOgPersisterService,
         )
 
     private lateinit var beregningService: BeregningService
@@ -126,6 +127,7 @@ class BeregningServiceTest {
     @Test
     fun `Skal mappe perioderesultat til andel ytelser for innvilget vedtak med 18-års vilkår som sluttdato`() {
         val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2002, 7, 1))
         val søker = lagPerson(type = PersonType.SØKER)
@@ -191,6 +193,7 @@ class BeregningServiceTest {
     @Test
     fun `Skal mappe perioderesultat til andel ytelser for innvilget vedtak som spenner over flere satsperioder`() {
         val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2016, 5, 4))
         val søker = lagPerson(type = PersonType.SØKER)
@@ -265,6 +268,7 @@ class BeregningServiceTest {
     @Test
     fun `Skal verifisere at endret utbetaling andel appliseres på en innvilget utbetaling andel`() {
         val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2016, 4, 5))
         val søker = lagPerson(type = PersonType.SØKER)
         val vilkårsvurdering =
@@ -364,6 +368,7 @@ class BeregningServiceTest {
     @Test
     fun `Skal mappe perioderesultat til andel ytelser for avslått vedtak`() {
         val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
         val barn = lagPerson(type = PersonType.BARN)
         val søker = lagPerson(type = PersonType.SØKER)
         val vilkårsvurdering =
@@ -419,6 +424,7 @@ class BeregningServiceTest {
     @Test
     fun `For flere barn med forskjellige perioderesultat skal perioderesultat mappes til andel ytelser`() {
         val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
         val barnFødselsdato = LocalDate.of(2019, 1, 1)
         val barn1 = lagPerson(type = PersonType.BARN, fødselsdato = barnFødselsdato)
         val barn2 = lagPerson(type = PersonType.BARN, fødselsdato = barnFødselsdato)
@@ -1075,6 +1081,8 @@ class BeregningServiceTest {
         skalLageSplitt: Boolean,
     ) {
         val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
+
         val barnFødselsdato = LocalDate.of(2019, 1, 1)
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = barnFødselsdato)
         val søker = lagPerson(type = PersonType.SØKER)
@@ -1235,6 +1243,7 @@ class BeregningServiceTest {
         søker: Person,
     ): List<AndelTilkjentYtelse> {
         val behandling = lagBehandling()
+        every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
         val vilkårsvurdering =
             lagVilkårsvurdering(søkerAktør = søker.aktør, behandling = behandling, resultat = Resultat.OPPFYLT)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har noen satsendringer som ikke går gjennom fordi de endrede utbetalingene ikke lenger passerer valideringene. Vi har gått gjennom sakene det gjelder og ser at andelene og brevene har blitt riktige. 

Endrer så behandlingen ikke stopper på valideringene for endret utbetaling dersom vi er på en satsendringssak. 
