### PR TITLE
Gjør oppdatering av utenlandsk periodebeløp transactional

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpService.kt
@@ -21,6 +21,7 @@ class UtenlandskPeriodebeløpService(
     fun hentUtenlandskePeriodebeløp(behandlingId: BehandlingId) =
         skjemaService.hentMedBehandlingId(behandlingId)
 
+    @Transactional
     fun oppdaterUtenlandskPeriodebeløp(
         behandlingId: BehandlingId,
         utenlandskPeriodebeløp: UtenlandskPeriodebeløp,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Endringer i utenlandsk periodebeløp fører til at valutakurser blir oppdatert.
Dersom noe galt skjer under oppdatering av valutakurser blir utenlandsk periodebeløp slettet uten at nye perioder genereres.

Gjør oppdateringen `@Transactional` slik at alt rulles tilbake hvis noe feiler