### PR TITLE
Avslutt fagsaker der tilkjentYtelse.stønadTom er null

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -84,7 +84,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
                 
                 SELECT silp.fk_fagsak_id
                 FROM sisteiverksatte silp
-                WHERE  silp.stonad_tom < DATE_TRUNC('month', NOW())""",
+                WHERE  silp.stonad_tom < DATE_TRUNC('month', NOW()) OR silp.stonad_tom IS NULL""",
         nativeQuery = true,
     )
     fun finnFagsakerSomSkalAvsluttes(): List<Long>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ref disse to
[Favro1](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-19991)
[Favro2](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20727)

Dersom en fagsak har en tilkjentYtelse med stønadTom == null og fagsak.status != opprettet bør det bety at fagsaken ikke har noen utbetalinger / andel tilkjent ytelse og kan avsluttes. Velger derfor å legge til denne casen i finnFagsakerSomSkalAvsluttes()


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er antagelsen over nødvendigvis sann eller finnes det caser/grunner til at TilkjentYtelse.stønadTom er null når fagsaken er løpende?


