### PR TITLE
Forenkle valideringskode som sjekker at det ikke er noen endringer i andeler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -8,9 +8,12 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærTilOgMed
@@ -76,67 +79,58 @@ object BehandlingsresultatValideringUtils {
         nåMåned: YearMonth,
     ) {
         val forrigeMåned = nåMåned.minusMonths(1)
-        val andelerIFortidenTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
-        val andelerIFortidenForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
+        val andelerIFortidenTidslinje = andelerDenneBehandlingen.tilTidslinjerPerPersonOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
+        val andelerIFortidenForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerPersonOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
 
-        val erEndringTilbakeITidTidslinjer =
+        val endringerIAndelerTilbakeITidTidslinjer =
             andelerIFortidenTidslinje.outerJoin(andelerIFortidenForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
-                nyAndel?.kalkulertUtbetalingsbeløp != gammelAndel?.kalkulertUtbetalingsbeløp
-            }
-
-        erEndringTilbakeITidTidslinjer.forEach { _, erEndringTilbakeITidTidslinje ->
-            erEndringTilbakeITidTidslinje.perioder().forEach {
-                val erEndring = it.innhold == true
-                if (erEndring) {
-                    secureLogger.info(
-                        "Er endring i kalkulert utbetalt beløp i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
-                            "Andeler denne behandlingen: ${
-                                andelerDenneBehandlingen.sortedWith(
-                                    compareBy(
-                                        { it.aktør.aktørId },
-                                        { it.stønadFom },
-                                    ),
-                                )
-                            }\n" +
-                            "Andeler forrige behandling: ${
-                                andelerForrigeBehandling.sortedWith(
-                                    compareBy(
-                                        { it.aktør.aktørId },
-                                        { it.stønadFom },
-                                    ),
-                                )
-                            }",
-                    )
-                    throw Feil("Det er endringer i kalkulert utbetalt beløp som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
+                if (nyAndel?.kalkulertUtbetalingsbeløp != gammelAndel?.kalkulertUtbetalingsbeløp) {
+                    ErEndringIAndel(gammelAndel, nyAndel)
+                } else {
+                    IngenEndringIAndel
                 }
             }
-        }
+
+        endringerIAndelerTilbakeITidTidslinjer.kastFeilOgLoggVedEndringerIAndeler()
     }
 
     fun validerSatsErUendret(
         andelerDenneBehandlingen: List<AndelTilkjentYtelse>,
         andelerForrigeBehandling: List<AndelTilkjentYtelse>,
     ) {
-        val andelerDenneBehandlingTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType()
-        val andelerForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType()
+        val andelerDenneBehandlingTidslinje = andelerDenneBehandlingen.tilTidslinjerPerPersonOgType()
+        val andelerForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerPersonOgType()
 
-        val erEndringISatsTidslinjer =
+        val endringISatsTidslinjer =
             andelerDenneBehandlingTidslinje.outerJoin(andelerForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
-                nyAndel?.sats != gammelAndel?.sats
+                if (nyAndel?.sats != gammelAndel?.sats) {
+                    ErEndringIAndel(gammelAndel, nyAndel)
+                } else {
+                    IngenEndringIAndel
+                }
             }
 
-        erEndringISatsTidslinjer.forEach { _, erEndringISatsTidslinje ->
-            erEndringISatsTidslinje.perioder().forEach {
-                val erEndring = it.innhold == true
-                if (erEndring) {
+        endringISatsTidslinjer.kastFeilOgLoggVedEndringerIAndeler()
+    }
+
+    private fun Map<Pair<Aktør, YtelseType>, Tidslinje<EndringIAndel, Måned>>.kastFeilOgLoggVedEndringerIAndeler() {
+        this.forEach { _, endringIAndelTidslinje ->
+            endringIAndelTidslinje.perioder().forEach {
+                if (it.innhold is ErEndringIAndel) {
                     secureLogger.info(
-                        "Er endring i sats for andel i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
-                            "Andeler denne behandlingen: $andelerDenneBehandlingen\n" +
-                            "Andeler forrige behandling: $andelerForrigeBehandling",
+                        "Er endring i andel i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
+                            "Andel denne behandlingen: ${it.innhold.andelDenneBehandlingen}\n" +
+                            "Andel forrige behandling: ${it.innhold.andelForrigeBehandling}",
                     )
-                    throw Feil("Det er endringer i andelene relatert til sats som går tilbake i tid. Gjelder andelene fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
+                    throw Feil("Det er en uforventet endring i andel. Gjelder andel fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
                 }
             }
         }
     }
 }
+
+private sealed interface EndringIAndel
+
+private object IngenEndringIAndel : EndringIAndel
+
+private data class ErEndringIAndel(val andelForrigeBehandling: AndelTilkjentYtelse?, val andelDenneBehandlingen: AndelTilkjentYtelse?) : EndringIAndel

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
@@ -79,8 +79,8 @@ object BehandlingsresultatValideringUtils {
         nåMåned: YearMonth,
     ) {
         val forrigeMåned = nåMåned.minusMonths(1)
-        val andelerIFortidenTidslinje = andelerDenneBehandlingen.tilTidslinjerPerPersonOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
-        val andelerIFortidenForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerPersonOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
+        val andelerIFortidenTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
+        val andelerIFortidenForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType().beskjærTilOgMed(forrigeMåned.tilTidspunkt())
 
         val endringerIAndelerTilbakeITidTidslinjer =
             andelerIFortidenTidslinje.outerJoin(andelerIFortidenForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
@@ -98,8 +98,8 @@ object BehandlingsresultatValideringUtils {
         andelerDenneBehandlingen: List<AndelTilkjentYtelse>,
         andelerForrigeBehandling: List<AndelTilkjentYtelse>,
     ) {
-        val andelerDenneBehandlingTidslinje = andelerDenneBehandlingen.tilTidslinjerPerPersonOgType()
-        val andelerForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerPersonOgType()
+        val andelerDenneBehandlingTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType()
+        val andelerForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType()
 
         val endringISatsTidslinjer =
             andelerDenneBehandlingTidslinje.outerJoin(andelerForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -85,7 +85,7 @@ object BehandlingsresultatValideringUtils {
         val endringerIAndelerTilbakeITidTidslinjer =
             andelerIFortidenTidslinje.outerJoin(andelerIFortidenForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
                 if (nyAndel?.kalkulertUtbetalingsbeløp != gammelAndel?.kalkulertUtbetalingsbeløp) {
-                    ErEndringIAndel(gammelAndel, nyAndel)
+                    ErEndringIAndel(andelForrigeBehandling = gammelAndel, andelDenneBehandlingen = nyAndel)
                 } else {
                     IngenEndringIAndel
                 }
@@ -104,7 +104,7 @@ object BehandlingsresultatValideringUtils {
         val endringISatsTidslinjer =
             andelerDenneBehandlingTidslinje.outerJoin(andelerForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
                 if (nyAndel?.sats != gammelAndel?.sats) {
-                    ErEndringIAndel(gammelAndel, nyAndel)
+                    ErEndringIAndel(andelForrigeBehandling = gammelAndel, andelDenneBehandlingen = nyAndel)
                 } else {
                     IngenEndringIAndel
                 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -114,15 +114,15 @@ object BehandlingsresultatValideringUtils {
     }
 
     private fun Map<Pair<Aktør, YtelseType>, Tidslinje<EndringIAndel, Måned>>.kastFeilOgLoggVedEndringerIAndeler() {
-        this.forEach { _, endringIAndelTidslinje ->
+        this.forEach { (aktør, ytelsetype), endringIAndelTidslinje ->
             endringIAndelTidslinje.perioder().forEach {
                 if (it.innhold is ErEndringIAndel) {
                     secureLogger.info(
-                        "Er endring i andel i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
+                        "Det er en uforventet endring i $ytelsetype-andel for $aktør i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}.\n" +
                             "Andel denne behandlingen: ${it.innhold.andelDenneBehandlingen}\n" +
                             "Andel forrige behandling: ${it.innhold.andelForrigeBehandling}",
                     )
-                    throw Feil("Det er en uforventet endring i andel. Gjelder andel fra ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
+                    throw Feil("Det er en uforventet endring i andel. Gjelder andel i perioden ${it.fraOgMed.tilYearMonth()} til ${it.tilOgMed.tilYearMonth()}. Se secure log for mer detaljer.")
                 }
             }
         }
@@ -133,4 +133,7 @@ private sealed interface EndringIAndel
 
 private object IngenEndringIAndel : EndringIAndel
 
-private data class ErEndringIAndel(val andelForrigeBehandling: AndelTilkjentYtelse?, val andelDenneBehandlingen: AndelTilkjentYtelse?) : EndringIAndel
+private data class ErEndringIAndel(
+    val andelForrigeBehandling: AndelTilkjentYtelse?,
+    val andelDenneBehandlingen: AndelTilkjentYtelse?,
+) : EndringIAndel

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjeMedAndeler
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunkt
@@ -68,8 +68,8 @@ object TilkjentYtelseValidering {
         andelerFraForrigeBehandling: List<AndelTilkjentYtelse>,
         andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
     ) {
-        val andelerGruppert = andelerTilkjentYtelse.tilTidslinjerPerPersonOgType()
-        val forrigeAndelerGruppert = andelerFraForrigeBehandling.tilTidslinjerPerPersonOgType()
+        val andelerGruppert = andelerTilkjentYtelse.tilTidslinjerPerAktørOgType()
+        val forrigeAndelerGruppert = andelerFraForrigeBehandling.tilTidslinjerPerAktørOgType()
 
         andelerGruppert
             .outerJoin(forrigeAndelerGruppert) { nåværendeAndel, forrigeAndel ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -216,7 +216,7 @@ fun Collection<AndelTilkjentYtelse>.tilTidslinjerPerPersonOgType(): Map<Pair<Akt
         )
     }
 
-fun List<AndelTilkjentYtelse>.tilTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseForVedtaksperioderTidslinje> =
+fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseForVedtaksperioderTidslinje> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
         AndelTilkjentYtelseForVedtaksperioderTidslinje(
             andelerTilkjentYtelsePåPerson,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -209,7 +209,7 @@ private fun regelverkAvhengigeVilkår() =
         Vilkår.LOVLIG_OPPHOLD,
     )
 
-fun Collection<AndelTilkjentYtelse>.tilTidslinjerPerPersonOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseTidslinje> =
+fun Collection<AndelTilkjentYtelse>.tilTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseTidslinje> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
         AndelTilkjentYtelseTidslinje(
             andelerTilkjentYtelsePåPerson,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelse.kt
@@ -66,7 +66,7 @@ data class TilkjentYtelse(
 
 fun TilkjentYtelse.tilTidslinjeMedAndeler(): Tidslinje<Iterable<AndelTilkjentYtelse>, Måned> =
     this.andelerTilkjentYtelse
-        .tilTidslinjerPerPersonOgType()
+        .tilTidslinjerPerAktørOgType()
         .values
         .kombiner()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -20,7 +20,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatOpphørUtils.filtrerBortIrrelevanteAndeler
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
@@ -347,7 +347,7 @@ fun hentUtbetalingerPerMndEøs(
 ): Map<String, UtbetalingMndEøs> {
     // Ønsker kun andeler som ikke er satt til 0 pga endret utbetaling andel med årsakene ALLEREDE_UTBETALT, ENDRE_MOTTAKER eller ETTERBETALING_3ÅR
     val filtrerteAndelTilkjentYtelser = andelTilkjentYtelserForBehandling.filtrerBortIrrelevanteAndeler(endretutbetalingAndeler)
-    val andelerForVedtaksperioderPerAktørOgType = filtrerteAndelTilkjentYtelser.tilTidslinjerPerPersonOgType()
+    val andelerForVedtaksperioderPerAktørOgType = filtrerteAndelTilkjentYtelser.tilTidslinjerPerAktørOgType()
 
     // Ønsker kun andeler etter endringstidspunkt så beskjærer fra og med endringstidspunktet
     val andelerForVedtaksperioderPerAktørOgTypeAvgrensetTilVedtaksperioder =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -1,5 +1,5 @@
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
@@ -25,7 +25,7 @@ fun hentPerioderMedUtbetaling(
 
     val alleAndelerKombinertTidslinje =
         andelerTilkjentYtelse
-            .tilTidslinjerPerPersonOgType()
+            .tilTidslinjerPerAktørOgType()
             .values
             .kombinerUtenNull { it }
             .filtrer { !it?.toList().isNullOrEmpty() }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.InternPeriodeOvergangsstønad
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.IUtfyltEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilIEndretUtbetalingAndel
@@ -499,7 +499,7 @@ private fun lagGrunnlagMedOvergangsstønad(
 
 fun List<AndelTilkjentYtelse>.tilAndelerForVedtaksPeriodeTidslinje(): Tidslinje<Iterable<AndelForVedtaksperiode>, Måned> =
     this
-        .tilTidslinjerPerAktørOgType()
+        .tilAndelForVedtaksperiodeTidslinjerPerAktørOgType()
         .values
         .map { tidslinje -> tidslinje.mapIkkeNull { it }.slåSammenLike() }
         .kombiner()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
@@ -480,7 +480,7 @@ fun lagPeriodeForOmregningsbehandling(
     nåDato: LocalDate,
 ): List<VedtaksperiodeMedBegrunnelser> {
     val andelerTidslinje: Tidslinje<List<AndelForVedtaksperiode>, Måned> =
-        andelTilkjentYtelser.tilTidslinjerPerAktørOgType().values.kombiner { it.toList() }
+        andelTilkjentYtelser.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType().values.kombiner { it.toList() }
 
     val nesteEndringITilkjentYtelse =
         andelerTidslinje

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -136,7 +136,7 @@ class StønadsstatistikkService(
         val utbetalingsPerioder =
             andelerMedEndringer
                 .map { it.andel }
-                .tilTidslinjerPerPersonOgType()
+                .tilTidslinjerPerAktørOgType()
                 .values
                 .kombiner<AndelTilkjentYtelse, Iterable<AndelTilkjentYtelse>?, Måned> { it }
         val søkerOgBarn = persongrunnlag.søkerOgBarn

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SendVedtakTilInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SendVedtakTilInfotrygdTask.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.integrasjoner.infotrygd.domene.InfotrygdVedtakFeedD
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.domene.InfotrygdVedtakFeedTaskDto
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
-import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerPersonOgType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
@@ -50,7 +50,7 @@ class SendVedtakTilInfotrygdTask(
         val førsteUtbetalingsperiode =
             andelerMedEndringer
                 .map { it.andel }
-                .tilTidslinjerPerPersonOgType()
+                .tilTidslinjerPerAktørOgType()
                 .values
                 .kombiner<AndelTilkjentYtelse, Iterable<AndelTilkjentYtelse>?, Måned> { it }
                 .perioder()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I valideringene som sjekker at andelene ikke har endret seg tilbake i tid fra forrige behandling for måndelig valutajustering lager vi en boolsk tidslinje som returner om det er endring. Dersom det er en endring logger vi ut hvilken periode det er endring i og alle andelene for begge behandlingene. 

Forenkler slik at vi også sender med andelene som har endret seg dersom det er en uforventet endring, slik at vi kan bruke de direkte i loggene. Gjenbruker også loggefunksjonen som logger ut andelene med endring

Renamer også `tilTidslinjerPerAktørOgType`-funksjonen til `tilAndelForVedtaksperiodeTidslinjerPerAktørOgType` slik at det blir eksplisitt at den ikke lager en tidslinje av vanlige andeler
