### PR TITLE
Bug: feil offset i utbetalingsoppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -99,7 +99,7 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
               JOIN Behandling b ON b.id = aty.fk_behandling_id
              WHERE b.fk_fagsak_id = :fagsakId
                AND ty.utbetalingsoppdrag IS NOT NULL
-               AND jsonb_array_length((utbetalingsoppdrag::json ->> 'utbetalingsperiode')::jsonb) != 0
+               AND json_extract_path_text(cast(utbetalingsoppdrag as json), 'utbetalingsperiode') != '[]'
                AND aty.periode_offset IS NOT NULL
                AND b.status = 'AVSLUTTET')
         SELECT aty.* FROM andel_tilkjent_ytelse aty WHERE id IN (SELECT id FROM andeler WHERE rn = 1)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -99,7 +99,7 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
               JOIN Behandling b ON b.id = aty.fk_behandling_id
              WHERE b.fk_fagsak_id = :fagsakId
                AND ty.utbetalingsoppdrag IS NOT NULL
-               AND utbetalingsoppdrag::json ->> 'utbetalingsperiode' != '[]'
+               AND jsonb_array_length((utbetalingsoppdrag::json ->> 'utbetalingsperiode')::jsonb) != 0
                AND aty.periode_offset IS NOT NULL
                AND b.status = 'AVSLUTTET')
         SELECT aty.* FROM andel_tilkjent_ytelse aty WHERE id IN (SELECT id FROM andeler WHERE rn = 1)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -99,7 +99,7 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
               JOIN Behandling b ON b.id = aty.fk_behandling_id
              WHERE b.fk_fagsak_id = :fagsakId
                AND ty.utbetalingsoppdrag IS NOT NULL
-               AND json_extract_path_text(cast(utbetalingsoppdrag as json), 'utbetalingsperiode') != '[]'
+               AND json_extract_path_text(cast(ty.utbetalingsoppdrag as json), 'utbetalingsperiode') != '[]'
                AND aty.periode_offset IS NOT NULL
                AND b.status = 'AVSLUTTET')
         SELECT aty.* FROM andel_tilkjent_ytelse aty WHERE id IN (SELECT id FROM andeler WHERE rn = 1)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -99,6 +99,7 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
               JOIN Behandling b ON b.id = aty.fk_behandling_id
              WHERE b.fk_fagsak_id = :fagsakId
                AND ty.utbetalingsoppdrag IS NOT NULL
+               AND ty.utbetalingsoppdrag NOT LIKE '%"utbetalingsperiode":[]%'
                AND aty.periode_offset IS NOT NULL
                AND b.status = 'AVSLUTTET')
         SELECT aty.* FROM andel_tilkjent_ytelse aty WHERE id IN (SELECT id FROM andeler WHERE rn = 1)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -99,7 +99,7 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
               JOIN Behandling b ON b.id = aty.fk_behandling_id
              WHERE b.fk_fagsak_id = :fagsakId
                AND ty.utbetalingsoppdrag IS NOT NULL
-               AND ty.utbetalingsoppdrag NOT LIKE '%"utbetalingsperiode":[]%'
+               AND utbetalingsoppdrag::json ->> 'utbetalingsperiode' != '[]'
                AND aty.periode_offset IS NOT NULL
                AND b.status = 'AVSLUTTET')
         SELECT aty.* FROM andel_tilkjent_ytelse aty WHERE id IN (SELECT id FROM andeler WHERE rn = 1)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragIntegrasjonTest.kt
@@ -48,6 +48,34 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.YearMonth
 
+private const val UTBETALINGS_OPPDRAG = """
+    {
+      "kodeEndring": "NY",
+      "fagSystem": "BA",
+      "saksnummer": "100",
+      "aktoer": "123456",
+      "saksbehandlerId": "Z994212",
+      "avstemmingTidspunkt": "2024-01-04T13:41:32.190821",
+      "utbetalingsperiode": [
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 0,
+          "forrigePeriodeId": null,
+          "datoForVedtak": "2024-01-04",
+          "klassifisering": "BATR",
+          "vedtakdatoFom": "2018-02-01",
+          "vedtakdatoTom": "2019-02-28",
+          "sats": 970,
+          "satsType": "MND",
+          "utbetalesTil": "123456",
+          "behandlingId": 1000,
+          "utbetalingsgrad": null
+        }
+      ]
+    }
+"""
+
 class UtbetalingsoppdragIntegrasjonTest(
     @Autowired
     private val beregningService: BeregningService,
@@ -295,7 +323,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 ),
             )
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerFørstegangsbehandling)
-        tilkjentYtelse.utbetalingsoppdrag = "Oppdrag"
+        tilkjentYtelse.utbetalingsoppdrag = UTBETALINGS_OPPDRAG
 
         utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             "saksbehandler",
@@ -446,7 +474,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 ),
             )
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerFørstegangsbehandling)
-        tilkjentYtelse.utbetalingsoppdrag = "Oppdrag"
+        tilkjentYtelse.utbetalingsoppdrag = UTBETALINGS_OPPDRAG
 
         utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             "saksbehandler",
@@ -697,7 +725,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             )
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerFørstegangsbehandling)
 
-        tilkjentYtelse.utbetalingsoppdrag = "Oppdrag"
+        tilkjentYtelse.utbetalingsoppdrag = UTBETALINGS_OPPDRAG
 
         utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             "saksbehandler",
@@ -868,7 +896,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 ),
             )
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerFørstegangsbehandling)
-        tilkjentYtelse.utbetalingsoppdrag = "Oppdrag"
+        tilkjentYtelse.utbetalingsoppdrag = UTBETALINGS_OPPDRAG
 
         utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             "saksbehandler",
@@ -1017,7 +1045,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 ),
             )
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerFørstegangsbehandling)
-        tilkjentYtelse.utbetalingsoppdrag = "Oppdrag"
+        tilkjentYtelse.utbetalingsoppdrag = UTBETALINGS_OPPDRAG
 
         utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             "saksbehandler",
@@ -1042,7 +1070,7 @@ class UtbetalingsoppdragIntegrasjonTest(
         val tilkjentYtelse2 = lagInitiellTilkjentYtelse(behandling2)
         val andelerRevurdering = emptyList<AndelTilkjentYtelse>()
         tilkjentYtelse2.andelerTilkjentYtelse.addAll(andelerRevurdering)
-        tilkjentYtelse2.utbetalingsoppdrag = "Oppdrag"
+        tilkjentYtelse2.utbetalingsoppdrag = UTBETALINGS_OPPDRAG
 
         utbetalingsoppdragGenerator.lagUtbetalingsoppdragOgOppdaterTilkjentYtelse(
             "saksbehandler",
@@ -1115,7 +1143,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 ),
             )
         førsteTilkjentYtelse.andelerTilkjentYtelse.addAll(førsteAndelerTilkjentYtelse)
-        førsteTilkjentYtelse.utbetalingsoppdrag = "utbetalingsoppdrg"
+        førsteTilkjentYtelse.utbetalingsoppdrag = UTBETALINGS_OPPDRAG
         tilkjentYtelseRepository.saveAndFlush(førsteTilkjentYtelse)
 
         utbetalingsoppdragGeneratorService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
@@ -1254,7 +1282,7 @@ class UtbetalingsoppdragIntegrasjonTest(
 
         @Test
         fun `skal hente siste andelene per ident og ytelsestype`() {
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(this, fom, tom),
@@ -1270,7 +1298,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             val andreBehandling = opprettRevurdering()
             val andreVedtak = lagVedtak(behandling = andreBehandling)
 
-            with(lagInitiellTilkjentYtelse(andreBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(andreBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(this, fom, tom),
@@ -1304,7 +1332,7 @@ class UtbetalingsoppdragIntegrasjonTest(
             val barn = tilfeldigPerson()
             val aktørBarn = personidentService.hentOgLagreAktør(barn.aktør.aktivFødselsnummer(), true)
 
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndelTilkjentYtelse(
@@ -1360,7 +1388,7 @@ class UtbetalingsoppdragIntegrasjonTest(
 
             val revurdering = opprettRevurdering()
 
-            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndelTilkjentYtelse(
@@ -1437,7 +1465,7 @@ class UtbetalingsoppdragIntegrasjonTest(
                 }
             }
 
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(this, fom = fom, tom = tom),
@@ -1452,7 +1480,7 @@ class UtbetalingsoppdragIntegrasjonTest(
 
             val andreBehandling = opprettRevurdering()
 
-            with(lagInitiellTilkjentYtelse(andreBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(andreBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 andelerTilkjentYtelse.add(lagAndel(this, fom = fom, tom = tom))
                 tilkjentYtelseRepository.saveAndFlush(this)
             }
@@ -1462,7 +1490,7 @@ class UtbetalingsoppdragIntegrasjonTest(
 
             avsluttOgLagreBehandling(andreBehandling)
             val tredjeBehandling = opprettRevurdering()
-            with(lagInitiellTilkjentYtelse(tredjeBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(tredjeBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 tilkjentYtelseRepository.saveAndFlush(this)
             }
             with(genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(lagVedtak(behandling = tredjeBehandling))) {
@@ -1472,7 +1500,7 @@ class UtbetalingsoppdragIntegrasjonTest(
 
         @Test
         fun `ny andel etter opphør skal peke til siste andelen`() {
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(this, fom = fom, tom = tom),
@@ -1487,7 +1515,7 @@ class UtbetalingsoppdragIntegrasjonTest(
 
             val andreBehandling = opprettRevurdering()
 
-            with(lagInitiellTilkjentYtelse(andreBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(andreBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 andelerTilkjentYtelse.add(lagAndel(this, fom = fom, tom = tom))
                 tilkjentYtelseRepository.saveAndFlush(this)
             }
@@ -1495,7 +1523,7 @@ class UtbetalingsoppdragIntegrasjonTest(
 
             avsluttOgLagreBehandling(andreBehandling)
             val tredjeBehandling = opprettRevurdering()
-            with(lagInitiellTilkjentYtelse(tredjeBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(tredjeBehandling, utbetalingsoppdrag = UTBETALINGS_OPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(this, fom = fom, tom = tom),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -43,6 +43,34 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.YearMonth
 
+private const val UTBETALINGSOPPDRAG = """
+    {
+      "kodeEndring": "NY",
+      "fagSystem": "BA",
+      "saksnummer": "100",
+      "aktoer": "123456",
+      "saksbehandlerId": "Z994212",
+      "avstemmingTidspunkt": "2024-01-04T13:41:32.190821",
+      "utbetalingsperiode": [
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 0,
+          "forrigePeriodeId": null,
+          "datoForVedtak": "2024-01-04",
+          "klassifisering": "BATR",
+          "vedtakdatoFom": "2018-02-01",
+          "vedtakdatoTom": "2019-02-28",
+          "sats": 970,
+          "satsType": "MND",
+          "utbetalesTil": "123456",
+          "behandlingId": 1000,
+          "utbetalingsgrad": null
+        }
+      ]
+    }
+    """
+
 class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
     @Autowired
     private lateinit var beregningService: BeregningService
@@ -360,7 +388,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
         @Test
         fun `gitt fagsak har ikke noen andeler`() {
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGSOPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(
@@ -381,7 +409,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
         @Test
         fun `2 ulike personer med samme type`() {
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGSOPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(
@@ -423,7 +451,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
         @Test
         fun `førstegångsbehandling med flere andeler per person`() {
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGSOPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(
@@ -471,7 +499,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
         @Test
         fun `siste andelen kommer fra revurderingen`() {
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGSOPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(
@@ -486,7 +514,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
             }
             avsluttOgLagreBehandling(førsteBehandling)
             val revurdering = lagRevurdering()
-            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = UTBETALINGSOPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(
@@ -515,7 +543,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
         @Test
         fun `en revurdering opphører en andel, sånn at siste andelen finnes i en tidligere behandling`() {
-            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(førsteBehandling, utbetalingsoppdrag = UTBETALINGSOPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(
@@ -537,7 +565,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
             }
             avsluttOgLagreBehandling(førsteBehandling)
             val revurdering = lagRevurdering()
-            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(revurdering, utbetalingsoppdrag = UTBETALINGSOPPDRAG)) {
                 val andeler =
                     listOf(
                         lagAndel(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17858

I saken lenket til på favro får vi feil forrigePeriodeOffset i utbetalingsoppdraget på en av personene. Grunnen til dette er at funksjonen som finner siste offset i kjede per person finner feil siste offset for denne personen. I denne saken så har første behandling (søknad) kun 0-utbetalinger, men det er laget andeler som har lagret ned offset i databasen og det finnes et utbetalingsoppdrag, men dette har en tom liste med utbetalingsperioder. Sørger derfor i denne PRen for at vi ikke ser på behandlinger hvor utbetalingsoppdraget har en tom liste med perioder sendt til økonomi, fordi da er egentlig ingen av offsetene i den behandlingen relevante å ta med.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Lurer litt på om spørringen også burde sjekke at behandlingen ikke er henlagt, og eventuelt sortere der man plukker ut rad 1 - kunne man ha sortert på behandling vedtatt-dato eller noe i den duren? Så får man alltid den siste behandlingen? 🤔 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har ikke prioritert å skrive tester til spørringen, men har testet at vi får returnert riktig verdier for saken som hadde feil.

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja, kan godt det hvis det er ønskelig. Men har allerede snakket med @stigebil om denne
- [ ] Nei
