### PR TITLE
Sett endringstidspunk dersom det er en splitt i vilkårene 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -150,7 +150,7 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     "| ${vilkårResultatRad.resultat} " +
                     "| ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"}" +
                     "| ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}" +
-                    "| ${vilkårResultatRad.vurderesEtter}" +
+                    "| ${vilkårResultatRad.vurderesEtter ?: ""}" +
                     "| \n"
             }
     } ?: ""

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -122,8 +122,8 @@ private fun hentTekstForVilkårresultater(
     return """
         
     Og legg til nye vilkårresultater for behandling $behandlingId
-      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter |""" +
-        tilVilkårResultatRader(personResultater)
+      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter |
+      """ + tilVilkårResultatRader(personResultater)
 }
 
 private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -25,18 +25,13 @@ fun utledEndringstidspunkt(
 ): LocalDate {
     val grunnlagTidslinjePerPerson =
         behandlingsGrunnlagForVedtaksperioder.copy(
-            personResultater =
-                behandlingsGrunnlagForVedtaksperioder
-                    .personResultater.beholdKunOppfylteVilkårResultater(),
-        ).utledGrunnlagTidslinjePerPerson()
-            .mapValues { it.value.vedtaksperiodeGrunnlagForPerson }
+            personResultater = behandlingsGrunnlagForVedtaksperioder.personResultater.beholdKunOppfylteVilkårResultater(),
+        ).utledGrunnlagTidslinjePerPerson().mapValues { it.value.vedtaksperiodeGrunnlagForPerson }
+
     val grunnlagTidslinjePerPersonForrigeBehandling =
         behandlingsGrunnlagForVedtaksperioderForrigeBehandling?.copy(
-            personResultater =
-                behandlingsGrunnlagForVedtaksperioderForrigeBehandling
-                    .personResultater.beholdKunOppfylteVilkårResultater(),
-        )?.utledGrunnlagTidslinjePerPerson()
-            ?.mapValues { it.value.vedtaksperiodeGrunnlagForPerson } ?: emptyMap()
+            personResultater = behandlingsGrunnlagForVedtaksperioderForrigeBehandling.personResultater.beholdKunOppfylteVilkårResultater(),
+        )?.utledGrunnlagTidslinjePerPerson()?.mapValues { it.value.vedtaksperiodeGrunnlagForPerson } ?: emptyMap()
 
     val erPeriodeLikSammePeriodeIForrigeBehandlingTidslinjer =
         grunnlagTidslinjePerPerson.outerJoin(grunnlagTidslinjePerPersonForrigeBehandling) { grunnlagForVedtaksperiode, grunnlagForVedtaksperiodeForrigeBehandling ->
@@ -130,16 +125,15 @@ private fun loggEndringstidspunktOgEndringer(
 }
 
 private fun Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<Boolean, Måned>>.finnTidligsteForskjell() =
-    this
-        .map { (aktørOgRolleForVedtaksgrunnlag, erPeriodeLikTidslinje) ->
-            val førsteEndringForAktør =
-                erPeriodeLikTidslinje.perioder()
-                    .filter { it.innhold == false }
-                    .minOfOrNull { it.fraOgMed.tilYearMonthEllerUendeligFortid().førsteDagIInneværendeMåned() }
-                    ?: TIDENES_ENDE
+    this.map { (aktørOgRolleForVedtaksgrunnlag, erPeriodeLikTidslinje) ->
+        val førsteEndringForAktør =
+            erPeriodeLikTidslinje.perioder()
+                .filter { it.innhold == false }
+                .minOfOrNull { it.fraOgMed.tilYearMonthEllerUendeligFortid().førsteDagIInneværendeMåned() }
+                ?: TIDENES_ENDE
 
-            aktørOgRolleForVedtaksgrunnlag to førsteEndringForAktør
-        }.minByOrNull { it.second }
+        aktørOgRolleForVedtaksgrunnlag to førsteEndringForAktør
+    }.minByOrNull { it.second }
 
 private fun VedtaksperiodeGrunnlagForPerson?.erLik(
     grunnlagForVedtaksperiodeForrigeBehandling: VedtaksperiodeGrunnlagForPerson?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -15,7 +15,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusen
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VedtaksperiodeGrunnlagForPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VedtaksperiodeGrunnlagForPersonVilkårInnvilget
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.erLikUtenFomOgTom
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.erLikUtenomTom
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import java.time.LocalDate
 
@@ -84,7 +84,7 @@ private fun loggEndringstidspunktOgEndringer(
     when (grunnlagIPeriodeMedEndring) {
         is VedtaksperiodeGrunnlagForPersonVilkårInnvilget -> {
             if (grunnlagIPeriodeMedEndringForrigeBehanlding is VedtaksperiodeGrunnlagForPersonVilkårInnvilget) {
-                if (!grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.erLikUtenFomOgTom(
+                if (!grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.erLikUtenomTom(
                         grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode,
                     )
                 ) {
@@ -109,7 +109,7 @@ private fun loggEndringstidspunktOgEndringer(
 
         is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget ->
             if (grunnlagIPeriodeMedEndringForrigeBehanlding is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget) {
-                if (!grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.erLikUtenFomOgTom(
+                if (!grunnlagIPeriodeMedEndring.vilkårResultaterForVedtaksperiode.erLikUtenomTom(
                         grunnlagIPeriodeMedEndringForrigeBehanlding.vilkårResultaterForVedtaksperiode,
                     )
                 ) {
@@ -147,7 +147,7 @@ private fun VedtaksperiodeGrunnlagForPerson?.erLik(
     when (this) {
         is VedtaksperiodeGrunnlagForPersonVilkårInnvilget ->
             grunnlagForVedtaksperiodeForrigeBehandling is VedtaksperiodeGrunnlagForPersonVilkårInnvilget &&
-                this.vilkårResultaterForVedtaksperiode.erLikUtenFomOgTom(
+                this.vilkårResultaterForVedtaksperiode.erLikUtenomTom(
                     grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode,
                 ) &&
                 this.kompetanse == grunnlagForVedtaksperiodeForrigeBehandling.kompetanse &&

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
@@ -107,8 +107,8 @@ data class VilkårResultatForVedtaksperiode(
     )
 }
 
-fun List<VilkårResultatForVedtaksperiode>.erLikUtenFomOgTom(other: List<VilkårResultatForVedtaksperiode>): Boolean {
-    return this.map { it.copy(fom = null, tom = null) }.toSet() == other.map { it.copy(fom = null, tom = null) }.toSet()
+fun List<VilkårResultatForVedtaksperiode>.erLikUtenomTom(other: List<VilkårResultatForVedtaksperiode>): Boolean {
+    return this.map { it.copy(tom = null) }.toSet() == other.map { it.copy(tom = null) }.toSet()
 }
 
 fun Iterable<VilkårResultatForVedtaksperiode>.erOppfyltForBarn(): Boolean =

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
@@ -238,3 +238,59 @@ Egenskap: Vedtaksperioder - Endringstidspunkt
       | Fra dato   | Til dato | Vedtaksperiodetype |
       | 01.06.2035 |          | OPPHØR             |
       |            |          | AVSLAG             |
+
+  Scenario: Skal oppdage endring dersom det er lagt inn en splitt i vilkårene innenfor en måned
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende vedtak
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat          | Behandlingsårsak |
+      | 1            | 1        |                     | ENDRET_UTBETALING            | SATSENDRING      |
+      | 2            | 1        | 1                   | ENDRET_OG_FORTSATT_INNVILGET | SØKNAD           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 22.11.1964  |
+      | 1            | 2       | BARN       | 07.12.2011  |
+      | 2            | 1       | SØKER      | 22.11.1964  |
+      | 2            | 2       | BARN       | 07.12.2011  |
+
+    Og dagens dato er 08.04.2024
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD,BOSATT_I_RIKET               |                  | 15.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | UTVIDET_BARNETRYGD                          |                  | 01.02.2022 |            | OPPFYLT  | Nei                  |                      |                  |
+
+      | 2       | GIFT_PARTNERSKAP                            |                  | 07.12.2011 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | UNDER_18_ÅR                                 |                  | 07.12.2011 | 06.12.2029 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOSATT_I_RIKET,LOVLIG_OPPHOLD,BOR_MED_SØKER |                  | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD,BOSATT_I_RIKET               |                  | 15.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | UTVIDET_BARNETRYGD                          |                  | 01.02.2022 | 06.03.2024 | OPPFYLT  | Nei                  |                      |                  |
+      | 1       | UTVIDET_BARNETRYGD                          |                  | 13.03.2024 |            | OPPFYLT  | Nei                  |                      |                  |
+
+      | 2       | GIFT_PARTNERSKAP                            |                  | 07.12.2011 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | UNDER_18_ÅR                                 |                  | 07.12.2011 | 06.12.2029 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER,LOVLIG_OPPHOLD |                  | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.02.2024 | 30.11.2029 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 2       | 1            | 01.02.2024 | 30.11.2029 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 1       | 2            | 01.02.2024 | 30.11.2029 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 2       | 2            | 01.02.2024 | 30.11.2029 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 2
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.04.2024 | 31.11.2029 | UTBETALING         |           |
+      | 01.12.2029 |            | OPPHØR             |           |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20060

Vi har en sak der endringen fra forrige behandling er at utvidet barnetrygd avsluttes og starter opp igjen innenfor samme måned. Dette fører ikke til noen endring i utbetaling. Tidligere har vi kun sammenlignet vilkårene måned for måned når vi har sett etter endringer mellom behandlingene. Det gjør at vi ikke oppdager noen endring per i dag, men vi ønsker at systemet skal tolke dette som en endring.

Endrer så vi også sjekker om fra-og-med-datoen på vilkårene er den samme. Dersom den er ulik anser vi det som en endring.

Leses enklest commit for commit. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
