### PR TITLE
Forbedre feilmeldinger og logger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -380,7 +380,7 @@ fun hentTekstForValutakurser(
     } else {
         """
 
-    Og med utenlandsk periodebeløp for begrunnelse
+    Og med valutakurs for begrunnelse
       | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs |""" +
             rader
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.internal.vedtak.begrunnelser
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.tilddMMyyyy
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -351,9 +352,9 @@ private fun hentUtenlandskPeriodebeløpRader(utenlandskePeriodebeløp: Collectio
       | ${
                 utenlandskPeriodebeløp.barnAktører.joinToString(", ") { it.aktørId }
             } |${
-                utenlandskPeriodebeløp.fom.førsteDagIInneværendeMåned().tilddMMyyyy()
+                utenlandskPeriodebeløp.fom.tilKortString()
             }|${
-                utenlandskPeriodebeløp.tom?.sisteDagIInneværendeMåned()?.tilddMMyyyy() ?: ""
+                utenlandskPeriodebeløp.tom?.tilKortString() ?: ""
             }|${
                 utenlandskPeriodebeløp.behandlingId
             }|${

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -87,7 +88,12 @@ object BehandlingsresultatValideringUtils {
             erEndringTilbakeITidTidslinje.perioder().forEach {
                 val erEndring = it.innhold == true
                 if (erEndring) {
-                    throw Feil("Det er endringer i andelene som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.")
+                    secureLogger.info(
+                        "Er endring i kalkulert utbetalt beløp i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
+                            "Andeler denne behandlingen: $andelerDenneBehandlingen\n" +
+                            "Andeler forrige behandling: $andelerForrigeBehandling",
+                    )
+                    throw Feil("Det er endringer i kalkulert utbetalt beløp som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
                 }
             }
         }
@@ -109,7 +115,12 @@ object BehandlingsresultatValideringUtils {
             erEndringISatsTidslinje.perioder().forEach {
                 val erEndring = it.innhold == true
                 if (erEndring) {
-                    throw Feil("Det er endringer i andelene som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.")
+                    secureLogger.info(
+                        "Er endring i sats for andel i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
+                            "Andeler denne behandlingen: $andelerDenneBehandlingen\n" +
+                            "Andeler forrige behandling: $andelerForrigeBehandling",
+                    )
+                    throw Feil("Det er endringer i andelene relatert til sats som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
                 }
             }
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når behandlingssteg for automatisk valutajustering valideres, kastes to like feilmeldinger.

Kaster mer utfyllende feilmeldinger og logger