### PR TITLE
Ikke kast feil ved blandet regelverk dersom det er månedlig valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -58,7 +58,7 @@ fun validerIkkeBlandetRegelverk(
     if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
         val feilmelding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna."
 
-        if (behandling.opprettetÅrsak == BehandlingÅrsak.SATSENDRING) {
+        if (behandling.opprettetÅrsak in listOf(BehandlingÅrsak.SATSENDRING, BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING)) {
             logger.warn("$feilmelding Gjelder $behandling")
         } else {
             throw FunksjonellFeil(melding = feilmelding)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21410)

Vi har en validering som stopper saker fra å ha forskjellig regelverk på søker og barn. Denne valideringen har ikke alltid vært på, og vi har noen saker med blandet regelverk. I de sakene blir resultatet det samme som om begge partene har nasjonalt regelverk. 

Siden vi nå har fått en validering stoppes disse sakene ved månedlig valutajustering. 

Endrer så vi hopper over valideringen ved månedlig valutajustering.
