### PR TITLE
Validerer at UtenlandskPeriodebeløp og Valutakurs er utfylt ved kjøring av BehandlingsresultatSteg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -224,7 +224,7 @@ class BehandlingsresultatSteg(
         val valutakurser by lazy { valutakursRepository.finnFraBehandlingId(behandlingId = behandling.id) }
 
         if (utenlandskePeriodeBeløp.any { !it.erObligatoriskeFelterSatt() } || valutakurser.any { !it.erObligatoriskeFelterSatt() }) {
-            throw FunksjonellFeil("Kan ikke fullføre behandlingsresultat-steg før utenlandsk periodebeløp og valutakurs er fylt ut for alle barn og perioder")
+            throw FunksjonellFeil("Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder")
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -197,7 +197,7 @@ class BehandlingsresultatStegTest {
 
         val exception = assertThrows<FunksjonellFeil> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
         assertEquals(
-            "Kan ikke fullføre behandlingsresultat-steg før utenlandsk periodebeløp og valutakurs er fylt ut for alle barn og perioder",
+            "Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder",
             exception.message,
         )
     }
@@ -218,7 +218,7 @@ class BehandlingsresultatStegTest {
 
         val exception = assertThrows<FunksjonellFeil> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
         assertEquals(
-            "Kan ikke fullføre behandlingsresultat-steg før utenlandsk periodebeløp og valutakurs er fylt ut for alle barn og perioder",
+            "Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder",
             exception.message,
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -182,7 +182,7 @@ class BehandlingsresultatStegTest {
     }
 
     @Test
-    fun `skal kaste exception dersom det finnes utenlandsperiodebeløp som ikke er fylt ut`() {
+    fun `skal kaste exception dersom det finnes utenlandskperiodebeløp som ikke er fylt ut`() {
         every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.FORTSATT_INNVILGET
 
         every {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/MockAutovedtakSmåbarnstilleggService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/MockAutovedtakSmåbarnstilleggService.kt
@@ -259,6 +259,8 @@ fun mockAutovedtakSmåbarnstilleggService(
             beregningService = beregningService,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
+            valutakursRepository = valutakursRepository,
         )
 
     val registrerPersongrunnlag =


### PR DESCRIPTION
Favro: [NAV-18723](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18723)

### 💰 Hva skal gjøres, og hvorfor?
Ved satsendring i juni og i januar har vi fullført behandlingsresultat-steget med tilfeller av UtenlandsPeriodebeløp- og Valutakurs -perioder som ikke har vært utfylt. Legger nå inn en validering som vil stanse saksbehandling dersom alle perioder ikke er utfylt.

Dette er kun en validering som hindrer videre saksbehandling og ikke en fix av selve feilen som skaper problemet. Kode som retter feilen kommer i egen PR.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
