### PR TITLE
Refaktorerererer filtrering av sanity begrunnelser basert på miljø

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
@@ -60,7 +60,7 @@ class BehandlingMetrikker(
 
     fun hentBegrunnelserOgByggMetrikker() {
         try {
-            sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
+            sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser(filtrerPåMiljø = false)
         } catch (exception: Exception) {
             logger.warn("Kunne ikke hente EØS-begrunnelser fra sanity-api", exception)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingMetrikker.kt
@@ -79,7 +79,7 @@ class BehandlingMetrikker(
             }
 
         try {
-            sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
+            sanityBegrunnelser = sanityService.hentSanityBegrunnelser(filtrerPåMiljø = false)
         } catch (exception: Exception) {
             logger.warn("Klarte ikke å bygge tellere for begrunnelser")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -399,8 +399,8 @@ class BrevService(
 
         return hentHjemmeltekst(
             vedtaksperioder = vedtaksperioder,
-            standardbegrunnelseTilSanityBegrunnelse = sanityService.hentSanityBegrunnelser(),
-            eøsStandardbegrunnelseTilSanityBegrunnelse = sanityService.hentSanityEØSBegrunnelser(),
+            standardbegrunnelseTilSanityBegrunnelse = sanityService.hentSanityBegrunnelser(filtrerPåMiljø = true),
+            eøsStandardbegrunnelseTilSanityBegrunnelse = sanityService.hentSanityEØSBegrunnelser(filtrerPåMiljø = true),
             opplysningspliktHjemlerSkalMedIBrev = opplysningspliktHjemlerSkalMedIBrev,
             målform = målform,
             vedtakKorrigertHjemmelSkalMedIBrev = vedtakKorrigertHjemmelSkalMedIBrev,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 
 import no.nav.familie.ba.sak.common.BehandlingValidering.validerBehandlingIkkeErAvsluttet
 import no.nav.familie.ba.sak.common.BehandlingValidering.validerBehandlingKanRedigeres
-import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
@@ -25,8 +24,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndre
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.brev.brevBegrunnelseProdusent.GrunnlagForBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
-import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
@@ -90,7 +87,6 @@ class VedtaksperiodeService(
     private val integrasjonClient: IntegrasjonClient,
     private val valutakursRepository: ValutakursRepository,
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
-    private val envService: EnvService,
 ) {
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,
@@ -146,7 +142,7 @@ class VedtaksperiodeService(
 
         val persongrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id)
 
-        val sanityBegrunnelser = hentSanityBegrunnelserFiltrertPåMiljø()
+        val sanityBegrunnelser = sanityService.hentSanityBegrunnelser(filtrerPåMiljø = true)
 
         vedtaksperiodeMedBegrunnelser.settBegrunnelser(
             standardbegrunnelserFraFrontend.mapNotNull {
@@ -491,8 +487,8 @@ class VedtaksperiodeService(
         val behandlingsGrunnlagForVedtaksperioder = behandling.hentGrunnlagForVedtaksperioder()
         val behandlingsGrunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder()
 
-        val sanityBegrunnelser = hentSanityBegrunnelserFiltrertPåMiljø()
-        val sanityEØSBegrunnelser = hentSanityEøsBegrunnelserFiltrertPåMiljø()
+        val sanityBegrunnelser = sanityService.hentSanityBegrunnelser(filtrerPåMiljø = true)
+        val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser(filtrerPåMiljø = true)
 
         return GrunnlagForBegrunnelse(
             behandlingsGrunnlagForVedtaksperioder = behandlingsGrunnlagForVedtaksperioder,
@@ -501,24 +497,6 @@ class VedtaksperiodeService(
             sanityEØSBegrunnelser = sanityEØSBegrunnelser,
             nåDato = LocalDate.now(),
         )
-    }
-
-    private fun hentSanityEøsBegrunnelserFiltrertPåMiljø(): Map<EØSStandardbegrunnelse, SanityEØSBegrunnelse> {
-        val sanityEøsBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
-
-        return when (envService.erProd()) {
-            true -> sanityEøsBegrunnelser.filter { !it.value.slåttAvIProduksjon }
-            false -> sanityEøsBegrunnelser
-        }
-    }
-
-    private fun hentSanityBegrunnelserFiltrertPåMiljø(): Map<Standardbegrunnelse, SanityBegrunnelse> {
-        val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
-
-        return when (envService.erProd()) {
-            true -> sanityBegrunnelser.filter { !it.value.slåttAvIProduksjon }
-            false -> sanityBegrunnelser
-        }
     }
 
     fun oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
@@ -61,8 +61,8 @@ class VilkårsvurderingService(
     }
 
     fun hentVilkårsbegrunnelser(): Map<VedtakBegrunnelseType, List<RestVedtakBegrunnelseTilknyttetVilkår>> =
-        standardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityBegrunnelser()) +
-            eøsStandardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityEØSBegrunnelser())
+        standardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityBegrunnelser(filtrerPåMiljø = true)) +
+            eøsStandardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityEØSBegrunnelser(filtrerPåMiljø = true))
 
     fun hentTidligsteVilkårsvurderingKnyttetTilMigrering(behandlingId: Long): YearMonth? {
         val vilkårsvurdering =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
@@ -24,6 +24,8 @@ class SanityServiceTest {
 
     @Test
     fun `hentSanityEØSBegrunnelser - skal ikke filtrere bort nye begrunnelser tilknyttet EØS praksisendring`() {
+        every { envService.erProd() } returns false
+
         every { sanityKlient.hentEØSBegrunnelser() } returns
             EØSStandardbegrunnelse.values().map {
                 SanityEØSBegrunnelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import org.assertj.core.api.Assertions.assertThat
@@ -14,6 +15,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 class SanityServiceTest {
     @MockK
     private lateinit var sanityKlient: SanityKlient
+
+    @MockK
+    private lateinit var envService: EnvService
 
     @InjectMockKs
     private lateinit var sanityService: SanityService

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
-import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
@@ -44,7 +43,6 @@ class VedtaksperiodeServiceTest {
     private val refusjonEøsRepository = mockk<RefusjonEøsRepository>()
     private val integrasjonClient = mockk<IntegrasjonClient>()
     private val kompetanseRepository = mockk<KompetanseRepository>()
-    private val envService = mockk<EnvService>()
 
     private val vedtaksperiodeService =
         spyk(
@@ -67,7 +65,6 @@ class VedtaksperiodeServiceTest {
                 integrasjonClient = integrasjonClient,
                 valutakursRepository = mockk(),
                 utenlandskPeriodebeløpRepository = mockk(),
-                envService = envService,
             ),
         )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -5,7 +5,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
-import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.LocalDateProvider
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.common.tilPersonEnkel
@@ -150,7 +149,6 @@ class CucumberMock(
     val behandlingMetrikker = mockBehandlingMetrikker()
     val tilbakekrevingService = mockTilbakekrevingService()
     val taskRepository = mockTaskRepositoryWrapper()
-    val envService = mockEnvService(dataFraCucumber)
 
     val behandlingstemaService =
         BehandlingstemaService(
@@ -229,7 +227,6 @@ class CucumberMock(
             integrasjonClient = mockk(),
             valutakursRepository = valutakursRepository,
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
-            envService = envService,
         )
 
     val behandlingService =
@@ -935,15 +932,6 @@ private fun oppdaterEllerLagreBehandling(
 
     dataFraCucumber.behandlinger[behandling.id] = behandling
     return behandling
-}
-
-private fun mockEnvService(dataFraCucumber: BegrunnelseTeksterStepDefinition): EnvService {
-    val envService = mockk<EnvService>()
-    val erProduksjon = dataFraCucumber.erProduksjon
-
-    every { envService.erProd() } returns erProduksjon
-
-    return envService
 }
 
 private fun mockVedtaksperiodeService(): VedtaksperiodeService {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20240

Jeg refaktorer skruddAvIProduksjon logikken slik at filtreringen skjer i sanityService.
Dette fordi det blir mye kode duplikat dersom hver service selv skal gjøre denne filtreringen.
Legger til mulighet for filtrering slik at steder som BehandlingMetrikker der vi ønsker alle begrunnelser uavhengig av skruddAvIProduksjon skal komme med.