### PR TITLE
Endre fra sjekk på behandle sed til kanal EESSI

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
@@ -14,6 +14,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentstatus
+import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.LogiskVedlegg
 import no.nav.familie.kontrakter.felles.journalpost.Sak
 import java.time.LocalDateTime
@@ -46,11 +47,11 @@ data class RestJournalføring(
 ) {
     fun oppdaterMedDokumentOgSak(
         sak: Sak,
-        oppgavetype: String?,
+        journalpost: Journalpost,
     ): OppdaterJournalpostRequest {
         val avsenderMottakerIdType =
             when {
-                oppgavetype == "BEH_SED" -> AvsenderMottakerIdType.UTL_ORG
+                journalpost.kanal == "EESSI" -> journalpost.avsenderMottaker?.type
                 this.avsender.id != "" -> AvsenderMottakerIdType.FNR
                 else -> null
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
@@ -126,7 +126,6 @@ class InnkommendeJournalføringService(
         val tilknyttedeBehandlingIder: MutableList<String> = request.tilknyttedeBehandlingIder.toMutableList()
         val journalpost = integrasjonClient.hentJournalpost(journalpostId)
         val brevkode = journalpost.dokumenter?.firstNotNullOfOrNull { it.brevkode }
-        val oppgave = integrasjonClient.finnOppgaveMedId(oppgaveId.toLong())
 
         if (request.opprettOgKnyttTilNyBehandling) {
             val nyBehandling =
@@ -165,7 +164,7 @@ class InnkommendeJournalføringService(
         oppdaterLogiskeVedlegg(request)
 
         oppdaterOgFerdigstill(
-            request = request.oppdaterMedDokumentOgSak(sak, oppgave.oppgavetype),
+            request = request.oppdaterMedDokumentOgSak(sak, journalpost),
             journalpostId = journalpostId,
             behandlendeEnhet = behandlendeEnhet,
             oppgaveId = oppgaveId,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ba.sak.integrasjoner.lagTestOppgaveDTO
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.enhet.Enhet
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.kodeverk.BeskrivelseDto
 import no.nav.familie.kontrakter.felles.kodeverk.BetydningDto
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
@@ -82,6 +83,8 @@ class IntegrasjonClientMock {
                 lagTestJournalpost(
                     søkerFnr,
                     UUID.randomUUID().toString(),
+                    AvsenderMottakerIdType.FNR,
+                    "NAV_NO",
                 )
 
             every { mockIntegrasjonClient.hentJournalposterForBruker(any()) } returns
@@ -89,10 +92,14 @@ class IntegrasjonClientMock {
                     lagTestJournalpost(
                         søkerFnr,
                         UUID.randomUUID().toString(),
+                        AvsenderMottakerIdType.FNR,
+                        "NAV_NO",
                     ),
                     lagTestJournalpost(
                         søkerFnr,
                         UUID.randomUUID().toString(),
+                        AvsenderMottakerIdType.FNR,
+                        "NAV_NO",
                     ),
                 )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/Datagenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/Datagenerator.kt
@@ -32,6 +32,8 @@ import java.time.LocalDateTime
 fun lagTestJournalpost(
     personIdent: String,
     journalpostId: String,
+    avsenderMottakerIdType: AvsenderMottakerIdType?,
+    kanal: String,
 ): Journalpost =
     Journalpost(
         journalpostId = journalpostId,
@@ -46,10 +48,10 @@ fun lagTestJournalpost(
                 erLikBruker = true,
                 id = personIdent,
                 land = "NO",
-                type = AvsenderMottakerIdType.FNR,
+                type = avsenderMottakerIdType,
             ),
         journalforendeEnhet = DEFAULT_JOURNALFØRENDE_ENHET,
-        kanal = "NAV_NO",
+        kanal = kanal,
         dokumenter =
             listOf(
                 DokumentInfo(
@@ -90,6 +92,8 @@ fun lagTilgangsstyrtJournalpost(
         lagTestJournalpost(
             personIdent = personIdent,
             journalpostId = journalpostId,
+            avsenderMottakerIdType = AvsenderMottakerIdType.FNR,
+            kanal = "NAV_NO",
         ),
         harTilgang = harTilgang,
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/RestJournalføringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/RestJournalføringTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.journalføring
 
 import no.nav.familie.ba.sak.ekstern.restDomene.NavnOgIdent
+import no.nav.familie.ba.sak.integrasjoner.lagTestJournalpost
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.lagMockRestJournalføring
 import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.journalpost.Sak
@@ -12,7 +13,7 @@ class RestJournalføringTest {
     @Nested
     inner class OppdaterMedDokumentOgSak {
         @Test
-        fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til UTL_ORG dersom oppgavetype er BEH_SED`() {
+        fun `Skal beholde originalt avsender mottaker type dersom kanal er EESSI`() {
             // Arrange
             val sak =
                 Sak(
@@ -23,18 +24,18 @@ class RestJournalføringTest {
                     fagsaksystem = "BA",
                 )
 
-            val oppgaveType = "BEH_SED"
+            val journalpost = lagTestJournalpost("testIdent", "1", AvsenderMottakerIdType.UTL_ORG, "EESSI")
             val restJournalføring = lagMockRestJournalføring(NavnOgIdent("testbruker", "testIdent"))
 
             // Act
-            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, oppgaveType)
+            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, journalpost)
 
             // Assert
             assertThat(oppdaterJournalpostRequest.avsenderMottaker?.idType).isEqualTo(AvsenderMottakerIdType.UTL_ORG)
         }
 
         @Test
-        fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til FNR dersom ident er fylt ut og det ikke er BEH_SED`() {
+        fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til FNR dersom ident er fylt ut`() {
             // Arrange
             val sak =
                 Sak(
@@ -45,11 +46,11 @@ class RestJournalføringTest {
                     fagsaksystem = "BA",
                 )
 
-            val oppgaveType = "BEH_SAK"
             val restJournalføring = lagMockRestJournalføring(NavnOgIdent("testbruker", "testIdent"))
+            val journalpost = lagTestJournalpost("testIdent", "1", null, "NAV_NO")
 
             // Act
-            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, oppgaveType)
+            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, journalpost)
 
             // Assert
             assertThat(oppdaterJournalpostRequest.avsenderMottaker?.idType).isEqualTo(AvsenderMottakerIdType.FNR)
@@ -67,11 +68,11 @@ class RestJournalføringTest {
                     fagsaksystem = "BA",
                 )
 
-            val oppgaveType = "BEH_SAK"
+            val journalpost = lagTestJournalpost("", "1", AvsenderMottakerIdType.FNR, "NAV_NO")
             val restJournalføring = lagMockRestJournalføring(NavnOgIdent("testbruker", ""))
 
             // Act
-            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, oppgaveType)
+            val oppdaterJournalpostRequest = restJournalføring.oppdaterMedDokumentOgSak(sak, journalpost)
 
             // Assert
             assertThat(oppdaterJournalpostRequest.avsenderMottaker?.idType).isNull()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntergrasjonTjenesteTest.kt
@@ -46,6 +46,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
@@ -383,7 +384,7 @@ class IntergrasjonTjenesteTest : AbstractSpringIntegrationTest() {
                 okJson(
                     objectMapper.writeValueAsString(
                         success(
-                            lagTestJournalpost(fnr, journalpostId),
+                            lagTestJournalpost(fnr, journalpostId, AvsenderMottakerIdType.FNR, "NAV_NO"),
                         ),
                     ),
                 ),


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22897

Det må sjekkes på kanal EESSI istedenfor BEH_SED når man skal se om man skal videreføre AvsenderMottakerIdType originalt på journalpost.