### PR TITLE
Hent liste med valutakurser fra ECB cache

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBService.kt
@@ -35,7 +35,7 @@ class ECBService(
         utenlandskValuta: String,
         kursDato: LocalDate,
     ): BigDecimal {
-        val valutakurs = ecbValutakursCacheRepository.findByValutakodeAndValutakursdato(utenlandskValuta, kursDato)
+        val valutakurs = ecbValutakursCacheRepository.findByValutakodeAndValutakursdato(utenlandskValuta, kursDato)?.firstOrNull()
         if (valutakurs == null) {
             logger.info("Henter valutakurs for ${utenlandskValuta.saner()} på $kursDato")
             try {

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/domene/ECBValutakursCacheRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/domene/ECBValutakursCacheRepository.kt
@@ -7,5 +7,5 @@ interface ECBValutakursCacheRepository : JpaRepository<ECBValutakursCache, Long>
     fun findByValutakodeAndValutakursdato(
         valutakode: String,
         valutakursdato: LocalDate,
-    ): ECBValutakursCache?
+    ): List<ECBValutakursCache>?
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBServiceTest.kt
@@ -52,7 +52,7 @@ class ECBServiceTest {
                 listOf(Pair("NOK", BigDecimal.valueOf(10.337)), Pair("SEK", BigDecimal.valueOf(10.6543))),
                 valutakursDato.toString(),
             )
-        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns null
+        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns emptyList()
         every { evbValutakursCacheRepository.save(any()) } returns ECBValutakursCache(kurs = BigDecimal.valueOf(10.6543), valutakode = "SEK", valutakursdato = valutakursDato)
         every {
             ecbClient.hentValutakurs(
@@ -74,7 +74,7 @@ class ECBServiceTest {
                 listOf(Pair("NOK", BigDecimal.valueOf(10.337))),
                 valutakursDato.toString(),
             )
-        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns null
+        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns emptyList()
         every {
             ecbClient.hentValutakurs(
                 Frequency.Daily,
@@ -94,7 +94,7 @@ class ECBServiceTest {
                 listOf(Pair("NOK", BigDecimal.valueOf(10.337)), Pair("SEK", BigDecimal.valueOf(10.6543))),
                 valutakursDato.minusDays(1).toString(),
             )
-        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns null
+        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns emptyList()
         every {
             ecbClient.hentValutakurs(
                 Frequency.Daily,
@@ -115,7 +115,7 @@ class ECBServiceTest {
                 listOf(Pair("NOK", BigDecimal.valueOf(9.4567))),
                 valutakursDato.toString(),
             )
-        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns null
+        every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns emptyList()
         every { evbValutakursCacheRepository.save(any()) } returns ECBValutakursCache(kurs = BigDecimal.valueOf(9.4567), valutakode = "EUR", valutakursdato = valutakursDato)
         every {
             ecbClient.hentValutakurs(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBIntegrationTest.kt
@@ -69,7 +69,7 @@ class ECBIntegrationTest : AbstractSpringIntegrationTest() {
         } returns ecbExchangeRatesData.toExchangeRates()
 
         ecbService.hentValutakurs("EUR", valutakursDato)
-        val valutakurs = ecbValutakursCacheRepository.findByValutakodeAndValutakursdato("EUR", valutakursDato)
+        val valutakurs = ecbValutakursCacheRepository.findByValutakodeAndValutakursdato("EUR", valutakursDato)?.firstOrNull()
         assertEquals(valutakurs!!.kurs, BigDecimal.valueOf(9.4567))
         ecbService.hentValutakurs("EUR", valutakursDato)
         verify(exactly = 1) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ved månedlig valutajustering 01.07 ble enkelte valutaer hentet fra ECB klienten og lagret til ECB cachen flere ganger.
Dette førte til at alle tasker som brukte disse valutaene feilet fordi det ikke ble returnert et unikt resultat fra cachen.
Midlertidig løsning på problemet er å hente ut valutakursene med lik valutakursdato og valutakode som en liste, og hente første valutakurs fra listen.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
