### PR TITLE
Nye endepunkter for henting av journalpost og dokument

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
@@ -476,7 +476,7 @@ class IntegrasjonClient(
         dokumentInfoId: String,
         journalpostId: String,
     ): ByteArray {
-        val uri = URI.create("$integrasjonUri/journalpost/hentdokument/$journalpostId/$dokumentInfoId")
+        val uri = URI.create("$integrasjonUri/journalpost/hentdokument/tilgangsstyrt/baks/$journalpostId/$dokumentInfoId")
 
         return kallEksternTjenesteRessurs(
             tjeneste = "dokarkiv",

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt
@@ -351,7 +351,7 @@ class IntegrasjonClient(
         backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS),
     )
     fun hentJournalpost(journalpostId: String): Journalpost {
-        val uri = URI.create("$integrasjonUri/journalpost?journalpostId=$journalpostId")
+        val uri = URI.create("$integrasjonUri/journalpost/tilgangsstyrt/baks?journalpostId=$journalpostId")
 
         return kallEksternTjenesteRessurs(
             tjeneste = "dokarkiv",

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
@@ -379,7 +379,7 @@ class IntergrasjonTjenesteTest : AbstractSpringIntegrationTest() {
         val journalpostId = "1234"
         val fnr = randomFnr()
         wireMockServer.stubFor(
-            get("/api/journalpost?journalpostId=$journalpostId").willReturn(
+            get("/api/journalpost/tilgangsstyrt/baks?journalpostId=$journalpostId").willReturn(
                 okJson(
                     objectMapper.writeValueAsString(
                         success(
@@ -395,7 +395,7 @@ class IntergrasjonTjenesteTest : AbstractSpringIntegrationTest() {
         assertThat(oppgave.journalpostId).isEqualTo(journalpostId)
         assertThat(oppgave.bruker?.id).isEqualTo(fnr)
 
-        wireMockServer.verify(getRequestedFor(urlEqualTo("/api/journalpost?journalpostId=$journalpostId")))
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/api/journalpost/tilgangsstyrt/baks?journalpostId=$journalpostId")))
     }
 
     @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
@@ -399,6 +399,30 @@ class IntergrasjonTjenesteTest : AbstractSpringIntegrationTest() {
     }
 
     @Test
+    fun `hentDokument returnerer OK`() {
+        val journalpostId = "1234"
+        val dokumentId = "5678"
+        val fnr = randomFnr()
+        wireMockServer.stubFor(
+            get("/api/journalpost/hentdokument/tilgangsstyrt/baks/$journalpostId/$dokumentId").willReturn(
+                okJson(
+                    objectMapper.writeValueAsString(
+                        success(
+                            "Test".toByteArray(),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val dokument = integrasjonClient.hentDokument(journalpostId = journalpostId, dokumentInfoId = dokumentId)
+        assertThat(dokument).isNotNull
+        assertThat(dokument.decodeToString()).isEqualTo("Test")
+
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/api/journalpost/hentdokument/tilgangsstyrt/baks/$journalpostId/$dokumentId")))
+    }
+
+    @Test
     @Tag("integration")
     fun `skal hente arbeidsforhold for person`() {
         val fnr = randomFnr()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
@@ -390,10 +390,10 @@ class IntergrasjonTjenesteTest : AbstractSpringIntegrationTest() {
             ),
         )
 
-        val oppgave = integrasjonClient.hentJournalpost(journalpostId)
-        assertThat(oppgave).isNotNull
-        assertThat(oppgave.journalpostId).isEqualTo(journalpostId)
-        assertThat(oppgave.bruker?.id).isEqualTo(fnr)
+        val journalpost = integrasjonClient.hentJournalpost(journalpostId)
+        assertThat(journalpost).isNotNull
+        assertThat(journalpost.journalpostId).isEqualTo(journalpostId)
+        assertThat(journalpost.bruker?.id).isEqualTo(fnr)
 
         wireMockServer.verify(getRequestedFor(urlEqualTo("/api/journalpost/tilgangsstyrt/baks?journalpostId=$journalpostId")))
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tar i bruk nye endepunkter for henting av journalpost og dokument. De nye endepunktene kjører tilgangskontroll dersom journalposten inneholder eller dokumentet er en digital søknad. Har ikke saksbehandler tilgang til personene i søknaden får vi en 403 - forbidden respons. Grunnen til at vi går over til dette er for å hindre at saksbehandlere som ikke har kode 6, 7 eller 19 tilgang får tilgang til å journalføre innkommende søknader.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
