### PR TITLE
Bug: behandlingsresultat når ingen andeler til nullutbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -176,13 +176,13 @@ private fun erEndringIBeløpForPersonOgType(
     val endringIBeløpTidslinje =
         nåværendeTidslinje
             .kombinerMed(forrigeTidslinje) { nåværende, forrige ->
-                val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp ?: 0
-                val forrigeBeløp = forrige?.kalkulertUtbetalingsbeløp ?: 0
+                val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp
+                val forrigeBeløp = forrige?.kalkulertUtbetalingsbeløp
 
                 if (erFremstiltKravForPerson) {
                     // Hvis det er søkt for person vil vi kun ha med endringer som går fra beløp > 0 til 0/null
                     when {
-                        forrigeBeløp > 0 && nåværendeBeløp == 0 -> true
+                        forrigeBeløp.erStørreEnn0() && nåværendeBeløp.er0EllerNull() -> true
                         else -> false
                     }
                 } else {
@@ -197,6 +197,10 @@ private fun erEndringIBeløpForPersonOgType(
 
     return endringIBeløpTidslinje.perioder().any { it.innhold == true }
 }
+
+private fun Int?.erStørreEnn0(): Boolean = this != null && this > 0
+
+private fun Int?.er0EllerNull(): Boolean = this == null || this == 0
 
 private fun Tidslinje<Boolean, Måned>.fjernPerioderEtterOpphørsdato(opphørstidspunkt: YearMonth) =
     this.beskjær(fraOgMed = TIDENES_MORGEN.tilMånedTidspunkt(), tilOgMed = opphørstidspunkt.forrigeMåned().tilTidspunkt())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -637,6 +637,45 @@ class BehandlingsresultatEndringUtilsTest {
     }
 
     @Test
+    fun `Endring i beløp - Skal returnere true når beløp i periode har gått fra null til 0kr og det ikke er søkt for person`() {
+        val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
+
+        val nåværendeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = jan22,
+                    tom = aug22,
+                    beløp = 0,
+                    aktør = barn1Aktør,
+                ),
+            )
+
+        val erEndringIBeløp =
+            listOf(barn1Aktør).any { aktør ->
+
+                val opphørstidspunktForBehandling =
+                    nåværendeAndeler.utledOpphørsdatoForNåværendeBehandlingMedFallback(
+                        forrigeAndelerIBehandling = emptyList(),
+                        nåværendeEndretAndelerIBehandling = emptyList(),
+                        endretAndelerForForrigeBehandling = emptyList(),
+                    )
+
+                val erEndringIBeløpForPerson =
+                    erEndringIBeløpForPerson(
+                        nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør },
+                        forrigeAndelerForPerson = emptyList(),
+                        opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
+                        erFremstiltKravForPerson = false,
+                        nåMåned = YearMonth.now(),
+                    )
+
+                erEndringIBeløpForPerson
+            }
+
+        assertEquals(true, erEndringIBeløp)
+    }
+
+    @Test
     fun `Endring i beløp - Skal returnere true hvis utvidet ikke er endret men småbarnstillegg kun er lagt på`() {
         val søker = lagPerson(type = PersonType.SØKER).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21810

Når man går fra å ikke ha andeler i en periode til å få andeler som er 0kr-andeler ønsker vi å gi resultatet "Endret" så lenge det ikke er fremstilt krav for personen. Resten av logikken for å detektere endringer for å gi "endret" som behandlingsresultat ser kun på perioder hvor det fantes noe før og det finnes noe nå - så dette er det eneste stedet hvor man ønsker å se på hvor det er lagt til eller fjernet noe. Uten denne endringen får revurderinger som har lagt til 0-kr andeler resultatet "fortsatt innvilget", men det er ikke ønskelig - det er faktisk gjort en endring her som vi trenger å reflektere i behandlingsresultatet for å få riktig brev.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._
Nei, har avklart med Anna

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
