### PR TITLE
Utvider ISanityBegrunnelse med feltet stotterFritekst og eksponerer feltet til frontend via RestVedtaksbegrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
@@ -25,6 +25,7 @@ sealed interface ISanityBegrunnelse {
     val periodeType: BrevPeriodeType?
     val begrunnelseTypeForPerson: VedtakBegrunnelseType? // TODO: Fjern når migrering av ny felter er ferdig
     val øvrigeTriggere: List<ØvrigTrigger>
+    val støtterFritekst: Boolean
 
     val gjelderEtterEndretUtbetaling
         get() =
@@ -58,6 +59,7 @@ data class SanityBegrunnelse(
     override val periodeType: BrevPeriodeType? = null,
     override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
     override val øvrigeTriggere: List<ØvrigTrigger> = emptyList(),
+    override val støtterFritekst: Boolean = false,
     val rolle: List<VilkårRolle> = emptyList(),
     val hjemler: List<String> = emptyList(),
     val hjemlerFolketrygdloven: List<String> = emptyList(),
@@ -100,6 +102,7 @@ data class SanityEØSBegrunnelse(
     override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
     override val valgbarhet: Valgbarhet?,
     override val øvrigeTriggere: List<ØvrigTrigger> = emptyList(),
+    override val støtterFritekst: Boolean = false,
     val annenForeldersAktivitet: List<KompetanseAktivitet>,
     val barnetsBostedsland: List<BarnetsBostedsland>,
     val kompetanseResultat: List<KompetanseResultat>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/RestSanityBegrunnelse.kt
@@ -32,6 +32,7 @@ data class RestSanityBegrunnelse(
     val endringsaarsaker: List<String>? = emptyList(),
     val hjemler: List<String>? = emptyList(),
     val hjemlerFolketrygdloven: List<String>?,
+    val stotterFritekst: Boolean?,
     val endretUtbetalingsperiodeDeltBostedUtbetalingTrigger: String?,
     val endretUtbetalingsperiodeTriggere: List<String>? = emptyList(),
     val utvidetBarnetrygdTriggere: List<String>? = emptyList(),
@@ -81,6 +82,7 @@ data class RestSanityBegrunnelse(
                 } ?: emptyList(),
             hjemler = hjemler ?: emptyList(),
             hjemlerFolketrygdloven = hjemlerFolketrygdloven ?: emptyList(),
+            støtterFritekst = stotterFritekst ?: false,
             endretUtbetalingsperiodeDeltBostedUtbetalingTrigger =
                 endretUtbetalingsperiodeDeltBostedUtbetalingTrigger
                     .finnEnumverdiNullable<EndretUtbetalingsperiodeDeltBostedTriggere>(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/RestSanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/RestSanityEØSBegrunnelse.kt
@@ -27,6 +27,7 @@ data class RestSanityEØSBegrunnelse(
     val hjemlerEOSForordningen883: List<String>?,
     val hjemlerEOSForordningen987: List<String>?,
     val hjemlerSeperasjonsavtalenStorbritannina: List<String>?,
+    val stotterFritekst: Boolean?,
     val eosVilkaar: List<String>? = null,
     val ovrigeTriggere: List<String>? = emptyList(),
     @Deprecated("Skal bruke periodeResultatForPerson i stedet")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/IVedtakBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/IVedtakBegrunnelse.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 
 sealed interface IVedtakBegrunnelse {
     val sanityApiNavn: String
@@ -31,6 +32,9 @@ sealed interface IVedtakBegrunnelse {
 
 fun IVedtakBegrunnelse.erAvslagUregistrerteBarnBegrunnelse() =
     this in setOf(Standardbegrunnelse.AVSLAG_UREGISTRERT_BARN, EØSStandardbegrunnelse.AVSLAG_EØS_UREGISTRERT_BARN)
+
+fun IVedtakBegrunnelse.støtterFritekst(sanityBegrunnelser: List<ISanityBegrunnelse>) =
+    sanityBegrunnelser.first { it.apiNavn == this.sanityApiNavn }.støtterFritekst
 
 class IVedtakBegrunnelseDeserializer : StdDeserializer<List<IVedtakBegrunnelse>>(List::class.java) {
     override fun deserialize(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/EØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/EØSBegrunnelse.kt
@@ -13,7 +13,9 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
+import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.støtterFritekst
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestVedtaksbegrunnelse
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
@@ -44,10 +46,11 @@ class EØSBegrunnelse(
             begrunnelse = this.begrunnelse,
         )
 
-    fun tilRestVedtaksbegrunnelse() =
+    fun tilRestVedtaksbegrunnelse(sanityBegrunnelser: List<ISanityBegrunnelse>) =
         RestVedtaksbegrunnelse(
             standardbegrunnelse = this.begrunnelse.enumnavnTilString(),
             vedtakBegrunnelseType = this.begrunnelse.vedtakBegrunnelseType,
             vedtakBegrunnelseSpesifikasjon = this.begrunnelse.enumnavnTilString(),
+            støtterFritekst = this.begrunnelse.støtterFritekst(sanityBegrunnelser),
         )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -13,9 +13,11 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.støtterFritekst
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.RestVedtaksbegrunnelse
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 
@@ -50,11 +52,12 @@ class Vedtaksbegrunnelse(
     }
 }
 
-fun Vedtaksbegrunnelse.tilRestVedtaksbegrunnelse() =
+fun Vedtaksbegrunnelse.tilRestVedtaksbegrunnelse(sanityBegrunnelser: List<SanityBegrunnelse>) =
     RestVedtaksbegrunnelse(
         standardbegrunnelse = this.standardbegrunnelse.enumnavnTilString(),
         vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
         vedtakBegrunnelseSpesifikasjon = this.standardbegrunnelse.enumnavnTilString(),
+        støtterFritekst = this.standardbegrunnelse.støtterFritekst(sanityBegrunnelser),
     )
 
 enum class Begrunnelsetype {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -402,6 +402,9 @@ class VedtaksperiodeService(
     fun hentRestUtvidetVedtaksperiodeMedBegrunnelser(behandlingId: Long): List<RestUtvidetVedtaksperiodeMedBegrunnelser> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
 
+        val sanityBegrunnelser = sanityService.hentSanityBegrunnelser().values.toList()
+        val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser().values.toList()
+
         val vedtaksperioder =
             if (behandling.status != BehandlingStatus.AVSLUTTET) {
                 val utvidetVedtaksperiodeMedBegrunnelser =
@@ -411,7 +414,7 @@ class VedtaksperiodeService(
                     )
                 utvidetVedtaksperiodeMedBegrunnelser
                     .sorter()
-                    .map { it.tilRestUtvidetVedtaksperiodeMedBegrunnelser() }
+                    .map { it.tilRestUtvidetVedtaksperiodeMedBegrunnelser(sanityBegrunnelser, sanityEØSBegrunnelser) }
             } else {
                 emptyList()
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/RestUtvidetVedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/RestUtvidetVedtaksperiodeMedBegrunnelser.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene
 
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.tilRestVedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.UtbetalingsperiodeDetalj
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
@@ -16,13 +18,16 @@ data class RestUtvidetVedtaksperiodeMedBegrunnelser(
     val utbetalingsperiodeDetaljer: List<UtbetalingsperiodeDetalj> = emptyList(),
 )
 
-fun UtvidetVedtaksperiodeMedBegrunnelser.tilRestUtvidetVedtaksperiodeMedBegrunnelser(): RestUtvidetVedtaksperiodeMedBegrunnelser {
+fun UtvidetVedtaksperiodeMedBegrunnelser.tilRestUtvidetVedtaksperiodeMedBegrunnelser(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    sanityEØSBegrunnelser: List<SanityEØSBegrunnelse>,
+): RestUtvidetVedtaksperiodeMedBegrunnelser {
     return RestUtvidetVedtaksperiodeMedBegrunnelser(
         id = this.id,
         fom = this.fom,
         tom = this.tom,
         type = this.type,
-        begrunnelser = this.begrunnelser.map { it.tilRestVedtaksbegrunnelse() } + this.eøsBegrunnelser.map { it.tilRestVedtaksbegrunnelse() },
+        begrunnelser = this.begrunnelser.map { it.tilRestVedtaksbegrunnelse(sanityBegrunnelser) } + this.eøsBegrunnelser.map { it.tilRestVedtaksbegrunnelse(sanityEØSBegrunnelser) },
         fritekster = this.fritekster,
         utbetalingsperiodeDetaljer = this.utbetalingsperiodeDetaljer,
         gyldigeBegrunnelser = this.gyldigeBegrunnelser.map { it.enumnavnTilString() },

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/RestVedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/RestVedtaksbegrunnelse.kt
@@ -6,4 +6,5 @@ data class RestVedtaksbegrunnelse(
     val standardbegrunnelse: String,
     val vedtakBegrunnelseSpesifikasjon: String,
     val vedtakBegrunnelseType: VedtakBegrunnelseType,
+    val støtterFritekst: Boolean,
 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1265,6 +1265,7 @@ fun lagRestSanityBegrunnelse(
     regelverk: String? = null,
     brevPeriodeType: String? = null,
     begrunnelseTypeForPerson: String? = null,
+    stotterFritekst: Boolean? = false,
 ): RestSanityBegrunnelse =
     RestSanityBegrunnelse(
         apiNavn = apiNavn,
@@ -1286,6 +1287,7 @@ fun lagRestSanityBegrunnelse(
         regelverk = regelverk,
         brevPeriodeType = brevPeriodeType,
         begrunnelseTypeForPerson = begrunnelseTypeForPerson,
+        stotterFritekst = stotterFritekst,
     )
 
 fun lagSanityBegrunnelse(


### PR DESCRIPTION
Favro: [NAV-20229](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20229)

### 💰 Hva skal gjøres, og hvorfor?
Utvider ISanityBegrunnelse med feltet stotterFritekst og eksponerer feltet til frontend via RestVedtaksbegrunnelse.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
