### PR TITLE
Legg til endret utbetaling-årsak ETTERBETALING_3_MND

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.config
 class FeatureToggleConfig {
     companion object {
         // Release
+        const val ETTERBETALING_3_MND = "familie-ba-sak.etterbetaling-3-mnd"
 
         // Operasjonelle
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -125,6 +125,7 @@ object BehandlingsresultatSøknadUtils {
                             Årsak.ALLEREDE_UTBETALT,
                             Årsak.ENDRE_MOTTAKER,
                             Årsak.ETTERBETALING_3ÅR,
+                            Årsak.ETTERBETALING_3MND,
                             -> Søknadsresultat.AVSLÅTT
                         }
                     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtils.kt
@@ -71,17 +71,17 @@ object TilkjentYtelseUtils {
                     )
                 }
 
-        val barnasAndelerInkludertEtterbetaling3ÅrEndringer =
+        val barnasAndelerInkludertEtterbetaling3ÅrEller3MndEndringer =
             oppdaterTilkjentYtelseMedEndretUtbetalingAndeler(
                 andelTilkjentYtelserUtenEndringer = andelerTilkjentYtelseBarnaUtenEndringer,
-                endretUtbetalingAndeler = endretUtbetalingAndelerBarna.filter { it.årsak == Årsak.ETTERBETALING_3ÅR },
+                endretUtbetalingAndeler = endretUtbetalingAndelerBarna.filter { it.årsak in listOf(Årsak.ETTERBETALING_3ÅR, Årsak.ETTERBETALING_3MND) },
             )
 
         val andelerTilkjentYtelseUtvidetMedAlleEndringer =
             UtvidetBarnetrygdUtil.beregnTilkjentYtelseUtvidet(
                 utvidetVilkår = finnUtvidetVilkår(vilkårsvurdering),
                 tilkjentYtelse = tilkjentYtelse,
-                andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer = barnasAndelerInkludertEtterbetaling3ÅrEndringer,
+                andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEller3MndEndringer = barnasAndelerInkludertEtterbetaling3ÅrEller3MndEndringer,
                 endretUtbetalingAndelerSøker = endretUtbetalingAndelerSøker,
                 personResultater = vilkårsvurdering.personResultater,
             )
@@ -89,7 +89,7 @@ object TilkjentYtelseUtils {
         val småbarnstilleggErMulig =
             erSmåbarnstilleggMulig(
                 utvidetAndeler = andelerTilkjentYtelseUtvidetMedAlleEndringer,
-                barnasAndeler = barnasAndelerInkludertEtterbetaling3ÅrEndringer,
+                barnasAndeler = barnasAndelerInkludertEtterbetaling3ÅrEller3MndEndringer,
             )
 
         val andelerTilkjentYtelseSmåbarnstillegg =
@@ -103,7 +103,7 @@ object TilkjentYtelseUtils {
                             personopplysningGrunnlag.søker.aktør,
                         ),
                     utvidetAndeler = andelerTilkjentYtelseUtvidetMedAlleEndringer,
-                    barnasAndeler = barnasAndelerInkludertEtterbetaling3ÅrEndringer,
+                    barnasAndeler = barnasAndelerInkludertEtterbetaling3ÅrEller3MndEndringer,
                     barnasAktørerOgFødselsdatoer =
                         personopplysningGrunnlag.barna.map {
                             Pair(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -37,7 +37,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.YearMonth
 
 fun hentGyldigEtterbetaling3ÅrFom(kravDato: LocalDate) =
@@ -121,11 +120,8 @@ object TilkjentYtelseValidering {
     fun finnAktørIderMedUgyldigEtterbetalingsperiode(
         forrigeAndelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
         andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
-        kravDato: LocalDateTime,
+        gyldigEtterbetalingFom: YearMonth,
     ): List<Aktør> {
-        // TODO: Finne ut hvordan etterbetaling 3 måneder skal håndteres her
-        val gyldigEtterbetalingFom = hentGyldigEtterbetaling3ÅrFom(kravDato.toLocalDate())
-
         val aktører = unikeAntører(andelerTilkjentYtelse, forrigeAndelerTilkjentYtelse)
 
         val personerMedUgyldigEtterbetaling =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -40,10 +40,14 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
 
-// 3 år (krav i loven)
-fun hentGyldigEtterbetalingFom(kravDato: LocalDate) =
+fun hentGyldigEtterbetaling3ÅrFom(kravDato: LocalDate) =
     kravDato
         .minusYears(3)
+        .toYearMonth()
+
+fun hentGyldigEtterbetaling3MndFom(kravDato: LocalDate) =
+    kravDato
+        .minusMonths(3)
         .toYearMonth()
 
 fun hentSøkersAndeler(
@@ -119,7 +123,8 @@ object TilkjentYtelseValidering {
         andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
         kravDato: LocalDateTime,
     ): List<Aktør> {
-        val gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(kravDato.toLocalDate())
+        // TODO: Finne ut hvordan etterbetaling 3 måneder skal håndteres her
+        val gyldigEtterbetalingFom = hentGyldigEtterbetaling3ÅrFom(kravDato.toLocalDate())
 
         val aktører = unikeAntører(andelerTilkjentYtelse, forrigeAndelerTilkjentYtelse)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.ETTERBETALING_3_MND
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.finnAktørIderMedUgyldigEtterbetalingsperiode
@@ -20,6 +22,7 @@ class TilkjentYtelseValideringService(
     private val beregningService: BeregningService,
     private val persongrunnlagService: PersongrunnlagService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun validerAtIngenUtbetalingerOverstiger100Prosent(behandling: Behandling) {
         if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring()) return
@@ -99,10 +102,16 @@ class TilkjentYtelseValideringService(
                 ?.let { beregningService.hentOptionalTilkjentYtelseForBehandling(behandlingId = it.id) }
                 ?.andelerTilkjentYtelse
 
+        val gyldigEtterbetalingFom =
+            when (unleashNextMedContextService.isEnabled(ETTERBETALING_3_MND)) {
+                true -> hentGyldigEtterbetaling3MndFom(behandling.opprettetTidspunkt.toLocalDate())
+                false -> hentGyldigEtterbetaling3ÅrFom(behandling.opprettetTidspunkt.toLocalDate())
+            }
+
         return finnAktørIderMedUgyldigEtterbetalingsperiode(
             forrigeAndelerTilkjentYtelse = forrigeAndelerTilkjentYtelse ?: emptyList(),
             andelerTilkjentYtelse = tilkjentYtelse?.andelerTilkjentYtelse?.toList() ?: emptyList(),
-            kravDato = behandling.opprettetTidspunkt,
+            gyldigEtterbetalingFom = gyldigEtterbetalingFom,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
@@ -25,7 +25,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 object UtvidetBarnetrygdUtil {
     internal fun beregnTilkjentYtelseUtvidet(
         utvidetVilkår: List<VilkårResultat>,
-        andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+        andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEller3MndEndringer: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
         tilkjentYtelse: TilkjentYtelse,
         endretUtbetalingAndelerSøker: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
         personResultater: Set<PersonResultat>,
@@ -36,7 +36,7 @@ object UtvidetBarnetrygdUtil {
                 tilkjentYtelse = tilkjentYtelse,
             ).lagUtvidetBarnetrygdAndeler(
                 utvidetVilkår = utvidetVilkår,
-                andelerBarna = andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer.map { it.andel },
+                andelerBarna = andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEller3MndEndringer.map { it.andel },
                 perioderBarnaBorMedSøkerTidslinje = personResultater.tilPerioderBarnaBorMedSøkerTidslinje(),
             )
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
@@ -22,7 +22,8 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.hentGyldigEtterbetalingFom
+import no.nav.familie.ba.sak.kjerne.beregning.hentGyldigEtterbetaling3MndFom
+import no.nav.familie.ba.sak.kjerne.beregning.hentGyldigEtterbetaling3ÅrFom
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -119,8 +120,10 @@ object EndretUtbetalingAndelValidering {
                 )
             }
 
-            Årsak.ETTERBETALING_3ÅR ->
-                validerEtterbetalingMaks3ÅrFørSøknadstidspunkt(
+            Årsak.ETTERBETALING_3MND,
+            Årsak.ETTERBETALING_3ÅR,
+            ->
+                validerEtterbetalingMaks3ÅrEller3MndFørSøknadstidspunkt(
                     endretUtbetalingAndel = endretUtbetalingAndel,
                     behandlingOpprettetTidspunkt = vilkårsvurdering?.behandling?.opprettetTidspunkt?.toLocalDate(),
                 )
@@ -137,25 +140,22 @@ object EndretUtbetalingAndelValidering {
         }
     }
 
-    private fun validerEtterbetalingMaks3ÅrFørSøknadstidspunkt(
+    private fun validerEtterbetalingMaks3ÅrEller3MndFørSøknadstidspunkt(
         endretUtbetalingAndel: EndretUtbetalingAndel,
         behandlingOpprettetTidspunkt: LocalDate?,
     ) {
         val kravDato = endretUtbetalingAndel.søknadstidspunkt ?: behandlingOpprettetTidspunkt
+        val (feilmeldingPeriode, gyldigEtterbetalingFom) =
+            when (endretUtbetalingAndel.årsak) {
+                Årsak.ETTERBETALING_3ÅR -> "tre år" to hentGyldigEtterbetaling3ÅrFom(kravDato = kravDato ?: LocalDate.now())
+                Årsak.ETTERBETALING_3MND -> "tre måneder" to hentGyldigEtterbetaling3MndFom(kravDato = kravDato ?: LocalDate.now())
+                else -> throw FunksjonellFeil("Ugyldig årsak for etterbetaling")
+            }
+
         if (endretUtbetalingAndel.prosent == BigDecimal.valueOf(100)) {
-            throw FunksjonellFeil(
-                "Du kan ikke endre til full utbetaling når det er mer enn tre år siden søknadstidspunktet.",
-            )
-        } else if (
-            endretUtbetalingAndel.tom?.isAfter(
-                hentGyldigEtterbetalingFom(
-                    kravDato = kravDato ?: LocalDate.now(),
-                ),
-            ) == true
-        ) {
-            throw FunksjonellFeil(
-                "Du kan ikke stoppe etterbetaling for en periode som ikke strekker seg mer enn 3 år tilbake i tid.",
-            )
+            throw FunksjonellFeil("Du kan ikke endre til full utbetaling når det er mer enn $feilmeldingPeriode siden søknadstidspunktet.")
+        } else if (endretUtbetalingAndel.tom?.isAfter(gyldigEtterbetalingFom) == true) {
+            throw FunksjonellFeil("Du kan kun stoppe etterbetaling for en periode som strekker seg mer enn $feilmeldingPeriode tilbake i tid.")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -111,13 +111,14 @@ enum class Årsak(
 ) {
     DELT_BOSTED("Delt bosted"),
     ETTERBETALING_3ÅR("Etterbetaling 3 år"),
+    ETTERBETALING_3MND("Etterbetaling 3 måneder"),
     ENDRE_MOTTAKER("Endre mottaker, begge foreldre rett"),
     ALLEREDE_UTBETALT("Allerede utbetalt"),
     ;
 
     fun førerTilOpphørVed0Prosent() =
         when (this) {
-            ALLEREDE_UTBETALT, ENDRE_MOTTAKER, ETTERBETALING_3ÅR -> true
+            ALLEREDE_UTBETALT, ENDRE_MOTTAKER, ETTERBETALING_3ÅR, ETTERBETALING_3MND -> true
             DELT_BOSTED -> false
         }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/EndretUtbetalingAndelTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/EndretUtbetalingAndelTidslinjeService.kt
@@ -27,7 +27,7 @@ class EndretUtbetalingAndelTidslinjeService(
 
 internal fun Iterable<EndretUtbetalingAndel>.tilBarnasSkalIkkeUtbetalesTidslinjer(): Map<Aktør, Tidslinje<Boolean, Måned>> =
     this
-        .filter { it.årsak in listOf(Årsak.ETTERBETALING_3ÅR, Årsak.ALLEREDE_UTBETALT, Årsak.ENDRE_MOTTAKER) && it.prosent == BigDecimal.ZERO }
+        .filter { it.årsak in listOf(Årsak.ETTERBETALING_3ÅR, Årsak.ETTERBETALING_3MND, Årsak.ALLEREDE_UTBETALT, Årsak.ENDRE_MOTTAKER) && it.prosent == BigDecimal.ZERO }
         .filter { it.person?.type == PersonType.BARN }
         .filter { it.person?.aktør != null }
         .groupBy { it.person?.aktør!! }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringServiceTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.tilfeldigPerson
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
@@ -22,6 +23,7 @@ class TilkjentYtelseValideringServiceTest {
     private val beregningServiceMock = mockk<BeregningService>()
     private val totrinnskontrollServiceMock = mockk<TotrinnskontrollService>()
     private val persongrunnlagServiceMock = mockk<PersongrunnlagService>()
+    private val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
 
     private lateinit var tilkjentYtelseValideringService: TilkjentYtelseValideringService
 
@@ -33,6 +35,7 @@ class TilkjentYtelseValideringServiceTest {
                 totrinnskontrollService = totrinnskontrollServiceMock,
                 persongrunnlagService = persongrunnlagServiceMock,
                 behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+                unleashNextMedContextService = unleashNextMedContextService,
             )
 
         every {
@@ -139,6 +142,7 @@ class TilkjentYtelseValideringServiceTest {
         every { behandlingHentOgPersisterService.hent(behandlingId = behandling.id) } answers { behandling }
         every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling = behandling) } answers { forrigeBehandling }
         every { beregningServiceMock.hentOptionalTilkjentYtelseForBehandling(behandlingId = forrigeBehandling.id) } answers { forrigeTilkjentYtelse }
+        every { unleashNextMedContextService.isEnabled(any()) } returns true
 
         Assertions.assertTrue(tilkjentYtelseValideringService.finnAktørerMedUgyldigEtterbetalingsperiode(behandlingId = behandling.id).size == 1)
         Assertions.assertEquals(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringTest.kt
@@ -20,7 +20,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 class TilkjentYtelseValideringTest {
-    val gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(LocalDate.now())
+    val gyldigEtterbetalingFom = hentGyldigEtterbetaling3ÅrFom(LocalDate.now())
 
     @Test
     fun `Skal returnere true når person har etterbetaling som er mer enn 3 år tilbake i tid`() {
@@ -200,7 +200,7 @@ class TilkjentYtelseValideringTest {
             TilkjentYtelseValidering.erUgyldigEtterbetalingPåPerson(
                 forrigeAndelerForPerson = forrigeAndeler,
                 andelerForPerson = andeler,
-                gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(LocalDate.now().minusYears(2)),
+                gyldigEtterbetalingFom = hentGyldigEtterbetaling3ÅrFom(LocalDate.now().minusYears(2)),
             ),
         )
 
@@ -208,7 +208,7 @@ class TilkjentYtelseValideringTest {
             TilkjentYtelseValidering.erUgyldigEtterbetalingPåPerson(
                 forrigeAndelerForPerson = emptyList(),
                 andelerForPerson = andeler,
-                gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(LocalDate.now().minusYears(2)),
+                gyldigEtterbetalingFom = hentGyldigEtterbetaling3ÅrFom(LocalDate.now().minusYears(2)),
             ),
         )
 
@@ -216,7 +216,7 @@ class TilkjentYtelseValideringTest {
             TilkjentYtelseValidering.erUgyldigEtterbetalingPåPerson(
                 forrigeAndelerForPerson = emptyList(),
                 andelerForPerson = andeler,
-                gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(LocalDate.now().minusYears(2)),
+                gyldigEtterbetalingFom = hentGyldigEtterbetaling3ÅrFom(LocalDate.now().minusYears(2)),
             ),
         )
 
@@ -224,7 +224,7 @@ class TilkjentYtelseValideringTest {
             TilkjentYtelseValidering.erUgyldigEtterbetalingPåPerson(
                 forrigeAndelerForPerson = forrigeAndeler,
                 andelerForPerson = emptyList(),
-                gyldigEtterbetalingFom = hentGyldigEtterbetalingFom(LocalDate.now().minusYears(2)),
+                gyldigEtterbetalingFom = hentGyldigEtterbetaling3ÅrFom(LocalDate.now().minusYears(2)),
             ),
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
@@ -131,7 +131,7 @@ class UtvidetBarnetrygdUtilTest {
                 beregnTilkjentYtelseUtvidet(
                     utvidetVilkår = listOf(utvidetVilkår),
                     tilkjentYtelse = tilkjentYtelse,
-                    andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEndringer =
+                    andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEller3MndEndringer =
                         listOf(
                             lagAndelTilkjentYtelseMedEndreteUtbetalinger(
                                 person = barn,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -52,6 +52,7 @@ class EndretUtbetalingAndelServiceTest {
                 andelTilkjentYtelseRepository = mockAndelTilkjentYtelseRepository,
                 vilkårsvurderingService = mockVilkårsvurderingService,
                 endretUtbetalingAndelHentOgPersisterService = mockEndretUtbetalingAndelHentOgPersisterService,
+                unleashMedContextService = mockk(),
             )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -881,4 +881,70 @@ class EndretUtbetalingAndelValideringTest {
 
         assertThat(feil.frontendFeilmelding).isEqualTo("Du kan ikke endre til full utbetaling når det er mer enn tre år siden søknadstidspunktet.")
     }
+
+    @Test
+    fun `Skal kaste feil dersom endringsårsak er 'Etterbetaling 3 år' og perioden er mindre er 3 år siden`() {
+        val endretUtbetalingAndel =
+            EndretUtbetalingAndel(
+                behandlingId = 1,
+                fom = YearMonth.now().minusYears(2),
+                tom = YearMonth.now().minusYears(1),
+                årsak = Årsak.ETTERBETALING_3ÅR,
+                prosent = BigDecimal(0),
+                søknadstidspunkt = LocalDate.now(),
+            )
+
+        val feil =
+            assertThrows<FunksjonellFeil> {
+                validerÅrsak(
+                    endretUtbetalingAndel = endretUtbetalingAndel,
+                    vilkårsvurdering = null,
+                )
+            }
+
+        assertThat(feil.frontendFeilmelding).isEqualTo("Du kan kun stoppe etterbetaling for en periode som strekker seg mer enn tre år tilbake i tid.")
+    }
+
+    @Test
+    fun `Skal kaste feil dersom endringsårsak er 'Etterbetaling 3 måneder' og perioden er mindre er 3 måneder siden`() {
+        val endretUtbetalingAndel =
+            EndretUtbetalingAndel(
+                behandlingId = 1,
+                fom = YearMonth.now().minusMonths(2),
+                tom = YearMonth.now().minusMonths(1),
+                årsak = Årsak.ETTERBETALING_3MND,
+                prosent = BigDecimal(0),
+                søknadstidspunkt = LocalDate.now(),
+            )
+
+        val feil =
+            assertThrows<FunksjonellFeil> {
+                validerÅrsak(
+                    endretUtbetalingAndel = endretUtbetalingAndel,
+                    vilkårsvurdering = null,
+                )
+            }
+
+        assertThat(feil.frontendFeilmelding).isEqualTo("Du kan kun stoppe etterbetaling for en periode som strekker seg mer enn tre måneder tilbake i tid.")
+    }
+
+    @Test
+    fun `Skal ikke kaste feil dersom endringsårsak er 'Etterbetaling 3 måneder' og perioden er mellom 3 måneder og 3 år siden`() {
+        val endretUtbetalingAndel =
+            EndretUtbetalingAndel(
+                behandlingId = 1,
+                fom = YearMonth.now().minusMonths(10),
+                tom = YearMonth.now().minusMonths(3),
+                årsak = Årsak.ETTERBETALING_3MND,
+                prosent = BigDecimal(0),
+                søknadstidspunkt = LocalDate.now(),
+            )
+
+        assertDoesNotThrow {
+            validerÅrsak(
+                endretUtbetalingAndel = endretUtbetalingAndel,
+                vilkårsvurdering = null,
+            )
+        }
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -35,6 +35,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvu
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -856,5 +857,28 @@ class EndretUtbetalingAndelValideringTest {
                 vilkårsvurdering = mockk(),
             )
         }
+    }
+
+    @Test
+    fun `Skal kaste feil dersom endringsårsak er 'Etterbetaling 3 år' og øker til hundre prosent utbetaling`() {
+        val endretUtbetalingAndel =
+            EndretUtbetalingAndel(
+                behandlingId = 1,
+                fom = YearMonth.now().minusYears(4),
+                tom = YearMonth.now().minusYears(3),
+                årsak = Årsak.ETTERBETALING_3ÅR,
+                prosent = BigDecimal(100),
+                søknadstidspunkt = LocalDate.now(),
+            )
+
+        val feil =
+            assertThrows<FunksjonellFeil> {
+                validerÅrsak(
+                    endretUtbetalingAndel = endretUtbetalingAndel,
+                    vilkårsvurdering = null,
+                )
+            }
+
+        assertThat(feil.frontendFeilmelding).isEqualTo("Du kan ikke endre til full utbetaling når det er mer enn tre år siden søknadstidspunktet.")
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -345,6 +345,7 @@ class CucumberMock(
             totrinnskontrollService = totrinnskontrollService,
             persongrunnlagService = persongrunnlagService,
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            unleashNextMedContextService = unleashNextMedContextService,
         )
 
     val utbetalingsoppdragGeneratorService =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22314 NAV-21612

Legger til årsak ETTERBETALING_3_MND for endret utbetaling.
Endrer feilmelding til å passe til etterbetaling 3 måneder i stedet for 3 år.
Feilmeldinger og funksjon som kalles fra frontend via endepunkt ligger bak [feature toggle](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ba-sak.etterbetaling-3-mnd)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
