### PR TITLE
Gjør så tester ikke er avhengige av rekkefølge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,6 +503,7 @@
                     <!--suppress UnresolvedMavenProperty -->
                     <excludedGroups>${excludedGroups}</excludedGroups>
                     <threadCount>1</threadCount>
+                    <runOrder>random</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
@@ -13,8 +13,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import java.time.YearMonth
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ForvalterSchedulerTest {
     private val taskRepository = mockk<TaskRepositoryWrapper>()
     private val envService = mockk<EnvService>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.internal
 
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -9,6 +10,7 @@ import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.task.FinnSakerMedFlereMigreringsbehandlingerTask
 import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.YearMonth
@@ -25,6 +27,11 @@ class ForvalterSchedulerTest {
         every { YearMonth.now() }.returns(YearMonth.of(2022, 5))
         every { envService.erDev() } returns true
         every { taskRepository.save(capture(slot)) } returns Task(type = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE, payload = "")
+    }
+
+    @AfterAll
+    fun clearMocks() {
+        clearAllMocks()
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.behandling.behandlingstema
 
+import io.mockk.MockK
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.defaultFagsak
@@ -56,6 +58,9 @@ class BehandlingstemaServiceTest {
 
     @BeforeAll
     fun init() {
+        clearAllMocks()
+
+        MockK.useImpl { }
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(defaultFagsak.id) } returns defaultBehandling
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -16,11 +16,13 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.math.BigDecimal
 import java.time.YearMonth
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BehandlingsresultatOpphørUtilsTest {
     val søker = tilfeldigPerson()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
+import io.mockk.clearAllMocks
 import io.mockk.clearStaticMockk
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -11,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatOpph�
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatOpphørUtils.hentOpphørsresultatPåBehandling
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -31,6 +33,11 @@ class BehandlingsresultatOpphørUtilsTest {
     @BeforeEach
     fun reset() {
         clearStaticMockk(YearMonth::class)
+    }
+
+    @AfterAll
+    fun clearMocks() {
+        clearAllMocks()
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggBarnetrygdGeneratorTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
@@ -31,6 +32,7 @@ class SmåbarnstilleggBarnetrygdGeneratorTest {
 
     @BeforeEach
     fun førHverTest() {
+        clearAllMocks()
         mockkObject(SatsTidspunkt)
         every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2022, 12, 31)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
@@ -49,6 +50,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 import kotlin.random.Random
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EndretUtbetalingAndelValideringTest {
     val søker = lagPerson(type = PersonType.SØKER)
     val barn = lagPerson(type = PersonType.BARN)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.endretutbetaling
 
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -36,6 +37,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvu
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -54,6 +56,11 @@ class EndretUtbetalingAndelValideringTest {
         endretUtbetalingAndel(søker, YtelseType.UTVIDET_BARNETRYGD, BigDecimal.ZERO)
     val endretUtbetalingAndelDeltBostedNullutbetaling =
         endretUtbetalingAndel(barn, YtelseType.ORDINÆR_BARNETRYGD, BigDecimal.ZERO)
+
+    @AfterAll
+    fun clearMocks() {
+        clearAllMocks()
+    }
 
     @Test
     fun `skal sjekke at en endret periode ikke overlapper med eksisterende endringsperioder`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/TaskUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/TaskUtilsTest.kt
@@ -6,11 +6,13 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.core.env.Environment
 import java.time.LocalDateTime
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TaskUtilsTest {
     @AfterAll
     fun clearMocks() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/TaskUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/TaskUtilsTest.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.ba.sak.task
 
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -10,6 +12,11 @@ import org.springframework.core.env.Environment
 import java.time.LocalDateTime
 
 class TaskUtilsTest {
+    @AfterAll
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
     @ParameterizedTest
     @CsvSource(
         "2020-06-09T13:37:00, 2020-06-09T14:37:00, Innenfor dagtid",


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når vi mocker statiske metoder, som feks `YearMonth.now()`, endrer vi dette globalt for _*alle*_ tester. Testene som kjører etter vil derfor returnere det samme som `YearMonth.now()` er mocka til når de kjører `YearMonth.now()`. 

Endrer så vi rytter opp der vi mocker statikste metoder. Endrer også så rekkefølgen på testene er random, slik at vi kan oppdage slike feil raskere i fremtiden. 
