### PR TITLE
Fjernet bruk av differanseberegning-toggle

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -23,8 +23,5 @@ class FeatureToggleConfig {
 
         // Kjører satsendring lørdag
         const val SATSENDRING_LØRDAG: String = "familie-ba-sak.satsendring-lordag"
-
-        // Bruker utvidede regler for differanseberegning
-        const val BRUK_UTVIDEDE_DIFFERANSEBEREGNINGSREGLER: String = "familie-ba-sak.bruk-utvidede-differanseberegningsregler"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -76,7 +76,6 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
     barna: List<Person>,
     kompetanser: Collection<Kompetanse>,
     personResultater: Set<PersonResultat> = emptySet(),
-    skalBrukeUtvidedeRegler: Boolean = false,
 ): List<AndelTilkjentYtelse> {
     // Ta bort eventuell eksisterende differanseberegning, slik at kalkulertUtbetalingsbeløp er nasjonal sats
     // Men behold funksjonelle splitter som er påført tidligere ved å beholde fom og tom på andelene
@@ -95,14 +94,9 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
     // Finn alle andelene frem til barna er 18 år. Det vil i praksis være ALLE andelene
     // Bruk bare andelene som kvalifiserer for differanseberegning mot søkers ytelser
     val barnasRelevanteAndelerInntil18År =
-        when {
-            skalBrukeUtvidedeRegler ->
-                barnasAndelerTidslinjer
-                    .filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
-                    .kunReneSekundærlandsperioder(kompetanser)
-
-            else -> barnasAndelerTidslinjer.kunReneSekundærlandsperioder(kompetanser)
-        }
+        barnasAndelerTidslinjer
+            .filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
+            .kunReneSekundærlandsperioder(kompetanser)
 
     // Lag tidslinjer for hvert barn som inneholder underskuddet fra differanseberegningen på ordinær barnetrygd.
     // Resultatet er tidslinjer med underskuddet som positivt beløp der det inntreffer
@@ -140,15 +134,10 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
     // Bruk bare andelene som kvalifiserer for differanseberegning mot søkers ytelser
     // Må ta utgangspunkt i alle andeler for være sikker på at vi vurderer sekundærlandsperioder bare når barna er inntil 3 år
     val barnasRelevanteAndelerInntil3ÅrTidslinjer =
-        when {
-            skalBrukeUtvidedeRegler ->
-                barnasAndelerTidslinjer
-                    .kunAndelerTilOgMed3År(barna)
-                    .filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
-                    .kunReneSekundærlandsperioder(kompetanser)
-
-            else -> barnasAndelerTidslinjer.kunAndelerTilOgMed3År(barna).kunReneSekundærlandsperioder(kompetanser)
-        }
+        barnasAndelerTidslinjer
+            .kunAndelerTilOgMed3År(barna)
+            .filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
+            .kunReneSekundærlandsperioder(kompetanser)
 
     // Vi finner hvor mye hvert barn skal ha som andel av småbarnstillegget på hvert tidspunkt.
     // Det tilsvarer småbarnstillegget på et gitt tidspunkt delt på antall relevante barn under 3 år som har ytelse på det tidspunktet

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -75,7 +75,7 @@ fun beregnDifferanse(
 fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
     barna: List<Person>,
     kompetanser: Collection<Kompetanse>,
-    personResultater: Set<PersonResultat> = emptySet(),
+    personResultater: Set<PersonResultat>,
 ): List<AndelTilkjentYtelse> {
     // Ta bort eventuell eksisterende differanseberegning, slik at kalkulertUtbetalingsbeløp er nasjonal sats
     // Men behold funksjonelle splitter som er påført tidligere ved å beholde fom og tom på andelene

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseEndretAbonnent
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -112,7 +111,6 @@ class TilpassDifferanseberegningSøkersYtelserService(
                 barna = persongrunnlagService.hentBarna(tilkjentYtelse.behandling.id),
                 kompetanser = kompetanseRepository.finnFraBehandlingId(tilkjentYtelse.behandling.id),
                 personResultater = vilkårsvurderingRepository.findByBehandlingAndAktiv(tilkjentYtelse.behandling.id)!!.personResultater,
-                skalBrukeUtvidedeRegler = unleashService.isEnabled(FeatureToggleConfig.BRUK_UTVIDEDE_DIFFERANSEBEREGNINGSREGLER, mapOf("fagsakId" to tilkjentYtelse.behandling.fagsak.id.toString())),
             )
         tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -436,7 +436,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering().personResultater
 
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
-            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater, true)
+            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -491,7 +491,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering().personResultater
 
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
-            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater, true)
+            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -546,7 +546,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering().personResultater
 
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
-            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater, true)
+            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -608,7 +608,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering().personResultater
 
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
-            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater, true)
+            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -675,7 +675,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering().personResultater
 
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
-            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater, true)
+            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -741,7 +741,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering().personResultater
 
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
-            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater, skalBrukeUtvidedeRegler = true)
+            tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2016), behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.util.VilkårsvurderingBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.des
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -58,8 +59,18 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>", 100, { 1000 }, { -700 }) { 0 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, des(2016))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn2, des(2017))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn3, des(2018))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -128,8 +139,16 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("                                                $$$>", 100, { 1000 }, { -700 }) { 0 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, des(2016))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn2, des(2017))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
@@ -156,8 +175,16 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("            $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, des(2016))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn2, des(2017))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
@@ -168,7 +195,7 @@ class DifferanseberegningSøkersYtelserTest {
 
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse
-                .differanseberegnSøkersYtelser(emptyList(), emptyList())
+                .differanseberegnSøkersYtelser(emptyList(), emptyList(), emptySet())
 
         assertEquals(emptyList<AndelTilkjentYtelse>(), nyeAndeler)
     }
@@ -212,8 +239,18 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, des(2016))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn2, des(2017))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn3, des(2018))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         // Dette er litt trist. Men selv om andelene er identiske, kan de ikke slås sammen fordi
         // de er til forveksling like som andeler som har en funksjonell årsak til å være splittet
@@ -266,8 +303,14 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$>", 100, { 1000 }, { -650 }) { 0 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, des(2016))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -302,8 +345,14 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$>", 100, { 1000 }, { -2650 }) { 0 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, des(2016))
+                .medVilkår("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jan(2017), behandling)
@@ -341,8 +390,18 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, jun(2020))
+                .medVilkår("eeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn2, jun(2020))
+                .medVilkår("eeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn3, jun(2020))
+                .medVilkår("eeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jul(2020), behandling)
@@ -381,8 +440,18 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
                 .bygg()
 
+        val personResultater =
+            VilkårsvurderingBuilder<Måned>(behandling = behandling)
+                .forPerson(barn1, jun(2020))
+                .medVilkår("eeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn2, jun(2020))
+                .medVilkår("eeeeeee", Vilkår.BOR_MED_SØKER)
+                .forPerson(barn3, jun(2020))
+                .medVilkår("eeeeeee", Vilkår.BOR_MED_SØKER)
+                .byggVilkårsvurdering().personResultater
+
         val nyeAndeler =
-            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser)
+            tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(barna, kompetanser, personResultater)
 
         val forventet =
             TilkjentYtelseBuilder(jul(2020), behandling)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Utvidede regler for differanseberegning er tatt i bruk i prod. Fjerner derfor bruk av toggle.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
