### PR TITLE
Tving oppdatering av andeler i vilkårsvurderingsteget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyService.kt
@@ -58,7 +58,11 @@ class TestVerktøyService(
                             Vilkår.GIFT_PARTNERSKAP,
                             -> person?.fødselsdato
 
-                            else -> fraDato ?: person?.fødselsdato
+                            Vilkår.BOR_MED_SØKER,
+                            Vilkår.BOSATT_I_RIKET,
+                            Vilkår.LOVLIG_OPPHOLD,
+                            Vilkår.UTVIDET_BARNETRYGD,
+                            -> fraDato ?: person?.fødselsdato
                         }
                     vilkårResultat.resultat = Resultat.OPPFYLT
                     vilkårResultat.begrunnelse = "Opprettet automatisk fra \"Fyll ut vilkårsvurdering\"-knappen"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.tilSiste
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassValutakurserTilUtenlandskePeriodebeløpService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
@@ -46,7 +47,14 @@ class AutomatiskOppdaterValutakursService(
     private val simuleringService: SimuleringService,
     private val vurderingsstrategiForValutakurserRepository: VurderingsstrategiForValutakurserRepository,
     private val unleashNextMedContextService: UnleashNextMedContextService,
+    private val tilpassDifferanseberegningEtterValutakursService: TilpassDifferanseberegningEtterValutakursService,
 ) {
+    @Transactional
+    fun oppdaterAndelerMedValutakurser(behandlingId: BehandlingId) {
+        val valutakurser = valutakursService.hentValutakurser(behandlingId)
+        tilpassDifferanseberegningEtterValutakursService.skjemaerEndret(behandlingId, valutakurser)
+    }
+
     @Transactional
     fun resettValutakurserOgLagValutakurserEtterEndringstidspunkt(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -101,6 +101,8 @@ class VilkårsvurderingSteg(
             månedligValutajusteringSevice.oppdaterValutakurserForMåned(BehandlingId(behandling.id), localDateProvider.now().toYearMonth())
         }
 
+        automatiskOppdaterValutakursService.oppdaterAndelerMedValutakurser(BehandlingId(behandling.id))
+
         behandlingstemaService.oppdaterBehandlingstema(
             behandling = behandlingHentOgPersisterService.hent(behandlingId = behandling.id),
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
@@ -1,6 +1,7 @@
 ﻿package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
 
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.MockedDateProvider
 import no.nav.familie.ba.sak.common.lagBehandling
@@ -12,6 +13,7 @@ import no.nav.familie.ba.sak.datagenerator.simulering.mockØkonomiSimuleringPost
 import no.nav.familie.ba.sak.integrasjoner.ecb.ECBService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassValutakurserTilUtenlandskePeriodebeløpService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
@@ -39,6 +41,7 @@ class AutomatiskOppdaterValutakursServiceTest {
     val valutakursRepository: PeriodeOgBarnSkjemaRepository<Valutakurs> = mockPeriodeBarnSkjemaRepository()
     val utenlandskPeriodebeløpRepository: PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp> = mockPeriodeBarnSkjemaRepository()
     val tilpassValutakurserTilUtenlandskePeriodebeløpService = TilpassValutakurserTilUtenlandskePeriodebeløpService(valutakursRepository = valutakursRepository, utenlandskPeriodebeløpRepository, emptyList())
+    val tilpassDifferanseberegningEtterValutakursService = mockk<TilpassDifferanseberegningEtterValutakursService>()
 
     val valutakursService = ValutakursService(valutakursRepository, emptyList())
     val vedtaksperiodeService = mockk<VedtaksperiodeService>()
@@ -60,6 +63,7 @@ class AutomatiskOppdaterValutakursServiceTest {
             simuleringService = simuleringService,
             vurderingsstrategiForValutakurserRepository = vurderingsstrategiForValutakurserRepository,
             unleashNextMedContextService = unleashNextMedContextService,
+            tilpassDifferanseberegningEtterValutakursService = tilpassDifferanseberegningEtterValutakursService,
         )
 
     val forrigeBehandlingId = BehandlingId(9L)
@@ -83,6 +87,7 @@ class AutomatiskOppdaterValutakursServiceTest {
         every { unleashNextMedContextService.isEnabled(any()) } returns true
         valutakursRepository.deleteAll()
         utenlandskPeriodebeløpRepository.deleteAll()
+        justRun { tilpassDifferanseberegningEtterValutakursService.skjemaerEndret(any(), any()) }
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
 import junit.framework.TestCase.assertTrue
 import no.nav.familie.ba.sak.common.FunksjonellFeil
@@ -22,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassKompetanserTilRegelverkService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
@@ -47,6 +49,7 @@ class VilkårsvurderingStegTest {
     private val tilbakestillBehandlingService: TilbakestillBehandlingService = mockk()
     private val tilpassKompetanserTilRegelverkService: TilpassKompetanserTilRegelverkService = mockk()
     private val vilkårsvurderingForNyBehandlingService: VilkårsvurderingForNyBehandlingService = mockk()
+    private val automatiskOppdaterValutakursService: AutomatiskOppdaterValutakursService = mockk()
 
     private val vilkårsvurderingSteg: VilkårsvurderingSteg =
         VilkårsvurderingSteg(
@@ -60,7 +63,7 @@ class VilkårsvurderingStegTest {
             vilkårsvurderingForNyBehandlingService = vilkårsvurderingForNyBehandlingService,
             månedligValutajusteringSevice = mockk(),
             localDateProvider = RealDateProvider(),
-            automatiskOppdaterValutakursService = mockk(),
+            automatiskOppdaterValutakursService = automatiskOppdaterValutakursService,
         )
 
     val behandling =
@@ -86,6 +89,7 @@ class VilkårsvurderingStegTest {
             )
 
         every { tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id)) } just Runs
+        justRun { automatiskOppdaterValutakursService.oppdaterAndelerMedValutakurser(any()) }
     }
 
     @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -183,7 +183,7 @@ fun lagVilkårsvurdering(
                 lagPersonResultat(
                     vilkårsvurdering = vilkårsvurdering,
                     person = person,
-                    resultat = Resultat.OPPFYLT,
+                    resultat = Resultat.IKKE_VURDERT,
                     personType = person.type,
                     lagFullstendigVilkårResultat = true,
                     periodeFom = null,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
@@ -184,6 +184,36 @@ class VedtaksperioderOgBegrunnelserStepDefinition {
             leggTilVilkårResultatPåPersonResultat(personResultatForBehandling, vilkårResultaterPerPerson, behandlingId)
     }
 
+    @Og("fyll ut vikårresultater for behandling {} fra dato {}")
+    fun `fyll ut vikårresultater for behandling fra dato`(
+        behandlingId: Long,
+        fraDato: String? = null,
+    ) {
+        CucumberMock(
+            this,
+            behandlingId,
+        ).testVerktøyService.oppdaterVilkårUtenFomTilFødselsdato(behandlingId, parseValgfriDato(fraDato))
+    }
+
+    @Og("kopier vilkårresultater fra behandling {} til behandling {}")
+    fun `kopier vilkårresultater fra behandling til behandling`(
+        fraBehandlingId: Long,
+        tilBehandlingId: Long,
+    ) {
+        val personResultatForFraBehandling =
+            vilkårsvurderinger[fraBehandlingId]?.personResultater
+                ?: error("Finner ikke personresultater for behandling med id $fraBehandlingId")
+
+        val vilkårsvurderingTilBehandling =
+            vilkårsvurderinger[tilBehandlingId]
+                ?: error("Finner ikke vilkårsvurdering for behandling med id $tilBehandlingId")
+
+        vilkårsvurderinger[tilBehandlingId]?.personResultater =
+            personResultatForFraBehandling
+                .map { it.apply { vilkårsvurdering = vilkårsvurderingTilBehandling } }
+                .toSet()
+    }
+
     /**
      * Mulige felt:
      * | AktørId | Fra dato | Til dato | Resultat | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BasisDomeneParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/BasisDomeneParser.kt
@@ -84,6 +84,13 @@ fun parseDato(dato: String): LocalDate =
         LocalDate.parse(dato, isoDatoFormatter)
     }
 
+fun parseValgfriDato(dato: String?): LocalDate? =
+    when {
+        dato == null || dato == "" -> null
+        dato.contains(".") -> LocalDate.parse(dato, norskDatoFormatter)
+        else -> LocalDate.parse(dato, isoDatoFormatter)
+    }
+
 fun parseValgfriDato(
     domenebegrep: String,
     rad: Map<String, String?>,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGenerator
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsoppdragGeneratorService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
+import no.nav.familie.ba.sak.internal.TestVerktøyService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringSevice
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.AutovedtakSmåbarnstilleggService
@@ -188,6 +189,21 @@ class CucumberMock(
             persongrunnlagService = persongrunnlagService,
         )
 
+    val testVerktøyService =
+        TestVerktøyService(
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            vilkårService = vilkårService,
+            personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            endretUtbetalingRepository = endretUtbetalingAndelRepository,
+            vedtaksperiodeHentOgPersisterService = vedtaksperiodeHentOgPersisterService,
+            vedtakRepository = vedtakRepository,
+            kompetanseRepository = kompetanseRepository,
+            utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
+            valutakursRepository = valutakursRepository,
+            søknadGrunnlagService = søknadGrunnlagService,
+        )
+
     val vedtaksperiodeService =
         VedtaksperiodeService(
             personidentService = personidentService,
@@ -265,6 +281,7 @@ class CucumberMock(
             simuleringService = simuleringService,
             vurderingsstrategiForValutakurserRepository = vurderingsstrategiForValutakurserRepository,
             unleashNextMedContextService = unleashNextMedContextService,
+            tilpassDifferanseberegningEtterValutakursService = tilpassDifferanseberegningEtterValutakursService,
         )
 
     val tilpassDifferanseberegningEtterUtenlandskPeriodebeløpService =

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/automatisk_valutajustering/ingen_endringer_fra_forrige_behandling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/automatisk_valutajustering/ingen_endringer_fra_forrige_behandling.feature
@@ -1,0 +1,75 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Automatisk valutajustering
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype | Status  |
+      | 1        | NORMAL     | LØPENDE |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak         | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus | Behandlingssteg      | Behandlingstype |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | MÅNEDLIG_VALUTAJUSTERING | Ja                        | EØS                 | AVSLUTTET         | BEHANDLING_AVSLUTTET | REVURDERING     |
+      | 2            | 1        | 1                   | ENDRET_UTBETALING   | ÅRLIG_KONTROLL           | Nei                       | EØS                 | UTREDES           | VILKÅRSVURDERING     | REVURDERING     |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 08.06.1984  |
+      | 1            | 2       | BARN       | 18.03.2011  |
+      | 2            | 1       | SØKER      | 08.06.1984  |
+      | 2            | 2       | BARN       | 18.03.2011  |
+
+  Scenario: Skal oppdatere andel tilkjent ytelse når vilkårsvurderingsteget utføres, selv om det ikke er noen endring
+    Og dagens dato er 24.08.2024
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og fyll ut vikårresultater for behandling 1 fra dato 01.12.2022
+    Og kopier vilkårresultater fra behandling 1 til behandling 2
+
+    Og med kompetanser
+      | AktørId | Fra dato   | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.01.2023 | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | LV                             | LV                  |
+      | 2       | 01.01.2023 | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | LV                             | LV                  |
+
+    Og med utenlandsk periodebeløp
+      | AktørId | Fra måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 01.2023   | 1            | 25    | EUR         | MÅNEDLIG  | LV              |
+      | 2       | 01.2023   | 2            | 25    | EUR         | MÅNEDLIG  | LV              |
+
+    Og med valutakurser
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs    | Vurderingsform |
+      | 2       | 01.01.2023 | 31.05.2024 | 1            | 2022-12-30     | EUR         | 10.5138 | MANUELL        |
+      | 2       | 01.06.2024 | 30.06.2024 | 1            | 2024-05-31     | EUR         | 11.383  | AUTOMATISK     |
+      | 2       | 01.07.2024 | 31.07.2024 | 1            | 2024-06-28     | EUR         | 11.3965 | AUTOMATISK     |
+      | 2       | 01.08.2024 |            | 1            | 2024-07-31     | EUR         | 11.8175 | AUTOMATISK     |
+      | 2       | 01.01.2023 |            | 2            | 2022-12-30     | EUR         | 10.5138 | MANUELL        |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.01.2023 | 28.02.2023 | 792   | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.03.2023 | 30.06.2023 | 821   | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 1            | 01.07.2023 | 31.12.2023 | 1048  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 1            | 01.01.2024 | 31.05.2024 | 1248  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.06.2024 | 31.07.2024 | 1226  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.08.2024 | 28.02.2029 | 1215  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+
+    Når vi utfører vilkårsvurderingssteget for behandling 2
+
+    Så forvent følgende valutakurser for behandling 2
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs    | Vurderingsform |
+      | 2       | 01.01.2023 | 31.05.2024 | 2            | 2022-12-30     | EUR         | 10.5138 | MANUELL        |
+      | 2       | 01.06.2024 | 30.06.2024 | 2            | 2024-05-31     | EUR         | 11.383  | AUTOMATISK     |
+      | 2       | 01.07.2024 | 31.07.2024 | 2            | 2024-06-28     | EUR         | 11.3965 | AUTOMATISK     |
+      | 2       | 01.08.2024 |            | 2            | 2024-07-31     | EUR         | 11.8175 | AUTOMATISK     |
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats | Differanseberegnet beløp |
+      | 2       | 2            | 01.01.2023 | 28.02.2023 | 792   | ORDINÆR_BARNETRYGD | 100     | 1054 | 792                      |
+      | 2       | 2            | 01.03.2023 | 30.06.2023 | 821   | ORDINÆR_BARNETRYGD | 100     | 1083 | 821                      |
+      | 2       | 2            | 01.07.2023 | 31.12.2023 | 1048  | ORDINÆR_BARNETRYGD | 100     | 1310 | 1048                     |
+      | 2       | 2            | 01.01.2024 | 31.05.2024 | 1248  | ORDINÆR_BARNETRYGD | 100     | 1510 | 1248                     |
+      | 2       | 2            | 01.06.2024 | 31.07.2024 | 1226  | ORDINÆR_BARNETRYGD | 100     | 1510 | 1226                     |
+      | 2       | 2            | 01.08.2024 | 31.08.2024 | 1215  | ORDINÆR_BARNETRYGD | 100     | 1510 | 1215                     |
+      | 2       | 2            | 01.09.2024 | 28.02.2029 | 1471  | ORDINÆR_BARNETRYGD | 100     | 1766 | 1471                     |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/steg/vilkårsvurderingsteg.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/steg/vilkårsvurderingsteg.feature
@@ -30,7 +30,7 @@ Egenskap: Vilkårsvurderingssteg
       | 2       | UNDER_18_ÅR        |                                     | 15.07.2018 | 14.07.2036 | OPPFYLT  | Nei                  |                      |                  |
       | 2       | GIFT_PARTNERSKAP   |                                     | 15.07.2018 |            | OPPFYLT  | Nei                  |                      |                  |
       | 2       | BOSATT_I_RIKET     | BARN_BOR_I_EØS                      | 14.11.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
-      | 2       | BOR_MED_SØKER      | BARN_BOR_I_EØS_MED_ANNEN_FORELDER   | 14.11.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER      | BARN_BOR_I_EØS_MED_SØKER            | 14.11.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
       | 2       | LOVLIG_OPPHOLD     |                                     | 14.11.2021 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
 
     Og med kompetanser
@@ -62,6 +62,7 @@ Egenskap: Vilkårsvurderingssteg
   Scenario: skal generere valutakurser for behandling med type teknisk endring
 
     Og lag personresultater for behandling 2
+    Og kopier vilkårresultater fra behandling 1 til behandling 2
     Og kopier kompetanser fra behandling 1 til behandling 2
     Og kopier utenlandsk periodebeløp fra behandling 1 til behandling 2
 
@@ -81,6 +82,7 @@ Egenskap: Vilkårsvurderingssteg
   Scenario: skal generere valutakurser for behandling med type revurdering
 
     Og lag personresultater for behandling 3
+    Og kopier vilkårresultater fra behandling 1 til behandling 3
     Og kopier kompetanser fra behandling 1 til behandling 3
     Og kopier utenlandsk periodebeløp fra behandling 1 til behandling 3
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

I behandlinger der det ikke er noen endringer i kompetanse eller utenlandsk periodebeløp, blir valutakurser fra forrige behandling kopiert over, men andelene blir ikke oppdatert. Dette fører til at saksbehandler kan gå forbi behandlingsresultatsteget med andeler som ikke er valutajustert.

Fikser dette ved å oppdatere andeler med valutakurser på slutten av vikårsvurderingsteget.

Les commit for commit

La også til noen snacks Cucumber-funksjoner, som krevde litt refaktorering

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
