### PR TITLE
legg til endepunkt for å slette alle kompetanser på en behandling som utredes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -26,6 +26,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlerRolle
+import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.ba.sak.statistikk.stønadsstatistikk.StønadsstatistikkService
 import no.nav.familie.ba.sak.task.GrensesnittavstemMotOppdrag
@@ -359,13 +360,13 @@ class ForvalterController(
     }
 
     @DeleteMapping("/slett-alle-kompetanser-for-behandling/{behandlingId}")
-    @Operation(summary = "Slett kompetanser, utenlandsk periodebeløp og valutakurser for en behandling som utredes.")
+    @Operation(summary = "Slett kompetanser, utenlandsk periodebeløp og valutakurser for en behandling som er på vilkårsvurderingssteget.")
     fun slettKompetanser(
         @PathVariable behandlingId: Long,
     ): ResponseEntity<Ressurs<String>> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
-        if (!behandling.aktiv || behandling.status != BehandlingStatus.UTREDES) {
-            error("Behandling $behandlingId er enten ikke aktiv eller ikke under utredning.")
+        if (!behandling.aktiv || behandling.status != BehandlingStatus.UTREDES || behandling.steg.rekkefølge <= StegType.BEHANDLINGSRESULTAT.rekkefølge) {
+            error("Behandling $behandlingId er gått forbi behandlingsresultatsteget og bør settes tilbake til et tidligere steg før man sletter kompetanse.")
         }
         kompetanseService.slettKompetanserForBehandling(BehandlingId(behandlingId))
         return ResponseEntity.ok(Ressurs.success("Kompetanser slettet"))

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/JusteringAvOppdatering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/JusteringAvOppdatering.kt
@@ -17,7 +17,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.utenInnholdTilOgMed
  * 2a. Lukker periode på det gjeldende skjemaet, dvs til-og-med går fra <null> til en verdi, eller til-og-med er tidligere
  * 2b. og/eller reduserer antall barn
  * så skal det lages en ny oppdatering med blankt skjema for det som ligger "utenfor" [oppdatering], dvs har
- * 1. Perioden som starter måneden etter ny til-og-med-dato, og frem frem til eksisterende til-og-med (kan være <null>)
+ * 1. Perioden som starter måneden etter ny til-og-med-dato, og frem til eksisterende til-og-med (kan være <null>)
  * 2. Barnet/barna som blir fjernet
  *
  * Problemet som skal løses er at skjemaer som kun varierer i periode eller barn, slås sammen fordi de ellers er like

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -29,7 +29,7 @@ class KompetanseService(
     ) =
         skjemaService.endreSkjemaer(behandlingId, oppdatering)
 
-    @Transactional()
+    @Transactional
     fun slettKompetanse(
         behandlingId: BehandlingId,
         kompetanseId: Long,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -29,14 +29,7 @@ class KompetanseService(
     ) =
         skjemaService.endreSkjemaer(behandlingId, oppdatering)
 
-    fun slettKompetanserForBehandling(behandlingId: BehandlingId) {
-        val kompetanser = skjemaService.hentMedBehandlingId(behandlingId)
-        kompetanser.forEach { kompetanse ->
-            slettKompetanse(behandlingId, kompetanse.id)
-        }
-    }
-
-    @Transactional
+    @Transactional()
     fun slettKompetanse(
         behandlingId: BehandlingId,
         kompetanseId: Long,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -29,6 +29,13 @@ class KompetanseService(
     ) =
         skjemaService.endreSkjemaer(behandlingId, oppdatering)
 
+    fun slettKompetanserForBehandling(behandlingId: BehandlingId) {
+        val kompetanser = skjemaService.hentMedBehandlingId(behandlingId)
+        kompetanser.forEach { kompetanse ->
+            slettKompetanse(behandlingId, kompetanse.id)
+        }
+    }
+
     @Transactional
     fun slettKompetanse(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SlettKompetanserTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SlettKompetanserTask.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
-import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -23,7 +22,7 @@ class SlettKompetanserTask(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        val behandlingId = objectMapper.readValue(task.payload, Long::class.java)
+        val behandlingId = task.payload.toLong()
 
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         if (!behandling.aktiv || behandling.status != BehandlingStatus.UTREDES || behandling.steg.rekkefølge > StegType.BEHANDLINGSRESULTAT.rekkefølge) {
@@ -45,7 +44,7 @@ class SlettKompetanserTask(
         fun opprettTask(behandlingId: Long): Task =
             Task(
                 type = TASK_STEP_TYPE,
-                payload = objectMapper.writeValueAsString(behandlingId),
+                payload = behandlingId.toString(),
             )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SlettKompetanserTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SlettKompetanserTask.kt
@@ -1,0 +1,51 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseService
+import no.nav.familie.ba.sak.kjerne.steg.StegType
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = SlettKompetanserTask.TASK_STEP_TYPE,
+    beskrivelse = "Sletter alle kompetanse, utenlandske periodebeløp og valutakurser på en behandling som ikke er ferdig med behandlingsresultatsteget.",
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = false,
+)
+class SlettKompetanserTask(
+    private val kompetanseService: KompetanseService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val behandlingId = objectMapper.readValue(task.payload, Long::class.java)
+
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        if (!behandling.aktiv || behandling.status != BehandlingStatus.UTREDES || behandling.steg.rekkefølge > StegType.BEHANDLINGSRESULTAT.rekkefølge) {
+            error("Behandling $behandlingId er gått forbi behandlingsresultatsteget og bør settes tilbake til et tidligere steg før man sletter kompetanse.")
+        }
+        slettKompetanserForBehandling(BehandlingId(behandlingId))
+    }
+
+    private fun slettKompetanserForBehandling(behandlingId: BehandlingId) {
+        val kompetanser = kompetanseService.hentKompetanser(behandlingId)
+        kompetanser.forEach { kompetanse ->
+            kompetanseService.slettKompetanse(behandlingId, kompetanse.id)
+        }
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "SlettKompetanserTask"
+
+        fun opprettTask(behandlingId: Long): Task =
+            Task(
+                type = TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(behandlingId),
+            )
+    }
+}


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22230)

### 💰 Hva skal gjøres, og hvorfor?
Hvis en behandling ligger inne med kompetanser som fører til at vi kaster feilmelding og så blir satt tilbake til vilkårsvurderingssteget er det ingen mulighet for å komme tilbake til behandlingsresultat og ordne opp i kompetansene funksjonelt. 

Legger til et endepunkt man kan bruke for å slette alle kompetanser på en behandling som utredes slik at man kan komme seg videre i et slikt tilfelle. I praksis vil da også alle utenlandske periodebeløp og valutakurser også slettes. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
