### PR TITLE
legg til endepunkt for å oppdatere løpende flagg på fagsaker slik at man ikke må vente til første dag i måneden

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.Månedli
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatusScheduler
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.ba.sak.task.GrensesnittavstemMotOppdrag
@@ -72,6 +73,7 @@ class ForvalterController(
     private val fagsakService: FagsakService,
     private val unleashNextMedContextService: UnleashNextMedContextService,
     private val taskRepository: TaskRepositoryWrapper,
+    private val fagsakStatusScheduler: FagsakStatusScheduler,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ForvalterController::class.java)
 
@@ -353,6 +355,13 @@ class ForvalterController(
         @RequestBody fagsakListe: List<Long>,
     ): ResponseEntity<Ressurs<String>> {
         fagsakListe.forEach { taskRepository.save(opprettStønadTomTask(it)) }
+        return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
+    }
+
+    @PostMapping("/kjør-oppdater-løpende-flagg-task")
+    @Operation(summary = "Kjører oppdaterLøpendeFlagg-tasken slik at man oppdaterer tasker som er løpende til avsluttet ved behov.")
+    fun kjørOppdaterLøpendeFlaggTask(): ResponseEntity<Ressurs<String>> {
+        fagsakStatusScheduler.oppdaterFagsakStatuser()
         return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
     }
 }


### PR DESCRIPTION

### 💰 Hva skal gjøres, og hvorfor?
Ref [denne](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-19991) oppgaven. Etter å ha oppdatert tilkjentYtelse.stønadTom ønsker vi å oppdatere fagsakstatus på fagsakene det gjelder for å kunne sjekke at fiksen funker (og kunne rydde vekk taskene i familie-prossessering før det glemmes). 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Bør dette endepunktet fjernes eller beholdes etter at vi er ferdig med denne fiksen? 
