### PR TITLE
Validerer brevmottakere ved sending av brev og iverksetting av vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -113,7 +113,7 @@ class DokumentService(
         if (!BrevmottakerValidering.erBrevmottakereGyldige(brevmottakere)) {
             throw FunksjonellFeil(
                 melding = "Det finnes ugyldige brevmottakere i utsending av manuelt brev",
-                frontendFeilmelding = "Det finnes ugyldige brevmottakere i dette brevet som må oppdateres før brevet kan sendes.",
+                frontendFeilmelding = "Adressen som er lagt til manuelt har ugyldig format, og brevet kan ikke sendes. Du må legge til manuell adresse på nytt.",
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -109,6 +109,13 @@ class DokumentService(
         val brevmottakere =
             manueltBrevRequest.manuelleBrevmottakere + brevmottakereFraBehandling.map { ManuellBrevmottaker(it) }
 
+        if (!brevmottakerService.erBrevmottakereGyldige(brevmottakere)) {
+            throw FunksjonellFeil(
+                melding = "Det finnes ugyldige brevmottakere i utsending av manuelt brev",
+                frontendFeilmelding = "Det finnes ugyldige brevmottakere i dette brevet som må oppdateres før brevet kan sendes.",
+            )
+        }
+
         val mottakere =
             lagMottakere(
                 fagsak = fagsak,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerValidering
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.Bruker
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.FullmektigEllerVerge
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.Institusjon
@@ -109,7 +110,7 @@ class DokumentService(
         val brevmottakere =
             manueltBrevRequest.manuelleBrevmottakere + brevmottakereFraBehandling.map { ManuellBrevmottaker(it) }
 
-        if (!brevmottakerService.erBrevmottakereGyldige(brevmottakere)) {
+        if (!BrevmottakerValidering.erBrevmottakereGyldige(brevmottakere)) {
             throw FunksjonellFeil(
                 melding = "Det finnes ugyldige brevmottakere i utsending av manuelt brev",
                 frontendFeilmelding = "Det finnes ugyldige brevmottakere i dette brevet som må oppdateres før brevet kan sendes.",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -65,6 +65,21 @@ data class ManuellBrevmottaker(
         poststed = brevmottakerDb.poststed,
         landkode = brevmottakerDb.landkode,
     )
+
+    fun harGyldigAdresse(): Boolean {
+        if (this.landkode == "NO") {
+            return this.navn.isNotEmpty() &&
+                this.adresselinje1.isNotEmpty() &&
+                this.postnummer.isNotEmpty() &&
+                this.poststed.isNotEmpty()
+        } else {
+            // Utenlandske manuelle brevmottakere skal ha postnummer og poststed satt i adresselinjene
+            return this.navn.isNotEmpty() &&
+                this.adresselinje1.isNotEmpty() &&
+                this.postnummer.isEmpty() &&
+                this.poststed.isEmpty()
+        }
+    }
 }
 
 data class ManueltBrevRequest(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
@@ -110,4 +110,28 @@ class BrevmottakerService(
             poststed = brevmottaker.poststed,
             landkode = brevmottaker.landkode,
         )
+
+    fun erBrevmottakerGyldig(brevmottaker: ManuellBrevmottaker): Boolean {
+        if (brevmottaker.landkode == "NO") {
+            return brevmottaker.navn.isNotEmpty() &&
+                brevmottaker.adresselinje1.isNotEmpty() &&
+                brevmottaker.postnummer.isNotEmpty() &&
+                brevmottaker.poststed.isNotEmpty()
+        } else {
+            // Utenlandske manuelle brevmottakere skal ha postnummer og poststed satt i adresselinjene
+            return brevmottaker.navn.isNotEmpty() &&
+                brevmottaker.adresselinje1.isNotEmpty() &&
+                brevmottaker.postnummer.isEmpty() &&
+                brevmottaker.poststed.isEmpty()
+        }
+    }
+
+    fun erBrevmottakereGyldige(brevmottakere: List<ManuellBrevmottaker>): Boolean {
+        brevmottakere.forEach {
+            if (!erBrevmottakerGyldig(it)) {
+                return false
+            }
+        }
+        return true
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerService.kt
@@ -110,28 +110,4 @@ class BrevmottakerService(
             poststed = brevmottaker.poststed,
             landkode = brevmottaker.landkode,
         )
-
-    fun erBrevmottakerGyldig(brevmottaker: ManuellBrevmottaker): Boolean {
-        if (brevmottaker.landkode == "NO") {
-            return brevmottaker.navn.isNotEmpty() &&
-                brevmottaker.adresselinje1.isNotEmpty() &&
-                brevmottaker.postnummer.isNotEmpty() &&
-                brevmottaker.poststed.isNotEmpty()
-        } else {
-            // Utenlandske manuelle brevmottakere skal ha postnummer og poststed satt i adresselinjene
-            return brevmottaker.navn.isNotEmpty() &&
-                brevmottaker.adresselinje1.isNotEmpty() &&
-                brevmottaker.postnummer.isEmpty() &&
-                brevmottaker.poststed.isEmpty()
-        }
-    }
-
-    fun erBrevmottakereGyldige(brevmottakere: List<ManuellBrevmottaker>): Boolean {
-        brevmottakere.forEach {
-            if (!erBrevmottakerGyldig(it)) {
-                return false
-            }
-        }
-        return true
-    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerValidering.kt
@@ -3,23 +3,8 @@ package no.nav.familie.ba.sak.kjerne.brev.mottaker
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
 
 object BrevmottakerValidering {
-    fun erBrevmottakerGyldig(brevmottaker: ManuellBrevmottaker): Boolean {
-        if (brevmottaker.landkode == "NO") {
-            return brevmottaker.navn.isNotEmpty() &&
-                brevmottaker.adresselinje1.isNotEmpty() &&
-                brevmottaker.postnummer.isNotEmpty() &&
-                brevmottaker.poststed.isNotEmpty()
-        } else {
-            // Utenlandske manuelle brevmottakere skal ha postnummer og poststed satt i adresselinjene
-            return brevmottaker.navn.isNotEmpty() &&
-                brevmottaker.adresselinje1.isNotEmpty() &&
-                brevmottaker.postnummer.isEmpty() &&
-                brevmottaker.poststed.isEmpty()
-        }
-    }
-
     fun erBrevmottakereGyldige(brevmottakere: List<ManuellBrevmottaker>): Boolean =
         brevmottakere.all {
-            erBrevmottakerGyldig(it)
+            it.harGyldigAdresse()
         }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerValidering.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.ba.sak.kjerne.brev.mottaker
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
+
+object BrevmottakerValidering {
+    fun erBrevmottakerGyldig(brevmottaker: ManuellBrevmottaker): Boolean {
+        if (brevmottaker.landkode == "NO") {
+            return brevmottaker.navn.isNotEmpty() &&
+                brevmottaker.adresselinje1.isNotEmpty() &&
+                brevmottaker.postnummer.isNotEmpty() &&
+                brevmottaker.poststed.isNotEmpty()
+        } else {
+            // Utenlandske manuelle brevmottakere skal ha postnummer og poststed satt i adresselinjene
+            return brevmottaker.navn.isNotEmpty() &&
+                brevmottaker.adresselinje1.isNotEmpty() &&
+                brevmottaker.postnummer.isEmpty() &&
+                brevmottaker.poststed.isEmpty()
+        }
+    }
+
+    fun erBrevmottakereGyldige(brevmottakere: List<ManuellBrevmottaker>): Boolean =
+        brevmottakere.all {
+            erBrevmottakerGyldig(it)
+        }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -253,7 +253,7 @@ class BeslutteVedtak(
         totrinnskontrollErGodkjent: Boolean,
     ) {
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId.id).map { ManuellBrevmottaker(it) }
-        if (toTrinnskontrollErGodkjent && !BrevmottakerValidering.erBrevmottakereGyldige(brevmottakere)) {
+        if (totrinnskontrollErGodkjent && !BrevmottakerValidering.erBrevmottakereGyldige(brevmottakere)) {
             throw FunksjonellFeil(
                 melding = "Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket",
                 frontendFeilmelding = "Det finnes ugyldige brevmottakere i denne behandlingen, den må underkjennes og brevmottakerne oppdateres",

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -256,7 +256,7 @@ class BeslutteVedtak(
         if (totrinnskontrollErGodkjent && !BrevmottakerValidering.erBrevmottakereGyldige(brevmottakere)) {
             throw FunksjonellFeil(
                 melding = "Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket",
-                frontendFeilmelding = "Det finnes ugyldige brevmottakere i denne behandlingen, den må underkjennes og brevmottakerne oppdateres",
+                frontendFeilmelding = "Adressen som er lagt til manuelt har ugyldig format, og vedtaksbrevet kan ikke sendes. Behandlingen må underkjennes, og saksbehandler må legge til manuell adresse på nytt.",
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -250,7 +250,7 @@ class BeslutteVedtak(
 
     private fun validerBrevmottakere(
         behandlingId: BehandlingId,
-        toTrinnskontrollErGodkjent: Boolean,
+        totrinnskontrollErGodkjent: Boolean,
     ) {
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId.id).map { ManuellBrevmottaker(it) }
         if (toTrinnskontrollErGodkjent && !BrevmottakerValidering.erBrevmottakereGyldige(brevmottakere)) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -43,6 +43,8 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
 import no.nav.familie.ba.sak.kjerne.brev.domene.eøs.BarnetsBostedsland
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerDb
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.MottakerType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
@@ -1468,5 +1470,25 @@ fun ikkeOppfyltVilkår(vilkår: Vilkår) =
         vilkår = vilkår,
         regelverkResultat = RegelverkResultat.IKKE_OPPFYLT,
     )
+
+fun lagBrevmottakerDb(
+    behandlingId: Long,
+    type: MottakerType = MottakerType.FULLMEKTIG,
+    navn: String = "Test Testesen",
+    adresselinje1: String = "En adresse her",
+    adresselinje2: String? = null,
+    postnummer: String = "0661",
+    poststed: String = "Oslo",
+    landkode: String = "NO",
+) = BrevmottakerDb(
+    behandlingId = behandlingId,
+    type = type,
+    navn = navn,
+    adresselinje1 = adresselinje1,
+    adresselinje2 = adresselinje2,
+    postnummer = postnummer,
+    poststed = poststed,
+    landkode = landkode,
+)
 
 val Number.årSiden: LocalDate get() = LocalDate.now().minusYears(this.toLong())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.verify
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.defaultFagsak
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagBrevmottakerDb
 import no.nav.familie.ba.sak.common.lagPerson
 import no.nav.familie.ba.sak.common.lagVilkårsvurdering
 import no.nav.familie.ba.sak.common.randomAktør
@@ -23,7 +24,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
-import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerDb
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerRepository
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.MottakerType
@@ -297,15 +297,7 @@ internal class DokumentServiceTest {
 
         every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
             listOf(
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
-                ),
+                lagBrevmottakerDb(behandlingId = behandling.id, navn = "Fullmektig navn"),
             )
         every {
             utgåendeJournalføringService.journalførManueltBrev(
@@ -352,12 +344,7 @@ internal class DokumentServiceTest {
         val brevmottakere =
             listOf(
                 ManuellBrevmottaker(
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
+                    lagBrevmottakerDb(behandlingId = 1234, type = MottakerType.FULLMEKTIG, navn = "Fullmektig navn"),
                 ),
             )
         val manueltBrevRequest =
@@ -452,24 +439,8 @@ internal class DokumentServiceTest {
 
         every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
             listOf(
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Sverige",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Stockholm",
-                    landkode = "SE",
-                ),
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Norge",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
-                ),
+                lagBrevmottakerDb(behandlingId = behandling.id, landkode = "SE"),
+                lagBrevmottakerDb(behandlingId = behandling.id, landkode = "NO"),
             )
         every {
             utgåendeJournalføringService.journalførManueltBrev(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.defaultFagsak
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.lagPerson
@@ -41,6 +42,7 @@ import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class DokumentServiceTest {
     val integrasjonClient = mockk<IntegrasjonClient>(relaxed = true)
@@ -439,6 +441,75 @@ internal class DokumentServiceTest {
         }
         verify(exactly = 0) { journalføringRepository.save(any()) }
         verify(exactly = 1) { taskRepository.save(any()) }
+    }
+
+    @Test
+    fun `sendManueltBrev skal feile hvis den manuelle brevmottakeren er ugyldig`() {
+        // Arrange
+        val behandling = lagBehandling()
+        val manueltBrevRequest = ManueltBrevRequest(brevmal = Brevmal.SVARTIDSBREV)
+        val avsenderMottakere = mutableListOf<AvsenderMottaker>()
+
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
+            listOf(
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Sverige",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Stockholm",
+                    landkode = "SE",
+                ),
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Norge",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Oslo",
+                    landkode = "NO",
+                ),
+            )
+        every {
+            utgåendeJournalføringService.journalførManueltBrev(
+                fnr = any(),
+                fagsakId = any(),
+                journalførendeEnhet = any(),
+                brev = any(),
+                dokumenttype = any(),
+                førsteside = any(),
+                eksternReferanseId = any(),
+                avsenderMottaker = capture(avsenderMottakere),
+            )
+        } returns "mockJournalPostId" andThen "mockJournalPostId1"
+
+        every { journalføringRepository.save(any()) } returns mockk()
+        every { taskRepository.save(any()) } returns mockk()
+        every { fagsakRepository.finnFagsak(behandling.fagsak.id) } returns behandling.fagsak
+
+        // Act
+        val exception =
+            assertThrows<FunksjonellFeil> {
+                dokumentService.sendManueltBrev(manueltBrevRequest, behandling, behandling.fagsak.id)
+            }
+
+        assertThat(exception.message).isEqualTo("Det finnes ugyldige brevmottakere i utsending av manuelt brev")
+
+        verify(exactly = 0) {
+            utgåendeJournalføringService.journalførManueltBrev(
+                fnr = any(),
+                fagsakId = any(),
+                journalførendeEnhet = any(),
+                brev = any(),
+                dokumenttype = any(),
+                førsteside = any(),
+                eksternReferanseId = any(),
+                avsenderMottaker = any(),
+            )
+        }
+        verify(exactly = 0) { journalføringRepository.save(any()) }
+        verify(exactly = 0) { taskRepository.save(any()) }
     }
 
     private fun sendBrev(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -488,7 +488,7 @@ internal class DokumentServiceTest {
         every { taskRepository.save(any()) } returns mockk()
         every { fagsakRepository.finnFagsak(behandling.fagsak.id) } returns behandling.fagsak
 
-        // Act
+        // Act & assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 dokumentService.sendManueltBrev(manueltBrevRequest, behandling, behandling.fagsak.id)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -327,6 +327,7 @@ class BeslutteVedtakTest {
 
     @Test
     fun `Skal feile ferdigstilling av Godkjenne vedtak-oppgave ved Godkjent vedtak når brevmottakerne er ugyldige`() {
+        // Arrange
         val behandling = lagBehandling()
         behandling.status = BehandlingStatus.FATTER_VEDTAK
         behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -139,7 +139,6 @@ class BeslutteVedtakTest {
                     landkode = "NO",
                 ),
             )
-        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns true
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -181,7 +180,6 @@ class BeslutteVedtakTest {
                     landkode = "NO",
                 ),
             )
-        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns true
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -231,7 +229,6 @@ class BeslutteVedtakTest {
                     landkode = "NO",
                 ),
             )
-        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns true
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -278,8 +275,6 @@ class BeslutteVedtakTest {
                     landkode = "NO",
                 ),
             )
-
-        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns false
 
         beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
         verify(exactly = 1) { behandlingService.opprettOgInitierNyttVedtakForBehandling(behandling, true) }
@@ -365,8 +360,6 @@ class BeslutteVedtakTest {
                     landkode = "NO",
                 ),
             )
-
-        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns false
 
         // Act
         val exception =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -361,7 +361,7 @@ class BeslutteVedtakTest {
                 ),
             )
 
-        // Act
+        // Act & assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -9,6 +9,7 @@ import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagBrevmottakerDb
 import no.nav.familie.ba.sak.common.lagVedtak
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
@@ -20,9 +21,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
-import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerDb
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
-import no.nav.familie.ba.sak.kjerne.brev.mottaker.MottakerType
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
@@ -129,15 +128,7 @@ class BeslutteVedtakTest {
         every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
         every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
             listOf(
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Norge",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
-                ),
+                lagBrevmottakerDb(behandlingId = behandling.id),
             )
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
@@ -170,15 +161,7 @@ class BeslutteVedtakTest {
         every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
         every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
             listOf(
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Norge",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
-                ),
+                lagBrevmottakerDb(behandlingId = behandling.id),
             )
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
@@ -219,15 +202,7 @@ class BeslutteVedtakTest {
         every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
         every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
             listOf(
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Norge",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
-                ),
+                lagBrevmottakerDb(behandlingId = behandling.id),
             )
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
@@ -265,15 +240,7 @@ class BeslutteVedtakTest {
 
         every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
             listOf(
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Norge",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
-                ),
+                lagBrevmottakerDb(behandlingId = behandling.id),
             )
 
         beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
@@ -342,24 +309,8 @@ class BeslutteVedtakTest {
 
         every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
             listOf(
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Sverige",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Stockholm",
-                    landkode = "SE",
-                ),
-                BrevmottakerDb(
-                    behandlingId = behandling.id,
-                    type = MottakerType.FULLMEKTIG,
-                    navn = "Fullmektig navn i Norge",
-                    adresselinje1 = "Test adresse",
-                    postnummer = "0000",
-                    poststed = "Oslo",
-                    landkode = "NO",
-                ),
+                lagBrevmottakerDb(behandlingId = behandling.id, landkode = "SE"),
+                lagBrevmottakerDb(behandlingId = behandling.id, landkode = "NO"),
             )
 
         // Act & assert

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -20,6 +20,9 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerDb
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.MottakerType
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
@@ -39,6 +42,7 @@ import no.nav.familie.ba.sak.task.JournalførVedtaksbrevTask
 import no.nav.familie.ba.sak.task.OpprettOppgaveTask
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -60,6 +64,7 @@ class BeslutteVedtakTest {
     private val valutakursRepository = mockk<ValutakursRepository>()
     private val simuleringService = mockk<SimuleringService>()
     private val tilbakekrevingService = mockk<TilbakekrevingService>()
+    private val brevmottakerService = mockk<BrevmottakerService>()
 
     val beslutteVedtak =
         BeslutteVedtak(
@@ -77,6 +82,7 @@ class BeslutteVedtakTest {
             valutakursRepository = valutakursRepository,
             simuleringService = simuleringService,
             tilbakekrevingService = tilbakekrevingService,
+            brevmottakerService = brevmottakerService,
         )
 
     private val randomVilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
@@ -121,6 +127,19 @@ class BeslutteVedtakTest {
         every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
         every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
         every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
+            listOf(
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Norge",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Oslo",
+                    landkode = "NO",
+                ),
+            )
+        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns true
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -150,6 +169,19 @@ class BeslutteVedtakTest {
         } returns Task(OpprettOppgaveTask.TASK_STEP_TYPE, "")
 
         every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
+            listOf(
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Norge",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Oslo",
+                    landkode = "NO",
+                ),
+            )
+        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns true
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -187,6 +219,19 @@ class BeslutteVedtakTest {
         } returns Task(OpprettOppgaveTask.TASK_STEP_TYPE, "")
 
         every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
+            listOf(
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Norge",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Oslo",
+                    landkode = "NO",
+                ),
+            )
+        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns true
 
         val nesteSteg = beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
 
@@ -220,6 +265,21 @@ class BeslutteVedtakTest {
             )
 
         every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
+            listOf(
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Norge",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Oslo",
+                    landkode = "NO",
+                ),
+            )
+
+        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns false
 
         beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
         verify(exactly = 1) { behandlingService.opprettOgInitierNyttVedtakForBehandling(behandling, true) }
@@ -268,5 +328,52 @@ class BeslutteVedtakTest {
             )
 
         assertThrows<FunksjonellFeil> { beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak) }
+    }
+
+    @Test
+    fun `Skal feile ferdigstilling av Godkjenne vedtak-oppgave ved Godkjent vedtak når brevmottakerne er ugyldige`() {
+        val behandling = lagBehandling()
+        behandling.status = BehandlingStatus.FATTER_VEDTAK
+        behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))
+        val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
+
+        every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
+        every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
+        mockkObject(FerdigstillOppgaver.Companion)
+        every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
+        every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
+        every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
+            listOf(
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Sverige",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Stockholm",
+                    landkode = "SE",
+                ),
+                BrevmottakerDb(
+                    behandlingId = behandling.id,
+                    type = MottakerType.FULLMEKTIG,
+                    navn = "Fullmektig navn i Norge",
+                    adresselinje1 = "Test adresse",
+                    postnummer = "0000",
+                    poststed = "Oslo",
+                    landkode = "NO",
+                ),
+            )
+
+        every { brevmottakerService.erBrevmottakereGyldige(any()) } returns false
+
+        // Act
+        val exception =
+            assertThrows<FunksjonellFeil> {
+                beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
+            }
+
+        assertThat(exception.message).isEqualTo("Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket")
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.SmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterTilkjentYtelseService
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterUtenlandskPeriodebeløpService
@@ -125,6 +126,7 @@ class CucumberMock(
     val opprettTaskService = mockk<OpprettTaskService>()
     val endretUtbetalingAndelTidslinjeService = EndretUtbetalingAndelTidslinjeService(endretUtbetalingAndelHentOgPersisterService)
     val vurderingsstrategiForValutakurserRepository = mockVurderingsstrategiForValutakurserRepository()
+    val brevmottakerService = mockk<BrevmottakerService>()
 
     val behandlingstemaService =
         BehandlingstemaService(
@@ -504,6 +506,7 @@ class CucumberMock(
             valutakursRepository = valutakursRepository,
             simuleringService = simuleringService,
             tilbakekrevingService = tilbakekrevingService,
+            brevmottakerService = brevmottakerService,
         )
 
     val stegService =


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23182

### 💰 Hva skal gjøres, og hvorfor?
Vi har lagt på validering på brevmottakere i frontend, men dette fjerner jo ikke brevmottakerne som allerede er lagt inn feil i databasen. Legger derfor på validering på utsending av brev og iverksetting av vedtak (som jo også sender brev)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er koden god nok? Pirk gjerne! Jeg er også usikker på om sjekken på `BeslutteVedtak.kt` er god nok. Det gir for meg og Ole Kristian mening at man kun skal kjøre valideringen når vedtaket er godkjent. Siden man skal underkjenne når brevmottakerne ikke er gyldige.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
