### PR TITLE
Unngå Ø i metrikknavn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
@@ -70,7 +70,7 @@ class BehandlingMetrikker(
                 val tittel = sanityEØSBegrunnelser[it]?.navnISystem ?: it.name
 
                 Metrics.counter(
-                    "eøs-begrunnelse",
+                    "eos-begrunnelse",
                     "type",
                     it.name,
                     "beskrivelse",


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Oppdaget at vi logger noen tusen linjer med stacktrace (ett innslag per linje i stacktrace...!) jenvlig, for å si ifra om at metrikken `eøs-begrunnelse` har ugyldig navn. Endrer til å unngå ø. Metrikken leses i grafana, men vi har ingen skjermer ennå som trenger å oppdateres med nytt metrikknavn

```
[otel.javaagent 2024-03-04 10:07:39:940 +0100] [TaskWorker-1] WARN io.opentelemetry.sdk.metrics.SdkMeter - Instrument name "eøs-begrunnelse" is invalid, returning noop instrument. Instrument names must consist of 255 or fewer characters including alphanumeric, _, ., -, and start with a letter.
```

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
