### PR TITLE
Fiks feil i Cucumber util

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/VedtaksperioderOgBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/VedtaksperioderOgBegrunnelserTestUtil.kt
@@ -192,7 +192,7 @@ private fun hentTekstForPersonerFremstiltKravFor(
     """
     Og med personer fremstilt krav for
     | BehandlingId | AktørId |""" +
-        personerFremstiltKravFor.joinToString {
+        personerFremstiltKravFor.joinToString(separator = "") {
             """
     | $behandlingId | ${it.aktørId} |"""
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Linjer ble separert med komma pga default behaviour til `joinToString`
![image](https://github.com/user-attachments/assets/d0106b5c-39b5-4d25-804e-a0809ad86dce)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
