### PR TITLE
Flytt ferdigstilling av oppgave inn i task

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -19,7 +19,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.validerPerioderInneholderBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
-import no.nav.familie.ba.sak.task.FerdigstillOppgaver
+import no.nav.familie.ba.sak.task.FerdigstillLagVedtakOppgaver
 import no.nav.familie.ba.sak.task.OpprettOppgaveTask
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.springframework.stereotype.Service
@@ -85,26 +85,11 @@ class SendTilBeslutter(
             loggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = true)
         }
 
-        opprettFerdigstillOppgaveTasker(behandling)
+        taskRepository.save(FerdigstillLagVedtakOppgaver.opprettTask(behandling.id))
 
         behandlingService.sendBehandlingTilBeslutter(behandling)
 
         return hentNesteStegForNormalFlyt(behandling)
-    }
-
-    private fun opprettFerdigstillOppgaveTasker(behandling: Behandling) {
-        listOf(
-            Oppgavetype.BehandleSak,
-            Oppgavetype.BehandleUnderkjentVedtak,
-            Oppgavetype.VurderLivshendelse,
-        ).forEach { oppgavetype ->
-            oppgaveService.hentOppgaverSomIkkeErFerdigstilt(oppgavetype, behandling).also {
-                if (it.isNotEmpty()) {
-                    val ferdigstillOppgaverTask = FerdigstillOppgaver.opprettTask(behandling.id, oppgavetype)
-                    taskRepository.save(ferdigstillOppgaverTask)
-                }
-            }
-        }
     }
 
     override fun stegType(): StegType {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/FerdigstillLagVedtakOppgaver.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/FerdigstillLagVedtakOppgaver.kt
@@ -1,0 +1,45 @@
+﻿package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.util.Properties
+
+data class FerdigstillLagVedtakOppgaverDTO(
+    val behandlingId: Long,
+)
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = FerdigstillLagVedtakOppgaver.TASK_STEP_TYPE,
+    beskrivelse = "Ferdigstill oppgavene for å lage vedtak i GOSYS",
+    maxAntallFeil = 3,
+)
+class FerdigstillLagVedtakOppgaver(
+    private val oppgaveService: OppgaveService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val ferdigstillLagVedtakOppgaverDTO = objectMapper.readValue(task.payload, FerdigstillLagVedtakOppgaverDTO::class.java)
+        oppgaveService.ferdigstillLagVedtakOppgaver(behandlingId = ferdigstillLagVedtakOppgaverDTO.behandlingId)
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "ferdigstillBehandleVedtakOppgaver"
+
+        fun opprettTask(
+            behandlingId: Long,
+        ): Task {
+            return Task(
+                type = TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(FerdigstillLagVedtakOppgaverDTO(behandlingId = behandlingId)),
+                properties =
+                    Properties().apply {
+                        this["behandlingsId"] = behandlingId.toString()
+                    },
+            )
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -20,11 +20,9 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
-import no.nav.familie.ba.sak.kjerne.brev.DokumentService
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -42,37 +40,37 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class BeslutteVedtakTest {
-    private lateinit var beslutteVedtak: BeslutteVedtak
-    private lateinit var vedtakService: VedtakService
-    private lateinit var behandlingService: BehandlingService
-    private lateinit var beregningService: BeregningService
-    private lateinit var taskRepository: TaskRepositoryWrapper
-    private lateinit var dokumentService: DokumentService
-    private lateinit var vilkårsvurderingService: VilkårsvurderingService
-    private val unleashService = mockk<UnleashNextMedContextService>()
-    private lateinit var tilkjentYtelseValideringService: TilkjentYtelseValideringService
-    private lateinit var simuleringService: SimuleringService
-    private lateinit var automatiskBeslutningService: AutomatiskBeslutningService
-
+    private val toTrinnKontrollService = mockk<TotrinnskontrollService>()
+    private val vedtakService: VedtakService = mockk()
+    private val behandlingService: BehandlingService = mockk()
+    private val beregningService: BeregningService = mockk()
+    private val taskRepository: TaskRepositoryWrapper = mockk()
+    private val vilkårsvurderingService: VilkårsvurderingService = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
+    private val tilkjentYtelseValideringService: TilkjentYtelseValideringService = mockk()
+    private val automatiskBeslutningService: AutomatiskBeslutningService = mockk()
     private val saksbehandlerContext = mockk<SaksbehandlerContext>()
+    private val loggService = mockk<LoggService>()
+
+    val beslutteVedtak =
+        BeslutteVedtak(
+            totrinnskontrollService = toTrinnKontrollService,
+            vedtakService = vedtakService,
+            behandlingService = behandlingService,
+            beregningService = beregningService,
+            taskRepository = taskRepository,
+            loggService = loggService,
+            vilkårsvurderingService = vilkårsvurderingService,
+            unleashService = unleashService,
+            tilkjentYtelseValideringService = tilkjentYtelseValideringService,
+            saksbehandlerContext = saksbehandlerContext,
+            automatiskBeslutningService = automatiskBeslutningService,
+        )
 
     private val randomVilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
 
     @BeforeEach
     fun setUp() {
-        val toTrinnKontrollService = mockk<TotrinnskontrollService>()
-        vedtakService = mockk()
-        taskRepository = mockk()
-        dokumentService = mockk()
-        behandlingService = mockk()
-        beregningService = mockk()
-        vilkårsvurderingService = mockk()
-        tilkjentYtelseValideringService = mockk()
-        simuleringService = mockk()
-        automatiskBeslutningService = mockk()
-
-        val loggService = mockk<LoggService>()
-
         every { taskRepository.save(any()) } returns Task(OpprettOppgaveTask.TASK_STEP_TYPE, "")
         every {
             toTrinnKontrollService.besluttTotrinnskontroll(
@@ -94,21 +92,6 @@ class BeslutteVedtakTest {
         every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns randomVilkårsvurdering
         every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(any()) } returns randomVilkårsvurdering
         every { saksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "saksbehandlerNavn"
-
-        beslutteVedtak =
-            BeslutteVedtak(
-                totrinnskontrollService = toTrinnKontrollService,
-                vedtakService = vedtakService,
-                behandlingService = behandlingService,
-                beregningService = beregningService,
-                taskRepository = taskRepository,
-                loggService = loggService,
-                vilkårsvurderingService = vilkårsvurderingService,
-                unleashService = unleashService,
-                tilkjentYtelseValideringService = tilkjentYtelseValideringService,
-                saksbehandlerContext = saksbehandlerContext,
-                automatiskBeslutningService = automatiskBeslutningService,
-            )
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17857

Når vi har sendt behandling til godkjenning har vi tidligere hentet alle behandlingene av type BehandleSak, BehandleUnderkjentVedtak eller VurderLivshendelse på behandlingen og ferdigstilt dem. I tilfellet i favrooppgavnen var saksbehandler så rask at behandleSak-oppgavenikke var opprettet enda, og den ble derfor ikke ferdigstilt. 

Endrer så vi kaster en feil dersom vi ikke har en oppgave av typen BehandleSak, BehandleUnderkjentVedtak eller VurderLivshendelse når vi godkjenner vedtak og legger det inn i en task slik at det kan rekjøres senere.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
