### PR TITLE
Eksponerer github sitt branchnavn og sha1 til frontend

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -135,6 +135,10 @@ spec:
       value: preprod
     - name: JAVA_OPTS
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError"
+    - name: GITHUB_BRANCH
+      value: {{GITHUB_BRANCH}}
+    - name: GITHUB_SHA
+      value: {{GITHUB_SHA}}
   kafka:
     pool: nav-dev
   strategy:

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -168,6 +168,10 @@ spec:
       value: prod
     - name: JAVA_OPTS
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError"
+    - name: GITHUB_BRANCH
+      value: {{GITHUB_BRANCH}}
+    - name: GITHUB_SHA
+      value: {{GITHUB_SHA}}
   kafka:
     pool: nav-prod
   strategy:

--- a/.github/workflows/build-and-deploy-krise-eksisterende-image-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-eksisterende-image-rett-i-prod.yml
@@ -22,7 +22,7 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
-          VAR: image=${{ env.IMAGE }}:${{ inputs.tag }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
+          VAR: image=${{ env.IMAGE }}:${{ inputs.tag }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA=${{ github.sha }}
 
   loggfeil:
     name: Send logg til slack ved feil

--- a/.github/workflows/build-and-deploy-krise-eksisterende-image-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-eksisterende-image-rett-i-prod.yml
@@ -22,7 +22,7 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
-          VAR: image=${{ env.IMAGE }}:${{ inputs.tag }}
+          VAR: image=${{ env.IMAGE }}:${{ inputs.tag }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
 
   loggfeil:
     name: Send logg til slack ved feil

--- a/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
@@ -2,10 +2,6 @@ name: KRISE-RETT-I-PROD
 on:
   workflow_dispatch:
 
-env:
-  GITHUB_BRANCH: ${{ github.ref_name }}
-  GITHUB_SHA: ${{ github.sha }}
-
 jobs:
   bygg:
     name: Bygg app/image, push til github, deploy til prod-gcp (MÅ KUN BRUKES VED KRISE)
@@ -61,7 +57,7 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          VAR: image=${{ needs.bygg.outputs.image }}
+          VAR: image=${{ needs.bygg.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
 
   deploy-to-prod:
     name: Deploy til prod-gcp
@@ -81,6 +77,7 @@ jobs:
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
           IMAGE: ${{ needs.bygg.outputs.image }}
+          VAR: GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
 
   loggfeil:
     name: Send logg til slack ved feil

--- a/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
@@ -57,7 +57,7 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          VAR: image=${{ needs.bygg.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
+          VAR: image=${{ needs.bygg.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA=${{ github.sha }}
 
   deploy-to-prod:
     name: Deploy til prod-gcp
@@ -77,7 +77,7 @@ jobs:
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
           IMAGE: ${{ needs.bygg.outputs.image }}
-          VAR: GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
+          VAR: GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA=${{ github.sha }}
 
   loggfeil:
     name: Send logg til slack ved feil

--- a/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
@@ -2,6 +2,10 @@ name: KRISE-RETT-I-PROD
 on:
   workflow_dispatch:
 
+env:
+  GITHUB_BRANCH: ${{ github.ref_name }}
+  GITHUB_SHA: ${{ github.sha }}
+
 jobs:
   bygg:
     name: Bygg app/image, push til github, deploy til prod-gcp (MÅ KUN BRUKES VED KRISE)

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -28,6 +28,8 @@ jobs:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BRANCH: ${{ github.ref_name }}
+          GITHUB_SHA: ${{ github.sha }}
         run: mvn -Dmaven.test.skip=true -e -B --no-transfer-progress package verify --settings .m2/maven-settings.xml --file pom.xml
 
       - uses: nais/docker-build-push@v0

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -43,4 +43,4 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          VAR: image=${{ steps.docker-push.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
+          VAR: image=${{ steps.docker-push.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA=${{ github.sha }}

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -2,6 +2,10 @@ name: Build-Deploy-Preprod-GCP
 on:
   workflow_dispatch:
 
+env:
+  GITHUB_BRANCH: ${{ github.ref_name }}
+  GITHUB_SHA: ${{ github.sha }}
+
 jobs:
   deploy-to-dev:
     name: Bygg app/image, push til github, deploy til dev-gcp

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -2,10 +2,6 @@ name: Build-Deploy-Preprod-GCP
 on:
   workflow_dispatch:
 
-env:
-  GITHUB_BRANCH: ${{ github.ref_name }}
-  GITHUB_SHA: ${{ github.sha }}
-
 jobs:
   deploy-to-dev:
     name: Bygg app/image, push til github, deploy til dev-gcp
@@ -28,8 +24,6 @@ jobs:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_BRANCH: ${{ github.ref_name }}
-          GITHUB_SHA: ${{ github.sha }}
         run: mvn -Dmaven.test.skip=true -e -B --no-transfer-progress package verify --settings .m2/maven-settings.xml --file pom.xml
 
       - uses: nais/docker-build-push@v0
@@ -49,4 +43,4 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          VAR: image=${{ steps.docker-push.outputs.image }}
+          VAR: image=${{ steps.docker-push.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -63,7 +63,7 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          VAR: image=${{ needs.bygg.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
+          VAR: image=${{ needs.bygg.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA=${{ github.sha }}
 
   deploy-to-prod:
     name: Deploy til prod-gcp
@@ -83,7 +83,7 @@ jobs:
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
           IMAGE: ${{ needs.bygg.outputs.image }}
-          VAR: GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
+          VAR: GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA=${{ github.sha }}
 
   loggfeil:
     name: Send logg til slack ved feil

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -8,10 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
-env:
-  GITHUB_BRANCH: ${{ github.ref_name }}
-  GITHUB_SHA: ${{ github.sha }}
-
 jobs:
   bygg:
     name: Bygg app/image, push til github, deploy til preprod-gcp
@@ -67,7 +63,7 @@ jobs:
           APIKEY: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          VAR: image=${{ needs.bygg.outputs.image }}
+          VAR: image=${{ needs.bygg.outputs.image }},GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
 
   deploy-to-prod:
     name: Deploy til prod-gcp
@@ -87,6 +83,7 @@ jobs:
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
           IMAGE: ${{ needs.bygg.outputs.image }}
+          VAR: GITHUB_BRANCH=${{ github.ref_name }},GITHUB_SHA:${{ github.sha }}
 
   loggfeil:
     name: Send logg til slack ved feil

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+env:
+  GITHUB_BRANCH: ${{ github.ref_name }}
+  GITHUB_SHA: ${{ github.sha }}
+
 jobs:
   bygg:
     name: Bygg app/image, push til github, deploy til preprod-gcp

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/GithubConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/GithubConfig.kt
@@ -1,0 +1,13 @@
+package no.nav.familie.ba.sak.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GithubConfig(
+    // Verdiene blir sendt inn til docker-imaget via github actions
+    @Value("\${GITHUB_BRANCH:Ikke satt}")
+    val githubBranch: String,
+    @Value("\${GITHUB_SHA:#{null}}")
+    val githubSha: String?,
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/GithubController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/GithubController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.internal
 
+import no.nav.familie.ba.sak.config.GithubConfig
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
@@ -11,11 +12,13 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @ProtectedWithClaims(issuer = "azuread")
-class GithubController {
+class GithubController(
+    private val githubConfig: GithubConfig,
+) {
     @GetMapping("/hent-branch")
     fun hentBranch(): ResponseEntity<Ressurs<GithubBranchDto>> {
-        val branch: String? = System.getenv("GITHUB_BRANCH")
-        val sha: String? = System.getenv("GITHUB_SHA")
+        val branch: String? = githubConfig.githubBranch
+        val sha: String? = githubConfig.githubSha
         return ResponseEntity.ok().body(
             Ressurs.success(
                 data = GithubBranchDto(branch = branch, sha = sha),

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/GithubController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/GithubController.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ba.sak.internal
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(path = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@ProtectedWithClaims(issuer = "azuread")
+class GithubController {
+    @GetMapping("/hent-branch")
+    fun hentBranch(): ResponseEntity<Ressurs<GithubBranchDto>> {
+        val branch: String? = System.getenv("GITHUB_BRANCH")
+        val sha: String? = System.getenv("GITHUB_SHA")
+        return ResponseEntity.ok().body(
+            Ressurs.success(
+                data = GithubBranchDto(branch = branch, sha = sha),
+            ),
+        )
+    }
+}
+
+data class GithubBranchDto(
+    val branch: String?,
+    val sha: String?,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/GithubControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/GithubControllerTest.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ba.sak.internal
+
+import no.nav.familie.ba.sak.config.GithubConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GithubControllerTest {
+    private val githubConfig: GithubConfig = GithubConfig(githubBranch = "tester", githubSha = "123")
+    private val githubController = GithubController(githubConfig = githubConfig)
+
+    @Test
+    fun `skal vise info om github branch og sha`() {
+        // Act
+        val response = githubController.hentBranch()
+
+        // Assert
+        assertThat(response.body?.data).isEqualTo(GithubBranchDto(branch = "tester", sha = "123"))
+    }
+}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22519

### 💰 Hva skal gjøres, og hvorfor?
Lager eget endepunkt som eksponerer ut hvilken github branch og hvilken commit hash som ligger deployet i miljøet

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Burde URLen være annerledes? Og burde jeg nevne variablene `GITHUB_BRANCH` og `GITHUB_SHA` i en eller `application.yaml` fil? Per nå settes variablene kun i github actions, er det OK?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
