### PR TITLE
Returnerer false i skalHenteUtbetalingerEøs dersom endringstidspunktet er satt til tidenes ende.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.sisteDagIMåned
@@ -301,9 +302,13 @@ fun skalHenteUtbetalingerEøs(
     endringstidspunkt: LocalDate,
     valutakurser: List<Valutakurs>,
 ): Boolean {
+    // Hvis endringstidspunktet er satt til tidenes ende så ønsker vi ikke å hente eøs utbetalinger
+    if (endringstidspunkt == TIDENES_ENDE) return false
+
     val valutakurserEtterEndringtidspunktet =
         valutakurser.tilSeparateTidslinjerForBarna()
             .mapValues { (_, valutakursTidslinjeForBarn) -> valutakursTidslinjeForBarn.beskjærFraOgMed(endringstidspunkt.tilMånedTidspunkt()) }
+
     return valutakurserEtterEndringtidspunktet.any { it.value.erIkkeTom() }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -302,7 +302,7 @@ fun skalHenteUtbetalingerEøs(
     endringstidspunkt: LocalDate,
     valutakurser: List<Valutakurs>,
 ): Boolean {
-    // Hvis endringstidspunktet er satt til tidenes ende så ønsker vi ikke å hente eøs utbetalinger
+    // Hvis endringstidspunktet er satt til tidenes ende så returner vi bare false da det ikke finnes valutakurser etter det tidspunktet.
     if (endringstidspunkt == TIDENES_ENDE) return false
 
     val valutakurserEtterEndringtidspunktet =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtilsTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagSanityBegrunnelse
@@ -963,6 +964,23 @@ internal class BrevUtilsTest {
             listOf(
                 lagValutakurs(fom = LocalDate.now().minusMonths(4).toYearMonth(), tom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), kurs = BigDecimal.valueOf(1)),
                 lagValutakurs(fom = LocalDate.now().minusMonths(3).toYearMonth(), tom = LocalDate.now().minusMonths(3).toYearMonth(), barnAktører = setOf(barn), kurs = BigDecimal.valueOf(1.2)),
+            )
+
+        assertThat(skalHenteUtbetalingerEøs(endringstidspunkt = endringstidspunkt, valutakurser = valutakurser)).isFalse
+    }
+
+    @Test
+    fun `skalHenteUtbetalingerEøs - skal returnere false uavhengig av valutakurs dersom endringstidspunktet er satt til tidenes ende`() {
+        val endringstidspunkt = TIDENES_ENDE
+        val barn = randomAktør()
+
+        val valutakurser =
+            listOf(
+                lagValutakurs(fom = LocalDate.now().minusMonths(4).toYearMonth(), tom = LocalDate.now().minusMonths(4).toYearMonth(), barnAktører = setOf(barn), kurs = BigDecimal.valueOf(1)),
+                lagValutakurs(fom = LocalDate.now().minusMonths(3).toYearMonth(), tom = LocalDate.now().minusMonths(3).toYearMonth(), barnAktører = setOf(barn), kurs = BigDecimal.valueOf(1.2)),
+                lagValutakurs(fom = LocalDate.now().minusMonths(2).toYearMonth(), tom = LocalDate.now().minusMonths(2).toYearMonth(), barnAktører = setOf(barn), kurs = BigDecimal.valueOf(1.1)),
+                lagValutakurs(fom = LocalDate.now().minusMonths(1).toYearMonth(), tom = LocalDate.now().minusMonths(1).toYearMonth(), barnAktører = setOf(barn), kurs = BigDecimal.valueOf(1.2)),
+                lagValutakurs(fom = LocalDate.now().toYearMonth(), tom = LocalDate.now().toYearMonth(), barnAktører = setOf(barn), kurs = BigDecimal.valueOf(1.3)),
             )
 
         assertThat(skalHenteUtbetalingerEøs(endringstidspunkt = endringstidspunkt, valutakurser = valutakurser)).isFalse


### PR DESCRIPTION
Vi har en feil når vi prøver å sammenligne tidslinjer etter at det har blitt beskjært fra og med tidenes ende.
Vi returnerer derfor bare false med engang i `skalHenteUtbetalingerEøs` dersom endringstidspunktet er tidenes ende, da det uansett ikke finnes noe valutakurs etter det tidspunktet.

Opprinnelig feil:

```
Caused by: java.time.DateTimeException: Invalid value for Year (valid values -999999999 - 999999999): 1000000000
	at java.base/java.time.temporal.ValueRange.checkValidIntValue(Unknown Source)
	at java.base/java.time.temporal.ChronoField.checkValidIntValue(Unknown Source)
	at java.base/java.time.YearMonth.plusMonths(Unknown Source)
	at no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.flytt(MånedTidspunkt.kt:25)
	at no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.flytt(MånedTidspunkt.kt:7)
	at no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.TidspunktKonverteringKt.neste(TidspunktKonvertering.kt:58)
	at no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom.TidspunktClosedRange$iterator$1.next(TidspunktClosedRange.kt:96)
	at no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom.TidspunktClosedRange$iterator$1.next(TidspunktClosedRange.kt:54)
	at no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TidslinjeFraTidspunktKt$tidslinjeFraTidspunkt$1.invoke(TidslinjeFraTidspunkt.kt:97)
	at no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TidslinjeFraTidspunktKt$tidslinjeFraTidspunkt$1.invoke(TidslinjeFraTidspunkt.kt:16)
	at no.nav.familie.ba.sak.kjerne.tidslinje.TidslinjeKt$tidslinje$1.lagPerioder(Tidslinje.kt:115)
	at no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje.perioder(Tidslinje.kt:22)
	at no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje.equals(Tidslinje.kt:81)
	at kotlin.jvm.internal.Intrinsics.areEqual(Intrinsics.java:169)
	at no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinjeKt.erTom(TomTidslinje.kt:11)
	at no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinjeKt.erIkkeTom(TomTidslinje.kt:13)
	at no.nav.familie.ba.sak.kjerne.brev.BrevUtilKt.skalHenteUtbetalingerEøs(BrevUtil.kt:307)
	at no.nav.familie.ba.sak.kjerne.brev.BrevService.hentUtbetalingerPerMndEøs(BrevService.kt:489)
	at no.nav.familie.ba.sak.kjerne.brev.BrevService.lagVedtaksbrevFellesfelter(BrevService.kt:382)
	at no.nav.familie.ba.sak.kjerne.brev.BrevService.hentVedtaksbrevData(BrevService.kt:103)
	at no.nav.familie.ba.sak.kjerne.brev.DokumentGenereringService.genererBrevForVedtak(DokumentGenereringService.kt:41)
```