### PR TITLE
Vi bruker UTL_ORG på avsendermottaker ved behandle sed oppgaver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20241011144712_deb1f2c</prosessering.version>
         <felles.version>3.20240913110742_adb42f8</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20241025090301_fcf1202</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20241030085021_493c354</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20240311083956_0558f2a</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20241021103522_3adb9fa</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentstatus
 import no.nav.familie.kontrakter.felles.journalpost.LogiskVedlegg
@@ -44,33 +45,41 @@ data class RestJournalføring(
     val fagsakType: FagsakType,
     val institusjon: RestInstitusjon? = null,
 ) {
-    fun oppdaterMedDokumentOgSak(sak: Sak): OppdaterJournalpostRequest =
-        OppdaterJournalpostRequest(
+    fun oppdaterMedDokumentOgSak(sak: Sak, oppgavetype: String?): OppdaterJournalpostRequest {
+        val avsenderMottakerIdType =
+            when {
+                oppgavetype == "BEH_SED" -> AvsenderMottakerIdType.UTL_ORG
+                this.avsender.id != "" -> AvsenderMottakerIdType.FNR
+                else -> null
+            }
+
+        return OppdaterJournalpostRequest(
             avsenderMottaker =
-                AvsenderMottaker(
-                    id = this.avsender.id,
-                    idType = if (this.avsender.id != "") BrukerIdType.FNR else null,
-                    navn = this.avsender.navn,
-                ),
+            AvsenderMottaker(
+                id = this.avsender.id,
+                idType = avsenderMottakerIdType,
+                navn = this.avsender.navn,
+            ),
             bruker =
-                Bruker(
-                    this.bruker.id,
-                    navn = this.bruker.navn,
-                ),
+            Bruker(
+                this.bruker.id,
+                navn = this.bruker.navn,
+            ),
             sak = sak,
             tittel = this.journalpostTittel,
             dokumenter =
-                dokumenter.map { dokument ->
-                    DokumentInfo(
-                        dokumentInfoId = dokument.dokumentInfoId,
-                        tittel = dokument.dokumentTittel,
-                        brevkode = dokument.brevkode,
-                        dokumentstatus = Dokumentstatus.FERDIGSTILT,
-                        dokumentvarianter = null,
-                        logiskeVedlegg = null,
-                    )
-                },
+            dokumenter.map { dokument ->
+                DokumentInfo(
+                    dokumentInfoId = dokument.dokumentInfoId,
+                    tittel = dokument.dokumentTittel,
+                    brevkode = dokument.brevkode,
+                    dokumentstatus = Dokumentstatus.FERDIGSTILT,
+                    dokumentvarianter = null,
+                    logiskeVedlegg = null,
+                )
+            },
         )
+    }
 
     fun hentUnderkategori(): BehandlingUnderkategori {
         if (underkategori is BehandlingUnderkategori) return underkategori

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
-import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
@@ -45,7 +44,10 @@ data class RestJournalføring(
     val fagsakType: FagsakType,
     val institusjon: RestInstitusjon? = null,
 ) {
-    fun oppdaterMedDokumentOgSak(sak: Sak, oppgavetype: String?): OppdaterJournalpostRequest {
+    fun oppdaterMedDokumentOgSak(
+        sak: Sak,
+        oppgavetype: String?,
+    ): OppdaterJournalpostRequest {
         val avsenderMottakerIdType =
             when {
                 oppgavetype == "BEH_SED" -> AvsenderMottakerIdType.UTL_ORG
@@ -55,29 +57,29 @@ data class RestJournalføring(
 
         return OppdaterJournalpostRequest(
             avsenderMottaker =
-            AvsenderMottaker(
-                id = this.avsender.id,
-                idType = avsenderMottakerIdType,
-                navn = this.avsender.navn,
-            ),
+                AvsenderMottaker(
+                    id = this.avsender.id,
+                    idType = avsenderMottakerIdType,
+                    navn = this.avsender.navn,
+                ),
             bruker =
-            Bruker(
-                this.bruker.id,
-                navn = this.bruker.navn,
-            ),
+                Bruker(
+                    this.bruker.id,
+                    navn = this.bruker.navn,
+                ),
             sak = sak,
             tittel = this.journalpostTittel,
             dokumenter =
-            dokumenter.map { dokument ->
-                DokumentInfo(
-                    dokumentInfoId = dokument.dokumentInfoId,
-                    tittel = dokument.dokumentTittel,
-                    brevkode = dokument.brevkode,
-                    dokumentstatus = Dokumentstatus.FERDIGSTILT,
-                    dokumentvarianter = null,
-                    logiskeVedlegg = null,
-                )
-            },
+                dokumenter.map { dokument ->
+                    DokumentInfo(
+                        dokumentInfoId = dokument.dokumentInfoId,
+                        tittel = dokument.dokumentTittel,
+                        brevkode = dokument.brevkode,
+                        dokumentstatus = Dokumentstatus.FERDIGSTILT,
+                        dokumentvarianter = null,
+                        logiskeVedlegg = null,
+                    )
+                },
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestFerdigstillOppgaveKnyttJourn
 import no.nav.familie.ba.sak.ekstern.restDomene.RestInstitusjon
 import no.nav.familie.ba.sak.ekstern.restDomene.RestJournalføring
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
-import no.nav.familie.ba.sak.integrasjoner.journalføring.InnkommendeJournalføringService.Companion.NAV_NO
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpost
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.DbJournalpostType
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.FagsakSystem
@@ -127,6 +126,7 @@ class InnkommendeJournalføringService(
         val tilknyttedeBehandlingIder: MutableList<String> = request.tilknyttedeBehandlingIder.toMutableList()
         val journalpost = integrasjonClient.hentJournalpost(journalpostId)
         val brevkode = journalpost.dokumenter?.firstNotNullOfOrNull { it.brevkode }
+        val oppgave = integrasjonClient.finnOppgaveMedId(oppgaveId.toLong())
 
         if (request.opprettOgKnyttTilNyBehandling) {
             val nyBehandling =
@@ -165,7 +165,7 @@ class InnkommendeJournalføringService(
         oppdaterLogiskeVedlegg(request)
 
         oppdaterOgFerdigstill(
-            request = request.oppdaterMedDokumentOgSak(sak),
+            request = request.oppdaterMedDokumentOgSak(sak, oppgave.oppgavetype),
             journalpostId = journalpostId,
             behandlendeEnhet = behandlendeEnhet,
             oppgaveId = oppgaveId,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/MottakerInfo.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/MottakerInfo.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.brev.mottaker
 
-import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/MottakerInfo.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/MottakerInfo.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.brev.mottaker
 
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 
 sealed interface MottakerInfo {
     val navn: String
@@ -41,7 +42,7 @@ fun MottakerInfo.tilAvsenderMottaker(): AvsenderMottaker? =
             )
         is Institusjon ->
             AvsenderMottaker(
-                idType = BrukerIdType.ORGNR,
+                idType = AvsenderMottakerIdType.ORGNR,
                 id = orgNummer,
                 navn = navn,
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/RestJournalføringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/RestJournalføringTest.kt
@@ -1,0 +1,80 @@
+package no.nav.familie.ba.sak.integrasjoner.journalføring
+
+import no.nav.familie.ba.sak.ekstern.restDomene.NavnOgIdent
+import no.nav.familie.ba.sak.kjerne.verdikjedetester.lagMockRestJournalføring
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
+import no.nav.familie.kontrakter.felles.journalpost.Sak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RestJournalføringTest {
+    @Nested
+    inner class OppdaterMedDokumentOgSak {
+        @Test
+        fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til UTL_ORG dersom oppgavetype er BEH_SED`() {
+            // Arrange
+            val sak =
+                Sak(
+                    arkivsaksnummer = "arkivsaksnummer",
+                    arkivsaksystem = "arkivsaksystem",
+                    fagsakId = "1",
+                    sakstype = "sakstype",
+                    fagsaksystem = "BA",
+                )
+
+            val oppgaveType = "BEH_SED"
+            val restJournalføring = lagMockRestJournalføring(NavnOgIdent("testbruker", "testIdent"))
+
+            // Act
+            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, oppgaveType)
+
+            // Assert
+            assertThat(oppdaterJournalpostRequest.avsenderMottaker?.idType).isEqualTo(AvsenderMottakerIdType.UTL_ORG)
+        }
+
+        @Test
+        fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til FNR dersom ident er fylt ut og det ikke er BEH_SED`() {
+            // Arrange
+            val sak =
+                Sak(
+                    arkivsaksnummer = "arkivsaksnummer",
+                    arkivsaksystem = "arkivsaksystem",
+                    fagsakId = "1",
+                    sakstype = "sakstype",
+                    fagsaksystem = "BA",
+                )
+
+            val oppgaveType = "BEH_SAK"
+            val restJournalføring = lagMockRestJournalføring(NavnOgIdent("testbruker", "testIdent"))
+
+            // Act
+            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, oppgaveType)
+
+            // Assert
+            assertThat(oppdaterJournalpostRequest.avsenderMottaker?.idType).isEqualTo(AvsenderMottakerIdType.FNR)
+        }
+
+        @Test
+        fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til null dersom ident er blank`() {
+            // Arrange
+            val sak =
+                Sak(
+                    arkivsaksnummer = "arkivsaksnummer",
+                    arkivsaksystem = "arkivsaksystem",
+                    fagsakId = "1",
+                    sakstype = "sakstype",
+                    fagsaksystem = "BA",
+                )
+
+            val oppgaveType = "BEH_SAK"
+            val restJournalføring = lagMockRestJournalføring(NavnOgIdent("testbruker", ""))
+
+            // Act
+            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, oppgaveType)
+
+            // Assert
+            assertThat(oppdaterJournalpostRequest.avsenderMottaker?.idType).isNull()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -37,6 +37,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -132,7 +133,7 @@ internal class DokumentServiceTest {
             )
         }
         assert(avsenderMottaker.isCaptured) { "AvsenderMottaker skal være satt for ikke å defaulte til Bruker" }
-        assertThat(avsenderMottaker.captured.idType).isEqualTo(BrukerIdType.ORGNR)
+        assertThat(avsenderMottaker.captured.idType).isEqualTo(AvsenderMottakerIdType.ORGNR)
         assertThat(avsenderMottaker.captured.id).isEqualTo(orgNummer)
         assertThat(avsenderMottaker.captured.navn).isEqualTo("Testinstitusjon")
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -34,7 +34,6 @@ import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
-import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22897

Ved alle typer journalføring fra BA i dag vil vi konvertere hva enn som var avsendermottakeridtype til FNR.
Dette er feil, og ikke ønskelig når det gjelder behandle sed oppgavene.

Har avklart med Anna at for alle behandle sed oppgaver, så ønsker vi å bruke UTL_ORG.