### PR TITLE
Støtt tom streng i validering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
@@ -2,6 +2,6 @@
 
 const val ALFANUMERISKE_TEGN = "a-zæøåA-ZÆØÅ0-9"
 
-fun String.saner(): String = Regex("[^$ALFANUMERISKE_TEGN]+").replace(this, "")
+fun String.saner(): String = Regex("[^$ALFANUMERISKE_TEGN]*").replace(this, "")
 
-fun String.erAlfanummerisk(): Boolean = Regex("[$ALFANUMERISKE_TEGN]+").matches(this)
+fun String.erAlfanummerisk(): Boolean = Regex("[$ALFANUMERISKE_TEGN]*").matches(this)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
@@ -16,8 +16,10 @@ class TekstSaniteringUtilTest {
     fun `erSanert fungerer som forventet`() {
         val tekst = "Dette er en tekst med 1234 og spesialtegn som: !@#¤%&/()=?`^*¨'\""
         val sanertTekst = "Detteerentekstmed1234ogspesialtegnsom"
+        val tomStreng = ""
 
         assertThat(tekst.erAlfanummerisk()).isFalse()
         assertThat(sanertTekst.erAlfanummerisk()).isTrue()
+        assertThat(tomStreng.erAlfanummerisk()).isTrue()
     }
 }


### PR DESCRIPTION
Ønsker at valideringen skal være gyldig ved tom streng