### PR TITLE
Bytter dev-url til integrasjoner vekk fra en deprekert en

### DIFF
--- a/src/test/resources/application-dev-postgres-preprod.yaml
+++ b/src/test/resources/application-dev-postgres-preprod.yaml
@@ -162,7 +162,7 @@ spring:
 
 SANITY_DATASET: "ba-brev"
 
-FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.dev.intern.nav.no/api
+FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.intern.dev.nav.no/api
 FAMILIE_INTEGRASJONER_SCOPE: api://dev-fss.teamfamilie.familie-integrasjoner/.default
 PDL_URL: https://pdl-api.dev.intern.nav.no/
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Endrer over til intern.dev ingress for familie-integrasjoner
