### PR TITLE
Reverterer at vi hopper over validering av 18-års vilkåret dersom det er månedlig valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -338,8 +338,6 @@ enum class BehandlingÅrsak(val visningsnavn: String) {
     fun erOmregningsårsak(): Boolean =
         this == OMREGNING_6ÅR || this == OMREGNING_18ÅR || this == OMREGNING_SMÅBARNSTILLEGG
 
-    fun erMånedligValutajustering(): Boolean = this == MÅNEDLIG_VALUTAJUSTERING
-
     fun hentOverstyrtDokumenttittelForOmregningsbehandling(): String? {
         return when (this) {
             OMREGNING_6ÅR -> "Vedtak om endret barnetrygd - barn 6 år"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -74,7 +74,7 @@ fun valider18ÅrsVilkårEksistererFraFødselsdato(
     vilkårsvurdering.personResultater.forEach { personResultat ->
         val person = søkerOgBarn.find { it.aktør == personResultat.aktør }
         if (person?.type == PersonType.BARN && !personResultat.vilkårResultater.finnesUnder18VilkårFraFødselsdato(person.fødselsdato)) {
-            if (behandling.erSatsendring() || behandling.opprettetÅrsak.erOmregningsårsak() || behandling.opprettetÅrsak.erMånedligValutajustering()) {
+            if (behandling.erSatsendring() || behandling.opprettetÅrsak.erOmregningsårsak()) {
                 secureLogger.warn(
                     "Fødselsdato ${person.fødselsdato} ulik fom ${
                         personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I https://github.com/navikt/familie-ba-sak/pull/4630 , hoppet vi over validering av 18-årsvilkåret for månedlig valutajusterings-behandlinger. Litt senere valideres det samme uansett på nytt. Trodde i utgangspunktet at vi også hoppet over alle disse valideringene for satsendring, men ser nå at vi validerer vilkårene også for satsendring, så da reverserer jeg endringene her.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
