### PR TITLE
Fix: Bruke LocalDateTime som parameter fremfor LocalDate

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakRepository.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.vedtak
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 interface VedtakRepository : JpaRepository<Vedtak, Long> {
@@ -19,5 +18,5 @@ interface VedtakRepository : JpaRepository<Vedtak, Long> {
     fun finnVedtaksdatoForBehandling(behandlingId: Long): LocalDateTime?
 
     @Query("SELECT DISTINCT v.behandling.id FROM Vedtak v WHERE v.vedtaksdato > :dato AND v.aktiv = true")
-    fun finnBehandlingerMedVedtakEtterDato(dato: LocalDate): List<Long>
+    fun finnBehandlingerMedVedtakEtterDato(dato: LocalDateTime): List<Long>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @RestController
 @RequestMapping("/api/stonadsstatistikk")
@@ -49,7 +49,7 @@ class StønadsstatistikkController(
     @PostMapping(path = ["/send-til-dvh-vedtak-etter-dato"])
     @Transactional
     fun sendTilStønadsstatistikkAlleVedtakEtterDato(
-        @RequestBody(required = true) dato: LocalDate,
+        @RequestBody(required = true) dato: LocalDateTime,
     ) {
         val behandlingerEtterDato: List<Long> = vedtakRepository.finnBehandlingerMedVedtakEtterDato(dato = dato)
 


### PR DESCRIPTION
Relatert til: [NAV-21536](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21536)

### 💰 Hva skal gjøres, og hvorfor?
Vi får feilen 
```
Argument [2024-06-16] of type [java.time.LocalDate] did not match parameter type [java.time.LocalDateTime (n/a)]
```

Dette fordi vedtaksdato er av typen `LocalDateTime` og vi forsøker å sammenligne denne med innsendt `LocalDate`. Endrer derfor dato-parameter til `LocalDateTime`.

Tidligere PR denne retter: https://github.com/navikt/familie-ba-sak/pull/4636

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
