### PR TITLE
Fikser noen compiler-warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <properties>
         <java.version>21</java.version>
         <kotlin.version>2.0.21</kotlin.version>
+        <kotlin.compiler.languageVersion>2.0</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>2.0</kotlin.compiler.apiVersion>
         <revision>1</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
@@ -56,6 +58,7 @@
         <sonar.projectKey>navikt_familie-ba-sak</sonar.projectKey>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <sonar.projectKey>navikt_familie-ba-sak</sonar.projectKey>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-
     </properties>
 
     <dependencyManagement>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseRepositoryUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseRepositoryUtil.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.erIPraksisLik
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.AndelTilkjentYtelsePraktiskLikhet.inneholderIPraksis
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 
 /**
  * En litt risikabel funksjon, som benytter "funksjonell likhet" for å sjekke etter endringer på andel tilkjent ytelse
@@ -35,27 +34,5 @@ fun TilkjentYtelseRepository.oppdaterTilkjentYtelse(
     tilkjentYtelse.andelerTilkjentYtelse.clear()
     tilkjentYtelse.andelerTilkjentYtelse.addAll(skalBeholdes + skalLeggesTil)
 
-    // Ekstra forsikring: Bygger tidslinjene på nytt for å sjekke at det ikke er introdusert duplikater
-    // Krasjer med Exception hvis det forekommer perioder per aktør og ytelsetype som overlapper
-    // Bør fjernes hvis det ikke forekommer feil
-    tilkjentYtelse.andelerTilkjentYtelse.sjekkForDuplikater()
-
     return this.saveAndFlush(tilkjentYtelse)
-}
-
-@Deprecated("Brukes som sikkerhetsnett for å sjekke at det ikke oppstår duplikater. Burde være unødvendig")
-private fun Iterable<AndelTilkjentYtelse>.sjekkForDuplikater() {
-    try {
-        // Det skal ikke være overlapp i andeler for en gitt ytelsestype og aktør
-        this
-            .groupBy { it.aktør.aktørId + it.type }
-            .mapValues { (_, andeler) -> tidslinje { andeler.map { it.tilPeriode() } } }
-            .values
-            .forEach { it.perioder() }
-    } catch (throwable: Throwable) {
-        throw IllegalStateException(
-            "Endring av andeler tilkjent ytelse i differanseberegning holder på å introdusere duplikater",
-            throwable,
-        )
-    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -104,7 +104,7 @@ private class AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(
             endretUtbetalingAndel.periode.overlapperHeltEllerDelvisMed(andelTilkjentYtelse.periode)
 }
 
-data class AndelTilkjentYtelseMedEndreteUtbetalinger internal constructor(
+data class AndelTilkjentYtelseMedEndreteUtbetalinger(
     private val andelTilkjentYtelse: AndelTilkjentYtelse,
     private val endreteUtbetalingerAndeler: Collection<EndretUtbetalingAndel>,
 ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
@@ -227,8 +227,11 @@ class LoggService(
                 .filter { Identkonverterer.er11Siffer(it) }
                 .distinct()
                 .map { Fødselsnummer(it) }
-                .map { it.fødselsdato }
-                .map { it.tilKortString() },
+                .map {
+                    // En litt forenklet løsning for å hente fødselsdato uten å kalle PDL. Gir ikke helt riktige data, men godt nok.
+                    @Suppress("DEPRECATION")
+                    it.fødselsdato
+                }.map { it.tilKortString() },
         )
 
     fun opprettBehandlingLogg(behandlingLogg: BehandlingLoggRequest) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/DagTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/DagTidspunkt.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt
 
 import java.time.LocalDate
 
-data class DagTidspunkt internal constructor(
+data class DagTidspunkt(
     internal val dato: LocalDate,
     override val uendelighet: Uendelighet,
 ) : Tidspunkt<Dag>(uendelighet) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/MånedTidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/MånedTidspunkt.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import java.time.LocalDate
 import java.time.YearMonth
 
-data class MånedTidspunkt internal constructor(
+data class MånedTidspunkt(
     internal val måned: YearMonth,
     override val uendelighet: Uendelighet,
 ) : Tidspunkt<Måned>(uendelighet) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/Tidspunkt.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidspunkt/Tidspunkt.kt
@@ -12,7 +12,7 @@ class Dag : Tidsenhet
 
 class Måned : Tidsenhet
 
-abstract class Tidspunkt<T : Tidsenhet> internal constructor(
+abstract class Tidspunkt<T : Tidsenhet>(
     internal open val uendelighet: Uendelighet,
 ) : Comparable<Tidspunkt<T>> {
     abstract fun flytt(tidsenheter: Long): Tidspunkt<T>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -121,6 +121,7 @@ fun List<VedtaksperiodeMedBegrunnelser>.erAlleredeBegrunnetMedBegrunnelse(
         it.fom?.toYearMonth() == måned && it.begrunnelser.any { standardbegrunnelse -> standardbegrunnelse.standardbegrunnelse in standardbegrunnelser }
     }
 
+@Suppress("DEPRECATION")
 fun VedtaksperiodeMedBegrunnelser.hentUtbetalingsperiodeDetaljer(
     andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
     personopplysningGrunnlag: PersonopplysningGrunnlag,
@@ -206,6 +207,7 @@ fun hentBrevPeriodeType(
         erUtbetalingEllerDeltBostedIPeriode = erUtbetalingEllerDeltBostedIPeriode,
     )
 
+@Suppress("DEPRECATION")
 fun hentBrevPeriodeType(
     vedtaksperiodetype: Vedtaksperiodetype,
     fom: LocalDate?,
@@ -222,5 +224,6 @@ fun hentBrevPeriodeType(
         Vedtaksperiodetype.AVSLAG -> if (fom != null) BrevPeriodeType.INGEN_UTBETALING else BrevPeriodeType.INGEN_UTBETALING_UTEN_PERIODE
         Vedtaksperiodetype.OPPHØR -> BrevPeriodeType.INGEN_UTBETALING
         Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING -> BrevPeriodeType.UTBETALING
-        Vedtaksperiodetype.ENDRET_UTBETALING -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
+        Vedtaksperiodetype.ENDRET_UTBETALING,
+        -> throw Feil("Endret utbetaling skal ikke benyttes lenger.")
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiodetype.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiodetype.kt
@@ -70,10 +70,11 @@ enum class Vedtaksperiodetype(
         ),
     ),
 
-    @Deprecated("Legacy. Kan ikke fjernes uten at det ryddes opp i Vedtaksperioder-tabellen")
+    @Deprecated("Legacy. Kan ikke fjernes uten at det ryddes opp i Vedtaksperioder-tabellen og man kan ikke endre i tabellen fordi man ikke vet om det er en økning eller reduksjon")
     ENDRET_UTBETALING(emptySet()),
     ;
 
+    @Suppress("DEPRECATION")
     fun sorteringsRekkefølge(): Int =
         when (this) {
             UTBETALING -> 1

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
@@ -54,7 +54,7 @@ class BehandleFødselshendelseTask(
             // En litt forenklet løsning for å hente fødselsdato uten å kalle PDL. Gir ikke helt riktige data, men godt nok.
             val dagerSidenBarnetBleFødt =
                 ChronoUnit.DAYS.between(
-                    Fødselsnummer(it).fødselsdato,
+                    @Suppress("DEPRECATION") Fødselsnummer(it).fødselsdato,
                     LocalDateTime.now(),
                 )
             dagerSidenBarnBleFødt.record(dagerSidenBarnetBleFødt.toDouble())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
     val barnsFødselsdato = 13.jan(2020)
@@ -22,48 +21,6 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
     val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato.tilLocalDate())
 
     val tilkjentYtelseRepository: TilkjentYtelseRepository = mockk(relaxed = true)
-
-    @Test
-    fun `skal kaste exception hvis tilkjent ytelse oppdateres med overlappende andel tilkjent ytelse for et barn`() {
-        val behandling = lagBehandling()
-
-        val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling).bygg()
-
-        val nyTilkjentYtelse =
-            TilkjentYtelseBuilder(startMåned, behandling)
-                .forPersoner(barn1)
-                .medOrdinær(" $$$$$$")
-                .medOrdinær("      $$$$$")
-                .bygg()
-
-        assertThrows<IllegalStateException> {
-            tilkjentYtelseRepository.oppdaterTilkjentYtelse(
-                forrigeTilkjentYtelse,
-                nyTilkjentYtelse.andelerTilkjentYtelse,
-            )
-        }
-    }
-
-    @Test
-    fun `skal kaste exception hvis tilkjent ytelse oppdateres med overlappende andel tilkjent ytelse for søker`() {
-        val behandling = lagBehandling()
-
-        val forrigeTilkjentYtelse = TilkjentYtelseBuilder(startMåned, behandling).bygg()
-
-        val nyTilkjentYtelse =
-            TilkjentYtelseBuilder(startMåned, behandling)
-                .forPersoner(søker)
-                .medUtvidet(" $$$$$$")
-                .medUtvidet("      $$$$$")
-                .bygg()
-
-        assertThrows<IllegalStateException> {
-            tilkjentYtelseRepository.oppdaterTilkjentYtelse(
-                forrigeTilkjentYtelse,
-                nyTilkjentYtelse.andelerTilkjentYtelse,
-            )
-        }
-    }
 
     @Test
     fun `skal ikke kaste exception hvis tilkjent ytelse oppdateres med gyldige andeler`() {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

- Fikser warning Data class copy function to have the same visibility as constructor
Fra kotlin 2.1 så blir denne kompiler warningen en error. Endringer i copy funksjonalitet slik at copy har samme visibility som konstruktor. Det er 2 nye  annoteringer for dette. ConsistentCopyVisibility og ExposedCopyVisibility. I stedet valgte vi å skrive oss vekk fra å bruker internal constructor.
- Skjuler deprecation warnings for å hente fødselsdato fra fnr
- Sletter deprecated metode sjekkForDuplikater
- Skjuler deprecation warning for ENDRET_UTBETALING som ikke kan slettes

sikkert lettest commit for commit
