### PR TITLE
Legger til en frontendfeilmelding for Ugyldig ident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
@@ -75,14 +75,16 @@ class ApiExceptionHandler {
     fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<Ressurs<Nothing>> {
         val mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(e)
 
-        return if (mostSpecificCause is DateTimeParseException) {
-            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-                Ressurs.failure(
-                    frontendFeilmelding = "Ugyldig datoformat ${mostSpecificCause.parsedString}",
-                ),
-            )
-        } else {
-            illegalState(mostSpecificCause.message.toString(), mostSpecificCause)
+        return when (mostSpecificCause) {
+            is DateTimeParseException -> {
+                ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    Ressurs.failure(
+                        frontendFeilmelding = "Ugyldig datoformat ${mostSpecificCause.parsedString}",
+                    ),
+                )
+            }
+            is FunksjonellFeil -> funksjonellFeil(mostSpecificCause)
+            else -> illegalState(mostSpecificCause.message.toString(), mostSpecificCause)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestOppdaterJournalpost.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestOppdaterJournalpost.kt
@@ -63,7 +63,10 @@ data class NavnOgIdent(
     init {
         if (!id.erAlfanummeriskPlussKolon()) {
             secureLogger.info("Ugyldig ident: $id")
-            throw FunksjonellFeil("Ugyldig ident. Se securelog for mer informasjon.")
+            throw FunksjonellFeil(
+                melding = "Ugyldig ident. Se securelog for mer informasjon.",
+                frontendFeilmelding = "Ugyldig ident. Normalt et fødselsnummer eller organisasjonsnummer",
+            )
         }
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Hvis en saksbehandler prøver å skrive en ident som ikke validerer i avsendermottaker, så får ikke saksbehandler noen god feilmelding i frontend. Og vil gjøre igjen og igjen og skape støy i sentry

**Fø**r:
![Screenshot 2024-04-11 at 15 24 01](https://github.com/navikt/familie-ba-sak/assets/1121978/837e591e-3228-4c9d-80eb-bca1c8c250c1)



**Etter**:
<img width="585" alt="Screenshot 2024-04-12 at 12 15 42" src="https://github.com/navikt/familie-ba-sak/assets/1121978/1984f6ea-5ae4-4bb8-aaec-8a15f1fd05af">



### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
