### PR TITLE
søk opp kompetanser i db på nytt mellom hver sletting så vi unngår å referere til kompetanser som allerede er slettet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SlettKompetanserTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SlettKompetanserTask.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.task
 
+import no.nav.familie.ba.sak.common.LocalDateProvider
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service
 class SlettKompetanserTask(
     private val kompetanseService: KompetanseService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val localDateProvider: LocalDateProvider,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val behandlingId = task.payload.toLong()
@@ -28,14 +31,22 @@ class SlettKompetanserTask(
         if (!behandling.aktiv || behandling.status != BehandlingStatus.UTREDES || behandling.steg.rekkefølge > StegType.BEHANDLINGSRESULTAT.rekkefølge) {
             error("Behandling $behandlingId er gått forbi behandlingsresultatsteget og bør settes tilbake til et tidligere steg før man sletter kompetanse.")
         }
-        slettKompetanserForBehandling(BehandlingId(behandlingId))
+        slettKompetanserForBehandlingRekursivt(BehandlingId(behandlingId))
     }
 
-    private fun slettKompetanserForBehandling(behandlingId: BehandlingId) {
+    // Rekursivt siden sletting av kompetanse kan propagere ut og skape feil hvis vi ikke henter inn alle kompetanser på nytt hver gang vi sletter
+    private fun slettKompetanserForBehandlingRekursivt(behandlingId: BehandlingId) {
         val kompetanser = kompetanseService.hentKompetanser(behandlingId)
-        kompetanser.forEach { kompetanse ->
-            kompetanseService.slettKompetanse(behandlingId, kompetanse.id)
+
+        // autogeneres en tom kompetanse dersom alle er slettet
+        if (kompetanser.size == 1 &&
+            !kompetanser.first().erObligatoriskeFelterSatt() &&
+            kompetanser.first().fom!! < localDateProvider.now().toYearMonth()
+        ) {
+            return
         }
+        kompetanseService.slettKompetanse(behandlingId, kompetanser.first().id)
+        slettKompetanserForBehandlingRekursivt(behandlingId)
     }
 
     companion object {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når vi prøver å slette alle kompetanser får vi tidvis feil fordi vi referer til en kompetanse som allerede er slettet. Henter inn alle kompetansene på nytt mellom hver sletting for å unngå dette.
