### PR TITLE
Tar ikke med uregistrerte barn dersom det ikke er AVSLAG_UREGISTERT_BARN

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -310,8 +310,7 @@ fun ISanityBegrunnelse.hentBarnasFødselsdatoerForBegrunnelse(
                                 barnMistetUtbetalingFraForrigeBehandling
                         }.toSet()
 
-                    relevanteBarn.map { it.fødselsdato } +
-                        uregistrerteBarnPåBehandlingen.mapNotNull { it.fødselsdato }
+                    relevanteBarn.map { it.fødselsdato }
                 }
 
                 else -> (barnMedUtbetaling + barnPåBegrunnelse).toSet().map { it.fødselsdato }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/uregistrerte_barn.feature
@@ -97,3 +97,36 @@ Egenskap: Vedtaksperioder for behandling med uregistrert barn
       | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar | Begrunnelser            |
       | 01.02.1970 |          | Avslag             |           |                         |
       |            |          | Avslag             |           | AVSLAG_UREGISTRERT_BARN |
+
+  Scenario: Skal ikke inkludere uregistrerte barn i begrunnelser som ikke er AVSLAG_UREGISTRERT_BARN
+    Gitt følgende behandling
+      | BehandlingId |
+      | 1            |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1234    | SØKER      | 11.01.1970  |
+      | 1            | 3456    | BARN       | 13.04.2020  |
+
+    Og lag personresultater for begrunnelse for behandling 1
+
+    Og med uregistrerte barn
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår                                           | Fra dato   | Til dato   | Resultat |
+      | 1234    | BOSATT_I_RIKET, LOVLIG_OPPHOLD                   | 11.01.1970 |            | Oppfylt  |
+      | 3456    | UNDER_18_ÅR                                      | 13.04.2020 | 12.04.2038 | Oppfylt  |
+      | 3456    | GIFT_PARTNERSKAP, BOSATT_I_RIKET, LOVLIG_OPPHOLD | 13.04.2020 |            | Oppfylt  |
+      | 3456    | BOR_MED_SØKER                                    | 13.04.2020 | 10.03.2021 | Oppfylt  |
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | Fra dato   | Til dato   | Beløp | BehandlingId |
+      | 3456    | 01.05.2020 | 31.03.2021 | 1354  | 1            |
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato | Standardbegrunnelser          | Eøsbegrunnelser | Fritekster |
+      | 01.04.2021 |          | OPPHØR_BARN_FLYTTET_FRA_SØKER |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.04.2021 til -
+      | Begrunnelse                   | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet |
+      | OPPHØR_BARN_FLYTTET_FRA_SØKER | Nei           | 13.04.20             | 1           | mars 2021                            | NB      | 0     |                  | SØKER_HAR_IKKE_RETT     |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21668
Vi skal ikke inkludere uregistrerte barn ved ikke innvilget perioder. De skal bare inkluderes når begrunnelsen AVSLAG_UREGISTRERT_BARN blir brukt.