### PR TITLE
Flytter oppretteFremleggsoppgaveDersomEØSMedlem bak toggle og skrur den av i miljøene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -15,6 +15,9 @@ class FeatureToggleConfig {
         const val KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK = "familie-ba-sak.kan-kjore-autmatisk-valutajustering-behandling-for-enkelt-sak"
         const val KAN_OVERSTYRE_AUTOMATISKE_VALUTAKURSER = "familie-ba-sak.kan-overstyre-automatiske-valutakurser"
 
+        // NAV-21071 lagt bak toggle og kan evt fjernes på sikt hvis man ikke har trengt å skru den på igjen
+        const val SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM = "familie-ba-sak.skalOpprettFremleggsoppgaveDersomEOSMedlem"
+
         // satsendring
         // Oppretter satsendring-tasker for de som ikke har fått ny task
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilKortString
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
@@ -40,6 +41,7 @@ import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
+import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -61,6 +63,7 @@ class AutovedtakFødselshendelseService(
     private val statsborgerskapService: StatsborgerskapService,
     private val opprettTaskService: OpprettTaskService,
     private val oppgaveService: OppgaveService,
+    private val unleashService: UnleashService,
 ) : AutovedtakBehandlingService<FødselshendelseData> {
     val stansetIAutomatiskFiltreringCounter =
         Metrics.counter("familie.ba.sak.henvendelse.stanset", "steg", "filtrering")
@@ -165,7 +168,9 @@ class AutovedtakFødselshendelseService(
                 )
             taskRepository.save(task)
 
-            opprettFremleggsoppgaveDersomEØSMedlem(behandling)
+            if (unleashService.isEnabled(FeatureToggleConfig.SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM, false)) {
+                opprettFremleggsoppgaveDersomEØSMedlem(behandling)
+            }
 
             passertFiltreringOgVilkårsvurderingCounter.increment()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
@@ -49,6 +49,7 @@ import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
+import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.Month
@@ -69,6 +70,7 @@ class FødselshendelseServiceTest {
     val personopplysningerService = mockk<PersonopplysningerService>()
     val opprettTaskService = mockk<OpprettTaskService>()
     val oppgaveService = mockk<OppgaveService>()
+    val mockUnleashService = mockk<UnleashService>()
 
     val integrasjonClient = mockk<IntegrasjonClient>()
     val statsborgerskapService =
@@ -93,6 +95,7 @@ class FødselshendelseServiceTest {
             statsborgerskapService,
             opprettTaskService,
             oppgaveService,
+            mockUnleashService,
         )
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-21071
Forventet oppførsel:  Det skal ikke opprettes automatiske oppgaver for oppfølging med årsak "kontroller gyldig opphold" når mor er utenlandsk statsborger.

Ida skrevi kortet: Avklart med Anna: Vi tror aldri dette har blitt skrudd av, så ønsket for denne oppgaven er at funksjonaliteten skal bli lagt bak en feature toggle, og eventuelt fjernet på sikt hvis vi ikke trenger det lenger

Denne PR legger denne funksjonaliteten som oppretter oppgaver med "Kontroller gyldig opphold" bak en toggle.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
