### PR TITLE
Fjernet begrunnelser som er avpublisert i Sanity og merket som 'Utgått'

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -11,10 +11,6 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val sanityApiNavn = "innvilgetPrimarlandBarnetBorINorge"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_INNVILGET
     },
-    INNVILGET_PRIMÆRLAND_BARNETRYGD_ALLEREDE_UTBETALT {
-        override val sanityApiNavn = "innvilgetPrimarlandBarnetrygdAlleredeUtbetalt"
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_INNVILGET
-    },
     INNVILGET_PRIMÆRLAND_UK_BARNETRYGD_ALLEREDEUTBETALT {
         override val sanityApiNavn = "innvilgetPrimarlandUkBarnetrygdAlleredeUtbetalt"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_INNVILGET

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -1522,18 +1522,6 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val sanityApiNavn = "etterEndretUtbetalingAvtaleDeltBosted"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
     },
-    ETTER_ENDRET_UTBETALING_ETTERBETALING {
-        override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreAarTilbakeITid"
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
-    },
-    ETTER_ENDRET_UTBETALING_ETTERBETALING_UTVIDET {
-        override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreAarTilbakeITidKunUtvidetDel"
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
-    },
-    ETTER_ENDRET_UTBETALING_ETTERBETALING_SED {
-        override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreAarTilbakeITidSed"
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
-    },
     ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_AAR {
         override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreAar"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi kaster feil ved henting av begrunnelser for hver begrunnelse vi forventer at skal finnes i Sanity. Det var nå 4 begrunnelser som var avpublisert og merket som 'Utgått' i Sanity, men som fortsatt lå inne begrunnelse-enumene våre. Disse skaper mye støy i loggene.

Fjerner her de 4 utgåtte begrunnelsene. Har verifisert at de kan fjernes med Anna.

De utgåtte begrunnelsene i Sanity:
* [[Utgått] Etterbetaling tre år tilbake i tid kun utvidet del](https://familie-brev.sanity.studio/ba-brev/structure/__edit__7ca99085-f7ef-4d37-9a82-28bc7a83b8cb%2Ctype%3Dbegrunnelse)
* [[Utgått] Etterbetaling tre år tilbake i tid](https://familie-brev.sanity.studio/ba-brev/structure/__edit__090a065e-b055-44bf-b974-950037ecd944%2Ctype%3Dbegrunnelse)
* [[Utgått] Etterbetaling tre år tilbake i tid SED](https://familie-brev.sanity.studio/ba-brev/structure/__edit__3e24a8e6-8978-4dd3-8692-6495f95c6456%2Ctype%3Dbegrunnelse)
* [[Utgått] Primærland barnetrygd allerede utbetalt](https://familie-brev.sanity.studio/ba-brev/structure/__edit__1c983aec-d505-4117-bb2f-c2cb067a40fa%2Ctype%3Dbegrunnelse)

![image](https://github.com/navikt/familie-ba-sak/assets/70642183/baaed594-569c-408f-95bf-f1b584317938)

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Jeg har ikke skrevet tester fordi:
Ingen funksjonell endring

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
