### PR TITLE
Spesifiser starttidspunkt for utbetalingstabell ved årlig kontroll

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -594,12 +594,12 @@ class BrevService(
     }
 
     fun finnStarttidspunktForUtbetalingstabell(behandling: Behandling): LocalDate {
+        val førsteJanuarIFjor = LocalDate.now().minusYears(1).withDayOfYear(1)
         val endringstidspunkt = vedtaksperiodeService.finnEndringstidspunktForBehandling(behandling.id)
 
         return when {
-            behandling.opprettetÅrsak != BehandlingÅrsak.ÅRLIG_KONTROLL || endringstidspunkt != TIDENES_ENDE -> endringstidspunkt
+            behandling.opprettetÅrsak != BehandlingÅrsak.ÅRLIG_KONTROLL || endringstidspunkt.isBefore(førsteJanuarIFjor) -> endringstidspunkt
             else -> {
-                val førsteJanuarIFjor = LocalDate.now().minusYears(1).withDayOfYear(1)
                 val endretutbetalingAndeler = endretUtbetalingAndelRepository.findByBehandlingId(behandlingId = behandling.id)
                 val tidligsteUtbetaling =
                     andelTilkjentYtelseRepository

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -2,17 +2,24 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDate
 import java.time.YearMonth
 
 class BrevServiceTest {
@@ -20,6 +27,8 @@ class BrevServiceTest {
     val brevmalService = mockk<BrevmalService>()
     val unleashService = mockk<UnleashNextMedContextService>()
     val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+    val vedtaksperiodeService = mockk<VedtaksperiodeService>()
+    val endretUtbetalingAndelRepository = mockk<EndretUtbetalingAndelRepository>()
 
     val brevService =
         BrevService(
@@ -27,7 +36,7 @@ class BrevServiceTest {
             persongrunnlagService = mockk(),
             arbeidsfordelingService = mockk(),
             simuleringService = mockk(),
-            vedtaksperiodeService = mockk(),
+            vedtaksperiodeService = vedtaksperiodeService,
             sanityService = mockk(),
             vilkårsvurderingService = mockk(),
             korrigertEtterbetalingService = mockk(),
@@ -42,7 +51,7 @@ class BrevServiceTest {
             utenlandskPeriodebeløpRepository = mockk(),
             valutakursRepository = mockk(),
             kompetanseRepository = mockk(),
-            endretUtbetalingAndelRepository = mockk(),
+            endretUtbetalingAndelRepository = endretUtbetalingAndelRepository,
         )
 
     @BeforeEach
@@ -191,5 +200,57 @@ class BrevServiceTest {
         val erLøpendeDifferanseUtbetalingPåBehandling = brevService.sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling(behandling)
 
         assertThat(erLøpendeDifferanseUtbetalingPåBehandling).isTrue()
+    }
+
+    @ParameterizedTest
+    @EnumSource(BehandlingÅrsak::class)
+    fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for alle behandlingsårsaker`(
+        behandlingÅrsak: BehandlingÅrsak,
+    ) {
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2024, 1, 1)
+
+        val behandling = lagBehandling(årsak = behandlingÅrsak)
+
+        val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
+
+        assertThat(starttidspunkt).isEqualTo(LocalDate.of(2024, 1, 1))
+    }
+
+    @Test
+    fun `finnStarttidspunktForUtbetalingstabell returnerer tidligst første januar i fjor hvis endringstidspunkt er TIDENES_ENDE`() {
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
+        every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2020, 1),
+                    tom = YearMonth.now().plusYears(1),
+                ),
+            )
+
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
+
+        val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
+
+        assertThat(starttidspunkt).isEqualTo(LocalDate.now().minusYears(1).withDayOfYear(1))
+    }
+
+    @Test
+    fun `finnStarttidspunktForUtbetalingstabell returnerer første utbetalingstidspunkt hvis endringstidspunkt er TIDENES_ENDE`() {
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
+        every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2024, 5),
+                    tom = YearMonth.now().plusYears(1),
+                ),
+            )
+
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
+
+        val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
+
+        assertThat(starttidspunkt).isEqualTo(LocalDate.of(2024, 5, 1))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -236,6 +236,25 @@ class BrevServiceTest {
     }
 
     @Test
+    fun `finnStarttidspunktForUtbetalingstabell returnerer første januar i fjor selv om endringstidspunkt er senere`() {
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2024, 1, 1)
+        every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2020, 1),
+                    tom = YearMonth.now().plusYears(1),
+                ),
+            )
+
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
+
+        val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
+
+        assertThat(starttidspunkt).isEqualTo(LocalDate.now().minusYears(1).withDayOfYear(1))
+    }
+
+    @Test
     fun `finnStarttidspunktForUtbetalingstabell returnerer første utbetalingstidspunkt hvis endringstidspunkt er TIDENES_ENDE`() {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -217,7 +217,7 @@ class BrevServiceTest {
     }
 
     @Test
-    fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er tidligere enn første januar i fjor`() {
+    fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er tidligere enn 1 januar i fjor`() {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2020, 1, 1)
 
         val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
@@ -228,7 +228,7 @@ class BrevServiceTest {
     }
 
     @Test
-    fun `finnStarttidspunktForUtbetalingstabell returnerer tidligst første januar i fjor for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er TIDENES_ENDE`() {
+    fun `finnStarttidspunktForUtbetalingstabell returnerer tidligst 1 januar i fjor for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er TIDENES_ENDE`() {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
@@ -247,7 +247,7 @@ class BrevServiceTest {
     }
 
     @Test
-    fun `finnStarttidspunktForUtbetalingstabell returnerer første januar i fjor for behandlingsårsak ÅRLIG_KONTROLL, selv om endringstidspunkt er senere`() {
+    fun `finnStarttidspunktForUtbetalingstabell returnerer 1 januar i fjor for behandlingsårsak ÅRLIG_KONTROLL, selv om endringstidspunkt er senere`() {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2024, 1, 1)
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -203,8 +203,8 @@ class BrevServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(BehandlingÅrsak::class)
-    fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for alle behandlingsårsaker`(
+    @EnumSource(BehandlingÅrsak::class, mode = EnumSource.Mode.EXCLUDE, names = ["ÅRLIG_KONTROLL"])
+    fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for alle behandlingsårsaker utenom ÅRLIG_KONTROLL`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2020, 1, 1)
@@ -217,7 +217,18 @@ class BrevServiceTest {
     }
 
     @Test
-    fun `finnStarttidspunktForUtbetalingstabell returnerer tidligst første januar i fjor hvis endringstidspunkt er TIDENES_ENDE`() {
+    fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er tidligere enn første januar i fjor`() {
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2020, 1, 1)
+
+        val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
+
+        val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
+
+        assertThat(starttidspunkt).isEqualTo(LocalDate.of(2020, 1, 1))
+    }
+
+    @Test
+    fun `finnStarttidspunktForUtbetalingstabell returnerer tidligst første januar i fjor for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er TIDENES_ENDE`() {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
@@ -236,7 +247,7 @@ class BrevServiceTest {
     }
 
     @Test
-    fun `finnStarttidspunktForUtbetalingstabell returnerer første januar i fjor selv om endringstidspunkt er senere`() {
+    fun `finnStarttidspunktForUtbetalingstabell returnerer første januar i fjor for behandlingsårsak ÅRLIG_KONTROLL, selv om endringstidspunkt er senere`() {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2024, 1, 1)
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -266,7 +266,7 @@ class BrevServiceTest {
     }
 
     @Test
-    fun `finnStarttidspunktForUtbetalingstabell returnerer første utbetalingstidspunkt hvis endringstidspunkt er TIDENES_ENDE`() {
+    fun `finnStarttidspunktForUtbetalingstabell returnerer første utbetalingstidspunkt ved ÅRLIG_KONTROLL dersom endringstidspunkt er TIDENES_ENDE og første utbetaling er etter 1 januar i fjor`() {
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -207,13 +207,13 @@ class BrevServiceTest {
     fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for alle behandlingsårsaker`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
-        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2024, 1, 1)
+        every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2020, 1, 1)
 
         val behandling = lagBehandling(årsak = behandlingÅrsak)
 
         val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
 
-        assertThat(starttidspunkt).isEqualTo(LocalDate.of(2024, 1, 1))
+        assertThat(starttidspunkt).isEqualTo(LocalDate.of(2020, 1, 1))
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22065

Ved behandlingsårsak årlig kontroll skal utbetalingstabellen vise utbetalinger tilbake i tid med fom etter disse reglene:
- Hvis det er gjort endringer tidligere enn 1. januar i fjor $\rightarrow$ Endringstidspunkt
- Hvis det er gjort endring senere enn 1. januar i fjor $\rightarrow$ Seneste av 1. januar i fjor og første utbetaling i fjor
- Hvis det ikke er gjort noen endring $\rightarrow$ Seneste av 1. januar i fjor og første utbetaling i fjor

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
