### PR TITLE
Månedlig valutajustering skal følge satsendring sin behandlingsløype

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -84,8 +84,8 @@ class ArbeidsfordelingService(
             }
 
         val oppdatertArbeidsfordelingPåBehandling =
-            if (behandling.erSatsendring()) {
-                fastsettArbeidsfordelingsenhetPåSatsendringsbehandling(
+            if (behandling.erSatsendringEllerMånedligValutajustering()) {
+                fastsettArbeidsfordelingsenhetUtIfraForrigeBehandling(
                     behandling,
                     sisteBehandlingSomErIverksatt,
                     aktivArbeidsfordelingPåBehandling,
@@ -127,7 +127,7 @@ class ArbeidsfordelingService(
         )
     }
 
-    private fun fastsettArbeidsfordelingsenhetPåSatsendringsbehandling(
+    private fun fastsettArbeidsfordelingsenhetUtIfraForrigeBehandling(
         behandling: Behandling,
         sisteBehandlingSomErIverksatt: Behandling?,
         aktivArbeidsfordelingPåBehandling: ArbeidsfordelingPåBehandling?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -235,8 +235,6 @@ data class Behandling(
 
     fun erKorrigereVedtak() = opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV
 
-    fun årsakNavn() = opprettetÅrsak.visningsnavn.lowercase()
-
     fun kanLeggeTilOgFjerneUtvidetVilkår() =
         erManuellMigrering() || erTekniskEndring() || erKorrigereVedtak() || erKlage()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -115,9 +115,8 @@ data class Behandling(
     fun erBehandlingMedVedtaksbrevutsending(): Boolean =
         when {
             type == BehandlingType.TEKNISK_ENDRING -> false
-            erSatsendring() -> false
             opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID -> false
-            erMånedligValutajustering() -> false
+            erSatsendringEllerMånedligValutajustering() -> false
             erManuellMigrering() -> false
             erMigrering() -> false
             else -> true

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -115,9 +115,9 @@ data class Behandling(
     fun erBehandlingMedVedtaksbrevutsending(): Boolean =
         when {
             type == BehandlingType.TEKNISK_ENDRING -> false
-            opprettetÅrsak == BehandlingÅrsak.SATSENDRING -> false
+            erSatsendring() -> false
             opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID -> false
-            opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING -> false
+            erMånedligValutajustering() -> false
             erManuellMigrering() -> false
             erMigrering() -> false
             else -> true
@@ -164,7 +164,7 @@ data class Behandling(
             skalBehandlesAutomatisk && erFødselshendelse() -> true
             skalBehandlesAutomatisk && erSatsendring() && erEndringFraForrigeBehandlingSendtTilØkonomi -> true
             skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID && this.resultat == Behandlingsresultat.FORTSATT_INNVILGET -> true
-            skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING -> true
+            skalBehandlesAutomatisk && erMånedligValutajustering() -> true
             else -> false
         }
 
@@ -220,7 +220,9 @@ data class Behandling(
 
     fun erSatsendring() = this.opprettetÅrsak == BehandlingÅrsak.SATSENDRING
 
-    fun erValutajustering() = this.opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING
+    fun erMånedligValutajustering() = this.opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING
+
+    fun erSatsendringEllerMånedligValutajustering() = erSatsendring() || erMånedligValutajustering()
 
     fun erManuellMigreringForEndreMigreringsdato() =
         erMigrering() &&
@@ -233,6 +235,8 @@ data class Behandling(
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 
     fun erKorrigereVedtak() = opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV
+
+    fun årsakNavn() = opprettetÅrsak.visningsnavn.lowercase()
 
     fun kanLeggeTilOgFjerneUtvidetVilkår() =
         erManuellMigrering() || erTekniskEndring() || erKorrigereVedtak() || erKlage()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -63,7 +63,7 @@ class BehandlingsresultatSteg(
         behandling: Behandling,
         stegService: StegService?,
     ) {
-        if (!behandling.erSatsendringEllerMånedligValutajustering() && behandling.skalBehandlesAutomatisk) return
+        if (!behandling.erSatsendring() && !behandling.erMånedligValutajustering() && behandling.skalBehandlesAutomatisk) return
 
         val søkerOgBarn = persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(behandling.id)
         if (behandling.type != BehandlingType.TEKNISK_ENDRING && behandling.type != BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT) {
@@ -84,7 +84,7 @@ class BehandlingsresultatSteg(
             søkerOgBarn = søkerOgBarn,
         )
 
-        if (!behandling.erSatsendring()) {
+        if (!behandling.erSatsendringEllerMånedligValutajustering()) {
             val endreteUtbetalingerMedAndeler =
                 andelerTilkjentYtelseOgEndreteUtbetalingerService
                     .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -63,7 +63,7 @@ class BehandlingsresultatSteg(
         behandling: Behandling,
         stegService: StegService?,
     ) {
-        if (!behandling.erSatsendring() && !behandling.erMånedligValutajustering() && behandling.skalBehandlesAutomatisk) return
+        if (!behandling.erSatsendringEllerMånedligValutajustering() && behandling.skalBehandlesAutomatisk) return
 
         val søkerOgBarn = persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(behandling.id)
         if (behandling.type != BehandlingType.TEKNISK_ENDRING && behandling.type != BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -63,7 +63,7 @@ class BehandlingsresultatSteg(
         behandling: Behandling,
         stegService: StegService?,
     ) {
-        if (!behandling.erSatsendring() && !behandling.erValutajustering() && behandling.skalBehandlesAutomatisk) return
+        if (!behandling.erSatsendringEllerMånedligValutajustering() && behandling.skalBehandlesAutomatisk) return
 
         val søkerOgBarn = persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(behandling.id)
         if (behandling.type != BehandlingType.TEKNISK_ENDRING && behandling.type != BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT) {
@@ -84,14 +84,14 @@ class BehandlingsresultatSteg(
             søkerOgBarn = søkerOgBarn,
         )
 
-        if (behandling.opprettetÅrsak != BehandlingÅrsak.SATSENDRING) {
+        if (!behandling.erSatsendring()) {
             val endreteUtbetalingerMedAndeler =
                 andelerTilkjentYtelseOgEndreteUtbetalingerService
                     .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
             endreteUtbetalingerMedAndeler.validerEndredeUtbetalingsandeler(tilkjentYtelse, vilkårService.hentVilkårsvurdering(behandling.id))
         }
 
-        if (behandling.opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING) {
+        if (behandling.erMånedligValutajustering()) {
             BehandlingsresultatValideringUtils.validerIngenEndringTilbakeITid(
                 andelerDenneBehandlingen = tilkjentYtelse.andelerTilkjentYtelse.toList(),
                 andelerForrigeBehandling = andelerForrigeBehandling.toList(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -27,7 +27,6 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.validerAtDetFinnesDeltBoste
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.validerBarnasVilkår
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
-import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.barn
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
@@ -59,7 +58,6 @@ class BehandlingsresultatSteg(
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
     private val valutakursRepository: ValutakursRepository,
     private val localDateProvider: LocalDateProvider,
-    private val valutakursService: ValutakursService,
 ) : BehandlingSteg<String> {
     override fun preValiderSteg(
         behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggService.kt
@@ -35,7 +35,7 @@ class SmåbarnstilleggService(
         søkerAktør: Aktør,
         behandling: Behandling,
     ) {
-        if (behandling.erSatsendring()) {
+        if (behandling.erSatsendringEllerMånedligValutajustering()) {
             kopierPerioderMedOvergangsstønadFraForrigeBehandling(
                 behandling,
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -30,7 +30,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val endreteUtbetalingerMedAndeler = lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
 
-        return if (!behandling.erSatsendring()) {
+        return if (!behandling.erSatsendringEllerMånedligValutajustering()) {
             // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
             // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
             // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.overlapperHeltEllerDelvisMed
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseUtils.skalAndelerSlåsSammen
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidering.validerPeriodeInnenforTilkjentytelse
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidering.validerÅrsak
@@ -31,7 +30,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val endreteUtbetalingerMedAndeler = lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
 
-        return if (behandling.opprettetÅrsak != BehandlingÅrsak.SATSENDRING) {
+        return if (!behandling.erSatsendring()) {
             // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
             // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
             // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -218,7 +218,7 @@ class PersongrunnlagService(
     ): PersonopplysningGrunnlag {
         val personopplysningGrunnlag = lagreOgDeaktiverGammel(PersonopplysningGrunnlag(behandlingId = behandling.id))
 
-        val enkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
+        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
         val søker =
             hentPerson(
                 aktør = aktør,
@@ -229,7 +229,7 @@ class PersongrunnlagService(
                         NORMAL -> PersonType.SØKER
                         BARN_ENSLIG_MINDREÅRIG, INSTITUSJON -> PersonType.BARN
                     },
-                enkelPersonInfo = enkelPersonInfo,
+                skalHenteEnkelPersonInfo = skalHenteEnkelPersonInfo,
                 hentArbeidsforhold = behandling.skalBehandlesAutomatisk,
             )
         personopplysningGrunnlag.personer.add(søker)
@@ -241,7 +241,7 @@ class PersongrunnlagService(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     målform = målform,
                     personType = PersonType.BARN,
-                    enkelPersonInfo = enkelPersonInfo,
+                    skalHenteEnkelPersonInfo = skalHenteEnkelPersonInfo,
                 ),
             )
         }
@@ -254,7 +254,7 @@ class PersongrunnlagService(
                         personopplysningGrunnlag = personopplysningGrunnlag,
                         målform = målform,
                         personType = PersonType.ANNENPART,
-                        enkelPersonInfo = enkelPersonInfo,
+                        skalHenteEnkelPersonInfo = skalHenteEnkelPersonInfo,
                         hentArbeidsforhold = true,
                     ),
                 )
@@ -276,11 +276,11 @@ class PersongrunnlagService(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         målform: Målform,
         personType: PersonType,
-        enkelPersonInfo: Boolean = false,
+        skalHenteEnkelPersonInfo: Boolean = false,
         hentArbeidsforhold: Boolean = false,
     ): Person {
         val personinfo =
-            if (enkelPersonInfo) {
+            if (skalHenteEnkelPersonInfo) {
                 personopplysningerService.hentPersoninfoEnkel(aktør)
             } else {
                 personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(aktør)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -218,7 +218,7 @@ class PersongrunnlagService(
     ): PersonopplysningGrunnlag {
         val personopplysningGrunnlag = lagreOgDeaktiverGammel(PersonopplysningGrunnlag(behandlingId = behandling.id))
 
-        val enkelPersonInfo = behandling.erMigrering() || behandling.erSatsendring()
+        val enkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
         val søker =
             hentPerson(
                 aktør = aktør,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -97,7 +97,7 @@ class VilkårsvurderingSteg(
             tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
         }
 
-        if (behandling.opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING) {
+        if (behandling.erMånedligValutajustering()) {
             månedligValutajusteringSevice.oppdaterValutakurserForMåned(BehandlingId(behandling.id), localDateProvider.now().toYearMonth())
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
@@ -24,7 +24,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
     ) {
         if (behandling.erSatsendring()) {
             if (forrigeBehandlingSomErVedtatt == null) {
-                throw Feil("Vi kan ikke kjøre satsendring dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
+                throw Feil("Vi kan ikke kjøre ${behandling.årsakNavn()} dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
             }
             opprettKopiAvPersonopplysningGrunnlag(behandling, forrigeBehandlingSomErVedtatt, søkerIdent)
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
@@ -24,7 +24,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
     ) {
         if (behandling.erSatsendringEllerMånedligValutajustering()) {
             if (forrigeBehandlingSomErVedtatt == null) {
-                throw Feil("Vi kan ikke kjøre ${behandling.årsakNavn()} dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
+                throw Feil("Vi kan ikke kjøre behandling med årsal ${behandling.opprettetÅrsak} dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
             }
             opprettKopiAvPersonopplysningGrunnlag(behandling, forrigeBehandlingSomErVedtatt, søkerIdent)
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
@@ -22,7 +22,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
         søkerIdent: String,
         barnasIdenter: List<String>,
     ) {
-        if (behandling.erSatsendring()) {
+        if (behandling.erSatsendringEllerMånedligValutajustering()) {
             if (forrigeBehandlingSomErVedtatt == null) {
                 throw Feil("Vi kan ikke kjøre ${behandling.årsakNavn()} dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
@@ -24,7 +24,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
     ) {
         if (behandling.erSatsendringEllerMånedligValutajustering()) {
             if (forrigeBehandlingSomErVedtatt == null) {
-                throw Feil("Vi kan ikke kjøre behandling med årsal ${behandling.opprettetÅrsak} dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
+                throw Feil("Vi kan ikke kjøre behandling med årsak ${behandling.opprettetÅrsak} dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
             }
             opprettKopiAvPersonopplysningGrunnlag(behandling, forrigeBehandlingSomErVedtatt, søkerIdent)
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -62,7 +62,9 @@ class VilkårsvurderingForNyBehandlingService(
                 behandlingService.lagreNedMigreringsdato(nyMigreringsdato, behandling)
             }
 
-            BehandlingÅrsak.SATSENDRING -> {
+            BehandlingÅrsak.SATSENDRING,
+            BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING,
+            -> {
                 genererVilkårsvurderingForSatsendring(
                     forrigeBehandlingSomErVedtatt =
                         forrigeBehandlingSomErVedtatt

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -66,7 +66,7 @@ class VilkårsvurderingForNyBehandlingService(
                 genererVilkårsvurderingForSatsendring(
                     forrigeBehandlingSomErVedtatt =
                         forrigeBehandlingSomErVedtatt
-                            ?: throw Feil("Kan ikke opprette behandling med årsak 'Satsendring' hvis det ikke finnes en tidligere behandling"),
+                            ?: throw Feil("Kan ikke opprette behandling med årsak ${behandling.årsakNavn()} hvis det ikke finnes en tidligere behandling"),
                     inneværendeBehandling = behandling,
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -68,7 +68,7 @@ class VilkårsvurderingForNyBehandlingService(
                 genererVilkårsvurderingForSatsendring(
                     forrigeBehandlingSomErVedtatt =
                         forrigeBehandlingSomErVedtatt
-                            ?: throw Feil("Kan ikke opprette behandling med årsak ${behandling.årsakNavn()} hvis det ikke finnes en tidligere behandling"),
+                            ?: throw Feil("Kan ikke opprette behandling med årsak ${behandling.opprettetÅrsak} hvis det ikke finnes en tidligere behandling"),
                     inneværendeBehandling = behandling,
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -74,7 +74,7 @@ fun valider18ÅrsVilkårEksistererFraFødselsdato(
     vilkårsvurdering.personResultater.forEach { personResultat ->
         val person = søkerOgBarn.find { it.aktør == personResultat.aktør }
         if (person?.type == PersonType.BARN && !personResultat.vilkårResultater.finnesUnder18VilkårFraFødselsdato(person.fødselsdato)) {
-            if (behandling.erSatsendring() || behandling.opprettetÅrsak.erOmregningsårsak()) {
+            if (behandling.erSatsendringEllerMånedligValutajustering() || behandling.opprettetÅrsak.erOmregningsårsak()) {
                 secureLogger.warn(
                     "Fødselsdato ${person.fødselsdato} ulik fom ${
                         personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 class BehandlingTest {
     @Test
@@ -66,32 +68,15 @@ class BehandlingTest {
         assertTrue { behandling.erBehandlingMedVedtaksbrevutsending() }
     }
 
-    @Test
-    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for migrering med endre migreringsdato`() {
+    @ParameterizedTest
+    @EnumSource(value = BehandlingÅrsak::class, names = ["ENDRE_MIGRERINGSDATO", "HELMANUELL_MIGRERING", "MIGRERING"])
+    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for behandlingstype MIGRERING_FRA_INFOTRYGD`(
+        årsak: BehandlingÅrsak,
+    ) {
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                årsak = BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
-            )
-        assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
-    }
-
-    @Test
-    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for helmanuell migrering`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
-            )
-        assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
-    }
-
-    @Test
-    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for automatisk migrering`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                årsak = BehandlingÅrsak.MIGRERING,
+                årsak = årsak,
             )
         assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
     }
@@ -105,12 +90,15 @@ class BehandlingTest {
         assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
     }
 
-    @Test
-    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for revurdering med satsendring`() {
+    @ParameterizedTest
+    @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
+    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for revurdering med årsak satsendring eller månedlig valutajustering`(
+        årsak: BehandlingÅrsak,
+    ) {
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.REVURDERING,
-                årsak = BehandlingÅrsak.SATSENDRING,
+                årsak = årsak,
             )
         assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -98,7 +98,6 @@ class BehandlingsresultatStegTest {
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             valutakursRepository = valutakursRepository,
             localDateProvider = RealDateProvider(),
-            valutakursService = valutakursService,
         )
 
     private val behandling =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -104,7 +104,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
         }
 
         @Test
-        fun `For behandling blir endrete utbetalinger med overlappende andeler kombinert`() {
+        fun `For behandling med årsak nye opplsyninger blir endrete utbetalinger med overlappende andeler kombinert`() {
             val behandling =
                 lagBehandling(
                     behandlingType = BehandlingType.REVURDERING,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -1,0 +1,158 @@
+package no.nav.familie.ba.sak.kjerne.beregning
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagEndretUtbetalingAndel
+import no.nav.familie.ba.sak.common.lagPerson
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.YearMonth
+
+class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
+    val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+    val endretUtbetalingAndelRepository = mockk<EndretUtbetalingAndelRepository>()
+    val vilkårsvurderingRepository = mockk<VilkårsvurderingRepository>()
+    val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+
+    val andelerTilkjentYtelseOgEndreteUtbetalingerService =
+        AndelerTilkjentYtelseOgEndreteUtbetalingerService(
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            endretUtbetalingAndelRepository = endretUtbetalingAndelRepository,
+            vilkårsvurderingRepository = vilkårsvurderingRepository,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+        )
+
+    @BeforeEach
+    fun setup() {
+        every { vilkårsvurderingRepository.findByBehandlingAndAktiv(any()) } returns null
+    }
+
+    @Nested
+    inner class FinnEndreteUtbetalingerMedAndelerTilkjentYtelse {
+        @ParameterizedTest
+        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
+        fun `For behandling med årsak satsendring og månedlig valutajustering blir ikke endrete utbetalinger filtrert bort`(
+            årsak: BehandlingÅrsak,
+        ) {
+            val behandling =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = årsak,
+                )
+
+            val endretUtbetalingAndel = EndretUtbetalingAndel(behandlingId = behandling.id)
+
+            every { behandlingHentOgPersisterService.hent(any()) } returns behandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns emptyList()
+            every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns listOf(endretUtbetalingAndel)
+
+            val endreteUtbetalinger = andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
+
+            assertThat(endreteUtbetalinger).hasSize(1)
+        }
+
+        @Test
+        fun `For behandling med årsak nye opplysinger blir endrete utbetalinger uten overlappende andeler filtrert bort`() {
+            val behandling =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                )
+
+            val aktør = lagPerson()
+
+            every { behandlingHentOgPersisterService.hent(any()) } returns behandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        person = aktør,
+                        fom = YearMonth.now().minusMonths(2),
+                        tom = YearMonth.now().minusMonths(1),
+                    ),
+                )
+            every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns
+                listOf(
+                    lagEndretUtbetalingAndel(
+                        person = aktør,
+                        fom = YearMonth.now().minusMonths(3),
+                        tom = YearMonth.now().minusMonths(2),
+                        årsak = Årsak.ENDRE_MOTTAKER,
+                    ),
+                )
+
+            val endreteUtbetalinger = andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
+
+            assertThat(endreteUtbetalinger)
+                .singleElement()
+                .extracting { it.andelerTilkjentYtelse }
+                .satisfies({ assertThat(it).isEmpty() })
+        }
+
+        @Test
+        fun `For behandling blir endrete utbetalinger med overlappende andeler kombinert`() {
+            val behandling =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                )
+
+            val aktør = lagPerson()
+
+            every { behandlingHentOgPersisterService.hent(any()) } returns behandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        person = aktør,
+                        fom = YearMonth.now().minusMonths(3),
+                        tom = YearMonth.now().minusMonths(2),
+                    ),
+                    lagAndelTilkjentYtelse(
+                        person = aktør,
+                        fom = YearMonth.now().minusMonths(2),
+                        tom = YearMonth.now().minusMonths(1),
+                    ),
+                )
+            every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns
+                listOf(
+                    lagEndretUtbetalingAndel(
+                        person = aktør,
+                        fom = YearMonth.now().minusMonths(3),
+                        tom = YearMonth.now().minusMonths(1),
+                        årsak = Årsak.ENDRE_MOTTAKER,
+                    ),
+                )
+
+            val endreteUtbetalinger = andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
+
+            assertThat(endreteUtbetalinger)
+                .singleElement()
+                .extracting { it.andelerTilkjentYtelse }
+                .satisfies({
+                    assertThat(it)
+                        .hasSize(2)
+                        .anySatisfy {
+                            assertThat(it.stønadFom).isEqualTo(YearMonth.now().minusMonths(3))
+                            assertThat(it.stønadTom).isEqualTo(YearMonth.now().minusMonths(2))
+                        }.anySatisfy {
+                            assertThat(it.stønadFom).isEqualTo(YearMonth.now().minusMonths(2))
+                            assertThat(it.stønadTom).isEqualTo(YearMonth.now().minusMonths(1))
+                        }
+                })
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggServiceTest.kt
@@ -25,6 +25,8 @@ import no.nav.familie.kontrakter.felles.ef.EksternePerioderResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 
 class SmåbarnstilleggServiceTest {
@@ -56,12 +58,15 @@ class SmåbarnstilleggServiceTest {
         every { localDateProvider.now() } returns LocalDate.now()
     }
 
-    @Test
-    fun `Ved satsendring skal gamle perioder kopieres`() {
+    @ParameterizedTest
+    @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
+    fun `Ved satsendring og månedlig valutajustering skal gamle perioder kopieres`(
+        årsak: BehandlingÅrsak,
+    ) {
         val søker = lagPerson(type = PersonType.SØKER)
         val fagsak = Fagsak(aktør = søker.aktør)
         val forrigeBehandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD, fagsak = fagsak)
-        val behandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING, fagsak = fagsak)
+        val behandling = lagBehandling(årsak = årsak, fagsak = fagsak)
 
         val perioderForrigeBehandling =
             listOf(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
@@ -37,6 +37,8 @@ import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTANDTYPE
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 
 class PersonopplysningGrunnlagForNyBehandlingServiceTest {
@@ -100,10 +102,13 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest {
         }
     }
 
-    @Test
-    fun `hentOgLagrePersonopplysningGrunnlag - skal kopiere persongrunnlaget fra forrige behandling ved satsendring`() {
+    @ParameterizedTest
+    @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
+    fun `hentOgLagrePersonopplysningGrunnlag - skal kopiere persongrunnlaget fra forrige behandling ved satsendring og månedlig valutajustering`(
+        årsak: BehandlingÅrsak,
+    ) {
         val forrigeBehandling = lagBehandling()
-        val nyBehandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING)
+        val nyBehandling = lagBehandling(årsak = årsak)
         val søker = PersonIdent(randomFnr())
         val barn = PersonIdent(randomFnr())
         val søkerPerson = lagPerson(personIdent = søker, id = 1)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
@@ -17,145 +17,198 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 
 class VilkårsvurderingValideringTest {
-    @Test
-    fun `skal kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS`() {
-        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
-        val søker = lagPersonEnkel(PersonType.SØKER)
-        val barn1 = lagPersonEnkel(PersonType.BARN)
-        val barn2 = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
-        val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn2 = byggPersonResultatForPersonEnkel(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+    @Nested
+    inner class ValiderIkkeBlandetRegelverk {
+        @Test
+        fun `skal kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS`() {
+            val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+            val søker = lagPersonEnkel(PersonType.SØKER)
+            val barn1 = lagPersonEnkel(PersonType.BARN)
+            val barn2 = lagPersonEnkel(PersonType.BARN)
+            val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+            val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+            val personResultatBarn2 = byggPersonResultatForPersonEnkel(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
 
-        vilkårsvurdering.personResultater =
-            setOf(
-                personResultatSøker,
-                personResultatBarn1,
-                personResultatBarn2,
-            )
+            vilkårsvurdering.personResultater =
+                setOf(
+                    personResultatSøker,
+                    personResultatBarn1,
+                    personResultatBarn2,
+                )
 
-        assertThrows<FunksjonellFeil> {
-            validerIkkeBlandetRegelverk(
-                vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn1, barn2),
-                behandling = lagBehandling(),
-            )
+            assertThrows<FunksjonellFeil> {
+                validerIkkeBlandetRegelverk(
+                    vilkårsvurdering = vilkårsvurdering,
+                    søkerOgBarn = listOf(søker, barn1, barn2),
+                    behandling = lagBehandling(),
+                )
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS om der er satsendring`() {
+            val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+            val søker = lagPersonEnkel(PersonType.SØKER)
+            val barn1 = lagPersonEnkel(PersonType.BARN)
+            val barn2 = lagPersonEnkel(PersonType.BARN)
+            val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+            val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+            val personResultatBarn2 = byggPersonResultatForPersonEnkel(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+
+            vilkårsvurdering.personResultater =
+                setOf(
+                    personResultatSøker,
+                    personResultatBarn1,
+                    personResultatBarn2,
+                )
+
+            assertDoesNotThrow {
+                validerIkkeBlandetRegelverk(
+                    vilkårsvurdering = vilkårsvurdering,
+                    søkerOgBarn = listOf(søker, barn1, barn2),
+                    behandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING),
+                )
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil hvis både søker og barn vurderes etter eøs`() {
+            val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+            val søker = lagPersonEnkel(PersonType.SØKER)
+            val barn1 = lagPersonEnkel(PersonType.BARN)
+            val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+            val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+
+            vilkårsvurdering.personResultater =
+                setOf(
+                    personResultatSøker,
+                    personResultatBarn1,
+                )
+
+            assertDoesNotThrow {
+                validerIkkeBlandetRegelverk(
+                    vilkårsvurdering = vilkårsvurdering,
+                    søkerOgBarn = listOf(søker, barn1),
+                    behandling = lagBehandling(),
+                )
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil hvis søker vurderes etter eøs, men barn vurderes etter nasjonal`() {
+            val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+            val søker = lagPersonEnkel(PersonType.SØKER)
+            val barn1 = lagPersonEnkel(PersonType.BARN)
+            val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+            val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+
+            vilkårsvurdering.personResultater =
+                setOf(
+                    personResultatSøker,
+                    personResultatBarn1,
+                )
+
+            assertDoesNotThrow {
+                validerIkkeBlandetRegelverk(
+                    vilkårsvurdering = vilkårsvurdering,
+                    søkerOgBarn = listOf(søker, barn1),
+                    behandling = lagBehandling(),
+                )
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil hvis både søker og barn vurderes etter nasjonal og eøs, men i samme perioder`() {
+            val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+            val søker = lagPersonEnkel(PersonType.SØKER)
+            val barn = lagPersonEnkel(PersonType.BARN)
+
+            val vilkårPerioder =
+                listOf(
+                    VilkårPeriode(
+                        regelverk = Regelverk.EØS_FORORDNINGEN,
+                        fom = LocalDate.now().minusMonths(9),
+                        tom = LocalDate.now().minusMonths(1),
+                    ),
+                    VilkårPeriode(
+                        regelverk = Regelverk.NASJONALE_REGLER,
+                        fom = LocalDate.now().minusMonths(1).plusMonths(1),
+                        tom = null,
+                    ),
+                )
+
+            val personResultatSøker = byggPersonResultatForPersonIPerioder(søker, vilkårPerioder, vilkårsvurdering)
+            val personResultatBarn = byggPersonResultatForPersonIPerioder(barn, vilkårPerioder, vilkårsvurdering)
+
+            vilkårsvurdering.personResultater =
+                setOf(
+                    personResultatSøker,
+                    personResultatBarn,
+                )
+
+            assertDoesNotThrow {
+                validerIkkeBlandetRegelverk(
+                    vilkårsvurdering = vilkårsvurdering,
+                    søkerOgBarn = listOf(søker, barn),
+                    behandling = lagBehandling(),
+                )
+            }
         }
     }
 
-    @Test
-    fun `skal ikke kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS om der er satsendring`() {
-        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
-        val søker = lagPersonEnkel(PersonType.SØKER)
-        val barn1 = lagPersonEnkel(PersonType.BARN)
-        val barn2 = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
-        val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn2 = byggPersonResultatForPersonEnkel(barn2, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
+    @Nested
+    inner class Valider18ÅrsVilkårEksistererFraFødselsdato {
+        @Test
+        fun `skal kaste feil hvis barn ikke har 18-års vilkår vurdert fra fødselsdato`() {
+            val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
+            val barn = lagPersonEnkel(PersonType.BARN)
+            val personResultatBarn = byggPersonResultatForPersonEnkel(barn, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
 
-        vilkårsvurdering.personResultater =
-            setOf(
-                personResultatSøker,
-                personResultatBarn1,
-                personResultatBarn2,
-            )
+            personResultatBarn.vilkårResultater.first { it.vilkårType == Vilkår.UNDER_18_ÅR }.periodeFom =
+                barn.fødselsdato.minusDays(1)
 
-        assertDoesNotThrow {
-            validerIkkeBlandetRegelverk(
-                vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn1, barn2),
-                behandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING),
-            )
+            vilkårsvurdering.personResultater = setOf(personResultatBarn)
+
+            assertThrows<FunksjonellFeil> {
+                valider18ÅrsVilkårEksistererFraFødselsdato(
+                    vilkårsvurdering = vilkårsvurdering,
+                    søkerOgBarn = listOf(barn),
+                    behandling = lagBehandling(),
+                )
+            }
         }
-    }
 
-    @Test
-    fun `skal ikke kaste feil hvis både søker og barn vurderes etter eøs`() {
-        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
-        val søker = lagPersonEnkel(PersonType.SØKER)
-        val barn1 = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
+        @ParameterizedTest
+        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
+        fun `skal ikke kaste feil for satsendring og månedlig valutajustering selv om barn ikke har 18-års vilkår vurdert fra fødselsdato`(
+            årsak: BehandlingÅrsak,
+        ) {
+            val behandling = lagBehandling(årsak = årsak)
+            val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
+            val barn = lagPersonEnkel(PersonType.BARN)
+            val personResultatBarn = byggPersonResultatForPersonEnkel(barn, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
 
-        vilkårsvurdering.personResultater =
-            setOf(
-                personResultatSøker,
-                personResultatBarn1,
-            )
+            personResultatBarn.vilkårResultater.first { it.vilkårType == Vilkår.UNDER_18_ÅR }.periodeFom =
+                barn.fødselsdato.minusDays(1)
 
-        assertDoesNotThrow {
-            validerIkkeBlandetRegelverk(
-                vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn1),
-                behandling = lagBehandling(),
-            )
-        }
-    }
+            vilkårsvurdering.personResultater = setOf(personResultatBarn)
 
-    @Test
-    fun `skal ikke kaste feil hvis søker vurderes etter eøs, men barn vurderes etter nasjonal`() {
-        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
-        val søker = lagPersonEnkel(PersonType.SØKER)
-        val barn1 = lagPersonEnkel(PersonType.BARN)
-        val personResultatSøker = byggPersonResultatForPersonEnkel(søker, Regelverk.EØS_FORORDNINGEN, vilkårsvurdering)
-        val personResultatBarn1 = byggPersonResultatForPersonEnkel(barn1, Regelverk.NASJONALE_REGLER, vilkårsvurdering)
-
-        vilkårsvurdering.personResultater =
-            setOf(
-                personResultatSøker,
-                personResultatBarn1,
-            )
-
-        assertDoesNotThrow {
-            validerIkkeBlandetRegelverk(
-                vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn1),
-                behandling = lagBehandling(),
-            )
-        }
-    }
-
-    @Test
-    fun `skal ikke kaste feil hvis både søker og barn vurderes etter nasjonal og eøs, men i samme perioder`() {
-        val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
-        val søker = lagPersonEnkel(PersonType.SØKER)
-        val barn = lagPersonEnkel(PersonType.BARN)
-
-        val vilkårPerioder =
-            listOf(
-                VilkårPeriode(
-                    regelverk = Regelverk.EØS_FORORDNINGEN,
-                    fom = LocalDate.now().minusMonths(9),
-                    tom = LocalDate.now().minusMonths(1),
-                ),
-                VilkårPeriode(
-                    regelverk = Regelverk.NASJONALE_REGLER,
-                    fom = LocalDate.now().minusMonths(1).plusMonths(1),
-                    tom = null,
-                ),
-            )
-
-        val personResultatSøker = byggPersonResultatForPersonIPerioder(søker, vilkårPerioder, vilkårsvurdering)
-        val personResultatBarn = byggPersonResultatForPersonIPerioder(barn, vilkårPerioder, vilkårsvurdering)
-
-        vilkårsvurdering.personResultater =
-            setOf(
-                personResultatSøker,
-                personResultatBarn,
-            )
-
-        assertDoesNotThrow {
-            validerIkkeBlandetRegelverk(
-                vilkårsvurdering = vilkårsvurdering,
-                søkerOgBarn = listOf(søker, barn),
-                behandling = lagBehandling(),
-            )
+            assertDoesNotThrow {
+                valider18ÅrsVilkårEksistererFraFødselsdato(
+                    vilkårsvurdering = vilkårsvurdering,
+                    søkerOgBarn = listOf(barn),
+                    behandling = behandling,
+                )
+            }
         }
     }
 
@@ -168,7 +221,7 @@ class VilkårsvurderingValideringTest {
         val vilkårResultater =
             lagVilkårResultatForPersonIPeriode(
                 vilkårsvurdering = vilkårsvurdering,
-                person = lagPerson(type = person.type, aktør = person.aktør),
+                person = lagPerson(type = person.type, aktør = person.aktør, fødselsdato = person.fødselsdato),
                 periodeFom = LocalDate.now().minusMonths(2),
                 periodeTom = LocalDate.now().minusMonths(1),
                 vurderesEtter = regelverk,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -352,7 +352,6 @@ class CucumberMock(
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             valutakursRepository = valutakursRepository,
             localDateProvider = mockedDateProvider,
-            valutakursService = valutakursService,
         )
 
     val saksbehandlerContext = SaksbehandlerContext("")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22581
Månedlig valutajustering-tasker feiler oftere enn ønsket, som følge av for mye validering.
For satsendringer blir enkelte valideringer hoppet over, da vi heller ønsker at noen type feil skal bli korrigert i en manuell revurdering på et senere tidspunkt. Vi ønsker også dette for månedlig valutajustering, så fikser så det enkelte steder brukes satsendring sin løype i stedet for den manuelle behandlingsløypen.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Vær gjerne litt kritisk der månedlig valutajustering har fått ny løype <|:^)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
