### PR TITLE
Tillater kolon i ident, siden journalposter med EESSI kommer inn med kolon i ident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
@@ -5,3 +5,5 @@ const val ALFANUMERISKE_TEGN = "a-zæøåA-ZÆØÅ0-9"
 fun String.saner(): String = Regex("[^$ALFANUMERISKE_TEGN]*").replace(this, "")
 
 fun String.erAlfanummerisk(): Boolean = Regex("[$ALFANUMERISKE_TEGN]*").matches(this)
+
+fun String.erAlfanummeriskPlussKolon(): Boolean = Regex("[$ALFANUMERISKE_TEGN:]*").matches(this)

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestOppdaterJournalpost.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestOppdaterJournalpost.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.common.erAlfanummerisk
+import no.nav.familie.ba.sak.common.erAlfanummeriskPlussKolon
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Bruker
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.OppdaterJournalpostRequest
@@ -61,7 +61,7 @@ data class NavnOgIdent(
 ) {
     // Bruker init til å validere personidenten
     init {
-        if (!id.erAlfanummerisk()) {
+        if (!id.erAlfanummeriskPlussKolon()) {
             secureLogger.info("Ugyldig ident: $id")
             throw FunksjonellFeil("Ugyldig ident. Se securelog for mer informasjon.")
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
@@ -22,4 +22,13 @@ class TekstSaniteringUtilTest {
         assertThat(sanertTekst.erAlfanummerisk()).isTrue()
         assertThat(tomStreng.erAlfanummerisk()).isTrue()
     }
+
+    @Test
+    fun `erAlfanummeriskPlussKolon skal tillate tekst med kolon, mens erAlfanummerisk skal ikke tillate tekst med kolon`() {
+        assertThat("Tekst:MedKolon".erAlfanummeriskPlussKolon()).isTrue()
+        assertThat("TekstUtenKolon".erAlfanummeriskPlussKolon()).isTrue()
+        assertThat("TekstUtenKolon".erAlfanummerisk()).isTrue()
+        assertThat("Tekst:MedKolon".erAlfanummerisk()).isFalse()
+        assertThat("".erAlfanummeriskPlussKolon()).isTrue()
+    }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Journalføring feiler nå ved mottak av EESSI dokumenter sendt inn av et firma. ID på avsendre vil være på et format som PL:PL21212120WR, som henviser til et utenlandsk orgnr. Myker opp valideringen til å også godta kolon

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Testet også lokalt

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
