### PR TITLE
wrap fells.LeaderClient.isLeader() i eget interface

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/LeaderClientService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/LeaderClientService.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ba.sak.config
+
+import no.nav.familie.leader.LeaderClient
+import org.springframework.stereotype.Service
+
+interface LeaderClientService {
+    fun isLeader(): Boolean?
+}
+
+@Service
+class DefaultLeaderClientService : LeaderClientService {
+    override fun isLeader(): Boolean? {
+        return LeaderClient.isLeader()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/LeaderClientService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/LeaderClientService.kt
@@ -4,12 +4,12 @@ import no.nav.familie.leader.LeaderClient
 import org.springframework.stereotype.Service
 
 interface LeaderClientService {
-    fun isLeader(): Boolean?
+    fun isLeader(): Boolean
 }
 
 @Service
 class DefaultLeaderClientService : LeaderClientService {
-    override fun isLeader(): Boolean? {
-        return LeaderClient.isLeader()
+    override fun isLeader(): Boolean {
+        return LeaderClient.isLeader() == true
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakScheduler.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ba.sak.integrasjoner.skyggesak
 
 import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.log.mdc.MDCConstants
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -19,17 +19,18 @@ class SkyggesakScheduler(
     val skyggesakRepository: SkyggesakRepository,
     val fagsakRepository: FagsakRepository,
     val integrasjonClient: IntegrasjonClient,
+    val leaderClientService: LeaderClientService,
 ) {
     @Scheduled(fixedDelay = 60000)
     fun opprettSkyggesaker() {
-        if (LeaderClient.isLeader() == true) {
+        if (leaderClientService.isLeader() == true) {
             sendSkyggesaker()
         }
     }
 
     @Scheduled(cron = "0 0 6 * * *")
     fun ryddOppISendteSkyggesaker() {
-        if (LeaderClient.isLeader() == true) {
+        if (leaderClientService.isLeader() == true) {
             fjernGamleSkyggesakInnslag()
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakScheduler.kt
@@ -23,14 +23,14 @@ class SkyggesakScheduler(
 ) {
     @Scheduled(fixedDelay = 60000)
     fun opprettSkyggesaker() {
-        if (leaderClientService.isLeader() == true) {
+        if (leaderClientService.isLeader()) {
             sendSkyggesaker()
         }
     }
 
     @Scheduled(cron = "0 0 6 * * *")
     fun ryddOppISendteSkyggesaker() {
-        if (leaderClientService.isLeader() == true) {
+        if (leaderClientService.isLeader()) {
             fjernGamleSkyggesakInnslag()
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingScheduler.kt
@@ -13,7 +13,7 @@ class InternKonsistensavstemmingScheduler(
 ) {
     @Scheduled(cron = "0 0 0 29 * *")
     fun startInternKonsistensavstemming() {
-        if (leaderClientService.isLeader() == true) {
+        if (leaderClientService.isLeader()) {
             taskService.save(OpprettInternKonsistensavstemmingTaskerTask.opprettTask())
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingScheduler.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.internkonsistensavstemming
 
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.task.internkonsistensavstemming.OpprettInternKonsistensavstemmingTaskerTask
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -9,10 +9,11 @@ import org.springframework.stereotype.Component
 @Component
 class InternKonsistensavstemmingScheduler(
     val taskService: TaskService,
+    val leaderClientService: LeaderClientService,
 ) {
     @Scheduled(cron = "0 0 0 29 * *")
     fun startInternKonsistensavstemming() {
-        if (LeaderClient.isLeader() == true) {
+        if (leaderClientService.isLeader() == true) {
             taskService.save(OpprettInternKonsistensavstemmingTaskerTask.opprettTask())
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterScheduler.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ba.sak.internal
 
 import no.nav.familie.ba.sak.common.EnvService
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.task.FinnSakerMedFlereMigreringsbehandlingerTask
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
@@ -14,13 +14,14 @@ import java.time.YearMonth
 class ForvalterScheduler(
     private val taskRepository: TaskRepositoryWrapper,
     private val envService: EnvService,
+    private val leaderClientService: LeaderClientService,
 ) {
     /*
      * Oppretter task månedlig for å identifisere løpende fagsaker som har flere migreringer sist måned
      */
     @Scheduled(cron = "0 0 7 1 * *")
     fun opprettFinnSakerMedFlereMigreringsbehandlingerTask() {
-        when (LeaderClient.isLeader() == true || envService.erDev()) {
+        when (leaderClientService.isLeader() == true || envService.erDev()) {
             true -> {
                 val finnSakerMedFlereMigreringsbehandlingerTask =
                     Task(

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterScheduler.kt
@@ -21,7 +21,7 @@ class ForvalterScheduler(
      */
     @Scheduled(cron = "0 0 7 1 * *")
     fun opprettFinnSakerMedFlereMigreringsbehandlingerTask() {
-        when (leaderClientService.isLeader() == true || envService.erDev()) {
+        when (leaderClientService.isLeader() || envService.erDev()) {
             true -> {
                 val finnSakerMedFlereMigreringsbehandlingerTask =
                     Task(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevScheduler.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.omregning
 
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.util.VirkedagerProvider
 import org.slf4j.LoggerFactory
@@ -12,7 +12,10 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Component
-class AutobrevScheduler(val taskRepository: TaskRepositoryWrapper) {
+class AutobrevScheduler(
+    val taskRepository: TaskRepositoryWrapper,
+    val leaderClientService: LeaderClientService,
+) {
     /**
      * Denne funksjonen kjøres kl.7 den første dagen i måneden og setter triggertid på tasken til kl.8 den første virkedagen i måneden.
      * For testformål kan funksjonen opprettTask også kalles direkte via et restendepunkt.
@@ -20,7 +23,7 @@ class AutobrevScheduler(val taskRepository: TaskRepositoryWrapper) {
     @Transactional
     @Scheduled(cron = "0 0 $KLOKKETIME_SCHEDULER_TRIGGES 1 * *")
     fun opprettAutobrevTask() {
-        when (LeaderClient.isLeader()) {
+        when (leaderClientService.isLeader()) {
             true -> {
                 // Timen for triggertid økes med en. Det er nødvendig å sette klokkeslettet litt frem dersom den 1. i
                 // måneden også er en virkedag (slik at både denne skeduleren og tasken som opprettes vil kjøre på samme dato).

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevScheduler.kt
@@ -36,7 +36,6 @@ class AutobrevScheduler(
             }
 
             false -> logger.info("Poden er ikke satt opp som leader - oppretter ikke task")
-            null -> logger.info("Poden svarer ikke om den er leader eller ikke - oppretter ikke task")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -37,7 +37,7 @@ class AutovedtakSatsendringScheduler(
     }
 
     private fun startSatsendring(antallFagsaker: Int) {
-        if (leaderClientService.isLeader() == true) {
+        if (leaderClientService.isLeader()) {
             logger.info("Starter schedulert jobb for satsendring 2024-01. antallFagsaker=$antallFagsaker")
             startSatsendring.startSatsendring(
                 antallFagsaker = antallFagsaker,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.leader.LeaderClient
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service
 class AutovedtakSatsendringScheduler(
     private val startSatsendring: StartSatsendring,
     private val unleashService: UnleashService,
+    private val leaderClientService: LeaderClientService,
 ) {
     @Scheduled(cron = CRON_HVERT_10_MIN_UKEDAG)
     fun triggSatsendring() {
@@ -36,7 +37,7 @@ class AutovedtakSatsendringScheduler(
     }
 
     private fun startSatsendring(antallFagsaker: Int) {
-        if (LeaderClient.isLeader() == true) {
+        if (leaderClientService.isLeader() == true) {
             logger.info("Starter schedulert jobb for satsendring 2024-01. antallFagsaker=$antallFagsaker")
             startSatsendring.startSatsendring(
                 antallFagsaker = antallFagsaker,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggService.kt
@@ -40,7 +40,7 @@ class RestartAvSmåbarnstilleggService(
     @Scheduled(cron = "0 0 7 1 * *")
     @Transactional
     fun scheduledFinnRestartetSmåbarnstilleggOgOpprettOppgave() {
-        if (leaderClientService.isLeader() == true) {
+        if (leaderClientService.isLeader()) {
             finnOgOpprettetOppgaveForSmåbarnstilleggSomSkalRestartesIDenneMåned(true)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg
 
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingMigreringsinfoRepository
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
@@ -13,7 +14,6 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.erAlleredeBegrunnetMedBegrunne
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import no.nav.familie.leader.LeaderClient
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -30,6 +30,7 @@ class RestartAvSmåbarnstilleggService(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val behandlingMigreringsinfoRepository: BehandlingMigreringsinfoRepository,
     private val andelerTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    private val leaderClientService: LeaderClientService,
 ) {
     /**
      * Første dag hver måned sjekkes det om noen fagsaker har oppstart av småbarnstillegg inneværende måned, etter å ha
@@ -39,7 +40,7 @@ class RestartAvSmåbarnstilleggService(
     @Scheduled(cron = "0 0 7 1 * *")
     @Transactional
     fun scheduledFinnRestartetSmåbarnstilleggOgOpprettOppgave() {
-        if (LeaderClient.isLeader() == true) {
+        if (leaderClientService.isLeader() == true) {
             finnOgOpprettetOppgaveForSmåbarnstilleggSomSkalRestartesIDenneMåned(true)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentScheduler.kt
@@ -1,24 +1,28 @@
 package no.nav.familie.ba.sak.kjerne.behandling.settpåvent
 
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.task.TaBehandlingerEtterVentefristAvVentTask
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
-class SettPåVentScheduler(val taskRepository: TaskRepositoryWrapper) {
+class SettPåVentScheduler(
+    val taskRepository: TaskRepositoryWrapper,
+    val leaderClientService: LeaderClientService,
+) {
     @Scheduled(cron = "0 0 7 * * *")
     fun taBehandlingerEtterVentefristAvVent() {
-        when (LeaderClient.isLeader()) {
+        when (leaderClientService.isLeader()) {
             true -> {
                 val taBehandlingerEtterVentefristAvVentTask =
                     Task(type = TaBehandlingerEtterVentefristAvVentTask.TASK_STEP_TYPE, payload = "")
                 taskRepository.save(taBehandlingerEtterVentefristAvVentTask)
                 logger.info("Opprettet taBehandlingerAvVentTask")
             }
+
             false, null -> {
                 logger.info("Ikke opprettet taBehandlingerAvVentTask på denne poden")
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentScheduler.kt
@@ -23,7 +23,7 @@ class SettPåVentScheduler(
                 logger.info("Opprettet taBehandlingerAvVentTask")
             }
 
-            false, null -> {
+            false -> {
                 logger.info("Ikke opprettet taBehandlingerAvVentTask på denne poden")
             }
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ba.sak.kjerne.fagsak
 
 import no.nav.familie.ba.sak.common.EnvService
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.task.OppdaterLøpendeFlagg
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component
 class FagsakStatusScheduler(
     private val taskRepository: TaskRepositoryWrapper,
     private val envService: EnvService,
+    private val leaderClientService: LeaderClientService,
 ) {
     /*
      * Siden barnetrygd er en månedsytelse vil en fagsak alltid løpe ut en måned
@@ -21,12 +22,13 @@ class FagsakStatusScheduler(
 
     @Scheduled(cron = "\${CRON_FAGSAKSTATUS_SCHEDULER}")
     fun oppdaterFagsakStatuser() {
-        when (LeaderClient.isLeader() == true || envService.erDev()) {
+        when (leaderClientService.isLeader() == true || envService.erDev()) {
             true -> {
                 val oppdaterLøpendeFlaggTask = Task(type = OppdaterLøpendeFlagg.TASK_STEP_TYPE, payload = "")
                 taskRepository.save(oppdaterLøpendeFlaggTask)
                 logger.info("Opprettet oppdaterLøpendeFlaggTask")
             }
+
             false -> {
                 logger.info("Ikke opprettet oppdaterLøpendeFlaggTask på denne poden")
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -22,7 +22,7 @@ class FagsakStatusScheduler(
 
     @Scheduled(cron = "\${CRON_FAGSAKSTATUS_SCHEDULER}")
     fun oppdaterFagsakStatuser() {
-        when (leaderClientService.isLeader() == true || envService.erDev()) {
+        when (leaderClientService.isLeader() || envService.erDev()) {
             true -> {
                 val oppdaterLøpendeFlaggTask = Task(type = OppdaterLøpendeFlagg.TASK_STEP_TYPE, payload = "")
                 taskRepository.save(oppdaterLøpendeFlaggTask)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
@@ -4,9 +4,9 @@ import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.MultiGauge
 import io.micrometer.core.instrument.Tags
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
-import no.nav.familie.leader.LeaderClient
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -18,6 +18,7 @@ import java.time.YearMonth
 class TeamStatistikkService(
     private val behandlingRepository: BehandlingRepository,
     private val fagsakRepository: FagsakRepository,
+    private val leaderClientService: LeaderClientService,
 ) {
     val utbetalingerPerMånedGauge =
         MultiGauge.builder("UtbetalingerPerMaanedGauge").register(Metrics.globalRegistry)
@@ -179,7 +180,7 @@ class TeamStatistikkService(
     }
 
     private fun erLeader(): Boolean {
-        return LeaderClient.isLeader() == true
+        return leaderClientService.isLeader() == true
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/metrikker/TeamStatistikkService.kt
@@ -180,7 +180,7 @@ class TeamStatistikkService(
     }
 
     private fun erLeader(): Boolean {
-        return leaderClientService.isLeader() == true
+        return leaderClientService.isLeader()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkScheduler.kt
@@ -1,10 +1,10 @@
 package no.nav.familie.ba.sak.statistikk.saksstatistikk
 
 import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.statistikk.producer.KafkaProducer
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.domene.SaksstatistikkMellomlagringRepository
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.domene.SaksstatistikkMellomlagringType
-import no.nav.familie.leader.LeaderClient
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -14,10 +14,11 @@ import org.springframework.transaction.annotation.Transactional
 class SaksstatistikkScheduler(
     val saksstatistikkMellomlagringRepository: SaksstatistikkMellomlagringRepository,
     val kafkaProducer: KafkaProducer,
+    val leaderClientService: LeaderClientService,
 ) {
     @Scheduled(fixedDelay = 60000)
     fun sendKafkameldinger() {
-        if (LeaderClient.isLeader() == true) {
+        if (leaderClientService.isLeader() == true) {
             sendSaksstatistikk()
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkScheduler.kt
@@ -18,7 +18,7 @@ class SaksstatistikkScheduler(
 ) {
     @Scheduled(fixedDelay = 60000)
     fun sendKafkameldinger() {
-        if (leaderClientService.isLeader() == true) {
+        if (leaderClientService.isLeader()) {
             sendSaksstatistikk()
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.config
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.slot
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.guttenBarnesenFødselsdato
@@ -39,7 +38,6 @@ import no.nav.familie.kontrakter.felles.personopplysning.Opphold
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 import no.nav.familie.kontrakter.felles.personopplysning.Sivilstand
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.unleash.UnleashService
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
@@ -640,15 +638,6 @@ class ClientMocks {
                         adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG,
                     ),
             )
-    }
-
-    @Bean
-    @Profile("mock-leader-client")
-    @Primary
-    fun mockLeaderClient(): LeaderClient {
-        mockkStatic(LeaderClient::class)
-        every { LeaderClient.isLeader() } returns true
-        return LeaderClient
     }
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockLeaderClientService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockLeaderClientService.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.ba.sak.config
+
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Service
+@Profile("mock-leader-client")
+@Primary
+class MockLeaderClientService : LeaderClientService {
+    override fun isLeader(): Boolean {
+        return true
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
@@ -19,7 +19,7 @@ import java.time.YearMonth
 class ForvalterSchedulerTest {
     private val taskRepository = mockk<TaskRepositoryWrapper>()
     private val envService = mockk<EnvService>()
-    private val service = ForvalterScheduler(taskRepository, envService)
+    private val service = ForvalterScheduler(taskRepository = taskRepository, envService = envService, mockk(relaxed = true))
     private val slot = slot<Task>()
 
     @BeforeEach

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
@@ -24,6 +24,7 @@ class RestartAvSmåbarnstilleggServiceTest {
                 vedtaksperiodeService = mockk(),
                 behandlingMigreringsinfoRepository = behandlingMigreringsinfoRepository,
                 andelerTilkjentYtelseRepository = mockk(),
+                leaderClientService = mockk(relaxed = true),
             ),
         )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakSchedulerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakSchedulerTest.kt
@@ -23,7 +23,7 @@ import java.time.LocalDateTime
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(initializers = [DbContainerInitializer::class])
-@ActiveProfiles("postgres", "integrasjonstest")
+@ActiveProfiles("postgres", "integrasjonstest", "mock-leader-client")
 @Tag("integration")
 class SkyggesakSchedulerTest {
     @Autowired

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakSchedulerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakSchedulerTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.DbContainerInitializer
+import no.nav.familie.ba.sak.config.MockLeaderClientService
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import org.junit.jupiter.api.Assertions
@@ -28,11 +29,20 @@ class SkyggesakSchedulerTest {
     @Autowired
     lateinit var skyggesakRepository: SkyggesakRepository
 
+    @Autowired
+    lateinit var mockLeaderClientService: MockLeaderClientService
+
     lateinit var skyggesakScheduler: SkyggesakScheduler
 
     @BeforeEach
     fun init() {
-        skyggesakScheduler = SkyggesakScheduler(skyggesakRepository, mockk(), mockk(relaxed = true))
+        skyggesakScheduler =
+            SkyggesakScheduler(
+                skyggesakRepository = skyggesakRepository,
+                fagsakRepository = mockk(),
+                integrasjonClient = mockk(relaxed = true),
+                leaderClientService = mockLeaderClientService,
+            )
         skyggesakRepository.deleteAll()
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
@@ -31,7 +31,9 @@ import org.junit.jupiter.api.Test
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
 
+@ActiveProfiles("mock-leader-client")
 class SaksstatistikkTest(
     @Autowired
     private val fagsakService: FagsakService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockLeaderClientService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakController
@@ -42,6 +43,8 @@ class SaksstatistikkTest(
     private val databaseCleanupService: DatabaseCleanupService,
     @Autowired
     private val saksstatistikkMellomlagringRepository: SaksstatistikkMellomlagringRepository,
+    @Autowired
+    private val mockLeaderClientService: MockLeaderClientService,
 ) : AbstractSpringIntegrationTest() {
     private lateinit var saksstatistikkScheduler: SaksstatistikkScheduler
 
@@ -51,7 +54,12 @@ class SaksstatistikkTest(
         BrukerContextUtil.mockBrukerContext(SikkerhetContext.SYSTEM_FORKORTELSE)
 
         val kafkaProducer = MockKafkaProducer(saksstatistikkMellomlagringRepository)
-        saksstatistikkScheduler = SaksstatistikkScheduler(saksstatistikkMellomlagringRepository, kafkaProducer)
+        saksstatistikkScheduler =
+            SaksstatistikkScheduler(
+                saksstatistikkMellomlagringRepository = saksstatistikkMellomlagringRepository,
+                kafkaProducer = kafkaProducer,
+                leaderClientService = mockLeaderClientService,
+            )
         databaseCleanupService.truncate()
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18021)
Ønsker å skrive oss vekk fra statisk mocking av metoder siden det kan skape ustabile tester.

Wrapper felles sin LeaderClient.isLeader() i et interface som kan mockes når det trengs, f.eks. i integrasjonstester. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Kunne dette gjøres på en lurere måte? 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
