### PR TITLE
Automatisk valutajustering for teknisk endring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -14,7 +14,6 @@ class FeatureToggleConfig {
         const val TEKNISK_ENDRING = "familie-ba-sak.behandling.teknisk-endring"
         const val HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD = "familie-ba-sak.hent-identer-til-psys-fra-infotrygd"
         const val KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK = "familie-ba-sak.kan-kjore-autmatisk-valutajustering-behandling-for-enkelt-sak"
-        const val KAN_OVERSTYRE_AUTOMATISKE_VALUTAKURSER = "familie-ba-sak.kan-overstyre-automatiske-valutakurser"
         const val KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER = "familie-ba-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"
 
         // NAV-21071 lagt bak toggle og kan evt fjernes på sikt hvis man ikke har trengt å skru den på igjen

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.common.rangeTo
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KAN_OVERSTYRE_AUTOMATISKE_VALUTAKURSER
+import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.TEKNISK_ENDRING
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.integrasjoner.ecb.ECBService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.tilSisteVirkedag
@@ -218,7 +218,7 @@ class AutomatiskOppdaterValutakursService(
         nyStrategi: VurderingsstrategiForValutakurser,
     ): VurderingsstrategiForValutakurserDB {
         if (!unleashNextMedContextService.isEnabled(KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER) ||
-            !unleashNextMedContextService.isEnabled(KAN_OVERSTYRE_AUTOMATISKE_VALUTAKURSER)
+            !unleashNextMedContextService.isEnabled(TEKNISK_ENDRING)
         ) {
             throw Feil("Relevante toggler for å overstyre vurderingsstrategi for valutakurser er ikke satt.")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -89,7 +89,10 @@ class VilkårsvurderingSteg(
 
         beregningService.genererTilkjentYtelseFraVilkårsvurdering(behandling, personopplysningGrunnlag)
 
-        if (unleashNextMedContextService.isEnabled(KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER) && behandling.type == BehandlingType.REVURDERING && behandling.skalBehandlesAutomatisk == false) {
+        if (unleashNextMedContextService.isEnabled(KAN_OPPRETTE_AUTOMATISKE_VALUTAKURSER_PÅ_MANUELLE_SAKER) &&
+            behandling.type in listOf(BehandlingType.REVURDERING, BehandlingType.TEKNISK_ENDRING) &&
+            !behandling.skalBehandlesAutomatisk
+        ) {
             automatiskOppdaterValutakursService.resettValutakurserOgLagValutakurserEtterEndringstidspunkt(BehandlingId(behandling.id))
         }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
@@ -591,7 +591,7 @@ class VedtaksperioderOgBegrunnelserStepDefinition {
 
         assertThat(valutakurs[behandlingId]!!.sortedBy { it.valutakursdato })
             .usingRecursiveComparison()
-            .ignoringFieldsMatchingRegexes(".*endretTidspunkt", ".*opprettetTidspunkt", ".*id")
+            .ignoringFieldsMatchingRegexes(".*endretTidspunkt", ".*opprettetTidspunkt", ".*id", ".*personidenter")
             .isEqualTo(forventedeValutakurser[behandlingId]!!.sortedBy { it.valutakursdato })
     }
 
@@ -688,6 +688,37 @@ class VedtaksperioderOgBegrunnelserStepDefinition {
             .usingRecursiveComparison()
             .ignoringFieldsMatchingRegexes(".*endretTidspunkt", ".*opprettetTidspunkt")
             .isEqualTo(forventedeVedtaksperioder.sortedWith(vedtaksperioderComparator))
+    }
+
+    @Og("kopier kompetanser fra behandling {} til behandling {}")
+    fun `kopier kompetanser fra behandling til behandling`(
+        fraBehandlingId: Long,
+        tilBehandlingId: Long,
+    ) {
+        kompetanser[tilBehandlingId] = kompetanser[fraBehandlingId]
+            ?: error("Finner ikke kompetanser for behandling med id $fraBehandlingId")
+    }
+
+    @Og("kopier utenlandsk periodebeløp fra behandling {} til behandling {}")
+    fun `kopier utenlandsk periodebeløp fra behandling til behandling`(
+        fraBehandlingId: Long,
+        tilBehandlingId: Long,
+    ) {
+        utenlandskPeriodebeløp[tilBehandlingId] = utenlandskPeriodebeløp[fraBehandlingId]
+            ?: error("Finner ikke utenlandsk periodebeløp for behandling med id $fraBehandlingId")
+    }
+
+    @Når("vi utfører vilkårsvurderingssteget for behandling {}")
+    fun `vi utfører vilkårsvurderingssteg for behandling`(
+        behandlingId: Long,
+    ) {
+        val mock =
+            CucumberMock(
+                dataFraCucumber = this,
+                nyBehanldingId = behandlingId,
+            )
+
+        mock.stegService.håndterVilkårsvurdering(behandlinger[behandlingId]!!)
     }
 }
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/steg/vilkårsvurderingsteg.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/steg/vilkårsvurderingsteg.feature
@@ -1,0 +1,98 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Vilkårsvurderingssteg
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype | Status  |
+      | 1        | NORMAL     | LØPENDE |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus | Behandlingssteg      | Underkategori | Behandlingstype |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | SATSENDRING      | Ja                        | EØS                 | AVSLUTTET         | BEHANDLING_AVSLUTTET | UTVIDET       | REVURDERING     |
+      | 2            | 1        | 1                   | ENDRET_UTBETALING   | TEKNISK_ENDRING  | Nei                       | EØS                 | UTREDES           | VILKÅRSVURDERING     | UTVIDET       | TEKNISK_ENDRING |
+      | 3            | 1        | 1                   | ENDRET_UTBETALING   | NYE_OPPLYSNINGER | Nei                       | EØS                 | UTREDES           | VILKÅRSVURDERING     | UTVIDET       | REVURDERING     |
+
+    Og dagens dato er 01.06.2023
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1, 2, 3      | 1       | SØKER      | 20.03.1995  |              |
+      | 1, 2, 3      | 2       | BARN       | 15.07.2018  |              |
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår             | Utdypende vilkår                    | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD     |                                     | 01.03.2020 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET     | OMFATTET_AV_NORSK_LOVGIVNING_UTLAND | 01.03.2020 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | UTVIDET_BARNETRYGD |                                     | 14.11.2021 |            | OPPFYLT  | Nei                  |                      |                  |
+
+      | 2       | UNDER_18_ÅR        |                                     | 15.07.2018 | 14.07.2036 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | GIFT_PARTNERSKAP   |                                     | 15.07.2018 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOSATT_I_RIKET     | BARN_BOR_I_EØS                      | 14.11.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER      | BARN_BOR_I_EØS_MED_ANNEN_FORELDER   | 14.11.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | LOVLIG_OPPHOLD     |                                     | 14.11.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+    Og med kompetanser
+      | AktørId | Fra dato   | Til dato | Resultat              | BehandlingId | Søkers aktivitet  | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.12.2021 |          | NORGE_ER_SEKUNDÆRLAND | 1            | MOTTAR_UFØRETRYGD | I_ARBEID                  | NO                    | SE                             | SE                  |
+
+    Og med utenlandsk periodebeløp
+      | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 12.2021   |           | 1            | 1250  | SEK         | MÅNEDLIG  | SE              |
+
+    Og med valutakurser
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 2       | 01.12.2021 | 31.12.2021 | 1            | 2021-12-31     | SEK         | 0.9744885516 | MANUELL        |
+      | 2       | 01.01.2022 | 31.12.2022 | 1            | 2022-12-30     | SEK         | 0.9453325900 | MANUELL        |
+      | 2       | 01.01.2023 |            | 1            | 2023-06-07     | SEK         | 1.0147950626 | MANUELL        |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.12.2021 | 28.02.2023 | 1054  | UTVIDET_BARNETRYGD | 100     | 1054 |
+      | 1       | 1            | 01.03.2023 | 30.06.2023 | 2489  | UTVIDET_BARNETRYGD | 100     | 2489 |
+      | 1       | 1            | 01.07.2023 | 30.06.2036 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 2       | 1            | 01.12.2021 | 31.12.2021 | 436   | ORDINÆR_BARNETRYGD | 100     | 1654 |
+      | 2       | 1            | 01.01.2022 | 31.12.2022 | 495   | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 1            | 01.01.2023 | 28.02.2023 | 408   | ORDINÆR_BARNETRYGD | 100     | 1676 |
+      | 2       | 1            | 01.03.2023 | 30.06.2023 | 455   | ORDINÆR_BARNETRYGD | 100     | 1723 |
+      | 2       | 1            | 01.07.2023 | 30.06.2024 | 498   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.07.2024 | 30.06.2036 | 42    | ORDINÆR_BARNETRYGD | 100     | 1310 |
+
+  Scenario: skal generere valutakurser for behandling med type teknisk endring
+
+    Og lag personresultater for behandling 2
+    Og kopier kompetanser fra behandling 1 til behandling 2
+    Og kopier utenlandsk periodebeløp fra behandling 1 til behandling 2
+
+    Når vi utfører vilkårsvurderingssteget for behandling 2
+
+    Så forvent følgende valutakurser for behandling 2
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 2       | 01.12.2021 | 31.12.2021 | 2            | 2021-12-31     | SEK         | 0.9744885516 | MANUELL        |
+      | 2       | 01.01.2022 | 31.12.2022 | 2            | 2022-12-30     | SEK         | 0.9453325900 | MANUELL        |
+      | 2       | 01.01.2023 | 31.01.2023 | 2            | 2022-12-30     | SEK         | 0.9453325900 | AUTOMATISK     |
+      | 2       | 01.02.2023 | 28.02.2023 | 2            | 2023-01-31     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.03.2023 | 31.03.2023 | 2            | 2023-02-28     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.04.2023 | 30.04.2023 | 2            | 2023-03-31     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.05.2023 | 31.05.2023 | 2            | 2023-04-28     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.06.2023 |            | 2            | 2023-05-31     | SEK         | 10           | AUTOMATISK     |
+
+  Scenario: skal generere valutakurser for behandling med type revurdering
+
+    Og lag personresultater for behandling 3
+    Og kopier kompetanser fra behandling 1 til behandling 3
+    Og kopier utenlandsk periodebeløp fra behandling 1 til behandling 3
+
+    Når vi utfører vilkårsvurderingssteget for behandling 3
+
+    Så forvent følgende valutakurser for behandling 3
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 2       | 01.12.2021 | 31.12.2021 | 3            | 2021-12-31     | SEK         | 0.9744885516 | MANUELL        |
+      | 2       | 01.01.2022 | 31.12.2022 | 3            | 2022-12-30     | SEK         | 0.9453325900 | MANUELL        |
+      | 2       | 01.01.2023 | 31.01.2023 | 3            | 2022-12-30     | SEK         | 0.9453325900 | AUTOMATISK     |
+      | 2       | 01.02.2023 | 28.02.2023 | 3            | 2023-01-31     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.03.2023 | 31.03.2023 | 3            | 2023-02-28     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.04.2023 | 30.04.2023 | 3            | 2023-03-31     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.05.2023 | 31.05.2023 | 3            | 2023-04-28     | SEK         | 10           | AUTOMATISK     |
+      | 2       | 01.06.2023 |            | 3            | 2023-05-31     | SEK         | 10           | AUTOMATISK     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-21691

Automatiske valutaperioder skal genereres for behandlinger som er teknisk endring når saksbehandler går fra vilkårsvurderingssteget til behandlingsresultatsteget.

Det skal være mulig å overstyre dette i tekniske endringer, se [frontend-PR](https://github.com/navikt/familie-ba-sak-frontend/pull/3267)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
