### PR TITLE
Les fra identhendelse kafka kø

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <token-validation-test-support.version>2.0.5</token-validation-test-support.version>
         <fpsak-tidslinje.version>2.7.1</fpsak-tidslinje.version>
         <awaitility-kotlin.version>4.2.0</awaitility-kotlin.version>
+        <avro.version>1.11.3</avro.version>
+        <confluent.version>7.6.0</confluent.version>
     </properties>
 
     <dependencyManagement>
@@ -198,6 +200,17 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-logback</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>${confluent.version}</version>
         </dependency>
 
         <!-- swagger -->
@@ -405,6 +418,10 @@
 
     <repositories>
         <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+        <repository>
             <id>github</id>
             <url>https://maven.pkg.github.com/navikt/familie-felles</url>
         </repository>
@@ -468,6 +485,24 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${avro.version}</version>
+
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>idl-protocol</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>src/main/resources/avro</sourceDirectory>
+                            <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/KafkaAivenConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/KafkaAivenConfig.kt
@@ -24,7 +24,6 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.core.ProducerFactory
 import org.springframework.kafka.listener.ContainerProperties
 import org.springframework.kafka.support.LoggingProducerListener
-import java.time.Duration
 
 @Configuration
 class KafkaAivenConfig(val environment: Environment) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/KafkaAivenConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/KafkaAivenConfig.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import no.nav.familie.kontrakter.felles.Applikasjon
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.apache.kafka.clients.CommonClientConfigs
@@ -23,6 +24,7 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.core.ProducerFactory
 import org.springframework.kafka.listener.ContainerProperties
 import org.springframework.kafka.support.LoggingProducerListener
+import java.time.Duration
 
 @Configuration
 class KafkaAivenConfig(val environment: Environment) {
@@ -54,6 +56,14 @@ class KafkaAivenConfig(val environment: Environment) {
         factory.setCommonErrorHandler(kafkaErrorHandler)
         return factory
     }
+
+    @Bean
+    fun kafkaAivenHendelseListenerAvroLatestContainerFactory(kafkaErrorHandler: KafkaAivenErrorHandler): ConcurrentKafkaListenerContainerFactory<String, String> =
+        ConcurrentKafkaListenerContainerFactory<String, String>().apply {
+            containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
+            consumerFactory = DefaultKafkaConsumerFactory(consumerConfigsLatestAvro())
+            setCommonErrorHandler(kafkaErrorHandler)
+        }
 
     @Bean(name = [KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME])
     fun kafkaListenerEndpointRegistry(): KafkaListenerEndpointRegistry? {
@@ -94,6 +104,31 @@ class KafkaAivenConfig(val environment: Environment) {
                 ConsumerConfig.GROUP_ID_CONFIG to "familie-ba-sak",
                 ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ba-sak-1",
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "latest",
+            )
+        if (environment.activeProfiles.none { it.contains("dev") || it.contains("postgres") }) {
+            return consumerConfigs + securityConfig()
+        }
+        return consumerConfigs.toMap()
+    }
+
+    private fun consumerConfigsLatestAvro(): Map<String, Any> {
+        val kafkaBrokers = System.getenv("KAFKA_BROKERS") ?: "http://localhost:9092"
+        val schemaRegisty = System.getenv("KAFKA_SCHEMA_REGISTRY") ?: "http://localhost:9093"
+        val schemaRegistryUser = System.getenv("KAFKA_SCHEMA_REGISTRY_USER") ?: "mangler i pod"
+        val schemaRegistryPassword = System.getenv("KAFKA_SCHEMA_REGISTRY_PASSWORD") ?: "mangler i pod"
+        val consumerConfigs =
+            mutableMapOf(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaBrokers,
+                "schema.registry.url" to schemaRegisty,
+                "basic.auth.credentials.source" to "USER_INFO",
+                "basic.auth.user.info" to "$schemaRegistryUser:$schemaRegistryPassword",
+                "specific.avro.reader" to true,
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to KafkaAvroDeserializer::class.java,
+                ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ba-sak-2",
+                ConsumerConfig.MAX_POLL_RECORDS_CONFIG to "1",
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "latest",
+                ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
             )
         if (environment.activeProfiles.none { it.contains("dev") || it.contains("postgres") }) {
             return consumerConfigs + securityConfig()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdenthendelseV2Consumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdenthendelseV2Consumer.kt
@@ -9,7 +9,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.annotation.Profile
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Service
@@ -21,7 +20,8 @@ import java.util.UUID
     value = ["funksjonsbrytere.kafka.producer.enabled"],
     havingValue = "true",
     matchIfMissing = false,
-)class IdenthendelseV2Consumer(
+    )
+class IdenthendelseV2Consumer(
     val personidentService: PersonidentService,
 ) {
     @KafkaListener(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdenthendelseV2Consumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdenthendelseV2Consumer.kt
@@ -20,7 +20,7 @@ import java.util.UUID
     value = ["funksjonsbrytere.kafka.producer.enabled"],
     havingValue = "true",
     matchIfMissing = false,
-    )
+)
 class IdenthendelseV2Consumer(
     val personidentService: PersonidentService,
 ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdenthendelseV2Consumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdenthendelseV2Consumer.kt
@@ -1,0 +1,80 @@
+package no.nav.familie.ba.sak.kjerne.personident
+
+import no.nav.familie.kontrakter.felles.PersonIdent
+import no.nav.familie.log.mdc.MDCConstants
+import no.nav.person.pdl.aktor.v2.Aktor
+import no.nav.person.pdl.aktor.v2.Type
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@ConditionalOnProperty(
+    value = ["funksjonsbrytere.kafka.producer.enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)class IdenthendelseV2Consumer(
+    val personidentService: PersonidentService,
+) {
+    @KafkaListener(
+        id = "familie-ba-sak-aktorv2",
+        groupId = "familie-ba-sak-aktorv2-group",
+        topics = ["pdl.aktor-v2"],
+        containerFactory = "kafkaAivenHendelseListenerAvroLatestContainerFactory",
+    )
+    @Transactional
+    fun listen(
+        consumerRecord: ConsumerRecord<String, Aktor?>,
+        ack: Acknowledgment,
+    ) {
+        try {
+            Thread.sleep(60000) // Venter 1 min da det kan hende at PDL ikke er ferdig med å populere sine opplysninger rett etter at vi har lest meldingen
+            MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
+            SECURE_LOGGER.info("Har mottatt ident-hendelse $consumerRecord")
+
+            val aktør = consumerRecord.value()
+            val aktørIdPåHendelse = consumerRecord.key()
+
+            if (aktør == null) {
+                log.warn("Tom aktør fra identhendelse")
+                SECURE_LOGGER.warn("Tom aktør fra identhendelse med nøkkel $aktørIdPåHendelse")
+            }
+
+            val aktivAktørid =
+                aktør?.identifikatorer?.singleOrNull { ident ->
+                    ident.type == Type.AKTORID && ident.gjeldende
+                }?.idnummer.toString()
+
+            // I tilfeller som ved merge av hendelser vil man få både identhendelse på gammel og ny aktørid, så for å unngå duplikater så sender man bare på aktiv ident
+            if (aktørIdPåHendelse.contains(aktivAktørid)) {
+                aktør?.identifikatorer?.singleOrNull { ident ->
+                    ident.type == Type.FOLKEREGISTERIDENT && ident.gjeldende
+                }?.also { folkeregisterident ->
+                    personidentService.opprettTaskForIdentHendelse(PersonIdent(folkeregisterident.idnummer.toString()))
+                }
+            } else {
+                SECURE_LOGGER.info("Ignorerer å lage task på ident-hendelse fordi aktør $aktørIdPåHendelse ikke lenger er en gyldig aktør")
+            }
+        } catch (e: RuntimeException) {
+            log.warn("Feil i prosessering av ident-hendelser", e)
+            SECURE_LOGGER.warn("Feil i prosessering av ident-hendelser $consumerRecord", e)
+            throw RuntimeException("Feil i prosessering av ident-hendelser")
+        } finally {
+            MDC.clear()
+        }
+        ack.acknowledge()
+    }
+
+    companion object {
+        val SECURE_LOGGER: Logger = LoggerFactory.getLogger("secureLogger")
+        val log: Logger = LoggerFactory.getLogger(IdenthendelseV2Consumer::class.java)
+    }
+}

--- a/src/main/resources/avro/AktorV2.avdl
+++ b/src/main/resources/avro/AktorV2.avdl
@@ -1,0 +1,19 @@
+@namespace("no.nav.person.pdl.aktor.v2")
+protocol AktorProtoV2 {
+
+  enum Type {
+    FOLKEREGISTERIDENT,
+    AKTORID,
+    NPID
+  }
+
+  record Identifikator {
+    string idnummer;
+    Type type;
+    boolean gjeldende;
+  }
+
+  record Aktor {
+    array<Identifikator> identifikatorer;
+  }
+}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20711

Siden vi nå leser direkte fra køen i ks-sak istedenfor å få hendelsene sendt gjennom REST fra baks-mottak, så ønsker vi å gjøre tilsvarende for ba-sak. Dette betyr også da at vi kan slette kode fra baks-mottak når det er ferdiggjort.

Endepunktet som baks-mottak benytter seg av tenker jeg å ta i en annen PR som kommer etter denne.
