### PR TITLE
Ikke resett valutakurser til forrige behandling dersom vi er på en førstegangsbehandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -45,11 +45,13 @@ class AutomatiskOppdaterValutakursService(
         val behandling = behandlingHentOgPersisterService.hent(behandlingId.id)
         val forrigeBehandlingVedtatt = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
 
-        // Resetter valutaen til slik den var i forrige behandling
-        valutakursService.kopierOgErstattValutakurser(
-            fraBehandlingId = BehandlingId(forrigeBehandlingVedtatt!!.id),
-            tilBehandlingId = behandlingId,
-        )
+        if (forrigeBehandlingVedtatt != null) {
+            // Resetter valutaen til slik den var i forrige behandling
+            valutakursService.kopierOgErstattValutakurser(
+                fraBehandlingId = BehandlingId(forrigeBehandlingVedtatt.id),
+                tilBehandlingId = behandlingId,
+            )
+        }
 
         // Tilpasser valutaen til potensielle endringer i utenlandske periodebeløp fra denne behandlingen
         tilpassValutakurserTilUtenlandskePeriodebeløpService.tilpassValutakursTilUtenlandskPeriodebeløp(behandlingId)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20661

Sjekk om vi har en tidligere behandling når vi resetter valutakursene. Om vi har en tidligere behandling skal kursene settes slik de var før vi genererer automatiske, om ikke genererer vi bare de automatiske
