### PR TITLE
Vi ønsker også å avslutte fagsaker som bare har andeler med 0 prosent…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -72,19 +72,26 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
     ): Page<Long>
 
     @Query(
-        value = """WITH sisteiverksatte AS (
-                    SELECT DISTINCT ON (b.fk_fagsak_id) b.id, b.fk_fagsak_id, stonad_tom
-                    FROM behandling b
-                             INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
-                             INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
-                    WHERE f.status = 'LØPENDE'
-                      AND f.arkivert = FALSE
-                      AND b.resultat != 'AVSLÅTT'
-                    ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC)
-                
-                SELECT silp.fk_fagsak_id
-                FROM sisteiverksatte silp
-                WHERE  silp.stonad_tom < DATE_TRUNC('month', NOW())""",
+        value = """
+WITH sisteiverksatte AS (SELECT DISTINCT ON (b.fk_fagsak_id) b.id, b.fk_fagsak_id, stonad_tom
+                         FROM behandling b
+                                  INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
+                                  INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
+                         WHERE f.status = 'LØPENDE'
+                           AND f.arkivert = FALSE
+                           AND b.status = 'AVSLUTTET'
+                           AND b.resultat != 'AVSLÅTT'
+                         ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC)
+
+SELECT silp.fk_fagsak_id
+FROM sisteiverksatte silp
+WHERE silp.stonad_tom < DATE_TRUNC('month', NOW())
+   OR NOT EXISTS (SELECT 1
+                  FROM andel_tilkjent_ytelse
+                  WHERE fk_behandling_id = silp.id
+                    AND stonad_tom >= DATE_TRUNC('month', NOW())
+                    AND prosent > 0);
+                """,
         nativeQuery = true,
     )
     fun finnFagsakerSomSkalAvsluttes(): List<Long>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -87,10 +87,10 @@ SELECT silp.fk_fagsak_id
 FROM sisteiverksatte silp
 WHERE silp.stonad_tom < DATE_TRUNC('month', NOW())
    OR NOT EXISTS (SELECT 1
-                  FROM andel_tilkjent_ytelse
-                  WHERE fk_behandling_id = silp.id
-                    AND stonad_tom >= DATE_TRUNC('month', NOW())
-                    AND prosent > 0);
+                  FROM andel_tilkjent_ytelse aty
+                  WHERE aty.fk_behandling_id = silp.id
+                    AND aty.stonad_tom >= DATE_TRUNC('month', NOW())
+                    AND aty.prosent > 0);
                 """,
         nativeQuery = true,
     )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
@@ -128,7 +128,7 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
     }
 
     @Test
-    fun `skal sette ikke status til avsluttet hvis alle løpende andeler er satt til 0 grunnet nullutbetaling`() {
+    fun `skal ikke sette status til avsluttet hvis alle løpende andeler er satt til 0 grunnet nullutbetaling`() {
         val forelderIdent = randomFnr()
 
         val fagsakOriginal =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
@@ -86,6 +86,7 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
                 personIdent = forelderIdent,
                 offsetPåAndeler = listOf(1L),
                 fagsakId = fagsakOriginal.id,
+                medStatus = BehandlingStatus.AVSLUTTET,
             )
 
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(førstegangsbehandling.id)


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22423

Logikk i dag:
Hver måned avslutter vi fagsaker der den siste iverksatte behandlingen har en tilkjent ytelse som har en stonad_tom som er mindre enn dagens dato.

Hva er problemet med logikken:
stonad_tom i tilkjent_ytelse settes til den seneste tom i andel tilkjent ytelse.
Dette blir feil når vi ønsker å avslutte fagsak basert på stonad_tom i tilkjent_ytelse, fordi det er ikke gitt at andelene som kommer etter dagens dato har utbetalingsbeløp høyere enn 0. Dette f.eks ved nullutbetalinger eller endret utbetaling andeler

Hvordan vi løser det:
Dersom DET bare finnes andeler med nullutbetalinger etter dagens dato, ønsker vi alikevel ikke å avslutte fagsaken (avklart med funksjonelle). MEN dersom det bare finnes andeler satt til 0 pga endret utbetalinger etter dagens dato (eller samme måned), så ønsker vi å avslutte fagsaken. Derfor sjekkes det på prosent og ikke kalkulert utbetalings beløp.