### PR TITLE
Logging av endringer i beløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -60,6 +60,8 @@ object EndringIUtbetalingUtil {
         val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndeler)
         val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndeler)
 
+        val endringer = mutableListOf<String>()
+
         val endringIBeløpTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
                 val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp ?: 0
@@ -68,11 +70,15 @@ object EndringIUtbetalingUtil {
                 val erEndringIBeløp = nåværendeBeløp != forrigeBeløp
 
                 if (erEndringIBeløp) {
-                    secureLogger.info("Endring i beløp for ytelseType ${nåværende?.type ?: forrige?.type}. Nytt beløp = $nåværendeBeløp , forrige beløp = $forrigeBeløp")
+                    endringer.add("Endring i beløp for ytelseType ${nåværende?.type ?: forrige?.type}. Nytt beløp = $nåværendeBeløp , forrige beløp = $forrigeBeløp")
                 }
 
                 erEndringIBeløp
             }
+
+        if (endringer.isNotEmpty()) {
+            secureLogger.info(endringer.joinToString(" ,"))
+        }
 
         return endringIBeløpTidslinje
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunkt
@@ -64,7 +65,13 @@ object EndringIUtbetalingUtil {
                 val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp ?: 0
                 val forrigeBeløp = forrige?.kalkulertUtbetalingsbeløp ?: 0
 
-                nåværendeBeløp != forrigeBeløp
+                val erEndringIBeløp = nåværendeBeløp != forrigeBeløp
+
+                if (erEndringIBeløp) {
+                    secureLogger.info("Endring i beløp for ytelseType ${nåværende?.type ?: forrige?.type}. Nytt beløp = $nåværendeBeløp , forrige beløp = $forrigeBeløp")
+                }
+
+                erEndringIBeløp
             }
 
         return endringIBeløpTidslinje


### PR DESCRIPTION
Logger ut ytelsetype og endring i beløp for å få litt bedre innsikt i feil som har oppstått i omregningsbehandlinger.