### PR TITLE
NAV-22778: Korrigerer kall til integrasjoner ved endring av behandlede enhet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
@@ -307,7 +307,7 @@ class IntegrasjonClient(
         }
     }
 
-    fun tilordneEnhetForOppgave(
+    fun tilordneEnhetOgRessursForOppgave(
         oppgaveId: Long,
         nyEnhet: String,
     ): OppgaveResponse {
@@ -316,6 +316,7 @@ class IntegrasjonClient(
             UriComponentsBuilder
                 .fromUri(baseUri)
                 .queryParam("fjernMappeFraOppgave", true)
+                .queryParam("nullstillTilordnetRessurs", true)
                 .build()
                 .toUri() // fjerner alltid mappe fra Barnetrygd siden hver enhet sin mappestruktur
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -205,8 +205,7 @@ class OppgaveService(
             if (oppgave.status == FERDIGSTILT && oppgave.oppgavetype == Oppgavetype.VurderLivshendelse.value) {
                 dbOppgave.erFerdigstilt = true
             } else {
-                val oppgaveOppdatering = Oppgave(id = oppgave.id, tildeltEnhetsnr = nyEnhet, tilordnetRessurs = null, mappeId = null)
-                patchOppgave(oppgaveOppdatering)
+                integrasjonClient.tilordneEnhetOgRessursForOppgave(oppgaveId = oppgave.id!!, nyEnhet = nyEnhet)
             }
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
@@ -111,7 +111,7 @@ class IntegrasjonClientMock {
             every { mockIntegrasjonClient.patchOppgave(any()) } returns
                 OppgaveResponse(12345678L)
 
-            every { mockIntegrasjonClient.tilordneEnhetForOppgave(any(), any()) } returns
+            every { mockIntegrasjonClient.tilordneEnhetOgRessursForOppgave(any(), any()) } returns
                 OppgaveResponse(12345678L)
 
             every { mockIntegrasjonClient.fordelOppgave(any(), any()) } returns

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingIntegrationTest.kt
@@ -305,7 +305,7 @@ class ArbeidsfordelingIntegrationTest(
             arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id)
         assertEquals(IKKE_FORTROLIG_ENHET, arbeidsfordelingPåBehandling.behandlendeEnhetId)
 
-        oppgaveService.opprettOppgave(behandling.id, Oppgavetype.BehandleSak, now())
+        val oppgaveId = oppgaveService.opprettOppgave(behandling.id, Oppgavetype.BehandleSak, now())
 
         stegService.håndterSøknad(
             behandling,
@@ -320,7 +320,7 @@ class ArbeidsfordelingIntegrationTest(
         )
 
         verify(exactly = 1) {
-            integrasjonClient.patchOppgave(any())
+            integrasjonClient.tilordneEnhetOgRessursForOppgave(any(), any())
         }
 
         val arbeidsfordelingPåBehandlingEtterSøknadsregistreringUtenDiskresjonskode =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22778

Patch-endepunktet fungere ikke som tenkt i `familie-integrasjoner`. Det vil ikke nullstille `mappeId` og `tilordnetRessurs` når de er satt til `null` da koden er satt opp til å ingorere `null` felt. 

Bytter om til metoden som ble brukt tidligre for å "patch" oppgaven, men utvider det nå til å også nullstill `tilordnetRessurs` 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Hotfix for et problem, skal endres i med en gang etter merge

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
