### PR TITLE
Oppdater valutakurs i beslutte vedtak-steg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -13,6 +13,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
@@ -43,6 +45,7 @@ class BeslutteVedtak(
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val saksbehandlerContext: SaksbehandlerContext,
     private val automatiskBeslutningService: AutomatiskBeslutningService,
+    private val automatiskOppdaterValutakursService: AutomatiskOppdaterValutakursService,
 ) : BehandlingSteg<RestBeslutningPåVedtak> {
     override fun utførStegOgAngiNeste(
         behandling: Behandling,
@@ -92,6 +95,8 @@ class BeslutteVedtak(
             beslutning = data,
             behandlingErAutomatiskBesluttet = behandlingSkalAutomatiskBesluttes,
         )
+
+        automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(BehandlingId(behandling.id))
 
         return if (data.beslutning.erGodkjent()) {
             val vedtak =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
@@ -96,7 +97,9 @@ class BeslutteVedtak(
             behandlingErAutomatiskBesluttet = behandlingSkalAutomatiskBesluttes,
         )
 
-        automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(BehandlingId(behandling.id))
+        if (unleashService.isEnabled(KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER)) {
+            automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(BehandlingId(behandling.id))
+        }
 
         return if (data.beslutning.erGodkjent()) {
             val vedtak =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -96,6 +96,7 @@ class BeslutteVedtakTest {
         every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(any()) } returns randomVilkårsvurdering
         every { saksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "saksbehandlerNavn"
         every { automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(any()) } just runs
+        every { unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
@@ -51,6 +52,7 @@ class BeslutteVedtakTest {
     private val automatiskBeslutningService: AutomatiskBeslutningService = mockk()
     private val saksbehandlerContext = mockk<SaksbehandlerContext>()
     private val loggService = mockk<LoggService>()
+    private val automatiskOppdaterValutakursService = mockk<AutomatiskOppdaterValutakursService>()
 
     val beslutteVedtak =
         BeslutteVedtak(
@@ -65,6 +67,7 @@ class BeslutteVedtakTest {
             tilkjentYtelseValideringService = tilkjentYtelseValideringService,
             saksbehandlerContext = saksbehandlerContext,
             automatiskBeslutningService = automatiskBeslutningService,
+            automatiskOppdaterValutakursService = automatiskOppdaterValutakursService,
         )
 
     private val randomVilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
@@ -92,6 +95,7 @@ class BeslutteVedtakTest {
         every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns randomVilkårsvurdering
         every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(any()) } returns randomVilkårsvurdering
         every { saksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "saksbehandlerNavn"
+        every { automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(any()) } just runs
     }
 
     @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
@@ -30,6 +30,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.brev.BrevmalService
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
@@ -63,6 +64,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import java.time.LocalDate
 
 class StegServiceIntegrationTest(
@@ -95,6 +97,9 @@ class StegServiceIntegrationTest(
     @Autowired
     private val økonomiKlient: ØkonomiKlient,
 ) : AbstractSpringIntegrationTest() {
+    @MockBean
+    private lateinit var automatiskOppdaterValutakursService: AutomatiskOppdaterValutakursService
+
     @BeforeEach
     fun init() {
         databaseCleanupService.truncate()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-21205
En behandling som ligger lenge til godkjenning vil ikke få oppdatert valutakurser i perioden den ligger til godkjenning.
Endrer derfor slik at vi oppdaterer valutakurser når beslutter godkjenner/underkjenner behandlingen

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Oppdatering av valutakurser er allerede testet. Virker unødvendig å kun teste at funksjonen blir kjørt

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
