### PR TITLE
Kjør automatisk månedlig valutajustering på alle saker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/MånedligValutajusteringScheduler.kt
@@ -1,9 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
-import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.task.MånedligValutajusteringFinnFagsakerTask
@@ -22,7 +20,6 @@ class MånedligValutajusteringScheduler(
     val fagsakService: FagsakService,
     val leaderClientService: LeaderClientService,
     val taskRepository: TaskRepositoryWrapper,
-    private val unleashService: UnleashNextMedContextService,
 ) {
     private val logger = LoggerFactory.getLogger(MånedligValutajusteringScheduler::class.java)
 
@@ -40,11 +37,6 @@ class MånedligValutajusteringScheduler(
 
     fun lagMånedligValutajusteringTask(triggerTid: LocalDateTime) {
         val inneværendeMåned = YearMonth.now()
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ALLE_SAKER)) {
-            logger.info("FeatureToggle ${FeatureToggleConfig.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ALLE_SAKER} er skrudd av. Avbryter månedlig valutajustering.")
-            return
-        }
-
         logger.info("Kjører scheduled månedlig valutajustering for $inneværendeMåned")
         taskRepository.save(
             MånedligValutajusteringFinnFagsakerTask.lagTask(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -45,8 +45,7 @@ class MånedligValutajusteringFinnFagsakerTask(
 
         val fagsakerMedLøpendeValutakurs = behandlingService.hentAlleFagsakerMedLøpendeValutakursIMåned(data.måned)
 
-        // Hardkoder denne til å kun ta 1000 behanldinger i første omgang slik at vi er helt sikre på at vi ikke kjører på alle behandlinger mens vi tester.
-        fagsakerMedLøpendeValutakurs.take(1000).forEach { fagsakId ->
+        fagsakerMedLøpendeValutakurs.forEach { fagsakId ->
             val sisteVedtatteBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId) ?: throw Feil("Fant ikke siste vedtatte behandling for $fagsakId")
             val valutakurser = valutakursService.hentValutakurser(BehandlingId(sisteVedtatteBehandling.id))
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringFinnFagsakerTask.kt
@@ -1,12 +1,9 @@
 package no.nav.familie.ba.sak.task
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
-import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.erAlleValutakurserOppdaterteIMåned
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.IdUtils
@@ -45,16 +42,7 @@ class MånedligValutajusteringFinnFagsakerTask(
 
         val fagsakerMedLøpendeValutakurs = behandlingService.hentAlleFagsakerMedLøpendeValutakursIMåned(data.måned)
 
-        fagsakerMedLøpendeValutakurs.forEach { fagsakId ->
-            val sisteVedtatteBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId) ?: throw Feil("Fant ikke siste vedtatte behandling for $fagsakId")
-            val valutakurser = valutakursService.hentValutakurser(BehandlingId(sisteVedtatteBehandling.id))
-
-            if (!valutakurser.erAlleValutakurserOppdaterteIMåned(data.måned)) {
-                taskRepository.save(MånedligValutajusteringTask.lagTask(fagsakId, data.måned))
-            } else {
-                logger.info("Valutakursene er allerede oppdatert for fagsak $fagsakId. Hopper over")
-            }
-        }
+        fagsakerMedLøpendeValutakurs.forEach { taskRepository.save(MånedligValutajusteringTask.lagTask(it, data.måned)) }
     }
 
     companion object {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Skrur på funksjonalitet for å starte månedlig valutajustering første virkedag hver måned. Tidligere har dette ligget bak en toggle og kun kjørt et mindretall av sakene i en startfase. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
