### PR TITLE
Valider person ident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
@@ -1,0 +1,5 @@
+﻿package no.nav.familie.ba.sak.common
+
+const val ALFANUMERISKE_TEGN = "a-zæøåA-ZÆØÅ0-9"
+
+fun String.saniter(): String = Regex("[^$ALFANUMERISKE_TEGN]+").replace(this, "")

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsakSøk.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
@@ -12,7 +13,11 @@ data class RestSøkParam(
 ) {
     // Bruker init til å validere personidenten
     init {
-        Fødselsnummer(personIdent)
+        try {
+            Fødselsnummer(personIdent)
+        } catch (e: IllegalStateException) {
+            throw FunksjonellFeil("Ugyldig personident")
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsakSøk.kt
@@ -3,12 +3,18 @@ package no.nav.familie.ba.sak.ekstern.restDomene
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 
 data class RestSøkParam(
     val personIdent: String,
     val barnasIdenter: List<String> = emptyList(),
-)
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}
 
 enum class FagsakDeltagerRolle {
     BARN,

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestHentFagsakForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestHentFagsakForPerson.kt
@@ -1,5 +1,11 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 
-data class RestHentFagsakForPerson(val personIdent: String, val fagsakType: FagsakType = FagsakType.NORMAL)
+data class RestHentFagsakForPerson(val personIdent: String, val fagsakType: FagsakType = FagsakType.NORMAL) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestHentFagsakerForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestHentFagsakerForPerson.kt
@@ -1,5 +1,11 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 
-data class RestHentFagsakerForPerson(val personIdent: String, val fagsakTyper: List<FagsakType> = FagsakType.values().toList())
+data class RestHentFagsakerForPerson(val personIdent: String, val fagsakTyper: List<FagsakType> = FagsakType.values().toList()) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestManuellDødsfall.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestManuellDødsfall.kt
@@ -1,9 +1,15 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import java.time.LocalDate
 
 data class RestManuellDødsfall(
     val dødsfallDato: LocalDate,
     val personIdent: String,
     val begrunnelse: String,
-)
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestNyttVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestNyttVilkår.kt
@@ -1,8 +1,14 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 
 data class RestNyttVilkår(
     val personIdent: String,
     val vilkårType: Vilkår,
-)
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestOppdaterJournalpost.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestOppdaterJournalpost.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
-import jakarta.validation.constraints.Pattern
-import no.nav.familie.ba.sak.common.PERSONIDENT_IKKE_GYLDIG_FEILMELDING
-import no.nav.familie.ba.sak.common.PERSONIDENT_REGEX
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Bruker
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.OppdaterJournalpostRequest
 import no.nav.familie.kontrakter.felles.BrukerIdType
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentstatus
@@ -56,7 +54,11 @@ data class RestOppdaterJournalpost(
 }
 
 data class NavnOgIdent(
-    @field:Pattern(regexp = PERSONIDENT_REGEX, message = PERSONIDENT_IKKE_GYLDIG_FEILMELDING)
     val navn: String,
     val id: String,
-)
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(id)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestPersonResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestPersonResultat.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.ResultatBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -17,7 +18,12 @@ data class RestPersonResultat(
     val personIdent: String,
     val vilkårResultater: List<RestVilkårResultat>,
     val andreVurderinger: List<RestAnnenVurdering> = emptyList(),
-)
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}
 
 data class RestVilkårResultat(
     val id: Long,

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestSlettVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestSlettVilkår.kt
@@ -1,5 +1,14 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 
-data class RestSlettVilkår(val personIdent: String, val vilkårType: Vilkår)
+data class RestSlettVilkår(
+    val personIdent: String,
+    val vilkårType: Vilkår,
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/SøknadDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/SøknadDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.objectMapper
 import java.time.LocalDate
 
@@ -21,7 +22,12 @@ fun SøknadDTO.writeValueAsString(): String = objectMapper.writeValueAsString(th
 data class SøkerMedOpplysninger(
     val ident: String,
     val målform: Målform = Målform.NB,
-)
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(ident)
+    }
+}
 
 data class BarnMedOpplysninger(
     val ident: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.internal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import jakarta.validation.Valid
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
@@ -217,6 +218,7 @@ class ForvalterController(
                     "identen ikke er merget av folketrygden.",
         )
         @RequestBody
+        @Valid
         patchMergetIdentDto: PatchMergetIdentDto,
     ): ResponseEntity<String> {
         opprettTaskService.opprettTaskForÅPatcheMergetIdent(patchMergetIdentDto)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/VedtakOmOvergangsstønadController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/VedtakOmOvergangsstønadController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg
 
+import jakarta.validation.Valid
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.Personident
 import no.nav.familie.ba.sak.task.VedtakOmOvergangsstønadTask
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 class VedtakOmOvergangsstønadController(private val taskRepository: TaskRepositoryWrapper) {
     @PostMapping
     fun håndterVedtakOmOvergangsstønad(
+        @Valid
         @RequestBody personIdent: Personident,
     ): Ressurs<String> {
         taskRepository.save(VedtakOmOvergangsstønadTask.opprettTask(personIdent.ident))

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingController.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
 import no.nav.familie.ba.sak.task.dto.BehandleFødselshendelseTaskDTO
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
@@ -176,6 +177,9 @@ data class NyBehandling(
                 )
             }
         }
+
+        // Valider ident
+        Fødselsnummer(søkersIdent)
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakController.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
@@ -176,7 +177,12 @@ class FagsakController(
         return ResponseEntity.ok().body(Ressurs.success(fagsakIdOgTilknyttetAktørId))
     }
 
-    data class RestSøkFagsakRequest(val personIdent: String)
+    data class RestSøkFagsakRequest(val personIdent: String) {
+        // Bruker init til å validere personidenten
+        init {
+            Fødselsnummer(personIdent)
+        }
+    }
 
     data class RestFagsakIdOgTilknyttetAktørId(
         val aktørId: String,
@@ -240,7 +246,12 @@ data class FagsakRequest(
     val personIdent: String,
     val fagsakType: FagsakType? = FagsakType.NORMAL,
     val institusjon: InstitusjonInfo? = null,
-)
+) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(personIdent)
+    }
+}
 
 data class RestBeslutningPåVedtak(
     val beslutning: Beslutning,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger
 
+import jakarta.validation.Valid
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.ekstern.restDomene.RestManuellDødsfall
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonInfo
@@ -12,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -40,8 +42,11 @@ class PersonController(
     @GetMapping
     fun hentPerson(
         @RequestHeader personIdent: String,
+        @Valid
         @RequestBody personIdentBody: PersonIdent?,
     ): ResponseEntity<Ressurs<RestPersonInfo>> {
+        // Valider personIdent
+        Fødselsnummer(personIdent)
         val aktør = personidentService.hentAktør(personIdent)
         val personinfo =
             familieIntegrasjonerTilgangskontrollService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
@@ -53,8 +58,12 @@ class PersonController(
     @GetMapping(path = ["/enkel"])
     fun hentPersonEnkel(
         @RequestHeader personIdent: String,
+        @Valid
         @RequestBody personIdentBody: PersonIdent?,
     ): ResponseEntity<Ressurs<RestPersonInfo>> {
+        // Valider personIdent
+        Fødselsnummer(personIdent)
+
         val aktør = personidentService.hentAktør(personIdent)
         val personinfo =
             familieIntegrasjonerTilgangskontrollService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
@@ -67,6 +76,9 @@ class PersonController(
     fun hentPersonAdresse(
         @RequestHeader personIdent: String,
     ): ResponseEntity<Ressurs<RestPersonInfo>> {
+        // For validering
+        Fødselsnummer(personIdent)
+
         val aktør = personidentService.hentAktør(personIdent)
         val personinfo =
             familieIntegrasjonerTilgangskontrollService.hentMaskertPersonInfoVedManglendeTilgang(aktør)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/GrunnlagController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/GrunnlagController.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagSe
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.kjerne.steg.TilbakestillBehandlingService
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
@@ -56,5 +57,10 @@ class GrunnlagController(
         )
     }
 
-    class LeggTilBarnDto(val barnIdent: String)
+    class LeggTilBarnDto(val barnIdent: String) {
+        // Bruker init til å validere personidenten
+        init {
+            Fødselsnummer(barnIdent)
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdentController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdentController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.personident
 
+import jakarta.validation.Valid
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -19,6 +20,7 @@ class IdentController(
 ) {
     @PostMapping
     fun håndterPdlHendelse(
+        @Valid
         @RequestBody nyIdent: PersonIdent,
     ): ResponseEntity<Ressurs<String>> {
         personidentService.opprettTaskForIdentHendelse(nyIdent)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.personident
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.saniter
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
@@ -98,7 +99,7 @@ class PersonidentService(
             try {
                 personidentRepository.findByFødselsnummerOrNull(ident)
             } catch (e: Exception) {
-                secureLogger.info("Feil ved henting av ident=$ident, lagre=$lagre", e)
+                secureLogger.info("Feil ved henting av ident=${ident.saniter()}, lagre=$lagre", e)
                 throw e
             }
         if (personident != null) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårController.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.kjerne.steg.TilbakestillBehandlingService
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
@@ -89,6 +90,9 @@ class VilkårController(
         @PathVariable vilkaarId: Long,
         @RequestBody personIdent: String,
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
+        // Valider persionIdent
+        Fødselsnummer(personIdent)
+
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.DELETE)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangController.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.ekstern.restDomene.TilgangDTO
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
@@ -41,4 +42,9 @@ class TilgangController(
     }
 }
 
-class TilgangRequestDTO(val brukerIdent: String)
+class TilgangRequestDTO(val brukerIdent: String) {
+    // Bruker init til å validere personidenten
+    init {
+        Fødselsnummer(brukerIdent)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
@@ -1,0 +1,14 @@
+﻿package no.nav.familie.ba.sak.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TekstSaniteringUtilTest {
+    @Test
+    fun `Sanitering av tekst fungerer som forventet`() {
+        val tekst = "Dette er en tekst med 1234 og spesialtegn som: !@#¤%&/()=?`^*¨'\""
+        val forventetResultat = "Detteerentekstmed1234ogspesialtegnsom"
+
+        assertThat(tekst.saniter()).isEqualTo(forventetResultat)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -146,7 +146,6 @@ class ClientMocks {
             mockPersonopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(any())
         } returns "NO"
 
-        val ukjentId = "43125678910"
         val ukjentAktør = tilAktør(ukjentId)
 
         every {
@@ -637,6 +636,7 @@ class ClientMocks {
                         adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG,
                     ),
             )
+        val ukjentId = randomFnr()
     }
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -7,7 +7,6 @@ import io.mockk.slot
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.guttenBarnesenFødselsdato
 import no.nav.familie.ba.sak.common.randomFnr
-import no.nav.familie.ba.sak.common.tilddMMyy
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonException
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
@@ -458,7 +457,7 @@ class ClientMocks {
                 guttenBarnesenFødselsdato,
                 LocalDate.now().withDayOfMonth(18).minusYears(2),
             )
-        val barnFnr = arrayOf(barnFødselsdatoer[0].tilddMMyy() + "50033", barnFødselsdatoer[1].tilddMMyy() + "50033")
+        val barnFnr = arrayOf(randomFnr(), randomFnr())
         const val BARN_DET_IKKE_GIS_TILGANG_TIL_FNR = "12345678912"
         const val INTEGRASJONER_FNR = "10000111111"
         val bostedsadresse =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
@@ -5,6 +5,8 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.lagSøknadDTO
+import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
 import no.nav.familie.ba.sak.config.tilAktør
@@ -398,13 +400,17 @@ class ArbeidsfordelingIntegrationTest(
             fagsakId = fagsakId,
         )
 
+    val søkerAktør = randomAktør()
+    val barnUtenDiskresjonskodetAktør = randomAktør()
+    val barnMedDiskjesjonskodeaktør = randomAktør()
+
     companion object {
         const val MANUELT_OVERSTYRT_ENHET = "1234"
         const val IKKE_FORTROLIG_ENHET = "4820"
         const val FORTROLIG_ENHET = "1122"
-        const val SØKER_FNR = "12445678910"
-        const val BARN_UTEN_DISKRESJONSKODE = "12345678911"
-        const val BARN_MED_DISKRESJONSKODE = "12345678912"
+        val SØKER_FNR = randomFnr()
+        val BARN_UTEN_DISKRESJONSKODE = randomFnr()
+        val BARN_MED_DISKRESJONSKODE = randomFnr()
 
         val søkerBostedsadresse =
             Bostedsadresse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
@@ -726,7 +726,7 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Skal lagre og sende korrekt sakstatistikk for behandlingsresultat`() {
-        val fnr = "12345678910"
+        val fnr = randomFnr()
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr))
         val behandling =
             behandlingService.opprettBehandling(nyOrdinærBehandling(søkersIdent = fnr, fagsakId = fagsak.data!!.id))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
@@ -179,7 +179,8 @@ class FagsakControllerTest(
     @Test
     fun `Skal oppgi det første barnet i listen som fagsakdeltaker`() {
         val personAktør = mockPersonidentService.hentOgLagreAktør(randomFnr(), true)
-        val søkerAktør = mockPersonidentService.hentOgLagreAktør(ClientMocks.søkerFnr[0], true)
+        val søkerFnr = randomFnr()
+        val søkerAktør = mockPersonidentService.hentOgLagreAktør(søkerFnr, true)
         val barnaAktør = mockPersonidentService.hentOgLagreAktørIder(ClientMocks.barnFnr.toList().subList(0, 1), true)
 
         val fagsak = fagsakService.hentEllerOpprettFagsak(søkerAktør.aktivFødselsnummer())
@@ -187,7 +188,7 @@ class FagsakControllerTest(
         val behandling =
             behandlingService.opprettBehandling(
                 nyOrdinærBehandling(
-                    søkersIdent = ClientMocks.søkerFnr[0],
+                    søkersIdent = søkerFnr,
                     fagsakId = fagsak.id,
                 ),
             )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/SøkFagsakNegativeTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/SøkFagsakNegativeTest.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.fagsak
 
 import no.nav.familie.ba.sak.common.DbContainerInitializer
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.ekstern.restDomene.RestFagsakDeltager
 import no.nav.familie.ba.sak.ekstern.restDomene.RestSøkParam
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonException
@@ -46,7 +48,7 @@ class SøkFagsakNegativeTest {
 
     @Test
     fun `test generer riktig ressur ved feil`() {
-        val ukjentId = "43125678910"
+        val ukjentId = ClientMocks.ukjentId
         val feilId = "41235678910"
 
         val resEntity1 = fagsakController.søkFagsak(RestSøkParam(ukjentId))
@@ -55,7 +57,7 @@ class SøkFagsakNegativeTest {
         assertThat(Ressurs.Status.SUKSESS).isEqualTo(ress.status)
         assertThat(ress.data).isEqualTo(emptyList<RestFagsakDeltager>())
 
-        assertThrows<IntegrasjonException> {
+        assertThrows<FunksjonellFeil> {
             fagsakController.søkFagsak(RestSøkParam(feilId))
         }
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
@@ -270,8 +270,8 @@ class SøknadGrunnlagTest(
     @Test
     fun `Skal fjerne barn og mapping til restbehandling skal kjøre ok`() {
         val søkerFnr = randomFnr()
-        val barn1Fnr = ClientMocks.barnFnr[0]
-        val barn2Fnr = ClientMocks.barnFnr[1]
+        val barn1Fnr = randomFnr()
+        val barn2Fnr = randomFnr()
         val behandlingEtterVilkårsvurderingSteg =
             kjørStegprosessForFGB(
                 tilSteg = StegType.VILKÅRSVURDERING,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
@@ -90,8 +90,8 @@ class TilbakekrevingServiceTest(
         val behandling =
             kjørStegprosessForFGB(
                 tilSteg = StegType.VENTE_PÅ_STATUS_FRA_ØKONOMI,
-                søkerFnr = "09121079074",
-                barnasIdenter = listOf("09121079074"),
+                søkerFnr = ClientMocks.barnFnr[0],
+                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,
@@ -121,8 +121,8 @@ class TilbakekrevingServiceTest(
         val behandling =
             kjørStegprosessForFGB(
                 tilSteg = StegType.VENTE_PÅ_STATUS_FRA_ØKONOMI,
-                søkerFnr = "10031000033",
-                barnasIdenter = listOf("10031000033"),
+                søkerFnr = ClientMocks.barnFnr[0],
+                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Codeql klager på at vi saniterer dataene før vi bruker det i logger](https://github.com/navikt/familie-ba-sak/security/code-scanning/52). 

Endrer så vi saniterer den variabelen. 

Egentlig burde vi validere disse dataene tidligere, både syntaktisk og semantisk. Se [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html). Endrer også så vi kjører valideringer på personidentene vi får i endepunktene våre. 