### PR TITLE
Rekjøring av månedlig valutajustering-task

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
@@ -31,7 +31,6 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
-import java.time.temporal.ChronoUnit
 
 @Service
 class AutovedtakMånedligValutajusteringService(
@@ -132,14 +131,10 @@ class AutovedtakMånedligValutajusteringService(
             BehandlingStatus.SATT_PÅ_VENT,
             ->
                 if (snikeIKøenService.kanSnikeForbi(åpenBehandling)) {
-                    try {
-                        snikeIKøenService.settAktivBehandlingPåMaskinellVent(
-                            åpenBehandling.id,
-                            SettPåMaskinellVentÅrsak.MÅNEDLIG_VALUTAJUSTERING,
-                        )
-                    } catch (e: Exception) {
-                        throw Feil("Behandling ${åpenBehandling.id} er ikke aktiv")
-                    }
+                    snikeIKøenService.settAktivBehandlingPåMaskinellVent(
+                        åpenBehandling.id,
+                        SettPåMaskinellVentÅrsak.MÅNEDLIG_VALUTAJUSTERING,
+                    )
                 } else {
                     throw RekjørSenereException(
                         årsak = "Åpen behandling med status ${åpenBehandling.status} ble endret for under fire timer siden. Prøver igjen klokken 06.00 i morgen",
@@ -151,7 +146,7 @@ class AutovedtakMånedligValutajusteringService(
             BehandlingStatus.SATT_PÅ_MASKINELL_VENT,
             -> throw RekjørSenereException(
                 årsak = "Åpen behandling har status ${åpenBehandling.status}. Prøver igjen om én time",
-                triggerTid = LocalDateTime.now().plusMinutes(119).truncatedTo(ChronoUnit.HOURS), // Nærmeste hele time minst en time frem i tid
+                triggerTid = LocalDateTime.now().plusHours(1),
             )
 
             BehandlingStatus.FATTER_VEDTAK,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.FerdigstillBehandlingTask
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
 import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.util.VirkedagerProvider
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -137,8 +138,8 @@ class AutovedtakMånedligValutajusteringService(
                     )
                 } else {
                     throw RekjørSenereException(
-                        årsak = "Åpen behandling med status ${åpenBehandling.status} ble endret for under fire timer siden. Prøver igjen klokken 06.00 i morgen",
-                        triggerTid = LocalDate.now().plusDays(1).atTime(6, 0),
+                        årsak = "Åpen behandling med status ${åpenBehandling.status} ble endret for under fire timer siden. Prøver igjen klokken 06.00 neste virkedag",
+                        triggerTid = VirkedagerProvider.nesteVirkedag(LocalDate.now()).atTime(6, 0),
                     )
                 }
 
@@ -151,8 +152,8 @@ class AutovedtakMånedligValutajusteringService(
 
             BehandlingStatus.FATTER_VEDTAK,
             -> throw RekjørSenereException(
-                årsak = "Åpen behandling har status ${åpenBehandling.status}. Prøver igjen klokken 06.00 i morgen",
-                triggerTid = LocalDate.now().plusDays(1).atTime(6, 0),
+                årsak = "Åpen behandling har status ${åpenBehandling.status}. Prøver igjen klokken 06.00 neste virkedag",
+                triggerTid = VirkedagerProvider.nesteVirkedag(LocalDate.now()).atTime(6, 0),
             )
 
             else -> throw Feil("Ikke håndtert feilsituasjon på $åpenBehandling")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
@@ -3,7 +3,6 @@
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.LocalDateProvider
-import no.nav.familie.ba.sak.common.MånedligValutaJusteringFeil
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
@@ -11,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.SettPåMaskinellVentÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.SnikeIKøenService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -23,11 +23,15 @@ import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.FerdigstillBehandlingTask
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
+import no.nav.familie.prosessering.error.RekjørSenereException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
+import java.time.temporal.ChronoUnit
 
 @Service
 class AutovedtakMånedligValutajusteringService(
@@ -69,15 +73,7 @@ class AutovedtakMånedligValutajusteringService(
         val aktivOgÅpenBehandling = behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsakId)
 
         if (aktivOgÅpenBehandling != null) {
-            if (snikeIKøenService.kanSnikeForbi(aktivOgÅpenBehandling)) {
-                snikeIKøenService.settAktivBehandlingPåMaskinellVent(
-                    aktivOgÅpenBehandling.id,
-                    SettPåMaskinellVentÅrsak.MÅNEDLIG_VALUTAJUSTERING,
-                )
-            } else {
-                månedligvalutajusteringIgnorertÅpenBehandling.increment()
-                throw MånedligValutaJusteringFeil(melding = "Kan ikke utføre månedlig valutajustering for fagsak=$fagsakId fordi det er en åpen behandling vi ikke klarer å snike forbi")
-            }
+            validerOgSettÅpenBehandlingPåMaskinellVent(aktivOgÅpenBehandling)
         }
 
         val søkerAktør = sisteVedtatteBehandling.fagsak.aktør
@@ -128,5 +124,43 @@ class AutovedtakMånedligValutajusteringService(
                 else -> throw Feil("Ugyldig neste steg ${behandlingEtterBehandlingsresultat.steg} ved månedlig valutajustering for fagsak=$fagsakId")
             }
         taskRepository.save(task)
+    }
+
+    private fun validerOgSettÅpenBehandlingPåMaskinellVent(åpenBehandling: Behandling) {
+        when (åpenBehandling.status) {
+            BehandlingStatus.UTREDES,
+            BehandlingStatus.SATT_PÅ_VENT,
+            ->
+                if (snikeIKøenService.kanSnikeForbi(åpenBehandling)) {
+                    try {
+                        snikeIKøenService.settAktivBehandlingPåMaskinellVent(
+                            åpenBehandling.id,
+                            SettPåMaskinellVentÅrsak.MÅNEDLIG_VALUTAJUSTERING,
+                        )
+                    } catch (e: Exception) {
+                        throw Feil("Behandling ${åpenBehandling.id} er ikke aktiv")
+                    }
+                } else {
+                    throw RekjørSenereException(
+                        årsak = "Åpen behandling med status ${åpenBehandling.status} ble endret for under fire timer siden. Prøver igjen klokken 06.00 i morgen",
+                        triggerTid = LocalDate.now().plusDays(1).atTime(6, 0),
+                    )
+                }
+
+            BehandlingStatus.IVERKSETTER_VEDTAK,
+            BehandlingStatus.SATT_PÅ_MASKINELL_VENT,
+            -> throw RekjørSenereException(
+                årsak = "Åpen behandling har status ${åpenBehandling.status}. Prøver igjen om én time",
+                triggerTid = LocalDateTime.now().plusMinutes(119).truncatedTo(ChronoUnit.HOURS), // Nærmeste hele time minst en time frem i tid
+            )
+
+            BehandlingStatus.FATTER_VEDTAK,
+            -> throw RekjørSenereException(
+                årsak = "Åpen behandling har status ${åpenBehandling.status}. Prøver igjen klokken 06.00 i morgen",
+                triggerTid = LocalDate.now().plusDays(1).atTime(6, 0),
+            )
+
+            else -> throw Feil("Ikke håndtert feilsituasjon på $åpenBehandling")
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
@@ -14,11 +14,9 @@ import java.time.YearMonth
 
 @Service
 @TaskStepBeskrivelse(
-    taskStepType =
-        MånedligValutajusteringTask
-            .TASK_STEP_TYPE,
+    taskStepType = MånedligValutajusteringTask.TASK_STEP_TYPE,
     beskrivelse = "månedlig valutajustering",
-    maxAntallFeil = 1,
+    maxAntallFeil = 3,
     settTilManuellOppfølgning = true,
 )
 class MånedligValutajusteringTask(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
@@ -1,0 +1,163 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.månedligValutajustering
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.LocalDateProvider
+import no.nav.familie.ba.sak.common.defaultFagsak
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Vurderingsform
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.prosessering.error.RekjørSenereException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.time.temporal.ChronoUnit
+
+class AutovedtakMånedligValutajusteringServiceTest {
+    val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    val valutaKursService = mockk<ValutakursService>()
+    val localDateProvider = mockk<LocalDateProvider>()
+
+    val autovedtakMånedligValutajusteringService =
+        AutovedtakMånedligValutajusteringService(
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            valutakursService = valutaKursService,
+            localDateProvider = localDateProvider,
+            autovedtakService = mockk(),
+            snikeIKøenService = mockk(),
+            behandlingService = mockk(),
+            simuleringService = mockk(),
+            taskRepository = mockk(),
+        )
+
+    @Test
+    fun `utførMånedligValutajustering kaster Feil hvis en annen enn nåværende måned blir sendt inn`() {
+        every { localDateProvider.now() } returns LocalDate.now()
+
+        assertThrows<Feil> {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+                fagsakId = 0,
+                måned = YearMonth.now().minusMonths(1),
+            )
+        }.run {
+            assertThat(message).isEqualTo("Prøver å utføre månedlig valutajustering for en annen måned enn nåværende måned.")
+        }
+    }
+
+    @Test
+    fun `utførMånedligValutajustering kaster IllegalStateException hvis fagsak ikke har en vedtatt behandling`() {
+        every { localDateProvider.now() } returns LocalDate.now()
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns null
+
+        assertThrows<IllegalStateException> {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+                fagsakId = 0,
+                måned = YearMonth.now(),
+            )
+        }.run {
+            assertThat(message).isEqualTo("Fant ikke siste vedtatte behandling for 0")
+        }
+    }
+
+    @Test
+    fun `utførMånedligValutajustering kaster Feil hvis fagsakstatus ikke er løpende`() {
+        val fagsak = defaultFagsak()
+        val behandling = lagBehandling(fagsak = fagsak)
+
+        every { localDateProvider.now() } returns LocalDate.now()
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns behandling
+        every { valutaKursService.hentValutakurser(any()) } returns
+            listOf(
+                Valutakurs(
+                    fom = YearMonth.now().minusMonths(1),
+                    tom = null,
+                    vurderingsform = Vurderingsform.AUTOMATISK,
+                ),
+            )
+
+        assertThrows<Feil> {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+                fagsakId = fagsak.id,
+                måned = YearMonth.now(),
+            )
+        }.run {
+            assertThat(message).isEqualTo("Forsøker å utføre satsendring på ikke løpende fagsak ${fagsak.id}")
+        }
+    }
+
+    @Test
+    fun `utførMånedligValutajustering kaster RekjørSenereException hvis åpen behandling har status FATTER_VEDTAK`() {
+        val fagsak = defaultFagsak().apply { status = FagsakStatus.LØPENDE }
+        val behandling = lagBehandling(fagsak = fagsak, status = BehandlingStatus.AVSLUTTET)
+        val åpenBehandling = lagBehandling(fagsak = fagsak, status = BehandlingStatus.FATTER_VEDTAK)
+        val klokkenSeksIMorgen = LocalDate.now().plusDays(1).atTime(6, 0)
+
+        every { localDateProvider.now() } returns LocalDate.now()
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns behandling
+        every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(any()) } returns åpenBehandling
+        every { valutaKursService.hentValutakurser(any()) } returns
+            listOf(
+                Valutakurs(
+                    fom = YearMonth.now().minusMonths(1),
+                    tom = null,
+                    vurderingsform = Vurderingsform.AUTOMATISK,
+                ),
+            )
+
+        assertThrows<RekjørSenereException> {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+                fagsakId = fagsak.id,
+                måned = YearMonth.now(),
+            )
+        }.run {
+            assertThat(message).startsWith("Rekjører senere")
+            assertThat(årsak).startsWith("Åpen behandling har status FATTER_VEDTAK")
+            assertThat(triggerTid).isEqualTo(klokkenSeksIMorgen)
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(BehandlingStatus::class, names = ["SATT_PÅ_MASKINELL_VENT", "IVERKSETTER_VEDTAK"])
+    fun `utførMånedligValutajustering kaster RekjørSenereException hvis åpen behandling har status SATT_PÅ_MASKINELL_VENT eller IVERKSETTER_VEDTAK`(
+        behandlingStatus: BehandlingStatus,
+    ) {
+        val fagsak = defaultFagsak().apply { status = FagsakStatus.LØPENDE }
+        val behandling = lagBehandling(fagsak = fagsak, status = BehandlingStatus.AVSLUTTET)
+        val åpenBehandling = lagBehandling(fagsak = fagsak, status = behandlingStatus)
+        val omEnTime = LocalDateTime.now().plusMinutes(119).truncatedTo(ChronoUnit.HOURS)
+
+        every { localDateProvider.now() } returns LocalDate.now()
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns behandling
+        every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(any()) } returns åpenBehandling
+        every { valutaKursService.hentValutakurser(any()) } returns
+            listOf(
+                Valutakurs(
+                    fom = YearMonth.now().minusMonths(1),
+                    tom = null,
+                    vurderingsform = Vurderingsform.AUTOMATISK,
+                ),
+            )
+
+        assertThrows<RekjørSenereException> {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+                fagsakId = fagsak.id,
+                måned = YearMonth.now(),
+            )
+        }.run {
+            assertThat(message).startsWith("Rekjører senere")
+            assertThat(årsak).startsWith("Åpen behandling har status $behandlingStatus")
+            assertThat(triggerTid).isEqualTo(omEnTime)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Vurderingsform
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.util.VirkedagerProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -102,7 +103,7 @@ class AutovedtakMånedligValutajusteringServiceTest {
         val fagsak = defaultFagsak().apply { status = FagsakStatus.LØPENDE }
         val behandling = lagBehandling(fagsak = fagsak, status = BehandlingStatus.AVSLUTTET)
         val åpenBehandling = lagBehandling(fagsak = fagsak, status = BehandlingStatus.FATTER_VEDTAK)
-        val klokkenSeksIMorgen = LocalDate.now().plusDays(1).atTime(6, 0)
+        val klokkenSeksNesteVirkedag = VirkedagerProvider.nesteVirkedag(LocalDate.now()).atTime(6, 0)
 
         every { localDateProvider.now() } returns LocalDate.now()
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns behandling
@@ -124,7 +125,7 @@ class AutovedtakMånedligValutajusteringServiceTest {
         }.run {
             assertThat(message).startsWith("Rekjører senere")
             assertThat(årsak).startsWith("Åpen behandling har status FATTER_VEDTAK")
-            assertThat(triggerTid).isEqualTo(klokkenSeksIMorgen)
+            assertThat(triggerTid).isEqualTo(klokkenSeksNesteVirkedag)
         }
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Tidligere måneder har månedlig valutajustering blitt satt til manuell oppfølging for alle behandlinger som ikke har blit suksessfulle på første forsøk. Dette har oversvømt prosessering med feilede tasks.

Løser problemet ved å kaste forskjellige exception avhengig av hvordan tasken feiler:
Hvis status på åpen behandling er `IVERKSETTER_VEDTAK` eller `SATT_PÅ MASKINELL_VENT` kjøres valutajustering igjen om en time
Hvis status på åpen behandling er `FATTER_VEDTAK` kjøres valutajustering igjen klokken 6 morgenen etter
Hvis åpen behandlingen har blitt endret siste 4 timene kjøres valutajustering igjen klokken 6 morgenen etter

Månedlig valutajustering-tasker kjører 3 ganger før de settes til manuell oppfølging

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
