### PR TITLE
Forvalter-endepunkter for patching av upb med feil utbetalingsland

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -371,9 +371,18 @@ class ForvalterController(
     }
 
     @PostMapping("/finn-korrigerte-utenlandske-periodebeløp")
-    @Operation(summary = "Kjører korrigerUtbetalingslandForUtenlandskPeriodebeløp slik at utenlandske periodebeløp med utbetalingsland 'NO' eller null blir korrigert")
-    fun kjørKorrigerUtbetalingslandForUtenlandskePeriodebeløp(): ResponseEntity<Ressurs<UtenlandskePeriodebeløpEndringerOgBehandlingerMedFeilIKompetanse>> {
+    @Operation(summary = "Kjører finnUtenlandskePeriodebeløpSomSkalKorrigeres for å finne alle utenlandske periodebeløp med utbetalingsland 'NO' eller null")
+    fun kjørfinnUtenlandskePeriodebeløpSomSkalKorrigeres(): ResponseEntity<Ressurs<UtenlandskePeriodebeløpEndringerOgBehandlingerMedFeilIKompetanse>> {
         val utenlandskePeriodebeløpEndringer = forvalterService.finnUtenlandskePeriodebeløpSomSkalKorrigeres()
         return ResponseEntity.ok(Ressurs.success(utenlandskePeriodebeløpEndringer))
+    }
+
+    @PostMapping("/korriger-utenlandske-periodebeløp")
+    @Operation(summary = "Kjører korrigerUtenlandskePeriodebeløp slik at utenlandske periodebeløp med utbetalingsland 'NO' eller null blir korrigert")
+    fun kjørkorrigerUtenlandskePeriodebeløpForBehandlinger(
+        @RequestBody behandlinger: List<Long>,
+    ): ResponseEntity<Ressurs<String>> {
+        forvalterService.korrigerUtenlandskePeriodebeløp(behandlinger)
+        return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -369,4 +369,11 @@ class ForvalterController(
         }
         return ResponseEntity.ok(Ressurs.success("Kjørt ok"))
     }
+
+    @PostMapping("/finn-korrigerte-utenlandske-periodebeløp")
+    @Operation(summary = "Kjører korrigerUtbetalingslandForUtenlandskPeriodebeløp slik at utenlandske periodebeløp med utbetalingsland 'NO' eller null blir korrigert")
+    fun kjørKorrigerUtbetalingslandForUtenlandskePeriodebeløp(): ResponseEntity<Ressurs<List<UtenlandskPeriodebeløpEndring>>> {
+        val utenlandskePeriodebeløpEndringer = forvalterService.finnUtenlandskePeriodebeløpSomSkalKorrigeres()
+        return ResponseEntity.ok(Ressurs.success(utenlandskePeriodebeløpEndringer))
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.Autovedt
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringScheduler
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatusScheduler
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
@@ -372,7 +373,7 @@ class ForvalterController(
 
     @PostMapping("/finn-korrigerte-utenlandske-periodebeløp")
     @Operation(summary = "Kjører korrigerUtbetalingslandForUtenlandskPeriodebeløp slik at utenlandske periodebeløp med utbetalingsland 'NO' eller null blir korrigert")
-    fun kjørKorrigerUtbetalingslandForUtenlandskePeriodebeløp(): ResponseEntity<Ressurs<List<UtenlandskPeriodebeløpEndring>>> {
+    fun kjørKorrigerUtbetalingslandForUtenlandskePeriodebeløp(): ResponseEntity<Ressurs<Pair<List<UtenlandskPeriodebeløpEndring>, List<Kompetanse>>>> {
         val utenlandskePeriodebeløpEndringer = forvalterService.finnUtenlandskePeriodebeløpSomSkalKorrigeres()
         return ResponseEntity.ok(Ressurs.success(utenlandskePeriodebeløpEndringer))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -20,7 +20,6 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.Autovedt
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringScheduler
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatusScheduler
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
@@ -373,7 +372,7 @@ class ForvalterController(
 
     @PostMapping("/finn-korrigerte-utenlandske-periodebeløp")
     @Operation(summary = "Kjører korrigerUtbetalingslandForUtenlandskPeriodebeløp slik at utenlandske periodebeløp med utbetalingsland 'NO' eller null blir korrigert")
-    fun kjørKorrigerUtbetalingslandForUtenlandskePeriodebeløp(): ResponseEntity<Ressurs<Pair<List<UtenlandskPeriodebeløpEndring>, List<Kompetanse>>>> {
+    fun kjørKorrigerUtbetalingslandForUtenlandskePeriodebeløp(): ResponseEntity<Ressurs<UtenlandskePeriodebeløpEndringerOgBehandlingerMedFeilIKompetanse>> {
         val utenlandskePeriodebeløpEndringer = forvalterService.finnUtenlandskePeriodebeløpSomSkalKorrigeres()
         return ResponseEntity.ok(Ressurs.success(utenlandskePeriodebeløpEndringer))
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -291,7 +291,7 @@ class ForvalterService(
 
         val utenlandskePeriodebeløpPerBehandling = utenlandskePeriodebeløpMedFeilUtbetalingsland.groupBy { it.behandlingId }
 
-        val kompetanserMedFeil: List<Kompetanse> = emptyList()
+        val kompetanserMedFeil: MutableList<Kompetanse> = mutableListOf()
 
         val korrigerteUtenlandskePeriodebeløp =
             utenlandskePeriodebeløpPerBehandling.entries.flatMap { (behandlingId, utenlandskePeriodebeløp) ->
@@ -308,7 +308,7 @@ class ForvalterService(
                             else -> null
                         }
                     } catch (e: Exception) {
-                        kompetanserMedFeil.plus(kompetanse)
+                        kompetanserMedFeil.add(kompetanse!!)
                         null
                     }
                 }.flatMap { (_, tidslinjer) -> tidslinjer.perioder().mapNotNull { periode -> periode.innhold } }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseRepository.kt
@@ -7,4 +7,7 @@ import org.springframework.data.jpa.repository.Query
 interface KompetanseRepository : PeriodeOgBarnSkjemaRepository<Kompetanse> {
     @Query("SELECT k FROM Kompetanse k WHERE k.behandlingId = :behandlingId")
     override fun finnFraBehandlingId(behandlingId: Long): Collection<Kompetanse>
+
+    @Query("SELECT k FROM Kompetanse k WHERE k.behandlingId in :behandlinger and k.resultat = 'NORGE_ER_SEKUNDÆRLAND'")
+    fun hentSekundærlandsKompetanserForBehandlinger(behandlinger: Set<Long>): Collection<Kompetanse>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepository.kt
@@ -6,4 +6,7 @@ import org.springframework.data.jpa.repository.Query
 interface UtenlandskPeriodebeløpRepository : PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp> {
     @Query("SELECT upb FROM UtenlandskPeriodebeløp upb WHERE upb.behandlingId = :behandlingId")
     override fun finnFraBehandlingId(behandlingId: Long): Collection<UtenlandskPeriodebeløp>
+
+    @Query("SELECT upb FROM UtenlandskPeriodebeløp  upb WHERE (upb.utbetalingsland = 'NO' or upb.utbetalingsland = null)")
+    fun hentUtenlandskePeriodebeløpMedFeilUtbetalingsland(): Collection<UtenlandskPeriodebeløp>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepository.kt
@@ -7,6 +7,6 @@ interface UtenlandskPeriodebeløpRepository : PeriodeOgBarnSkjemaRepository<Uten
     @Query("SELECT upb FROM UtenlandskPeriodebeløp upb WHERE upb.behandlingId = :behandlingId")
     override fun finnFraBehandlingId(behandlingId: Long): Collection<UtenlandskPeriodebeløp>
 
-    @Query("SELECT upb FROM UtenlandskPeriodebeløp  upb WHERE (upb.utbetalingsland = 'NO' or upb.utbetalingsland = null)")
+    @Query("SELECT upb FROM UtenlandskPeriodebeløp  upb WHERE (upb.utbetalingsland = 'NO' or upb.utbetalingsland is null)")
     fun hentUtenlandskePeriodebeløpMedFeilUtbetalingsland(): Collection<UtenlandskPeriodebeløp>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/KorrigerUtenlandskePeriodebeløpTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/KorrigerUtenlandskePeriodebeløpTask.kt
@@ -1,0 +1,26 @@
+package no.nav.familie.ba.sak.task
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ba.sak.internal.ForvalterService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = KorrigerUtenlandskePeriodebeløpTask.TASK_STEP_TYPE,
+    beskrivelse = "Korriger utenlandske periodebeløp med feil",
+    maxAntallFeil = 1,
+)
+class KorrigerUtenlandskePeriodebeløpTask(val forvalterService: ForvalterService) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val behandlinger: List<Long> = objectMapper.readValue(task.payload)
+        forvalterService.korrigerUtenlandskePeriodebeløp(behandlinger)
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "korrigerUtenlandskePeriodebeløp"
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -23,6 +23,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
@@ -94,6 +96,12 @@ class ForvalterServiceTest {
 
     @MockK
     lateinit var infotrygdService: InfotrygdService
+
+    @MockK
+    lateinit var kompetanseRepository: KompetanseRepository
+
+    @MockK
+    lateinit var utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository
 
     @InjectMockKs
     lateinit var forvalterService: ForvalterService


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ca 2500 utenlandske periodebeløp har feil verdi i feltet `utbetalingsland`. Enten er det satt til `NO` eller så er det satt til `null`, og begge disse skal ikke være mulig.

Legger her inn funksjonalitet for å finne og korrigere de utenlandske periodebeløpene med feil. Starter med noen få og justerer opp dersom det ser bra ut. Har testet ok i preprod.

Dette må kjøres før vi kan skru på nye regler for utledning av utbetalingsland.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
