### PR TITLE
Sletter enda ubrukt kolonne i db

### DIFF
--- a/src/main/resources/db/migration/V258__slett_samlet_resultat_vilkaarsvurdering.sql
+++ b/src/main/resources/db/migration/V258__slett_samlet_resultat_vilkaarsvurdering.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vilkaarsvurdering
+    DROP COLUMN samlet_resultat;


### PR DESCRIPTION
Sletter enda ubrukt kolonne i db i vilkårsvurdering tabellen.
Ingen referanser til kolonna i koden, så antar at man på et tidspunkt fjernet feltet fra klassen, men glemte å slette kolonna.