### PR TITLE
Legg til fritekst avsnitt delmal logikk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.EnkeltInformasjonsbrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.FlettefelterForDokumentImpl
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.ForlengetSvartidsbrev
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.FritekstAvsnitt
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.HenleggeTrukketSøknadBrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.HenleggeTrukketSøknadData
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.InformasjonsbrevDeltBostedBrev
@@ -81,6 +82,7 @@ data class ManueltBrevRequest(
     val vedrørende: Person? = null,
     val mottakerlandSed: List<String> = emptyList(),
     val manuelleBrevmottakere: List<ManuellBrevmottaker> = emptyList(),
+    val fritekstAvsnitt: String? = null,
 ) {
     override fun toString(): String {
         return "${ManueltBrevRequest::class}, $brevmal"
@@ -212,7 +214,14 @@ fun ManueltBrevRequest.tilBrev(
                 mal = brevmal,
                 data =
                     InnhenteOpplysningerData(
-                        delmalData = InnhenteOpplysningerData.DelmalData(signatur = signaturDelmal),
+                        delmalData =
+                            InnhenteOpplysningerData.DelmalData(
+                                signatur = signaturDelmal,
+                                fritekstAvsnitt =
+                                    this.fritekstAvsnitt
+                                        ?.takeIf { it.isNotBlank() }
+                                        ?.let { FritekstAvsnitt(it) },
+                            ),
                         flettefelter =
                             InnhenteOpplysningerData.Flettefelter(
                                 navn = this.mottakerNavn,
@@ -237,6 +246,7 @@ fun ManueltBrevRequest.tilBrev(
                             ),
                     ),
             )
+
         Brevmal.HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON ->
             HenleggeTrukketSøknadBrev(
                 mal = Brevmal.HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/FellesDelmaler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/FellesDelmaler.kt
@@ -85,3 +85,11 @@ data class RefusjonEøsUavklart(
         flettefelt(perioderMedRefusjonEøsUavklart.toList()),
     )
 }
+
+data class FritekstAvsnitt(
+    val fritekstAvsnittTekst: Flettefelt,
+) {
+    constructor(fritekstAvsnittTekst: String) : this(
+        flettefelt(fritekstAvsnittTekst),
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/InnhenteOpplysningerBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/InnhenteOpplysningerBrev.kt
@@ -37,5 +37,6 @@ data class InnhenteOpplysningerData(
 
     data class DelmalData(
         val signatur: SignaturDelmal,
+        val fritekstAvsnitt: FritekstAvsnitt?,
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/InnhenteOpplysningerOmBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/InnhenteOpplysningerOmBarn.kt
@@ -15,6 +15,7 @@ data class InnhenteOpplysningerOmBarn(
         enhet: String,
         dokumentliste: List<String>,
         saksbehandlerNavn: String,
+        fritekstAvsnitt: String? = null,
     ) : this(
         mal = mal,
         data =
@@ -26,6 +27,10 @@ data class InnhenteOpplysningerOmBarn(
                                 enhet = enhet,
                                 saksbehandlerNavn = saksbehandlerNavn,
                             ),
+                        fritekstAvsnitt =
+                            fritekstAvsnitt
+                                ?.takeIf { it.isNotBlank() }
+                                ?.let { FritekstAvsnitt(it) },
                     ),
                 flettefelter =
                     InnhenteOpplysningerOmBarnData.Flettefelter(
@@ -64,5 +69,6 @@ data class InnhenteOpplysningerOmBarnData(
 
     data class DelmalData(
         val signatur: SignaturDelmal,
+        val fritekstAvsnitt: FritekstAvsnitt?,
     )
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20702

Vi ønsker å legge til muligheten for å legge til et avsnitt der man kan skrive fritekst i.
Forskjellen mellom denne og kulepunkt funksjonaliteten er at teksten som skrives her ikke skal være bundet til noe kulepunkt

Frontend PR:   https://github.com/navikt/familie-ba-sak-frontend/pull/3155