### PR TITLE
Drop index drop index tilkjent_ytelse_utbetalingsoppdrag_not_null_idx

### DIFF
--- a/src/main/resources/db/migration/V266__drop_index_oppdrag_not_null.sql
+++ b/src/main/resources/db/migration/V266__drop_index_oppdrag_not_null.sql
@@ -1,0 +1,1 @@
+drop index if exists tilkjent_ytelse_utbetalingsoppdrag_not_null_idx;


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-21667
Utbetalingsoppdrag er text og skalerer ikke med indextype btree. Som gjør at task feiler fordi oppdraget er for stort til å bygge index. Så dropper index, og sjekker hvordan ytelsen blir på de tunge spørrringene, siden vi er usikker på om den faktiske indeksen gjør noe for ytelsen.

Legger evt på senere indeks av annen type hvis det likevel skulle være behov

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
