### PR TITLE
Fix: Oppdage reduksjon fra forrige behandling når alle vilkår har tom-dato innenfor samme år og måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -356,19 +356,24 @@ private fun erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype(
     innvilgedeYtelsestyperDennePeriodenForrigeBehandling: Set<YtelseType>?,
 ): Boolean =
     YtelseType.entries.any { ytelseType ->
-        val ytelseInnvilgetDennePerioden =
-            innvilgedeYtelsestyperDennePerioden?.contains(ytelseType) ?: false
-        val ytelseInnvilgetForrigePeriode =
-            innvilgedeYtelsestyperForrigePeriode?.contains(ytelseType) ?: false
-        val ytelseInnvilgetDennePeriodenForrigeBehandling =
-            innvilgedeYtelsestyperDennePeriodenForrigeBehandling?.contains(ytelseType) ?: false
-        val ytelseInnvilgetForrigePeriodeForrigeBehandling =
-            innvilgedeYtelsestyperForrigePeriodeForrigeBehandling?.contains(ytelseType) ?: false
 
-        !ytelseInnvilgetForrigePeriode &&
-            !ytelseInnvilgetDennePerioden &&
-            !ytelseInnvilgetForrigePeriodeForrigeBehandling &&
-            ytelseInnvilgetDennePeriodenForrigeBehandling
+        if (innvilgedeYtelsestyperDennePerioden == null) {
+            innvilgedeYtelsestyperDennePeriodenForrigeBehandling?.contains(ytelseType) ?: false
+        } else {
+            val ytelseInnvilgetDennePerioden =
+                innvilgedeYtelsestyperDennePerioden.contains(ytelseType)
+            val ytelseInnvilgetForrigePeriode =
+                innvilgedeYtelsestyperForrigePeriode?.contains(ytelseType) ?: false
+            val ytelseInnvilgetDennePeriodenForrigeBehandling =
+                innvilgedeYtelsestyperDennePeriodenForrigeBehandling?.contains(ytelseType) ?: false
+            val ytelseInnvilgetForrigePeriodeForrigeBehandling =
+                innvilgedeYtelsestyperForrigePeriodeForrigeBehandling?.contains(ytelseType) ?: false
+
+            !ytelseInnvilgetForrigePeriode &&
+                !ytelseInnvilgetDennePerioden &&
+                !ytelseInnvilgetForrigePeriodeForrigeBehandling &&
+                ytelseInnvilgetDennePeriodenForrigeBehandling
+        }
     }
 
 private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSammenSammenhengendeOpphørsperioder(personerFremstiltKravFor: List<Aktør>): Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned> {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -63,6 +63,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.lagDødsfall
+import no.nav.familie.ba.sak.kjerne.institusjon.Institusjon
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
@@ -99,6 +100,7 @@ fun lagFagsaker(dataTable: DataTable) =
                 type = parseValgfriEnum<FagsakType>(Domenebegrep.FAGSAK_TYPE, rad) ?: FagsakType.NORMAL,
                 aktør = randomAktør(),
                 status = parseValgfriEnum<FagsakStatus>(Domenebegrep.STATUS, rad) ?: FagsakStatus.OPPRETTET,
+                institusjon = Institusjon(orgNummer = "", tssEksternId = ""),
             )
         }.associateBy { it.id }
         .toMutableMap()

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/opphør_ved_lik_tom_alle_vilkår.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/vedtaksperioder/opphør_ved_lik_tom_alle_vilkår.feature
@@ -1,0 +1,59 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Opphør når alle vilkår har samme tom, som f.eks ved dødsfall
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype  | Status  |
+      | 1        | INSTITUSJON | LØPENDE |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | SATSENDRING      | Ja                        | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | OPPHØRT             | NYE_OPPLYSNINGER | Nei                       | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | BARN       | 26.12.2007  |              |
+      | 2            | 1       | BARN       | 26.12.2007  | 13.07.2024   |
+
+  Scenario: Dersom alle vilkår har samme tom og ingenting annet er endret i behandlingen skal vi få et opphør fra og med mnd etter tom
+    Og dagens dato er 02.08.2024
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 1            | 1       |
+      | 2            | 1       |
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | GIFT_PARTNERSKAP                            |                  | 26.12.2007 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 1       | UNDER_18_ÅR                                 |                  | 26.12.2007 | 25.12.2025 | OPPFYLT  | Nei                  |                      |                  |
+      | 1       | BOSATT_I_RIKET,LOVLIG_OPPHOLD,BOR_MED_SØKER |                  | 01.02.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                                      | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | UNDER_18_ÅR,GIFT_PARTNERSKAP                |                  | 26.12.2007 | 13.07.2024 | OPPFYLT  | Nei                  |                      |                  |
+      | 1       | BOSATT_I_RIKET,BOR_MED_SØKER,LOVLIG_OPPHOLD |                  | 01.02.2023 | 13.07.2024 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 1       | 1            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 1       | 1            | 01.01.2024 | 30.11.2025 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+      | 1       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 1       | 2            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 1       | 2            | 01.01.2024 | 31.07.2024 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent følgende vedtaksperioder for behandling 2
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
+      | 01.08.2024 |          | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk | Gyldige begrunnelser | Ugyldige begrunnelser |
+      | 01.08.2024 |          | OPPHØR             |           | OPPHØR_BARN_DØD      |                       |


### PR DESCRIPTION
Favro: [NAV-21881](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21881)

### 💰 Hva skal gjøres, og hvorfor?
Når alle vilkår har samme `tom`, eller `tom` faller innenfor samme år og måned, får vi ingen vedtaksperioder og saksbehandler får ikke mulighet til å begrunne hvorfor ytelsen opphører. 

Dette kommer av at logikken vår for reduksjon ikke håndterer tilfellet når `grunnlagTidslinjeForPerson` i nåværende behandling sitt grunnlag er `null` i perioden reduksjonen/opphøret inntreffer. Når vi ikke oppdager reduksjonen/opphøret og dette er den eneste endringen i behandlingen finner vi ikke noen perioder som skal begrunnes.

Fikser dette ved å spesifikt håndtere tilfellet når grunnlaget i nåværende behandling er `null`. Da sjekker jeg kun om samme periode i forrige behandling har en innvilget ytelsetype. Finnes det en innvilget ytelsetype samme periode i forrige behandling sier vi at vi har en reduksjon i perioden.

La inn en cucumber-test basert på fagsaken som feilet pga dette.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. 
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
