### PR TITLE
Legg til mulighet for å kunne kjøre MånedligValutajustering utenom første virkedag i måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -50,6 +50,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.UUID
 import kotlin.concurrent.thread
@@ -342,7 +343,7 @@ class ForvalterController(
     @PostMapping("/start-valutajustering-scheduler")
     @Operation(summary = "Start valutajustering for alle sekundærlandsaker i gjeldende måned")
     fun lagMånedligValutajusteringTask(): ResponseEntity<Ressurs<String>> {
-        månedligValutajusteringScheduler.lagMånedligValutajusteringTask()
+        månedligValutajusteringScheduler.lagMånedligValutajusteringTask(LocalDateTime.now())
         return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -343,7 +343,7 @@ class ForvalterController(
     @PostMapping("/start-valutajustering-scheduler")
     @Operation(summary = "Start valutajustering for alle sekundærlandsaker i gjeldende måned")
     fun lagMånedligValutajusteringTask(): ResponseEntity<Ressurs<String>> {
-        månedligValutajusteringScheduler.lagMånedligValutajusteringTask(LocalDateTime.now())
+        månedligValutajusteringScheduler.lagMånedligValutajusteringTask(triggerTid = LocalDateTime.now())
         return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
@@ -58,6 +58,6 @@ class MånedligValutajusteringScheduler(
         ).atTime(KLOKKETIME_SCHEDULER_TRIGGES.inc(), 0)
 
     companion object {
-        const val KLOKKETIME_SCHEDULER_TRIGGES = 6
+        const val KLOKKETIME_SCHEDULER_TRIGGES = 2
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
@@ -32,7 +32,9 @@ class MånedligValutajusteringScheduler(
      */
     @Scheduled(cron = "0 0 $KLOKKETIME_SCHEDULER_TRIGGES 1 * *")
     @Transactional
-    fun lagMånedligValutajusteringTask(triggerTid: LocalDateTime = hentNesteVirkedag()) {
+    fun lagScheduledMånedligValutajusteringTask() = lagMånedligValutajusteringTask(triggerTid = hentNesteVirkedag())
+
+    fun lagMånedligValutajusteringTask(triggerTid: LocalDateTime) {
         val inneværendeMåned = YearMonth.now()
         if (!unleashService.isEnabled(FeatureToggleConfig.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ALLE_SAKER)) {
             logger.info("FeatureToggle ${FeatureToggleConfig.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ALLE_SAKER} er skrudd av. Avbryter månedlig valutajustering.")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
@@ -104,7 +105,7 @@ class BehandlingHentOgPersisterService(
         behandlingRepository.finnSisteIverksatteBehandlingFraLøpendeFagsaker()
 
     fun hentAlleFagsakerMedLøpendeValutakursIMåned(måned: YearMonth): List<Long> =
-        behandlingRepository.finnAlleFagsakerMedLøpendeValutakursIMåned(måned)
+        behandlingRepository.finnAlleFagsakerMedLøpendeValutakursIMåned(måned.førsteDagIInneværendeMåned())
 
     fun hentBehandlinger(fagsakId: Long): List<Behandling> {
         return behandlingRepository.finnBehandlinger(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -79,7 +79,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                     WHERE f.status = 'LØPENDE'
                       AND f.arkivert = false 
                       AND ty.stonad_tom >= :måned
-                      AND (v.tom >= :måned OR v.tom IS null)""",
+                      AND (v.tom IS null OR v.tom >= :måned)""",
         nativeQuery = true,
     )
     fun finnAlleFagsakerMedLøpendeValutakursIMåned(måned: YearMonth): List<Long>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.YearMonth
 
 interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Query(value = "SELECT b FROM Behandling b WHERE b.id = :behandlingId")
@@ -82,7 +81,7 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
                       AND (v.tom IS null OR v.tom >= :måned)""",
         nativeQuery = true,
     )
-    fun finnAlleFagsakerMedLøpendeValutakursIMåned(måned: YearMonth): List<Long>
+    fun finnAlleFagsakerMedLøpendeValutakursIMåned(måned: LocalDate): List<Long>
 
     @Query(
         """select b from Behandling b

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -43,7 +43,7 @@ class MånedligValutajusteringFinnFagsakerTask(
 
         logger.info("Starter månedlig valutajustering for ${data.måned}")
 
-        val fagsakerMedLøpendeValutakurs = behandlingService.hentAlleFagsakerMedLøpendeValutakursIMåned(data.måned).toSet().sorted()
+        val fagsakerMedLøpendeValutakurs = behandlingService.hentAlleFagsakerMedLøpendeValutakursIMåned(data.måned)
 
         // Hardkoder denne til å kun ta 10 behanldinger i første omgang slik at vi er helt sikre på at vi ikke kjører på alle behandlinger mens vi tester.
         fagsakerMedLøpendeValutakurs.take(10).forEach { fagsakId ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -9,10 +9,13 @@ import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.erAlleValutakurserOppdaterteIMåned
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.log.IdUtils
+import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -64,7 +67,10 @@ class MånedligValutajusteringFinnFagsakerTask(
             Task(
                 type = MånedligValutajusteringFinnFagsakerTask.TASK_STEP_TYPE,
                 payload = objectMapper.writeValueAsString(MånedligValutajusteringFinnFagsakerTaskDto(inneværendeMåned)),
-                mapOf("måned" to inneværendeMåned.toString()).toProperties(),
+                mapOf(
+                    "måned" to inneværendeMåned.toString(),
+                    "callId" to (MDC.get(MDCConstants.MDC_CALL_ID) ?: IdUtils.generateId()),
+                ).toProperties(),
             ).medTriggerTid(
                 triggerTid = triggerTid,
             )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Funksjonen som starter månedlig valutajustering tillater enn så lenge kun av vi starter det første virkedag i måneden. 

Endrer så vi starter månedlig valutajustering umiddelbart dersom vi starter det fra endepunkt. 