### PR TITLE
Hent første vedtaksperiode som faktisk har en fom dato før vi sjekker etter endringstidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -255,7 +255,7 @@ class BrevService(
         utbetalingerPerMndEøs: Map<String, UtbetalingMndEøs>?,
     ): UtbetalingstabellAutomatiskValutajustering? =
         utbetalingerPerMndEøs?.let {
-            val endringstidspunkt = hentSorterteVedtaksperioderMedBegrunnelser(vedtak).first().fom!!.tilMånedTidspunkt()
+            val endringstidspunkt = hentSorterteVedtaksperioderMedBegrunnelser(vedtak).first { it.fom != null }.fom!!.tilMånedTidspunkt()
             val landkoder = integrasjonClient.hentLandkoderISO2()
             val kompetanser = kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id)
             return hentLandOgStartdatoForUtbetalingstabell(endringstidspunkt, landkoder, kompetanser)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -248,7 +248,7 @@ class BrevService(
         vedtakFellesfelter: VedtakFellesfelter,
     ): UtbetalingstabellAutomatiskValutajustering? =
         vedtakFellesfelter.utbetalingerPerMndEøs?.let {
-            val endringstidspunkt = hentSorterteVedtaksperioderMedBegrunnelser(vedtak).first().fom!!.tilMånedTidspunkt()
+            val endringstidspunkt = hentSorterteVedtaksperioderMedBegrunnelser(vedtak).first { it.fom != null }.fom!!.tilMånedTidspunkt()
             val landkoder = integrasjonClient.hentLandkoderISO2()
             val kompetanser = kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id)
             return hentLandOgStartdatoForUtbetalingstabell(endringstidspunkt, landkoder, kompetanser)


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21380

Vi henter endringstidspunkt i denne koden ved å hente alle sorterte vedtaksperioder (ved å bruke fom), og deretter så tar vi den tidligste fommen. Problemet med dette er at hvis fom er null i et vedtaksperiode som f.eks ved avslag, så vil den bli plassert først i lista. (se https://pl.kotl.in/EI5fbYvTC)

Henter derfor første som faktisk har fom.