### PR TITLE
Fiks autovedtak småbarnstillegg fram i tid

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -194,7 +194,7 @@ data class Behandling(
             skalBehandlesAutomatisk && erMigrering() && !erManuellMigreringForEndreMigreringsdato() && resultat == Behandlingsresultat.INNVILGET -> true
             skalBehandlesAutomatisk && erFødselshendelse() -> true
             skalBehandlesAutomatisk && erSatsendring() && erEndringFraForrigeBehandlingSendtTilØkonomi -> true
-            skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID
+            skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID && this.resultat == Behandlingsresultat.FORTSATT_INNVILGET
             -> true
             else -> false
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
+import no.nav.familie.ba.sak.common.LocalDateProvider
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -28,6 +30,7 @@ class BehandlingsresultatService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingAndelHentOgPersisterService: EndretUtbetalingAndelHentOgPersisterService,
     private val kompetanseService: KompetanseService,
+    private val localDateProvider: LocalDateProvider,
 ) {
     internal fun finnPersonerFremstiltKravFor(
         behandling: Behandling,
@@ -121,6 +124,7 @@ class BehandlingsresultatService(
                     personerFremstiltKravFor = personerFremstiltKravFor,
                     personerIBehandling = personerIBehandling,
                     personerIForrigeBehandling = personerIForrigeBehandling,
+                    nåMåned = localDateProvider.now().toYearMonth(),
                 )
             } else {
                 Endringsresultat.INGEN_ENDRING

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -52,6 +52,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `utledEndringsresultat skal returnere INGEN_ENDRING dersom det ikke finnes noe endringer i behandling`() {
         val endringsresultat =
             utledEndringsresultat(
+                nåMåned = YearMonth.now(),
                 nåværendeAndeler = emptyList(),
                 forrigeAndeler = emptyList(),
                 personerFremstiltKravFor = emptyList(),
@@ -82,6 +83,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val endringsresultat =
             utledEndringsresultat(
+                nåMåned = YearMonth.now(),
                 forrigeAndeler = listOf(forrigeAndel),
                 nåværendeAndeler = listOf(forrigeAndel.copy(kalkulertUtbetalingsbeløp = 40)),
                 personerFremstiltKravFor = emptyList(),
@@ -174,6 +176,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val endringsresultat =
             utledEndringsresultat(
+                nåMåned = YearMonth.now(),
                 forrigeAndeler = forrigeAndeler,
                 nåværendeAndeler = nåværendeAndeler,
                 personerFremstiltKravFor = emptyList(),
@@ -213,6 +216,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val endringsresultat =
             utledEndringsresultat(
+                nåMåned = YearMonth.now(),
                 nåværendeAndeler = emptyList(),
                 forrigeAndeler = emptyList(),
                 personerFremstiltKravFor = emptyList(),
@@ -248,6 +252,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val endringsresultat =
             utledEndringsresultat(
+                nåMåned = YearMonth.now(),
                 nåværendeAndeler = emptyList(),
                 forrigeAndeler = emptyList(),
                 personerFremstiltKravFor = emptyList(),
@@ -300,6 +305,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeAndelerForPerson = forrigeAndeler,
                 opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                 erFremstiltKravForPerson = false,
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(false, erEndringIBeløp)
@@ -359,6 +365,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = erFremstiltKravForPerson,
+                        nåMåned = YearMonth.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -428,6 +435,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = erFremstiltKravForPerson,
+                        nåMåned = YearMonth.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -487,6 +495,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = false,
+                        nåMåned = YearMonth.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -550,6 +559,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = erFremstiltKravForPerson,
+                        nåMåned = YearMonth.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -616,6 +626,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = false,
+                        nåMåned = YearMonth.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -685,6 +696,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = false,
+                        nåMåned = YearMonth.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -745,6 +757,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == barn1Aktør },
                 opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                 erFremstiltKravForPerson = false,
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(false, erEndringIBeløp)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ba.sak.common.LocalDateProvider
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.randomFnr
@@ -57,6 +58,9 @@ internal class BehandlingsresultatServiceTest {
 
     @MockK
     private lateinit var andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository
+
+    @MockK
+    private lateinit var localDateProvider: LocalDateProvider
 
     @InjectMockKs
     private lateinit var behandlingsresultatService: BehandlingsresultatService

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -34,6 +34,8 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -53,6 +55,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
+import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
@@ -131,6 +134,9 @@ fun lagBehandlinger(
             parseValgfriEnum<BehandlingKategori>(Domenebegrep.BEHANDLINGSKATEGORI, rad)
                 ?: BehandlingKategori.NASJONAL
         val status = parseValgfriEnum<BehandlingStatus>(Domenebegrep.BEHANDLINGSSTATUS, rad)
+        val behandlingstype = parseValgfriEnum<BehandlingType>(Domenebegrep.BEHANDLINGSTYPE, rad) ?: BehandlingType.FØRSTEGANGSBEHANDLING
+        val behandlingssteg = parseValgfriEnum<StegType>(Domenebegrep.BEHANDLINGSSTEG, rad) ?: StegType.REGISTRERE_PERSONGRUNNLAG
+        val underkategori = parseValgfriEnum<BehandlingUnderkategori>(Domenebegrep.UNDERKATEGORI, rad) ?: BehandlingUnderkategori.ORDINÆR
 
         lagBehandling(
             fagsak = fagsak,
@@ -139,6 +145,9 @@ fun lagBehandlinger(
             skalBehandlesAutomatisk = skalBehandlesAutomatisk,
             behandlingKategori = behandlingKategori,
             status = status ?: BehandlingStatus.UTREDES,
+            behandlingType = behandlingstype,
+            førsteSteg = behandlingssteg,
+            underkategori = underkategori,
         ).copy(id = behandlingId)
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -97,33 +97,7 @@ fun lagVedtak(
     fagsaker: MutableMap<Long, Fagsak>,
 ) {
     behandlinger.putAll(
-        dataTable.asMaps().map { rad ->
-            val behandlingId = parseLong(Domenebegrep.BEHANDLING_ID, rad)
-            val fagsakId = parseValgfriLong(Domenebegrep.FAGSAK_ID, rad)
-            val fagsak =
-                fagsaker.getOrDefault(fagsakId, defaultFagsak()).also {
-                    if (it.id !in fagsaker.keys) {
-                        fagsaker[it.id] = it
-                    }
-                }
-
-            val behandlingÅrsak = parseValgfriEnum<BehandlingÅrsak>(Domenebegrep.BEHANDLINGSÅRSAK, rad)
-            val behandlingResultat = parseValgfriEnum<Behandlingsresultat>(Domenebegrep.BEHANDLINGSRESULTAT, rad)
-            val skalBehandlesAutomatisk = parseValgfriBoolean(Domenebegrep.SKAL_BEHANLDES_AUTOMATISK, rad) ?: false
-            val behandlingKategori =
-                parseValgfriEnum<BehandlingKategori>(Domenebegrep.BEHANDLINGSKATEGORI, rad)
-                    ?: BehandlingKategori.NASJONAL
-            val status = parseValgfriEnum<BehandlingStatus>(Domenebegrep.BEHANDLINGSSTATUS, rad)
-
-            lagBehandling(
-                fagsak = fagsak,
-                årsak = behandlingÅrsak ?: BehandlingÅrsak.SØKNAD,
-                resultat = behandlingResultat ?: Behandlingsresultat.IKKE_VURDERT,
-                skalBehandlesAutomatisk = skalBehandlesAutomatisk,
-                behandlingKategori = behandlingKategori,
-                status = status ?: BehandlingStatus.UTREDES,
-            ).copy(id = behandlingId)
-        }.associateBy { it.id },
+        lagBehandlinger(dataTable, fagsaker).associateBy { it.id },
     )
     behandlingTilForrigeBehandling.putAll(
         dataTable.asMaps().associate { rad ->
@@ -135,6 +109,38 @@ fun lagVedtak(
             .map { no.nav.familie.ba.sak.common.lagVedtak(behandlinger[it.key] ?: error("Finner ikke behandling")) },
     )
 }
+
+fun lagBehandlinger(
+    dataTable: DataTable,
+    fagsaker: MutableMap<Long, Fagsak>,
+): List<Behandling> =
+    dataTable.asMaps().map { rad ->
+        val behandlingId = parseLong(Domenebegrep.BEHANDLING_ID, rad)
+        val fagsakId = parseValgfriLong(Domenebegrep.FAGSAK_ID, rad)
+        val fagsak =
+            fagsaker.getOrDefault(fagsakId, defaultFagsak()).also {
+                if (it.id !in fagsaker.keys) {
+                    fagsaker[it.id] = it
+                }
+            }
+
+        val behandlingÅrsak = parseValgfriEnum<BehandlingÅrsak>(Domenebegrep.BEHANDLINGSÅRSAK, rad)
+        val behandlingResultat = parseValgfriEnum<Behandlingsresultat>(Domenebegrep.BEHANDLINGSRESULTAT, rad)
+        val skalBehandlesAutomatisk = parseValgfriBoolean(Domenebegrep.SKAL_BEHANLDES_AUTOMATISK, rad) ?: false
+        val behandlingKategori =
+            parseValgfriEnum<BehandlingKategori>(Domenebegrep.BEHANDLINGSKATEGORI, rad)
+                ?: BehandlingKategori.NASJONAL
+        val status = parseValgfriEnum<BehandlingStatus>(Domenebegrep.BEHANDLINGSSTATUS, rad)
+
+        lagBehandling(
+            fagsak = fagsak,
+            årsak = behandlingÅrsak ?: BehandlingÅrsak.SØKNAD,
+            resultat = behandlingResultat ?: Behandlingsresultat.IKKE_VURDERT,
+            skalBehandlesAutomatisk = skalBehandlesAutomatisk,
+            behandlingKategori = behandlingKategori,
+            status = status ?: BehandlingStatus.UTREDES,
+        ).copy(id = behandlingId)
+    }
 
 fun lagVilkårsvurdering(
     persongrunnlagForBehandling: PersonopplysningGrunnlag,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/DomeneparserUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/DomeneparserUtil.kt
@@ -21,6 +21,9 @@ enum class Domenebegrep(override val nøkkel: String) : Domenenøkkel {
     SØKNADSTIDSPUNKT("Søknadstidspunkt"),
     BEHANDLINGSKATEGORI("Behandlingskategori"),
     BEHANDLINGSSTATUS("Behandlingsstatus"),
+    BEHANDLINGSTYPE("Behandlingstype"),
+    BEHANDLINGSSTEG("Behandlingssteg"),
+    UNDERKATEGORI("Underkategori"),
 }
 
 object DomeneparserUtil {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import no.nav.familie.ba.sak.common.LocalDateProvider
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
@@ -95,6 +96,9 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
     @Autowired
     private lateinit var aktørIdRepository: AktørIdRepository
+
+    @Autowired
+    private lateinit var localDateProvider: LocalDateProvider
 
     @BeforeEach
     fun førHverTest() {

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/autovedtak_småbarnstillegg.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/autovedtak_småbarnstillegg.feature
@@ -38,6 +38,9 @@ Egenskap: Småbarnstillegg autovedtak
       | 1       | 2            | 01.03.2023 | 30.06.2023 | 678   | SMÅBARNSTILLEGG    | 100     | 678  |
       | 1       | 2            | 01.07.2023 | 31.01.2024 | 696   | SMÅBARNSTILLEGG    | 100     | 696  |
       | 1       | 2            | 01.07.2023 | 30.11.2024 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 2       | 2            | 01.05.2022 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 2            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 2       | 2            | 01.07.2023 | 30.12.2024 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
 
     Og med overgangsstønad for begrunnelse
       | BehandlingId | AktørId | Fra dato   | Til dato   |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/autovedtak_småbarnstillegg.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/autovedtak_småbarnstillegg.feature
@@ -65,3 +65,41 @@ Egenskap: Småbarnstillegg autovedtak
     # Forventer at det ikke skal være noen brevperioder
     Så forvent følgende brevperioder for behandling 3
       | Brevperiodetype | Fra dato | Til dato | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
+
+  Scenario: Skal sende autovedtak småbarnstillegg til manuell behandling dersom noe endrer seg tilbake i tid
+    Og følgende dagens dato 27.11.2023
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD               |                  | 01.04.2022 | 31.12.2024 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | UTVIDET_BARNETRYGD                          |                  | 01.04.2022 |            | OPPFYLT  | Nei                  |                      |                  |
+
+      | 2       | UNDER_18_ÅR                                 |                  | 29.07.2021 | 28.07.2039 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | GIFT_PARTNERSKAP                            |                  | 29.07.2021 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER,LOVLIG_OPPHOLD |                  | 01.04.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 2            | 01.05.2022 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     | 1054 |
+      | 1       | 2            | 01.05.2022 | 28.02.2023 | 660   | SMÅBARNSTILLEGG    | 100     | 660  |
+      | 1       | 2            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
+      | 1       | 2            | 01.03.2023 | 30.06.2023 | 678   | SMÅBARNSTILLEGG    | 100     | 678  |
+      | 1       | 2            | 01.07.2023 | 31.01.2024 | 696   | SMÅBARNSTILLEGG    | 100     | 696  |
+      | 1       | 2            | 01.07.2023 | 30.11.2024 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+
+    Og med overgangsstønad for begrunnelse
+      | BehandlingId | AktørId | Fra dato   | Til dato   |
+      | 2            | 1       | 01.05.2022 | 31.01.2024 |
+
+    Og med dødsfall
+      | AktørId | Dødsfalldato |
+      | 1       | 27.11.2023   |
+
+    Når vi lager automatisk behandling med id 3 på fagsak 1 på grunn av nye overgangsstønadsperioder
+      | Fra dato   | Til dato   |
+      | 01.05.2022 | 30.06.2024 |
+
+    Så forvent disse behandlingene
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak                   | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus | Behandlingstype | Behandlingssteg     | Underkategori |
+      | 3            | 1        | 2                   | ENDRET_UTBETALING   | SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID | Nei                       | NASJONAL            | UTREDES           | Revurdering     | BEHANDLINGSRESULTAT | UTVIDET       |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Leses lettest commit for commit

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18278)
Fortsettelse av https://github.com/navikt/familie-ba-sak/pull/4398

I forrige PR gjorde vi at endringer i overgangstønad som kun endret andeler etter neste måned kunne kjøre automatisk. Dersom det også fører til en endring tilbake i tid, skal vi ikke kjøre disse automatisk. 

Endrer så vi kun behandler automatisk dersom behandlingsresultatet blir fortsatt innvilget. 

Utvider også på testrammeverket

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
