### PR TITLE
NAV-22995: Endrer fra Clock til ClockProvider for å sikre at sommertid/vintertid fungerer korrekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/ClockProvider.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/ClockProvider.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.ba.sak.common
+
+import java.time.Clock
+
+fun interface ClockProvider {
+    fun get(): Clock
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ClockProviderConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ClockProviderConfig.kt
@@ -1,11 +1,15 @@
 package no.nav.familie.ba.sak.config
 
+import no.nav.familie.ba.sak.common.ClockProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Clock
 
 @Configuration
-class ClockConfig {
+class ClockProviderConfig {
     @Bean
-    fun clock(): Clock = Clock.systemDefaultZone()
+    fun clockProvider(): ClockProvider =
+        ClockProvider {
+            Clock.systemDefaultZone()
+        }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TestClockProvider.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TestClockProvider.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ba.sak
+
+import no.nav.familie.ba.sak.common.ClockProvider
+import java.time.Clock
+
+class TestClockProvider(
+    private val clock: Clock,
+) : ClockProvider {
+    override fun get(): Clock = clock
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClockProviderConfigTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ClockProviderConfigTest.kt
@@ -4,14 +4,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
 
-class ClockConfigTest {
+class ClockProviderConfigTest {
     @Test
-    fun `skal returnere system default zone clock`() {
+    fun `skal returnere system default zone clock fra clock provider`() {
         // Arrange
-        val clockConfig = ClockConfig()
+        val clockProvider = ClockProviderConfig().clockProvider()
 
         // Act
-        val clock = clockConfig.clock()
+        val clock = clockProvider.get()
 
         // Assert
         assertThat(clock).isEqualTo(Clock.systemDefaultZone())


### PR DESCRIPTION
Favro: [NAV-22995](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22995)

### 💰 Hva skal gjøres, og hvorfor?
ClockProvider oppretter en ny instanse av Clock hver gang det kalles. Dette sikrer at sommertid/vintertid vil fungere.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
