### PR TITLE
Lagt til -Dsurefire.rerunFailingTestsCount=2 for integrasjonstester for å rekjøre flaky tester

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -66,7 +66,7 @@ jobs:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -Dgroups=integration -DexcludedGroups=verdikjedetest
+          mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -Dgroups=integration -DexcludedGroups=verdikjedetest -Dsurefire.rerunFailingTestsCount=2
 
   verdikjedetesterFeatureToggleOff:
     name: Verdikjedetester m/ feature toggles slått av


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Lagt til -Dsurefire.rerunFailingTestsCount=2 for integrasjonstester for å rekjøre flaky tester

Flaky tester vil bli markert som
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Flakes: 1

men blir grønn
![Screenshot 2024-05-23 at 08 29 08](https://github.com/navikt/familie-ba-sak/assets/1121978/4695cc63-4422-480c-a159-21d5bc8c81b6)
