### PR TITLE
Ikke valider at vi har en oppgave på migrering eller teknisk behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -390,8 +390,12 @@ class OppgaveService(
                     )
             }
 
-        if (lagVedtakOppgaver.isEmpty() && !behandling.skalBehandlesAutomatisk) {
-            throw Feil("Fant ingen oppgaver")
+        if (lagVedtakOppgaver.isEmpty() &&
+            !behandling.skalBehandlesAutomatisk &&
+            !behandling.erMigrering() &&
+            !behandling.erTekniskBehandling()
+        ) {
+            throw Feil("Fant ingen oppgaver å avslutte ved sending til godkjenner på $behandling")
         }
 
         lagVedtakOppgaver


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til https://github.com/navikt/familie-ba-sak/pull/4329

Vi validerer at vi får lukket oppgaven for å lage vedtak når vi sender til godkjenner. Disse oppgavene finnes ikke på migreringer eller tekniske behandlinger. Tar bort valideringen i de tilfellene



