### PR TITLE
Flytt eøs reduksjon begrunnelse til nasjonal

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -656,10 +656,6 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val sanityApiNavn = "reduksjonIkkeAnsvarForBarn"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_REDUKSJON
     },
-    REDUKSJON_BOR_IKKE_FAST_MED_BARN {
-        override val sanityApiNavn = "reduksjonBorIkkeFastMedBarn"
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_REDUKSJON
-    },
     REDUKSJON_TILLEGGSTEKST_VALUTAJUSTERING {
         override val sanityApiNavn = "reduksjonTilleggstekstValutajustering"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_REDUKSJON

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -641,6 +641,10 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override val sanityApiNavn = "reduksjonFlyttetSammenMedEktefelle"
     },
+    REDUKSJON_BOR_IKKE_FAST_MED_BARN {
+        override val sanityApiNavn = "reduksjonBorIkkeFastMedBarn"
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
+    },
     REDUKSJON_IKKE_AVTALE_DELT_BOSTED {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override val sanityApiNavn = "reduksjonIkkeAvtaleDeltBosted"


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23140

Står EØS i oppgaven, men begrunnelsen ønskes å benyttes i periode med nasjonale begrunnelser. 
Flyttes derfor.