### PR TITLE
fjern UNDER-18 vilkår fra vilkår man flytter fom på

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -36,6 +36,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.UNDER_18_ÅR
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
@@ -223,7 +224,9 @@ class ForvalterService(
                 ?: throw Feil("Det er ingen vilkårsvurdering for behandling: $behandlingId")
 
         vilkårsvurdering.personResultater.forEach { personResultat ->
-            personResultat.vilkårResultater.forEach { vilkårResultat ->
+            personResultat.vilkårResultater.forEach vilkårresultatLoop@{ vilkårResultat ->
+                if (vilkårResultat.vilkårType == UNDER_18_ÅR) return@vilkårresultatLoop
+
                 val person =
                     personerPåBehandling?.singleOrNull { it.aktør == personResultat.aktør }
                         ?: throw Feil("Finner ikke person på behandling med aktørId ${personResultat.aktør.aktørId}.")
@@ -252,7 +255,7 @@ class ForvalterService(
                 personerPåBehandling?.singleOrNull { it.aktør == personResultat.aktør }
                     ?: throw Feil("Finner ikke person på behandling.")
 
-            if (personResultat.vilkårResultater.any { it.periodeFom?.isBefore(person.fødselsdato) == true }) {
+            if (personResultat.vilkårResultater.any { it.periodeFom?.isBefore(person.fødselsdato) == true && it.vilkårType != UNDER_18_ÅR }) {
                 throw Feil("Er fortsatt vilkår som starter før fødselsdato på barn.")
             }
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -123,13 +123,13 @@ class ForvalterServiceTest {
 
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
-        val vilkårsVurdering =
+        val vilkårsvurdering =
             lagVilkårsvurdering(
                 behandling = behandling,
                 søkerAktør = søker.aktør,
                 resultat = Resultat.OPPFYLT,
             )
-        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
+        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         barnResultat.setSortedVilkårResultater(
             setOf(
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.førsteDagIInneværendeMåned(), periodeTom = barn.fødselsdato.plusMonths(3), vilkårType = Vilkår.BOSATT_I_RIKET),
@@ -141,9 +141,9 @@ class ForvalterServiceTest {
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.GIFT_PARTNERSKAP),
             ),
         )
-        vilkårsVurdering.personResultater += barnResultat
+        vilkårsvurdering.personResultater += barnResultat
 
-        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsVurdering
+        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsvurdering
 
         val vilkårsvurderingEndret = forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandling.id)
         vilkårsvurderingEndret.personResultater.singleOrNull { !it.erSøkersResultater() }
@@ -184,13 +184,13 @@ class ForvalterServiceTest {
 
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
-        val vilkårsVurdering =
+        val vilkårsvurdering =
             lagVilkårsvurdering(
                 behandling = behandling,
                 søkerAktør = søker.aktør,
                 resultat = Resultat.OPPFYLT,
             )
-        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
+        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         barnResultat.setSortedVilkårResultater(
             setOf(
                 lagVilkårResultat(
@@ -210,9 +210,9 @@ class ForvalterServiceTest {
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.GIFT_PARTNERSKAP),
             ),
         )
-        vilkårsVurdering.personResultater += barnResultat
+        vilkårsvurdering.personResultater += barnResultat
 
-        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsVurdering
+        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsvurdering
 
         assertThrows<Feil> {
             forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandling.id)
@@ -245,13 +245,13 @@ class ForvalterServiceTest {
 
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
-        val vilkårsVurdering =
+        val vilkårsvurdering =
             lagVilkårsvurdering(
                 behandling = behandling,
                 søkerAktør = søker.aktør,
                 resultat = Resultat.OPPFYLT,
             )
-        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
+        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         barnResultat.setSortedVilkårResultater(
             setOf(
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.minusMonths(2), vilkårType = Vilkår.BOSATT_I_RIKET),
@@ -261,9 +261,9 @@ class ForvalterServiceTest {
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.GIFT_PARTNERSKAP),
             ),
         )
-        vilkårsVurdering.personResultater += barnResultat
+        vilkårsvurdering.personResultater += barnResultat
 
-        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsVurdering
+        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsvurdering
 
         assertThrows<Feil> {
             forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandling.id)
@@ -296,13 +296,13 @@ class ForvalterServiceTest {
 
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
-        val vilkårsVurdering =
+        val vilkårsvurdering =
             lagVilkårsvurdering(
                 behandling = behandling,
                 søkerAktør = søker.aktør,
                 resultat = Resultat.OPPFYLT,
             )
-        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsVurdering, aktør = barn.aktør)
+        val barnResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         barnResultat.setSortedVilkårResultater(
             setOf(
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato.førsteDagIInneværendeMåned(), vilkårType = Vilkår.BOSATT_I_RIKET),
@@ -312,9 +312,9 @@ class ForvalterServiceTest {
                 lagVilkårResultat(barnResultat = barnResultat, periodeFom = barn.fødselsdato, vilkårType = Vilkår.GIFT_PARTNERSKAP),
             ),
         )
-        vilkårsVurdering.personResultater += barnResultat
+        vilkårsvurdering.personResultater += barnResultat
 
-        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsVurdering
+        every { vilkårsvurderingService.hentAktivForBehandling(behandling.id) } returns vilkårsvurdering
 
         val vilkårsvurderingEndret = forvalterService.settFomPåVilkårTilPersonsFødselsdato(behandling.id)
         vilkårsvurderingEndret.personResultater.singleOrNull { !it.erSøkersResultater() }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når vi endrer fom på vilkårresultater som begynner før personens fødselsdato ønsker vi ikke å flytte på fom på under-18-vilkår siden vi da og må flytte på tom-verdien også og det kan føre til problemer. Dette gjelder gjerne en annen type feil enn den vi jobber med. 

Videre arbeid på [denne](https://github.com/navikt/familie-ba-sak/pull/4312) PR-en :)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
