### PR TITLE
Flytt validering av personidenter inn i spring slik at feil kan fanges opp av exception handeleren

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsakSøk.kt
@@ -11,12 +11,12 @@ data class RestSøkParam(
     val personIdent: String,
     val barnasIdenter: List<String> = emptyList(),
 ) {
-    // Bruker init til å validere personidenten
-    init {
+    fun valider() {
         try {
             Fødselsnummer(personIdent)
+            barnasIdenter.forEach { Fødselsnummer(it) }
         } catch (e: IllegalStateException) {
-            throw FunksjonellFeil("Ugyldig personident")
+            throw FunksjonellFeil("Ugyldig fødsels- eller d-nummer")
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakController.kt
@@ -124,6 +124,7 @@ class FagsakController(
     fun søkFagsak(
         @RequestBody søkParam: RestSøkParam,
     ): ResponseEntity<Ressurs<List<RestFagsakDeltager>>> {
+        søkParam.valider()
         logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} søker fagsak")
 
         val fagsakDeltagere = fagsakService.hentFagsakDeltager(søkParam.personIdent)
@@ -193,6 +194,7 @@ class FagsakController(
     fun oppgiFagsakdeltagere(
         @RequestBody restSøkParam: RestSøkParam,
     ): ResponseEntity<Ressurs<List<RestFagsakDeltager>>> {
+        restSøkParam.valider()
         return Result.runCatching {
             val aktør = personidentService.hentAktør(restSøkParam.personIdent)
             val barnsAktørId = personidentService.hentAktørIder(restSøkParam.barnasIdenter)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Knyttet til disse feilene: 
https://nav-it.slack.com/archives/C036C6VAWH3/p1710320204256069

Når vi lager RestSøkParam og valideringen feiler i konstruktøren rekker vi ikke å komme inn i spring-contexten. Dette fører til at vi exception-handeleren ikke fanger opp den Funksjonelle feilen og vi får en 500-feil, når vi egentlig skulle gitt 200 med feilet ressurs. Endrer så valideringen ikke skjer i init-funksjonen av RestSøkParam, men i funksjonen når de blir brukt. 
