### PR TITLE
Sørger for at vi ikke genererer nye kompetanser ved satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -215,6 +215,7 @@ class BeregningService(
     // For at endret utbetaling andeler skal fungere så må man generere andeler før man kobler endringene på andelene
 // Dette er fordi en endring regnes som gyldig når den overlapper med en andel og har gyldig årsak
 // Hvis man ikke genererer andeler før man kobler på endringene så vil ingen av endringene ses på som gyldige, altså ikke oppdatere noen andeler
+    @Transactional
     fun genererTilkjentYtelseFraVilkårsvurdering(
         behandling: Behandling,
         personopplysningGrunnlag: PersonopplysningGrunnlag,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -215,7 +215,6 @@ class BeregningService(
     // For at endret utbetaling andeler skal fungere så må man generere andeler før man kobler endringene på andelene
 // Dette er fordi en endring regnes som gyldig når den overlapper med en andel og har gyldig årsak
 // Hvis man ikke genererer andeler før man kobler på endringene så vil ingen av endringene ses på som gyldige, altså ikke oppdatere noen andeler
-    @Transactional
     fun genererTilkjentYtelseFraVilkårsvurdering(
         behandling: Behandling,
         personopplysningGrunnlag: PersonopplysningGrunnlag,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -77,7 +77,9 @@ class VilkårsvurderingSteg(
         tilbakestillBehandlingService.tilbakestillDataTilVilkårsvurderingssteg(behandling)
         beregningService.genererTilkjentYtelseFraVilkårsvurdering(behandling, personopplysningGrunnlag)
 
-        tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
+        if (!behandling.erSatsendring()) {
+            tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
+        }
 
         behandlingstemaService.oppdaterBehandlingstema(
             behandling = behandlingHentOgPersisterService.hent(behandlingId = behandling.id),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Datagenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Datagenerator.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene
 
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.konverterBeløpTilMånedlig
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -66,4 +67,5 @@ fun lagUtenlandskPeriodebeløp(
     beløp = beløp,
     intervall = intervall,
     utbetalingsland = utbetalingsland,
+    kalkulertMånedligBeløp = if (beløp != null) intervall?.konverterBeløpTilMånedlig(beløp) else null,
 ).also { it.behandlingId = behandlingId }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
@@ -652,6 +653,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
     }
 
     @Test
+    @Transactional
     fun `genererTilkjentYtelseFraVilkårsvurdering - skal trigge differanseberegning`() {
         val søker = personidentService.hentOgLagreAktør(randomFnr(), true)
         val barn = personidentService.hentOgLagreAktør(randomFnr(), true)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.LocalDateProvider
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.common.lagPersonResultat
 import no.nav.familie.ba.sak.common.lagPersonResultaterForSøkerOgToBarn
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.randomFnr
@@ -18,16 +19,28 @@ import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.integrasjoner.økonomi.AndelTilkjentYtelseForUtbetalingsoppdrag
 import no.nav.familie.ba.sak.integrasjoner.økonomi.IdentOgYtelse
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagKompetanse
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagUtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagValutakurs
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
@@ -41,6 +54,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -99,6 +113,15 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
     @Autowired
     private lateinit var localDateProvider: LocalDateProvider
+
+    @Autowired
+    private lateinit var kompetanseRepository: KompetanseRepository
+
+    @Autowired
+    private lateinit var utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository
+
+    @Autowired
+    private lateinit var valutakursRepository: ValutakursRepository
 
     @BeforeEach
     fun førHverTest() {
@@ -626,6 +649,45 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
             behandlingService.lagreNyOgDeaktiverGammelBehandling(
                 lagBehandling(fagsak, behandlingType = BehandlingType.REVURDERING),
             )
+    }
+
+    @Test
+    fun `genererTilkjentYtelseFraVilkårsvurdering - skal trigge differanseberegning`() {
+        val søker = personidentService.hentOgLagreAktør(randomFnr(), true)
+        val barn = personidentService.hentOgLagreAktør(randomFnr(), true)
+
+        val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søker.aktivFødselsnummer())
+        val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(behandling = lagBehandling(fagsak = fagsak, behandlingKategori = BehandlingKategori.EØS, skalBehandlesAutomatisk = true))
+
+        val personopplysningGrunnlag =
+            lagTestPersonopplysningGrunnlag(
+                behandling.id,
+                søker.aktivFødselsnummer(),
+                listOf(barn.aktivFødselsnummer()),
+            )
+        personopplysningGrunnlagRepository.save(personopplysningGrunnlag)
+
+        val vilkårsvurdering =
+            Vilkårsvurdering(id = 0, behandling = behandling, aktiv = true).also {
+                it.personResultater =
+                    setOf(
+                        lagPersonResultat(vilkårsvurdering = it, person = personopplysningGrunnlag.søker, resultat = Resultat.OPPFYLT, periodeFom = LocalDate.now().minusMonths(4), periodeTom = LocalDate.now(), lagFullstendigVilkårResultat = true, personType = PersonType.SØKER),
+                        lagPersonResultat(vilkårsvurdering = it, person = personopplysningGrunnlag.barna.first(), resultat = Resultat.OPPFYLT, periodeFom = LocalDate.now().minusMonths(4), periodeTom = LocalDate.now(), lagFullstendigVilkårResultat = true, personType = PersonType.BARN),
+                    )
+            }
+        vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering)
+
+        val kompetanse = lagKompetanse(behandlingId = behandling.id, fom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), søkersAktivitet = KompetanseAktivitet.ARBEIDER, annenForeldersAktivitet = KompetanseAktivitet.ARBEIDER, annenForeldersAktivitetsland = "Sverige", søkersAktivitetsland = "Norge", barnetsBostedsland = "Norge", kompetanseResultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND)
+        val utenlandskPeriodebeløp = lagUtenlandskPeriodebeløp(behandlingId = behandling.id, fom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), beløp = BigDecimal.valueOf(1000), intervall = Intervall.MÅNEDLIG, valutakode = "SEK", utbetalingsland = "Sverige")
+        val valutakurs = lagValutakurs(behandlingId = behandling.id, fom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), valutakursdato = LocalDate.now(), valutakode = "SEK", kurs = BigDecimal.valueOf(1.1))
+
+        kompetanseRepository.save(kompetanse)
+        utenlandskPeriodebeløpRepository.save(utenlandskPeriodebeløp)
+        valutakursRepository.save(valutakurs)
+
+        val tilkjentYtelse = beregningService.genererTilkjentYtelseFraVilkårsvurdering(behandling = behandling, personopplysningGrunnlag = personopplysningGrunnlag)
+
+        assertThat(tilkjentYtelse.andelerTilkjentYtelse.any { it.differanseberegnetPeriodebeløp != null }).isEqualTo(true)
     }
 
     private fun avsluttOgLagreBehandling(behandling: Behandling) {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -659,7 +659,15 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
         val barn = personidentService.hentOgLagreAktør(randomFnr(), true)
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søker.aktivFødselsnummer())
-        val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(behandling = lagBehandling(fagsak = fagsak, behandlingKategori = BehandlingKategori.EØS, skalBehandlesAutomatisk = true))
+        val behandling =
+            behandlingService.lagreNyOgDeaktiverGammelBehandling(
+                behandling =
+                    lagBehandling(
+                        fagsak = fagsak,
+                        behandlingKategori = BehandlingKategori.EØS,
+                        skalBehandlesAutomatisk = true,
+                    ),
+            )
 
         val personopplysningGrunnlag =
             lagTestPersonopplysningGrunnlag(
@@ -673,17 +681,61 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
             Vilkårsvurdering(id = 0, behandling = behandling, aktiv = true).also {
                 it.personResultater =
                     setOf(
-                        lagPersonResultat(vilkårsvurdering = it, person = personopplysningGrunnlag.søker, resultat = Resultat.OPPFYLT, periodeFom = LocalDate.now().minusMonths(4), periodeTom = LocalDate.now(), lagFullstendigVilkårResultat = true, personType = PersonType.SØKER),
-                        lagPersonResultat(vilkårsvurdering = it, person = personopplysningGrunnlag.barna.first(), resultat = Resultat.OPPFYLT, periodeFom = LocalDate.now().minusMonths(4), periodeTom = LocalDate.now(), lagFullstendigVilkårResultat = true, personType = PersonType.BARN),
+                        lagPersonResultat(
+                            vilkårsvurdering = it,
+                            person = personopplysningGrunnlag.søker,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = LocalDate.now().minusMonths(4),
+                            periodeTom = LocalDate.now(),
+                            lagFullstendigVilkårResultat = true,
+                            personType = PersonType.SØKER,
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = it,
+                            person = personopplysningGrunnlag.barna.first(),
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = LocalDate.now().minusMonths(4),
+                            periodeTom = LocalDate.now(),
+                            lagFullstendigVilkårResultat = true,
+                            personType = PersonType.BARN,
+                        ),
                     )
             }
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering)
 
-        val kompetanse = lagKompetanse(behandlingId = behandling.id, fom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), søkersAktivitet = KompetanseAktivitet.ARBEIDER, annenForeldersAktivitet = KompetanseAktivitet.ARBEIDER, annenForeldersAktivitetsland = "Sverige", søkersAktivitetsland = "Norge", barnetsBostedsland = "Norge", kompetanseResultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND)
-        val utenlandskPeriodebeløp = lagUtenlandskPeriodebeløp(behandlingId = behandling.id, fom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), beløp = BigDecimal.valueOf(1000), intervall = Intervall.MÅNEDLIG, valutakode = "SEK", utbetalingsland = "Sverige")
-        val valutakurs = lagValutakurs(behandlingId = behandling.id, fom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), valutakursdato = LocalDate.now(), valutakode = "SEK", kurs = BigDecimal.valueOf(1.1))
+        val kompetanseNorgeErSekundærland =
+            lagKompetanse(
+                behandlingId = behandling.id,
+                fom = LocalDate.now().minusMonths(4).toYearMonth(),
+                barnAktører = setOf(barn),
+                søkersAktivitet = KompetanseAktivitet.ARBEIDER,
+                annenForeldersAktivitet = KompetanseAktivitet.ARBEIDER,
+                annenForeldersAktivitetsland = "Sverige",
+                søkersAktivitetsland = "Norge",
+                barnetsBostedsland = "Norge",
+                kompetanseResultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
+            )
+        val utenlandskPeriodebeløp =
+            lagUtenlandskPeriodebeløp(
+                behandlingId = behandling.id,
+                fom = LocalDate.now().minusMonths(4).toYearMonth(),
+                barnAktører = setOf(barn),
+                beløp = BigDecimal.valueOf(1000),
+                intervall = Intervall.MÅNEDLIG,
+                valutakode = "SEK",
+                utbetalingsland = "Sverige",
+            )
+        val valutakurs =
+            lagValutakurs(
+                behandlingId = behandling.id,
+                fom = LocalDate.now().minusMonths(4).toYearMonth(),
+                barnAktører = setOf(barn),
+                valutakursdato = LocalDate.now(),
+                valutakode = "SEK",
+                kurs = BigDecimal.valueOf(1.1),
+            )
 
-        kompetanseRepository.save(kompetanse)
+        kompetanseRepository.save(kompetanseNorgeErSekundærland)
         utenlandskPeriodebeløpRepository.save(utenlandskPeriodebeløp)
         valutakursRepository.save(valutakurs)
 


### PR DESCRIPTION
Favro: [NAV-18723](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18723)

### 💰 Hva skal gjøres, og hvorfor?
Som en del av satsendring, kjører vi gjennom VilkårsvurderingSteg på samme måte som for manuelle behandlinger. Vi genererer blant annet andeler og tilpasser skjemaer for kompetanse, utenlandsk periode beløp og valutakurs. I logikken som tilpasser kompetanse-skjemaene blir det opprettet en splitt dersom dagens dato er etter siste EØS-periode for ett av barna. Typisk at ett av barna har fylt 18 år. Når dette skjer opprettes også nye perioder med utenlandsk periodebeløp og valutakurs. I og med at vi ikke har noen måte å fylle ut disse periodene på ved satsendring blir ikke differanseberegning gjennomført og søker får utbetalt full norsk sats.

I og med at vi ikke ønsker å gjøre noen endringer annet enn å oppdatere sats ved satsendring, hopper vi nå over steget som tilpasser kompetanser. Differanseberegning kjøres som en del av generering av nye andeler.

Lagt inn test som validerer at differanseberegning kjøres.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan godt ta en gjennomgang om ønskelig.
