### PR TITLE
Ny "mock-pdl"-profil som erstatter ClientMocks-oppsettet for personinfo

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.common
 
 import no.nav.commons.foedselsnummer.testutils.FoedselsnummerGenerator
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.datagenerator.vedtak.lagVedtaksbegrunnelse
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
@@ -118,7 +117,10 @@ import kotlin.random.Random
 
 val fødselsnummerGenerator = FoedselsnummerGenerator()
 
-fun randomFnr(): String = fødselsnummerGenerator.foedselsnummer().asString
+fun randomFnr(foedselsdato: LocalDate? = null): String = fødselsnummerGenerator.foedselsnummer(foedselsdato).asString
+
+fun randomBarnFnr(alder: Int? = null): String =
+    randomFnr((alder ?: (1..16).random()).årSiden.minusDays((1..364).random().toLong()))
 
 fun randomPersonident(
     aktør: Aktør,
@@ -703,8 +705,8 @@ fun lagVilkårsvurdering(
  */
 fun kjørStegprosessForFGB(
     tilSteg: StegType,
+    barnasIdenter: List<String>,
     søkerFnr: String = randomFnr(),
-    barnasIdenter: List<String> = listOf(ClientMocks.barnFnr[0]),
     fagsakService: FagsakService,
     vedtakService: VedtakService,
     persongrunnlagService: PersongrunnlagService,
@@ -1378,3 +1380,5 @@ fun ikkeOppfyltVilkår(vilkår: Vilkår) =
         vilkår = vilkår,
         regelverkResultat = RegelverkResultat.IKKE_OPPFYLT,
     )
+
+val Number.årSiden: LocalDate get() = LocalDate.now().minusYears(this.toLong())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClientMocks.kt
@@ -5,30 +5,16 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ba.sak.common.EnvService
-import no.nav.familie.ba.sak.common.guttenBarnesenFødselsdato
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonException
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
-import no.nav.familie.ba.sak.integrasjoner.pdl.VergeResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjonMaskert
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.VergeData
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandling
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandling2
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandling2Fnr
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandlingFnr
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandlingSkalFeile
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandlingSkalFeileFnr
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandling
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandlingAktør
-import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandlingFnr
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.Personident
-import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
@@ -49,17 +35,6 @@ import java.time.LocalDate
 
 @TestConfiguration
 class ClientMocks {
-    @Bean
-    @Profile("mock-pdl")
-    @Primary
-    fun mockPersonopplysningerService(): PersonopplysningerService {
-        val mockPersonopplysningerService = mockk<PersonopplysningerService>(relaxed = false)
-
-        clearPdlMocks(mockPersonopplysningerService)
-
-        return mockPersonopplysningerService
-    }
-
     @Bean
     @Primary
     @Profile("mock-pdl-test-søk")
@@ -238,214 +213,8 @@ class ClientMocks {
             mockPersonopplysningerService: PersonopplysningerService,
         ) {
             clearMocks(mockPersonopplysningerService)
-
-            every {
-                mockPersonopplysningerService.hentGjeldendeStatsborgerskap(any())
-            } answers {
-                Statsborgerskap(
-                    "NOR",
-                    LocalDate.of(1990, 1, 25),
-                    LocalDate.of(1990, 1, 25),
-                    null,
-                )
-            }
-
-            every {
-                mockPersonopplysningerService.hentGjeldendeOpphold(any())
-            } answers {
-                Opphold(
-                    type = OPPHOLDSTILLATELSE.PERMANENT,
-                    oppholdFra = LocalDate.of(1990, 1, 25),
-                    oppholdTil = LocalDate.of(2499, 1, 1),
-                )
-            }
-
-            every {
-                mockPersonopplysningerService.hentVergeData(any())
-            } returns VergeData(false)
-
-            every {
-                mockPersonopplysningerService.harVerge(any())
-            } returns VergeResponse(false)
-
-            every {
-                mockPersonopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(any())
-            } returns "NO"
-
-            val idSlotForHentPersoninfo = slot<Aktør>()
-            every {
-                mockPersonopplysningerService.hentPersoninfoEnkel(capture(idSlotForHentPersoninfo))
-            } answers {
-                when (val id = idSlotForHentPersoninfo.captured.aktivFødselsnummer()) {
-                    barnFnr[0], barnFnr[1] -> personInfo.getValue(id)
-                    søkerFnr[0], søkerFnr[1] -> personInfo.getValue(id)
-                    "09121079074" -> personInfo.getValue(id)
-                    "10031000033" -> personInfo.getValue(id)
-                    "04068203010" -> personInfo.getValue(id)
-                    else -> personInfo.getValue(INTEGRASJONER_FNR)
-                }
-            }
-
-            val idSlotPersoninfoNavnOgAdresse = slot<Aktør>()
-            every {
-                mockPersonopplysningerService.hentPersoninfoNavnOgAdresse(capture(idSlotPersoninfoNavnOgAdresse))
-            } answers {
-                when (val id = idSlotPersoninfoNavnOgAdresse.captured.aktivFødselsnummer()) {
-                    barnFnr[0], barnFnr[1] -> personInfo.getValue(id)
-                    søkerFnr[0], søkerFnr[1] -> personInfo.getValue(id)
-                    "09121079074" -> personInfo.getValue(id)
-                    "10031000033" -> personInfo.getValue(id)
-                    "04068203010" -> personInfo.getValue(id)
-                    else -> personInfo.getValue(INTEGRASJONER_FNR)
-                }
-            }
-
-            val idSlot = slot<Aktør>()
-            every {
-                mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(capture(idSlot))
-            } answers {
-                when (val id = idSlot.captured.aktivFødselsnummer()) {
-                    "00000000000" -> throw HttpClientErrorException(
-                        HttpStatus.NOT_FOUND,
-                        "Fant ikke forespurte data på person.",
-                    )
-
-                    barnFnr[0], barnFnr[1], "09121079074", "10031000033", "04068203010" -> personInfo.getValue(id)
-
-                    søkerFnr[0] ->
-                        personInfo.getValue(id).copy(
-                            forelderBarnRelasjon =
-                                setOf(
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[0]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[0]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[0]).fødselsdato,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[1]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[1]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[1]).fødselsdato,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(søkerFnr[1]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.MEDMOR,
-                                    ),
-                                ),
-                        )
-
-                    søkerFnr[1] ->
-                        personInfo.getValue(id).copy(
-                            forelderBarnRelasjon =
-                                setOf(
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[0]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[0]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[0]).fødselsdato,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[1]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[1]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[1]).fødselsdato,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(søkerFnr[0]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.FAR,
-                                    ),
-                                ),
-                        )
-
-                    søkerFnr[2] ->
-                        personInfo.getValue(id).copy(
-                            forelderBarnRelasjon =
-                                setOf(
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[0]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[0]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[0]).fødselsdato,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[1]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[1]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[1]).fødselsdato,
-                                        adressebeskyttelseGradering = personInfo.getValue(barnFnr[1]).adressebeskyttelseGradering,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(søkerFnr[0]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.FAR,
-                                    ),
-                                ),
-                            forelderBarnRelasjonMaskert =
-                                setOf(
-                                    ForelderBarnRelasjonMaskert(
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        adressebeskyttelseGradering =
-                                            personInfo.getValue(
-                                                BARN_DET_IKKE_GIS_TILGANG_TIL_FNR,
-                                            ).adressebeskyttelseGradering!!,
-                                    ),
-                                ),
-                        )
-
-                    INTEGRASJONER_FNR ->
-                        personInfo.getValue(id).copy(
-                            forelderBarnRelasjon =
-                                setOf(
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[0]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[0]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[0]).fødselsdato,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(barnFnr[1]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.BARN,
-                                        navn = personInfo.getValue(barnFnr[1]).navn,
-                                        fødselsdato = personInfo.getValue(barnFnr[1]).fødselsdato,
-                                    ),
-                                    ForelderBarnRelasjon(
-                                        aktør = tilAktør(søkerFnr[1]),
-                                        relasjonsrolle = FORELDERBARNRELASJONROLLE.MEDMOR,
-                                    ),
-                                ),
-                        )
-
-                    mockBarnAutomatiskBehandlingFnr -> personInfo.getValue(id)
-                    mockBarnAutomatiskBehandling2Fnr -> personInfo.getValue(id)
-                    mockSøkerAutomatiskBehandlingFnr -> personInfo.getValue(id)
-                    mockBarnAutomatiskBehandlingSkalFeileFnr -> personInfo.getValue(id)
-                    else -> personInfo.getValue(INTEGRASJONER_FNR)
-                }
-            }
-
-            every {
-                mockPersonopplysningerService.hentAdressebeskyttelseSomSystembruker(capture(idSlot))
-            } answers {
-                if (BARN_DET_IKKE_GIS_TILGANG_TIL_FNR == idSlot.captured.aktivFødselsnummer()) {
-                    ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
-                } else {
-                    ADRESSEBESKYTTELSEGRADERING.UGRADERT
-                }
-            }
-
-            every { mockPersonopplysningerService.harVerge(mockSøkerAutomatiskBehandlingAktør) } returns
-                VergeResponse(
-                    harVerge = false,
-                )
         }
 
-        val søkerFnr = arrayOf("12345678910", "11223344556", "12345678911")
-        private val barnFødselsdatoer =
-            arrayOf(
-                guttenBarnesenFødselsdato,
-                LocalDate.now().withDayOfMonth(18).minusYears(2),
-            )
-        val barnFnr = arrayOf(randomFnr(), randomFnr())
         const val BARN_DET_IKKE_GIS_TILGANG_TIL_FNR = "12345678912"
         const val INTEGRASJONER_FNR = "10000111111"
         val bostedsadresse =
@@ -459,34 +228,6 @@ class ClientMocks {
                         kommunenummer = "2231",
                     ),
             )
-        private val bostedsadresseHistorikk =
-            mutableListOf(
-                Bostedsadresse(
-                    angittFlyttedato = LocalDate.now().minusDays(15),
-                    gyldigTilOgMed = null,
-                    matrikkeladresse =
-                        Matrikkeladresse(
-                            matrikkelId = 123L,
-                            bruksenhetsnummer = "H301",
-                            tilleggsnavn = "navn",
-                            postnummer = "0202",
-                            kommunenummer = "2231",
-                        ),
-                ),
-                Bostedsadresse(
-                    angittFlyttedato = LocalDate.now().minusYears(1),
-                    gyldigTilOgMed = LocalDate.now().minusDays(16),
-                    matrikkeladresse =
-                        Matrikkeladresse(
-                            matrikkelId = 123L,
-                            bruksenhetsnummer = "H301",
-                            tilleggsnavn = "navn",
-                            postnummer = "0202",
-                            kommunenummer = "2231",
-                        ),
-                ),
-            )
-
         private val sivilstandHistorisk =
             listOf(
                 Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8)),
@@ -495,112 +236,6 @@ class ClientMocks {
 
         val personInfo =
             mapOf(
-                søkerFnr[0] to
-                    PersonInfo(
-                        fødselsdato = LocalDate.of(1990, 2, 19),
-                        kjønn = Kjønn.KVINNE,
-                        navn = "Mor Moresen",
-                        bostedsadresser = bostedsadresseHistorikk,
-                        sivilstander = sivilstandHistorisk,
-                        statsborgerskap =
-                            listOf(
-                                Statsborgerskap(
-                                    land = "DNK",
-                                    bekreftelsesdato = LocalDate.now().minusYears(1),
-                                    gyldigFraOgMed = null,
-                                    gyldigTilOgMed = null,
-                                ),
-                            ),
-                    ),
-                søkerFnr[1] to
-                    PersonInfo(
-                        fødselsdato = LocalDate.of(1995, 2, 19),
-                        bostedsadresser = mutableListOf(),
-                        sivilstander =
-                            listOf(
-                                Sivilstand(
-                                    type = SIVILSTAND.GIFT,
-                                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
-                                ),
-                            ),
-                        kjønn = Kjønn.MANN,
-                        navn = "Far Faresen",
-                    ),
-                søkerFnr[2] to
-                    PersonInfo(
-                        fødselsdato = LocalDate.of(1985, 7, 10),
-                        bostedsadresser = mutableListOf(),
-                        sivilstander =
-                            listOf(
-                                Sivilstand(
-                                    type = SIVILSTAND.GIFT,
-                                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
-                                ),
-                            ),
-                        kjønn = Kjønn.KVINNE,
-                        navn = "Moder Jord",
-                        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT,
-                    ),
-                barnFnr[0] to
-                    PersonInfo(
-                        fødselsdato = barnFødselsdatoer[0],
-                        bostedsadresser = mutableListOf(bostedsadresse),
-                        sivilstander =
-                            listOf(
-                                Sivilstand(
-                                    type = SIVILSTAND.UOPPGITT,
-                                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
-                                ),
-                            ),
-                        kjønn = Kjønn.MANN,
-                        navn = "Gutten Barnesen",
-                    ),
-                barnFnr[1] to
-                    PersonInfo(
-                        fødselsdato = barnFødselsdatoer[1],
-                        bostedsadresser = mutableListOf(bostedsadresse),
-                        sivilstander =
-                            listOf(
-                                Sivilstand(
-                                    type = SIVILSTAND.GIFT,
-                                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
-                                ),
-                            ),
-                        kjønn = Kjønn.KVINNE,
-                        navn = "Jenta Barnesen",
-                        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.FORTROLIG,
-                    ),
-                mockBarnAutomatiskBehandlingFnr to mockBarnAutomatiskBehandling,
-                mockBarnAutomatiskBehandling2Fnr to mockBarnAutomatiskBehandling2,
-                mockSøkerAutomatiskBehandlingFnr to mockSøkerAutomatiskBehandling,
-                mockBarnAutomatiskBehandlingSkalFeileFnr to mockBarnAutomatiskBehandlingSkalFeile,
-                "09121079074" to
-                    PersonInfo(
-                        fødselsdato = LocalDate.of(2010, 12, 9),
-                        bostedsadresser = mutableListOf(bostedsadresse),
-                        sivilstander = listOf(Sivilstand(type = SIVILSTAND.UGIFT)),
-                        kjønn = Kjønn.KVINNE,
-                        navn = "Litt eldre barn",
-                        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT,
-                    ),
-                "10031000033" to
-                    PersonInfo(
-                        fødselsdato = LocalDate.of(2015, 2, 10),
-                        bostedsadresser = mutableListOf(bostedsadresse),
-                        sivilstander = listOf(Sivilstand(type = SIVILSTAND.UGIFT)),
-                        kjønn = Kjønn.KVINNE,
-                        navn = "Jenten 2015",
-                        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT,
-                    ),
-                "04068203010" to
-                    PersonInfo(
-                        fødselsdato = LocalDate.of(1982, 6, 4),
-                        bostedsadresser = mutableListOf(),
-                        sivilstander = listOf(Sivilstand(type = SIVILSTAND.UGIFT)),
-                        kjønn = Kjønn.KVINNE,
-                        navn = "Moder Jord",
-                        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT,
-                    ),
                 INTEGRASJONER_FNR to
                     PersonInfo(
                         fødselsdato = LocalDate.of(1965, 2, 19),
@@ -609,44 +244,9 @@ class ClientMocks {
                         navn = "Mor Integrasjon person",
                         sivilstander = sivilstandHistorisk,
                     ),
-                BARN_DET_IKKE_GIS_TILGANG_TIL_FNR to
-                    PersonInfo(
-                        fødselsdato = LocalDate.of(2019, 6, 22),
-                        bostedsadresser = mutableListOf(bostedsadresse),
-                        sivilstander =
-                            listOf(
-                                Sivilstand(
-                                    type = SIVILSTAND.UGIFT,
-                                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
-                                ),
-                            ),
-                        kjønn = Kjønn.KVINNE,
-                        navn = "Maskert Banditt",
-                        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG,
-                    ),
             )
         val ukjentId = randomFnr()
     }
-}
-
-fun mockHentPersoninfoForMedIdenter(
-    mockPersonopplysningerService: PersonopplysningerService,
-    søkerFnr: String,
-    barnFnr: String,
-) {
-    every {
-        mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(tilAktør(barnFnr)))
-    } returns
-        PersonInfo(
-            fødselsdato = LocalDate.of(2018, 5, 1),
-            kjønn = Kjønn.KVINNE,
-            navn = "Barn Barnesen",
-            sivilstander = listOf(Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8))),
-        )
-
-    every {
-        mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(tilAktør(søkerFnr)))
-    } returns PersonInfo(fødselsdato = LocalDate.of(1990, 2, 19), kjønn = Kjønn.KVINNE, navn = "Mor Moresen")
 }
 
 fun tilAktør(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
@@ -8,7 +8,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import no.nav.familie.ba.sak.config.ClientMocks.Companion.BARN_DET_IKKE_GIS_TILGANG_TIL_FNR
-import no.nav.familie.ba.sak.config.ClientMocks.Companion.søkerFnr
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollClient
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
@@ -63,6 +62,8 @@ class IntegrasjonClientMock {
     }
 
     companion object {
+        private val søkerFnr = "12345678910"
+
         fun clearIntegrasjonMocks(mockIntegrasjonClient: IntegrasjonClient) {
             /**
              * Mulig årsak til at appen må bruke dirties i testene.
@@ -77,18 +78,18 @@ class IntegrasjonClientMock {
 
             every { mockIntegrasjonClient.hentJournalpost(any()) } returns
                 lagTestJournalpost(
-                    søkerFnr[0],
+                    søkerFnr,
                     UUID.randomUUID().toString(),
                 )
 
             every { mockIntegrasjonClient.hentJournalposterForBruker(any()) } returns
                 listOf(
                     lagTestJournalpost(
-                        søkerFnr[0],
+                        søkerFnr,
                         UUID.randomUUID().toString(),
                     ),
                     lagTestJournalpost(
-                        søkerFnr[0],
+                        søkerFnr,
                         UUID.randomUUID().toString(),
                     ),
                 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockPersonopplysningerService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockPersonopplysningerService.kt
@@ -1,0 +1,335 @@
+package no.nav.familie.ba.sak.config
+
+import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
+import no.nav.familie.ba.sak.integrasjoner.pdl.PdlRestClient
+import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjonMaskert
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandling
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandling2
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandling2Fnr
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandlingFnr
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandlingSkalFeile
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockBarnAutomatiskBehandlingSkalFeileFnr
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandling
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.mockSøkerAutomatiskBehandlingFnr
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE.BARN
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE.FAR
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE.MEDMOR
+import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
+import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
+import no.nav.familie.kontrakter.felles.personopplysning.Sivilstand
+import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter.ofPattern
+
+@Service
+@Profile("mock-pdl")
+@Primary
+class MockPersonopplysningerService(
+    pdlRestClient: PdlRestClient,
+    systemOnlyPdlRestClient: SystemOnlyPdlRestClient,
+    familieIntegrasjonerTilgangskontrollService: FamilieIntegrasjonerTilgangskontrollService,
+) : PersonopplysningerService(
+        pdlRestClient,
+        systemOnlyPdlRestClient,
+        familieIntegrasjonerTilgangskontrollService,
+    ) {
+    init {
+        settPersoninfoMedRelasjonerForPredefinerteTestpersoner()
+    }
+
+    override fun hentPersoninfoMedRelasjonerOgRegisterinformasjon(aktør: Aktør): PersonInfo {
+        return when (val id = aktør.aktivFødselsnummer()) {
+            "00000000000" ->
+                throw HttpClientErrorException(
+                    HttpStatus.NOT_FOUND,
+                    "Fant ikke forespurte data på person.",
+                )
+
+            else ->
+                personInfo[id] ?: personInfo.getValue(INTEGRASJONER_FNR)
+        }
+    }
+
+    override fun hentPersoninfoEnkel(aktør: Aktør): PersonInfo {
+        return personInfo[aktør.aktivFødselsnummer()]
+            ?: personInfo.getValue(INTEGRASJONER_FNR)
+    }
+
+    override fun hentPersoninfoNavnOgAdresse(aktør: Aktør): PersonInfo {
+        return hentPersoninfoEnkel(aktør)
+    }
+
+    override fun hentAdressebeskyttelseSomSystembruker(aktør: Aktør): ADRESSEBESKYTTELSEGRADERING {
+        return if (aktør.aktivFødselsnummer() == BARN_DET_IKKE_GIS_TILGANG_TIL_FNR) {
+            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
+        } else {
+            personInfo[aktør.aktivFødselsnummer()]?.adressebeskyttelseGradering ?: ADRESSEBESKYTTELSEGRADERING.UGRADERT
+        }
+    }
+
+    override fun hentGjeldendeStatsborgerskap(aktør: Aktør): Statsborgerskap {
+        return personInfo[aktør.aktivFødselsnummer()]?.statsborgerskap?.firstOrNull()
+            ?: Statsborgerskap(
+                "NOR",
+                LocalDate.of(1990, 1, 25),
+                LocalDate.of(1990, 1, 25),
+                null,
+            )
+    }
+
+    override fun hentLandkodeAlpha2UtenlandskBostedsadresse(aktør: Aktør): String {
+        return "NO"
+    }
+
+    companion object {
+        val personInfo: MutableMap<String, PersonInfo> =
+            mutableMapOf(
+                mockBarnAutomatiskBehandlingFnr to mockBarnAutomatiskBehandling,
+                mockBarnAutomatiskBehandling2Fnr to mockBarnAutomatiskBehandling2,
+                mockSøkerAutomatiskBehandlingFnr to mockSøkerAutomatiskBehandling,
+                mockBarnAutomatiskBehandlingSkalFeileFnr to mockBarnAutomatiskBehandlingSkalFeile,
+            )
+
+        fun leggTilPersonInfo(
+            personIdent: String,
+            egendefinertMock: PersonInfo? = null,
+        ): String {
+            personInfo[personIdent] = egendefinertMock ?: PersonInfo(
+                fødselsdato = LocalDate.parse(personIdent.substring(0, 6), ofPattern("ddMMyy")),
+                bostedsadresser = mutableListOf(bostedsadresse),
+                kjønn = Kjønn.values().random(),
+                navn = "$personIdent sitt navn",
+            )
+            return personIdent
+        }
+
+        fun leggTilRelasjonIPersonInfo(
+            personIdent: String,
+            relatertPersonsIdent: String,
+            relatertPersonsRelasjonsrolle: FORELDERBARNRELASJONROLLE,
+        ) {
+            personInfo[personIdent] =
+                personInfo[personIdent]!!.copy(
+                    forelderBarnRelasjon =
+                        personInfo[personIdent]!!.forelderBarnRelasjon +
+                            ForelderBarnRelasjon(
+                                aktør = tilAktør(relatertPersonsIdent),
+                                relasjonsrolle = relatertPersonsRelasjonsrolle,
+                                navn = personInfo.getValue(relatertPersonsIdent).navn,
+                                fødselsdato = personInfo.getValue(relatertPersonsIdent).fødselsdato,
+                                adressebeskyttelseGradering = personInfo.getValue(relatertPersonsIdent).adressebeskyttelseGradering,
+                            ),
+                )
+        }
+
+        fun leggTilRelasjonIPersonInfoMaskert(
+            personIdent: String,
+            maskertPersonsRelasjonsrolle: FORELDERBARNRELASJONROLLE,
+        ) {
+            personInfo[personIdent] =
+                personInfo[personIdent]!!.copy(
+                    forelderBarnRelasjonMaskert =
+                        personInfo[personIdent]!!.forelderBarnRelasjonMaskert +
+                            ForelderBarnRelasjonMaskert(
+                                relasjonsrolle = maskertPersonsRelasjonsrolle,
+                                adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG,
+                            ),
+                )
+        }
+
+        fun settPersonInfoStatsborgerskap(
+            personIdent: String,
+            statsborgerskap: Statsborgerskap,
+        ) {
+            personInfo[personIdent] =
+                personInfo[personIdent]!!.copy(
+                    statsborgerskap = listOf(statsborgerskap),
+                )
+        }
+
+        fun settPersoninfoMedRelasjonerForPredefinerteTestpersoner() {
+            val (søker1, søker2, søker3) = søkerFnr
+            val (barn1, barn2) = barnFnr
+
+            personInfo[søker1] = personInfoSøker1
+            personInfo[søker2] = personInfoSøker2
+            personInfo[søker3] = personInfoSøker3
+            personInfo[barn1] = personInfoBarn1
+            personInfo[barn2] = personInfoBarn2
+            personInfo[INTEGRASJONER_FNR] = personInfoIntegrasjonerFnr
+
+            leggTilRelasjonIPersonInfo(søker1, barn1, BARN)
+            leggTilRelasjonIPersonInfo(søker1, barn2, BARN)
+            leggTilRelasjonIPersonInfo(søker1, søker2, MEDMOR)
+
+            leggTilRelasjonIPersonInfo(søker2, barn1, BARN)
+            leggTilRelasjonIPersonInfo(søker2, barn2, BARN)
+            leggTilRelasjonIPersonInfo(søker2, søker1, FAR)
+
+            leggTilRelasjonIPersonInfo(søker3, barn1, BARN)
+            leggTilRelasjonIPersonInfo(søker3, barn2, BARN)
+            leggTilRelasjonIPersonInfo(søker3, søker1, FAR)
+            leggTilRelasjonIPersonInfoMaskert(søker3, BARN)
+
+            leggTilRelasjonIPersonInfo(INTEGRASJONER_FNR, barn1, BARN)
+            leggTilRelasjonIPersonInfo(INTEGRASJONER_FNR, barn2, BARN)
+            leggTilRelasjonIPersonInfo(INTEGRASJONER_FNR, søker2, MEDMOR)
+        }
+    }
+}
+
+const val BARN_DET_IKKE_GIS_TILGANG_TIL_FNR = "12345678912"
+const val INTEGRASJONER_FNR = "10000111111"
+
+private val søkerFnr = arrayOf("12345678910", "11223344556", "12345678911")
+private val barnFnr = arrayOf(randomFnr(), randomFnr())
+
+private val bostedsadresse =
+    Bostedsadresse(
+        matrikkeladresse =
+            Matrikkeladresse(
+                matrikkelId = 123L,
+                bruksenhetsnummer = "H301",
+                tilleggsnavn = "navn",
+                postnummer = "0202",
+                kommunenummer = "2231",
+            ),
+    )
+
+private val bostedsadresseHistorikk =
+    mutableListOf(
+        Bostedsadresse(
+            angittFlyttedato = LocalDate.now().minusDays(15),
+            gyldigTilOgMed = null,
+            matrikkeladresse =
+                Matrikkeladresse(
+                    matrikkelId = 123L,
+                    bruksenhetsnummer = "H301",
+                    tilleggsnavn = "navn",
+                    postnummer = "0202",
+                    kommunenummer = "2231",
+                ),
+        ),
+        Bostedsadresse(
+            angittFlyttedato = LocalDate.now().minusYears(1),
+            gyldigTilOgMed = LocalDate.now().minusDays(16),
+            matrikkeladresse =
+                Matrikkeladresse(
+                    matrikkelId = 123L,
+                    bruksenhetsnummer = "H301",
+                    tilleggsnavn = "navn",
+                    postnummer = "0202",
+                    kommunenummer = "2231",
+                ),
+        ),
+    )
+
+private val sivilstandHistorisk =
+    listOf(
+        Sivilstand(type = SIVILSTAND.GIFT, gyldigFraOgMed = LocalDate.now().minusMonths(8)),
+        Sivilstand(type = SIVILSTAND.SKILT, gyldigFraOgMed = LocalDate.now().minusMonths(4)),
+    )
+
+private val personInfoSøker1 =
+    PersonInfo(
+        fødselsdato = LocalDate.of(1990, 2, 19),
+        kjønn = Kjønn.KVINNE,
+        navn = "Mor Moresen",
+        bostedsadresser = bostedsadresseHistorikk,
+        sivilstander = sivilstandHistorisk,
+        statsborgerskap =
+            listOf(
+                Statsborgerskap(
+                    land = "DNK",
+                    bekreftelsesdato = LocalDate.now().minusYears(1),
+                    gyldigFraOgMed = null,
+                    gyldigTilOgMed = null,
+                ),
+            ),
+    )
+
+private val personInfoBarn1 =
+    PersonInfo(
+        fødselsdato = LocalDate.now().withDayOfMonth(10).minusYears(6),
+        bostedsadresser = mutableListOf(bostedsadresse),
+        sivilstander =
+            listOf(
+                Sivilstand(
+                    type = SIVILSTAND.UOPPGITT,
+                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
+                ),
+            ),
+        kjønn = Kjønn.MANN,
+        navn = "Gutten Barnesen",
+    )
+
+private val personInfoBarn2 =
+    PersonInfo(
+        fødselsdato = LocalDate.now().withDayOfMonth(18).minusYears(2),
+        bostedsadresser = mutableListOf(bostedsadresse),
+        sivilstander =
+            listOf(
+                Sivilstand(
+                    type = SIVILSTAND.GIFT,
+                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
+                ),
+            ),
+        kjønn = Kjønn.KVINNE,
+        navn = "Jenta Barnesen",
+        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.FORTROLIG,
+    )
+
+private val personInfoSøker2 =
+    PersonInfo(
+        fødselsdato = LocalDate.of(1995, 2, 19),
+        bostedsadresser = mutableListOf(),
+        sivilstander =
+            listOf(
+                Sivilstand(
+                    type = SIVILSTAND.GIFT,
+                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
+                ),
+            ),
+        kjønn = Kjønn.MANN,
+        navn = "Far Faresen",
+    )
+
+private val personInfoSøker3 =
+    PersonInfo(
+        fødselsdato = LocalDate.of(1985, 7, 10),
+        bostedsadresser = mutableListOf(),
+        sivilstander =
+            listOf(
+                Sivilstand(
+                    type = SIVILSTAND.GIFT,
+                    gyldigFraOgMed = LocalDate.now().minusMonths(8),
+                ),
+            ),
+        kjønn = Kjønn.KVINNE,
+        navn = "Moder Jord",
+        adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT,
+    )
+
+private val personInfoIntegrasjonerFnr =
+    PersonInfo(
+        fødselsdato = LocalDate.of(1965, 2, 19),
+        bostedsadresser = mutableListOf(bostedsadresse),
+        kjønn = Kjønn.KVINNE,
+        navn = "Mor Integrasjon person",
+        sivilstander = sivilstandHistorisk,
+    )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
@@ -11,9 +11,8 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.common.nesteMåned
+import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.ClientMocks.Companion.barnFnr
-import no.nav.familie.ba.sak.config.ClientMocks.Companion.søkerFnr
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.sats
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -72,7 +71,9 @@ internal class StønadsstatistikkServiceTest(
             andelerTilkjentYtelseOgEndreteUtbetalingerService,
         )
     private val behandling = lagBehandling()
-    private val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søkerFnr[0], barnFnr.toList())
+    private val søkerFnr = "12345678910"
+    private val barnFnr = listOf(randomFnr(), randomFnr())
+    private val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søkerFnr, barnFnr)
     private val barn1 = personopplysningGrunnlag.barna.first()
     private val barn2 = personopplysningGrunnlag.barna.last()
 
@@ -181,7 +182,7 @@ internal class StønadsstatistikkServiceTest(
 
         vedtak.utbetalingsperioderV2
             .flatMap { it.utbetalingsDetaljer.map { ud -> ud.person } }
-            .filter { it.personIdent != søkerFnr[0] }
+            .filter { it.personIdent != søkerFnr }
             .forEach {
                 assertEquals(0, it.delingsprosentYtelse)
             }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdBarnetrygdClientTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdBarnetrygdClientTest.kt
@@ -6,8 +6,9 @@ import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import no.nav.familie.ba.sak.common.randomBarnFnr
+import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkRequest
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
 import no.nav.familie.kontrakter.ba.infotrygd.Sak
@@ -30,6 +31,9 @@ class InfotrygdBarnetrygdClientTest : AbstractSpringIntegrationTest() {
     val sakerURL = "/api/infotrygd/barnetrygd/saker"
     val stønaderURL = "/api/infotrygd/barnetrygd/stonad?historikk=false"
     val brevURL = "/api/infotrygd/barnetrygd/brev"
+
+    private val søkersIdenter = listOf(randomFnr(), randomFnr(), randomFnr())
+    private val barnasIdenter = listOf(randomBarnFnr(), randomBarnFnr())
 
     @Autowired
     @Qualifier("jwtBearer")
@@ -84,8 +88,6 @@ class InfotrygdBarnetrygdClientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
-        val søkersIdenter = ClientMocks.søkerFnr.toList()
-        val barnasIdenter = ClientMocks.barnFnr.toList()
         val infotrygdSøkRequest = InfotrygdSøkRequest(søkersIdenter, barnasIdenter)
 
         val finnesIkkeHosInfotrygd = client.harLøpendeSakIInfotrygd(søkersIdenter, barnasIdenter)
@@ -136,7 +138,6 @@ class InfotrygdBarnetrygdClientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
-        val søkersIdenter = ClientMocks.søkerFnr.toList()
         val infotrygdSøkRequest = InfotrygdSøkRequest(søkersIdenter, emptyList())
 
         val finnesIkkeHosInfotrygd = client.harLøpendeSakIInfotrygd(søkersIdenter, emptyList())
@@ -158,7 +159,7 @@ class InfotrygdBarnetrygdClientTest : AbstractSpringIntegrationTest() {
         wireMockServer.stubFor(post(løpendeBarnetrygdURL).willReturn(aResponse().withStatus(401)))
 
         assertThrows<HttpClientErrorException> {
-            client.harLøpendeSakIInfotrygd(ClientMocks.søkerFnr.toList(), ClientMocks.barnFnr.toList())
+            client.harLøpendeSakIInfotrygd(søkersIdenter, barnasIdenter)
         }
     }
 
@@ -169,8 +170,6 @@ class InfotrygdBarnetrygdClientTest : AbstractSpringIntegrationTest() {
                 okJson(objectMapper.writeValueAsString(InfotrygdBarnetrygdClient.SendtBrevResponse(true, emptyList()))),
             ),
         )
-
-        val søkersIdenter = ClientMocks.søkerFnr.toList()
 
         val harNyligSendtBrev =
             client.harNyligSendtBrevFor(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
 import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
@@ -160,6 +159,6 @@ class OppgaveIntegrationTest : AbstractSpringIntegrationTest() {
 
     companion object {
         private val SØKER_FNR = randomFnr()
-        private val BARN_FNR = ClientMocks.barnFnr[0]
+        private val BARN_FNR = randomFnr()
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/SnikeIKøenIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/SnikeIKøenIntegrationTest.kt
@@ -5,10 +5,12 @@ import no.nav.familie.ba.sak.common.guttenBarnesenFødselsdato
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.kjørStegprosessForRevurderingÅrligKontroll
 import no.nav.familie.ba.sak.common.randomFnr
+import no.nav.familie.ba.sak.common.årSiden
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService.Companion.BEHANDLING_FERDIG
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.SnikeIKøenService
@@ -85,7 +87,7 @@ class SnikeIKøenIntegrationTest(
     private val loggRepository: LoggRepository,
 ) : AbstractSpringIntegrationTest() {
     val søkerFnr = randomFnr()
-    val barnFnr = ClientMocks.barnFnr[0]
+    val barnFnr = leggTilPersonInfo(randomFnr(), PersonInfo(fødselsdato = 6.årSiden.withDayOfMonth(10)))
 
     @BeforeEach
     fun init() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutomatiskVilkårsvurderingIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutomatiskVilkårsvurderingIntegrasjonTest.kt
@@ -1,11 +1,10 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse
 
-import io.mockk.every
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.config.tilAktør
-import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -26,7 +25,6 @@ import java.time.LocalDate
 
 class AutomatiskVilkårsvurderingIntegrasjonTest(
     @Autowired val stegService: StegService,
-    @Autowired val mockPersonopplysningerService: PersonopplysningerService,
     @Autowired val persongrunnlagService: PersongrunnlagService,
     @Autowired val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     @Autowired val databaseCleanupService: DatabaseCleanupService,
@@ -42,8 +40,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         val barnFnr = randomFnr()
         val mockSøkerUtenHjem = genererAutomatiskTestperson(bostedsadresser = emptyList())
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(søkerFnr)) } returns mockSøkerUtenHjem
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(barnFnr)) } returns mockBarnAutomatiskBehandling
+        leggTilPersonInfo(søkerFnr, mockSøkerUtenHjem)
+        leggTilPersonInfo(barnFnr, mockBarnAutomatiskBehandling)
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =
@@ -59,8 +57,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         val barnFnr = randomFnr()
         val mockBarnGift = genererAutomatiskTestperson(sivilstander = listOf(Sivilstand(SIVILSTAND.GIFT)))
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(søkerFnr)) } returns mockSøkerAutomatiskBehandling
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(barnFnr)) } returns mockBarnGift
+        leggTilPersonInfo(søkerFnr, mockSøkerAutomatiskBehandling)
+        leggTilPersonInfo(barnFnr, mockBarnGift)
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =
@@ -86,8 +84,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
                 ),
                 emptyList(),
             )
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(barnFnr)) } returns barn
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(søkerFnr)) } returns søker
+        leggTilPersonInfo(barnFnr, barn)
+        leggTilPersonInfo(søkerFnr, søker)
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =
@@ -134,8 +132,8 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
                     ),
             )
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(barnFnr)) } returns barn
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(tilAktør(søkerFnr)) } returns søker
+        leggTilPersonInfo(barnFnr, barn)
+        leggTilPersonInfo(søkerFnr, søker)
 
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentServiceTest.kt
@@ -2,9 +2,11 @@ package no.nav.familie.ba.sak.kjerne.behandling.settpåvent
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.SettPåMaskinellVentÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.SnikeIKøenService
@@ -57,6 +59,8 @@ class SettPåVentServiceTest(
     @Autowired private val brevmalService: BrevmalService,
     @Autowired private val snikeIKøenService: SnikeIKøenService,
 ) : AbstractSpringIntegrationTest() {
+    private val barnFnr = leggTilPersonInfo(randomBarnFnr())
+
     @BeforeAll
     fun init() {
         databaseCleanupService.truncate()
@@ -121,6 +125,7 @@ class SettPåVentServiceTest(
     fun `Kan ikke endre på behandling etter at den er satt på vent`() {
         val behandlingEtterVilkårsvurderingSteg =
             kjørStegprosessForFGB(
+                barnasIdenter = listOf(barnFnr),
                 tilSteg = StegType.VILKÅRSVURDERING,
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -147,6 +152,7 @@ class SettPåVentServiceTest(
     fun `Kan endre på behandling etter venting er deaktivert`() {
         val behandlingEtterVilkårsvurderingSteg =
             kjørStegprosessForFGB(
+                barnasIdenter = listOf(barnFnr),
                 tilSteg = StegType.VILKÅRSVURDERING,
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -185,6 +191,7 @@ class SettPåVentServiceTest(
     fun `Kan ikke sette ventefrist til før dagens dato`() {
         val behandlingEtterVilkårsvurderingSteg =
             kjørStegprosessForFGB(
+                barnasIdenter = listOf(barnFnr),
                 tilSteg = StegType.VILKÅRSVURDERING,
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -208,6 +215,7 @@ class SettPåVentServiceTest(
     fun `Kan oppdatare set på vent på behandling`() {
         val behandlingEtterVilkårsvurderingSteg =
             kjørStegprosessForFGB(
+                barnasIdenter = listOf(barnFnr),
                 tilSteg = StegType.VILKÅRSVURDERING,
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -245,6 +253,7 @@ class SettPåVentServiceTest(
     fun `Skal gjennopta behandlinger etter ventefristen`() {
         val behandling1 =
             kjørStegprosessForFGB(
+                barnasIdenter = listOf(barnFnr),
                 tilSteg = StegType.VILKÅRSVURDERING,
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -257,6 +266,7 @@ class SettPåVentServiceTest(
 
         val behandling2 =
             kjørStegprosessForFGB(
+                barnasIdenter = listOf(barnFnr),
                 tilSteg = StegType.VILKÅRSVURDERING,
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceIntegrationTest.kt
@@ -6,10 +6,11 @@ import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.config.TEST_PDF
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.ekstern.restDomene.RestInstitusjon
@@ -89,6 +90,8 @@ class DokumentServiceIntegrationTest(
     @Autowired
     private val brevmalService: BrevmalService,
 ) : AbstractSpringIntegrationTest() {
+    val barnFnr = leggTilPersonInfo(randomBarnFnr())
+
     @BeforeEach
     fun setup() {
         databaseCleanupService.truncate()
@@ -100,7 +103,7 @@ class DokumentServiceIntegrationTest(
             kjørStegprosessForFGB(
                 tilSteg = StegType.VURDER_TILBAKEKREVING,
                 søkerFnr = randomFnr(),
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,
@@ -136,7 +139,7 @@ class DokumentServiceIntegrationTest(
             kjørStegprosessForFGB(
                 tilSteg = StegType.VURDER_TILBAKEKREVING,
                 søkerFnr = randomFnr(),
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,
@@ -176,7 +179,7 @@ class DokumentServiceIntegrationTest(
             kjørStegprosessForFGB(
                 tilSteg = StegType.VURDER_TILBAKEKREVING,
                 søkerFnr = randomFnr(),
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,
@@ -236,7 +239,7 @@ class DokumentServiceIntegrationTest(
             kjørStegprosessForFGB(
                 tilSteg = StegType.BESLUTTE_VEDTAK,
                 søkerFnr = randomFnr(),
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
@@ -3,9 +3,9 @@ package no.nav.familie.ba.sak.kjerne.fagsak
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.ekstern.restDomene.FagsakDeltagerRolle
@@ -174,8 +174,9 @@ class FagsakControllerTest(
     fun `Skal oppgi det første barnet i listen som fagsakdeltaker`() {
         val personAktør = mockPersonidentService.hentOgLagreAktør(randomFnr(), true)
         val søkerFnr = randomFnr()
+        val barnaFnr = listOf(randomBarnFnr())
         val søkerAktør = mockPersonidentService.hentOgLagreAktør(søkerFnr, true)
-        val barnaAktør = mockPersonidentService.hentOgLagreAktørIder(ClientMocks.barnFnr.toList().subList(0, 1), true)
+        val barnaAktør = mockPersonidentService.hentOgLagreAktørIder(barnaFnr, true)
 
         val fagsak = fagsakService.hentEllerOpprettFagsak(søkerAktør.aktivFødselsnummer())
 
@@ -196,11 +197,11 @@ class FagsakControllerTest(
         fagsakController.oppgiFagsakdeltagere(
             RestSøkParam(
                 personAktør.aktivFødselsnummer(),
-                ClientMocks.barnFnr.toList(),
+                barnaFnr + randomFnr(),
             ),
         )
             .apply {
-                assertEquals(ClientMocks.barnFnr.toList().subList(0, 1), body!!.data!!.map { it.ident })
+                assertEquals(barnaFnr, body!!.data!!.map { it.ident })
                 assertEquals(listOf(FagsakDeltagerRolle.BARN), body!!.data!!.map { it.rolle })
             }
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -8,11 +8,11 @@ import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.ekstern.restDomene.RestFagsakDeltager
 import no.nav.familie.ba.sak.ekstern.restDomene.RestInstitusjon
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
@@ -57,8 +57,6 @@ class FagsakServiceTest(
     private val personidentService: PersonidentService,
     @Autowired
     private val stegService: StegService,
-    @Autowired
-    private val mockPersonopplysningerService: PersonopplysningerService,
     @Autowired
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     @Autowired
@@ -106,19 +104,15 @@ class FagsakServiceTest(
         val barn3Fnr = randomFnr()
 
         val søker1Aktør = personidentService.hentAktør(søker1Fnr)
-        val søker2Aktør = personidentService.hentAktør(søker2Fnr)
         val søker3Aktør = personidentService.hentAktør(søker3Fnr)
-        val barn1Aktør = personidentService.hentAktør(barn1Fnr)
-        val barn2Aktør = personidentService.hentAktør(barn2Fnr)
-        val barn3Aktør = personidentService.hentAktør(barn3Fnr)
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(barn1Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(2018, 5, 1), kjønn = Kjønn.KVINNE, navn = "barn1")
+        leggTilPersonInfo(
+            barn1Fnr,
+            PersonInfo(fødselsdato = LocalDate.of(2018, 5, 1), kjønn = Kjønn.KVINNE, navn = "barn1"),
+        )
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(barn2Aktør))
-        } returns
+        leggTilPersonInfo(
+            barn2Fnr,
             PersonInfo(
                 fødselsdato = LocalDate.of(2019, 5, 1),
                 kjønn = Kjønn.MANN,
@@ -138,35 +132,28 @@ class FagsakServiceTest(
                             LocalDate.of(1990, 1, 10),
                         ),
                     ),
-            )
+            ),
+        )
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(søker1Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1990, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1")
+        leggTilPersonInfo(
+            søker1Fnr,
+            PersonInfo(fødselsdato = LocalDate.of(1990, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1"),
+        )
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(søker2Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1991, 2, 20), kjønn = Kjønn.MANN, navn = "søker2")
+        leggTilPersonInfo(
+            søker2Fnr,
+            PersonInfo(fødselsdato = LocalDate.of(1991, 2, 20), kjønn = Kjønn.MANN, navn = "søker2"),
+        )
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoEnkel(eq(barn2Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(2019, 5, 1), kjønn = Kjønn.MANN, navn = "barn2")
+        leggTilPersonInfo(
+            barn3Fnr,
+            PersonInfo(fødselsdato = LocalDate.of(2017, 3, 1), kjønn = Kjønn.KVINNE, navn = "barn3"),
+        )
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoEnkel(eq(barn3Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(2017, 3, 1), kjønn = Kjønn.KVINNE, navn = "barn3")
-
-        every {
-            mockPersonopplysningerService.hentPersoninfoEnkel(eq(søker1Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1990, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1")
-
-        every {
-            mockPersonopplysningerService.hentPersoninfoEnkel(eq(søker2Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1991, 2, 20), kjønn = Kjønn.MANN, navn = "søker2")
-
-        every {
-            mockPersonopplysningerService.hentPersoninfoEnkel(eq(søker3Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1990, 1, 10), kjønn = Kjønn.KVINNE, navn = "søker3")
+        leggTilPersonInfo(
+            søker3Fnr,
+            PersonInfo(fødselsdato = LocalDate.of(1990, 1, 10), kjønn = Kjønn.KVINNE, navn = "søker3"),
+        )
 
         val fagsak0 =
             fagsakService.hentEllerOpprettFagsak(
@@ -280,13 +267,10 @@ class FagsakServiceTest(
         val søker1Fnr = randomFnr()
         val søker1Aktør = tilAktør(søker1Fnr)
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(søker1Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1991, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1")
-
-        every {
-            mockPersonopplysningerService.hentPersoninfoEnkel(eq(søker1Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1991, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1")
+        leggTilPersonInfo(
+            søker1Fnr,
+            PersonInfo(fødselsdato = LocalDate.of(1991, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1"),
+        )
 
         val fagsak =
             fagsakService.hentEllerOpprettFagsak(
@@ -321,13 +305,10 @@ class FagsakServiceTest(
         val søker1Fnr = randomFnr()
         val søker1Aktør = tilAktør(søker1Fnr)
 
-        every {
-            mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(eq(søker1Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1992, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1")
-
-        every {
-            mockPersonopplysningerService.hentPersoninfoEnkel(eq(søker1Aktør))
-        } returns PersonInfo(fødselsdato = LocalDate.of(1992, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1")
+        leggTilPersonInfo(
+            søker1Fnr,
+            PersonInfo(fødselsdato = LocalDate.of(1992, 2, 19), kjønn = Kjønn.KVINNE, navn = "søker1"),
+        )
 
         fagsakService.hentEllerOpprettFagsak(
             FagsakRequest(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/RestFagsakTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/RestFagsakTest.kt
@@ -5,10 +5,11 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.kjørStegprosessForRevurderingÅrligKontroll
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.kjerne.beregning.SatsTidspunkt
 import no.nav.familie.ba.sak.kjerne.brev.BrevmalService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -62,7 +63,7 @@ class RestFagsakTest(
     @Test
     fun `Skal sjekke at gjeldende utbetalingsperioder kommer med i restfagsak`() {
         val søkerFnr = randomFnr()
-        val barnFnr = ClientMocks.barnFnr[0]
+        val barnFnr = leggTilPersonInfo(randomBarnFnr())
 
         val førstegangsbehandling =
             kjørStegprosessForFGB(
@@ -74,7 +75,7 @@ class RestFagsakTest(
                 persongrunnlagService = persongrunnlagService,
                 vilkårsvurderingService = vilkårsvurderingService,
                 stegService = stegService,
-                vedtaksperiodeService,
+                vedtaksperiodeService = vedtaksperiodeService,
                 brevmalService = brevmalService,
             )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagIntegrationTest.kt
@@ -1,12 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger
 
-import io.mockk.every
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.DødsfallData
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlKontaktinformasjonForDødsbo
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlKontaktinformasjonForDødsboAdresse
@@ -39,8 +38,6 @@ class PersongrunnlagIntegrationTest(
     @Autowired
     private val personidentService: PersonidentService,
     @Autowired
-    private val mockPersonopplysningerService: PersonopplysningerService,
-    @Autowired
     private val fagsakService: FagsakService,
     @Autowired
     private val behandlingService: BehandlingService,
@@ -55,7 +52,8 @@ class PersongrunnlagIntegrationTest(
         val poststedsnavn = "Oslo"
         val postnummer = "1234"
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(søkerAktør) } returns
+        leggTilPersonInfo(
+            søkerAktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(1990, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -74,9 +72,11 @@ class PersongrunnlagIntegrationTest(
                                 postnummer = postnummer,
                             ),
                     ),
-            )
+            ),
+        )
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(barn1Aktør) } returns
+        leggTilPersonInfo(
+            barn1Aktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(2009, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -87,7 +87,8 @@ class PersongrunnlagIntegrationTest(
                 sivilstander = listOf(Sivilstand(type = SIVILSTAND.UOPPGITT)),
                 dødsfall = null,
                 kontaktinformasjonForDoedsbo = null,
-            )
+            ),
+        )
 
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = søkerAktør.aktivFødselsnummer()))
         val behandling =
@@ -121,7 +122,8 @@ class PersongrunnlagIntegrationTest(
         val morAktør = personidentService.hentOgLagreAktør(randomFnr(), true)
         val barn1Aktør = personidentService.hentOgLagreAktør(randomFnr(), true)
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(morAktør) } returns
+        leggTilPersonInfo(
+            morAktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(1990, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -141,9 +143,11 @@ class PersongrunnlagIntegrationTest(
                     ),
                 dødsfall = null,
                 kontaktinformasjonForDoedsbo = null,
-            )
+            ),
+        )
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(barn1Aktør) } returns
+        leggTilPersonInfo(
+            barn1Aktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(2009, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -154,7 +158,8 @@ class PersongrunnlagIntegrationTest(
                 sivilstander = listOf(Sivilstand(type = SIVILSTAND.UOPPGITT)),
                 dødsfall = null,
                 kontaktinformasjonForDoedsbo = null,
-            )
+            ),
+        )
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = morAktør.aktivFødselsnummer()))
         val behandling =
             behandlingService.opprettBehandling(
@@ -185,7 +190,8 @@ class PersongrunnlagIntegrationTest(
         val morAktør = personidentService.hentOgLagreAktør(randomFnr(), true)
         val barn1Aktør = personidentService.hentOgLagreAktør(randomFnr(), true)
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(morAktør) } returns
+        leggTilPersonInfo(
+            morAktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(1990, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -205,9 +211,11 @@ class PersongrunnlagIntegrationTest(
                     ),
                 dødsfall = null,
                 kontaktinformasjonForDoedsbo = null,
-            )
+            ),
+        )
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(barn1Aktør) } returns
+        leggTilPersonInfo(
+            barn1Aktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(2009, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -218,7 +226,8 @@ class PersongrunnlagIntegrationTest(
                 sivilstander = listOf(Sivilstand(type = SIVILSTAND.UOPPGITT)),
                 dødsfall = null,
                 kontaktinformasjonForDoedsbo = null,
-            )
+            ),
+        )
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = morAktør.aktivFødselsnummer()))
         val behandling =
             behandlingService.opprettBehandling(
@@ -248,7 +257,8 @@ class PersongrunnlagIntegrationTest(
         val søkerAktør = personidentService.hentOgLagreAktør(randomFnr(), true)
         val barn1Aktør = personidentService.hentOgLagreAktør(randomFnr(), true)
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(søkerAktør) } returns
+        leggTilPersonInfo(
+            søkerAktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(1990, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -257,9 +267,11 @@ class PersongrunnlagIntegrationTest(
                 forelderBarnRelasjon = emptySet(),
                 bostedsadresser = mutableListOf(Bostedsadresse()) + defaultBostedsadresseHistorikk,
                 sivilstander = listOf(Sivilstand(type = SIVILSTAND.UOPPGITT)),
-            )
+            ),
+        )
 
-        every { mockPersonopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(barn1Aktør) } returns
+        leggTilPersonInfo(
+            barn1Aktør.aktivFødselsnummer(),
             PersonInfo(
                 fødselsdato = LocalDate.of(2009, 1, 1),
                 adressebeskyttelseGradering = null,
@@ -268,7 +280,8 @@ class PersongrunnlagIntegrationTest(
                 forelderBarnRelasjon = emptySet(),
                 bostedsadresser = mutableListOf(Bostedsadresse()) + defaultBostedsadresseHistorikk,
                 sivilstander = listOf(Sivilstand(type = SIVILSTAND.UOPPGITT)),
-            )
+            ),
+        )
 
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = søkerAktør.aktivFødselsnummer()))
         val behandling =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
@@ -2,10 +2,11 @@ package no.nav.familie.ba.sak.kjerne.grunnlag.søknad
 
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.lagSøknadDTO
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
@@ -135,7 +136,7 @@ class SøknadGrunnlagTest(
     @Test
     fun `Skal registrere søknad med uregistrerte barn og disse skal ikke komme med i persongrunnlaget`() {
         val søkerIdent = randomFnr()
-        val folkeregistrertBarn = ClientMocks.barnFnr[0]
+        val folkeregistrertBarn = randomFnr()
         val uregistrertBarn = randomFnr()
 
         val søkerAktør = personidentService.hentAktør(søkerIdent)
@@ -198,8 +199,8 @@ class SøknadGrunnlagTest(
     @Test
     fun `Skal tilbakestille behandling ved endring på søknadsregistrering`() {
         val søkerFnr = randomFnr()
-        val barn1Fnr = ClientMocks.barnFnr[0]
-        val barn2Fnr = ClientMocks.barnFnr[1]
+        val barn1Fnr = leggTilPersonInfo(randomBarnFnr(alder = 6))
+        val barn2Fnr = leggTilPersonInfo(randomBarnFnr(alder = 2))
         val behandlingEtterVilkårsvurderingSteg =
             kjørStegprosessForFGB(
                 tilSteg = StegType.VILKÅRSVURDERING,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceTest.kt
@@ -1,10 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.simulering
 
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.config.simuleringMottakerMock
 import no.nav.familie.ba.sak.kjerne.brev.BrevmalService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
@@ -39,11 +40,12 @@ class SimuleringServiceTest(
 
     @Test
     fun `Skal verifisere at simulering blir lagert og oppdatert`() {
+        val barnFnr = leggTilPersonInfo(randomBarnFnr())
         val behandlingEtterVilkårsvurderingSteg =
             kjørStegprosessForFGB(
                 tilSteg = StegType.VURDER_TILBAKEKREVING,
                 søkerFnr = randomFnr(),
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
@@ -2,10 +2,11 @@ package no.nav.familie.ba.sak.kjerne.tilbakekreving
 
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.opprettRestTilbakekreving
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.ekstern.restDomene.RestInstitusjon
 import no.nav.familie.ba.sak.kjerne.brev.BrevmalService
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerDb
@@ -48,6 +49,8 @@ class TilbakekrevingServiceTest(
     @Autowired private val brevmalService: BrevmalService,
     @Autowired private val brevmottakerRepository: BrevmottakerRepository,
 ) : AbstractSpringIntegrationTest() {
+    val barnFnr = leggTilPersonInfo(personIdent = randomBarnFnr())
+
     @BeforeEach
     fun init() {
         databaseCleanupService.truncate()
@@ -60,7 +63,7 @@ class TilbakekrevingServiceTest(
             kjørStegprosessForFGB(
                 tilSteg = StegType.VENTE_PÅ_STATUS_FRA_ØKONOMI,
                 søkerFnr = randomFnr(),
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,
@@ -89,8 +92,8 @@ class TilbakekrevingServiceTest(
         val behandling =
             kjørStegprosessForFGB(
                 tilSteg = StegType.VENTE_PÅ_STATUS_FRA_ØKONOMI,
-                søkerFnr = ClientMocks.barnFnr[0],
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                søkerFnr = barnFnr,
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,
@@ -123,7 +126,7 @@ class TilbakekrevingServiceTest(
             kjørStegprosessForFGB(
                 tilSteg = StegType.VENTE_PÅ_STATUS_FRA_ØKONOMI,
                 søkerFnr = randomFnr(),
-                barnasIdenter = listOf(ClientMocks.barnFnr[0]),
+                barnasIdenter = listOf(barnFnr),
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
                 persongrunnlagService = persongrunnlagService,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceIntegrationTest.kt
@@ -5,11 +5,12 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.inneværendeMåned
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.kjørStegprosessForRevurderingÅrligKontroll
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
@@ -56,9 +57,9 @@ class VedtaksperiodeServiceIntegrationTest(
     @Autowired
     private val brevmalService: BrevmalService,
 ) : AbstractSpringIntegrationTest() {
-    val søkerFnr = randomFnr()
-    val barnFnr = ClientMocks.barnFnr[0]
-    val barn2Fnr = ClientMocks.barnFnr[1]
+    val søkerFnr = MockPersonopplysningerService.leggTilPersonInfo(personIdent = randomFnr())
+    val barnFnr = MockPersonopplysningerService.leggTilPersonInfo(personIdent = randomBarnFnr(alder = 6))
+    val barn2Fnr = MockPersonopplysningerService.leggTilPersonInfo(personIdent = randomBarnFnr(alder = 2))
 
     @BeforeEach
     fun init() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -6,12 +6,13 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.common.lagVilkårResultat
 import no.nav.familie.ba.sak.common.nyOrdinærBehandling
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.common.vurderVilkårsvurderingTilInnvilget
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.datagenerator.vilkårsvurdering.lagBarnVilkårResultat
 import no.nav.familie.ba.sak.datagenerator.vilkårsvurdering.lagSøkerVilkårResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.RestNyttVilkår
@@ -1251,8 +1252,10 @@ class VilkårServiceTest(
 
     @Test
     fun `skal sette vurderes etter basert på behandlingstema`() {
+        val barnFnr = leggTilPersonInfo(randomBarnFnr())
         val behandling =
             kjørStegprosessForFGB(
+                barnasIdenter = listOf(barnFnr),
                 tilSteg = StegType.BEHANDLINGSRESULTAT,
                 fagsakService = fagsakService,
                 vedtakService = vedtakService,
@@ -1285,7 +1288,7 @@ class VilkårServiceTest(
             }
         }
 
-        vilkårService.postVilkår(behandling.id, RestNyttVilkår(ClientMocks.barnFnr[0], Vilkår.BOR_MED_SØKER))
+        vilkårService.postVilkår(behandling.id, RestNyttVilkår(barnFnr, Vilkår.BOR_MED_SØKER))
 
         vilkårsvurdering = vilkårService.hentVilkårsvurderingThrows(behandling.id)
         assertTrue {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingFlyttResultaterTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingFlyttResultaterTest.kt
@@ -4,9 +4,11 @@ import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagPersonResultat
 import no.nav.familie.ba.sak.common.lagVilkårResultat
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.personInfo
 import no.nav.familie.ba.sak.datagenerator.behandling.kjørStegprosessForBehandling
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -54,11 +56,10 @@ class VilkårsvurderingFlyttResultaterTest(
     @Test
     fun `Skal ikke endre på forrige behandling sin vilkårsvurdering ved flytting av resultater`() {
         val søker = lagPerson(type = PersonType.SØKER)
-
-        val barn1Fnr = ClientMocks.barnFnr[0]
+        val barn1Fnr = leggTilPersonInfo(randomBarnFnr(alder = 6))
         val barn1Aktør = personidentService.hentAktør(barn1Fnr)
 
-        val barn2Fnr = ClientMocks.barnFnr[1]
+        val barn2Fnr = leggTilPersonInfo(randomBarnFnr(alder = 2))
         val barn2Aktør = personidentService.hentAktør(barn2Fnr)
 
         // Lager førstegangsbehandling med utvidet vilkåret avslått
@@ -90,7 +91,7 @@ class VilkårsvurderingFlyttResultaterTest(
                 søkerPersonResultat,
                 lagPersonResultat(
                     vilkårsvurdering = vilkårsvurderingMedUtvidetAvslått,
-                    person = lagPerson(type = PersonType.BARN, aktør = barn1Aktør, fødselsdato = ClientMocks.personInfo[barn1Fnr]!!.fødselsdato),
+                    person = lagPerson(type = PersonType.BARN, aktør = barn1Aktør, fødselsdato = personInfo[barn1Fnr]!!.fødselsdato),
                     periodeFom = LocalDate.now().minusMonths(8),
                     periodeTom = LocalDate.now().plusYears(2),
                     lagFullstendigVilkårResultat = true,
@@ -99,7 +100,7 @@ class VilkårsvurderingFlyttResultaterTest(
                 ),
                 lagPersonResultat(
                     vilkårsvurdering = vilkårsvurderingMedUtvidetAvslått,
-                    person = lagPerson(type = PersonType.BARN, aktør = barn2Aktør, fødselsdato = ClientMocks.personInfo[barn2Fnr]!!.fødselsdato),
+                    person = lagPerson(type = PersonType.BARN, aktør = barn2Aktør, fødselsdato = personInfo[barn2Fnr]!!.fødselsdato),
                     periodeFom = LocalDate.now().minusMonths(8),
                     periodeTom = LocalDate.now().plusYears(2),
                     lagFullstendigVilkårResultat = true,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangControllerTest.kt
@@ -2,29 +2,30 @@ package no.nav.familie.ba.sak.sikkerhet
 
 import io.mockk.every
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.familie.util.FnrGenerator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 
 class TilgangControllerTest(
     @Autowired
     private val tilgangController: TilgangController,
     @Autowired
-    private val mockPersonopplysningerService: PersonopplysningerService,
-    @Autowired
     private val mockFamilieIntegrasjonerTilgangskontrollClient: FamilieIntegrasjonerTilgangskontrollClient,
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun testHarTilgangTilKode6Person() {
-        val fnr = FnrGenerator.generer()
-        every {
-            mockPersonopplysningerService.hentAdressebeskyttelseSomSystembruker(any())
-        } returns ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
+        val fnr =
+            leggTilPersonInfo(
+                FnrGenerator.generer(),
+                PersonInfo(fødselsdato = LocalDate.now(), adressebeskyttelseGradering = ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG),
+            )
         every {
             mockFamilieIntegrasjonerTilgangskontrollClient.sjekkTilgangTilPersoner(listOf(fnr))
         } answers { firstArg<List<String>>().map { Tilgang(it, true) } }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
@@ -2,10 +2,11 @@ package no.nav.familie.ba.sak.task
 
 import no.nav.familie.ba.sak.common.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.common.randomBarnFnr
 import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
-import no.nav.familie.ba.sak.config.ClientMocks
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.SettPåMaskinellVentÅrsak
@@ -91,7 +92,7 @@ class FerdigstillBehandlingTaskTest : AbstractSpringIntegrationTest() {
 
     private fun kjørSteg(resultat: Resultat): Behandling {
         val aktørId = personidentService.hentAktør(fnr)
-        val fnrBarn = ClientMocks.barnFnr[0]
+        val fnrBarn = leggTilPersonInfo(randomBarnFnr())
 
         val behandling =
             kjørStegprosessForFGB(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
En fortsettelse av arbeidet med å redusere testenes avhengigheter til ClientMocks https://github.com/navikt/familie-ba-sak/pull/4536

Går vekk fra bruken av mockk med felles testverdier på tvers, sånn at testene vanskeligere skal gå i beina på hverandre.

Relativt stor pr, men mye av det er repeterende mønstre, og totalt sett er det flere linjer som fjernes enn det som legges til

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
