### PR TITLE
Fjerner unntak om at man kan opprette behandling når det finnes åpen …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -18,13 +18,11 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.FATTER_VE
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.behandling.domene.initStatus
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValideringUtils
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.logg.BehandlingLoggRequest
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.steg.FØRSTE_STEG
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
@@ -136,11 +134,6 @@ class BehandlingService(
             }
 
             lagretBehandling
-        } else if (aktivBehandling.steg < StegType.BESLUTTE_VEDTAK) {
-            aktivBehandling.leggTilBehandlingStegTilstand(FØRSTE_STEG)
-            aktivBehandling.status = initStatus()
-
-            behandlingHentOgPersisterService.lagreEllerOppdater(aktivBehandling)
         } else {
             throw FunksjonellFeil(
                 melding = "Kan ikke lage ny behandling. Fagsaken har en aktiv behandling som ikke er ferdigstilt.",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -18,11 +18,13 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.FATTER_VE
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.behandling.domene.initStatus
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValideringUtils
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.logg.BehandlingLoggRequest
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
+import no.nav.familie.ba.sak.kjerne.steg.FØRSTE_STEG
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
@@ -134,6 +136,11 @@ class BehandlingService(
             }
 
             lagretBehandling
+        } else if (aktivBehandling.steg < StegType.BESLUTTE_VEDTAK) {
+            aktivBehandling.leggTilBehandlingStegTilstand(FØRSTE_STEG)
+            aktivBehandling.status = initStatus()
+
+            behandlingHentOgPersisterService.lagreEllerOppdater(aktivBehandling)
         } else {
             throw FunksjonellFeil(
                 melding = "Kan ikke lage ny behandling. Fagsaken har en aktiv behandling som ikke er ferdigstilt.",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -136,7 +136,7 @@ class BehandlingService(
             }
 
             lagretBehandling
-        } else if (aktivBehandling.steg < StegType.BESLUTTE_VEDTAK) {
+        } else if (aktivBehandling.steg < StegType.BESLUTTE_VEDTAK && nyBehandling.skalBehandlesAutomatisk) {
             aktivBehandling.leggTilBehandlingStegTilstand(FØRSTE_STEG)
             aktivBehandling.status = initStatus()
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
@@ -281,31 +281,6 @@ class BehandlingIntegrationTest(
     }
 
     @Test
-    fun `Bruk samme behandling hvis nytt barn kommer på fagsak med aktiv behandling`() {
-        val morId = randomFnr()
-
-        val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(morId)
-        behandlingService.opprettBehandling(nyOrdinærBehandling(søkersIdent = morId, fagsakId = fagsak.id))
-
-        assertEquals(1, behandlingHentOgPersisterService.hentBehandlinger(fagsakId = fagsak.id).size)
-
-        behandlingService.opprettBehandling(
-            NyBehandling(
-                kategori = BehandlingKategori.NASJONAL,
-                underkategori = BehandlingUnderkategori.ORDINÆR,
-                søkersIdent = morId,
-                behandlingType = BehandlingType.REVURDERING,
-                behandlingÅrsak = BehandlingÅrsak.SØKNAD,
-                søknadMottattDato = LocalDate.now(),
-                fagsakId = fagsak.id,
-            ),
-        )
-
-        val behandlinger = behandlingHentOgPersisterService.hentBehandlinger(fagsakId = fagsak.id)
-        assertEquals(1, behandlinger.size)
-    }
-
-    @Test
     fun `Opprett barnas beregning på vedtak`() {
         val søkerFnr = randomFnr()
         val barn1Fnr = randomFnr()


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22967
Slacktråd: https://nav-it.slack.com/archives/C01G9BA8JKZ/p1729671031409589

Ser ut som at saksbehandler har greid å opprette ny behandling når det allerede finnes åpen behandling ved å gjøre følgende:

1. Ha 2 faner
2. Opprett behandling i fane 1
3. Gå videre til vilkårsvurderingen
4. Opprett behandling i fane 2

Dette skaper trøbbel fordi personsopplyningsgrunnlaget opprettes på nytt, og barnet blir ikke lagt inn med engang.
Det fører til en mismatch mellom vilkårsvurderingen og personopplysningsgrunnlaget.

Er det noen som vet hvorfor vi tillater å opprette enda en behandling i backend når det allerede finnes et åpent et?
Vet at frontenden har sperre for dette.