### PR TITLE
Korrigert EØS-opphørsbegrunnelse og flyttet den til rett plass

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -368,7 +368,7 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val sanityApiNavn = "opphorSokerBoddeIkkeIEosLand"
     },
     OPPHØR_SEKUNDÆRLAND_INGEN_AV_FORELDRENE_JOBBER {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_OPPHØR
         override val sanityApiNavn = "opphorSekundarlandIngenAvForeldreneJobber"
     },
     AVSLAG_EØS_IKKE_EØS_BORGER {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -367,6 +367,10 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_OPPHØR
         override val sanityApiNavn = "opphorSokerBoddeIkkeIEosLand"
     },
+    OPPHØR_SEKUNDÆRLAND_INGEN_AV_FORELDRENE_JOBBER {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
+        override val sanityApiNavn = "opphorSekundarlandIngenAvForeldreneJobber"
+    },
     AVSLAG_EØS_IKKE_EØS_BORGER {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_AVSLAG
         override val sanityApiNavn = "avslagEosIkkeEosBorger"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -1265,10 +1265,6 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
         override val sanityApiNavn = "opphorEnsligMindrearigUtvandret"
     },
-    OPPHØR_SEKUNDÆRLAND_INGEN_AV_FORELDRENE_JOBBER {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.OPPHØR
-        override val sanityApiNavn = "opphorSekundarlandIngenAvForeldreneJobber"
-    },
     FORTSATT_INNVILGET_SØKER_OG_BARN_BOSATT_I_RIKET {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.FORTSATT_INNVILGET
         override val sanityApiNavn = "fortsattInnvilgetSokerOgBarnBosattIRiket"


### PR DESCRIPTION
Favro: [NAV-22051](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22051)

### 💰 Hva skal gjøres, og hvorfor?
Begrunnelse dukket ikke opp selv om den var lagt inn

Hadde lagt inn begrunnelsen i `Standardbegrunnelse` fremfor `EØSStandardbegrunnelse` og brukt `VedtakBegrunnelseType.OPPHØR` fremfor `VedtakBegrunnelse.EØS_OPPHØR`

PR retter opp dette ☝️ 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
