### PR TITLE
resterende behandlinger med feil tilkjent ytelse tom

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelerTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.førerTilOpphørVed0Prosent
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
@@ -151,7 +152,7 @@ fun utledStønadTom(
         andelerMedEndringer.filterNot { andelTilkjentYtelseMedEndreteUtbetalinger ->
             val harEndringSomFørerTilOpphørVed0Prosent =
                 andelTilkjentYtelseMedEndreteUtbetalinger.endreteUtbetalinger.any { endretUtbetaling ->
-                    endretUtbetaling.årsak?.førerTilOpphørVed0Prosent() ?: false
+                    endretUtbetaling.førerTilOpphørVed0Prosent()
                 }
             harEndringSomFørerTilOpphørVed0Prosent && andelTilkjentYtelseMedEndreteUtbetalinger.prosent == BigDecimal.ZERO
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
@@ -14,7 +14,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelerTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.førerTilOpphørVed0Prosent
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.førerTilOpphør
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
@@ -150,7 +150,7 @@ fun utledStønadTom(
     val andelerMedRelevantUtbetaling =
         andelerMedEndringer.filterNot { andelTilkjentYtelseMedEndreteUtbetalinger ->
             andelTilkjentYtelseMedEndreteUtbetalinger.endreteUtbetalinger.any { endretUtbetaling ->
-                endretUtbetaling.førerTilOpphørVed0Prosent()
+                endretUtbetaling.førerTilOpphør()
             }
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsoppdragGeneratorService.kt
@@ -23,7 +23,6 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -150,11 +149,9 @@ fun utledStønadTom(
 
     val andelerMedRelevantUtbetaling =
         andelerMedEndringer.filterNot { andelTilkjentYtelseMedEndreteUtbetalinger ->
-            val harEndringSomFørerTilOpphørVed0Prosent =
-                andelTilkjentYtelseMedEndreteUtbetalinger.endreteUtbetalinger.any { endretUtbetaling ->
-                    endretUtbetaling.førerTilOpphørVed0Prosent()
-                }
-            harEndringSomFørerTilOpphørVed0Prosent && andelTilkjentYtelseMedEndreteUtbetalinger.prosent == BigDecimal.ZERO
+            andelTilkjentYtelseMedEndreteUtbetalinger.endreteUtbetalinger.any { endretUtbetaling ->
+                endretUtbetaling.førerTilOpphørVed0Prosent()
+            }
         }
 
     return andelerMedRelevantUtbetaling.maxOfOrNull { it.stønadTom }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.EndretUtbetalingAndelTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.tilAndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import java.time.YearMonth
 
@@ -97,15 +96,10 @@ object BehandlingsresultatOpphørUtils {
             val kalkulertUtbetalingsbeløp = andelTilkjentYtelse?.kalkulertUtbetalingsbeløp ?: return@kombinerMed null
             val endringsperiodeÅrsak = endretUtbetalingAndel?.årsak ?: return@kombinerMed andelTilkjentYtelse
 
-            when (endringsperiodeÅrsak) {
-                Årsak.ALLEREDE_UTBETALT,
-                Årsak.ENDRE_MOTTAKER,
-                Årsak.ETTERBETALING_3ÅR,
-                ->
-                    // Vi ønsker å filtrere bort andeler som har 0 i kalkulertUtbetalingsbeløp
-                    if (kalkulertUtbetalingsbeløp == 0) null else andelTilkjentYtelse
-
-                Årsak.DELT_BOSTED -> andelTilkjentYtelse
+            if (endringsperiodeÅrsak.førerTilOpphørVed0Prosent() && kalkulertUtbetalingsbeløp == 0) {
+                null
+            } else {
+                andelTilkjentYtelse
             }
         }.tilAndelTilkjentYtelse()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.tilAndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
+import java.math.BigDecimal
 import java.time.YearMonth
 
 internal enum class Opphørsresultat {
@@ -93,10 +94,10 @@ object BehandlingsresultatOpphørUtils {
         val endretUtbetalingAndelTidslinje = EndretUtbetalingAndelTidslinje(endretAndelerPåPerson)
 
         return andelTilkjentYtelseTidslinje.kombinerMed(endretUtbetalingAndelTidslinje) { andelTilkjentYtelse, endretUtbetalingAndel ->
-            val kalkulertUtbetalingsbeløp = andelTilkjentYtelse?.kalkulertUtbetalingsbeløp ?: return@kombinerMed null
+            andelTilkjentYtelse ?: return@kombinerMed null
             val endringsperiodeÅrsak = endretUtbetalingAndel?.årsak ?: return@kombinerMed andelTilkjentYtelse
 
-            if (endringsperiodeÅrsak.førerTilOpphørVed0Prosent() && kalkulertUtbetalingsbeløp == 0) {
+            if (endringsperiodeÅrsak.førerTilOpphørVed0Prosent() && andelTilkjentYtelse.prosent == BigDecimal(0)) {
                 null
             } else {
                 andelTilkjentYtelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.nesteMåned
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelerTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.førerTilOpphørVed0Prosent
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.førerTilOpphør
 import java.time.YearMonth
 
 internal enum class Opphørsresultat {
@@ -92,7 +92,7 @@ object BehandlingsresultatOpphørUtils {
 
         val andelerMedRelevantUtbetaling =
             andelerMedEndringer.filterNot { andelTilkjentYtelseMedEndreteUtbetalinger ->
-                andelTilkjentYtelseMedEndreteUtbetalinger.endreteUtbetalinger.any { it.førerTilOpphørVed0Prosent() }
+                andelTilkjentYtelseMedEndreteUtbetalinger.endreteUtbetalinger.any { it.førerTilOpphør() }
             }
 
         return andelerMedRelevantUtbetaling.map { it.andel }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -111,6 +111,15 @@ enum class Årsak(val visningsnavn: String) {
     ETTERBETALING_3ÅR("Etterbetaling 3 år"),
     ENDRE_MOTTAKER("Endre mottaker, begge foreldre rett"),
     ALLEREDE_UTBETALT("Allerede utbetalt"),
+    ;
+
+    fun førerTilOpphørVed0Prosent() =
+        this in
+            listOf(
+                ALLEREDE_UTBETALT,
+                ENDRE_MOTTAKER,
+                ETTERBETALING_3ÅR,
+            )
 }
 
 fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilRestEndretUtbetalingAndel() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -111,15 +111,17 @@ enum class Årsak(val visningsnavn: String) {
     ETTERBETALING_3ÅR("Etterbetaling 3 år"),
     ENDRE_MOTTAKER("Endre mottaker, begge foreldre rett"),
     ALLEREDE_UTBETALT("Allerede utbetalt"),
+    ;
+
+    fun førerTilOpphør() =
+        when (this) {
+            ALLEREDE_UTBETALT, ENDRE_MOTTAKER, ETTERBETALING_3ÅR -> true
+            DELT_BOSTED -> false
+        }
 }
 
 fun EndretUtbetalingAndel.førerTilOpphørVed0Prosent() =
-    this.prosent == BigDecimal.ZERO && this.årsak in
-        listOf(
-            Årsak.ALLEREDE_UTBETALT,
-            Årsak.ENDRE_MOTTAKER,
-            Årsak.ETTERBETALING_3ÅR,
-        )
+    this.prosent == BigDecimal.ZERO && this.årsak != null && this.årsak!!.førerTilOpphør()
 
 fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilRestEndretUtbetalingAndel() =
     RestEndretUtbetalingAndel(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -114,12 +114,14 @@ enum class Årsak(val visningsnavn: String) {
     ;
 
     fun førerTilOpphørVed0Prosent() =
-        this in
-            listOf(
-                ALLEREDE_UTBETALT,
-                ENDRE_MOTTAKER,
-                ETTERBETALING_3ÅR,
-            )
+        when (this) {
+            ALLEREDE_UTBETALT,
+            ENDRE_MOTTAKER,
+            ETTERBETALING_3ÅR,
+            -> false
+
+            DELT_BOSTED -> true
+        }
 }
 
 fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilRestEndretUtbetalingAndel() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -111,18 +111,15 @@ enum class Årsak(val visningsnavn: String) {
     ETTERBETALING_3ÅR("Etterbetaling 3 år"),
     ENDRE_MOTTAKER("Endre mottaker, begge foreldre rett"),
     ALLEREDE_UTBETALT("Allerede utbetalt"),
-    ;
-
-    fun førerTilOpphørVed0Prosent() =
-        when (this) {
-            ALLEREDE_UTBETALT,
-            ENDRE_MOTTAKER,
-            ETTERBETALING_3ÅR,
-            -> false
-
-            DELT_BOSTED -> true
-        }
 }
+
+fun EndretUtbetalingAndel.førerTilOpphørVed0Prosent() =
+    this.prosent == BigDecimal.ZERO && this.årsak in
+        listOf(
+            Årsak.ALLEREDE_UTBETALT,
+            Årsak.ENDRE_MOTTAKER,
+            Årsak.ETTERBETALING_3ÅR,
+        )
 
 fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilRestEndretUtbetalingAndel() =
     RestEndretUtbetalingAndel(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -113,15 +113,15 @@ enum class Årsak(val visningsnavn: String) {
     ALLEREDE_UTBETALT("Allerede utbetalt"),
     ;
 
-    fun førerTilOpphør() =
+    fun førerTilOpphørVed0Prosent() =
         when (this) {
             ALLEREDE_UTBETALT, ENDRE_MOTTAKER, ETTERBETALING_3ÅR -> true
             DELT_BOSTED -> false
         }
 }
 
-fun EndretUtbetalingAndel.førerTilOpphørVed0Prosent() =
-    this.prosent == BigDecimal.ZERO && this.årsak != null && this.årsak!!.førerTilOpphør()
+fun EndretUtbetalingAndel.førerTilOpphør() =
+    this.prosent == BigDecimal.ZERO && this.årsak != null && this.årsak!!.førerTilOpphørVed0Prosent()
 
 fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilRestEndretUtbetalingAndel() =
     RestEndretUtbetalingAndel(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
@@ -33,8 +33,9 @@ class OppdaterStønadTomPåTilkjentYtelseTask(
 
         val behandling =
             behandlingRepository.finnBehandlinger(fagsakId)
-                .filter { it.status == BehandlingStatus.AVSLUTTET && it.aktiv }
-                .singleOrNull() ?: throw Feil("Finner ingen behandling på fagsak $fagsakId")
+                .filter { it.status == BehandlingStatus.AVSLUTTET }
+                .sortedByDescending { it.aktivertTidspunkt }
+                .firstOrNull() ?: throw Feil("Finner ingen behandling på fagsak $fagsakId")
 
         if (behandling.fagsak.status != FagsakStatus.LØPENDE) {
             throw Feil("Prøvde å oppdatere stønadTom på en tilkjentYtelse på en fagsak som ikke er løpende. ")

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
@@ -43,7 +43,7 @@ class OppdaterStønadTomPåTilkjentYtelseTask(
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandling.id)
         val endredeUtbetalinger = endretUtbetalingAndelRepository.findByBehandlingId(behandling.id)
 
-        val stønadTom = utledStønadTom(tilkjentYtelse, endredeUtbetalinger)
+        val stønadTom = utledStønadTom(tilkjentYtelse.andelerTilkjentYtelse.toList(), endredeUtbetalinger)
         val gammelStønadTom = tilkjentYtelse.stønadTom
 
         if (stønadTom == gammelStønadTom) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
@@ -33,7 +33,7 @@ class OppdaterStønadTomPåTilkjentYtelseTask(
 
         val behandling =
             behandlingRepository.finnBehandlinger(fagsakId)
-                .filter { it.status == BehandlingStatus.AVSLUTTET }
+                .filter { it.status == BehandlingStatus.AVSLUTTET && !it.erHenlagt() }
                 .sortedByDescending { it.aktivertTidspunkt }
                 .firstOrNull() ?: throw Feil("Finner ingen behandling på fagsak $fagsakId")
 
@@ -44,7 +44,7 @@ class OppdaterStønadTomPåTilkjentYtelseTask(
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandling.id)
         val endredeUtbetalinger = endretUtbetalingAndelRepository.findByBehandlingId(behandling.id)
 
-        val stønadTom = utledStønadTom(tilkjentYtelse.andelerTilkjentYtelse.toList(), endredeUtbetalinger)
+        val stønadTom = utledStønadTom(tilkjentYtelse.andelerTilkjentYtelse, endredeUtbetalinger)
         val gammelStønadTom = tilkjentYtelse.stønadTom
 
         if (stønadTom == gammelStønadTom) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterStønadTomPåTilkjentYtelseTask.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.task
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utledStønadTom
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
@@ -31,8 +32,9 @@ class OppdaterStønadTomPåTilkjentYtelseTask(
         logger.info("Oppdaterer stønadTom for TilkjentYtelse på fagsak $fagsakId")
 
         val behandling =
-            behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
-                ?: throw Feil("Finner ingen behandling på fagsak $fagsakId")
+            behandlingRepository.finnBehandlinger(fagsakId)
+                .filter { it.status == BehandlingStatus.AVSLUTTET && it.aktiv }
+                .singleOrNull() ?: throw Feil("Finner ingen behandling på fagsak $fagsakId")
 
         if (behandling.fagsak.status != FagsakStatus.LØPENDE) {
             throw Feil("Prøvde å oppdatere stønadTom på en tilkjentYtelse på en fagsak som ikke er løpende. ")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-19991)

Når vi finner behandlinger for å sjekke om stønadTom burde settes tidligere så vi tidligere på behandlinger som er iverksatt. Det blir feil når vi har fagsaker uten iverksatte behandlinger eller når behandlingen vi vil ente stønadTom fra ikke er iverksatt. Bytter derfor til å se etter siste behandling som er avsluttet i stedet. 
