### PR TITLE
Finner utfylte kompetanser per barn for å unngå tidslinje overlapp på tvers av barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -28,7 +28,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetalingM
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetalingMndEøsOppsummering
 import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilUtfylteKompetanserEtterEndringstidpunkt
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilUtfylteKompetanserEtterEndringstidpunktPerAktør
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilUtbetaltFraAnnetLand
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
@@ -313,14 +313,14 @@ fun hentLandOgStartdatoForUtbetalingstabell(
     kompetanser: Collection<Kompetanse>,
 ): UtbetalingstabellAutomatiskValutajustering {
     val utfylteKompetanserEtterEndringstidspunkt =
-        kompetanser.tilUtfylteKompetanserEtterEndringstidpunkt(endringstidspunkt)
+        kompetanser.tilUtfylteKompetanserEtterEndringstidpunktPerAktør(endringstidspunkt)
 
     if (utfylteKompetanserEtterEndringstidspunkt.isEmpty()) {
         throw Feil("Finner ingen kompetanser etter endringstidspunkt")
     }
 
     val eøsLandMedUtbetalinger =
-        utfylteKompetanserEtterEndringstidspunkt.map {
+        utfylteKompetanserEtterEndringstidspunkt.values.flatten().map {
             if (it.erAnnenForelderOmfattetAvNorskLovgivning) {
                 it.søkersAktivitetsland.tilLandNavn(landkoder).navn
             } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -202,10 +202,14 @@ fun List<UtfyltKompetanse>.tilTidslinje() =
         )
     }.tilTidslinje()
 
-fun Collection<Kompetanse>.tilUtfylteKompetanserEtterEndringstidpunkt(endringstidspunkt: MånedTidspunkt) =
-    this.map { it.tilIKompetanse() }
-        .filterIsInstance<UtfyltKompetanse>()
-        .tilTidslinje()
-        .beskjærFraOgMed(endringstidspunkt)
-        .perioder()
-        .mapNotNull { it.innhold }
+fun Collection<Kompetanse>.tilUtfylteKompetanserEtterEndringstidpunktPerAktør(endringstidspunkt: MånedTidspunkt): Map<Aktør, List<UtfyltKompetanse>> {
+    val alleBarnAktørIder = this.map { it.barnAktører }.reduce { akk, neste -> akk + neste }
+
+    val utfylteKompetanser =
+        this.map { it.tilIKompetanse() }
+            .filterIsInstance<UtfyltKompetanse>()
+
+    return alleBarnAktørIder.associateWith { aktør ->
+        utfylteKompetanser.filter { it.barnAktører.contains(aktør) }.tilTidslinje().beskjærFraOgMed(endringstidspunkt).perioder().mapNotNull { it.innhold }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Får overlapp i tidslinjer når vi lager 1 tidslinje for alle kompetansene etter endringstidspunkt i en behandling. Dette fører til at tidslinjefeil kastes.

Endrer til å lage 1 tidslinje per aktør og heller slå disse sammen igjen etter tidslinje-manipulering.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
