### PR TITLE
Fikser brukket swagger etter transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>2.2.21</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
                 <version>${kotlin.version}</version>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Swagger funker ikke. Ser ut til å være en transitive dependency som kommer inn i gammel versjon pga confluent jackson, så overstyrer

![image](https://github.com/navikt/familie-ba-sak/assets/1121978/5f317377-8827-4730-9b34-72979a9b2575)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
