### PR TITLE
Endret i scheduler for månedling valutajustering, endrer til første virkedag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
@@ -43,9 +43,10 @@ class MånedligValutajusteringScheduler(
             taskRepository.save(
                 MånedligValutajusteringFinnFagsakerTask.lagTask(
                     inneværendeMåned = inneværendeMåned,
-                    triggerTid = VirkedagerProvider.nesteVirkedag(
-                        LocalDate.now().minusDays(1),
-                    ).atTime(KLOKKETIME_SCHEDULER_TRIGGES.inc(), 0)
+                    triggerTid =
+                        VirkedagerProvider.nesteVirkedag(
+                            LocalDate.now().minusDays(1),
+                        ).atTime(KLOKKETIME_SCHEDULER_TRIGGES.inc(), 0),
                 ),
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevScheduler.kt
@@ -17,7 +17,7 @@ class AutobrevScheduler(
     val leaderClientService: LeaderClientService,
 ) {
     /**
-     * Denne funksjonen kjøres kl.7 den første dagen i måneden og setter triggertid på tasken til kl.8 den første virkedagen i måneden.
+     * Denne funksjonen kjøres kl.6 den første dagen i måneden og setter triggertid på tasken til kl.7 den første virkedagen i måneden.
      * For testformål kan funksjonen opprettTask også kalles direkte via et restendepunkt.
      */
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -61,7 +61,10 @@ class MånedligValutajusteringFinnFagsakerTask(
         const val TASK_STEP_TYPE = "månedligValutajusteringFinnFagsaker"
         private val logger = LoggerFactory.getLogger(MånedligValutajusteringFinnFagsakerTask::class.java)
 
-        fun lagTask(inneværendeMåned: YearMonth, triggerTid: LocalDateTime) =
+        fun lagTask(
+            inneværendeMåned: YearMonth,
+            triggerTid: LocalDateTime,
+        ) =
             Task(
                 type = MånedligValutajusteringFinnFagsakerTask.TASK_STEP_TYPE,
                 payload = objectMapper.writeValueAsString(MånedligValutajusteringFinnFagsakerTaskDto(inneværendeMåned)),

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -18,6 +18,7 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 @Service
@@ -60,11 +61,13 @@ class MånedligValutajusteringFinnFagsakerTask(
         const val TASK_STEP_TYPE = "månedligValutajusteringFinnFagsaker"
         private val logger = LoggerFactory.getLogger(MånedligValutajusteringFinnFagsakerTask::class.java)
 
-        fun lagTask(inneværendeMåned: YearMonth) =
+        fun lagTask(inneværendeMåned: YearMonth, triggerTid: LocalDateTime) =
             Task(
                 type = MånedligValutajusteringFinnFagsakerTask.TASK_STEP_TYPE,
                 payload = objectMapper.writeValueAsString(MånedligValutajusteringFinnFagsakerTaskDto(inneværendeMåned)),
                 mapOf("måned" to inneværendeMåned.toString()).toProperties(),
+            ).medTriggerTid(
+                triggerTid = triggerTid,
             )
 
         fun erSekundærlandIMåned(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Koden for månedlig valutajustering skal kjøres første virkedag per måned, som er fikset her. Har gjort det likt som `opprettAutobrevTask`, som allerede hadde lignende funksjonalitet.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
Kan/bør vi skrive tester for scheduled tasks?

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
