### PR TITLE
Ikke valider endret utbetaling ved satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -80,7 +80,9 @@ class BehandlingsresultatSteg(
             andelerTilkjentYtelseOgEndreteUtbetalingerService
                 .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
 
-        endreteUtbetalingerMedAndeler.validerEndredeUtbetalingsandeler(tilkjentYtelse, vilkårService.hentVilkårsvurdering(behandling.id))
+        if (behandling.opprettetÅrsak != BehandlingÅrsak.SATSENDRING) {
+            endreteUtbetalingerMedAndeler.validerEndredeUtbetalingsandeler(tilkjentYtelse, vilkårService.hentVilkårsvurdering(behandling.id))
+        }
 
         if (behandling.opprettetÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO) {
             validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Oppfølging til denne PRen: https://github.com/navikt/familie-ba-sak/pull/4313

Vi har noen satsendringer som ikke går gjennom fordi de endrede utbetalingene passerer valideringer som har kommet etter behandlingene de er laget i. Vi har gått gjennom sakene det gjelder og ser at andelene og brevene har blitt riktige, selv om de endrede utbetalingene er feil.

I forrige PR skrudde vi at validering ved satsendring, men etter å ha kjørt satsendringen på nytt ser vi at de endrede utbetalingene valideres flere steder. 

Endrer så behandlingen ikke stopper på valideringene for endret utbetaling dersom vi er på en satsendringssak i behandlingsrestultatssteget.
