### PR TITLE
NAV-22720: Legger til JaCoCo og Sonar

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -42,13 +42,19 @@ jobs:
           java-version: 21
           distribution: 'temurin'
           cache: 'maven'
-
       - name: Kjør enhetstester
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -DexcludedGroups=integration,verdikjedetest
+          mvn verify -B --no-transfer-progress --settings .m2/maven-settings.xml --file pom.xml -DexcludedGroups=integration,verdikjedetest -Pjacoco -DjacocoTestDirectory=UT
+      - name: Last opp Jacoco UT rapport
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacocoUT
+          path: target/jacoco/UT/jacoco.xml
+          retention-days: 1
+          overwrite: true
 
   integrasjonstester:
     name: Integrasjonstester
@@ -60,13 +66,56 @@ jobs:
           java-version: 21
           distribution: 'temurin'
           cache: 'maven'
-
       - name: Kjør integrasjonstester
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml -Dgroups=integration -DexcludedGroups=verdikjedetest -Dsurefire.rerunFailingTestsCount=2
+          mvn verify -B --no-transfer-progress --settings .m2/maven-settings.xml --file pom.xml -Dgroups=integration -DexcludedGroups=verdikjedetest -Dsurefire.rerunFailingTestsCount=2 -Pjacoco -DjacocoTestDirectory=IT
+      - name: Last opp Jacoco IT rapport
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacocoIT
+          path: target/jacoco/IT/jacoco.xml
+          retention-days: 1
+          overwrite: true
+
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest-8-cores
+    needs: [ enhetstester, integrasjonstester ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Last ned Jacoco UT rapport
+        uses: actions/download-artifact@v4
+        with:
+          name: jacocoUT
+          path: jacoco/UT
+      - name: Last ned Jacoco IT rapport
+        uses: actions/download-artifact@v4
+        with:
+          name: jacocoIT
+          path: jacoco/IT
+      - name: Cache Sonar packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Kjør Sonar
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths="jacoco/UT/jacoco.xml,jacoco/IT/jacoco.xml"
 
   verdikjedetesterFeatureToggleOff:
     name: Verdikjedetester m/ feature toggles slått av

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,91 @@
+name: Sonar
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  enhetstester:
+    name: Enhetstester
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Kjør enhetstester
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn test -B --no-transfer-progress--settings .m2/maven-settings.xml --file pom.xml -DexcludedGroups=integration,verdikjedetest -Pjacoco -DjacocoTestDirectory=UT
+      - name: Last opp Jacoco UT rapport
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacocoUT
+          path: target/jacoco/UT/jacoco.xml
+          retention-days: 1
+          overwrite: true
+
+  integrasjonstester:
+    name: Integrasjonstester
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Kjør integrasjonstester
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn verify -B --no-transfer-progress --settings .m2/maven-settings.xml --file pom.xml -Dgroups=integration -DexcludedGroups=verdikjedetest -Dsurefire.rerunFailingTestsCount=2 -Pjacoco -DjacocoTestDirectory=IT
+      - name: Last opp Jacoco IT rapport
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacocoIT
+          path: target/jacoco/IT/jacoco.xml
+          retention-days: 1
+          overwrite: true
+
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest-8-cores
+    needs: [ enhetstester, integrasjonstester ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Last ned Jacoco UT rapport
+        uses: actions/download-artifact@v4
+        with:
+          name: jacocoUT
+          path: jacoco/UT
+      - name: Last ned Jacoco IT rapport
+        uses: actions/download-artifact@v4
+        with:
+          name: jacocoIT
+          path: jacoco/IT
+      - name: Cache Sonar packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Kjør Sonar
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths="jacoco/UT/jacoco.xml,jacoco/IT/jacoco.xml"

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
         <awaitility-kotlin.version>4.2.0</awaitility-kotlin.version>
         <avro.version>1.12.0</avro.version>
         <confluent.version>7.7.1</confluent.version>
+        <sonar.organization>navikt</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.projectKey>navikt_familie-ba-sak</sonar.projectKey>
+        <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -597,7 +602,57 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar-maven-plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>
+                                        ${project.build.directory}/jacoco/${jacocoTestDirectory}/jacoco.exec
+                                    </destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>
+                                        ${project.build.directory}/jacoco/${jacocoTestDirectory}/jacoco.exec
+                                    </dataFile>
+                                    <outputDirectory>
+                                        ${project.build.directory}/jacoco/${jacocoTestDirectory}
+                                    </outputDirectory>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22720

Hensikten med endringene er analysere prosjektet med sonar med test coverage. I PRene skal man få en kommentar fra SonarCloud som sier hvilket (om noen) issue koden her, samt metrikker som test coverage og code duplications. Kommentar skal se ut som noe ala dette:

<img width="919" alt="image" src="https://github.com/user-attachments/assets/e8f5751e-4f9c-4923-bbf9-53484d7de94a">

Obs! Er ingen ekspert på maven så dette er bare slik jeg har forstått det. Om noe er galt er det bare å si ifra. 😁 

Siden vi ikke benytter av oss [Maven Failsafe Plugin](https://maven.apache.org/surefire/maven-failsafe-plugin/) for å kjøre integrasjonstester vil man ikke kunne kjøre JaCoCo på standard måte. Hadde vi benyttet oss av de kunne integrasjonstestene kjørt under `pre-integration-test`, `integration-test` og `post-integration-test` fasene. `jacoco-maven-plugin` forventer egentlig at dette skal skje, og har dermed blitt nødt til å legge til litt egendefinert logikk i denne PRen. [Maven Surefire Plugin](https://maven.apache.org/surefire/maven-surefire-plugin/) brukes per nå til å kjøre enhetstester, integrasjonstester, og verdikjedetester og bruker dermed `test` fasen. 

Siden vi også kjører enhetstester og integrasjonstester i forskjellige GHA jobber i `build-pr.yml` bestemte jeg meg for å benytte en egen JaCoCo maven profil hvor man kunne sende inn en egen `jacocoTestDirectory` variabel slik at det kunne gjenbrukes for både enhetstester og integrasjonstester. For enhetstester bruker man `-Pjacoco -DjacocoTestDirectory=UT`. For integrasjonstester bruker man `-Pjacoco -DjacocoTestDirectory=IT`. Se bilde under. Den egne maven profilen gjør også slik at JaCoCo er "opt-in". Siden enhetstestene og integrasjonstestene blir kjørt separat er det nødvendig å laste opp JaCoCo rapportene mellom hver jobb. Begge jobbene tilgjengeligjør rapportene som artifacter, se bilde under. De to artifactene blir lastet ned i Sonar jobben og brukt i analysen av koden. 

UT og IT jacoco directories:

<img width="247" alt="image" src="https://github.com/user-attachments/assets/a8585053-4da4-4e44-ab12-33b1540b3d8a">

To artifacter:

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/efc1d52f-1bc6-4b9b-af65-a3874028df3b">


Har laget en egen `sonar.yml` GHA for merge inn til main. Den kjører enhetstester og integrasjonstester, lager en rapport for hver av dem, og deretter analyserer prosjektet med test coverage via Sonar. Siden testene ikke blir kjørt i `build-and-deploy-prod.yml` valgte jeg å ta det i en egen GHA fil for enkelhetens skyld. Jeg prøvde først å kjøre testene i `build-and-deploy-prod.yml` men fikk problemer med å kjøre enhetstester og integrasjonstester samtidig pga. `integration` taggen. Alternativt kunne man ha gjort slik som i `build-pr.yml` og kjørt enhetstster og integrasjonstester separat. Gikk til slutt for en egen `sonar.yml` fil da vi også hadde en egen `codeql.yml` fil. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
