### PR TITLE
For Spring Boot 3 så bør man bruke jakartaversjonen av Sentry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
 
         <dependency>
             <groupId>io.sentry</groupId>
-            <artifactId>sentry-spring-boot-starter</artifactId>
+            <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Får advarsel i oppstart av app at man bruker feil versjon av sentry. Så bytter til den man bør bruke for Spring boot 3
![Screenshot 2024-03-27 at 12 57 37](https://github.com/navikt/familie-ba-sak/assets/1121978/833a18df-aafc-456a-838c-6d7e95a970c7)

https://docs.sentry.io/platforms/java/guides/spring-boot/
