### PR TITLE
Task og forvalterendepunkt for å oppdatere valutakurs for en behandling fra et gitt tidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -28,6 +28,7 @@ import no.nav.familie.ba.sak.statistikk.stønadsstatistikk.StønadsstatistikkSer
 import no.nav.familie.ba.sak.task.GrensesnittavstemMotOppdrag
 import no.nav.familie.ba.sak.task.MaskineltUnderkjennVedtakTask
 import no.nav.familie.ba.sak.task.OppdaterLøpendeFlagg
+import no.nav.familie.ba.sak.task.OppdaterValutakursTask
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.PatchFomPåVilkårTilFødselsdato
 import no.nav.familie.ba.sak.task.PatchMergetIdentDto
@@ -422,6 +423,21 @@ class ForvalterController(
 
         val fagsak = fagsakService.hentRestMinimalFagsak(fagsakId)
         return ResponseEntity.ok(fagsak)
+    }
+
+    @PutMapping("/oppdater-valutakurs/{behandlingId}/{endringstidspunkt}")
+    @Operation(summary = "Oppdaterer valutakurs for en behandling i behandlingsresultatsteget fra et gitt tidspunkt")
+    fun oppdaterValutakurs(
+        @PathVariable behandlingId: Long,
+        @PathVariable endringstidspunkt: YearMonth,
+    ): ResponseEntity<Ressurs<String>> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Oppdaterer valutakurs for en behandling i behandlingsresultatsteget fra et gitt tidspunkt",
+        )
+
+        val task = taskService.save(OppdaterValutakursTask.opprettTask(behandlingId, endringstidspunkt))
+        return ResponseEntity.ok(Ressurs.success("Oppdaterer valutakurser fra $endringstidspunkt i behandling $behandlingId i task ${task.id}"))
     }
 
     @PostMapping("/start-valutajustering-scheduler")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -86,12 +86,13 @@ class AutomatiskOppdaterValutakursService(
     fun oppdaterValutakurserEtterEndringstidspunkt(
         behandlingId: BehandlingId,
         utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>? = null,
+        endringstidspunkt: YearMonth? = null,
     ) {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId.id)
         oppdaterValutakurserEtterEndringstidspunkt(
             behandling = behandling,
             utenlandskePeriodebeløp = utenlandskePeriodebeløp ?: utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id),
-            endringstidspunkt = finnEndringstidspunktForOppdateringAvValutakurs(behandling),
+            endringstidspunkt = endringstidspunkt ?: finnEndringstidspunktForOppdateringAvValutakurs(behandling),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterValutakursTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OppdaterValutakursTask.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.ba.sak.task
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
+import no.nav.familie.ba.sak.kjerne.steg.StegType
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = OppdaterValutakursTask.TASK_STEP_TYPE,
+    beskrivelse = "Oppdater valutakurs i behandling etter endringstidspunkt.",
+    maxAntallFeil = 3,
+)
+class OppdaterValutakursTask(
+    private val automatiskOppdaterValutakursService: AutomatiskOppdaterValutakursService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val dto: OppdaterValutakursTaskDTO = objectMapper.readValue(task.payload)
+
+        val behandling = behandlingHentOgPersisterService.hent(dto.behandlingId)
+        require(behandling.steg == StegType.BEHANDLINGSRESULTAT && behandling.aktiv && behandling.status == BehandlingStatus.UTREDES) {
+            "Behandling ${dto.behandlingId} er ikke i behandlingresultatsteg."
+        }
+
+        automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(
+            behandlingId = BehandlingId(dto.behandlingId),
+            endringstidspunkt = dto.endringstidspunkt,
+        )
+    }
+
+    companion object {
+        fun opprettTask(
+            behandlingId: Long,
+            endringstidspunkt: YearMonth,
+        ): Task =
+            Task(
+                type = TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(OppdaterValutakursTaskDTO(behandlingId, endringstidspunkt)),
+            )
+
+        const val TASK_STEP_TYPE = "oppdaterValutakurs"
+    }
+
+    private data class OppdaterValutakursTaskDTO(
+        val behandlingId: Long,
+        val endringstidspunkt: YearMonth = YearMonth.now(),
+    )
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Som en følge av en tidligere bug, der saksbehandler kunne legge inn kompetanse frem  i tid, er det en behandling som har fått feil valutakurser som saksbehandler ikke får fikset.

Oppretter endepunkt for å trigge automatisk oppdatering av valutakurser fra et gitt tidspunkt, slik at SB kan gå videre i behandlingen

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har ikke forandret eksisterende funksjonalitet

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
