### PR TITLE
Lagt til mer logging for å kunne feilsøke valideringsfeil for tilkjent ytelse ved satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.SatsendringFeil
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
 import no.nav.familie.ba.sak.common.Utils
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.SatsendringSvar
@@ -77,7 +78,7 @@ object TilkjentYtelseValidering {
                             "Satsendring kan ikke legge til en andel som ikke var der i forrige behandling. " +
                                 "Satsendringen prøver å legge til en andel i perioden ${nåværendeAndel.stønadFom} - ${nåværendeAndel.stønadTom}",
                         satsendringSvar = SatsendringSvar.BEHANDLING_HAR_FEIL_PÅ_ANDELER,
-                    )
+                    ).also { secureLogger.info("forrigeAndel er null, nåværendeAndel=$nåværendeAndel") }
 
                 forrigeAndel != null && nåværendeAndel == null ->
                     throw SatsendringFeil(
@@ -85,7 +86,7 @@ object TilkjentYtelseValidering {
                             "Satsendring kan ikke fjerne en andel som fantes i forrige behandling. " +
                                 "Satsendringen prøver å fjerne andel i perioden ${forrigeAndel.stønadFom} - ${forrigeAndel.stønadTom}",
                         satsendringSvar = SatsendringSvar.BEHANDLING_HAR_FEIL_PÅ_ANDELER,
-                    )
+                    ).also { secureLogger.info("nåværendeAndel er null, forrigeAndel=$forrigeAndel") }
 
                 forrigeAndel != null && forrigeAndel.prosent != nåværendeAndel?.prosent ->
                     throw SatsendringFeil(
@@ -94,7 +95,7 @@ object TilkjentYtelseValidering {
                                 "Gjelder perioden ${forrigeAndel.stønadFom} - ${forrigeAndel.stønadTom}. " +
                                 "Prøver å endre fra ${forrigeAndel.prosent} til ${nåværendeAndel?.prosent} prosent.",
                         satsendringSvar = SatsendringSvar.BEHANDLING_HAR_FEIL_PÅ_ANDELER,
-                    )
+                    ).also { secureLogger.info("nåværendeAndel=$nåværendeAndel, forrigeAndel=$forrigeAndel") }
 
                 forrigeAndel != null && forrigeAndel.type != nåværendeAndel?.type ->
                     throw SatsendringFeil(
@@ -103,7 +104,7 @@ object TilkjentYtelseValidering {
                                 "Gjelder perioden ${forrigeAndel.stønadFom} - ${forrigeAndel.stønadTom}. " +
                                 "Prøver å endre fra ytelsetype ${forrigeAndel.type} til ${nåværendeAndel?.type}.",
                         satsendringSvar = SatsendringSvar.BEHANDLING_HAR_FEIL_PÅ_ANDELER,
-                    )
+                    ).also { secureLogger.info("nåværendeAndel=$nåværendeAndel, forrigeAndel=$forrigeAndel") }
 
                 else -> false
             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Logger andel ved valideringsfeil av andel ved satsendring. For å enklere feilsøke
