### PR TITLE
Fix: Finne alle kompetanser etter endringstidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import java.time.YearMonth
 
@@ -200,3 +201,11 @@ fun List<UtfyltKompetanse>.tilTidslinje() =
             innhold = it,
         )
     }.tilTidslinje()
+
+fun Collection<Kompetanse>.tilUtfylteKompetanserEtterEndringstidpunkt(endringstidspunkt: MånedTidspunkt) =
+    this.map { it.tilIKompetanse() }
+        .filterIsInstance<UtfyltKompetanse>()
+        .tilTidslinje()
+        .beskjærFraOgMed(endringstidspunkt)
+        .perioder()
+        .mapNotNull { it.innhold }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Datagenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Datagenerator.kt
@@ -22,6 +22,7 @@ fun lagKompetanse(
     barnetsBostedsland: String? = null,
     kompetanseResultat: KompetanseResultat? = null,
     søkersAktivitetsland: String? = null,
+    erAnnenForelderOmfattetAvNorskLovgivning: Boolean? = null,
 ) = Kompetanse(
     fom = fom,
     tom = tom,
@@ -32,6 +33,7 @@ fun lagKompetanse(
     barnetsBostedsland = barnetsBostedsland,
     resultat = kompetanseResultat,
     søkersAktivitetsland = søkersAktivitetsland,
+    erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
 ).also { it.behandlingId = behandlingId }
 
 fun lagValutakurs(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Brev-generering feiler i EØS-saker dersom man kan har 1 kompetanse og denne begynner før endringstidspunktet. 

Bruker her tidslinjer for å sørge for at vi får med oss alle gjeldende kompetanser fra endringstidspunktet og utover.


### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇