### PR TITLE
Legg til vurderingsstrategi for valutakursene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.VurderingsstrategiForValutakurser
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Utbetalingsperiode
 import java.time.LocalDate
@@ -45,4 +46,5 @@ data class RestUtvidetBehandling(
     val feilutbetaltValuta: List<RestFeilutbetaltValuta>,
     val brevmottakere: List<RestBrevmottaker>,
     val refusjonEøs: List<RestRefusjonEøs>,
+    val vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser? = VurderingsstrategiForValutakurser.AUTOMATISK,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.VurderingsstrategiForValutakurserRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.kjerne.korrigertetterbetaling.KorrigertEtterbetalingService
@@ -64,6 +65,7 @@ class UtvidetBehandlingService(
     private val feilutbetaltValutaService: FeilutbetaltValutaService,
     private val brevmottakerService: BrevmottakerService,
     private val refusjonEøsService: RefusjonEøsService,
+    private val vurderingsstrategiForValutakurserRepository: VurderingsstrategiForValutakurserRepository,
 ) {
     fun lagRestUtvidetBehandling(behandlingId: Long): RestUtvidetBehandling {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId)
@@ -152,6 +154,7 @@ class UtvidetBehandlingService(
             feilutbetaltValuta = feilutbetaltValuta,
             brevmottakere = brevmottakere,
             refusjonEøs = refusjonEøs,
+            vurderingsstrategiForValutakurser = vurderingsstrategiForValutakurserRepository.findByBehandlingId(behandling.id)?.vurderingsstrategiForValutakurser,
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -118,7 +118,7 @@ class AutomatiskOppdaterValutakursService(
     @Transactional
     fun endreVurderingsstrategiForValutakurser(
         behandlingId: BehandlingId,
-        strategi: VurderingsstrategiForValutakurser,
+        nyStrategi: VurderingsstrategiForValutakurser,
     ): VurderingsstrategiForValutakurserDB {
         val vurderingsstrategiForValutakurser = vurderingsstrategiForValutakurserRepository.findByBehandlingId(behandlingId.id)
         if (vurderingsstrategiForValutakurser != null) {
@@ -126,14 +126,14 @@ class AutomatiskOppdaterValutakursService(
             vurderingsstrategiForValutakurserRepository.flush()
         }
 
-        if (strategi == VurderingsstrategiForValutakurser.AUTOMATISK) {
+        if (nyStrategi == VurderingsstrategiForValutakurser.AUTOMATISK) {
             resettValutakurserOgLagValutakurserEtterEndringstidspunkt(behandlingId)
         }
 
         return vurderingsstrategiForValutakurserRepository.save(
             VurderingsstrategiForValutakurserDB(
                 behandlingId = behandlingId.id,
-                vurderingsstrategiForValutakurser = strategi,
+                vurderingsstrategiForValutakurser = nyStrategi,
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -117,22 +117,22 @@ class AutomatiskOppdaterValutakursService(
 
     @Transactional
     fun endreVurderingsstrategiForValutakurser(
-        behanlingId: BehandlingId,
+        behandlingId: BehandlingId,
         strategi: VurderingsstrategiForValutakurser,
     ): VurderingsstrategiForValutakurserDB {
-        val vurderingsstrategiForValutakurser = vurderingsstrategiForValutakurserRepository.findByBehandlingId(behanlingId.id)
+        val vurderingsstrategiForValutakurser = vurderingsstrategiForValutakurserRepository.findByBehandlingId(behandlingId.id)
         if (vurderingsstrategiForValutakurser != null) {
             vurderingsstrategiForValutakurserRepository.delete(vurderingsstrategiForValutakurser)
             vurderingsstrategiForValutakurserRepository.flush()
         }
 
         if (strategi == VurderingsstrategiForValutakurser.AUTOMATISK) {
-            resettValutakurserOgLagValutakurserEtterEndringstidspunkt(behanlingId)
+            resettValutakurserOgLagValutakurserEtterEndringstidspunkt(behandlingId)
         }
 
         return vurderingsstrategiForValutakurserRepository.save(
             VurderingsstrategiForValutakurserDB(
-                behandlingId = behanlingId.id,
+                behandlingId = behandlingId.id,
                 vurderingsstrategiForValutakurser = strategi,
             ),
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
@@ -127,7 +127,7 @@ class ValutakursController(
         @PathVariable behandlingId: Long,
         @PathVariable vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser,
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
-        automatiskOppdaterValutakursService.endreVurderingsstrategiForValutakurser(behanlingId = BehandlingId(behandlingId), strategi = vurderingsstrategiForValutakurser)
+        automatiskOppdaterValutakursService.endreVurderingsstrategiForValutakurser(behandlingId = BehandlingId(behandlingId), strategi = vurderingsstrategiForValutakurser)
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
@@ -121,4 +121,13 @@ class ValutakursController(
     ): Boolean {
         return restValutakurs.valutakode != null && restValutakurs.valutakursdato != null && (eksisterendeValutakurs.valutakursdato != restValutakurs.valutakursdato || eksisterendeValutakurs.valutakode != restValutakurs.valutakode)
     }
+
+    @PutMapping(path = ["behandling/{behandlingId}/endre-vurderingsstrategi-til/{vurderingsstrategiForValutakurser}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    private fun endreVurderingsstrategiForValutakurser(
+        @PathVariable behandlingId: Long,
+        @PathVariable vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser,
+    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
+        automatiskOppdaterValutakursService.endreVurderingsstrategiForValutakurser(behanlingId = BehandlingId(behandlingId), strategi = vurderingsstrategiForValutakurser)
+        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
@@ -122,7 +122,7 @@ class ValutakursController(
         return restValutakurs.valutakode != null && restValutakurs.valutakursdato != null && (eksisterendeValutakurs.valutakursdato != restValutakurs.valutakursdato || eksisterendeValutakurs.valutakode != restValutakurs.valutakode)
     }
 
-    @PutMapping(path = ["behandling/{behandlingId}/endre-vurderingsstrategi-til/{vurderingsstrategiForValutakurser}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PutMapping(path = ["behandlinger/{behandlingId}/endre-vurderingsstrategi-til/{vurderingsstrategiForValutakurser}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     private fun endreVurderingsstrategiForValutakurser(
         @PathVariable behandlingId: Long,
         @PathVariable vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
@@ -127,7 +127,7 @@ class ValutakursController(
         @PathVariable behandlingId: Long,
         @PathVariable vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser,
     ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
-        automatiskOppdaterValutakursService.endreVurderingsstrategiForValutakurser(behandlingId = BehandlingId(behandlingId), strategi = vurderingsstrategiForValutakurser)
+        automatiskOppdaterValutakursService.endreVurderingsstrategiForValutakurser(behandlingId = BehandlingId(behandlingId), nyStrategi = vurderingsstrategiForValutakurser)
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/VurderingsstrategiForValutakurser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/VurderingsstrategiForValutakurser.kt
@@ -1,0 +1,34 @@
+﻿package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+
+// Kan sannsynligvis slettes på sikt om vi ikke lenger trenger å ha mulighet til å overstyre valutakursene
+@EntityListeners(RollestyringMotDatabase::class)
+@Entity(name = "VurderingsstrategiForValutakurserDB")
+@Table(name = "vurderingsstrategi_for_valutakurser")
+data class VurderingsstrategiForValutakurserDB(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "vurderingsstrategi_for_valutakurser_seq_generator")
+    @SequenceGenerator(name = "vurderingsstrategi_for_valutakurser_seq_generator", sequenceName = "vurderingsstrategi_for_valutakurser_seq", allocationSize = 50)
+    val id: Long = 0,
+    @Column(name = "fk_behandling_id", nullable = false, updatable = false)
+    val behandlingId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vurderingsstrategi_for_valutakurser", nullable = false)
+    val vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser = VurderingsstrategiForValutakurser.AUTOMATISK,
+)
+
+enum class VurderingsstrategiForValutakurser {
+    MANUELL,
+    AUTOMATISK,
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/VurderingsstrategiForValutakurserRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/VurderingsstrategiForValutakurserRepository.kt
@@ -1,0 +1,7 @@
+﻿package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VurderingsstrategiForValutakurserRepository : JpaRepository<VurderingsstrategiForValutakurserDB, Long> {
+    fun findByBehandlingId(behandlingId: Long): VurderingsstrategiForValutakurserDB?
+}

--- a/src/main/resources/db/migration/V260__lag_vurderingsstrategi_for_valutakurser.sql
+++ b/src/main/resources/db/migration/V260__lag_vurderingsstrategi_for_valutakurser.sql
@@ -7,5 +7,3 @@ CREATE TABLE IF NOT EXISTS vurderingsstrategi_for_valutakurser
 
 CREATE SEQUENCE IF NOT EXISTS vurderingsstrategi_for_valutakurser_seq INCREMENT BY 50 START WITH 1000000 NO CYCLE;
 CREATE UNIQUE INDEX IF NOT EXISTS vurderingsstrategi_for_valutakurser_fk_behandling_id_idx ON vurderingsstrategi_for_valutakurser (fk_behandling_id);
-ALTER TABLE behandling
-    ADD COLUMN vurderingsstrategi_for_valutakurser TEXT DEFAULT null;

--- a/src/main/resources/db/migration/V260__lag_vurderingsstrategi_for_valutakurser.sql
+++ b/src/main/resources/db/migration/V260__lag_vurderingsstrategi_for_valutakurser.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS vurderingsstrategi_for_valutakurser
+(
+    id                                  BIGINT PRIMARY KEY,
+    fk_behandling_id                    BIGINT REFERENCES behandling (id) ON DELETE CASCADE NOT NULL,
+    vurderingsstrategi_for_valutakurser TEXT                                                NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS vurderingsstrategi_for_valutakurser_seq INCREMENT BY 50 START WITH 1000000 NO CYCLE;
+CREATE UNIQUE INDEX IF NOT EXISTS vurderingsstrategi_for_valutakurser_fk_behandling_id_idx ON vurderingsstrategi_for_valutakurser (fk_behandling_id);
+ALTER TABLE behandling
+    ADD COLUMN vurderingsstrategi_for_valutakurser TEXT DEFAULT null;

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
@@ -42,6 +42,7 @@ class AutomatiskOppdaterValutakursServiceTest {
     val ecbService = mockk<ECBService>()
     val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
     val simuleringService = mockk<SimuleringService>()
+    val vurderingsstrategiForValutakurserRepository = mockk<VurderingsstrategiForValutakurserRepository>()
 
     val automatiskOppdaterValutakursService =
         AutomatiskOppdaterValutakursService(
@@ -53,7 +54,7 @@ class AutomatiskOppdaterValutakursServiceTest {
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             tilpassValutakurserTilUtenlandskePeriodebeløpService = tilpassValutakurserTilUtenlandskePeriodebeløpService,
             simuleringService = simuleringService,
-            vurderingsstrategiForValutakurserRepository = mockk(),
+            vurderingsstrategiForValutakurserRepository = vurderingsstrategiForValutakurserRepository,
         )
 
     val forrigeBehandlingId = BehandlingId(9L)
@@ -73,6 +74,7 @@ class AutomatiskOppdaterValutakursServiceTest {
             val dato = secondArg<LocalDate>()
             dato.month.value.toBigDecimal()
         }
+        every { vurderingsstrategiForValutakurserRepository.findByBehandlingId(any()) } returns null
         valutakursRepository.deleteAll()
         utenlandskPeriodebeløpRepository.deleteAll()
     }
@@ -214,5 +216,33 @@ class AutomatiskOppdaterValutakursServiceTest {
             .ignoringFields("endretTidspunkt")
             .ignoringFields("opprettetTidspunkt")
             .isEqualTo(forventetUberørteValutakurser + forventetOppdaterteValutakurser)
+    }
+
+    @Test
+    fun `oppdaterValutakurserEtterEndringstidspunkt skal ikke automatisk hente valutakurser om vurderingsstrategien er satt til manuell`() {
+        UtenlandskPeriodebeløpBuilder(jan(2020), behandlingId)
+            .medBeløp("777777777", "EUR", "N", barn1, barn2, barn3)
+            .lagreTil(utenlandskPeriodebeløpRepository)
+
+        val manuelleValutakurserTidslinje =
+            ValutakursBuilder(jan(2020), behandlingId)
+                .medKurs("111111111", "EUR", barn1, barn2, barn3)
+                .medVurderingsform(Vurderingsform.MANUELL)
+
+        manuelleValutakurserTidslinje
+            .lagreTil(valutakursRepository)
+
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(behandlingId.id) } returns LocalDate.of(2020, 5, 15)
+        every { vurderingsstrategiForValutakurserRepository.findByBehandlingId(any()) } returns VurderingsstrategiForValutakurserDB(behandlingId = behandlingId.id, vurderingsstrategiForValutakurser = VurderingsstrategiForValutakurser.MANUELL)
+
+        automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(behandlingId)
+
+        assertThat(valutakursService.hentValutakurser(behandlingId))
+            .usingRecursiveComparison()
+            .ignoringFields("id")
+            .ignoringFields("valutakursdato")
+            .ignoringFields("endretTidspunkt")
+            .ignoringFields("opprettetTidspunkt")
+            .isEqualTo(manuelleValutakurserTidslinje.bygg())
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
@@ -53,6 +53,7 @@ class AutomatiskOppdaterValutakursServiceTest {
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             tilpassValutakurserTilUtenlandskePeriodebeløpService = tilpassValutakurserTilUtenlandskePeriodebeløpService,
             simuleringService = simuleringService,
+            vurderingsstrategiForValutakurserRepository = mockk(),
         )
 
     val forrigeBehandlingId = BehandlingId(9L)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -233,6 +233,7 @@ class CucumberMock(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             tilpassValutakurserTilUtenlandskePeriodebeløpService = tilpassValutakurserTilUtenlandskePeriodebeløpService,
             simuleringService = simuleringService,
+            mockk(),
         )
 
     val tilpassDifferanseberegningEtterUtenlandskPeriodebeløpService =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20661

For å være på den sikre siden ønsker vi å kunne skur av at valutakursene genereres automatisk. I så fall skal det være mulig å redigere de automatiske valutakursene og endringer i behandlingen skal ikke lenger føre til at vi henter kurser og lager perioder for kursene atuomatisk. 

Legger til en tabell for VurderingsstrategiForValutakurser som er koblet til behandlingen i tillegg til en controller for å opprette rader i tabellen. 

Dersom vi har satt strategien på en behandling til manuell vil ikke løypa for automatisk valutajustering kjøres. 
