### PR TITLE
Ikke lag automatiske valutakurser i migreringsbehandligner

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -81,6 +81,8 @@ class AutomatiskOppdaterValutakursService(
         utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>,
         endringstidspunkt: YearMonth,
     ) {
+        if (behandling.erMigrering() || behandling.opprettetÅrsak.erManuellMigreringsårsak()) return
+
         val vurderingsstrategiForValutakurser = vurderingsstrategiForValutakurserRepository.findByBehandlingId(behandling.id)
         if (vurderingsstrategiForValutakurser?.vurderingsstrategiForValutakurser == VurderingsstrategiForValutakurser.MANUELL) return
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bugfix etter tilbakemelding fra saksbehandlere.
Vi skal ikke lage automatikse valutakurser dersom det er en migreringsbehandling. 