### PR TITLE
Lagt til manglende EØS-avslagsbegrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -438,6 +438,10 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_AVSLAG
         override val sanityApiNavn = "avslagSelvstendigRettForeldreneBorSammen"
     },
+    AVSLAG_DELT_BOSTED_BEGGE_FORELDRE_IKKE_OMFATTET_NORSK_LOVVALG {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_AVSLAG
+        override val sanityApiNavn = "avslagDeltBostedBeggeForeldreIkkeOmfattetNorskLovvalg"
+    },
     FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD {
         override val sanityApiNavn = "fortsattInnvilgetPrimaerlandStandard"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_FORTSATT_INNVILGET


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi fikk en del feilmeldinger i loggene som sa at vi hentet en EØS begrunnelse fra Sanity som vi ikke hadde definert i koden. `Finner ikke EØSStandardbegrunnelse for avslagDeltBostedBeggeForeldreIkkeOmfattetNorskLovvalg`

Har nå lagt inn støtte for denne begrunnelsen.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Jeg har ikke skrevet tester fordi:
Ingen funksjonell endring.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
