### PR TITLE
Oppdater simulering ved behov før vi henter etter- og feilutbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
@@ -90,6 +90,8 @@ class AutovedtakMånedligValutajusteringService(
                 fagsakId = fagsakId,
             )
 
+        simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingEtterBehandlingsresultat.id)
+
         val etterutbetaling = simuleringService.hentEtterbetaling(behandlingEtterBehandlingsresultat.id)
         val feilutbetaling by lazy { simuleringService.hentFeilutbetaling(behandlingEtterBehandlingsresultat.id) }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I automatisk valutajustering kaster vi en feil dersom det er en etterutbetaling eller feilutbetaling.
For at disse skal bli korrekt oppdaterer vi simuleringen før vi henter verdiene

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ville bare endt opp med å teste mockingen

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
