### PR TITLE
Legg til egen brevmal for henlagte søknad institusjon og fiks bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <prosessering.version>2.20240214140223_83c31de</prosessering.version>
         <felles.version>3.20240322152837_a01cd9d</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20240326084609_597be6d</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20240403182559_640725f</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20240311083956_0558f2a</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20240208132236_bce5777</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -221,6 +221,7 @@ fun ManueltBrevRequest.tilBrev(
 
         Brevmal.HENLEGGE_TRUKKET_SØKNAD ->
             HenleggeTrukketSøknadBrev(
+                mal = Brevmal.HENLEGGE_TRUKKET_SØKNAD,
                 data =
                     HenleggeTrukketSøknadData(
                         delmalData = HenleggeTrukketSøknadData.DelmalData(signatur = signaturDelmal),
@@ -228,6 +229,21 @@ fun ManueltBrevRequest.tilBrev(
                             FlettefelterForDokumentImpl(
                                 navn = this.mottakerNavn,
                                 fodselsnummer = this.mottakerIdent,
+                            ),
+                    ),
+            )
+        Brevmal.HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON ->
+            HenleggeTrukketSøknadBrev(
+                mal = Brevmal.HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON,
+                data =
+                    HenleggeTrukketSøknadData(
+                        delmalData = HenleggeTrukketSøknadData.DelmalData(signatur = signaturDelmal),
+                        flettefelter =
+                            FlettefelterForDokumentImpl(
+                                navn = this.mottakerNavn,
+                                organisasjonsnummer = mottakerIdent,
+                                gjelder = this.vedrørende?.navn,
+                                fodselsnummer = this.vedrørende?.fødselsnummer ?: mottakerIdent,
                             ),
                     ),
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
@@ -33,6 +33,7 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
     ),
     INNHENTE_OPPLYSNINGER_INSTITUSJON(false, "innhenteOpplysningerInstitusjon", "Innhente opplysninger institusjon"),
     HENLEGGE_TRUKKET_SØKNAD(false, "henleggeTrukketSoknad", "Henlegge trukket søknad"),
+    HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON(false, "henleggeTrukketSoknadInstitusjon", "Henlegge trukket søknad institusjon"),
     VARSEL_OM_REVURDERING(false, "varselOmRevurdering", "Varsel om revurdering"),
     VARSEL_OM_REVURDERING_INSTITUSJON(false, "varselOmRevurderingInstitusjon", "Varsel om revurdering institusjon"),
     VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14(
@@ -154,6 +155,7 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
 
             INFORMASJONSBREV_DELT_BOSTED,
             HENLEGGE_TRUKKET_SØKNAD,
+            HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON,
             SVARTIDSBREV,
             SVARTIDSBREV_INSTITUSJON,
             FORLENGET_SVARTIDSBREV,
@@ -197,6 +199,7 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
             VARSEL_OM_REVURDERING_SAMBOER -> Dokumenttype.BARNETRYGD_VARSEL_OM_REVURDERING_SAMBOER
             INFORMASJONSBREV_DELT_BOSTED -> Dokumenttype.BARNETRYGD_INFORMASJONSBREV_DELT_BOSTED
             HENLEGGE_TRUKKET_SØKNAD -> Dokumenttype.BARNETRYGD_HENLEGGE_TRUKKET_SØKNAD
+            HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON -> Dokumenttype.BARNETRYGD_HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON
             SVARTIDSBREV -> Dokumenttype.BARNETRYGD_SVARTIDSBREV
             FORLENGET_SVARTIDSBREV -> Dokumenttype.BARNETRYGD_FORLENGET_SVARTIDSBREV
             INFORMASJONSBREV_FØDSEL_VERGEMÅL -> Dokumenttype.BARNETRYGD_INFORMASJONSBREV_FØDSEL_VERGEMÅL
@@ -247,6 +250,7 @@ enum class Brevmal(val erVedtaksbrev: Boolean, val apiNavn: String, val visnings
                 INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED -> Distribusjonstype.VIKTIG
                 INNHENTE_OPPLYSNINGER_OG_INFORMASJON_OM_AT_ANNEN_FORELDER_MED_SELVSTENDIG_RETT_HAR_SØKT -> Distribusjonstype.VIKTIG
                 HENLEGGE_TRUKKET_SØKNAD -> Distribusjonstype.ANNET
+                HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON -> Distribusjonstype.ANNET
                 VARSEL_OM_REVURDERING -> Distribusjonstype.VIKTIG
                 VARSEL_OM_REVURDERING_INSTITUSJON -> Distribusjonstype.VIKTIG
                 VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14 -> Distribusjonstype.VIKTIG


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20289

Denne PR'n gjør to ting

1.  Vi har en bug der henleggelse av søknad som tilhører institusjon blir sendt til barn. PR'n retter opp dette.
2. Ved utsendelse av brev relatert til henlegge av søknad som tilhører institusjon så bruker vi nå egen brevmal