### PR TITLE
Bytt rekkefølge på validering i utførMånedligValutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
@@ -55,15 +55,15 @@ class AutovedtakMånedligValutajusteringService(
     ) {
         logger.info("Utfører månedlig valutajustering for fagsak=$fagsakId og måned=$måned")
 
-        if (måned != localDateProvider.now().toYearMonth()) {
-            throw Feil("Prøver å utføre månedlig valutajustering for en annen måned enn nåværende måned.")
-        }
-
         val sisteVedtatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = fagsakId) ?: error("Fant ikke siste vedtatte behandling for $fagsakId")
         val sisteValutakurser = valutakursService.hentValutakurser(BehandlingId(sisteVedtatteBehandling.id))
         if (sisteValutakurser.erAlleValutakurserOppdaterteIMåned(måned)) {
             logger.info("Valutakursene er allerede oppdatert for fagsak $fagsakId. Hopper ut")
             return
+        }
+
+        if (måned != localDateProvider.now().toYearMonth()) {
+            throw Feil("Prøver å utføre månedlig valutajustering for en annen måned enn nåværende måned.")
         }
 
         if (sisteVedtatteBehandling.fagsak.status != FagsakStatus.LØPENDE) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -163,11 +163,12 @@ fun List<UtfyltValutakurs>.tilTidslinje() =
 
 fun Collection<Valutakurs>.erAlleValutakurserOppdaterteIMåned(
     måned: YearMonth,
-) = none {
-    val fom = it.fom ?: TIDENES_MORGEN.toYearMonth()
-    val tom = it.tom ?: TIDENES_ENDE.toYearMonth()
+) = isNotEmpty() &&
+    none {
+        val fom = it.fom ?: TIDENES_MORGEN.toYearMonth()
+        val tom = it.tom ?: TIDENES_ENDE.toYearMonth()
 
-    fom < måned && tom >= måned
-}
+        fom < måned && tom >= måned
+    }
 
 fun Collection<Valutakurs>.filtrerUtfylteValutakurser() = this.map { it.tilIValutakurs() }.filterIsInstance<UtfyltValutakurs>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
@@ -46,6 +46,8 @@ class AutovedtakMånedligValutajusteringServiceTest {
     @Test
     fun `utførMånedligValutajustering kaster Feil hvis en annen enn nåværende måned blir sendt inn`() {
         every { localDateProvider.now() } returns LocalDate.now()
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns lagBehandling()
+        every { valutaKursService.hentValutakurser(any()) } returns emptyList()
 
         assertThrows<Feil> {
             autovedtakMånedligValutajusteringService.utførMånedligValutajustering(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Bytter rekkefølge på validering, så MånedligValutajusteringTasks fra forrige måned kan rekjøres og hopper ut uten å feile, dersom det allerede finnes en valutakurs for gjeldende måned

Endre `erAlleValutakurserOppdaterteIMåned` til å returnere false dersom listen er tom (det eksisterer ingen valutakurser)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
