### PR TITLE
Oppdater valutakurs for beslutter i behandlingsresultatsteg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -84,6 +84,16 @@ class AutomatiskOppdaterValutakursService(
         endringstidspunkt = vedtaksperiodeService.finnEndringstidspunktForBehandling(behandlingId.id).toYearMonth(),
     )
 
+    @Transactional
+    fun oppdaterValutakurserEtterEndringstidspunkt(
+        behandling: Behandling,
+        utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>? = null,
+    ) = oppdaterValutakurserEtterEndringstidspunkt(
+        behandling = behandling,
+        utenlandskePeriodebeløp = utenlandskePeriodebeløp ?: utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandling.id),
+        endringstidspunkt = vedtaksperiodeService.finnEndringstidspunktForBehandling(behandling.id).toYearMonth(),
+    )
+
     private fun oppdaterValutakurserEtterEndringstidspunkt(
         behandling: Behandling,
         utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>,
@@ -200,6 +210,13 @@ class AutomatiskOppdaterValutakursService(
                 vurderingsstrategiForValutakurser = nyStrategi,
             ),
         )
+    }
+
+    @Transactional
+    fun oppdaterValutakurserOgSimulering(behandlingId: BehandlingId) {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId.id)
+        oppdaterValutakurserEtterEndringstidspunkt(behandling)
+        simuleringService.oppdaterSimuleringPåBehandling(behandling)
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursController.kt
@@ -37,6 +37,22 @@ class ValutakursController(
     private val automatiskOppdaterValutakursService: AutomatiskOppdaterValutakursService,
     private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
+    @PutMapping(path = ["{behandlingId}/oppdater-valutakurser-og-simulering-automatisk"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun oppdaterValutakurserOgSimuleringAutomatisk(
+        @PathVariable behandlingId: Long,
+    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
+        tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.UPDATE)
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.BESLUTTER,
+            handling = "Oppdaterer valutakurser og simulering automatisk",
+        )
+        tilgangService.validerErPåBeslutteVedtakSteg(behandlingId)
+
+        automatiskOppdaterValutakursService.oppdaterValutakurserOgSimulering(BehandlingId(behandlingId))
+
+        return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)))
+    }
+
     @PutMapping(path = ["{behandlingId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun oppdaterValutakurs(
         @PathVariable behandlingId: Long,

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -1,14 +1,17 @@
 package no.nav.familie.ba.sak.sikkerhet
 
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.RolleTilgangskontrollFeil
 import no.nav.familie.ba.sak.common.validerBehandlingKanRedigeres
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.RolleConfig
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.kjerne.steg.StegType
 import org.springframework.stereotype.Service
 
 @Service
@@ -156,5 +159,12 @@ class TilgangService(
 
     fun validerKanRedigereBehandling(behandlingId: Long) {
         validerBehandlingKanRedigeres(behandlingHentOgPersisterService.hentStatus(behandlingId))
+    }
+
+    fun validerErPåBeslutteVedtakSteg(behandlingId: Long) {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        if (behandling.status != BehandlingStatus.FATTER_VEDTAK && behandling.steg == StegType.BESLUTTE_VEDTAK) {
+            throw Feil(message = "Er ikke i riktig steg eller status. Forventer status FATTER_VEDTAK og steg BESLUTTE_VEDTAK")
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -21,12 +21,14 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTil
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
+import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
@@ -59,6 +61,7 @@ class BeslutteVedtakTest {
     private val valutakursRepository = mockk<ValutakursRepository>()
     private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
     private val simuleringService = mockk<SimuleringService>()
+    private val tilbakekrevingService = mockk<TilbakekrevingService>()
 
     val beslutteVedtak =
         BeslutteVedtak(
@@ -77,6 +80,7 @@ class BeslutteVedtakTest {
             valutakursRepository = valutakursRepository,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
             simuleringService = simuleringService,
+            tilbakekrevingService = tilbakekrevingService,
         )
 
     private val randomVilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
@@ -105,7 +109,7 @@ class BeslutteVedtakTest {
         every { vilkårsvurderingService.hentAktivForBehandling(any()) } returns randomVilkårsvurdering
         every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(any()) } returns randomVilkårsvurdering
         every { saksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "saksbehandlerNavn"
-        every { automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(any()) } just runs
+        every { automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(any<BehandlingId>()) } just runs
         every { unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER) } returns true
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -452,6 +452,7 @@ class CucumberMock(
             valutakursRepository = valutakursRepository,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
             simuleringService = simuleringService,
+            tilbakekrevingService = tilbakekrevingService,
         )
 
     val stegService =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-21578
Vi ønsker å oppdatere valutakurser i behandlingsresultatsteget når beslutter ser på behandling, slik at beslutter blir oppmerksom på om automatisk valutajustering fører til en feilutbetling som saksbehandler ikke har tatt stilling til

- Legger til endepunkt for å kunne automatisk oppdatere valutakurser og simulering som kalles når beslutter går inn på behandlingsresultatsteget
- Legger til validering i BeslutteVedtak-steg som kaster en feil dersom det er en feilutbetaling uten at det er en tilbakekreving

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Funksjoner som kalles er allerede testet

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
