### PR TITLE
Filtrer bort andeler som er satt til 0 pga endret utbetalingsandeler før vi fortsetter å hente utbetalingsinfo

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -140,16 +140,13 @@ data class AndelTilkjentYtelse(
     fun erDeltBosted() = this.prosent == BigDecimal(50)
 
     fun vurdertEtter(personResultater: Set<PersonResultat>): Regelverk {
-        val relevanteVilkårsResultaer = finnRelevanteVilkårsresulaterForRegelverk(personResultater)
+        val relevanteVilkårsResultater = finnRelevanteVilkårsresulaterForRegelverk(personResultater)
 
-        return if (relevanteVilkårsResultaer.isEmpty()) {
-            Regelverk.NASJONALE_REGLER
-        } else if (relevanteVilkårsResultaer.all { it.vurderesEtter == Regelverk.EØS_FORORDNINGEN }) {
-            Regelverk.EØS_FORORDNINGEN
-        } else if (relevanteVilkårsResultaer.all { it.vurderesEtter == Regelverk.NASJONALE_REGLER }) {
-            Regelverk.NASJONALE_REGLER
-        } else {
-            Regelverk.NASJONALE_REGLER
+        return when {
+            relevanteVilkårsResultater.isEmpty() -> Regelverk.NASJONALE_REGLER
+            relevanteVilkårsResultater.all { it.vurderesEtter == Regelverk.EØS_FORORDNINGEN } -> Regelverk.EØS_FORORDNINGEN
+            relevanteVilkårsResultater.all { it.vurderesEtter == Regelverk.NASJONALE_REGLER } -> Regelverk.NASJONALE_REGLER
+            else -> Regelverk.NASJONALE_REGLER
         }
     }
 
@@ -174,7 +171,7 @@ data class AndelTilkjentYtelse(
                     (it.periodeTom == null || this.stønadFom <= it.periodeTom?.toYearMonth())
             }
             .filter { vilkårResultat ->
-                regelverkavhenigeVilkår().any { it == vilkårResultat.vilkårType }
+                regelverkAvhengigeVilkår().any { it == vilkårResultat.vilkårType }
             }
 }
 
@@ -208,13 +205,12 @@ enum class YtelseType(val klassifisering: String) {
         }
 }
 
-private fun regelverkavhenigeVilkår(): List<Vilkår> {
-    return listOf(
+private fun regelverkAvhengigeVilkår() =
+    listOf(
         Vilkår.BOR_MED_SØKER,
         Vilkår.BOSATT_I_RIKET,
         Vilkår.LOVLIG_OPPHOLD,
     )
-}
 
 fun Collection<AndelTilkjentYtelse>.tilTidslinjerPerPersonOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseTidslinje> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
 import no.nav.familie.ba.sak.kjerne.brev.brevBegrunnelseProdusent.BrevBegrunnelseFeil
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.lagBrevPeriode
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Autovedtak6og18årOgSmåbarnstillegg
@@ -46,6 +45,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.VedtakEndring
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.VedtakFellesfelter
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Vedtaksbrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetalingMndEøs
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
@@ -91,6 +91,7 @@ class BrevService(
     private val kompetanseRepository: KompetanseRepository,
     private val valutakursRepository: ValutakursRepository,
     private val unleashService: UnleashNextMedContextService,
+    private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
 ) {
     fun hentVedtaksbrevData(vedtak: Vedtak): Vedtaksbrev {
         val behandling = vedtak.behandling
@@ -485,19 +486,21 @@ class BrevService(
         val behandlingId = vedtak.behandling.id
         val endringstidspunkt = vedtaksperiodeService.finnEndringstidspunktForBehandling(behandlingId = behandlingId)
         val valutakurser = valutakursRepository.finnFraBehandlingId(behandlingId = behandlingId)
+        val endretutbetalingAndeler = endretUtbetalingAndelRepository.findByBehandlingId(behandlingId = behandlingId)
 
         if (!skalHenteUtbetalingerEøs(endringstidspunkt = endringstidspunkt, valutakurser)) {
             return null
         }
 
-        val andelerForVedtaksperioderPerAktørOgType = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = behandlingId).tilTidslinjerPerPersonOgType()
+        val andelerTilkjentYtelseForBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = behandlingId)
         val utenlandskePeriodebeløp = utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId = behandlingId).toList()
 
         return hentUtbetalingerPerMndEøs(
             endringstidspunkt = endringstidspunkt,
-            andelerForVedtaksperioderPerAktørOgType = andelerForVedtaksperioderPerAktørOgType,
+            andelTilkjentYtelserForBehandling = andelerTilkjentYtelseForBehandling,
             utenlandskePeriodebeløp = utenlandskePeriodebeløp,
             valutakurser = valutakurser,
+            endretutbetalingAndeler = endretutbetalingAndeler,
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -44,6 +44,7 @@ class BrevServiceTest {
             valutakursRepository = mockk(),
             kompetanseRepository = mockk(),
             unleashService = unleashService,
+            endretUtbetalingAndelRepository = mockk(),
         )
 
     @BeforeEach


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21245

Vi har per i dag en liten bug når vi oppretter utbetalingstabellen.
Per nå inkluderer den andeler som er satt til 0 pga endret utbetaling andeler. Disse ønsker vi ikke å ha med.
Jeg tenker derfor det er greit at vi filtrerer bort andelene tidlig i løpet.



