### PR TITLE
Fjern ubrukt endepunkt fjern-behandles-av-applikasjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
@@ -305,35 +305,6 @@ class IntegrasjonClient(
         }
     }
 
-    @Retryable(
-        value = [Exception::class],
-        maxAttempts = 3,
-        backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS),
-    )
-    fun fjernBehandlesAvApplikasjon(oppgaveId: Long): OppgaveResponse {
-        val oppgave = finnOppgaveMedId(oppgaveId)
-        if (oppgave.behandlesAvApplikasjon == null) {
-            logger.info("behandlesAvApplikasjon er allerede null for $oppgaveId")
-            return OppgaveResponse(oppgaveId)
-        }
-
-        val baseUri = URI.create("$integrasjonUri/oppgave/$oppgaveId/fjern-behandles-av-applikasjon")
-        val uri =
-            UriComponentsBuilder.fromUri(baseUri).queryParam("versjon", oppgave.versjon).build()
-                .toUri()
-
-        return kallEksternTjenesteRessurs(
-            tjeneste = "oppgave",
-            uri = uri,
-            formål = "fjern behandlesAvApplikasjon",
-        ) {
-            patchForEntity(
-                uri,
-                HttpHeaders().medContentTypeJsonUTF8(),
-            )
-        }
-    }
-
     fun finnOppgaveMedId(oppgaveId: Long): Oppgave {
         val uri = URI.create("$integrasjonUri/oppgave/$oppgaveId")
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveController.kt
@@ -164,20 +164,4 @@ class OppgaveController(
 
         return ResponseEntity.ok(Ressurs.success(behandleSakOppgaveFrister))
     }
-
-    @PostMapping("/fjern-behandles-av-applikasjon")
-    fun fjernBehandlesAvApplikasjonFor(
-        @RequestBody oppgaver: List<Long>,
-    ): ResponseEntity<Ressurs<String>> {
-        val fjernetBehandlesAvApplikasjonForOppgaver =
-            oppgaveService.fjernBehandlesAvApplikasjon(
-                oppgaver,
-            )
-        logger.info("Fjernet behandlesAvApplikasjon for oppgaver=$fjernetBehandlesAvApplikasjonForOppgaver")
-        return ResponseEntity.ok(
-            Ressurs.success(
-                "Fjernet behandlesAvApplikasjon for $fjernetBehandlesAvApplikasjonForOppgaver",
-            ),
-        )
-    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -367,17 +367,6 @@ class OppgaveService(
         integrasjonClient.ferdigstillOppgave(oppgaveId = oppgave.id!!)
     }
 
-    fun fjernBehandlesAvApplikasjon(oppgaver: List<Long>): Set<Long> {
-        return oppgaver.fold(LinkedHashSet()) { accumulator, oppgaveId ->
-            val dbOppgave = oppgaveRepository.findByGsakId(oppgaveId.toString())
-            if (dbOppgave != null) {
-                integrasjonClient.fjernBehandlesAvApplikasjon(oppgaveId)
-                accumulator.add(oppgaveId)
-            }
-            accumulator
-        }
-    }
-
     fun ferdigstillLagVedtakOppgaver(behandlingId: Long) {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val oppgaverPåBehandling = oppgaveRepository.findByBehandlingAndIkkeFerdigstilt(behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -58,11 +58,9 @@ class HenleggBehandling(
             )
         }
 
-        val (oppgaverTekniskVedlikeholdPgaSatsendring, oppgaverSomSkalFerdigstilles) =
-            oppgaveService.hentOppgaverSomIkkeErFerdigstilt(
-                behandling,
-            )
-                .partition {
+        oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling)
+            .filter {
+                !(
                     data.årsak == HenleggÅrsak.TEKNISK_VEDLIKEHOLD && data.begrunnelse == SATSENDRING && it.type in
                         listOf(
                             BehandleSak,
@@ -70,16 +68,11 @@ class HenleggBehandling(
                             BehandleUnderkjentVedtak,
                             VurderLivshendelse,
                         )
-                }
-
-        oppgaverSomSkalFerdigstilles.forEach {
-            oppgaveService.ferdigstillOppgaver(behandling.id, it.type)
-        }
-
-        oppgaverTekniskVedlikeholdPgaSatsendring.forEach {
-            logger.info("Teknisk opphør pga satsendring. Fjerner behandlesAvApplikasjon for oppgaveId=${it.gsakId} slik at saksbehandler kan lukke den fra Gosys. fagsakId=${fagsak.id}, behandlingId=${behandling.id}")
-            oppgaveService.fjernBehandlesAvApplikasjon(listOf(it.gsakId.toLong()))
-        }
+                )
+            }
+            .forEach {
+                oppgaveService.ferdigstillOppgaver(behandling.id, it.type)
+            }
 
         loggService.opprettHenleggBehandling(behandling, data.årsak.beskrivelse, data.begrunnelse)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
@@ -115,9 +115,6 @@ class IntegrasjonClientMock {
             every { mockIntegrasjonClient.fordelOppgave(any(), any()) } returns
                 OppgaveResponse(12345678L)
 
-            every { mockIntegrasjonClient.fjernBehandlesAvApplikasjon(any()) } returns
-                OppgaveResponse(12345678L)
-
             every { mockIntegrasjonClient.oppdaterJournalpost(any(), any()) } returns
                 OppdaterJournalpostResponse("1234567")
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveIntegrationTest.kt
@@ -127,30 +127,6 @@ class OppgaveIntegrationTest : AbstractSpringIntegrationTest() {
             .anyMatch { message -> message.contains("Fant eksisterende oppgave med samme oppgavetype") }
     }
 
-    @Test
-    fun `Skal fjerne behandlesAvApplikasjon på liste med oppgaver som finnes i ba-ak`() {
-        databaseCleanupService.truncate()
-        val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(SØKER_FNR)
-        val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandling(fagsak))
-        val barnAktør = personidentService.hentOgLagreAktørIder(listOf(BARN_FNR), true)
-        val personopplysningGrunnlag =
-            lagTestPersonopplysningGrunnlag(
-                behandling.id,
-                SØKER_FNR,
-                listOf(BARN_FNR),
-                søkerAktør = fagsak.aktør,
-                barnAktør = barnAktør,
-            )
-
-        personopplysningGrunnlagRepository.save(personopplysningGrunnlag)
-
-        val oppgave1 =
-            oppgaveService.opprettOppgave(behandling.id, Oppgavetype.GodkjenneVedtak, LocalDate.now()).toLong()
-
-        val response = oppgaveService.fjernBehandlesAvApplikasjon(listOf(oppgave1, 123456L))
-        assertThat(response.toList()).hasSize(1).containsOnly(oppgave1)
-    }
-
     protected fun initLoggingEventListAppender(): ListAppender<ILoggingEvent> {
         val listAppender = ListAppender<ILoggingEvent>()
         listAppender.start()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner ubrukt endepunkt fjern-behandles-av-applikasjon. Denne er alt slettet i integrasjoner.

