### PR TITLE
Avbryt månedlig valutajustering dersom det ikke eksisterer valutakurser i forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
-import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.erAlleValutakurserOppdaterteIMåned
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.måValutakurserOppdateresForMåned
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
@@ -57,7 +57,7 @@ class AutovedtakMånedligValutajusteringService(
 
         val sisteVedtatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = fagsakId) ?: error("Fant ikke siste vedtatte behandling for $fagsakId")
         val sisteValutakurser = valutakursService.hentValutakurser(BehandlingId(sisteVedtatteBehandling.id))
-        if (sisteValutakurser.erAlleValutakurserOppdaterteIMåned(måned)) {
+        if (!sisteValutakurser.måValutakurserOppdateresForMåned(måned)) {
             logger.info("Valutakursene er allerede oppdatert for fagsak $fagsakId. Hopper ut")
             return
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -161,10 +161,10 @@ fun List<UtfyltValutakurs>.tilTidslinje() =
             )
         }.tilTidslinje()
 
-fun Collection<Valutakurs>.erAlleValutakurserOppdaterteIMåned(
+fun Collection<Valutakurs>.måValutakurserOppdateresForMåned(
     måned: YearMonth,
-) = isNotEmpty() &&
-    none {
+) =
+    any {
         val fom = it.fom ?: TIDENES_MORGEN.toYearMonth()
         val tom = it.tom ?: TIDENES_ENDE.toYearMonth()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
@@ -47,7 +47,14 @@ class AutovedtakMånedligValutajusteringServiceTest {
     fun `utførMånedligValutajustering kaster Feil hvis en annen enn nåværende måned blir sendt inn`() {
         every { localDateProvider.now() } returns LocalDate.now()
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns lagBehandling()
-        every { valutaKursService.hentValutakurser(any()) } returns emptyList()
+        every { valutaKursService.hentValutakurser(any()) } returns
+            listOf(
+                Valutakurs(
+                    fom = YearMonth.now().minusYears(1),
+                    tom = null,
+                    vurderingsform = Vurderingsform.MANUELL,
+                ),
+            )
 
         assertThrows<Feil> {
             autovedtakMånedligValutajusteringService.utførMånedligValutajustering(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
@@ -122,9 +122,9 @@ class ValutakursTest {
     }
 
     @Nested
-    inner class `Valider at erAlleValutakurserOppdaterteIMåned` {
+    inner class `Valider at måValutakurserOppdateresForMåned` {
         @Test
-        fun `gir true når alle valutakurser er oppdatert for gitt måned`() {
+        fun `gir false når alle valutakurser er oppdatert for gitt måned`() {
             val måned = LocalDate.now().toYearMonth()
 
             val valutakurs1 =
@@ -143,11 +143,11 @@ class ValutakursTest {
 
             val valutakurser = listOf(valutakurs1, valutakurs2)
 
-            assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isTrue()
+            assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isFalse()
         }
 
         @Test
-        fun `gir false når en valutakurs ikke er oppdatert for gitt måned`() {
+        fun `gir false når minst én valutakurs ikke er oppdatert for gitt måned`() {
             val måned = LocalDate.now().toYearMonth()
 
             val valutakurs1 =
@@ -166,7 +166,7 @@ class ValutakursTest {
 
             val valutakurser = listOf(valutakurs1, valutakurs2)
 
-            assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isFalse()
+            assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isTrue()
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
@@ -143,7 +143,7 @@ class ValutakursTest {
 
             val valutakurser = listOf(valutakurs1, valutakurs2)
 
-            assertThat(valutakurser.erAlleValutakurserOppdaterteIMåned(måned)).isTrue()
+            assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isTrue()
         }
 
         @Test
@@ -166,7 +166,7 @@ class ValutakursTest {
 
             val valutakurser = listOf(valutakurs1, valutakurs2)
 
-            assertThat(valutakurser.erAlleValutakurserOppdaterteIMåned(måned)).isFalse()
+            assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isFalse()
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
@@ -147,7 +147,7 @@ class ValutakursTest {
         }
 
         @Test
-        fun `gir false når minst én valutakurs ikke er oppdatert for gitt måned`() {
+        fun `gir true når minst én valutakurs ikke er oppdatert for gitt måned`() {
             val måned = LocalDate.now().toYearMonth()
 
             val valutakurs1 =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Dersom det ikke eksisterer valutaer på forrige behandling er det ingen valutakurser å oppdatere, så tasken avsluttes.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
