### PR TITLE
Fiks feilende tester. Bruk MockedDateProvider

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -6,7 +6,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
 import no.nav.familie.ba.sak.common.LocalDateProvider
-import no.nav.familie.ba.sak.common.RealDateProvider
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.common.tilPersonEnkel
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
@@ -325,7 +324,7 @@ class CucumberMock(
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             valutakursRepository = valutakursRepository,
-            localDateProvider = RealDateProvider(),
+            localDateProvider = mockedDateProvider,
         )
 
     val registrerPersongrunnlag =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
For å finne dato injiserer vi en LocalDateProvider i servicene våre. For prod bruker vi RealDateProvider som alltid gir dagens dato, men i testene ønsker vi å mocke dette til en dato vi setter selv. Endrer fra å bruke RealDateProvider til mockedDateProvider
