### PR TITLE
Ikke kjør automatisk valutajustering som fører til etterutbetaling eller feilutbetaling

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/MockAutovedtakMånedligValutajusteringService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/MockAutovedtakMånedligValutajusteringService.kt
@@ -45,5 +45,6 @@ fun mockAutovedtakMånedligValutajusteringService(
         snikeIKøenService = cucumberMock.snikeIKøenService,
         localDateProvider = cucumberMock.mockedDateProvider,
         valutakursService = cucumberMock.valutakursService,
+        simuleringService = cucumberMock.simuleringService,
     )
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSimuleringService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSimuleringService.kt
@@ -3,11 +3,14 @@
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
+import java.math.BigDecimal
 
 fun mockSimuleringService(): SimuleringService {
     val simuleringService = mockk<SimuleringService>()
     every { simuleringService.oppdaterSimuleringPåBehandling(any()) } returns emptyList()
     every { simuleringService.hentSimuleringPåBehandling(any()) } returns emptyList()
     every { simuleringService.oppdaterSimuleringPåBehandlingVedBehov(any()) } returns emptyList()
+    every { simuleringService.hentEtterbetaling(any<Long>()) } returns BigDecimal.ZERO
+    every { simuleringService.hentFeilutbetaling(any<Long>()) } returns BigDecimal.ZERO
     return simuleringService
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21237)

Automatisk valutajustering skal ikke gjøres dersom det fører til en etterutbetaling eller feilutbetaling

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Feilutbetaling og etterutbetaling hentes fra økonomi, så dette måtte i så fall måtte blitt mocket i en test, og vi hadde dermed endt opp med å teste at mocken funker

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
