### PR TITLE
Marker klagebehandlinger med klagebehandlingsårsak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <prosessering.version>2.20240925091323_ea1bd3c</prosessering.version>
         <felles.version>3.20240913110742_adb42f8</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20240919121839_57daa74</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20241004134208_2962899</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20240311083956_0558f2a</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20240902095239_88c7bc0</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
@@ -24,6 +24,7 @@ import no.nav.familie.kontrakter.felles.klage.IkkeOpprettetÅrsak
 import no.nav.familie.kontrakter.felles.klage.KanIkkeOppretteRevurderingÅrsak
 import no.nav.familie.kontrakter.felles.klage.KanOppretteRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
 import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
 import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.Opprettet
@@ -73,6 +74,7 @@ class KlageService(
                 fagsystem = Fagsystem.BA,
                 klageMottatt = kravMottattDato,
                 behandlendeEnhet = enhetId,
+                behandlingsårsak = Klagebehandlingsårsak.ORDINÆR,
             ),
         )
     }


### PR DESCRIPTION
har behov for at klagebehandlinger inneholder informasjon om behandlingsårsak for behandlingen

### 💰 Hva skal gjøres, og hvorfor?
Enslig Forsørger har behov for å markere klagebehandlinger med en behandlingsårsak. Oppdaterer derfor kontrakter og gjør det slik at dere i BAKS alltid sender inn Klagebehandlingsårsaken: Ordinær. 

Den andre årsaken som ble lagt til i kontrakter er _henvendelse fra kabal_. I dette tilfellet ønsker kabal, av ulike grunner, at våre saksbehandlere oppretter en klagebehandling og opprettholder denne slik at den sendes med til kabal. I dette tilfellet skal det ikke sendes noe brev ut mot sluttbruker.

En klagebehandling med årsak _henvendelse_fra_kabal_ vil derfor skille seg fra en ordinær klagebehandling ved at det ikke sendes ut et brev til sluttbruker.
