### PR TITLE
Finn første endringstidspunkt for automatisk valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -66,7 +66,7 @@ class AutomatiskOppdaterValutakursService(
         // Tilpasser valutaen til potensielle endringer i utenlandske periodebeløp fra denne behandlingen
         tilpassValutakurserTilUtenlandskePeriodebeløpService.tilpassValutakursTilUtenlandskPeriodebeløp(behandlingId)
 
-        val endringstidspunktUtenValutakursendringer = vedtaksperiodeService.finnEndringstidspunktForBehandlingUtenValutakursendringer(behandlingId.id).toYearMonth()
+        val endringstidspunktUtenValutakursendringer = finnEndringstidspunktForOppdateringAvValutakurs(behandling)
 
         oppdaterValutakurserEtterEndringstidspunkt(
             behandling = behandling,
@@ -79,11 +79,14 @@ class AutomatiskOppdaterValutakursService(
     fun oppdaterValutakurserEtterEndringstidspunkt(
         behandlingId: BehandlingId,
         utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>? = null,
-    ) = oppdaterValutakurserEtterEndringstidspunkt(
-        behandling = behandlingHentOgPersisterService.hent(behandlingId.id),
-        utenlandskePeriodebeløp = utenlandskePeriodebeløp ?: utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id),
-        endringstidspunkt = vedtaksperiodeService.finnEndringstidspunktForBehandling(behandlingId.id).toYearMonth(),
-    )
+    ) {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId.id)
+        oppdaterValutakurserEtterEndringstidspunkt(
+            behandling = behandling,
+            utenlandskePeriodebeløp = utenlandskePeriodebeløp ?: utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id),
+            endringstidspunkt = finnEndringstidspunktForOppdateringAvValutakurs(behandling),
+        )
+    }
 
     @Transactional
     fun oppdaterValutakurserEtterEndringstidspunkt(
@@ -92,7 +95,7 @@ class AutomatiskOppdaterValutakursService(
     ) = oppdaterValutakurserEtterEndringstidspunkt(
         behandling = behandling,
         utenlandskePeriodebeløp = utenlandskePeriodebeløp ?: utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandling.id),
-        endringstidspunkt = vedtaksperiodeService.finnEndringstidspunktForBehandling(behandling.id).toYearMonth(),
+        endringstidspunkt = finnEndringstidspunktForOppdateringAvValutakurs(behandling),
     )
 
     private fun oppdaterValutakurserEtterEndringstidspunkt(
@@ -124,6 +127,22 @@ class AutomatiskOppdaterValutakursService(
             utenlandskePeriodebeløp.tilAutomatiskeValutakurserEtter(månedForTidligsteTillatteAutomatiskeValutakurs)
 
         valutakursService.oppdaterValutakurser(BehandlingId(behandling.id), automatiskGenererteValutakurser)
+    }
+
+    private fun finnEndringstidspunktForOppdateringAvValutakurs(
+        behandling: Behandling,
+    ): YearMonth {
+        val endringstidspunkt = vedtaksperiodeService.finnEndringstidspunktForBehandling(behandling.id).toYearMonth()
+
+        val valutakurserDenneBehandling = valutakursService.hentValutakurser(BehandlingId(behandling.id))
+        val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+        val valutakurserForrigeBehandling = forrigeBehandling?.let { valutakursService.hentValutakurser(BehandlingId(forrigeBehandling.id)) } ?: emptyList()
+
+        val førsteEndringIValutakurs = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
+
+        logger.info("Finner minste av første endringstidspunkt for vedtaksperioder $endringstidspunkt og valutakurser $førsteEndringIValutakurs")
+
+        return minOf(endringstidspunkt, førsteEndringIValutakurs)
     }
 
     private fun Collection<UtenlandskPeriodebeløp>.tilAutomatiskeValutakurserEtter(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtil.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
+
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapIkkeNull
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.ValutakursForVedtaksperiode
+import java.time.YearMonth
+
+fun finnFørsteEndringIValutakurs(
+    valutakurserDenneBehandling: Collection<Valutakurs>,
+    valutakurserForrigeBehandling: Collection<Valutakurs>,
+): YearMonth {
+    val valutakurserDenneBehandlingTidslinje =
+        valutakurserDenneBehandling
+            .filtrerUtfylteValutakurser()
+            .groupBy { it.barnAktører }
+            .mapValues { (_, valutakurser) -> valutakurser.tilTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
+    val valutakurserForrigeBehandlingTidslinje =
+        valutakurserForrigeBehandling
+            .filtrerUtfylteValutakurser()
+            .groupBy { it.barnAktører }
+            .mapValues { (_, valutakurser) -> valutakurser.tilTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
+
+    val erEndringIValutakursTidslinje =
+        valutakurserDenneBehandlingTidslinje
+            .outerJoin(valutakurserForrigeBehandlingTidslinje) { valutakursDenneBehandling, valutakursForrigeBehandling ->
+                valutakursDenneBehandling != valutakursForrigeBehandling
+            }.values
+            .kombiner { erValutakursForPersonEndretIPeriode ->
+                erValutakursForPersonEndretIPeriode.any { it }
+            }
+
+    return erEndringIValutakursTidslinje
+        .perioder()
+        .firstOrNull { it.innhold == true }
+        ?.fraOgMed
+        ?.tilYearMonth() ?: TIDENES_ENDE.toYearMonth()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -169,3 +169,5 @@ fun Collection<Valutakurs>.erAlleValutakurserOppdaterteIMåned(
 
     fom < måned && tom >= måned
 }
+
+fun Collection<Valutakurs>.filtrerUtfylteValutakurser() = this.map { it.tilIValutakurs() }.filterIsInstance<UtfyltValutakurs>()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -122,18 +122,6 @@ class VedtaksperiodeService(
         )
     }
 
-    fun finnEndringstidspunktForBehandlingUtenValutakursendringer(behandlingId: Long): LocalDate {
-        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
-
-        val forrigeBehandling =
-            behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id)
-
-        return utledEndringstidspunktUtenValutakursendringer(
-            behandlingsGrunnlagForVedtaksperioder = behandling.hentGrunnlagForVedtaksperioder(),
-            behandlingsGrunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
-        )
-    }
-
     fun oppdaterVedtaksperiodeMedStandardbegrunnelser(
         vedtaksperiodeId: Long,
         standardbegrunnelserFraFrontend: List<Standardbegrunnelse>,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
@@ -144,7 +144,7 @@ class AutomatiskOppdaterValutakursServiceTest {
             .medVurderingsform(Vurderingsform.AUTOMATISK)
             .lagreTil(valutakursRepository)
 
-        every { vedtaksperiodeService.finnEndringstidspunktForBehandlingUtenValutakursendringer(behandlingId.id) } returns LocalDate.of(2023, 5, 15)
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(behandlingId.id) } returns LocalDate.of(2023, 5, 15)
 
         automatiskOppdaterValutakursService.resettValutakurserOgLagValutakurserEtterEndringstidspunkt(behandlingId)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtilTest.kt
@@ -1,0 +1,71 @@
+package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
+
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.lagValutakurs
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.YearMonth
+
+class AutomatiskOppdaterValutakursUtilTest {
+    val barnAktører = setOf(randomAktør())
+    val valutakursdato: LocalDate = LocalDate.now()
+    val valutakode = "DKK"
+
+    @Test
+    fun `finnFørsteEndringIValutakurs skal returnere TIDENES_ENDE hvis begge er tomme`() {
+        val valutakurserDenneBehandling = emptyList<Valutakurs>()
+        val valutakurserForrigeBehandling = emptyList<Valutakurs>()
+
+        val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
+
+        assertThat(actual).isEqualTo(TIDENES_ENDE.toYearMonth())
+    }
+
+    @Test
+    fun `finnFørsteEndringIValutakurs skal returnere første endring`() {
+        val fom = YearMonth.now()
+        val valutakurserDenneBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(1)))
+        val valutakurserForrigeBehandling = emptyList<Valutakurs>()
+
+        val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
+
+        assertThat(actual).isEqualTo(fom)
+    }
+
+    @Test
+    fun `finnFørsteEndringIValutakurs skal returnere TIDENES_ENDE hvis ingen endringer`() {
+        val fom = YearMonth.now()
+        val valutakurserDenneBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(1)))
+        val valutakurserForrigeBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(1)))
+
+        val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
+
+        assertThat(actual).isEqualTo(TIDENES_ENDE.toYearMonth())
+    }
+
+    @Test
+    fun `finnFørsteEndringIValutakurs skal returnere første endring i tidslinje med endring`() {
+        val fom = YearMonth.now()
+        val valutakurserDenneBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(2), kurs = BigDecimal.ONE))
+        val valutakurserForrigeBehandling =
+            listOf(
+                valutakurs(fom = fom, tom = fom.plusMonths(1), kurs = BigDecimal.ONE),
+                valutakurs(fom = fom.plusMonths(2), tom = fom.plusMonths(2), kurs = BigDecimal.TWO),
+            )
+
+        val expected = fom.plusMonths(2)
+        val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    private fun valutakurs(
+        fom: YearMonth,
+        tom: YearMonth,
+        kurs: BigDecimal = BigDecimal.ONE,
+    ) = lagValutakurs(fom = fom, tom = tom, kurs = kurs, barnAktører = barnAktører, valutakursdato = valutakursdato, valutakode = valutakode, vurderingsform = Vurderingsform.MANUELL)
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -624,6 +624,19 @@ class BegrunnelseTeksterStepDefinition {
 
         mock.utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(BehandlingId(behandlingId), utenlandskPeriodebeløp.single())
     }
+
+    @Når("vi automatisk oppdaterer valutakurser for behandling {}")
+    fun `når vi automatisk oppdaterer valutakurser for behandling`(
+        behandlingId: Long,
+    ) {
+        val mock =
+            CucumberMock(
+                dataFraCucumber = this,
+                nyBehanldingId = behandlingId,
+            )
+
+        mock.automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(BehandlingId(behandlingId))
+    }
 }
 
 data class SammenlignbarBegrunnelse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.parseEnumListe
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseInt
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseList
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseLong
+import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriBigDecimal
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriBoolean
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriDato
 import no.nav.familie.ba.sak.cucumber.domeneparser.parseValgfriEnum
@@ -347,7 +348,7 @@ fun lagValutakurs(
                         VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VALUTA_KODE,
                         rad,
                     ),
-                kurs = parseBigDecimal(VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.KURS, rad),
+                kurs = parseValgfriBigDecimal(VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.KURS, rad),
                 vurderingsform = parseValgfriEnum<Vurderingsform>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VURDERINGSFORM, rad) ?: Vurderingsform.MANUELL,
             ).also { it.behandlingId = behandlingId }
         }.groupBy { it.behandlingId }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BasisDomeneParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BasisDomeneParser.kt
@@ -178,6 +178,14 @@ fun parseBigDecimal(
     return verdi.toBigDecimal()
 }
 
+fun parseValgfriBigDecimal(
+    domenebegrep: Domenenøkkel,
+    rad: Map<String, String>,
+): BigDecimal? {
+    val verdi = valgfriVerdi(domenebegrep.nøkkel, rad)
+    return verdi?.toBigDecimal()
+}
+
 fun parseValgfriLong(
     domenebegrep: Domenenøkkel,
     rad: Map<String, String>,

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/automatisk_valutajustering/utenlandsk_periodebeløp_er_0_kroner.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/automatisk_valutajustering/utenlandsk_periodebeløp_er_0_kroner.feature
@@ -1,0 +1,118 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Automatiske valutakurser - Utenlandsk periodebeløp er 0 kroner
+
+  Bakgrunn:
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype | Status  |
+      | 1        | NORMAL     | LØPENDE |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat         | Behandlingsårsak         | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | FORTSATT_INNVILGET          | MÅNEDLIG_VALUTAJUSTERING | Ja                        | EØS                 | AVSLUTTET         |
+      | 2            | 1        | 1                   | HENLAGT_FEILAKTIG_OPPRETTET | ÅRLIG_KONTROLL           | Nei                       | EØS                 | AVSLUTTET         |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 24.11.1987  |              |
+      | 1            | 2       | BARN       | 12.05.2015  |              |
+      | 1            | 3       | BARN       | 08.02.2019  |              |
+      | 2            | 1       | SØKER      | 24.11.1987  |              |
+      | 2            | 2       | BARN       | 12.05.2015  |              |
+      | 2            | 3       | BARN       | 08.02.2019  |              |
+
+  Scenario: Automatisk oppdatering av valutakurser skal skje selv om det ikke fører til noen endringer i andelene
+    Og følgende dagens dato 24.06.2024
+    Og lag personresultater for begrunnelse for behandling 1
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | UNDER_18_ÅR      |                              | 12.05.2015 | 11.05.2033 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | GIFT_PARTNERSKAP |                              | 12.05.2015 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 3       | GIFT_PARTNERSKAP |                              | 08.02.2019 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | UNDER_18_ÅR      |                              | 08.02.2019 | 07.02.2037 | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | UNDER_18_ÅR      |                              | 12.05.2015 | 11.05.2033 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | GIFT_PARTNERSKAP |                              | 12.05.2015 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 3       | UNDER_18_ÅR      |                              | 08.02.2019 | 07.02.2037 | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | GIFT_PARTNERSKAP |                              | 08.02.2019 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+    Og med kompetanser for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2, 3    | 01.12.2022 | 31.12.2022 | NORGE_ER_PRIMÆRLAND   | 1            | ARBEIDER         | INAKTIV                   | NO                    | BG                             | BG                  |
+      | 2, 3    | 01.01.2023 |            | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | BG                             | BG                  |
+      | 2, 3    | 01.01.2023 |            | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | BG                             | BG                  |
+      | 2, 3    | 01.12.2022 | 31.12.2022 | NORGE_ER_PRIMÆRLAND   | 2            | ARBEIDER         | INAKTIV                   | NO                    | BG                             | BG                  |
+
+    Og med utenlandsk periodebeløp for begrunnelse
+      | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2, 3    | 01.2023   |           | 1            | 0     | BGN         | MÅNEDLIG  | BG              |
+      | 2, 3    | 01.2023   |           | 2            | 0     | BGN         | MÅNEDLIG  | BG              |
+
+    Og med valutakurs for begrunnelse
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 2, 3    | 01.01.2023 | 31.05.2024 | 1            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
+      | 2, 3    | 01.06.2024 |            | 1            | 2024-05-31     | BGN         | 5.8201247571 | AUTOMATISK     |
+      | 2, 3    | 01.01.2023 | 31.12.2023 | 2            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
+      | 2, 3    | 01.01.2024 |            | 2            |                | BGN         |              | IKKE_VURDERT   |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.12.2022 | 31.12.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 1            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 1            | 01.01.2024 | 30.04.2033 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 3       | 1            | 01.12.2022 | 31.12.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 3       | 1            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 3       | 1            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 3       | 1            | 01.07.2023 | 31.01.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 1            | 01.02.2025 | 31.01.2037 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+      | 2       | 2            | 01.12.2022 | 31.12.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 2            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.01.2024 | 30.04.2033 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 3       | 2            | 01.12.2022 | 31.12.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 3       | 2            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 3       | 2            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 3       | 2            | 01.07.2023 | 31.12.2023 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 2            | 01.01.2024 | 31.01.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 2            | 01.02.2025 | 31.01.2037 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+    Når vi automatisk oppdaterer valutakurser for behandling 2
+
+    Så forvent følgende valutakurser for behandling 2
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 2, 3    | 01.01.2023 | 31.12.2023 | 2            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
+      | 2, 3    | 01.01.2024 | 31.01.2024 | 2            | 2023-12-29     | BGN         | 10           | AUTOMATISK     |
+      | 2, 3    | 01.02.2024 | 29.02.2024 | 2            | 2024-01-31     | BGN         | 10           | AUTOMATISK     |
+      | 2, 3    | 01.03.2024 | 31.03.2024 | 2            | 2024-02-29     | BGN         | 10           | AUTOMATISK     |
+      | 2, 3    | 01.04.2024 | 30.04.2024 | 2            | 2024-03-27     | BGN         | 10           | AUTOMATISK     |
+      | 2, 3    | 01.05.2024 | 31.05.2024 | 2            | 2024-04-30     | BGN         | 10           | AUTOMATISK     |
+      | 2, 3    | 01.06.2024 |            | 2            | 2024-05-31     | BGN         | 5.8201247571 | AUTOMATISK     |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/automatisk_valutajustering/utenlandsk_periodebeløp_er_0_kroner.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/automatisk_valutajustering/utenlandsk_periodebeløp_er_0_kroner.feature
@@ -30,7 +30,7 @@ Egenskap: Automatiske valutakurser - Utenlandsk periodebeløp er 0 kroner
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
       | 1       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
-      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.11.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
 
       | 2       | UNDER_18_ÅR      |                              | 12.05.2015 | 11.05.2033 | OPPFYLT  | Nei                  |                      |                  |
       | 2       | GIFT_PARTNERSKAP |                              | 12.05.2015 |            | OPPFYLT  | Nei                  |                      |                  |
@@ -46,7 +46,7 @@ Egenskap: Automatiske valutakurser - Utenlandsk periodebeløp er 0 kroner
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 2
       | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
-      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.11.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
       | 1       | LOVLIG_OPPHOLD   |                              | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
 
       | 2       | UNDER_18_ÅR      |                              | 12.05.2015 | 11.05.2033 | OPPFYLT  | Nei                  |                      |                  |
@@ -62,46 +62,32 @@ Egenskap: Automatiske valutakurser - Utenlandsk periodebeløp er 0 kroner
       | 3       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 01.11.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
 
     Og med kompetanser for begrunnelse
-      | AktørId | Fra dato   | Til dato   | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
-      | 2, 3    | 01.12.2022 | 31.12.2022 | NORGE_ER_PRIMÆRLAND   | 1            | ARBEIDER         | INAKTIV                   | NO                    | BG                             | BG                  |
-      | 2, 3    | 01.01.2023 |            | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | BG                             | BG                  |
-      | 2, 3    | 01.01.2023 |            | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | BG                             | BG                  |
-      | 2, 3    | 01.12.2022 | 31.12.2022 | NORGE_ER_PRIMÆRLAND   | 2            | ARBEIDER         | INAKTIV                   | NO                    | BG                             | BG                  |
+      | AktørId | Fra dato   | Til dato | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2, 3    | 01.12.2023 |          | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | BG                             | BG                  |
+      | 2, 3    | 01.12.2023 |          | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | BG                             | BG                  |
 
     Og med utenlandsk periodebeløp for begrunnelse
       | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
-      | 2, 3    | 01.2023   |           | 1            | 0     | BGN         | MÅNEDLIG  | BG              |
-      | 2, 3    | 01.2023   |           | 2            | 0     | BGN         | MÅNEDLIG  | BG              |
+      | 2, 3    | 12.2023   |           | 1            | 0     | BGN         | MÅNEDLIG  | BG              |
+      | 2, 3    | 12.2023   |           | 2            | 0     | BGN         | MÅNEDLIG  | BG              |
 
     Og med valutakurs for begrunnelse
       | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
-      | 2, 3    | 01.01.2023 | 31.05.2024 | 1            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
+      | 2, 3    | 01.12.2023 | 31.05.2024 | 1            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
       | 2, 3    | 01.06.2024 |            | 1            | 2024-05-31     | BGN         | 5.8201247571 | AUTOMATISK     |
-      | 2, 3    | 01.01.2023 | 31.12.2023 | 2            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
+      | 2, 3    | 01.12.2023 | 31.12.2023 | 2            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
       | 2, 3    | 01.01.2024 |            | 2            |                | BGN         |              | IKKE_VURDERT   |
 
     Og med andeler tilkjent ytelse for begrunnelse
       | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
-      | 2       | 1            | 01.12.2022 | 31.12.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
-      | 2       | 1            | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
-      | 2       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
-      | 2       | 1            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 1            | 01.12.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
       | 2       | 1            | 01.01.2024 | 30.04.2033 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
-      | 3       | 1            | 01.12.2022 | 31.12.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
-      | 3       | 1            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
-      | 3       | 1            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
-      | 3       | 1            | 01.07.2023 | 31.01.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 1            | 01.12.2023 | 31.01.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
       | 3       | 1            | 01.02.2025 | 31.01.2037 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
 
-      | 2       | 2            | 01.12.2022 | 31.12.2022 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
-      | 2       | 2            | 01.01.2023 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
-      | 2       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
-      | 2       | 2            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.12.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
       | 2       | 2            | 01.01.2024 | 30.04.2033 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
-      | 3       | 2            | 01.12.2022 | 31.12.2022 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
-      | 3       | 2            | 01.01.2023 | 28.02.2023 | 1676  | ORDINÆR_BARNETRYGD | 100     | 1676 |
-      | 3       | 2            | 01.03.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
-      | 3       | 2            | 01.07.2023 | 31.12.2023 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 2            | 01.12.2023 | 31.12.2023 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
       | 3       | 2            | 01.01.2024 | 31.01.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
       | 3       | 2            | 01.02.2025 | 31.01.2037 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
 
@@ -109,7 +95,7 @@ Egenskap: Automatiske valutakurser - Utenlandsk periodebeløp er 0 kroner
 
     Så forvent følgende valutakurser for behandling 2
       | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
-      | 2, 3    | 01.01.2023 | 31.12.2023 | 2            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
+      | 2, 3    | 01.12.2023 | 31.12.2023 | 2            | 2023-07-31     | BGN         | 5.7165865630 | MANUELL        |
       | 2, 3    | 01.01.2024 | 31.01.2024 | 2            | 2023-12-29     | BGN         | 10           | AUTOMATISK     |
       | 2, 3    | 01.02.2024 | 29.02.2024 | 2            | 2024-01-31     | BGN         | 10           | AUTOMATISK     |
       | 2, 3    | 01.03.2024 | 31.03.2024 | 2            | 2024-02-29     | BGN         | 10           | AUTOMATISK     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-21649

Det er en saksbehandler som prøver å oppdatere valutakurser når utenlandsk periodebeløp er 0.
Normalt ville vi tenkt at vi lager automatisk valutakurser tilbake til første endring i valutakursene.
Koden vi bruker nå for å finne første endringstidspunkt ser kun på andelene.
Siden endringen i valutakursene ikke synes på andelene, påvirker det heller ikke endringstidspunktet.

Lager kode som også oppdager endringer i valutakurser når vi avgjør hvor langt tilbake i tid vi skal automatisk generere valutakurser.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
