### PR TITLE
Send med avstemmingId med Grensesnittavstemming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <prosessering.version>2.20240110093731_0eda75e</prosessering.version>
         <felles.version>2.20240117140616_50f71cd</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20240116082529_ee44807</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20240122110213_5591a29</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20230912090318_2267c05</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20240104161725_c2493c6</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/AvstemmingService.kt
@@ -32,8 +32,9 @@ class AvstemmingService(
     fun grensesnittavstemOppdrag(
         fraDato: LocalDateTime,
         tilDato: LocalDateTime,
+        avstemmingId: UUID,
     ) {
-        økonomiKlient.grensesnittavstemOppdrag(fraDato, tilDato)
+        økonomiKlient.grensesnittavstemOppdrag(fraDato, tilDato, avstemmingId)
     }
 
     fun sendKonsistensavstemmingStart(

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiKlient.kt
@@ -97,6 +97,7 @@ class ØkonomiKlient(
                     fagsystem = FAGSYSTEM,
                     fra = fraDato,
                     til = tilDato,
+                    avstemmingId = avstemmingId,
                 ),
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiKlient.kt
@@ -83,6 +83,7 @@ class ØkonomiKlient(
     fun grensesnittavstemOppdrag(
         fraDato: LocalDateTime,
         tilDato: LocalDateTime,
+        avstemmingId: UUID,
     ): String {
         val uri = URI.create("$familieOppdragUri/grensesnittavstemming")
         return kallEksternTjenesteRessurs(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdrag.kt
@@ -11,6 +11,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.util.UUID
 
 @Service
 @TaskStepBeskrivelse(
@@ -25,7 +26,7 @@ class GrensesnittavstemMotOppdrag(val avstemmingService: AvstemmingService, val 
         val avstemmingTask = objectMapper.readValue(task.payload, GrensesnittavstemmingTaskDTO::class.java)
         logger.info("Gjør avstemming mot oppdrag fra og med ${avstemmingTask.fomDato} til og med ${avstemmingTask.tomDato}")
 
-        avstemmingService.grensesnittavstemOppdrag(avstemmingTask.fomDato, avstemmingTask.tomDato)
+        avstemmingService.grensesnittavstemOppdrag(avstemmingTask.fomDato, avstemmingTask.tomDato, avstemmingTask.avstemmingId)
     }
 
     override fun onCompletion(task: Task) {
@@ -39,6 +40,7 @@ class GrensesnittavstemMotOppdrag(val avstemmingService: AvstemmingService, val 
             GrensesnittavstemmingTaskDTO(
                 tideligereTriggerDato.atStartOfDay(),
                 VirkedagerProvider.nesteVirkedag(tideligereTriggerDato).atStartOfDay(),
+                avstemmingId = UUID.randomUUID(),
             )
 
         private val logger: Logger = LoggerFactory.getLogger(GrensesnittavstemMotOppdrag::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/dto/GrensesnittavstemmingTaskDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/dto/GrensesnittavstemmingTaskDTO.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.task.dto
 
 import java.time.LocalDateTime
+import java.util.UUID
 
-data class GrensesnittavstemmingTaskDTO(val fomDato: LocalDateTime, val tomDato: LocalDateTime)
+data class GrensesnittavstemmingTaskDTO(val fomDato: LocalDateTime, val tomDato: LocalDateTime, val avstemmingId: UUID)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.time.LocalDate
 import java.util.Properties
+import java.util.UUID
 
 class GrensesnittavstemMotOppdragTest {
     private lateinit var grensesnittavstemMotOppdrag: GrensesnittavstemMotOppdrag
@@ -50,6 +51,7 @@ class GrensesnittavstemMotOppdragTest {
                         GrensesnittavstemmingTaskDTO(
                             fomDato = triggerDato.minusDays(1).atStartOfDay(),
                             tomDato = triggerDato.atStartOfDay(),
+                            avstemmingId = UUID.randomUUID(),
                         ),
                     ),
                 properties = Properties(),
@@ -116,6 +118,7 @@ class GrensesnittavstemMotOppdragTest {
                         GrensesnittavstemmingTaskDTO(
                             iDag.minusDays(1),
                             iDag,
+                            avstemmingId = UUID.randomUUID(),
                         ),
                     ),
             ).medTriggerTid(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17773

Når vi kjører grensesnittavstemming i ba-sak henter det at avstemmingen timer ut før den er ferdig, selv om det går bra mot oppdrag. I de tilfellene har vi ikke lyst til å kjøre grensesnittavstemmingen på nytt.

Endrer så vi sender med en avstemmingId som vil bli lagret i familie-oppdrag. Dersom vi prøver å rekjøre en grenseavsnittsavstemming på samme avstemmingId vil den bli ignorert dersom forrige avstemming gikk ok.
