### PR TITLE
Bedre feilmelding ved andel på 0kr som ikke skyldes differanseberegning eller endret utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -118,7 +118,7 @@ object BehandlingsresultatSøknadUtils {
                                     )
                                     throw FunksjonellFeil(
                                         melding = "Andel er satt til 0 kr, men det skyldes verken differanseberegning eller endret utbetaling andel",
-                                        frontendFeilmelding = "Du må fylle ut en endret utbetalingsperiode for alle personene det gjelder"
+                                        frontendFeilmelding = "Du må fylle ut en endret utbetalingsperiode for alle personene det gjelder",
                                     )
                                 }
                             Årsak.DELT_BOSTED -> Søknadsresultat.INNVILGET

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -116,7 +116,10 @@ object BehandlingsresultatSøknadUtils {
                                             "\nNåværende andeler: $nåværendeAndelerForPerson" +
                                             "\nEndret utbetaling andeler: $endretUtbetalingAndelerForPerson",
                                     )
-                                    throw Feil("Andel er satt til 0 kr, men det skyldes verken differanseberegning eller endret utbetaling andel")
+                                    throw FunksjonellFeil(
+                                        melding = "Andel er satt til 0 kr, men det skyldes verken differanseberegning eller endret utbetaling andel",
+                                        frontendFeilmelding = "Du må fylle ut en endret utbetalingsperiode for alle personene det gjelder"
+                                    )
                                 }
                             Årsak.DELT_BOSTED -> Søknadsresultat.INNVILGET
                             Årsak.ALLEREDE_UTBETALT,
@@ -171,6 +174,7 @@ object BehandlingsresultatSøknadUtils {
                     ),
                 )
             -> Søknadsresultat.DELVIS_INNVILGET
+
             else -> throw Feil("Klarer ikke kombinere søknadsresultater: $this")
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20244

Bytter til å kaste en funksjonell feilmelding med en bedre feilmeldingstekst for saksbehandler, slik at saksbehandler skjønner at det er hen som må gjøre en endring for å komme videre. Hvis en 0-andel ikke er knyttet til endret utbetaling eller skyldes differanseberegning er det fordi saksbehandler ikke har lagt inn endret utbetaling på søkers andeler, men "etterbetaling 3 år" på alle barna. I dette scenariet dannes det utvidet-andel med 0kr uten endret utbetaling, men med denne feilmeldingen får vi forhåpentligvis saksbehandler til å tvinges til å legge inn en endret utbetaling andel.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._
Nei. Dette er avklart med Anna og Birgitte.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bytter bare på feilmeldingen, så tenker det ikek er nødvendig

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
