### PR TITLE
reverter endringer på lagring av aktør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -55,7 +55,7 @@ class HåndterNyIdentService(
                 validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, aktuellFagsakIdVedMerging)
                 logger.info("Legger til ny ident")
                 secureLogger.info("Legger til ny ident ${nyIdent.ident} på aktør ${aktør.aktørId}")
-                personIdentService.opprettPersonIdent(aktør, nyIdent.ident, false)
+                personIdentService.opprettPersonIdent(aktør, nyIdent.ident, true)
             }
 
             // Samme aktørId, samme fødselsnummer -> ignorer hendelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
@@ -148,6 +148,8 @@ class PersonidentService(
                 it.gjelderTil = LocalDateTime.now()
             }
 
+            if (lagreNyAktør) aktørIdRepository.saveAndFlush(aktør)
+
             aktør.personidenter.add(
                 Personident(fødselsnummer = fødselsnummer, aktør = aktør),
             )


### PR DESCRIPTION
 slik at vi ikke får problemer med unike id-er.

Vi fjernet tidligere default lagring av aktør siden vi tenkte at dette kom til å løse en bug i enkelte identhåndteringstasker. Dette viste seg å skape mer problemer for andre caser og må reverteres. 

