### PR TITLE
Kast funksjonell feil ved regenererte vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeRepository.kt
@@ -24,5 +24,5 @@ interface VedtaksperiodeRepository : JpaRepository<VedtaksperiodeMedBegrunnelser
         """,
         nativeQuery = true,
     )
-    fun finnBehandlingIdForVedtaksperiode(vedtaksperiodeId: Long): Long
+    fun finnBehandlingIdForVedtaksperiode(vedtaksperiodeId: Long): Long?
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
@@ -32,6 +32,9 @@ class VedtaksperiodeHentOgPersisterService(
     fun finnVedtaksperioderFor(vedtakId: Long): List<VedtaksperiodeMedBegrunnelser> =
         vedtaksperiodeRepository.finnVedtaksperioderFor(vedtakId)
 
-    fun finnBehandlingIdFor(vedtaksperiodeId: Long): Long =
+    fun finnBehandlingIdFor(vedtaksperiodeId: Long): Long? =
         vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(vedtaksperiodeId)
+
+    fun hentBehandlingIdFor(vedtaksperiodeId: Long): Long =
+        finnBehandlingIdFor(vedtaksperiodeId) ?: throw Feil("Fant ingen behandling tilhørende vedtaksperiode")
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
@@ -36,5 +36,5 @@ class VedtaksperiodeHentOgPersisterService(
         vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(vedtaksperiodeId)
 
     fun hentBehandlingIdFor(vedtaksperiodeId: Long): Long =
-        finnBehandlingIdFor(vedtaksperiodeId) ?: throw Feil("Fant ingen behandling tilhørende vedtaksperiode")
+        finnBehandlingIdFor(vedtaksperiodeId) ?: throw Feil("Fant ingen behandling tilhørende vedtaksperiode med id $vedtaksperiodeId")
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
 
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.ekstern.restDomene.RestGenererVedtaksperioderForOverstyrtEndringstidspunkt
@@ -52,7 +53,9 @@ class VedtaksperiodeMedBegrunnelserController(
         @RequestBody
         restPutVedtaksperiodeMedStandardbegrunnelser: RestPutVedtaksperiodeMedStandardbegrunnelser,
     ): ResponseEntity<Ressurs<List<RestUtvidetVedtaksperiodeMedBegrunnelser>>> {
-        val behandlingId = vedtaksperiodeHentOgPersisterService.finnBehandlingIdFor(vedtaksperiodeId)
+        val behandlingId =
+            vedtaksperiodeHentOgPersisterService.finnBehandlingIdFor(vedtaksperiodeId)
+                ?: throw FunksjonellFeil("Vedtaksperiodene har blitt oppdatert. Oppdater siden og forsøk å legge til begrunnelser på nytt.")
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.UPDATE)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
@@ -89,7 +92,7 @@ class VedtaksperiodeMedBegrunnelserController(
         @RequestBody
         restPutVedtaksperiodeMedFritekster: RestPutVedtaksperiodeMedFritekster,
     ): ResponseEntity<Ressurs<List<RestUtvidetVedtaksperiodeMedBegrunnelser>>> {
-        val behandlingId = vedtaksperiodeHentOgPersisterService.finnBehandlingIdFor(vedtaksperiodeId)
+        val behandlingId = vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(vedtaksperiodeId)
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.UPDATE)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
@@ -134,7 +137,7 @@ class VedtaksperiodeMedBegrunnelserController(
     fun genererBrevBegrunnelserForPeriode(
         @PathVariable vedtaksperiodeId: Long,
     ): ResponseEntity<Ressurs<Set<String>>> {
-        val behandlingId = vedtaksperiodeHentOgPersisterService.finnBehandlingIdFor(vedtaksperiodeId)
+        val behandlingId = vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(vedtaksperiodeId)
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.VEILEDER,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterServiceTest.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class VedtaksperiodeHentOgPersisterServiceTest {
+    val vedtaksperiodeRepository = mockk<VedtaksperiodeRepository>()
+    val vedtaksperiodeHentOgPersisterService = VedtaksperiodeHentOgPersisterService(vedtaksperiodeRepository)
+
+    @Test
+    fun `hentVedtaksperiodeThrows skal returnere vedtaksperiode med begrunnelser dersom det finnes`() {
+        // Arrange
+        val mocketVedtaksperiodeMedBegrunnelser = mockk<VedtaksperiodeMedBegrunnelser>()
+        every { vedtaksperiodeRepository.hentVedtaksperiode(1) } returns mocketVedtaksperiodeMedBegrunnelser
+
+        // Act
+        val hentetVedtaksperiodeMedBegrunnelser = vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(1)
+
+        // Assert
+        assertThat(hentetVedtaksperiodeMedBegrunnelser).isSameAs(mocketVedtaksperiodeMedBegrunnelser)
+    }
+
+    @Test
+    fun `hentVedtaksperiodeThrows skal kaste feil hvis det ikke finnes noe vedtaksperiode med id`() {
+        // Arrange & Act
+        every { vedtaksperiodeRepository.hentVedtaksperiode(1) } returns null
+
+        val feil =
+            assertThrows<Feil> {
+                vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(1)
+            }
+
+        // Assert
+        assertThat(feil.message).isEqualTo("Fant ingen vedtaksperiode med id 1")
+    }
+
+    @Test
+    fun `hentBehandlingIdFor skal kaste feil hvis det ikke finnes noe behandling for vedtaksperiode`() {
+        // Arrange && Act
+        every { vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(1) } returns null
+
+        val feil =
+            assertThrows<Feil> {
+                vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(1)
+            }
+
+        // Assert
+        assertThat(feil.message).isEqualTo("Fant ingen behandling tilhørende vedtaksperiode med id 1")
+    }
+
+    @Test
+    fun `hentBehandlingIdFor skal kaste returnere behandlingId hvis det finnes noe behandling for vedtaksperiode`() {
+        // Arrange
+        every { vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(1) } returns 20
+
+        // Act
+        val behandlingIdForVedtaksperiode = vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(1)
+
+        // Assert
+        assertThat(behandlingIdForVedtaksperiode).isEqualTo(20)
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeRepositoryTest.kt
@@ -11,11 +11,9 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.dao.EmptyResultDataAccessException
 
 class VedtaksperiodeRepositoryTest(
     @Autowired private val aktørIdRepository: AktørIdRepository,
@@ -38,12 +36,6 @@ class VedtaksperiodeRepositoryTest(
 
             assertThat(vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(vedtaksperiode.id))
                 .isEqualTo(behandling.id)
-        }
-
-        @Test
-        fun `skal kaste feil hvis ikke vedtaksperiode finnes `() {
-            assertThatThrownBy { vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(1L) }
-                .isInstanceOf(EmptyResultDataAccessException::class.java)
         }
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21924

Feilen oppstår på følgende hvis:
Oppstår når man har to faner oppe.

Fane 1: Vedtakssiden
Fane 2: Behandlingsresultat.

Når man går videre fra behandlingsresultat, så vil vedtaksperiodene genereres på nytt. Det vil si at fane 1 blir utdatert, og prøver man å legge til nye begrunnelser så vil det feile.  Feilmeldingen er ikke veldig beskrivende, og i tillegg skaper det støy i loggene. Kaster derfor funksjonell feil som ber saksbehandler oppdatere siden på nytt (slik at frontend kan hente nye periode id) og forsøke igjen.

Før - Skapte støy i logger:
<img width="791" alt="støyemann" src="https://github.com/user-attachments/assets/1fda023b-4ac8-4d7d-adbe-df82087c540f">

Etter - skaper ikke støy i logger:
<img width="806" alt="stillemann" src="https://github.com/user-attachments/assets/aa4b8861-8f69-4784-9d50-0508ae0ca067">


