### PR TITLE
Populer mottakernavn ved institusjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
+import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.SATSENDRING
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -30,6 +31,7 @@ class HenleggBehandling(
     private val oppgaveService: OppgaveService,
     private val persongrunnlagService: PersongrunnlagService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val organisasjonService: OrganisasjonService
 ) : BehandlingSteg<RestHenleggBehandlingInfo> {
     private val logger = LoggerFactory.getLogger(HenleggBehandling::class.java)
 
@@ -42,12 +44,14 @@ class HenleggBehandling(
         if (data.årsak == HenleggÅrsak.SØKNAD_TRUKKET) {
             val mottakerIdent = fagsak.institusjon?.orgNummer ?: fagsak.aktør.aktivFødselsnummer()
             val brevmal = fagsak.institusjon?.let { Brevmal.HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON } ?: Brevmal.HENLEGGE_TRUKKET_SØKNAD
+            val mottakerNavnVedInstitusjonsak = fagsak.institusjon?.let { organisasjonService.hentOrganisasjon(it.orgNummer).navn }
 
             dokumentService.sendManueltBrev(
                 behandling = behandling,
                 fagsakId = fagsak.id,
                 manueltBrevRequest =
                     ManueltBrevRequest(
+                        mottakerNavn = mottakerNavnVedInstitusjonsak ?: "",
                         mottakerIdent = mottakerIdent,
                         brevmal = brevmal,
                     ).byggMottakerdata(behandling, persongrunnlagService, arbeidsfordelingService),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -31,7 +31,7 @@ class HenleggBehandling(
     private val oppgaveService: OppgaveService,
     private val persongrunnlagService: PersongrunnlagService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
-    private val organisasjonService: OrganisasjonService
+    private val organisasjonService: OrganisasjonService,
 ) : BehandlingSteg<RestHenleggBehandlingInfo> {
     private val logger = LoggerFactory.getLogger(HenleggBehandling::class.java)
 


### PR DESCRIPTION
Vi har en bug i dag som fører til dette:

<img width="1023" alt="tom navn" src="https://github.com/navikt/familie-ba-sak/assets/110383605/1a3c153c-c458-4ff7-bfef-b7fb7262ae36">

Dette oppstår fordi mottakerNavn ikke blir populert ved institusjon.
Fikser dette.