### PR TITLE
Bug: endringstidspunkt må ta hensyn til endring i valutakurs

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -23,20 +23,19 @@ import java.time.LocalDate
 fun utledEndringstidspunkt(
     behandlingsGrunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
     behandlingsGrunnlagForVedtaksperioderForrigeBehandling: BehandlingsGrunnlagForVedtaksperioder?,
-    erToggleForÅIkkeSplittePåValutakursendringerPå: Boolean,
 ): LocalDate {
     val grunnlagTidslinjePerPerson =
         behandlingsGrunnlagForVedtaksperioder
             .copy(
                 personResultater = behandlingsGrunnlagForVedtaksperioder.personResultater.beholdKunOppfylteVilkårResultater(),
-            ).utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå)
+            ).utledGrunnlagTidslinjePerPerson()
             .mapValues { it.value.vedtaksperiodeGrunnlagForPerson }
 
     val grunnlagTidslinjePerPersonForrigeBehandling =
         behandlingsGrunnlagForVedtaksperioderForrigeBehandling
             ?.copy(
                 personResultater = behandlingsGrunnlagForVedtaksperioderForrigeBehandling.personResultater.beholdKunOppfylteVilkårResultater(),
-            )?.utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå)
+            )?.utledGrunnlagTidslinjePerPerson()
             ?.mapValues { it.value.vedtaksperiodeGrunnlagForPerson } ?: emptyMap()
 
     val erPeriodeLikSammePeriodeIForrigeBehandlingTidslinjer =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -10,8 +10,6 @@ import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.common.validerBehandlingIkkeErAvsluttet
 import no.nav.familie.ba.sak.common.validerBehandlingKanRedigeres
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
-import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestGenererVedtaksperioderForOverstyrtEndringstidspunkt
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPutVedtaksperiodeMedFritekster
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
@@ -88,7 +86,6 @@ class VedtaksperiodeService(
     private val integrasjonClient: IntegrasjonClient,
     private val valutakursRepository: ValutakursRepository,
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,
@@ -122,10 +119,6 @@ class VedtaksperiodeService(
         return utledEndringstidspunkt(
             behandlingsGrunnlagForVedtaksperioder = behandling.hentGrunnlagForVedtaksperioder(),
             behandlingsGrunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
-            erToggleForÅIkkeSplittePåValutakursendringerPå =
-                unleashNextMedContextService.isEnabled(
-                    FeatureToggleConfig.IKKE_SPLITT_VEDTAKSPERIODE_PÅ_ENDRING_I_VALUTAKURS,
-                ),
         )
     }
 
@@ -324,10 +317,6 @@ class VedtaksperiodeService(
             grunnlagForVedtaksperioderForrigeBehandling = forrigeBehandling?.hentGrunnlagForVedtaksperioder(),
             vedtak = vedtak,
             nåDato = LocalDate.now(),
-            erToggleForÅIkkeSplittePåValutakursendringerPå =
-                unleashNextMedContextService.isEnabled(
-                    FeatureToggleConfig.IKKE_SPLITT_VEDTAKSPERIODE_PÅ_ENDRING_I_VALUTAKURS,
-                ),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
@@ -104,8 +104,6 @@ data class BehandlingsGrunnlagForVedtaksperioder(
         val erMinstEttBarnMedUtbetalingTidslinje =
             hentErMinstEttBarnMedUtbetalingTidslinje(personResultater, behandling.fagsak.type, persongrunnlag)
 
-        val erUtbetalingSmåbarnstilleggTidslinje = this.andelerTilkjentYtelse.hentErUtbetalingSmåbarnstilleggTidslinje()
-
         val personresultaterOgRolleForVilkår =
             if (behandling.fagsak.type.erBarnSøker()) {
                 personResultater.single().splittOppVilkårForBarnOgSøkerRolle()
@@ -147,13 +145,12 @@ data class BehandlingsGrunnlagForVedtaksperioder(
                             if (erToggleForÅIkkeSplittePåValutakursendringerPå) {
                                 forskjøvedeVilkårResultaterForPersonsAndeler.tilGrunnlagForPersonTidslinjeNy(
                                     person = person,
-                                    erUtbetalingSmåbarnstilleggTidslinje = erUtbetalingSmåbarnstilleggTidslinje,
                                     vilkårRolle = vilkårRolle,
                                 )
                             } else {
                                 forskjøvedeVilkårResultaterForPersonsAndeler.tilGrunnlagForPersonTidslinjeGammel(
                                     person = person,
-                                    erUtbetalingSmåbarnstilleggTidslinje = erUtbetalingSmåbarnstilleggTidslinje,
+                                    erUtbetalingSmåbarnstilleggTidslinje = this.andelerTilkjentYtelse.hentErUtbetalingSmåbarnstilleggTidslinje(),
                                     vilkårRolle = vilkårRolle,
                                 )
                             },
@@ -220,9 +217,9 @@ data class BehandlingsGrunnlagForVedtaksperioder(
 
     private fun Tidslinje<List<VilkårResultat>, Måned>.tilGrunnlagForPersonTidslinjeNy(
         person: Person,
-        erUtbetalingSmåbarnstilleggTidslinje: Tidslinje<Boolean, Måned>,
         vilkårRolle: PersonType,
     ): Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned> {
+        val småbarnstilleggTidslinje = andelerTilkjentYtelse.hentErUtbetalingSmåbarnstilleggTidslinje()
         val kompetanseTidslinje =
             utfylteKompetanser
                 .filtrerPåAktør(person.aktør)
@@ -244,7 +241,7 @@ data class BehandlingsGrunnlagForVedtaksperioder(
         val overgangsstønadTidslinje =
             perioderOvergangsstønad
                 .filtrerPåAktør(person.aktør)
-                .tilPeriodeOvergangsstønadForVedtaksperiodeTidslinje(erUtbetalingSmåbarnstilleggTidslinje)
+                .tilPeriodeOvergangsstønadForVedtaksperiodeTidslinje(småbarnstilleggTidslinje)
 
         val andelTilkjentYtelseTidslinje =
             andelerTilkjentYtelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
@@ -54,43 +54,21 @@ sealed interface VedtaksperiodeGrunnlagForPerson {
                     vilkårResultaterForVedtaksperiode,
                 )
 
-            is VedtaksperiodeGrunnlagForPersonVilkårInnvilgetNy -> this.copy(person, vilkårResultaterForVedtaksperiode)
+            is VedtaksperiodeGrunnlagForPersonVilkårInnvilget -> this.copy(person, vilkårResultaterForVedtaksperiode)
         }
 }
 
-sealed class VedtaksperiodeGrunnlagForPersonVilkårInnvilget(
+data class VedtaksperiodeGrunnlagForPersonVilkårInnvilget(
     override val person: Person,
     override val vilkårResultaterForVedtaksperiode: List<VilkårResultatForVedtaksperiode>,
-    open val andeler: Iterable<AndelForVedtaksobjekt>,
-    open val kompetanse: KompetanseForVedtaksperiode? = null,
-    open val endretUtbetalingAndel: IEndretUtbetalingAndelForVedtaksperiode? = null,
-    open val utenlandskPeriodebeløp: UtenlandskPeriodebeløpForVedtaksperiode? = null,
-    open val valutakurs: ValutakursForVedtaksperiode? = null,
-    open val overgangsstønad: OvergangsstønadForVedtaksperiode? = null,
+    val andeler: Iterable<AndelForVedtaksobjekt>,
+    val kompetanse: KompetanseForVedtaksperiode? = null,
+    val endretUtbetalingAndel: IEndretUtbetalingAndelForVedtaksperiode? = null,
+    val utenlandskPeriodebeløp: UtenlandskPeriodebeløpForVedtaksperiode? = null,
+    val valutakurs: ValutakursForVedtaksperiode? = null,
+    val overgangsstønad: OvergangsstønadForVedtaksperiode? = null,
 ) : VedtaksperiodeGrunnlagForPerson {
-    abstract fun erInnvilgetEndretUtbetaling(): Boolean
-}
-
-data class VedtaksperiodeGrunnlagForPersonVilkårInnvilgetNy(
-    override val person: Person,
-    override val vilkårResultaterForVedtaksperiode: List<VilkårResultatForVedtaksperiode>,
-    override val andeler: Iterable<AndelForVedtaksperiode>,
-    override val kompetanse: KompetanseForVedtaksperiode? = null,
-    override val endretUtbetalingAndel: IEndretUtbetalingAndelForVedtaksperiode? = null,
-    override val utenlandskPeriodebeløp: UtenlandskPeriodebeløpForVedtaksperiode? = null,
-    override val valutakurs: ValutakursForVedtaksperiode? = null,
-    override val overgangsstønad: OvergangsstønadForVedtaksperiode? = null,
-) : VedtaksperiodeGrunnlagForPersonVilkårInnvilget(
-        person,
-        vilkårResultaterForVedtaksperiode,
-        andeler,
-        kompetanse,
-        endretUtbetalingAndel,
-        utenlandskPeriodebeløp,
-        valutakurs,
-        overgangsstønad,
-    ) {
-    override fun erInnvilgetEndretUtbetaling() =
+    fun erInnvilgetEndretUtbetaling() =
         endretUtbetalingAndel?.prosent != BigDecimal.ZERO || endretUtbetalingAndel?.årsak == Årsak.DELT_BOSTED
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
@@ -55,8 +55,6 @@ sealed interface VedtaksperiodeGrunnlagForPerson {
                 )
 
             is VedtaksperiodeGrunnlagForPersonVilkårInnvilgetNy -> this.copy(person, vilkårResultaterForVedtaksperiode)
-
-            is VedtaksperiodeGrunnlagForPersonVilkårInnvilgetGammel -> this.copy(person, vilkårResultaterForVedtaksperiode)
         }
 }
 
@@ -77,30 +75,6 @@ data class VedtaksperiodeGrunnlagForPersonVilkårInnvilgetNy(
     override val person: Person,
     override val vilkårResultaterForVedtaksperiode: List<VilkårResultatForVedtaksperiode>,
     override val andeler: Iterable<AndelForVedtaksperiode>,
-    override val kompetanse: KompetanseForVedtaksperiode? = null,
-    override val endretUtbetalingAndel: IEndretUtbetalingAndelForVedtaksperiode? = null,
-    override val utenlandskPeriodebeløp: UtenlandskPeriodebeløpForVedtaksperiode? = null,
-    override val valutakurs: ValutakursForVedtaksperiode? = null,
-    override val overgangsstønad: OvergangsstønadForVedtaksperiode? = null,
-) : VedtaksperiodeGrunnlagForPersonVilkårInnvilget(
-        person,
-        vilkårResultaterForVedtaksperiode,
-        andeler,
-        kompetanse,
-        endretUtbetalingAndel,
-        utenlandskPeriodebeløp,
-        valutakurs,
-        overgangsstønad,
-    ) {
-    override fun erInnvilgetEndretUtbetaling() =
-        endretUtbetalingAndel?.prosent != BigDecimal.ZERO || endretUtbetalingAndel?.årsak == Årsak.DELT_BOSTED
-}
-
-@Deprecated("Bruk heller tilGrunnlagForPersonTidslinjeNy. Kan fjernes når feature toggle IKKE_SPLITT_VEDTAKSPERIODE_PÅ_ENDRING_I_VALUTAKURS ikke lenger er i bruk.")
-data class VedtaksperiodeGrunnlagForPersonVilkårInnvilgetGammel(
-    override val person: Person,
-    override val vilkårResultaterForVedtaksperiode: List<VilkårResultatForVedtaksperiode>,
-    override val andeler: Iterable<AndelForVedtaksbegrunnelse>,
     override val kompetanse: KompetanseForVedtaksperiode? = null,
     override val endretUtbetalingAndel: IEndretUtbetalingAndelForVedtaksperiode? = null,
     override val utenlandskPeriodebeløp: UtenlandskPeriodebeløpForVedtaksperiode? = null,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -61,10 +61,10 @@ fun genererVedtaksperioder(
 
     val grunnlagTidslinjePerPersonForrigeBehandling =
         grunnlagForVedtaksperioderForrigeBehandling
-            ?.let { grunnlagForVedtaksperioderForrigeBehandling.utledGrunnlagTidslinjePerPerson() }
+            ?.let { grunnlagForVedtaksperioderForrigeBehandling.utledGrunnlagTidslinjePerPerson(skalSplittePåValutakursendringer = false) }
             ?: emptyMap()
 
-    val grunnlagTidslinjePerPerson = grunnlagForVedtaksperioder.utledGrunnlagTidslinjePerPerson()
+    val grunnlagTidslinjePerPerson = grunnlagForVedtaksperioder.utledGrunnlagTidslinjePerPerson(skalSplittePåValutakursendringer = false)
 
     val perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling =
         finnPerioderSomSkalBegrunnes(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -46,7 +46,6 @@ fun genererVedtaksperioder(
     grunnlagForVedtaksperioderForrigeBehandling: BehandlingsGrunnlagForVedtaksperioder?,
     vedtak: Vedtak,
     nåDato: LocalDate,
-    erToggleForÅIkkeSplittePåValutakursendringerPå: Boolean,
 ): List<VedtaksperiodeMedBegrunnelser> {
     if (vedtak.behandling.opprettetÅrsak.erOmregningsårsak()) {
         return lagPeriodeForOmregningsbehandling(
@@ -62,10 +61,10 @@ fun genererVedtaksperioder(
 
     val grunnlagTidslinjePerPersonForrigeBehandling =
         grunnlagForVedtaksperioderForrigeBehandling
-            ?.let { grunnlagForVedtaksperioderForrigeBehandling.utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå) }
+            ?.let { grunnlagForVedtaksperioderForrigeBehandling.utledGrunnlagTidslinjePerPerson() }
             ?: emptyMap()
 
-    val grunnlagTidslinjePerPerson = grunnlagForVedtaksperioder.utledGrunnlagTidslinjePerPerson(erToggleForÅIkkeSplittePåValutakursendringerPå)
+    val grunnlagTidslinjePerPerson = grunnlagForVedtaksperioder.utledGrunnlagTidslinjePerPerson()
 
     val perioderSomSkalBegrunnesBasertPåDenneOgForrigeBehandling =
         finnPerioderSomSkalBegrunnes(
@@ -75,7 +74,6 @@ fun genererVedtaksperioder(
                 vedtak.behandling.overstyrtEndringstidspunkt ?: utledEndringstidspunkt(
                     behandlingsGrunnlagForVedtaksperioder = grunnlagForVedtaksperioder,
                     behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtaksperioderForrigeBehandling,
-                    erToggleForÅIkkeSplittePåValutakursendringerPå = erToggleForÅIkkeSplittePåValutakursendringerPå,
                 ),
             personerFremstiltKravFor = grunnlagForVedtaksperioder.personerFremstiltKravFor,
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -65,7 +65,6 @@ class VedtaksperiodeServiceTest {
                 integrasjonClient = integrasjonClient,
                 valutakursRepository = mockk(),
                 utenlandskPeriodebeløpRepository = mockk(),
-                unleashNextMedContextService = mockk(),
             ),
         )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BegrunnelseTeksterStepDefinition.kt
@@ -286,7 +286,6 @@ class BegrunnelseTeksterStepDefinition {
                 grunnlagForVedtaksperioder = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioder,
                 grunnlagForVedtaksperioderForrigeBehandling = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
                 nåDato = dagensDato,
-                erToggleForÅIkkeSplittePåValutakursendringerPå = true,
             )
 
         val utvidedeVedtaksperioderMedBegrunnelser =
@@ -606,7 +605,6 @@ class BegrunnelseTeksterStepDefinition {
             utledEndringstidspunkt(
                 behandlingsGrunnlagForVedtaksperioder = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioder,
                 behandlingsGrunnlagForVedtaksperioderForrigeBehandling = grunnlagForBegrunnelser.behandlingsGrunnlagForVedtaksperioderForrigeBehandling,
-                erToggleForÅIkkeSplittePåValutakursendringerPå = true,
             )
 
         val forventetEndringstidspunkt = parseNullableDato(forventetEndringstidspunktString) ?: error("Så forvent følgende endringstidspunkt {} forventer en dato")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -639,7 +639,6 @@ fun lagVedtaksPerioder(
         grunnlagForVedtaksperioder = grunnlagForVedtaksperiode,
         grunnlagForVedtaksperioderForrigeBehandling = grunnlagForVedtaksperiodeForrigeBehandling,
         nåDato = nåDato,
-        erToggleForÅIkkeSplittePåValutakursendringerPå = true,
     )
 }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -207,7 +207,6 @@ class CucumberMock(
             integrasjonClient = mockk(),
             valutakursRepository = valutakursRepository,
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
-            unleashNextMedContextService = unleashNextMedContextService,
         )
 
     val behandlingService =

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/valutajustering.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/valutajustering.feature
@@ -83,3 +83,125 @@ Egenskap: Vedtaksperioder med valutajustering
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar     |
       | 01.05.2024 | 30.06.2024 | Utbetaling         | Barn og søker |
       | 01.07.2024 |            | Opphør             | Barn og søker |
+
+
+  Scenario: Årlig kontroll får riktige vedtaksperioder når automatiske valutajusteringer er eneste endring tilbake i tid
+    Gitt følgende fagsaker for begrunnelse
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandling
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak         |
+      | 1            | 1        |                     | FORTSATT_INNVILGET  | MÅNEDLIG_VALUTAJUSTERING |
+      | 2            | 1        | 1                   | ENDRET_UTBETALING   | ÅRLIG_KONTROLL           |
+
+    Og følgende persongrunnlag for begrunnelse
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 18.01.1975  |
+      | 1            | 2       | BARN       | 16.07.2008  |
+      | 2            | 1       | SØKER      | 18.01.1975  |
+      | 2            | 2       | BARN       | 16.07.2008  |
+
+    Og følgende dagens dato 09.07.2024
+
+    Og lag personresultater for begrunnelse for behandling 1
+    Og lag personresultater for begrunnelse for behandling 2
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 1
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | LOVLIG_OPPHOLD   |                              | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | GIFT_PARTNERSKAP |                              | 16.07.2008 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | UNDER_18_ÅR      |                              | 16.07.2008 | 15.07.2026 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | LOVLIG_OPPHOLD   |                              | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+
+    Og legg til nye vilkårresultater for begrunnelse for behandling 2
+      | AktørId | Vilkår           | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET   | OMFATTET_AV_NORSK_LOVGIVNING | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | LOVLIG_OPPHOLD   |                              | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | GIFT_PARTNERSKAP |                              | 16.07.2008 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | UNDER_18_ÅR      |                              | 16.07.2008 | 15.07.2026 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOR_MED_SØKER    | BARN_BOR_I_EØS_MED_SØKER     | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOSATT_I_RIKET   | BARN_BOR_I_EØS               | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | LOVLIG_OPPHOLD   |                              | 31.12.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+
+    Og med andeler tilkjent ytelse for begrunnelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.01.2022 | 28.02.2023 | 796   | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.03.2023 | 30.06.2023 | 825   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 1            | 01.07.2023 | 31.12.2023 | 1052  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 1            | 01.01.2024 | 31.05.2024 | 1252  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.06.2024 | 30.06.2026 | 1226  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.01.2022 | 31.12.2022 | 803   | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.01.2023 | 31.01.2023 | 792   | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.02.2023 | 28.02.2023 | 782   | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.03.2023 | 31.03.2023 | 809   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 2            | 01.04.2023 | 30.04.2023 | 799   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 2            | 01.05.2023 | 31.05.2023 | 789   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 2            | 01.06.2023 | 30.06.2023 | 783   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 2            | 01.07.2023 | 31.07.2023 | 1018  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.08.2023 | 31.08.2023 | 1031  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.09.2023 | 30.09.2023 | 1021  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.10.2023 | 31.10.2023 | 1029  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.11.2023 | 30.11.2023 | 1014  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.12.2023 | 31.12.2023 | 1017  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.01.2024 | 31.01.2024 | 1229  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.02.2024 | 29.02.2024 | 1227  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.03.2024 | 31.03.2024 | 1223  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.04.2024 | 30.04.2024 | 1218  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.05.2024 | 31.05.2024 | 1215  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.06.2024 | 30.06.2026 | 1226  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+    Og med kompetanser for begrunnelse
+      | AktørId | Fra dato   | Til dato | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.01.2022 |          | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | LV                             | LV                  |
+      | 2       | 01.01.2022 |          | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | LV                             | LV                  |
+
+    Og med utenlandsk periodebeløp for begrunnelse
+      | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 01.2022   |           | 1            | 25    | EUR         | MÅNEDLIG  | LV              |
+      | 2       | 01.2022   |           | 2            | 25    | EUR         | MÅNEDLIG  | LV              |
+
+    Og med valutakurs for begrunnelse
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs    | Vurderingsform |
+      | 2       | 01.01.2022 | 31.05.2024 | 1            | 2022-06-30     | EUR         | 10.3485 | MANUELL        |
+      | 2       | 01.06.2024 | 30.06.2024 | 1            | 2024-05-31     | EUR         | 11.383  | AUTOMATISK     |
+      | 2       | 01.07.2024 |            | 1            | 2024-06-28     | EUR         | 11.3965 | AUTOMATISK     |
+      | 2       | 01.06.2024 | 30.06.2024 | 2            | 2024-05-31     | EUR         | 11.383  | AUTOMATISK     |
+      | 2       | 01.07.2024 |            | 2            | 2024-06-28     | EUR         | 11.3965 | AUTOMATISK     |
+      | 2       | 01.01.2022 | 31.12.2022 | 2            | 2022-06-01     | EUR         | 10.0438 | MANUELL        |
+      | 2       | 01.01.2023 | 31.01.2023 | 2            | 2022-12-30     | EUR         | 10.5138 | AUTOMATISK     |
+      | 2       | 01.02.2023 | 28.02.2023 | 2            | 2023-01-31     | EUR         | 10.9083 | AUTOMATISK     |
+      | 2       | 01.03.2023 | 31.03.2023 | 2            | 2023-02-28     | EUR         | 10.9713 | AUTOMATISK     |
+      | 2       | 01.04.2023 | 30.04.2023 | 2            | 2023-03-31     | EUR         | 11.394  | AUTOMATISK     |
+      | 2       | 01.05.2023 | 31.05.2023 | 2            | 2023-04-28     | EUR         | 11.791  | AUTOMATISK     |
+      | 2       | 01.06.2023 | 30.06.2023 | 2            | 2023-05-31     | EUR         | 12.0045 | AUTOMATISK     |
+      | 2       | 01.07.2023 | 31.07.2023 | 2            | 2023-06-30     | EUR         | 11.704  | AUTOMATISK     |
+      | 2       | 01.08.2023 | 31.08.2023 | 2            | 2023-07-31     | EUR         | 11.1805 | AUTOMATISK     |
+      | 2       | 01.09.2023 | 30.09.2023 | 2            | 2023-08-31     | EUR         | 11.58   | AUTOMATISK     |
+      | 2       | 01.10.2023 | 31.10.2023 | 2            | 2023-09-29     | EUR         | 11.2535 | AUTOMATISK     |
+      | 2       | 01.11.2023 | 30.11.2023 | 2            | 2023-10-31     | EUR         | 11.8735 | AUTOMATISK     |
+      | 2       | 01.12.2023 | 31.12.2023 | 2            | 2023-11-30     | EUR         | 11.72   | AUTOMATISK     |
+      | 2       | 01.01.2024 | 31.01.2024 | 2            | 2023-12-29     | EUR         | 11.2405 | AUTOMATISK     |
+      | 2       | 01.02.2024 | 29.02.2024 | 2            | 2024-01-31     | EUR         | 11.351  | AUTOMATISK     |
+      | 2       | 01.03.2024 | 31.03.2024 | 2            | 2024-02-29     | EUR         | 11.492  | AUTOMATISK     |
+      | 2       | 01.04.2024 | 30.04.2024 | 2            | 2024-03-27     | EUR         | 11.6825 | AUTOMATISK     |
+      | 2       | 01.05.2024 | 31.05.2024 | 2            | 2024-04-30     | EUR         | 11.815  | AUTOMATISK     |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent følgende vedtaksperioder for behandling 2
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.01.2022 | 28.02.2023 | UTBETALING         |           |
+      | 01.03.2023 | 30.06.2023 | UTBETALING         |           |
+      | 01.07.2023 | 31.12.2023 | UTBETALING         |           |
+      | 01.01.2024 | 30.06.2026 | UTBETALING         |           |
+      | 01.07.2026 |            | OPPHØR             |           |
+
+    Så forvent at endringstidspunktet er 01.01.2022 for behandling 2


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21773

Gjør hovedsakelig to ting:
1. Sletter toggle for å ikke splitte vedtaksperioder på valutakurs da den har vært i prod i to uker og nå er testet ok av Birgitte
2. Endrer logikk sånn at endringstidspunkt fortsatt tar hensyn til endring i valutakurser (det er kun selve vedtaksperiodene som genereres som ikke skal splittes). 

Syns ikke løsningen på problem 2 her ble spesielt sexy. Men, det skal ganske mye omskriving til for å gjøre det mer lekkert så jeg kan akseptere at det ikke er top notch for øyeblikket:) tar veldig gjerne i mot tilbakemeldinger på andre måter man evt kan løse problemet på. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._
⚠️ TESTEN MÅ OPPDATERES HVIS [DENNE](https://github.com/navikt/familie-ba-sak/pull/4683) PREN GÅR INN FØR DENNE

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
