### PR TITLE
Endre navn slåSammenSammenhengendeOpphørsPerioder -> slåSammenSammenhengendeOpphørsperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -333,7 +333,7 @@ private fun kombinerGjeldendeOgForrigeGrunnlag(
                     gjeldende = gjeldende?.grunnlagForPerson,
                     erReduksjonSidenForrigeBehandling = erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype,
                 )
-            }.slåSammenSammenhengendeOpphørsPerioder()
+            }.slåSammenSammenhengendeOpphørsperioder()
     }
 
 data class GjeldendeMedInnvilgedeYtelsestyperForrigeBehandling(
@@ -364,7 +364,7 @@ private fun erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype(
     }
 }
 
-private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSammenSammenhengendeOpphørsPerioder(): Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned> {
+private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSammenSammenhengendeOpphørsperioder(): Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned> {
     val perioder = this.perioder().sortedBy { it.fraOgMed }.toList()
 
     return perioder.fold(emptyList()) { acc: List<Periode<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>, periode ->


### PR DESCRIPTION
[Codeql klager på at vi har to funksjoner med samme navn, men med forskjellig kapitalisering](https://github.com/navikt/familie-ba-sak/security/code-scanning/46). Funksjonene opererer på forskjellige klasser, så tenker vi beholder de som de er, men endrer navn slik at ikke codeql skal klage. 