### PR TITLE
Kast feil ved endret utbetaling for omregningsårsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
@@ -200,7 +200,7 @@ fun hentNesteSteg(
         return when (utførendeStegType) {
             REGISTRERE_PERSONGRUNNLAG -> VILKÅRSVURDERING
             VILKÅRSVURDERING -> BEHANDLINGSRESULTAT
-            BEHANDLINGSRESULTAT -> JOURNALFØR_VEDTAKSBREV
+            BEHANDLINGSRESULTAT -> hentStegEtterBehandlingsresultatForOmregning(endringerIUtbetaling)
             JOURNALFØR_VEDTAKSBREV -> DISTRIBUER_VEDTAKSBREV
             DISTRIBUER_VEDTAKSBREV -> FERDIGSTILLE_BEHANDLING
             FERDIGSTILLE_BEHANDLING -> BEHANDLING_AVSLUTTET
@@ -415,6 +415,13 @@ private fun hentStegEtterBeslutteVedtakForTekniskEndring(endringerIUtbetaling: E
     when (endringerIUtbetaling) {
         EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING -> IVERKSETT_MOT_OPPDRAG
         EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING -> FERDIGSTILLE_BEHANDLING
+        EndringerIUtbetalingForBehandlingSteg.IKKE_RELEVANT -> throw Feil("Endringer i utbetaling må utledes før man kan gå videre til neste steg.")
+    }
+
+private fun hentStegEtterBehandlingsresultatForOmregning(endringerIUtbetaling: EndringerIUtbetalingForBehandlingSteg): StegType =
+    when (endringerIUtbetaling) {
+        EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING -> JOURNALFØR_VEDTAKSBREV
+        EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING -> throw Feil("Det finnes endringer i utbetaling for behandling med omregningsårsak.")
         EndringerIUtbetalingForBehandlingSteg.IKKE_RELEVANT -> throw Feil("Endringer i utbetaling må utledes før man kan gå videre til neste steg.")
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingStegTest.kt
@@ -251,12 +251,42 @@ class BehandlingStegTest {
             assertEquals(it, steg)
             steg =
                 hentNesteSteg(
-                    behandling =
-                        lagBehandling(
-                            årsak = BehandlingÅrsak.OMREGNING_18ÅR,
-                        ),
+                    behandling = lagBehandling(årsak = BehandlingÅrsak.OMREGNING_18ÅR),
                     utførendeStegType = it,
+                    endringerIUtbetaling = EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING,
                 )
+        }
+    }
+
+    @Test
+    fun `Tester at man ikke får lov til å komme videre etter behandlingsresultat dersom det er endringer i utbetaling for omregningsårsak`() {
+        var steg = FØRSTE_STEG
+
+        listOf(
+            StegType.REGISTRERE_PERSONGRUNNLAG,
+            StegType.VILKÅRSVURDERING,
+            StegType.BEHANDLINGSRESULTAT,
+        ).forEach {
+            assertEquals(it, steg)
+            if (it == StegType.BEHANDLINGSRESULTAT) {
+                assertThrows<Feil> {
+                    hentNesteSteg(
+                        behandling = lagBehandling(årsak = BehandlingÅrsak.OMREGNING_18ÅR),
+                        utførendeStegType = it,
+                        endringerIUtbetaling = EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING,
+                    )
+                }
+            } else {
+                steg =
+                    hentNesteSteg(
+                        behandling =
+                            lagBehandling(
+                                årsak = BehandlingÅrsak.OMREGNING_18ÅR,
+                            ),
+                        utførendeStegType = it,
+                        endringerIUtbetaling = EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING,
+                    )
+            }
         }
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-21383

Behandlinger med omregningsårsak skal ikke føre til endring i utbetaling

Løser problemet ved å kaste feil etter behandlingsresultatsteg dersom det et endring i utbetaling

✅ Checklist
Har du husket alle punktene i listen?

[x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
[ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
[x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
