### PR TITLE
Ikke send statistikk ved deaktivering av gammel behandlign

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -198,7 +198,6 @@ class BehandlingService(
 
         if (aktivBehandling != null) {
             behandlingHentOgPersisterService.lagreOgFlush(aktivBehandling.also { it.aktiv = false })
-            saksstatistikkEventPublisher.publiserBehandlingsstatistikk(aktivBehandling.id)
         } else if (harAktivInfotrygdSak(behandling)) {
             throw FunksjonellFeil(
                 "Kan ikke lage behandling på person med aktiv sak i Infotrygd",


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22880

Når vi oppretter en ny behandling så deaktiverer vi den gamle behandlingen, og deretter sender sakstatistikk på den gamle.
Dette fører til problemer fordi ved sending av sakstatistikk så sender vi alt relatert til behandlingen.
Dette inkluderer vedtaksperioder med begrunnelser som vi kan ha slettet fra kodebasen.

Dette kan skje potensielt 1+ år etter at en begrunnelse er slettet, avhengig av når ny behandling blir opprettet.
Har tatt en prat med @stigebil og med tanke på at vi allerede har sendt over siste tilstand til behandling ved ferdigstillelse, så tenker vi at å fjerne denne kodelinjen skal gå fint.