### PR TITLE
Hopp over validering av 18 års vilkåret for månedlig valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -338,6 +338,8 @@ enum class BehandlingÅrsak(val visningsnavn: String) {
     fun erOmregningsårsak(): Boolean =
         this == OMREGNING_6ÅR || this == OMREGNING_18ÅR || this == OMREGNING_SMÅBARNSTILLEGG
 
+    fun erMånedligValutajustering(): Boolean = this == MÅNEDLIG_VALUTAJUSTERING
+
     fun hentOverstyrtDokumenttittelForOmregningsbehandling(): String? {
         return when (this) {
             OMREGNING_6ÅR -> "Vedtak om endret barnetrygd - barn 6 år"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -74,7 +74,7 @@ fun valider18ÅrsVilkårEksistererFraFødselsdato(
     vilkårsvurdering.personResultater.forEach { personResultat ->
         val person = søkerOgBarn.find { it.aktør == personResultat.aktør }
         if (person?.type == PersonType.BARN && !personResultat.vilkårResultater.finnesUnder18VilkårFraFødselsdato(person.fødselsdato)) {
-            if (behandling.erSatsendring() || behandling.opprettetÅrsak.erOmregningsårsak()) {
+            if (behandling.erSatsendring() || behandling.opprettetÅrsak.erOmregningsårsak() || behandling.opprettetÅrsak.erMånedligValutajustering()) {
                 secureLogger.warn(
                     "Fødselsdato ${person.fødselsdato} ulik fom ${
                         personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Månedlig valutajustering stoppes dersom barnets fødselsdato ikke stemmer overens med 18-års vilkåret. Legger her inn at vi ikke stopper behandlingen dersom opprettetÅrsak er månedlig valutajustering, slik vi også gjør for satsendring og omregninger.

Dette gjør vi fordi vi allikevel ønsker å korrigere utbetalingsbeløpet for neste måned for å unngå feilutbetalinger. Vi har andre valideringer i senere i løypa som passer på at vi ikke endrer noe annet enn beløpet for inneværende måned. Endring/oppdatering av 18-års vilkåret kan rettes ved neste revurdering/årlig kontroll. Vi logger fortsatt ut at fødselsdato ikke stemmer overens med 18-års vilkåret.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
