### PR TITLE
forskyv eksplisitte avslag dersom de begynner og opphører innenfor samme måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/EndreTid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/EndreTid.kt
@@ -69,6 +69,32 @@ fun <I, R> Tidslinje<I, Dag>.tilMånedFraMånedsskifteIkkeNull(
 }
 
 /**
+ * Extention-metode som konverterer en dag-basert tidslinje til en måned-basert tidslinje.
+ * <mapper>-funksjonen tar inn verdiene fra de to dagene før og etter månedsskiftet,
+ * det vil si verdiene fra siste dag i forrige måned og første dag i inneværemde måned.
+ * Return-verdien er innholdet som blir brukt for inneværende måned.
+ * Hvis retur-verdien er <null>, vil den resulterende måneden mangle verdi.
+ * Funksjonen vil bruke månedsskiftene fra måneden før tidslinjens <fraOgMed> frem til og med måneden etter <tilOgMed>
+ */
+fun <I, R> Tidslinje<I, Dag>.tilMånedFraMånedsskifte(
+    mapper: (innholdSisteDagForrigeMåned: I?, innholdFørsteDagDenneMåned: I?) -> R?,
+): Tidslinje<R, Måned> {
+    val fraOgMed = fraOgMed()
+    val tilOgMed = tilOgMed()
+
+    return if (fraOgMed == null || tilOgMed == null) {
+        TomTidslinje()
+    } else {
+        (fraOgMed.tilForrigeMåned()..tilOgMed.tilNesteMåned()).tidslinjeFraTidspunkt { måned ->
+            val innholdSisteDagForrigeMåned = innholdForTidspunkt(måned.forrige().tilSisteDagIMåneden())
+            val innholdFørsteDagDenneMåned = innholdForTidspunkt(måned.tilFørsteDagIMåneden())
+
+            mapper(innholdSisteDagForrigeMåned.innhold, innholdFørsteDagDenneMåned.innhold).tilVerdi()
+        }
+    }
+}
+
+/**
  * Extension-metode for å konvertere fra Måned-tidslinje til Dag-tidslinje
  * Første dag i fra-og-med-måneden brukes som første dag i perioden
  * Siste dag i til-og-med-måneden brukes som siste dag i perioden

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
@@ -43,6 +43,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvni
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilTidslinje
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
@@ -228,8 +229,9 @@ private fun VedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerson(
             }
 
         val generelleAvslagsBegrunnelser =
-            generelleAvslag
-                .tilForskjøvedeVilkårTidslinjer(person.fødselsdato)
+            generelleAvslag.groupBy { it.vilkårType }.mapNotNull { (_, vilkårResultater) ->
+                listOf(månedPeriodeAv(null, null, vilkårResultater.single())).tilTidslinje()
+            }
 
         val ikkeGenerelleAvslagsbegrunnelserTidslinjer =
             vilkårResultaterUtenGenerelleAvslag

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -127,7 +127,6 @@ object VilkårsvurderingForskyvningUtils {
                     innholdSisteDagForrigeMåned
                 } else {
                     null
-                    
                 }
             }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.erUnder18ÅrVilkårTidslinje
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
@@ -135,7 +136,7 @@ object VilkårsvurderingForskyvningUtils {
     private fun VilkårResultat?.erEksplisittAvslagInnenforSammeMåned(): Boolean {
         return this?.erEksplisittAvslagPåSøknad == true &&
             this.periodeFom != null &&
-            this.periodeFom!!.month == this.periodeTom?.month
+            this.periodeFom!!.toYearMonth() == this.periodeTom?.toYearMonth()
     }
 
     private fun Tidslinje<VilkårResultat, Måned>.beskjærPå18ÅrHvisUnder18ÅrVilkår(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -122,13 +122,12 @@ object VilkårsvurderingForskyvningUtils {
                         !innholdSisteDagForrigeMåned.erOppfylt() -> innholdSisteDagForrigeMåned
                         else -> innholdFørsteDagDenneMåned
                     }
+                } else if (innholdFørsteDagDenneMåned == null && innholdSisteDagForrigeMåned.erEksplisittAvslagInnenforSammeMåned()
+                ) {
+                    innholdSisteDagForrigeMåned
                 } else {
-                    if (innholdFørsteDagDenneMåned == null && innholdSisteDagForrigeMåned.erEksplisittAvslagInnenforSammeMåned()
-                    ) {
-                        innholdSisteDagForrigeMåned
-                    } else {
-                        null
-                    }
+                    null
+                    
                 }
             }
     }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/avslag.feature
@@ -288,3 +288,143 @@ Egenskap: Brevbegrunnelser ved eksplisitte avslag vs avslag
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.10.2023 til -
       | Begrunnelse                                       | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet | Avtaletidspunkt delt bosted |
       | AVSLAG_IKKE_OPPHOLDSTILLATELSE_MER_ENN_12_MÅNEDER | STANDARD | Ja            | 16.02.13 og 02.08.16 | 2           | september 2023                       | NB      | 0     |                  |                         |                             |
+
+  Scenario: Skal forskyve eksplisitt avslag når avslaget starter og opphører innenfor samme måned
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat        | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        |                     | DELVIS_INNVILGET_OG_ENDRET | SØKNAD           | Nei                       | NASJONAL            |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 26.03.1977  |              |
+      | 1            | 2       | BARN       | 09.01.2012  |              |
+
+    Og følgende dagens dato 25.01.2024
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser              | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.02.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 1       | UTVIDET_BARNETRYGD            |                             | 16.01.2023 | 31.01.2023 | IKKE_OPPFYLT | Ja                   | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                  |
+
+      | 2       | UNDER_18_ÅR                   |                             | 09.01.2012 | 08.01.2030 | OPPFYLT      | Nei                  |                                   |                  |
+      | 2       | GIFT_PARTNERSKAP              |                             | 09.01.2012 |            | OPPFYLT      | Nei                  |                                   |                  |
+      | 2       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.02.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 |                             | 01.02.2022 | 31.01.2023 | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 | DELT_BOSTED_SKAL_IKKE_DELES | 01.02.2023 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+
+
+    Når vedtaksperiodene genereres for behandling 1
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser              | Ugyldige begrunnelser |
+      | 01.02.2023 | 28.02.2023 | AVSLAG             |                                | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                       |
+
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato   | Standardbegrunnelser              | Eøsbegrunnelser | Fritekster |
+      | 01.02.2023 | 28.02.2023 | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                 |            |
+
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.02.2023 til 28.02.2023
+      | Begrunnelse                       | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp |
+      | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE | STANDARD | Ja            | 09.01.12             | 0           | januar 2023                          | 0 |
+
+
+  Scenario: Skal ikke forskyve eksplisitt avslag når det varer mer enn én måned
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat        | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        |                     | DELVIS_INNVILGET_OG_ENDRET | SØKNAD           | Nei                       | NASJONAL            |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 26.03.1977  |              |
+      | 1            | 2       | BARN       | 09.01.2012  |              |
+
+    Og følgende dagens dato 25.01.2024
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser              | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.03.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 1       | UTVIDET_BARNETRYGD            |                             | 16.01.2023 | 28.02.2023 | IKKE_OPPFYLT | Ja                   | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                  |
+
+      | 2       | UNDER_18_ÅR                   |                             | 09.01.2012 | 08.01.2030 | OPPFYLT      | Nei                  |                                   |                  |
+      | 2       | GIFT_PARTNERSKAP              |                             | 09.01.2012 |            | OPPFYLT      | Nei                  |                                   |                  |
+      | 2       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.02.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 |                             | 01.02.2022 | 28.02.2023 | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 | DELT_BOSTED_SKAL_IKKE_DELES | 01.03.2023 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+
+    Når vedtaksperiodene genereres for behandling 1
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser              | Ugyldige begrunnelser |
+      | 01.02.2023 | 28.02.2023 | AVSLAG             |                                | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                       |
+
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato   | Standardbegrunnelser              | Eøsbegrunnelser | Fritekster |
+      | 01.02.2023 | 28.02.2023 | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                 |            |
+
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.02.2023 til 28.02.2023
+      | Begrunnelse                       | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp |
+      | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE | STANDARD | Ja            | 09.01.12             | 0           | januar 2023                          | 0 |
+
+
+  Scenario: Skal forskyve avslagsperioder når de etterfølges av innvilget periode
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat        | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        |                     | DELVIS_INNVILGET_OG_ENDRET | SØKNAD           | Nei                       | NASJONAL            |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 26.03.1977  |              |
+      | 1            | 2       | BARN       | 09.01.2012  |              |
+
+    Og følgende dagens dato 25.01.2024
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser              | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.02.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 1       | UTVIDET_BARNETRYGD            |                             | 16.01.2023 | 31.01.2023 | IKKE_OPPFYLT | Ja                   | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                  |
+      | 1       | UTVIDET_BARNETRYGD            |                             | 01.02.2023 |            | OPPFYLT      | Nei                  |                                   |                  |
+
+      | 2       | UNDER_18_ÅR                   |                             | 09.01.2012 | 08.01.2030 | OPPFYLT      | Nei                  |                                   |                  |
+      | 2       | GIFT_PARTNERSKAP              |                             | 09.01.2012 |            | OPPFYLT      | Nei                  |                                   |                  |
+      | 2       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.02.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 |                             | 01.02.2022 | 31.01.2023 | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 | DELT_BOSTED_SKAL_IKKE_DELES | 01.02.2023 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
+      | 1       | 1            | 01.07.2023 | 31.12.2029 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 2       | 1            | 01.03.2022 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 1            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 1            | 01.01.2024 | 31.12.2029 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+    Når vedtaksperiodene genereres for behandling 1
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser              | Ugyldige begrunnelser |
+      | 01.02.2023 | 28.02.2023 | AVSLAG             |                                | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                       |
+      | 01.03.2023 | 30.06.2023 | UTBETALING         |                                |                                   |                       |
+      | 01.07.2023 | 31.12.2023 | UTBETALING         |                                |                                   |                       |
+      | 01.01.2024 | 31.12.2029 | UTBETALING         |                                |                                   |                       |
+      | 01.01.2030 |            | OPPHØR             |                                |                                   |                       |
+
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato   | Standardbegrunnelser              | Eøsbegrunnelser | Fritekster |
+      | 01.02.2023 | 28.02.2023 | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE |                 |            |
+
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.02.2023 til 28.02.2023
+      | Begrunnelse                       | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp |
+      | AVSLAG_IKKE_FLYTTET_FRA_EKTEFELLE | STANDARD | Ja            | 09.01.12             | 0           | januar 2023                          | 1 054 |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør.feature
@@ -5,15 +5,15 @@ Egenskap: Brevbegrunnelser ved opphør
 
   Bakgrunn:
     Gitt følgende fagsaker for begrunnelse
-      | FagsakId  | Fagsaktype |
+      | FagsakId | Fagsaktype |
       | 1        | NORMAL     |
 
     Gitt følgende behandling
-      | BehandlingId | FagsakId  | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Skal behandles automatisk |
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Skal behandles automatisk |
       | 1            | 1        |                     | INNVILGET_OG_OPPHØRT | SØKNAD           | Nei                       |
 
     Og følgende persongrunnlag for begrunnelse
-      | BehandlingId | AktørId       | Persontype | Fødselsdato |
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1       | SØKER      | 10.07.1988  |
       | 1            | 2       | BARN       | 17.04.2017  |
       | 1            | 3       | BARN       | 11.07.2013  |
@@ -24,7 +24,7 @@ Egenskap: Brevbegrunnelser ved opphør
     Og lag personresultater for begrunnelse for behandling 1
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
-      | AktørId       | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
+      | AktørId | Vilkår                                                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag |
       | 1       | LOVLIG_OPPHOLD                                               |                  | 10.07.1988 |            | OPPFYLT  | Nei                  |
       | 1       | BOSATT_I_RIKET                                               |                  | 01.12.2022 | 01.02.2023 | OPPFYLT  | Nei                  |
 
@@ -36,7 +36,7 @@ Egenskap: Brevbegrunnelser ved opphør
       | 2       | UNDER_18_ÅR                                                  |                  | 17.04.2017 | 16.04.2035 | OPPFYLT  | Nei                  |
 
     Og med andeler tilkjent ytelse for begrunnelse
-      | AktørId       | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
       | 3       | 1            | 01.01.2023 | 31.01.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
       | 2       | 1            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
@@ -82,19 +82,19 @@ Egenskap: Vedtaksperioder med mor og to barn
       | 1234    | BOSATT_I_RIKET                   | 24.12.1987 |            | Oppfylt      |                      |
       | 1234    | LOVLIG_OPPHOLD                   |            |            | ikke_oppfylt | Ja                   |
       | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET | 01.12.2016 |            | Oppfylt      |                      |
-      | 3456    | LOVLIG_OPPHOLD                   | 01.12.2016 | 30.05.2020 | Oppfylt      |                      |
-      | 3456    | BOR_MED_SØKER                    | 01.12.2016 | 01.12.2020 | Oppfylt      |                      |
+      | 3456    | LOVLIG_OPPHOLD                   | 01.12.2016 | 31.05.2020 | Oppfylt      |                      |
+      | 3456    | BOR_MED_SØKER                    | 01.12.2016 | 30.11.2020 | Oppfylt      |                      |
       | 3456    | UNDER_18_ÅR                      | 01.12.2016 | 30.11.2034 | Oppfylt      |                      |
       | 5678    | GIFT_PARTNERSKAP, BOSATT_I_RIKET | 01.12.2017 |            | Oppfylt      |                      |
-      | 5678    | LOVLIG_OPPHOLD                   | 01.12.2017 | 30.05.2021 | Oppfylt      |                      |
-      | 5678    | BOR_MED_SØKER                    | 01.12.2017 | 01.12.2021 | Oppfylt      |                      |
+      | 5678    | LOVLIG_OPPHOLD                   | 01.12.2017 | 31.05.2021 | Oppfylt      |                      |
+      | 5678    | BOR_MED_SØKER                    | 01.12.2017 | 30.11.2021 | Oppfylt      |                      |
       | 5678    | UNDER_18_ÅR                      | 01.12.2017 | 30.11.2035 | Oppfylt      |                      |
 
       | 3456    | LOVLIG_OPPHOLD                   | 08.06.2020 | 30.09.2021 | ikke_oppfylt | Ja                   |
-      | 3456    | BOR_MED_SØKER                    | 02.12.2020 | 31.12.2021 | ikke_oppfylt | Ja                   |
+      | 3456    | BOR_MED_SØKER                    | 01.12.2020 | 31.12.2021 | ikke_oppfylt | Ja                   |
 
       | 5678    | LOVLIG_OPPHOLD                   | 08.06.2021 | 30.09.2022 | ikke_oppfylt | Ja                   |
-      | 5678    | BOR_MED_SØKER                    | 02.12.2021 | 31.12.2022 | ikke_oppfylt | Ja                   |
+      | 5678    | BOR_MED_SØKER                    | 01.12.2021 | 31.12.2022 | ikke_oppfylt | Ja                   |
 
     Når vedtaksperioder med begrunnelser genereres for behandling 1
 
@@ -102,12 +102,12 @@ Egenskap: Vedtaksperioder med mor og to barn
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar                          |
       |            |            | AVSLAG             | Søker har avslag                   |
 
-      | 01.07.2020 | 31.12.2020 | AVSLAG             | Barn1 har avslag på LOVLIG_OPPHOLD |
-      | 01.01.2021 | 30.09.2021 | AVSLAG             | Barn1 har avslag på to vilkår      |
+      | 01.07.2020 | 30.11.2020 | AVSLAG             | Barn1 har avslag på LOVLIG_OPPHOLD |
+      | 01.12.2020 | 30.09.2021 | AVSLAG             | Barn1 har avslag på to vilkår      |
       | 01.10.2021 | 31.12.2021 | AVSLAG             | Barn1 har avslag på BOR_MED_SØKER  |
 
-      | 01.07.2021 | 31.12.2021 | AVSLAG             | Barn2 har avslag på LOVLIG_OPPHOLD |
-      | 01.01.2022 | 30.09.2022 | AVSLAG             | Barn2 har avslag på to vilkår      |
+      | 01.07.2021 | 30.11.2021 | AVSLAG             | Barn2 har avslag på LOVLIG_OPPHOLD |
+      | 01.12.2021 | 30.09.2022 | AVSLAG             | Barn2 har avslag på to vilkår      |
       | 01.10.2022 | 31.12.2022 | AVSLAG             | Barn2 har avslag på BOR_MED_SØKER  |
 
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
@@ -82,19 +82,19 @@ Egenskap: Vedtaksperioder med mor og to barn
       | 1234    | BOSATT_I_RIKET                   | 24.12.1987 |            | Oppfylt      |                      |
       | 1234    | LOVLIG_OPPHOLD                   |            |            | ikke_oppfylt | Ja                   |
       | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET | 01.12.2016 |            | Oppfylt      |                      |
-      | 3456    | LOVLIG_OPPHOLD                   | 01.12.2016 | 31.05.2020 | Oppfylt      |                      |
-      | 3456    | BOR_MED_SØKER                    | 01.12.2016 | 30.11.2020 | Oppfylt      |                      |
+      | 3456    | LOVLIG_OPPHOLD                   | 01.12.2016 | 30.05.2020 | Oppfylt      |                      |
+      | 3456    | BOR_MED_SØKER                    | 01.12.2016 | 01.12.2020 | Oppfylt      |                      |
       | 3456    | UNDER_18_ÅR                      | 01.12.2016 | 30.11.2034 | Oppfylt      |                      |
       | 5678    | GIFT_PARTNERSKAP, BOSATT_I_RIKET | 01.12.2017 |            | Oppfylt      |                      |
-      | 5678    | LOVLIG_OPPHOLD                   | 01.12.2017 | 31.05.2021 | Oppfylt      |                      |
-      | 5678    | BOR_MED_SØKER                    | 01.12.2017 | 30.11.2021 | Oppfylt      |                      |
+      | 5678    | LOVLIG_OPPHOLD                   | 01.12.2017 | 30.05.2021 | Oppfylt      |                      |
+      | 5678    | BOR_MED_SØKER                    | 01.12.2017 | 01.12.2021 | Oppfylt      |                      |
       | 5678    | UNDER_18_ÅR                      | 01.12.2017 | 30.11.2035 | Oppfylt      |                      |
 
       | 3456    | LOVLIG_OPPHOLD                   | 08.06.2020 | 30.09.2021 | ikke_oppfylt | Ja                   |
-      | 3456    | BOR_MED_SØKER                    | 01.12.2020 | 31.12.2021 | ikke_oppfylt | Ja                   |
+      | 3456    | BOR_MED_SØKER                    | 02.12.2020 | 31.12.2021 | ikke_oppfylt | Ja                   |
 
       | 5678    | LOVLIG_OPPHOLD                   | 08.06.2021 | 30.09.2022 | ikke_oppfylt | Ja                   |
-      | 5678    | BOR_MED_SØKER                    | 01.12.2021 | 31.12.2022 | ikke_oppfylt | Ja                   |
+      | 5678    | BOR_MED_SØKER                    | 02.12.2021 | 31.12.2022 | ikke_oppfylt | Ja                   |
 
     Når vedtaksperioder med begrunnelser genereres for behandling 1
 
@@ -102,12 +102,12 @@ Egenskap: Vedtaksperioder med mor og to barn
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar                          |
       |            |            | AVSLAG             | Søker har avslag                   |
 
-      | 01.07.2020 | 30.11.2020 | AVSLAG             | Barn1 har avslag på LOVLIG_OPPHOLD |
-      | 01.12.2020 | 30.09.2021 | AVSLAG             | Barn1 har avslag på to vilkår      |
+      | 01.07.2020 | 31.12.2020 | AVSLAG             | Barn1 har avslag på LOVLIG_OPPHOLD |
+      | 01.01.2021 | 30.09.2021 | AVSLAG             | Barn1 har avslag på to vilkår      |
       | 01.10.2021 | 31.12.2021 | AVSLAG             | Barn1 har avslag på BOR_MED_SØKER  |
 
-      | 01.07.2021 | 30.11.2021 | AVSLAG             | Barn2 har avslag på LOVLIG_OPPHOLD |
-      | 01.12.2021 | 30.09.2022 | AVSLAG             | Barn2 har avslag på to vilkår      |
+      | 01.07.2021 | 31.12.2021 | AVSLAG             | Barn2 har avslag på LOVLIG_OPPHOLD |
+      | 01.01.2022 | 30.09.2022 | AVSLAG             | Barn2 har avslag på to vilkår      |
       | 01.10.2022 | 31.12.2022 | AVSLAG             | Barn2 har avslag på BOR_MED_SØKER  |
 
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17842)

Når en behandling har et eksplisitt avslag dukker ikke avslagsbegrunnelsene opp. Dette er fordi vi når vi har forskjøvet perioder som starter og stopper innenfor samme måned har satt perioden til å være tom (Fordi innholdSisteDagForrigeMåned eller innholdFørsteDagDenneMåned vil være null. Se dokumentasjonen til EndreTid.tilMånedFraMånedsskifteIkkeNull() ).

Ønsket oppførsel for eksplisitt avslag er:
* Vilkårsresultat som slutter innenfor samme måned, f.eks. 16. jan - 31. jan skal gi periode 1. feb - 28. feb
* Vilkårsresultat som varer lengre, f.eks. 16.jan - 30. april skal gi periode 1. feb - 30 april
* Dersom vi har en innvilget periode etter avslaget altså avslag 16. jan - 30. april, innvilget 1. mai og utover så skal vi forskyve avslaget og få 1. feb - 31. mai

Forskyver nå vilkårene før vi filtrerer ut de eksplisitte avslagene slik at de tar hensyn til etterfølgende periode. Har lagt til både enhets- og cucumber-tester siden enhetstestene ikke tar hensyn til filtreringen av eksplisitte avslag. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
