### PR TITLE
Fiks enhetstest som feiler pga ny måned

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
@@ -479,7 +479,7 @@ class RestartAvSmåbarnstilleggTest(
             vedtaksperiodeId = utvidetVedtaksperiodeMedBegrunnelser.id,
             restPutVedtaksperiodeMedStandardbegrunnelser =
                 RestPutVedtaksperiodeMedStandardbegrunnelser(
-                    standardbegrunnelser = utvidetVedtaksperiodeMedBegrunnelser.gyldigeBegrunnelser.filter(String::isNotEmpty),
+                    standardbegrunnelser = utvidetVedtaksperiodeMedBegrunnelser.gyldigeBegrunnelser.filter(String::isNotEmpty).take(5),
                 ),
         )
         if (skalBegrunneSmåbarnstillegg) {

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/autovedtak_småbarnstillegg.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/autovedtak_småbarnstillegg.feature
@@ -105,4 +105,4 @@ Egenskap: Småbarnstillegg autovedtak
 
     Så forvent disse behandlingene
       | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak                   | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus | Behandlingstype | Behandlingssteg     | Underkategori |
-      | 3            | 1        | 2                   | OPPHØRT             | SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID | Nei                       | NASJONAL            | UTREDES           | Revurdering     | BEHANDLINGSRESULTAT | UTVIDET       |
+      | 3            | 1        | 2                   | OPPHØRT             | SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID | Nei                       | NASJONAL            | UTREDES           | Revurdering     | BEHANDLINGSRESULTAT | ORDINÆR       |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Fikser enhetstest som feiler på grunn av ny måned. Testen tester fortsatt det den skal teste.
