### PR TITLE
Unngå duplikat av barnAktører i Valutakurs

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -93,7 +93,7 @@ data class Kompetanse(
         copy(
             fom = fom,
             tom = tom,
-            barnAktører = barnAktører,
+            barnAktører = barnAktører.toSet(),
         )
 
     fun erObligatoriskeFelterSatt() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -84,7 +84,7 @@ data class Valutakurs(
     ) = copy(
         fom = fom,
         tom = tom,
-        barnAktører = barnAktører,
+        barnAktører = barnAktører.toSet(),
     )
 
     fun erObligatoriskeFelterSatt() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursService.kt
@@ -23,18 +23,21 @@ class ValutakursService(
     fun hentValutakurser(behandlingId: BehandlingId) =
         skjemaService.hentMedBehandlingId(behandlingId)
 
+    @Transactional
     fun oppdaterValutakurs(
         behandlingId: BehandlingId,
         valutakurs: Valutakurs,
     ) =
         skjemaService.endreSkjemaer(behandlingId, valutakurs)
 
+    @Transactional
     fun oppdaterValutakurser(
         behandlingId: BehandlingId,
         valutakurser: List<Valutakurs>,
     ) =
         skjemaService.endreSkjemaer(behandlingId = behandlingId, oppdateringer = valutakurser)
 
+    @Transactional
     fun slettValutakurs(
         behandlingId: BehandlingId,
         valutakursId: Long,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Når det lages en kopi av et `Valutakurs`-objekt skal det lages en kopi av `barnAktører`-settet, slik at det ikke eksisterer to `Valutakurs`-objekter med referanse til samme `barnAktører`-sett. Dette gjelder for `Kompetanse` også.

Legger også på `@Transactional` i metoder i `ValutakursService`, da mangel på dette gjorde debugging endel vanskeligere

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
