### PR TITLE
fjern sonar-workflow for dependabot-PRer

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -57,6 +57,7 @@ jobs:
     name: Sonar
     runs-on: ubuntu-latest-8-cores
     needs: [ enhetstester, integrasjonstester ]
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når dependabot lager PR-er feiler alltid sonar-sjekken fordi dependabot ikke har tilgang til secrets.SONAR_TOKEN . Fjerner derfor sjekken for dependabot.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Burde dette vært løst på en annen måte? Mister vi noe av verdi dersom vi ikke kjører sonar-sjekkene for dependabot? 
