### PR TITLE
Bugfix: endringstidspunkt ved opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -170,7 +170,7 @@ private fun VedtaksperiodeGrunnlagForPerson?.erLik(
 
         is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget ->
             grunnlagForVedtaksperiodeForrigeBehandling is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget &&
-                this.vilkårResultaterForVedtaksperiode.toSet() == grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode.toSet()
+                this.vilkårResultaterForVedtaksperiode.erLikUtenomTom(grunnlagForVedtaksperiodeForrigeBehandling.vilkårResultaterForVedtaksperiode)
 
         null -> grunnlagForVedtaksperiodeForrigeBehandling == null
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -18,7 +18,6 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.parseDato
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriDato
 import no.nav.familie.ba.sak.cucumber.mock.mockAutovedtakMånedligValutajusteringService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -533,8 +532,6 @@ class BegrunnelseTeksterStepDefinition {
     ) {
         val fagsak = fagsaker[fagsakId]!!
 
-        val forrigeBehandling = behandlinger.values.filter { it.fagsak.id == fagsak.id && it.status == BehandlingStatus.AVSLUTTET }.maxByOrNull { it.id } ?: error("Finner ikke forrige behandling")
-
         val svarFraEcbMock = lagSvarFraEcbMock(dataTable)
 
         mockAutovedtakMånedligValutajusteringService(
@@ -559,7 +556,7 @@ class BegrunnelseTeksterStepDefinition {
     }
 
     @Så("forvent at endringstidspunktet er {} for behandling {}")
-    fun `generer vedtaksperioder fors `(
+    fun `forvent at endringstidspunktet er for behandling`(
         forventetEndringstidspunktString: String,
         behandlingId: Long,
     ) {
@@ -567,7 +564,7 @@ class BegrunnelseTeksterStepDefinition {
         val forrigeBehandlingId = behandlingTilForrigeBehandling[behandlingId]
         val grunnlagForBegrunnelser = hentGrunnlagForBegrunnelser(behandlingId, vedtak, forrigeBehandlingId)
 
-        val faktiskEntringstidspunkt =
+        val faktiskEndringstidspunkt =
             utledEndringstidspunkt(
                 behandlingsGrunnlagForVedtaksperioder = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioder,
                 behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
@@ -575,7 +572,7 @@ class BegrunnelseTeksterStepDefinition {
 
         val forventetEndringstidspunkt = parseNullableDato(forventetEndringstidspunktString) ?: error("Så forvent følgende endringstidspunkt {} forventer en dato")
 
-        assertThat(forventetEndringstidspunkt).isEqualTo(faktiskEntringstidspunkt)
+        assertThat(faktiskEndringstidspunkt).isEqualTo(forventetEndringstidspunkt)
     }
 }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -48,6 +48,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilUtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.utledEndringstidspunkt
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.hentGyldigeBegrunnelserForPeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.BehandlingsGrunnlagForVedtaksperioder
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.genererVedtaksperioder
@@ -555,6 +556,26 @@ class BegrunnelseTeksterStepDefinition {
             .usingRecursiveComparison()
             .ignoringFieldsMatchingRegexes(".*endretTidspunkt", ".*opprettetTidspunkt", ".*id")
             .isEqualTo(forventedeValutakurser[behandlingId]!!.sortedBy { it.valutakursdato })
+    }
+
+    @Så("forvent at endringstidspunktet er {} for behandling {}")
+    fun `generer vedtaksperioder fors `(
+        forventetEndringstidspunktString: String,
+        behandlingId: Long,
+    ) {
+        val vedtak = vedtaksliste.find { it.behandling.id == behandlingId && it.aktiv } ?: error("Finner ikke vedtak")
+        val forrigeBehandlingId = behandlingTilForrigeBehandling[behandlingId]
+        val grunnlagForBegrunnelser = hentGrunnlagForBegrunnelser(behandlingId, vedtak, forrigeBehandlingId)
+
+        val faktiskEntringstidspunkt =
+            utledEndringstidspunkt(
+                behandlingsGrunnlagForVedtaksperioder = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioder,
+                behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
+            )
+
+        val forventetEndringstidspunkt = parseNullableDato(forventetEndringstidspunktString) ?: error("Så forvent følgende endringstidspunkt {} forventer en dato")
+
+        assertThat(forventetEndringstidspunkt).isEqualTo(faktiskEntringstidspunkt)
     }
 }
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/endringstidspunkt/endringstidspunkt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/endringstidspunkt/endringstidspunkt.feature
@@ -1,7 +1,7 @@
 ﻿# language: no
 # encoding: UTF-8
 
-Egenskap: Plassholdertekst for egenskap - IKcO6bJvHH
+Egenskap: Endringstidspunkt
 
   Bakgrunn:
     Gitt følgende fagsaker for begrunnelse
@@ -20,7 +20,7 @@ Egenskap: Plassholdertekst for egenskap - IKcO6bJvHH
       | 2            | 1       | SØKER      | 06.07.1992  |              |
       | 2            | 2       | BARN       | 06.08.2020  |              |
 
-  Scenario: Plassholdertekst for scenario - x5xXxEy34h
+  Scenario: Skal sette opphørsdato som første endringstidspunkt
     Og følgende dagens dato 06.06.2024
     Og lag personresultater for begrunnelse for behandling 1
     Og lag personresultater for begrunnelse for behandling 2
@@ -60,12 +60,12 @@ Egenskap: Plassholdertekst for egenskap - IKcO6bJvHH
 
     Og med utenlandsk periodebeløp for begrunnelse
       | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
-      | 2       | 06.2023     | 12.2023     | 1            | 500   | PLN         | MÅNEDLIG  | PL              |
-      | 2       | 01.2024     |           | 1            | 800   | PLN         | MÅNEDLIG  | PL              |
-      | 2       | 05.2022     | 01.2023     | 1            | 500   | PLN         | MÅNEDLIG  | PL              |
-      | 2       | 06.2023     | 12.2023     | 2            | 500   | PLN         | MÅNEDLIG  | PL              |
-      | 2       | 05.2022     | 01.2023     | 2            | 500   | PLN         | MÅNEDLIG  | PL              |
-      | 2       | 01.2024     | 05.2024     | 2            | 800   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 06.2023   | 12.2023   | 1            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 01.2024   |           | 1            | 800   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 05.2022   | 01.2023   | 1            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 06.2023   | 12.2023   | 2            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 05.2022   | 01.2023   | 2            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 01.2024   | 05.2024   | 2            | 800   | PLN         | MÅNEDLIG  | PL              |
 
     Og med valutakurs for begrunnelse
       | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         |
@@ -74,18 +74,7 @@ Egenskap: Plassholdertekst for egenskap - IKcO6bJvHH
       | 2       | 01.06.2023 |            | 1            | 2023-12-29     | PLN         | 2.5902753773 |
       | 2       | 01.05.2022 | 31.12.2022 | 2            | 2022-12-30     | PLN         | 2.2461545035 |
       | 2       | 01.01.2023 | 31.01.2023 | 2            | 2023-12-29     | PLN         | 2.5902753773 |
-      | 2       | 01.06.2023 | 30.06.2023 | 2            | 2023-05-31     | PLN         | 2.6460280374 |
-      | 2       | 01.07.2023 | 31.07.2023 | 2            | 2023-06-30     | PLN         | 2.6367486708 |
-      | 2       | 01.08.2023 | 31.08.2023 | 2            | 2023-07-31     | PLN         | 2.5369866122 |
-      | 2       | 01.09.2023 | 30.09.2023 | 2            | 2023-08-31     | PLN         | 2.5921697670 |
-      | 2       | 01.10.2023 | 31.10.2023 | 2            | 2023-09-29     | PLN         | 2.4314543137 |
-      | 2       | 01.11.2023 | 30.11.2023 | 2            | 2023-10-31     | PLN         | 2.6739105957 |
-      | 2       | 01.12.2023 | 31.12.2023 | 2            | 2023-11-30     | PLN         | 2.6948723845 |
-      | 2       | 01.01.2024 | 31.01.2024 | 2            | 2023-12-29     | PLN         | 2.5902753773 |
-      | 2       | 01.02.2024 | 29.02.2024 | 2            | 2024-01-31     | PLN         | 2.6196630510 |
-      | 2       | 01.03.2024 | 31.03.2024 | 2            | 2024-02-29     | PLN         | 2.6596926495 |
-      | 2       | 01.04.2024 | 30.04.2024 | 2            | 2024-03-27     | PLN         | 2.7075414851 |
-      | 2       | 01.05.2024 | 31.05.2024 | 2            | 2024-04-30     | PLN         | 2.7363472139 |
+      | 2       | 01.06.2023 |            | 2            | 2023-12-29     | PLN         | 2.5902753773 |
 
     Og med andeler tilkjent ytelse for begrunnelse
       | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
@@ -100,17 +89,8 @@ Egenskap: Plassholdertekst for egenskap - IKcO6bJvHH
       | 2       | 2            | 01.03.2022 | 30.04.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
       | 2       | 2            | 01.05.2022 | 31.12.2022 | 553   | ORDINÆR_BARNETRYGD | 100     | 1676 |
       | 2       | 2            | 01.01.2023 | 31.01.2023 | 381   | ORDINÆR_BARNETRYGD | 100     | 1676 |
-      | 2       | 2            | 01.06.2023 | 30.06.2023 | 400   | ORDINÆR_BARNETRYGD | 100     | 1723 |
-      | 2       | 2            | 01.07.2023 | 31.07.2023 | 448   | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.08.2023 | 31.08.2023 | 498   | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.09.2023 | 30.09.2023 | 470   | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.10.2023 | 31.10.2023 | 551   | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.11.2023 | 30.11.2023 | 430   | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.12.2023 | 31.12.2023 | 419   | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.01.2024 | 31.01.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.02.2024 | 29.02.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.03.2024 | 31.03.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.04.2024 | 30.04.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
-      | 2       | 2            | 01.05.2024 | 31.05.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.06.2023 | 30.06.2023 | 428   | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 2       | 2            | 01.07.2023 | 31.12.2023 | 471   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.01.2024 | 31.05.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
 
-    Så forvent at endringstidspunktet er 01.12.2023 for behandling 2
+    Så forvent at endringstidspunktet er 01.06.2024 for behandling 2

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/test.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/test.feature
@@ -1,0 +1,116 @@
+﻿# language: no
+# encoding: UTF-8
+
+Egenskap: Plassholdertekst for egenskap - IKcO6bJvHH
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype | Status  |
+      | 1        | NORMAL     | LØPENDE |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | ÅRLIG_KONTROLL   | Nei                       | EØS                 | AVSLUTTET         |
+      | 2            | 1        | 1                   | ENDRET_OG_OPPHØRT   | NYE_OPPLYSNINGER | Nei                       | EØS                 | UTREDES           |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 06.07.1992  |              |
+      | 1            | 2       | BARN       | 06.08.2020  |              |
+      | 2            | 1       | SØKER      | 06.07.1992  |              |
+      | 2            | 2       | BARN       | 06.08.2020  |              |
+
+  Scenario: Plassholdertekst for scenario - x5xXxEy34h
+    Og følgende dagens dato 06.06.2024
+    Og lag personresultater for begrunnelse for behandling 1
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD   |                              | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.02.2022 | 31.01.2023 | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 08.05.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | UNDER_18_ÅR      |                              | 06.08.2020 | 05.08.2038 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | GIFT_PARTNERSKAP |                              | 06.08.2020 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | LOVLIG_OPPHOLD   |                              | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.02.2022 | 31.01.2023 | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | LOVLIG_OPPHOLD   |                              | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 08.05.2023 | 31.05.2024 | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | UNDER_18_ÅR      |                              | 06.08.2020 | 05.08.2038 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | GIFT_PARTNERSKAP |                              | 06.08.2020 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.02.2022 | 31.05.2024 | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | LOVLIG_OPPHOLD   |                              | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.02.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+    Og med kompetanser for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.03.2022 | 30.04.2022 | NORGE_ER_PRIMÆRLAND   | 1            | ARBEIDER         | INAKTIV                   | NO                    | PL                             | PL                  |
+      | 2       | 01.05.2022 | 31.01.2023 | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | PL                             | PL                  |
+      | 2       | 01.06.2023 |            | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | PL                             | PL                  |
+      | 2       | 01.03.2022 | 30.04.2022 | NORGE_ER_PRIMÆRLAND   | 2            | ARBEIDER         | INAKTIV                   | NO                    | PL                             | PL                  |
+      | 2       | 01.05.2022 | 31.01.2023 | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | PL                             | PL                  |
+      | 2       | 01.06.2023 | 31.05.2024 | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | PL                             | PL                  |
+
+    Og med utenlandsk periodebeløp for begrunnelse
+      | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 06.2023     | 12.2023     | 1            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 01.2024     |           | 1            | 800   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 05.2022     | 01.2023     | 1            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 06.2023     | 12.2023     | 2            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 05.2022     | 01.2023     | 2            | 500   | PLN         | MÅNEDLIG  | PL              |
+      | 2       | 01.2024     | 05.2024     | 2            | 800   | PLN         | MÅNEDLIG  | PL              |
+
+    Og med valutakurs for begrunnelse
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         |
+      | 2       | 01.05.2022 | 31.12.2022 | 1            | 2022-12-30     | PLN         | 2.2461545035 |
+      | 2       | 01.01.2023 | 31.01.2023 | 1            | 2023-12-29     | PLN         | 2.5902753773 |
+      | 2       | 01.06.2023 |            | 1            | 2023-12-29     | PLN         | 2.5902753773 |
+      | 2       | 01.05.2022 | 31.12.2022 | 2            | 2022-12-30     | PLN         | 2.2461545035 |
+      | 2       | 01.01.2023 | 31.01.2023 | 2            | 2023-12-29     | PLN         | 2.5902753773 |
+      | 2       | 01.06.2023 | 30.06.2023 | 2            | 2023-05-31     | PLN         | 2.6460280374 |
+      | 2       | 01.07.2023 | 31.07.2023 | 2            | 2023-06-30     | PLN         | 2.6367486708 |
+      | 2       | 01.08.2023 | 31.08.2023 | 2            | 2023-07-31     | PLN         | 2.5369866122 |
+      | 2       | 01.09.2023 | 30.09.2023 | 2            | 2023-08-31     | PLN         | 2.5921697670 |
+      | 2       | 01.10.2023 | 31.10.2023 | 2            | 2023-09-29     | PLN         | 2.4314543137 |
+      | 2       | 01.11.2023 | 30.11.2023 | 2            | 2023-10-31     | PLN         | 2.6739105957 |
+      | 2       | 01.12.2023 | 31.12.2023 | 2            | 2023-11-30     | PLN         | 2.6948723845 |
+      | 2       | 01.01.2024 | 31.01.2024 | 2            | 2023-12-29     | PLN         | 2.5902753773 |
+      | 2       | 01.02.2024 | 29.02.2024 | 2            | 2024-01-31     | PLN         | 2.6196630510 |
+      | 2       | 01.03.2024 | 31.03.2024 | 2            | 2024-02-29     | PLN         | 2.6596926495 |
+      | 2       | 01.04.2024 | 30.04.2024 | 2            | 2024-03-27     | PLN         | 2.7075414851 |
+      | 2       | 01.05.2024 | 31.05.2024 | 2            | 2024-04-30     | PLN         | 2.7363472139 |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.03.2022 | 30.04.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 1            | 01.05.2022 | 31.12.2022 | 553   | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 1            | 01.01.2023 | 31.01.2023 | 381   | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 1            | 01.06.2023 | 30.06.2023 | 428   | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 2       | 1            | 01.07.2023 | 31.12.2023 | 471   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.01.2024 | 31.07.2026 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.08.2026 | 31.07.2038 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+      | 2       | 2            | 01.03.2022 | 30.04.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 2            | 01.05.2022 | 31.12.2022 | 553   | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 2            | 01.01.2023 | 31.01.2023 | 381   | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 2            | 01.06.2023 | 30.06.2023 | 400   | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 2       | 2            | 01.07.2023 | 31.07.2023 | 448   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.08.2023 | 31.08.2023 | 498   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.09.2023 | 30.09.2023 | 470   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.10.2023 | 31.10.2023 | 551   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.11.2023 | 30.11.2023 | 430   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.12.2023 | 31.12.2023 | 419   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.01.2024 | 31.01.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.02.2024 | 29.02.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.03.2024 | 31.03.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.04.2024 | 30.04.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.05.2024 | 31.05.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+
+    Så forvent at endringstidspunktet er 01.12.2023 for behandling 2


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21290

Vi oppdaget en prodfeil hvor en sak fikk automatisk valutajustering lenger tilbake i tid enn forventet. Grunnen til dette var at endringstidspunktet var feil. Det eneste som hadde skjedd i behandlingen var opphør på et vilkår. Når den gamle koden da sammenlignet om alle vilkår var like før og nå for perioden 02.23-05.23 (som var ikke oppfylt for personen), fikk den feil svar, fordi tom-dato var forskjellig på vilkår som strakk seg over denne perioden. Sørger nå for at vi ser bort i fra tom-datoene når vi sammenligner vilkår - akkurat sånn som blir gjort på perioder som er innvilget.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._
Nei

Dette er fikset sammen med @halvorbmundal @MagnusTonnessen @idaame 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
