### PR TITLE
Fikse validering av valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -380,7 +380,7 @@ fun hentTekstForValutakurser(
     } else {
         """
 
-    Og med utenlandsk periodebeløp for begrunnelse
+    Og med valutakurs for begrunnelse
       | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs |""" +
             rader
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.internal.vedtak.begrunnelser
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.tilddMMyyyy
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -351,9 +352,9 @@ private fun hentUtenlandskPeriodebeløpRader(utenlandskePeriodebeløp: Collectio
       | ${
                 utenlandskPeriodebeløp.barnAktører.joinToString(", ") { it.aktørId }
             } |${
-                utenlandskPeriodebeløp.fom.førsteDagIInneværendeMåned().tilddMMyyyy()
+                utenlandskPeriodebeløp.fom.tilKortString()
             }|${
-                utenlandskPeriodebeløp.tom?.sisteDagIInneværendeMåned()?.tilddMMyyyy() ?: ""
+                utenlandskPeriodebeløp.tom?.tilKortString() ?: ""
             }|${
                 utenlandskPeriodebeløp.behandlingId
             }|${

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -75,7 +75,7 @@ class BehandlingsresultatSteg(
         }
 
         val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandling.id)
-        val andelerForrigeBehandling by lazy { beregningService.hentAndelerFraForrigeIverksattebehandling(behandling) }
+        val andelerForrigeBehandling by lazy { beregningService.hentAndelerFraForrigeVedtatteBehandling(behandling) }
 
         if (behandling.erSatsendring()) {
             validerSatsendring(tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -87,7 +88,12 @@ object BehandlingsresultatValideringUtils {
             erEndringTilbakeITidTidslinje.perioder().forEach {
                 val erEndring = it.innhold == true
                 if (erEndring) {
-                    throw Feil("Det er endringer i andelene som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.")
+                    secureLogger.info(
+                        "Er endring i kalkulert utbetalt beløp i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
+                            "Andeler denne behandlingen: $andelerDenneBehandlingen\n" +
+                            "Andeler forrige behandling: $andelerForrigeBehandling",
+                    )
+                    throw Feil("Det er endringer i kalkulert utbetalt beløp som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
                 }
             }
         }
@@ -109,7 +115,12 @@ object BehandlingsresultatValideringUtils {
             erEndringISatsTidslinje.perioder().forEach {
                 val erEndring = it.innhold == true
                 if (erEndring) {
-                    throw Feil("Det er endringer i andelene som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.")
+                    secureLogger.info(
+                        "Er endring i sats for andel i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
+                            "Andeler denne behandlingen: $andelerDenneBehandlingen\n" +
+                            "Andeler forrige behandling: $andelerForrigeBehandling",
+                    )
+                    throw Feil("Det er endringer i andelene relatert til sats som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
                 }
             }
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -103,11 +103,11 @@ object BehandlingsresultatValideringUtils {
         andelerDenneBehandlingen: List<AndelTilkjentYtelse>,
         andelerForrigeBehandling: List<AndelTilkjentYtelse>,
     ) {
-        val andelerIFortidenTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType()
-        val andelerIFortidenForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType()
+        val andelerDenneBehandlingTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType()
+        val andelerForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType()
 
         val erEndringISatsTidslinjer =
-            andelerIFortidenTidslinje.outerJoin(andelerIFortidenForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
+            andelerDenneBehandlingTidslinje.outerJoin(andelerForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
                 nyAndel?.sats != gammelAndel?.sats
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -140,6 +140,12 @@ class BeregningService(
             ?: emptyList()
     }
 
+    fun hentAndelerFraForrigeVedtatteBehandling(behandling: Behandling): List<AndelTilkjentYtelse> {
+        val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+        return forrigeBehandling?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
+            ?: emptyList()
+    }
+
     @Transactional
     fun oppdaterBehandlingMedBeregning(
         behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -65,7 +65,7 @@ class MånedligValutajusteringFinnFagsakerTask(
             triggerTid: LocalDateTime,
         ) =
             Task(
-                type = MånedligValutajusteringFinnFagsakerTask.TASK_STEP_TYPE,
+                type = TASK_STEP_TYPE,
                 payload = objectMapper.writeValueAsString(MånedligValutajusteringFinnFagsakerTaskDto(inneværendeMåned)),
                 mapOf(
                     "måned" to inneværendeMåned.toString(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -46,7 +46,7 @@ class MånedligValutajusteringFinnFagsakerTask(
         val fagsakerMedLøpendeValutakurs = behandlingService.hentAlleFagsakerMedLøpendeValutakursIMåned(data.måned)
 
         // Hardkoder denne til å kun ta 10 behanldinger i første omgang slik at vi er helt sikre på at vi ikke kjører på alle behandlinger mens vi tester.
-        fagsakerMedLøpendeValutakurs.take(10).forEach { fagsakId ->
+        fagsakerMedLøpendeValutakurs.take(100).forEach { fagsakId ->
             val sisteVedtatteBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId) ?: throw Feil("Fant ikke siste vedtatte behandling for $fagsakId")
             val valutakurser = valutakursService.hentValutakurser(BehandlingId(sisteVedtatteBehandling.id))
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
@@ -45,7 +45,7 @@ class MånedligValutajusteringTask(
             valutajusteringsMåned: YearMonth,
         ): Task =
             Task(
-                type = MånedligValutajusteringTask.TASK_STEP_TYPE,
+                type = TASK_STEP_TYPE,
                 payload = objectMapper.writeValueAsString(MånedligValutajusteringTaskDto(fagsakId = fagsakId, måned = valutajusteringsMåned)),
                 properties =
                     mapOf(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.task
 
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.log.IdUtils
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -51,6 +52,7 @@ class MånedligValutajusteringTask(
                     mapOf(
                         "fagsakId" to fagsakId.toString(),
                         "måned" to valutajusteringsMåned.toString(),
+                        "callId" to IdUtils.generateId(),
                     ).toProperties(),
             )
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Automatisk valutajustering tar utgangspunkt i siste iverksatte behandling. Dette blir feil for saker med nullutbetaling.

Fikser problemet ved å bruke siste vedtatte behandling i stedet for.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Vanskelig å teste fordi vi bruker en annen SQL spørring

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
