### PR TITLE
Logg andelene som blir bruk i intern konsistensavstemming ved feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtil.kt
@@ -34,7 +34,9 @@ fun erForskjellMellomAndelerOgOppdrag(
                 "Fagsak $fagsakId har sendt utbetalingsperiode(r) til økonomi som ikke har tilsvarende andel tilkjent ytelse." +
                     "\nDet er differanse i perioden(e) ${forskjellMellomAndeleneOgUtbetalingsoppdraget.utbetalingsperioder.tilTidStrenger()}." +
                     "\n\nSiste utbetalingsoppdrag som er sendt til familie-øknonomi på fagsaken er:" +
-                    "\n$utbetalingsoppdrag",
+                    "\n$utbetalingsoppdrag" +
+                    "\n\nAndelene i siste behandling som er sendt til økonomi er:" +
+                    "\n${andeler.joinToString("\n")} ",
             )
 
         is IngenForskjell -> Unit


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dersom det er feil i intern konsistensavstemming ønsker vi å ha litt med data i feilmedlingen. Endrer så vi sender med andelene som ble brukt i avstemmingen
