### PR TITLE
Inkluder uregistrerte barn i brevbegrunnelse for avslag på søker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -303,14 +303,17 @@ fun ISanityBegrunnelse.hentBarnasFødselsdatoerForBegrunnelse(
 
                     val relevanteBarn =
                         if (erAvslagPåSøker) {
-                            barnPåBehandlingen
+                            barnPåBehandlingen.map { it.fødselsdato } +
+                                uregistrerteBarnPåBehandlingen.mapNotNull { it.fødselsdato }
                         } else {
-                            barnMedUtbetalingIForrigeperiode +
-                                barnMedOppfylteVilkår +
-                                barnMistetUtbetalingFraForrigeBehandling
-                        }.toSet()
+                            (
+                                barnMedUtbetalingIForrigeperiode +
+                                    barnMedOppfylteVilkår +
+                                    barnMistetUtbetalingFraForrigeBehandling
+                            ).toSet().map { it.fødselsdato }
+                        }
 
-                    relevanteBarn.map { it.fødselsdato }
+                    relevanteBarn
                 }
 
                 else -> (barnMedUtbetaling + barnPåBegrunnelse).toSet().map { it.fødselsdato }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Barn som er manuelt registrert i førstegangsbehandlinger blir ikke tatt med i avslagsbegrunnelse. Det er et problem dersom det kun eksisterer manuelt registrerte barn og man tar med begrunnelse for eksplisitt avslag på søker, fordi brevbegrunnelsen trenger barnas fødselsdato.

![image](https://github.com/user-attachments/assets/99917698-2c66-4b14-b4a1-5b99d0901f6e)

Løser problemet ved å ta med uregistrerte barn i brevbegrunnelse som er avslag på søker

![image](https://github.com/user-attachments/assets/3be8fe0b-b643-4f38-9221-c919b600fd4f)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
