### PR TITLE
fjern fagsaker som er null slik at ikke null-fagsaker gjør at vi ikke patcher identer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -101,7 +101,7 @@ class HåndterNyIdentService(
                     }
                 }
 
-        if (fagsakDeltagere.map { it.fagsakId }.distinct().size > 1) {
+        if (fagsakDeltagere.mapNotNull { it.fagsakId }.distinct().size > 1) {
             throw Feil("Det eksisterer flere fagsaker på identer som skal merges: ${aktiveAktørerForHistoriskAktørIder.first()}. ${Companion.LENKE_INFO_OM_MERGING}")
         }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Task som feiler](https://familie-prosessering.intern.nav.no/service/familie-ba-sak/task/1269153301)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Når vi ser etter unike fagsak-ider filtrerer vi ikke bort null. Det gjør at vi i enkelte tilfeller kaster en exception selv om det bare er én fagsak
