### PR TITLE
valider valutakode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestValutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestValutakurs.kt
@@ -16,6 +16,12 @@ data class RestValutakurs(
     val kurs: BigDecimal?,
     override val status: UtfyltStatus = UtfyltStatus.IKKE_UTFYLT,
 ) : AbstractUtfyltStatus<RestValutakurs>() {
+
+    init {
+        if (valutakode != null) {
+            require(Valutakurs.validerValutakode(valutakode))
+        }
+    }
     override fun medUtfyltStatus(): RestValutakurs {
         return this.copy(status = utfyltStatus(finnAntallUtfylt(listOf(this.valutakursdato, this.kurs)), 2))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestValutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestValutakurs.kt
@@ -16,12 +16,12 @@ data class RestValutakurs(
     val kurs: BigDecimal?,
     override val status: UtfyltStatus = UtfyltStatus.IKKE_UTFYLT,
 ) : AbstractUtfyltStatus<RestValutakurs>() {
-
     init {
         if (valutakode != null) {
             require(Valutakurs.validerValutakode(valutakode))
         }
     }
+
     override fun medUtfyltStatus(): RestValutakurs {
         return this.copy(status = utfyltStatus(finnAntallUtfylt(listOf(this.valutakursdato, this.kurs)), 2))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/domene/ECBValutakursCache.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/domene/ECBValutakursCache.kt
@@ -8,7 +8,9 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
+import jakarta.validation.constraints.Pattern
 import no.nav.familie.ba.sak.common.BaseEntitet
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -27,4 +29,10 @@ data class ECBValutakursCache(
     val valutakode: String? = null,
     @Column(name = "kurs", nullable = false)
     val kurs: BigDecimal,
-) : BaseEntitet()
+) : BaseEntitet() {
+    init {
+        if (valutakode != null) {
+            require(Valutakurs.validerValutakode(valutakode))
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/domene/ECBValutakursCache.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/domene/ECBValutakursCache.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
-import jakarta.validation.constraints.Pattern
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -61,6 +61,10 @@ data class Valutakurs(
     @Column(name = "fk_behandling_id", updatable = false, nullable = false)
     override var behandlingId: Long = 0
 
+    init {
+        if (valutakode != null) require(validerValutakode(valutakode))
+    }
+
     // Valutakode skal alltid være satt (muligens til null), så den slettes ikke
     override fun utenInnhold() =
         copy(
@@ -92,6 +96,13 @@ data class Valutakurs(
 
     companion object {
         val NULL = Valutakurs(null, null, emptySet())
+
+        //Nøyaktig tre uppercase bokstaver
+        private const val VALID_REGEXP = "^[A-Z]{3}\$"
+
+        fun validerValutakode(valutakode: String): Boolean {
+            return Regex(VALID_REGEXP).matches(valutakode)
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -97,7 +97,7 @@ data class Valutakurs(
     companion object {
         val NULL = Valutakurs(null, null, emptySet())
 
-        //Nøyaktig tre uppercase bokstaver
+        // Nøyaktig tre uppercase bokstaver
         private const val VALID_REGEXP = "^[A-Z]{3}\$"
 
         fun validerValutakode(valutakode: String): Boolean {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
CodeQl klager på at vi logger uvaliderte felt: https://github.com/navikt/familie-ba-sak/security/code-scanning/49
Legger til validering på at valutakoder er nøyaktig tre store bokstaver når vi tar det inn i RestValutakurs og før vi lagrer i db (ECValutakursCache og Valutakurs). 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Leker med tanken på å ha en liste over gyldige valutakurser som vi kan validere mot, men da må vi forvalte den fremover. Tar gjerne imot input på det og om man burde sanere andre steder eller på andre måter :) 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
