### PR TITLE
Gjør det mulig å starte valutajustering scheduleren

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClien
 import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
+import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringScheduler
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
@@ -61,6 +62,7 @@ class ForvalterController(
     private val satskjøringRepository: SatskjøringRepository,
     private val autovedtakMånedligValutajusteringService: AutovedtakMånedligValutajusteringService,
     private val envService: EnvService,
+    private val månedligValutajusteringScheduler: MånedligValutajusteringScheduler,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ForvalterController::class.java)
 
@@ -314,6 +316,19 @@ class ForvalterController(
     ): ResponseEntity<Ressurs<String>> {
         if (!envService.erProd()) {
             autovedtakMånedligValutajusteringService.utførMånedligValutajusteringPåFagsak(fagsakId = fagsakId, måned = YearMonth.now())
+        } else {
+            throw Feil("Kan ikke kjøre valutajustering fra forvaltercontroller i prod")
+        }
+        return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
+    }
+
+    @PostMapping("/start-valutajustering-scheduler")
+    @Operation(summary = "Start alle valutajusteringer for gjeldende måned")
+    fun lagMånedligValuttajusteringTask(
+        @PathVariable fagsakId: Long,
+    ): ResponseEntity<Ressurs<String>> {
+        if (!envService.erProd()) {
+            månedligValutajusteringScheduler.lagMånedligValuttajusteringTask()
         } else {
             throw Feil("Kan ikke kjøre valutajustering fra forvaltercontroller i prod")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -323,7 +323,7 @@ class ForvalterController(
     }
 
     @PostMapping("/start-valutajustering-scheduler")
-    @Operation(summary = "Start alle valutajusteringer for gjeldende måned")
+    @Operation(summary = "Start valutajustering for alle sekundærlandsaker i gjeldende måned")
     fun lagMånedligValuttajusteringTask(
         @PathVariable fagsakId: Long,
     ): ResponseEntity<Ressurs<String>> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.task
 
+import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -17,12 +18,17 @@ import java.time.YearMonth
     maxAntallFeil = 1,
     settTilManuellOppfølgning = true,
 )
-class MånedligValutajusteringTask() : AsyncTaskStep {
+class MånedligValutajusteringTask(
+    val autovedtakMånedligValutajusteringService: AutovedtakMånedligValutajusteringService,
+) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val taskdto = objectMapper.readValue(task.payload, MånedligValutajusteringTaskDto::class.java)
         logger.info("Starter Task månedlig valutajustering for $taskdto")
-        logger.info("Månedlig valutajustering er ikke implementert enda. Logger kun dette enn så lenge.")
-        // autovedtakMånedligValutajusteringService.utførMånedligValutajustering(taskdto)
+
+        autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+            behandlingid = taskdto.behandlingid,
+            måned = taskdto.måned,
+        )
     }
 
     data class MånedligValutajusteringTaskDto(


### PR DESCRIPTION
Oppgave: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18511

I forbindelse med at vi lager månedlig valutajusteringen har vi ikke koblet sammen scheduleren og selve koden for valutajustering. Fikser det i denne PRen. 

I tillegg trenger vi å kunne teste det vi lager. Legger også til et testendepunkt for å starte koden manuelt
