### PR TITLE
Vi fjerner teknisk opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -392,7 +392,7 @@ class OppgaveService(
         if (lagVedtakOppgaver.isEmpty() &&
             !behandling.skalBehandlesAutomatisk &&
             !behandling.erMigrering() &&
-            !behandling.erTekniskBehandling()
+            !behandling.erTekniskEndring()
         ) {
             throw Feil("Fant ingen oppgaver å avslutte ved sending til godkjenner på $behandling")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
@@ -199,7 +199,7 @@ class BehandlingStegController(
         behandling: Behandling,
         tekniskEndringToggle: Boolean,
     ) {
-        if (behandling.erTekniskBehandling() && !tekniskEndringToggle) {
+        if (behandling.erTekniskEndring() && !tekniskEndringToggle) {
             throw FunksjonellFeil("Du har ikke tilgang til å henlegge en behandling som er opprettet med årsak=${behandling.opprettetÅrsak.visningsnavn}. Ta kontakt med teamet dersom dette ikke stemmer.")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -232,8 +232,6 @@ data class Behandling(
 
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 
-    fun erTekniskBehandling() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_OPPHØR || erTekniskEndring()
-
     fun erKorrigereVedtak() = opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV
 
     fun kanLeggeTilOgFjerneUtvidetVilkår() =
@@ -323,7 +321,6 @@ enum class BehandlingÅrsak(val visningsnavn: String) {
     DØDSFALL_BRUKER("Dødsfall bruker"),
     NYE_OPPLYSNINGER("Nye opplysninger"),
     KLAGE("Klage"),
-    TEKNISK_OPPHØR("Teknisk opphør"), // Ikke lenger i bruk. Bruk heller teknisk endring
     TEKNISK_ENDRING("Teknisk endring"), // Brukes i tilfeller ved systemfeil og vi ønsker å iverksette mot OS på nytt
     KORREKSJON_VEDTAKSBREV("Korrigere vedtak med egen brevmal"),
     OMREGNING_6ÅR("Omregning 6 år"),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -17,7 +17,6 @@ import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
@@ -98,34 +97,7 @@ data class Behandling(
             "steg=$steg)"
     }
 
-    // Skal kun brukes på gamle behandlinger
-    fun erTekniskOpphør(): Boolean {
-        return if (type == BehandlingType.TEKNISK_OPPHØR ||
-            opprettetÅrsak == BehandlingÅrsak.TEKNISK_OPPHØR
-        ) {
-            if (type == BehandlingType.TEKNISK_OPPHØR &&
-                opprettetÅrsak == BehandlingÅrsak.TEKNISK_OPPHØR
-            ) {
-                true
-            } else {
-                throw Feil(
-                    "Behandling er teknisk opphør, men årsak $opprettetÅrsak " +
-                        "og type $type samsvarer ikke.",
-                )
-            }
-        } else {
-            false
-        }
-    }
-
     fun validerBehandlingstype(sisteBehandlingSomErVedtatt: Behandling? = null) {
-        if (type == BehandlingType.TEKNISK_OPPHØR) {
-            throw FunksjonellFeil(
-                melding = "Kan ikke lage teknisk opphør behandling.",
-                frontendFeilmelding = "Kan ikke lage teknisk opphør behandling, bruk heller teknisk endring.",
-            )
-        }
-
         if (type == BehandlingType.TEKNISK_ENDRING ||
             opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
         ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -360,7 +360,6 @@ enum class BehandlingType(val visningsnavn: String) {
     REVURDERING("Revurdering"),
     MIGRERING_FRA_INFOTRYGD("Migrering fra infotrygd"),
     MIGRERING_FRA_INFOTRYGD_OPPHØRT("Opphør migrering fra infotrygd"),
-    TEKNISK_OPPHØR("Teknisk opphør"), // Ikke lenger i bruk. Bruk heller teknisk endring
     TEKNISK_ENDRING("Teknisk endring"),
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalService.kt
@@ -207,7 +207,6 @@ class BrevmalService(
 
             BehandlingType.MIGRERING_FRA_INFOTRYGD,
             BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT,
-            BehandlingType.TEKNISK_OPPHØR,
             BehandlingType.TEKNISK_ENDRING,
             -> throw FunksjonellFeil(
                 melding = feilmelidingBehandlingType,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagUtil.kt
@@ -3,4 +3,4 @@ package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 
 fun skalTaMedBarnFraForrigeBehandling(behandling: Behandling) =
-    !behandling.erMigrering() && !behandling.erTekniskBehandling()
+    !behandling.erMigrering() && !behandling.erTekniskEndring()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
@@ -216,7 +216,6 @@ fun hentNesteSteg(
     }
 
     return when (behandlingÅrsak) {
-        BehandlingÅrsak.TEKNISK_OPPHØR -> throw Feil("Teknisk opphør er ikke mulig å behandle lenger")
         BehandlingÅrsak.MIGRERING -> throw Feil("Maskinell migrering er ikke mulig å behandle lenger")
 
         BehandlingÅrsak.HELMANUELL_MIGRERING -> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -59,7 +59,7 @@ class BeslutteVedtak(
                 melding = "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og toggle ${FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV} false",
                 frontendFeilmelding = "Du har ikke tilgang til å beslutte for denne behandlingen. Ta kontakt med teamet dersom dette ikke stemmer.",
             )
-        } else if (behandling.erTekniskBehandling() &&
+        } else if (behandling.erTekniskEndring() &&
             !unleashService.isEnabled(
                 FeatureToggleConfig.TEKNISK_ENDRING,
                 behandling.id,

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -191,7 +191,7 @@ class SaksstatistikkService(
     }
 
     private fun erRevurderingEllerTekniskBehandling(behandling: Behandling) =
-        behandling.type == BehandlingType.REVURDERING || behandling.type == BehandlingType.TEKNISK_OPPHØR || behandling.type == BehandlingType.TEKNISK_ENDRING
+        behandling.type == BehandlingType.REVURDERING || behandling.type == BehandlingType.TEKNISK_ENDRING
 
     private fun Behandling.resultatBegrunnelser(vedtak: Vedtak?): List<ResultatBegrunnelseDVH> {
         return when (resultat) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
@@ -23,16 +23,6 @@ class BehandlingTest {
     }
 
     @Test
-    fun `validerBehandling kaster feil hvis behandlingType er teknisk opphør`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.TEKNISK_OPPHØR,
-                årsak = BehandlingÅrsak.TEKNISK_OPPHØR,
-            )
-        assertThrows<RuntimeException> { behandling.validerBehandlingstype() }
-    }
-
-    @Test
     fun `validerBehandling kaster feil hvis man prøver å opprette revurdering uten andre vedtatte behandlinger`() {
         val behandling =
             lagBehandling(
@@ -58,36 +48,6 @@ class BehandlingTest {
                     ),
             )
         }
-    }
-
-    @Test
-    fun `erRentTekniskOpphør kastet feil hvis behandlingType og behandlingÅrsak ikke samsvarer ved teknisk opphør`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.TEKNISK_OPPHØR,
-                årsak = BehandlingÅrsak.SØKNAD,
-            )
-        assertThrows<RuntimeException> { behandling.erTekniskOpphør() }
-    }
-
-    @Test
-    fun `erRentTekniskOpphør gir true når teknisk opphør`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.TEKNISK_OPPHØR,
-                årsak = BehandlingÅrsak.TEKNISK_OPPHØR,
-            )
-        assertTrue(behandling.erTekniskOpphør())
-    }
-
-    @Test
-    fun `erRentTekniskOpphør gir false når ikke teknisk opphør`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.REVURDERING,
-                årsak = BehandlingÅrsak.SØKNAD,
-            )
-        assertFalse(behandling.erTekniskOpphør())
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
@@ -201,7 +201,6 @@ internal class StønadsstatistikkServiceTest(
     fun `Skal gi feil hvis det kommer en ny BehandlingÅrsak som det ikke er tatt høyde for mot stønaddstatistkk - Man trenger å oppdatere schema og varsle stønaddstatistikk - Tips i javadoc`() {
         val behandlingsÅrsakIBASak =
             enumValues<BehandlingÅrsak>()
-                .filter { it != BehandlingÅrsak.TEKNISK_OPPHØR } // IKke i bruk lenger
                 .map { it.name }
         val behandlingsÅrsakFraEksternKontrakt =
             ikkeAvvikleteEnumverdier<BehandlingÅrsakV2>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
@@ -284,7 +284,7 @@ internal class StønadsstatistikkServiceTest(
     fun `Skal gi feil hvis det kommer en ny BehandlingType som det ikke er tatt høyde for mot stønaddstatistkk - Man trenger å oppdatere schema og varsle stønaddstatistikk - Tips i javadoc`() {
         val behandlingsTypeIBasak =
             enumValues<BehandlingType>().map { it.name }
-                .filter { it != BehandlingType.TEKNISK_OPPHØR.name } // TEKNISK_OPPHØR er ikke i bruk
+
         val behandlingsTypeFraStønadskontrakt = ikkeAvvikleteEnumverdier<BehandlingTypeV2>()
 
         assertThat(behandlingsTypeIBasak)


### PR DESCRIPTION
Etter en diskusjon på kontoret har vi blitt enige å fjerne teknisk opphør enum verdien.
Den må migreres i db i preprod og prod.

Ingen behandlinger i preprod som hadde denne typen.
3 i prod.