### PR TITLE
tillat patching av identer når fødselsdato endrer seg mindre enn én måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -113,7 +113,7 @@ class HåndterNyIdentService(
         alleIdenterFraPdl: List<IdentInformasjon>,
         fagsak: Fagsak,
     ) {
-        // Dersom søker endrer fødselsdato på virker ikke det andelene og vi kan fint patche ident
+        // Hvis søkers fødselsdato endrer seg kan vi alltid patche siden det ikke påvirker andeler. Med mindre søker er enslig mindreårig.
         if (fagsak.type != FagsakType.BARN_ENSLIG_MINDREÅRIG && fagsak.aktør.aktørId in alleIdenterFraPdl.hentAktørIder()) return
 
         val aktivFødselsnummer = alleIdenterFraPdl.hentAktivFødselsnummer()


### PR DESCRIPTION
tillat patching av identer når fødselsdato endrer seg mindre enn én måned eller det er søkers fødselsdato og fagsak ikke er enslig mindreårig

### 💰 Hva skal gjøres, og hvorfor?
Når fødselsdatoen endrer seg mindre enn én måned eller det er søkers fødselsdato som endrer seg (og det ikke er en enslig-mindreårig-sak) så vil ikke endringen i fødselsdato påvirke saken. Vi ønsker derfor å tillate automatisk patching av identer i disse tilfellene.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

