### PR TITLE
ikke lagre ny aktør når aktør allerede eksisterer for personident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -55,7 +55,7 @@ class HåndterNyIdentService(
                 validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, aktuellFagsakIdVedMerging)
                 logger.info("Legger til ny ident")
                 secureLogger.info("Legger til ny ident ${nyIdent.ident} på aktør ${aktør.aktørId}")
-                personIdentService.opprettPersonIdent(aktør, nyIdent.ident)
+                personIdentService.opprettPersonIdent(aktør, nyIdent.ident, false)
             }
 
             // Samme aktørId, samme fødselsnummer -> ignorer hendelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
@@ -136,23 +136,23 @@ class PersonidentService(
     fun opprettPersonIdent(
         aktør: Aktør,
         fødselsnummer: String,
-        lagre: Boolean = true,
+        lagreNyAktør: Boolean = true,
     ): Aktør {
-        secureLogger.info("Oppretter personIdent. aktørIdStr=${aktør.aktørId} fødselsnummer=$fødselsnummer lagre=$lagre, personidenter=${aktør.personidenter}")
+        secureLogger.info("Oppretter personIdent: aktørIdStr=${aktør.aktørId} fødselsnummer=$fødselsnummer lagreNyAktør=$lagreNyAktør, personidenter=${aktør.personidenter}")
         val eksisterendePersonIdent = aktør.personidenter.filter { it.fødselsnummer == fødselsnummer && it.aktiv }
         secureLogger.info("Aktøren har fødselsnummer ${aktør.personidenter.map { it.fødselsnummer }}")
         if (eksisterendePersonIdent.isEmpty()) {
-            secureLogger.info("Fins ikke eksisterende personIdent for. aktørIdStr=${aktør.aktørId} fødselsnummer=$fødselsnummer lagre=$lagre, personidenter=${aktør.personidenter}, så lager ny")
+            secureLogger.info("Fins ikke eksisterende personIdent for. aktørIdStr=${aktør.aktørId} fødselsnummer=$fødselsnummer lagre=$lagreNyAktør, personidenter=${aktør.personidenter}, så lager ny")
             aktør.personidenter.filter { it.aktiv }.map {
                 it.aktiv = false
                 it.gjelderTil = LocalDateTime.now()
             }
-            if (lagre) aktørIdRepository.saveAndFlush(aktør) // Må lagre her fordi unik index er en blanding av aktørid og gjelderTil, og hvis man ikke lagerer før man legger til ny, så feiler det pga indexen.
+            if (lagreNyAktør) aktørIdRepository.saveAndFlush(aktør) // Må lagre her fordi unik index er en blanding av aktørid og gjelderTil, og hvis man ikke lagerer før man legger til ny, så feiler det pga indexen.
 
             aktør.personidenter.add(
                 Personident(fødselsnummer = fødselsnummer, aktør = aktør),
             )
-            if (lagre) aktørIdRepository.saveAndFlush(aktør)
+            if (lagreNyAktør) aktørIdRepository.saveAndFlush(aktør)
         }
         return aktør
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -330,7 +330,6 @@ internal class HåndterNyIdentServiceTest {
                     .gjelderTil!!
                     .isBefore(LocalDateTime.now()),
             )
-            verify(exactly = 2) { aktørIdRepository.saveAndFlush(any()) }
             verify(exactly = 0) { personidentRepository.saveAndFlush(any()) }
         }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Har identhendelsetasker som feiler pga constraint på aktørid. Dette kommer at vi ikke sender ikke lagre = false når vi oppretter personident

renamer lagre -> lagreNyAktør
sender lagre = false når vi kaller fra en kontekst der vi vet at det eksisterer en aktør
