### PR TITLE
Bug: ikke se på eksplisitte avslag for barn det ikke er fremstilt krav for ved vedtaksperiode-generering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
+import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
@@ -33,6 +34,7 @@ class TestVerktøyService(
     private val kompetanseRepository: KompetanseRepository,
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
     private val valutakursRepository: ValutakursRepository,
+    private val søknadGrunnlagService: SøknadGrunnlagService,
 ) {
     @Transactional
     fun oppdaterVilkårUtenFomTilFødselsdato(behandlingId: Long) {
@@ -117,6 +119,7 @@ class TestVerktøyService(
             utenlandskePeriodebeløpForrigeBehandling = utenlandskePeriodebeløpForrigeBehandling,
             valutakurser = valutakurser,
             valutakurserForrigeBehandling = valutakurserForrigeBehandling,
+            personerFremstiltKravFor = søknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = forrigeBehandling),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
@@ -101,6 +101,8 @@ class TestVerktøyService(
                 vedtakRepository.findByBehandlingAndAktiv(behandlingId).id,
             )
 
+        val personerFremstiltKravFor = søknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = forrigeBehandling)
+
         return lagGyldigeBegrunnelserTest(
             behandling = behandling,
             forrigeBehandling = forrigeBehandling,
@@ -119,7 +121,7 @@ class TestVerktøyService(
             utenlandskePeriodebeløpForrigeBehandling = utenlandskePeriodebeløpForrigeBehandling,
             valutakurser = valutakurser,
             valutakurserForrigeBehandling = valutakurserForrigeBehandling,
-            personerFremstiltKravFor = søknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = forrigeBehandling),
+            personerFremstiltKravFor = personerFremstiltKravFor,
         )
     }
 
@@ -146,6 +148,7 @@ class TestVerktøyService(
             vedtaksperiodeHentOgPersisterService.finnVedtaksperioderFor(
                 vedtakRepository.findByBehandlingAndAktiv(behandlingId).id,
             )
+        val personerFremstiltKravFor = søknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = forrigeBehandling)
 
         return lagVedtaksperioderTest(
             behandling = behandling,
@@ -161,6 +164,7 @@ class TestVerktøyService(
             endredeUtbetalingerForrigeBehandling = endredeUtbetalingerForrigeBehandling,
             kompetanse = kompetanse,
             kompetanseForrigeBehandling = kompetanseForrigeBehandling,
+            personerFremstiltKravFor = personerFremstiltKravFor,
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -69,24 +69,24 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
     Og følgende dagens dato ${LocalDate.now().tilddMMyyyy()}""" +
             hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor)
     lagPersonresultaterTekst(forrigeBehandling) +
-            lagPersonresultaterTekst(behandling) +
-            hentTekstForVilkårresultater(
-                personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),
-                forrigeBehandling?.id,
-            ) +
-            hentTekstForVilkårresultater(personResultater.sorterPåFødselsdato(persongrunnlag), behandling.id) +
-            hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) +
-            hentTekstForUtenlandskPeriodebeløp(utenlandskePeriodebeløp, utenlandskePeriodebeløpForrigeBehandling) +
-            hentTekstForValutakurser(valutakurser, valutakurserForrigeBehandling) +
-            hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
-            hentTekstForTilkjentYtelse(andeler, persongrunnlag, andelerForrigeBehandling, persongrunnlagForrigeBehandling) + """
+        lagPersonresultaterTekst(behandling) +
+        hentTekstForVilkårresultater(
+            personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),
+            forrigeBehandling?.id,
+        ) +
+        hentTekstForVilkårresultater(personResultater.sorterPåFødselsdato(persongrunnlag), behandling.id) +
+        hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) +
+        hentTekstForUtenlandskPeriodebeløp(utenlandskePeriodebeløp, utenlandskePeriodebeløpForrigeBehandling) +
+        hentTekstForValutakurser(valutakurser, valutakurserForrigeBehandling) +
+        hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
+        hentTekstForTilkjentYtelse(andeler, persongrunnlag, andelerForrigeBehandling, persongrunnlagForrigeBehandling) + """
     
     Når vedtaksperiodene genereres for behandling ${behandling.id}""" +
-            hentTekstForGyligeBegrunnelserForVedtaksperiodene(vedtaksperioder) +
-            hentTekstValgteBegrunnelser(behandling.id, vedtaksperioder) +
-            hentTekstBrevPerioder(behandling.id, vedtaksperioder) +
-            hentBrevBegrunnelseTekster(behandling.id, vedtaksperioder) +
-            hentEØSBrevBegrunnelseTekster(behandling.id, vedtaksperioder) + """
+        hentTekstForGyligeBegrunnelserForVedtaksperiodene(vedtaksperioder) +
+        hentTekstValgteBegrunnelser(behandling.id, vedtaksperioder) +
+        hentTekstBrevPerioder(behandling.id, vedtaksperioder) +
+        hentBrevBegrunnelseTekster(behandling.id, vedtaksperioder) +
+        hentEØSBrevBegrunnelseTekster(behandling.id, vedtaksperioder) + """
 """
     return test.anonymiser(persongrunnlag, persongrunnlagForrigeBehandling, forrigeBehandling, behandling)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -67,26 +67,26 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
       
   Scenario: Plassholdertekst for scenario - ${RandomStringUtils.randomAlphanumeric(10)}
     Og følgende dagens dato ${LocalDate.now().tilddMMyyyy()}""" +
-            hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor)
-    lagPersonresultaterTekst(forrigeBehandling) +
-        lagPersonresultaterTekst(behandling) +
-        hentTekstForVilkårresultater(
-            personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),
-            forrigeBehandling?.id,
-        ) +
-        hentTekstForVilkårresultater(personResultater.sorterPåFødselsdato(persongrunnlag), behandling.id) +
-        hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) +
-        hentTekstForUtenlandskPeriodebeløp(utenlandskePeriodebeløp, utenlandskePeriodebeløpForrigeBehandling) +
-        hentTekstForValutakurser(valutakurser, valutakurserForrigeBehandling) +
-        hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
-        hentTekstForTilkjentYtelse(andeler, persongrunnlag, andelerForrigeBehandling, persongrunnlagForrigeBehandling) + """
+            hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor) +
+            lagPersonresultaterTekst(forrigeBehandling) +
+            lagPersonresultaterTekst(behandling) +
+            hentTekstForVilkårresultater(
+                personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),
+                forrigeBehandling?.id,
+            ) +
+            hentTekstForVilkårresultater(personResultater.sorterPåFødselsdato(persongrunnlag), behandling.id) +
+            hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) +
+            hentTekstForUtenlandskPeriodebeløp(utenlandskePeriodebeløp, utenlandskePeriodebeløpForrigeBehandling) +
+            hentTekstForValutakurser(valutakurser, valutakurserForrigeBehandling) +
+            hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
+            hentTekstForTilkjentYtelse(andeler, persongrunnlag, andelerForrigeBehandling, persongrunnlagForrigeBehandling) + """
     
     Når vedtaksperiodene genereres for behandling ${behandling.id}""" +
-        hentTekstForGyligeBegrunnelserForVedtaksperiodene(vedtaksperioder) +
-        hentTekstValgteBegrunnelser(behandling.id, vedtaksperioder) +
-        hentTekstBrevPerioder(behandling.id, vedtaksperioder) +
-        hentBrevBegrunnelseTekster(behandling.id, vedtaksperioder) +
-        hentEØSBrevBegrunnelseTekster(behandling.id, vedtaksperioder) + """
+            hentTekstForGyligeBegrunnelserForVedtaksperiodene(vedtaksperioder) +
+            hentTekstValgteBegrunnelser(behandling.id, vedtaksperioder) +
+            hentTekstBrevPerioder(behandling.id, vedtaksperioder) +
+            hentBrevBegrunnelseTekster(behandling.id, vedtaksperioder) +
+            hentEØSBrevBegrunnelseTekster(behandling.id, vedtaksperioder) + """
 """
     return test.anonymiser(persongrunnlag, persongrunnlagForrigeBehandling, forrigeBehandling, behandling)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.tilIValutakurs
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -49,6 +50,7 @@ fun lagGyldigeBegrunnelserTest(
     utenlandskePeriodebeløpForrigeBehandling: Collection<UtenlandskPeriodebeløp>?,
     valutakurser: Collection<Valutakurs>,
     valutakurserForrigeBehandling: Collection<Valutakurs>?,
+    personerFremstiltKravFor: List<Aktør>,
 ): String {
     val test =
         """
@@ -65,7 +67,8 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
       
   Scenario: Plassholdertekst for scenario - ${RandomStringUtils.randomAlphanumeric(10)}
     Og følgende dagens dato ${LocalDate.now().tilddMMyyyy()}""" +
-            lagPersonresultaterTekst(forrigeBehandling) +
+            hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor)
+    lagPersonresultaterTekst(forrigeBehandling) +
             lagPersonresultaterTekst(behandling) +
             hentTekstForVilkårresultater(
                 personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),
@@ -152,6 +155,18 @@ private fun hentPersongrunnlagRader(persongrunnlag: PersonopplysningGrunnlag?): 
         """
       | ${persongrunnlag.behandlingId} |${it.aktør.aktørId}|${it.type}|${it.fødselsdato.tilddMMyyyy()}|${it.dødsfall?.dødsfallDato?.tilddMMyyyy() ?: ""}|"""
     } ?: ""
+
+fun hentTekstForPersonerFremstiltKravFor(
+    behandlingId: Long?,
+    personerFremstiltKravFor: List<Aktør>,
+) =
+    """
+        Og med personer fremstilt krav for i behandling
+        | BehandlingId | AktørId |""" +
+        personerFremstiltKravFor.joinToString {
+            """
+        | $behandlingId | ${it.aktørId} |"""
+        }
 
 fun hentTekstForVilkårresultater(
     personResultater: List<PersonResultat>?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/begrunnelser/LagGyldigeBegrunnelserTestUtil.kt
@@ -156,7 +156,7 @@ private fun hentPersongrunnlagRader(persongrunnlag: PersonopplysningGrunnlag?): 
       | ${persongrunnlag.behandlingId} |${it.aktør.aktørId}|${it.type}|${it.fødselsdato.tilddMMyyyy()}|${it.dødsfall?.dødsfallDato?.tilddMMyyyy() ?: ""}|"""
     } ?: ""
 
-fun hentTekstForPersonerFremstiltKravFor(
+private fun hentTekstForPersonerFremstiltKravFor(
     behandlingId: Long?,
     personerFremstiltKravFor: List<Aktør>,
 ) =

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.tilddMMyyyy
 import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.VilkårResultatRad
 import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.anonymiser
-import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.hentTekstForPersonerFremstiltKravFor
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
@@ -114,6 +113,18 @@ private fun hentPersongrunnlagRader(persongrunnlag: PersonopplysningGrunnlag?): 
         """
       | ${persongrunnlag.behandlingId} |${it.aktør.aktørId}|${it.type}|${it.fødselsdato.tilddMMyyyy()}|"""
     } ?: ""
+
+private fun hentTekstForPersonerFremstiltKravFor(
+    behandlingId: Long?,
+    personerFremstiltKravFor: List<Aktør>,
+) =
+    """
+        Og med personer fremstilt krav for
+        | BehandlingId | AktørId |""" +
+        personerFremstiltKravFor.joinToString {
+            """
+        | $behandlingId | ${it.aktørId} |"""
+        }
 
 private fun hentTekstForVilkårresultater(
     personResultater: List<PersonResultat>?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -52,20 +52,20 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
       
   Scenario: Plassholdertekst for scenario - ${RandomStringUtils.randomAlphanumeric(10)}
     Og dagens dato er ${LocalDate.now().tilddMMyyyy()}""" +
-            hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor)
-    lagPersonresultaterTekst(forrigeBehandling) +
-        lagPersonresultaterTekst(behandling) +
-        hentTekstForVilkårresultater(
-            personResultaterForrigeBehandling?.sorterPåFøselsdato(persongrunnlagForrigeBehandling!!),
-            forrigeBehandling?.id,
-        ) +
-        hentTekstForVilkårresultater(personResultater.sorterPåFøselsdato(persongrunnlag), behandling.id) +
-        hentTekstForTilkjentYtelse(andeler, andelerForrigeBehandling) +
-        hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
-        hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) + """
+            hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor) +
+            lagPersonresultaterTekst(forrigeBehandling) +
+            lagPersonresultaterTekst(behandling) +
+            hentTekstForVilkårresultater(
+                personResultaterForrigeBehandling?.sorterPåFøselsdato(persongrunnlagForrigeBehandling!!),
+                forrigeBehandling?.id,
+            ) +
+            hentTekstForVilkårresultater(personResultater.sorterPåFøselsdato(persongrunnlag), behandling.id) +
+            hentTekstForTilkjentYtelse(andeler, andelerForrigeBehandling) +
+            hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
+            hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) + """
     
     Når vedtaksperioder med begrunnelser genereres for behandling ${behandling.id}""" +
-        hentTekstForVedtaksperioder(vedtaksperioder) + """
+            hentTekstForVedtaksperioder(vedtaksperioder) + """
     """
 
     return test.anonymiser(persongrunnlag, persongrunnlagForrigeBehandling, forrigeBehandling, behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/vedtaksperioder/LagVedtaksperiodeTestUtil.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.tilddMMyyyy
 import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.VilkårResultatRad
 import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.anonymiser
+import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.hentTekstForPersonerFremstiltKravFor
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
@@ -14,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import org.apache.commons.lang3.RandomStringUtils
@@ -33,6 +35,7 @@ fun lagVedtaksperioderTest(
     vedtaksperioder: List<VedtaksperiodeMedBegrunnelser>,
     kompetanse: Collection<Kompetanse>,
     kompetanseForrigeBehandling: Collection<Kompetanse>?,
+    personerFremstiltKravFor: List<Aktør>,
 ): String {
     val test =
         """
@@ -49,19 +52,20 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
       
   Scenario: Plassholdertekst for scenario - ${RandomStringUtils.randomAlphanumeric(10)}
     Og dagens dato er ${LocalDate.now().tilddMMyyyy()}""" +
-            lagPersonresultaterTekst(forrigeBehandling) +
-            lagPersonresultaterTekst(behandling) +
-            hentTekstForVilkårresultater(
-                personResultaterForrigeBehandling?.sorterPåFøselsdato(persongrunnlagForrigeBehandling!!),
-                forrigeBehandling?.id,
-            ) +
-            hentTekstForVilkårresultater(personResultater.sorterPåFøselsdato(persongrunnlag), behandling.id) +
-            hentTekstForTilkjentYtelse(andeler, andelerForrigeBehandling) +
-            hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
-            hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) + """
+            hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor)
+    lagPersonresultaterTekst(forrigeBehandling) +
+        lagPersonresultaterTekst(behandling) +
+        hentTekstForVilkårresultater(
+            personResultaterForrigeBehandling?.sorterPåFøselsdato(persongrunnlagForrigeBehandling!!),
+            forrigeBehandling?.id,
+        ) +
+        hentTekstForVilkårresultater(personResultater.sorterPåFøselsdato(persongrunnlag), behandling.id) +
+        hentTekstForTilkjentYtelse(andeler, andelerForrigeBehandling) +
+        hentTekstForEndretUtbetaling(endredeUtbetalinger, endredeUtbetalingerForrigeBehandling) +
+        hentTekstForKompetanse(kompetanse, kompetanseForrigeBehandling) + """
     
     Når vedtaksperioder med begrunnelser genereres for behandling ${behandling.id}""" +
-            hentTekstForVedtaksperioder(vedtaksperioder) + """
+        hentTekstForVedtaksperioder(vedtaksperioder) + """
     """
 
     return test.anonymiser(persongrunnlag, persongrunnlagForrigeBehandling, forrigeBehandling, behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -30,7 +30,6 @@ class BehandlingsresultatService(
         val forrigeBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id)
 
         val søknadGrunnlag = søknadGrunnlagService.hentAktiv(behandlingId = behandling.id)
-        val søknadDTO = søknadGrunnlag?.hentSøknadDto()
 
         val forrigeAndelerTilkjentYtelse = forrigeBehandling?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = it.id) } ?: emptyList()
         val andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = behandlingId)
@@ -46,7 +45,6 @@ class BehandlingsresultatService(
         val personerFremstiltKravFor =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = søknadDTO,
                 forrigeBehandling = forrigeBehandling,
             )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -2,12 +2,8 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import no.nav.familie.ba.sak.common.LocalDateProvider
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
-import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatUtils.skalUtledeSøknadsresultatForBehandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelHentOgPersisterService
@@ -15,8 +11,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import org.springframework.stereotype.Service
 
@@ -24,7 +18,6 @@ import org.springframework.stereotype.Service
 class BehandlingsresultatService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val søknadGrunnlagService: SøknadGrunnlagService,
-    private val personidentService: PersonidentService,
     private val persongrunnlagService: PersongrunnlagService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
@@ -32,37 +25,6 @@ class BehandlingsresultatService(
     private val kompetanseService: KompetanseService,
     private val localDateProvider: LocalDateProvider,
 ) {
-    internal fun finnPersonerFremstiltKravFor(
-        behandling: Behandling,
-        søknadDTO: SøknadDTO?,
-        forrigeBehandling: Behandling?,
-    ): List<Aktør> {
-        val personerFremstiltKravFor =
-            when {
-                behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD -> {
-                    // alle barna som er krysset av på søknad
-                    val barnFraSøknad =
-                        søknadDTO
-                            ?.barnaMedOpplysninger
-                            ?.filter { it.erFolkeregistrert && it.inkludertISøknaden }
-                            ?.map { personidentService.hentAktør(it.ident) }
-                            ?: emptyList()
-
-                    // hvis det søkes om utvidet skal søker med
-                    val utvidetBarnetrygdSøker =
-                        if (søknadDTO?.underkategori == BehandlingUnderkategoriDTO.UTVIDET) listOf(behandling.fagsak.aktør) else emptyList()
-
-                    barnFraSøknad + utvidetBarnetrygdSøker
-                }
-
-                behandling.opprettetÅrsak == BehandlingÅrsak.FØDSELSHENDELSE -> persongrunnlagService.finnNyeBarn(behandling, forrigeBehandling).map { it.aktør }
-                behandling.erManuellMigrering() || behandling.opprettetÅrsak == BehandlingÅrsak.KLAGE -> persongrunnlagService.hentAktivThrows(behandling.id).personer.map { it.aktør }
-                else -> emptyList()
-            }
-
-        return personerFremstiltKravFor.distinct()
-    }
-
     internal fun utledBehandlingsresultat(behandlingId: Long): Behandlingsresultat {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val forrigeBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id)
@@ -82,7 +44,7 @@ class BehandlingsresultatService(
         val personerIForrigeBehandling = forrigeBehandling?.let { persongrunnlagService.hentAktivThrows(behandlingId = forrigeBehandling.id).personer.toSet() } ?: emptySet()
 
         val personerFremstiltKravFor =
-            finnPersonerFremstiltKravFor(
+            søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 søknadDTO = søknadDTO,
                 forrigeBehandling = forrigeBehandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagService.kt
@@ -1,11 +1,20 @@
 package no.nav.familie.ba.sak.kjerne.grunnlag.søknad
 
+import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
+import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SøknadGrunnlagService(
     private val søknadGrunnlagRepository: SøknadGrunnlagRepository,
+    private val personidentService: PersonidentService,
+    private val persongrunnlagService: PersongrunnlagService,
 ) {
     @Transactional
     fun lagreOgDeaktiverGammel(søknadGrunnlag: SøknadGrunnlag): SøknadGrunnlag {
@@ -21,4 +30,35 @@ class SøknadGrunnlagService(
     fun hentAlle(behandlingId: Long): List<SøknadGrunnlag> = søknadGrunnlagRepository.hentAlle(behandlingId)
 
     fun hentAktiv(behandlingId: Long): SøknadGrunnlag? = søknadGrunnlagRepository.hentAktiv(behandlingId)
+
+    internal fun finnPersonerFremstiltKravFor(
+        behandling: Behandling,
+        søknadDTO: SøknadDTO?,
+        forrigeBehandling: Behandling?,
+    ): List<Aktør> {
+        val personerFremstiltKravFor =
+            when {
+                behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD -> {
+                    // alle barna som er krysset av på søknad
+                    val barnFraSøknad =
+                        søknadDTO
+                            ?.barnaMedOpplysninger
+                            ?.filter { it.erFolkeregistrert && it.inkludertISøknaden }
+                            ?.map { personidentService.hentAktør(it.ident) }
+                            ?: emptyList()
+
+                    // hvis det søkes om utvidet skal søker med
+                    val utvidetBarnetrygdSøker =
+                        if (søknadDTO?.underkategori == BehandlingUnderkategoriDTO.UTVIDET) listOf(behandling.fagsak.aktør) else emptyList()
+
+                    barnFraSøknad + utvidetBarnetrygdSøker
+                }
+
+                behandling.opprettetÅrsak == BehandlingÅrsak.FØDSELSHENDELSE -> persongrunnlagService.finnNyeBarn(behandling, forrigeBehandling).map { it.aktør }
+                behandling.erManuellMigrering() || behandling.opprettetÅrsak == BehandlingÅrsak.KLAGE -> persongrunnlagService.hentAktivThrows(behandling.id).personer.map { it.aktør }
+                else -> emptyList()
+            }
+
+        return personerFremstiltKravFor.distinct()
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagService.kt
@@ -31,11 +31,13 @@ class SøknadGrunnlagService(
 
     fun hentAktiv(behandlingId: Long): SøknadGrunnlag? = søknadGrunnlagRepository.hentAktiv(behandlingId)
 
+    fun hentAktivSøknadDto(behandlingId: Long): SøknadDTO? = hentAktiv(behandlingId)?.hentSøknadDto()
+
     internal fun finnPersonerFremstiltKravFor(
         behandling: Behandling,
-        søknadDTO: SøknadDTO?,
         forrigeBehandling: Behandling?,
     ): List<Aktør> {
+        val søknadDTO = hentAktivSøknadDto(behandlingId = behandling.id)
         val personerFremstiltKravFor =
             when {
                 behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD -> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -320,8 +320,8 @@ class VedtaksperiodeService(
         val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
 
         return genererVedtaksperioder(
-            grunnlagForVedtakPerioder = behandling.hentGrunnlagForVedtaksperioder(),
-            grunnlagForVedtakPerioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
+            grunnlagForVedtaksperioder = behandling.hentGrunnlagForVedtaksperioder(),
+            grunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
             vedtak = vedtak,
             nåDato = LocalDate.now(),
             erToggleForÅIkkeSplittePåValutakursendringerPå =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -348,7 +348,6 @@ class VedtaksperiodeService(
             personerFremstiltKravFor =
                 søknadGrunnlagService.finnPersonerFremstiltKravFor(
                     behandling = this,
-                    søknadDTO = søknadGrunnlagService.hentAktiv(behandlingId = this.id)?.hentSøknadDto(),
                     forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(this),
                 ),
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -319,15 +319,6 @@ class VedtaksperiodeService(
         val behandling = vedtak.behandling
         val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
 
-        val søknadGrunnlag = søknadGrunnlagService.hentAktiv(behandlingId = behandling.id)
-
-        val personerFremstiltKravFor =
-            søknadGrunnlagService.finnPersonerFremstiltKravFor(
-                behandling = behandling,
-                søknadDTO = søknadGrunnlag?.hentSøknadDto(),
-                forrigeBehandling = forrigeBehandling,
-            )
-
         return genererVedtaksperioder(
             grunnlagForVedtakPerioder = behandling.hentGrunnlagForVedtaksperioder(),
             grunnlagForVedtakPerioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
@@ -337,7 +328,6 @@ class VedtaksperiodeService(
                 unleashNextMedContextService.isEnabled(
                     FeatureToggleConfig.IKKE_SPLITT_VEDTAKSPERIODE_PÅ_ENDRING_I_VALUTAKURS,
                 ),
-            personerFremstiltKravFor = personerFremstiltKravFor,
         )
     }
 
@@ -355,6 +345,12 @@ class VedtaksperiodeService(
             uregistrerteBarn =
                 søknadGrunnlagService.hentAktiv(behandlingId = this.id)?.hentUregistrerteBarn()
                     ?: emptyList(),
+            personerFremstiltKravFor =
+                søknadGrunnlagService.finnPersonerFremstiltKravFor(
+                    behandling = this,
+                    søknadDTO = søknadGrunnlagService.hentAktiv(behandlingId = this.id)?.hentSøknadDto(),
+                    forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(this),
+                ),
         )
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -324,11 +324,21 @@ class VedtaksperiodeService(
         val behandling = vedtak.behandling
         val forrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
 
+        val søknadGrunnlag = søknadGrunnlagService.hentAktiv(behandlingId = behandling.id)
+
+        val personerFremstiltKravFor =
+            søknadGrunnlagService.finnPersonerFremstiltKravFor(
+                behandling = behandling,
+                søknadDTO = søknadGrunnlag?.hentSøknadDto(),
+                forrigeBehandling = forrigeBehandling,
+            )
+
         return genererVedtaksperioder(
             grunnlagForVedtakPerioder = behandling.hentGrunnlagForVedtaksperioder(),
             grunnlagForVedtakPerioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
             vedtak = vedtak,
             nåDato = LocalDate.now(),
+            personerFremstiltKravFor = personerFremstiltKravFor,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
@@ -72,6 +72,7 @@ data class BehandlingsGrunnlagForVedtaksperioder(
     val uregistrerteBarn: List<BarnMedOpplysninger>,
     val utenlandskPeriodebeløp: List<UtenlandskPeriodebeløp>,
     val valutakurs: List<Valutakurs>,
+    val personerFremstiltKravFor: List<Aktør>,
 ) {
     val utfylteEndredeUtbetalinger =
         endredeUtbetalinger

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
@@ -77,7 +77,7 @@ data class VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget(
     override val vilkårResultaterForVedtaksperiode: List<VilkårResultatForVedtaksperiode>,
 ) : VedtaksperiodeGrunnlagForPerson {
     fun List<VilkårResultatForVedtaksperiode>.inneholderEksplisittAvslag(personerFremstiltKravFor: List<Aktør>) =
-        this.any { it.erEksplisittAvslagPåSøknad } && personerFremstiltKravFor.contains(person.aktør)
+        this.any { it.erEksplisittAvslagPåSøknad } && (personerFremstiltKravFor.contains(person.aktør) || person.type == PersonType.SØKER)
 }
 
 data class VilkårResultatForVedtaksperiode(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
@@ -28,8 +28,8 @@ sealed interface VedtaksperiodeGrunnlagForPerson {
     val person: Person
     val vilkårResultaterForVedtaksperiode: List<VilkårResultatForVedtaksperiode>
 
-    fun erEksplisittAvslag(): Boolean =
-        this is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget && this.erEksplisittAvslag
+    fun erEksplisittAvslag(personerFremstiltKravFor: List<Aktør>): Boolean =
+        this is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget && this.vilkårResultaterForVedtaksperiode.inneholderEksplisittAvslag(personerFremstiltKravFor)
 
     fun erInnvilget() = this is VedtaksperiodeGrunnlagForPersonVilkårInnvilget && this.erInnvilgetEndretUtbetaling()
 
@@ -76,10 +76,8 @@ data class VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget(
     override val person: Person,
     override val vilkårResultaterForVedtaksperiode: List<VilkårResultatForVedtaksperiode>,
 ) : VedtaksperiodeGrunnlagForPerson {
-    val erEksplisittAvslag: Boolean = vilkårResultaterForVedtaksperiode.inneholderEksplisittAvslag()
-
-    fun List<VilkårResultatForVedtaksperiode>.inneholderEksplisittAvslag() =
-        this.any { it.erEksplisittAvslagPåSøknad }
+    fun List<VilkårResultatForVedtaksperiode>.inneholderEksplisittAvslag(personerFremstiltKravFor: List<Aktør>) =
+        this.any { it.erEksplisittAvslagPåSøknad } && personerFremstiltKravFor.contains(person.aktør)
 }
 
 data class VilkårResultatForVedtaksperiode(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
@@ -429,7 +430,7 @@ fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksper
     }
 
 private fun VedtaksperiodeGrunnlagForPerson.finnVilkårResultaterSomGjelderPersonIVedtaksperiode(personerFremstiltKravFor: List<Aktør>): List<VilkårResultatForVedtaksperiode> =
-    this.vilkårResultaterForVedtaksperiode.filter { !it.erEksplisittAvslagPåSøknad || personerFremstiltKravFor.contains(this.person.aktør) }
+    this.vilkårResultaterForVedtaksperiode.filter { !it.erEksplisittAvslagPåSøknad || personerFremstiltKravFor.contains(this.person.aktør) || this.person.type == PersonType.SØKER }
 
 private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
     val erUtbetalingsperiode =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -47,7 +47,6 @@ fun genererVedtaksperioder(
     vedtak: Vedtak,
     nåDato: LocalDate,
     erToggleForÅIkkeSplittePåValutakursendringerPå: Boolean,
-    personerFremstiltKravFor: List<Aktør>,
 ): List<VedtaksperiodeMedBegrunnelser> {
     if (vedtak.behandling.opprettetÅrsak.erOmregningsårsak()) {
         return lagPeriodeForOmregningsbehandling(
@@ -78,11 +77,11 @@ fun genererVedtaksperioder(
                     behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtakPerioderForrigeBehandling,
                     erToggleForÅIkkeSplittePåValutakursendringerPå = erToggleForÅIkkeSplittePåValutakursendringerPå,
                 ),
-            personerFremstiltKravFor = personerFremstiltKravFor,
+            personerFremstiltKravFor = grunnlagForVedtakPerioder.personerFremstiltKravFor,
         )
 
     val vedtaksperioder =
-        perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak, personerFremstiltKravFor) }
+        perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak, grunnlagForVedtakPerioder.personerFremstiltKravFor) }
 
     return if (grunnlagForVedtakPerioder.uregistrerteBarn.isNotEmpty()) {
         vedtaksperioder.leggTilPeriodeForUregistrerteBarn(vedtak)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -432,7 +432,11 @@ fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksper
     }
 
 private fun VedtaksperiodeGrunnlagForPerson.finnVilkårResultaterSomGjelderPersonIVedtaksperiode(personerFremstiltKravFor: List<Aktør>): List<VilkårResultatForVedtaksperiode> =
-    this.vilkårResultaterForVedtaksperiode.filter { !it.erEksplisittAvslagPåSøknad || personerFremstiltKravFor.contains(this.person.aktør) || this.person.type == PersonType.SØKER }
+    if (personerFremstiltKravFor.contains(this.person.aktør) || this.person.type == PersonType.SØKER) {
+        this.vilkårResultaterForVedtaksperiode
+    } else {
+        this.vilkårResultaterForVedtaksperiode.filter { !it.erEksplisittAvslagPåSøknad }
+    }
 
 private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
     val erUtbetalingsperiode =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -409,9 +409,9 @@ fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksper
         val begrunnelser =
             this.innhold?.flatMap { grunnlagForGjeldendeOgForrigeBehandling ->
                 grunnlagForGjeldendeOgForrigeBehandling.gjeldende
-                    ?.vilkårResultaterForVedtaksperiode
+                    ?.finnVilkårResultaterSomGjelderPersonIVedtaksperiode(personerFremstiltKravFor)
                     ?.flatMap { it.standardbegrunnelser } ?: emptyList()
-            } ?: emptyList()
+            }?.toSet() ?: emptyList()
 
         vedtaksperiode.begrunnelser.addAll(
             begrunnelser
@@ -427,6 +427,9 @@ fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksper
 
         vedtaksperiode
     }
+
+private fun VedtaksperiodeGrunnlagForPerson.finnVilkårResultaterSomGjelderPersonIVedtaksperiode(personerFremstiltKravFor: List<Aktør>): List<VilkårResultatForVedtaksperiode> =
+    this.vilkårResultaterForVedtaksperiode.filter { !it.erEksplisittAvslagPåSøknad || personerFremstiltKravFor.contains(this.person.aktør) }
 
 private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
     val erUtbetalingsperiode =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
@@ -44,6 +45,7 @@ fun genererVedtaksperioder(
     grunnlagForVedtakPerioderForrigeBehandling: BehandlingsGrunnlagForVedtaksperioder?,
     vedtak: Vedtak,
     nåDato: LocalDate,
+    personerFremstiltKravFor: List<Aktør>,
 ): List<VedtaksperiodeMedBegrunnelser> {
     if (vedtak.behandling.opprettetÅrsak.erOmregningsårsak()) {
         return lagPeriodeForOmregningsbehandling(
@@ -73,10 +75,11 @@ fun genererVedtaksperioder(
                     behandlingsGrunnlagForVedtaksperioder = grunnlagForVedtakPerioder,
                     behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtakPerioderForrigeBehandling,
                 ),
+            personerFremstiltKravFor = personerFremstiltKravFor,
         )
 
     val vedtaksperioder =
-        perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak) }
+        perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak, personerFremstiltKravFor) }
 
     return if (grunnlagForVedtakPerioder.uregistrerteBarn.isNotEmpty()) {
         vedtaksperioder.leggTilPeriodeForUregistrerteBarn(vedtak)
@@ -131,26 +134,28 @@ fun finnPerioderSomSkalBegrunnes(
     grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
     grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
     endringstidspunkt: LocalDate,
+    personerFremstiltKravFor: List<Aktør>,
 ): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
     val gjeldendeOgForrigeGrunnlagKombinert =
         kombinerGjeldendeOgForrigeGrunnlag(
             grunnlagTidslinjePerPerson = grunnlagTidslinjePerPerson.mapValues { it.value.vedtaksperiodeGrunnlagForPerson },
             grunnlagTidslinjePerPersonForrigeBehandling = grunnlagTidslinjePerPersonForrigeBehandling.mapValues { it.value.vedtaksperiodeGrunnlagForPerson },
+            personerFremstiltKravFor = personerFremstiltKravFor,
         )
 
     val sammenslåttePerioderUtenEksplisittAvslag =
         gjeldendeOgForrigeGrunnlagKombinert
-            .slåSammenUtenEksplisitteAvslag()
+            .slåSammenUtenEksplisitteAvslag(personerFremstiltKravFor)
             .filtrerPåEndringstidspunkt(endringstidspunkt)
             .slåSammenSammenhengendeOpphørsperioder()
 
-    val eksplisitteAvslagsperioder = gjeldendeOgForrigeGrunnlagKombinert.utledEksplisitteAvslagsperioder()
+    val eksplisitteAvslagsperioder = gjeldendeOgForrigeGrunnlagKombinert.utledEksplisitteAvslagsperioder(personerFremstiltKravFor = personerFremstiltKravFor)
 
     val overlappendeGenerelleAvslagPerioder = grunnlagTidslinjePerPerson.lagOverlappendeGenerelleAvslagsPerioder()
 
     return (overlappendeGenerelleAvslagPerioder + sammenslåttePerioderUtenEksplisittAvslag + eksplisitteAvslagsperioder)
         .slåSammenAvslagOgReduksjonsperioderMedSammeFomOgTom()
-        .leggTilUendelighetPåSisteOpphørsPeriode()
+        .leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor)
 }
 
 fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.slåSammenSammenhengendeOpphørsperioder(): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
@@ -172,14 +177,14 @@ fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.slåSam
     }
 }
 
-fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.leggTilUendelighetPåSisteOpphørsPeriode(): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
+fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor: List<Aktør>): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
     val sortertePerioder =
         this
             .sortedWith(compareBy({ it.fraOgMed }, { it.tilOgMed }))
 
     val sistePeriode = sortertePerioder.lastOrNull()
     val sistePeriodeInneholderEksplisittAvslag =
-        sistePeriode?.innhold?.any { it.gjeldende?.erEksplisittAvslag() == true } == true
+        sistePeriode?.innhold?.any { it.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true } == true
     return if (sistePeriode != null &&
         !sistePeriode.erPersonMedInnvilgedeVilkårIPeriode() &&
         !sistePeriodeInneholderEksplisittAvslag
@@ -212,12 +217,12 @@ private fun Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, M�
     (it.tilOgMed.tilLocalDateEllerNull() ?: TIDENES_ENDE).isSameOrAfter(endringstidspunkt)
 }
 
-private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.slåSammenUtenEksplisitteAvslag(): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
+private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.slåSammenUtenEksplisitteAvslag(personerFremstiltKravFor: List<Aktør>): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
     val kombinerteAvslagOgReduksjonsperioder =
         this.map { grunnlagForDenneOgForrigeBehandlingTidslinje ->
             grunnlagForDenneOgForrigeBehandlingTidslinje.filtrerIkkeNull {
                 val gjeldendeErIkkeInnvilgetIkkeAvslag =
-                    it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget && !it.gjeldende.erEksplisittAvslag
+                    it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget && !it.gjeldende.erEksplisittAvslag(personerFremstiltKravFor)
                 val gjeldendeErInnvilget = it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
                 val erReduksjonSidenForrigeBehandling = it.erReduksjonSidenForrigeBehandling
 
@@ -231,10 +236,10 @@ private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.sl�
         }.perioder()
 }
 
-private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.utledEksplisitteAvslagsperioder(): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
+private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.utledEksplisitteAvslagsperioder(personerFremstiltKravFor: List<Aktør>): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
     val avslagsperioderPerPerson =
         this
-            .map { it.filtrerErAvslagsperiode() }
+            .map { it.filtrerErAvslagsperiode(personerFremstiltKravFor) }
             .map { tidslinje -> tidslinje.map { it?.medVilkårSomHarEksplisitteAvslag() } }
             .flatMap { it.splittVilkårPerPerson() }
             .map { it.slåSammenLike() }
@@ -281,8 +286,8 @@ private fun Periode<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.splittOppTi
     }
 }
 
-private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.filtrerErAvslagsperiode() =
-    filtrer { it?.gjeldende?.erEksplisittAvslag() == true }
+private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.filtrerErAvslagsperiode(personerFremstiltKravFor: List<Aktør>) =
+    filtrer { it?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
 
 private fun GrunnlagForGjeldendeOgForrigeBehandling.medVilkårSomHarEksplisitteAvslag(): GrunnlagForGjeldendeOgForrigeBehandling =
     copy(
@@ -302,6 +307,7 @@ private fun GrunnlagForGjeldendeOgForrigeBehandling.medVilkårSomHarEksplisitteA
 private fun kombinerGjeldendeOgForrigeGrunnlag(
     grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned>>,
     grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned>>,
+    personerFremstiltKravFor: List<Aktør>,
 ): List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>> =
     grunnlagTidslinjePerPerson.map { (aktørId, grunnlagstidslinje) ->
         val grunnlagForrigeBehandling = grunnlagTidslinjePerPersonForrigeBehandling[aktørId]
@@ -335,7 +341,7 @@ private fun kombinerGjeldendeOgForrigeGrunnlag(
                     gjeldende = gjeldende?.grunnlagForPerson,
                     erReduksjonSidenForrigeBehandling = erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype,
                 )
-            }.slåSammenSammenhengendeOpphørsperioder()
+            }.slåSammenSammenhengendeOpphørsperioder(personerFremstiltKravFor)
     }
 
 data class GjeldendeMedInnvilgedeYtelsestyperForrigeBehandling(
@@ -349,7 +355,7 @@ private fun erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype(
     innvilgedeYtelsestyperDennePerioden: Set<YtelseType>?,
     innvilgedeYtelsestyperDennePeriodenForrigeBehandling: Set<YtelseType>?,
 ): Boolean =
-    YtelseType.values().any { ytelseType ->
+    YtelseType.entries.any { ytelseType ->
         val ytelseInnvilgetDennePerioden =
             innvilgedeYtelsestyperDennePerioden?.contains(ytelseType) ?: false
         val ytelseInnvilgetForrigePeriode =
@@ -365,7 +371,7 @@ private fun erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype(
             ytelseInnvilgetDennePeriodenForrigeBehandling
     }
 
-private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSammenSammenhengendeOpphørsperioder(): Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned> {
+private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSammenSammenhengendeOpphørsperioder(personerFremstiltKravFor: List<Aktør>): Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned> {
     val perioder = this.perioder().sortedBy { it.fraOgMed }.toList()
 
     return perioder
@@ -380,8 +386,8 @@ private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSamme
                 !erVilkårInnvilgetForrigePeriode &&
                 !erVilkårInnvilget &&
                 periode.innhold?.erReduksjonSidenForrigeBehandling != true &&
-                periode.innhold?.gjeldende?.erEksplisittAvslag() != true &&
-                sistePeriode.innhold?.gjeldende?.erEksplisittAvslag() != true
+                periode.innhold?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) != true &&
+                sistePeriode.innhold?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) != true
             ) {
                 acc.dropLast(1) + sistePeriode.copy(tilOgMed = periode.tilOgMed)
             } else {
@@ -392,12 +398,13 @@ private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSamme
 
 fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeMedBegrunnelser(
     vedtak: Vedtak,
+    personerFremstiltKravFor: List<Aktør>,
 ): VedtaksperiodeMedBegrunnelser =
     VedtaksperiodeMedBegrunnelser(
         vedtak = vedtak,
         fom = fraOgMed.tilDagEllerFørsteDagIPerioden().tilLocalDateEllerNull(),
         tom = tilOgMed.tilLocalDateEllerNull(),
-        type = this.tilVedtaksperiodeType(),
+        type = this.tilVedtaksperiodeType(personerFremstiltKravFor = personerFremstiltKravFor),
     ).let { vedtaksperiode ->
         val begrunnelser =
             this.innhold?.flatMap { grunnlagForGjeldendeOgForrigeBehandling ->
@@ -421,10 +428,10 @@ fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksper
         vedtaksperiode
     }
 
-private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeType(): Vedtaksperiodetype {
+private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
     val erUtbetalingsperiode =
         this.innhold != null && this.innhold.any { it.gjeldende?.erInnvilget() == true }
-    val erAvslagsperiode = this.innhold != null && this.innhold.all { it.gjeldende?.erEksplisittAvslag() == true }
+    val erAvslagsperiode = this.innhold != null && this.innhold.all { it.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
 
     return when {
         erUtbetalingsperiode ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -408,11 +408,12 @@ fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksper
         type = this.tilVedtaksperiodeType(personerFremstiltKravFor = personerFremstiltKravFor),
     ).let { vedtaksperiode ->
         val begrunnelser =
-            this.innhold?.flatMap { grunnlagForGjeldendeOgForrigeBehandling ->
-                grunnlagForGjeldendeOgForrigeBehandling.gjeldende
-                    ?.finnVilkårResultaterSomGjelderPersonIVedtaksperiode(personerFremstiltKravFor)
-                    ?.flatMap { it.standardbegrunnelser } ?: emptyList()
-            }?.toSet() ?: emptyList()
+            this.innhold
+                ?.flatMap { grunnlagForGjeldendeOgForrigeBehandling ->
+                    grunnlagForGjeldendeOgForrigeBehandling.gjeldende
+                        ?.finnVilkårResultaterSomGjelderPersonIVedtaksperiode(personerFremstiltKravFor)
+                        ?.flatMap { it.standardbegrunnelser } ?: emptyList()
+                }?.toSet() ?: emptyList()
 
         vedtaksperiode.begrunnelser.addAll(
             begrunnelser

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -42,8 +42,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.utledEndringstidspunkt
 import java.time.LocalDate
 
 fun genererVedtaksperioder(
-    grunnlagForVedtakPerioder: BehandlingsGrunnlagForVedtaksperioder,
-    grunnlagForVedtakPerioderForrigeBehandling: BehandlingsGrunnlagForVedtaksperioder?,
+    grunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
+    grunnlagForVedtaksperioderForrigeBehandling: BehandlingsGrunnlagForVedtaksperioder?,
     vedtak: Vedtak,
     nåDato: LocalDate,
     erToggleForÅIkkeSplittePåValutakursendringerPå: Boolean,
@@ -52,7 +52,7 @@ fun genererVedtaksperioder(
         return lagPeriodeForOmregningsbehandling(
             vedtak = vedtak,
             nåDato = nåDato,
-            andelTilkjentYtelser = grunnlagForVedtakPerioder.andelerTilkjentYtelse,
+            andelTilkjentYtelser = grunnlagForVedtaksperioder.andelerTilkjentYtelse,
         )
     }
 
@@ -61,11 +61,11 @@ fun genererVedtaksperioder(
     }
 
     val grunnlagTidslinjePerPersonForrigeBehandling =
-        grunnlagForVedtakPerioderForrigeBehandling
-            ?.let { grunnlagForVedtakPerioderForrigeBehandling.utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå) }
+        grunnlagForVedtaksperioderForrigeBehandling
+            ?.let { grunnlagForVedtaksperioderForrigeBehandling.utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå) }
             ?: emptyMap()
 
-    val grunnlagTidslinjePerPerson = grunnlagForVedtakPerioder.utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå)
+    val grunnlagTidslinjePerPerson = grunnlagForVedtaksperioder.utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå)
 
     val perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling =
         finnPerioderSomSkalBegrunnes(
@@ -73,17 +73,17 @@ fun genererVedtaksperioder(
             grunnlagTidslinjePerPersonForrigeBehandling = grunnlagTidslinjePerPersonForrigeBehandling,
             endringstidspunkt =
                 vedtak.behandling.overstyrtEndringstidspunkt ?: utledEndringstidspunkt(
-                    behandlingsGrunnlagForVedtaksperioder = grunnlagForVedtakPerioder,
-                    behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtakPerioderForrigeBehandling,
+                    behandlingsGrunnlagForVedtaksperioder = grunnlagForVedtaksperioder,
+                    behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtaksperioderForrigeBehandling,
                     erToggleForÅIkkeSplittePåValutakursendringerPå = erToggleForÅIkkeSplittePåValutakursendringerPå,
                 ),
-            personerFremstiltKravFor = grunnlagForVedtakPerioder.personerFremstiltKravFor,
+            personerFremstiltKravFor = grunnlagForVedtaksperioder.personerFremstiltKravFor,
         )
 
     val vedtaksperioder =
-        perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak, grunnlagForVedtakPerioder.personerFremstiltKravFor) }
+        perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling.map { it.tilVedtaksperiodeMedBegrunnelser(vedtak, grunnlagForVedtaksperioder.personerFremstiltKravFor) }
 
-    return if (grunnlagForVedtakPerioder.uregistrerteBarn.isNotEmpty()) {
+    return if (grunnlagForVedtaksperioder.uregistrerteBarn.isNotEmpty()) {
         vedtaksperioder.leggTilPeriodeForUregistrerteBarn(vedtak)
     } else {
         vedtaksperioder

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagServiceTest.kt
@@ -47,11 +47,11 @@ internal class SøknadGrunnlagServiceTest {
     @Test
     fun `finnPersonerFremstiltKravFor skal returnere tom liste dersom behandlingen ikke er søknad, fødselshendelse eller manuell migrering`() {
         val behandling = lagBehandling(årsak = BehandlingÅrsak.DØDSFALL_BRUKER)
+        every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns null
 
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = null,
                 forrigeBehandling = null,
             )
 
@@ -79,11 +79,11 @@ internal class SøknadGrunnlagServiceTest {
             )
 
         every { vilkårsvurderingService.hentAktivForBehandlingThrows(any()) } returns Vilkårsvurdering(behandling = behandling)
+        every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = søknadDto,
                 forrigeBehandling = null,
             )
 
@@ -113,11 +113,11 @@ internal class SøknadGrunnlagServiceTest {
 
         every { vilkårsvurderingService.hentAktivForBehandlingThrows(any()) } returns Vilkårsvurdering(behandling = behandling)
         every { personidentService.hentAktør(barn.aktør.aktivFødselsnummer()) } returns barn.aktør
+        every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = søknadDto,
                 forrigeBehandling = null,
             )
 
@@ -169,11 +169,11 @@ internal class SøknadGrunnlagServiceTest {
             )
 
         every { personidentService.hentAktør(barn1Fnr) } returns mocketAktør
+        every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = søknadDto,
                 forrigeBehandling = null,
             )
 
@@ -189,11 +189,11 @@ internal class SøknadGrunnlagServiceTest {
         val nyttBarn = lagPerson()
 
         every { persongrunnlagService.finnNyeBarn(behandling, forrigeBehandling) } returns listOf(nyttBarn)
+        every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns null
 
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = null,
                 forrigeBehandling = forrigeBehandling,
             )
 
@@ -214,11 +214,11 @@ internal class SøknadGrunnlagServiceTest {
             PersonopplysningGrunnlag(behandlingId = behandling.id, personer = mutableSetOf(eksisterendeBarn))
 
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns eksisterendePersonpplysningGrunnlag
+        every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns null
 
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = null,
                 forrigeBehandling = null,
             )
 
@@ -258,11 +258,11 @@ internal class SøknadGrunnlagServiceTest {
 
         every { vilkårsvurderingService.hentAktivForBehandlingThrows(any()) } returns Vilkårsvurdering(behandling = behandling)
         every { personidentService.hentAktør(barn.aktør.aktivFødselsnummer()) } returns barn.aktør
+        every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
-                søknadDTO = søknadDto,
                 forrigeBehandling = null,
             )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -283,8 +283,8 @@ class BegrunnelseTeksterStepDefinition {
         vedtaksperioderMedBegrunnelser =
             genererVedtaksperioder(
                 vedtak = vedtak,
-                grunnlagForVedtakPerioder = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioder,
-                grunnlagForVedtakPerioderForrigeBehandling = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
+                grunnlagForVedtaksperioder = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioder,
+                grunnlagForVedtaksperioderForrigeBehandling = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
                 nåDato = dagensDato,
                 erToggleForÅIkkeSplittePåValutakursendringerPå = true,
             )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -287,7 +287,6 @@ class BegrunnelseTeksterStepDefinition {
                 grunnlagForVedtakPerioderForrigeBehandling = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
                 nåDato = dagensDato,
                 erToggleForÅIkkeSplittePåValutakursendringerPå = true,
-                personerFremstiltKravFor = personerFremstiltKravFor[behandlingId] ?: emptyList(),
             )
 
         val utvidedeVedtaksperioderMedBegrunnelser =
@@ -332,6 +331,7 @@ class BegrunnelseTeksterStepDefinition {
                 uregistrerteBarn = emptyList(),
                 utenlandskPeriodebeløp = utenlandskPeriodebeløp[behandlingId] ?: emptyList(),
                 valutakurs = valutakurs[behandlingId] ?: emptyList(),
+                personerFremstiltKravFor = personerFremstiltKravFor[behandlingId] ?: emptyList(),
             )
 
         val grunnlagForVedtaksperiodeForrigeBehandling =
@@ -349,6 +349,7 @@ class BegrunnelseTeksterStepDefinition {
                     uregistrerteBarn = emptyList(),
                     utenlandskPeriodebeløp = utenlandskPeriodebeløp[forrigeBehandlingId] ?: emptyList(),
                     valutakurs = valutakurs[forrigeBehandlingId] ?: emptyList(),
+                    personerFremstiltKravFor = personerFremstiltKravFor[forrigeBehandlingId] ?: emptyList(),
                 )
             }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -63,6 +63,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
@@ -588,6 +589,7 @@ fun lagVedtaksPerioder(
     overgangsstønad: Map<Long, List<InternPeriodeOvergangsstønad>?>,
     uregistrerteBarn: List<BarnMedOpplysninger>,
     nåDato: LocalDate,
+    personerFremstiltKravFor: Map<Long, List<Aktør>>,
 ): List<VedtaksperiodeMedBegrunnelser> {
     val vedtak =
         vedtaksListe.find { it.behandling.id == behandlingId && it.aktiv }
@@ -634,6 +636,7 @@ fun lagVedtaksPerioder(
         grunnlagForVedtakPerioder = grunnlagForVedtaksperiode,
         grunnlagForVedtakPerioderForrigeBehandling = grunnlagForVedtaksperiodeForrigeBehandling,
         nåDato = nåDato,
+        personerFremstiltKravFor = personerFremstiltKravFor[behandlingId] ?: emptyList(),
     )
 }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -636,8 +636,8 @@ fun lagVedtaksPerioder(
 
     return genererVedtaksperioder(
         vedtak = vedtak,
-        grunnlagForVedtakPerioder = grunnlagForVedtaksperiode,
-        grunnlagForVedtakPerioderForrigeBehandling = grunnlagForVedtaksperiodeForrigeBehandling,
+        grunnlagForVedtaksperioder = grunnlagForVedtaksperiode,
+        grunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtaksperiodeForrigeBehandling,
         nåDato = nåDato,
         erToggleForÅIkkeSplittePåValutakursendringerPå = true,
     )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -609,6 +609,7 @@ fun lagVedtaksPerioder(
             uregistrerteBarn = uregistrerteBarn,
             utenlandskPeriodebeløp = utenlandskPeriodebeløp[behandlingId] ?: emptyList(),
             valutakurs = valutakurs[behandlingId] ?: emptyList(),
+            personerFremstiltKravFor = personerFremstiltKravFor[behandlingId] ?: emptyList(),
         )
 
     val forrigeBehandlingId = behandlingTilForrigeBehandling[behandlingId]
@@ -629,6 +630,7 @@ fun lagVedtaksPerioder(
                 uregistrerteBarn = emptyList(),
                 utenlandskPeriodebeløp = utenlandskPeriodebeløp[forrigeBehandlingId] ?: emptyList(),
                 valutakurs = valutakurs[forrigeBehandlingId] ?: emptyList(),
+                personerFremstiltKravFor = personerFremstiltKravFor[forrigeBehandlingId] ?: emptyList(),
             )
         }
 
@@ -638,7 +640,6 @@ fun lagVedtaksPerioder(
         grunnlagForVedtakPerioderForrigeBehandling = grunnlagForVedtaksperiodeForrigeBehandling,
         nåDato = nåDato,
         erToggleForÅIkkeSplittePåValutakursendringerPå = true,
-        personerFremstiltKravFor = personerFremstiltKravFor[behandlingId] ?: emptyList(),
     )
 }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -46,6 +46,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPerio
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.EndretUtbetalingAndelTidslinjeService
+import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import no.nav.familie.ba.sak.kjerne.steg.BeslutteVedtak
 import no.nav.familie.ba.sak.kjerne.steg.FerdigstillBehandling
 import no.nav.familie.ba.sak.kjerne.steg.IverksettMotOppdrag
@@ -99,7 +100,7 @@ class CucumberMock(
     val loggService = mockLoggService()
     val behandlingHentOgPersisterService = mockBehandlingHentOgPersisterService(forrigeBehandling = forrigeBehandling, dataFraCucumber = dataFraCucumber, idForNyBehandling = nyBehanldingId)
     val periodeOvergangsstønadGrunnlagRepository = mockPeriodeOvergangsstønadGrunnlagRepository(dataFraCucumber)
-    val søknadGrunnlagService = mockSøknadGrunnlagService(dataFraCucumber)
+    val søknadGrunnlagRepository = mockSøknadGrunnlagRepository(dataFraCucumber)
     val endretUtbetalingAndelHentOgPersisterService = mockEndretUtbetalingAndelHentOgPersisterService(dataFraCucumber)
     val vedtakRepository = mockVedtakRepository(dataFraCucumber)
     val dokumentGenereringService = mockDokumentGenereringService()
@@ -178,6 +179,13 @@ class CucumberMock(
             vedtakRepository = vedtakRepository,
             dokumentGenereringService = dokumentGenereringService,
         )
+
+    val søknadGrunnlagService =
+        SøknadGrunnlagService(
+            søknadGrunnlagRepository = søknadGrunnlagRepository,
+            personidentService = personidentService,
+            persongrunnlagService = persongrunnlagService,
+    )
 
     val vedtaksperiodeService =
         VedtaksperiodeService(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -185,7 +185,7 @@ class CucumberMock(
             søknadGrunnlagRepository = søknadGrunnlagRepository,
             personidentService = personidentService,
             persongrunnlagService = persongrunnlagService,
-    )
+        )
 
     val vedtaksperiodeService =
         VedtaksperiodeService(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -302,7 +302,6 @@ class CucumberMock(
         BehandlingsresultatService(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             søknadGrunnlagService = søknadGrunnlagService,
-            personidentService = personidentService,
             persongrunnlagService = persongrunnlagService,
             vilkårsvurderingService = vilkårsvurderingService,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSøknadGrunnlagRepository.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSøknadGrunnlagRepository.kt
@@ -7,12 +7,12 @@ import no.nav.familie.ba.sak.common.randomFnr
 import no.nav.familie.ba.sak.cucumber.BegrunnelseTeksterStepDefinition
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlag
-import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
+import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagRepository
 import no.nav.familie.kontrakter.felles.objectMapper
 
-fun mockSøknadGrunnlagService(dataFraCucumber: BegrunnelseTeksterStepDefinition): SøknadGrunnlagService {
-    val søknadGrunnlagService = mockk<SøknadGrunnlagService>()
-    every { søknadGrunnlagService.hentAktiv(any()) } answers {
+fun mockSøknadGrunnlagRepository(dataFraCucumber: BegrunnelseTeksterStepDefinition): SøknadGrunnlagRepository {
+    val søknadGrunnlagRepository = mockk<SøknadGrunnlagRepository>()
+    every { søknadGrunnlagRepository.hentAktiv(any()) } answers {
         val behandlingId = firstArg<Long>()
         val behandling = dataFraCucumber.behandlinger[behandlingId]!!
         if (behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD) {
@@ -21,5 +21,5 @@ fun mockSøknadGrunnlagService(dataFraCucumber: BegrunnelseTeksterStepDefinition
             null
         }
     }
-    return søknadGrunnlagService
+    return søknadGrunnlagRepository
 }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/avslag.feature
@@ -255,6 +255,11 @@ Egenskap: Brevbegrunnelser ved eksplisitte avslag vs avslag
     Og følgende dagens dato 01.02.2024
     Og lag personresultater for begrunnelse for behandling 1
 
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
+      | 1            | 3       |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser                              | Vurderes etter   |
       | 1       | LOVLIG_OPPHOLD               |                  | 25.09.2023 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_IKKE_OPPHOLDSTILLATELSE_MER_ENN_12_MÅNEDER | NASJONALE_REGLER |
@@ -303,6 +308,10 @@ Egenskap: Brevbegrunnelser ved eksplisitte avslag vs avslag
     Og følgende dagens dato 25.01.2024
     Og lag personresultater for begrunnelse for behandling 1
 
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser              | Vurderes etter   |
       | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.02.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
@@ -346,6 +355,10 @@ Egenskap: Brevbegrunnelser ved eksplisitte avslag vs avslag
     Og følgende dagens dato 25.01.2024
     Og lag personresultater for begrunnelse for behandling 1
 
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser              | Vurderes etter   |
       | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD |                             | 01.03.2022 |            | OPPFYLT      | Nei                  |                                   | NASJONALE_REGLER |
@@ -387,6 +400,10 @@ Egenskap: Brevbegrunnelser ved eksplisitte avslag vs avslag
 
     Og følgende dagens dato 25.01.2024
     Og lag personresultater for begrunnelse for behandling 1
+
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                        | Utdypende vilkår            | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser              | Vurderes etter   |
@@ -445,6 +462,10 @@ Egenskap: Brevbegrunnelser ved eksplisitte avslag vs avslag
 
     Og følgende dagens dato 30.04.2024
     Og lag personresultater for begrunnelse for behandling 1
+
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
 
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                        | Utdypende vilkår         | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser         | Vurderes etter   |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/avslag.feature
@@ -530,6 +530,12 @@ Egenskap: Brevbegrunnelser ved eksplisitte avslag vs avslag
     Og følgende dagens dato 24.06.2024
     Og lag personresultater for begrunnelse for behandling 1
 
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
+      | 1            | 3       |
+      | 1            | 4       |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser                          | Vurderes etter   |
       | 1       | LOVLIG_OPPHOLD   |                              | 31.05.2020 |            | OPPFYLT      | Nei                  |                                               | EØS_FORORDNINGEN |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør/opphør-eøs.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør/opphør-eøs.feature
@@ -21,6 +21,11 @@ Egenskap: Brevbegrunnelser ved opphør for EØS.
     Og følgende dagens dato 23.02.2022
     Og lag personresultater for begrunnelse for behandling 1
 
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
+      | 1            | 3       |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser            | Vurderes etter   |
       | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 01.09.2019 | 31.07.2020 | OPPFYLT      | Nei                  |                                 | EØS_FORORDNINGEN |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør/opphør.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør/opphør.feature
@@ -321,6 +321,12 @@ Egenskap: Brevbegrunnelser ved opphør
     Og lag personresultater for begrunnelse for behandling 1
     Og lag personresultater for begrunnelse for behandling 2
 
+
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 2            | 2       |
+      | 2            | 3       |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
       | 1       | BOSATT_I_RIKET                              |                  | 29.03.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/avslag.feature
@@ -16,6 +16,10 @@ Egenskap: Gyldige begrunnelser for avslag
   Scenario: Skal ikke krasje ved avslag uten fom- eller tomdato
     Og lag personresultater for begrunnelse for behandling 1
 
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 2       |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                            | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
       | 1       | LOVLIG_OPPHOLD                    |                  |            |            | IKKE_OPPFYLT | Ja                   |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/opphør_fra_forrige_behandling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/opphør_fra_forrige_behandling.feature
@@ -179,6 +179,10 @@ Egenskap: Gyldige begrunnelser for opphør fra forrige behandling
     Og følgende dagens dato 28.09.2023
     Og lag personresultater for begrunnelse for behandling 1
 
+    Og med personer fremstilt krav for i behandling
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
+
     Og legg til nye vilkårresultater for begrunnelse for behandling 1
       | AktørId | Vilkår                       | Utdypende vilkår         | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser  |
       | 1234    | LOVLIG_OPPHOLD               |                          | 23.04.1985 |            | OPPFYLT      | Nei                  |                       |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
@@ -202,3 +202,80 @@ Egenskap: Vedtaksperioder med mor og to barn
       | 01.01.2021 | 31.10.2021 | Opphør             | Barn 2 har opphør |
       | 01.11.2021 | 30.11.2034 | Utbetaling         |                   |
       | 01.12.2034 |            | Opphør             | Barna er over 18  |
+
+  Scenario: Skal kun lage avslagsperiode for eksplisitte avslåtte perioder for personer fremstilt krav for
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende vedtak
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat       | Behandlingsårsak |
+      | 1            | 1        |                     | FORTSATT_INNVILGET        | SATSENDRING      |
+      | 2            | 1        | 1                   | AVSLÅTT_ENDRET_OG_OPPHØRT | SØKNAD           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 15.10.1988  |
+      | 1            | 5       | BARN       | 24.05.2023  |
+      | 2            | 1       | SØKER      | 15.10.1988  |
+      | 2            | 2       | BARN       | 11.09.2016  |
+      | 2            | 3       | BARN       | 06.12.2017  |
+      | 2            | 4       | BARN       | 17.06.2020  |
+      | 2            | 5       | BARN       | 24.05.2023  |
+
+    Og dagens dato er 24.06.2024
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 2            | 2       |
+      | 2            | 3       |
+      | 2            | 4       |
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD               |                  | 24.05.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 5       | LOVLIG_OPPHOLD,BOSATT_I_RIKET,BOR_MED_SØKER |                  | 24.05.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 5       | GIFT_PARTNERSKAP                            |                  | 24.05.2023 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 5       | UNDER_18_ÅR                                 |                  | 24.05.2023 | 23.05.2041 | OPPFYLT  | Nei                  |                      |                  |
+
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                                      | Utdypende vilkår   | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser         | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET                              | VURDERT_MEDLEMSKAP | 30.09.2022 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_MEDLEM_I_FOLKETRYGDEN | NASJONALE_REGLER |
+      | 1       | LOVLIG_OPPHOLD                              |                    | 04.10.2022 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+
+      | 2       | UNDER_18_ÅR                                 |                    | 11.09.2016 | 10.09.2034 | OPPFYLT      | Nei                  |                              |                  |
+      | 2       | GIFT_PARTNERSKAP                            |                    | 11.09.2016 |            | OPPFYLT      | Nei                  |                              |                  |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER                |                    | 30.09.2022 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+      | 2       | LOVLIG_OPPHOLD                              |                    | 04.10.2022 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+
+      | 3       | UNDER_18_ÅR                                 |                    | 06.12.2017 | 05.12.2035 | OPPFYLT      | Nei                  |                              |                  |
+      | 3       | GIFT_PARTNERSKAP                            |                    | 06.12.2017 |            | OPPFYLT      | Nei                  |                              |                  |
+      | 3       | BOR_MED_SØKER,BOSATT_I_RIKET                |                    | 30.09.2022 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+      | 3       | LOVLIG_OPPHOLD                              |                    | 04.10.2022 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+
+      | 4       | UNDER_18_ÅR                                 |                    | 17.06.2020 | 16.06.2038 | OPPFYLT      | Nei                  |                              |                  |
+      | 4       | GIFT_PARTNERSKAP                            |                    | 17.06.2020 |            | OPPFYLT      | Nei                  |                              |                  |
+      | 4       | BOSATT_I_RIKET,BOR_MED_SØKER                |                    | 30.09.2022 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+      | 4       | LOVLIG_OPPHOLD                              |                    | 04.10.2022 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+
+      | 5       | LOVLIG_OPPHOLD,BOSATT_I_RIKET,BOR_MED_SØKER |                    | 24.05.2023 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER |
+      | 5       | UNDER_18_ÅR                                 |                    | 24.05.2023 | 23.05.2041 | OPPFYLT      | Nei                  |                              |                  |
+      | 5       | GIFT_PARTNERSKAP                            |                    | 24.05.2023 |            | OPPFYLT      | Nei                  |                              |                  |
+
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 5       | 1            | 01.06.2023 | 30.06.2023 | 1723  | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 5       | 1            | 01.07.2023 | 30.04.2029 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 5       | 1            | 01.05.2029 | 30.04.2041 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+    Når vedtaksperioder med begrunnelser genereres for behandling 2
+
+    Så forvent følgende vedtaksperioder med begrunnelser
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar | Begrunnelser                 |
+      | 01.10.2022 |          | AVSLAG             |           | AVSLAG_MEDLEM_I_FOLKETRYGDEN |
+      | 01.06.2023 |          | OPPHØR             |           |                              |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/avslag.feature
@@ -14,9 +14,11 @@ Egenskap: Vedtaksperioder med mor og to barn
       | 1            | 1234    | SØKER      | 24.12.1987  |
       | 1            | 3456    | BARN       | 01.02.2016  |
 
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
 
   Scenario: Skal kun lage én avslagsperiode når det er avslag på søker hele perioden og ingen andre avslag
-
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1
       | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
@@ -76,6 +78,11 @@ Egenskap: Vedtaksperioder med mor og to barn
       | 1            | 3456    | BARN       | 01.12.2016  |
       | 1            | 5678    | BARN       | 01.02.2017  |
 
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
+      | 1            | 5678    |
+
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1
       | AktørId | Vilkår                           | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |
@@ -118,6 +125,11 @@ Egenskap: Vedtaksperioder med mor og to barn
       | 1            | 1234    | SØKER      | 24.12.1987  |
       | 1            | 3456    | BARN       | 02.12.2016  |
       | 1            | 5678    | BARN       | 02.12.2016  |
+
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
+      | 1            | 5678    |
 
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/endringstidspunkt.feature
@@ -17,6 +17,10 @@ Egenskap: Vedtaksperioder - Endringstidspunkt
       | 2            | 1234    | SØKER      | 24.12.1987  |
       | 2            | 3456    | BARN       | 02.12.2016  |
 
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
+      | 2            | 3456    |
 
   Scenario: Skal kun ta med vedtaksperioder som kommer etter endringstidspunktet
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/enslig_mindreårig.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/enslig_mindreårig.feature
@@ -17,6 +17,9 @@ Egenskap: Vedtaksperioder for enslig mindreårig
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 3456    | BARN       | 02.12.2016  |
 
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
 
   Scenario: Enslig barn har utvidet oppfylt
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/filtrer_vekk_ikke_innvilgete_perioder.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/filtrer_vekk_ikke_innvilgete_perioder.feature
@@ -13,6 +13,10 @@ Egenskap: Vedtaksperioder skal filtrere vekk irrelevante perioder
       | 1            | 1234    | SØKER      | 11.01.1970  |
       | 1            | 3456    | BARN       | 13.04.2020  |
 
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
+
   Scenario: Skal kun ta med første opphørsperiode etter siste utbetalingsperiode. Eksplisitte avslag skal med uansett.
 
     Og lag personresultater for behandling 1

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
@@ -34,6 +34,10 @@ Egenskap: Vedtaksperioder for behandling med uregistrert barn
       | 1            | 1234    | SØKER      | 11.01.1970  |
       | 1            | 3456    | BARN       | 02.12.2016  |
 
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
+
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1
       | AktørId | Vilkår                                                          | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/vilkår.feature
@@ -13,6 +13,10 @@ Egenskap: Vedtaksperioder ved endring av vilkår for mor og et barn
       | 1            | 1234    | SØKER      | 11.01.1970  |
       | 1            | 3456    | BARN       | 13.04.2020  |
 
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 3456    |
+
   Scenario: Skal lage vedtaksperioder for mor med ett barn med vilkår
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21646

Vi ønsker ikke å regne et eksplisitt avslag på søker som et eksplisitt avslag for barnet med mindre det barnet er fremstilt krav for (= søkt for i en behandling av type søknad). Dette skapte feil i en sak hvor vi hadde ett barn (som tidligere hadde barnetrygd) som ikke var søkt for, og tre nye barn det ble søkt for. Siden barn 1 tidligere hadde barnetrygd som nå ble opphørt pga avslag på søker fikk vi veldig rare vedtaksperioder (pga endring i utbetaling siden forrige behandling). 

Til info så skal man egentlig kun kunne sette eksplisitte avslag på personer det er søkt for. Feks. i revurdering med årsak nye opplysninger er det ikke mulig å velge eksplisitt avslag fordi det ikke foreligger en søknad. Skille mellom eksplisitte avslag på personer det er fremstilt krav for og ikke gjøres allerede i behandlingsresultat-koden, så det er naturlig at vi utvider dette også til vedtaksperiode-generering.

I denne PRen sørger jeg for at vi kun tar med eksplisitte avslag hvis det er fremstilt krav for personen det gjelder _eller_ det er snakk om søker.

Utvidet også cucumber-testene så vi kan få testet dette ordentlig.

**Burde leses commit for commit**. PRen er mindre enn det ser ut som, har vært litt flytting av kode og mye testgreier.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._
Nei egentlig ikke.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta en runde på det muntlig om noen ønsker
