### PR TITLE
Fix identhendelser som feiler på dobbel lagring av aktør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -97,8 +97,8 @@ class HåndterNyIdentService(
 
         val fagsakIder =
             aktørerMedAktivPersonident
-                .flatMap { aktør -> aktør.personidenter.flatMap { ident -> fagsakService.hentFagsakDeltager(ident.fødselsnummer) } }
-                .mapNotNull { it.fagsakId }
+                .flatMap { aktør -> fagsakService.hentFagsakerPåPerson(aktør) }
+                .map { it.id }
 
         if (fagsakIder.toSet().size > 1) {
             throw Feil("Det eksisterer flere fagsaker på identer som skal merges: ${aktørerMedAktivPersonident.first()}. $LENKE_INFO_OM_MERGING")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
@@ -147,7 +147,6 @@ class PersonidentService(
                 it.aktiv = false
                 it.gjelderTil = LocalDateTime.now()
             }
-            if (lagreNyAktør) aktørIdRepository.saveAndFlush(aktør) // Må lagre her fordi unik index er en blanding av aktørid og gjelderTil, og hvis man ikke lagerer før man legger til ny, så feiler det pga indexen.
 
             aktør.personidenter.add(
                 Personident(fødselsnummer = fødselsnummer, aktør = aktør),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22663)
Vi har en del identhendelsetasker som feiler fordi vi lagrer ned aktør dobbelt. Går derfra vekk fra å lagre ned aktør to ganger i PersonidentService. 
Bruker hentFagsakerPåPerson() i stedet for hentFagsakDeltager() siden sistnevnte gjør veldig mye mer enn å bare hente fagsakene som er gjeldende for personen. 

