### PR TITLE
Lag task og endepunkt for å maskinelt underkjenne vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MaskineltUnderkjennVedtakTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MaskineltUnderkjennVedtakTask.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
+import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
+import no.nav.familie.ba.sak.kjerne.steg.StegService
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = MaskineltUnderkjennVedtakTask.TASK_STEP_TYPE,
+    beskrivelse = "Underkjenner et vedtak på vegne av system",
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = false,
+)
+class MaskineltUnderkjennVedtakTask(
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val stegService: StegService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val behandlingId = task.payload.toLong()
+
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        stegService.håndterBeslutningForVedtak(
+            behandling = behandling,
+            restBeslutningPåVedtak =
+                RestBeslutningPåVedtak(
+                    beslutning = Beslutning.UNDERKJENT,
+                    begrunnelse = "Maskinelt underkjent",
+                ),
+        )
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "maskineltUnderkjennVedtakTask"
+
+        fun opprettTask(behandlingId: Long): Task =
+            Task(
+                type = TASK_STEP_TYPE,
+                payload = behandlingId.toString(),
+            )
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22580

På grunn av en bug i automatisk valutajustering, som treffer når man går inn på behandlingsresultatsiden, har en behandling blitt låst i `BESLUTTE_VEDTAK`, og kan verken godkjennes eller underkjennes av beslutter eller saksbehandler.

Lager et endepunkt som oppretter en `MaskineltUnderkjennVedtakTask`, som prøver å underkjenne vedtak, uten å ha sett på alle sidene i behandlingen. `BeslutteVedtak::utførStegOgAngiNeste` tar seg av valideringen av at behandlingen er i en tilstand det er mulig å underkjenne fra.

_Jeg har ikke skrevet tester fordi:_
Ingen ny logikk innført og `BeslutteVedtak`-steg er allerede testet

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
