### PR TITLE
Inkluder barn med allerede utbetalt i brevbegrunnelse og brevperiode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -288,14 +288,15 @@ fun ISanityBegrunnelse.hentBarnasFødselsdatoerForBegrunnelse(
 ): List<LocalDate> {
     val barnPåBegrunnelse = personerIBegrunnelse.filter { it.type == PersonType.BARN }
     val barnMedUtbetaling =
-        hentPersonerMedUtbetalingIPeriode(begrunnelsesGrunnlagPerPerson).filter { it.type == PersonType.BARN }
-    val erUtvidet = hentUtvidetAndelerIPeriode(begrunnelsesGrunnlagPerPerson).isNotEmpty()
-    val barnMedUtbetalingEllerAlleredeBetaltIUtvidetPeriode =
-        if (barnMedUtbetaling.isEmpty() && erUtvidet) {
-            hentBarnMedAlleredeUtbetalt(begrunnelsesGrunnlagPerPerson)
-        } else {
-            barnMedUtbetaling
-        }
+        hentPersonerMedUtbetalingIPeriode(begrunnelsesGrunnlagPerPerson)
+            .filter { it.type == PersonType.BARN }
+            .ifEmpty {
+                val erUtvidet = hentUtvidetAndelerIPeriode(begrunnelsesGrunnlagPerPerson).isNotEmpty()
+                when {
+                    erUtvidet -> hentBarnMedAlleredeUtbetalt(begrunnelsesGrunnlagPerPerson)
+                    else -> emptySet()
+                }
+            }
     val uregistrerteBarnPåBehandlingen = grunnlag.behandlingsGrunnlagForVedtaksperioder.uregistrerteBarn
 
     val barnPåBehandlingen = grunnlag.behandlingsGrunnlagForVedtaksperioder.persongrunnlag.barna
@@ -326,7 +327,7 @@ fun ISanityBegrunnelse.hentBarnasFødselsdatoerForBegrunnelse(
                     relevanteBarn.map { it.fødselsdato }
                 }
 
-                else -> (barnMedUtbetalingEllerAlleredeBetaltIUtvidetPeriode + barnPåBegrunnelse).toSet().map { it.fødselsdato }
+                else -> (barnMedUtbetaling + barnPåBegrunnelse).toSet().map { it.fødselsdato }
             }
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
@@ -75,7 +75,14 @@ private fun VedtaksperiodeMedBegrunnelser.byggBrevPeriode(
     begrunnelseGrunnlagPerPerson: Map<Person, IBegrunnelseGrunnlagForPeriode>,
     grunnlagForBegrunnelse: GrunnlagForBegrunnelse,
 ): BrevPeriode {
-    val barnMedUtbetaling = begrunnelseGrunnlagPerPerson.finnBarnMedUtbetaling().keys
+    val barnMedUtbetaling = begrunnelseGrunnlagPerPerson.finnBarnMedUtbetaling()
+    val erUtvidetIPeriode = begrunnelseGrunnlagPerPerson.erUtvidetIPeriode()
+    val barnMedUtbetalingEllerAlleredeBetaltIUtvidetPeriode =
+        if (barnMedUtbetaling.isEmpty() && erUtvidetIPeriode) {
+            begrunnelseGrunnlagPerPerson.finnBarnMedAlleredeUtbetalt()
+        } else {
+            barnMedUtbetaling
+        }
     val beløp = begrunnelseGrunnlagPerPerson.hentTotaltUtbetaltIPeriode()
 
     val brevPeriodeType =
@@ -90,8 +97,8 @@ private fun VedtaksperiodeMedBegrunnelser.byggBrevPeriode(
         beløp = beløp.toString(),
         begrunnelser = begrunnelserOgFritekster,
         brevPeriodeType = brevPeriodeType,
-        antallBarn = barnMedUtbetaling.size.toString(),
-        barnasFodselsdager = barnMedUtbetaling.tilBarnasFødselsdatoer(),
+        antallBarn = barnMedUtbetalingEllerAlleredeBetaltIUtvidetPeriode.size.toString(),
+        barnasFodselsdager = barnMedUtbetalingEllerAlleredeBetaltIUtvidetPeriode.tilBarnasFødselsdatoer(),
         duEllerInstitusjonen =
             hentDuEllerInstitusjonenTekst(
                 brevPeriodeType = brevPeriodeType,
@@ -118,27 +125,29 @@ private fun VedtaksperiodeMedBegrunnelser.hentTomTekstForBrev(
 private fun Map<Person, IBegrunnelseGrunnlagForPeriode>.hentTotaltUtbetaltIPeriode() =
     this.values.sumOf { it.dennePerioden.andeler.sumOf { andeler -> andeler.kalkulertUtbetalingsbeløp } }
 
-private fun Map<Person, IBegrunnelseGrunnlagForPeriode>.finnBarnMedUtbetaling(): Map<Person, IBegrunnelseGrunnlagForPeriode> {
-    val utbetalesUtvidetIDennePerioden =
-        any {
-            it.value.dennePerioden.andeler
-                .any { andel -> andel.type == YtelseType.UTVIDET_BARNETRYGD && andel.kalkulertUtbetalingsbeløp > 0 }
-        }
-
-    return filterKeys { it.type == PersonType.BARN }
+private fun Map<Person, IBegrunnelseGrunnlagForPeriode>.finnBarnMedUtbetaling(): Set<Person> =
+    this
+        .filterKeys { it.type == PersonType.BARN }
         .filterValues { grunnlag ->
             val endretUtbetalingGjelderDeltBosted =
                 grunnlag.dennePerioden.endretUtbetalingAndel?.årsak == Årsak.DELT_BOSTED
-
-            val erUtvidetIPeriodenOgBarnHarEndretUtbetalingAlleredeUtbetalt =
-                grunnlag.dennePerioden.endretUtbetalingAndel?.årsak == Årsak.ALLEREDE_UTBETALT && utbetalesUtvidetIDennePerioden
-
             val harAndelerSomIkkeErPåNullProsent =
                 grunnlag.dennePerioden.andeler.any { it.prosent != BigDecimal.ZERO }
 
-            harAndelerSomIkkeErPåNullProsent || endretUtbetalingGjelderDeltBosted || erUtvidetIPeriodenOgBarnHarEndretUtbetalingAlleredeUtbetalt
-        }
-}
+            harAndelerSomIkkeErPåNullProsent || endretUtbetalingGjelderDeltBosted
+        }.keys
+
+private fun Map<Person, IBegrunnelseGrunnlagForPeriode>.erUtvidetIPeriode(): Boolean =
+    this.any {
+        it.value.dennePerioden.andeler
+            .any { andel -> andel.type == YtelseType.UTVIDET_BARNETRYGD && andel.kalkulertUtbetalingsbeløp > 0 }
+    }
+
+private fun Map<Person, IBegrunnelseGrunnlagForPeriode>.finnBarnMedAlleredeUtbetalt(): Set<Person> =
+    this
+        .filterKeys { it.type == PersonType.BARN }
+        .filterValues { grunnlag -> grunnlag.dennePerioden.endretUtbetalingAndel?.årsak == Årsak.ALLEREDE_UTBETALT }
+        .keys
 
 fun Set<Person>.tilBarnasFødselsdatoer(): String {
     val barnasFødselsdatoerListe: List<String> =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-21263

Forhåndsvisning av brevbegrunnelse feiler fordi `antallBarn = 0` når barn ikke har utbetaling pga allerede utbetalt i behandlinger med utvidet barnetrygd

- Forelder har krav på utvidet og har ett barn som allerede har utbetalt $\rightarrow$ inkluder barn i brevbegrunnelse
- Forelder har krav på utvidet og har ett barn med utbetaling og ett barn som allerede har utbetalt $\rightarrow$ inkluder barn med utbetaling i brevbegrunnelse

**Før**
![image](https://github.com/user-attachments/assets/30209c43-16eb-4120-bc3c-5f7a6578ca23)

**Etter**
![image](https://github.com/user-attachments/assets/1d609a7f-1672-42b2-9a15-13e1cb153214)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
