### PR TITLE
Reduser cpu-request

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -126,7 +126,7 @@ spec:
       memory: 1024Mi
     requests:
       memory: 1024Mi
-      cpu: 500m
+      cpu: 50m
   ingresses:
     - https://familie-ba-sak.intern.dev.nav.no
   secureLogs:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I følge [dokumenteringen til Nais](https://doc.nais.io/explanation/good-practices/?h=cp#set-reasonable-resource-requests-and-limits) skal man sette cpu-requests til hva applikasjonen bruker ved normal last. Ved å se på historisk data kan det se ut som dette ligger på rundt 7% av hva vi ber om i dag i preprod, se [nais console](https://console.nav.cloud.nais.io/team/teamfamilie/dev-gcp/app/familie-ba-sak/utilization?from=2023-10-17&to=2024-02-29) og bilde under. Endrer derfor cpu-request til 10% av det vi har i dag.

<img width="1485" alt="image" src="https://github.com/navikt/familie-ba-sak/assets/17828446/0b2e7dac-4060-4876-a563-b507d03def22">

