### PR TITLE
Håndterer infotrygd perioder med tidslinje rammeverk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -309,7 +309,8 @@ private fun List<BarnetrygdPeriode>.tilTidslinje() =
         .map {
             Periode(
                 fraOgMed = it.stønadFom.tilTidspunkt(),
-                tilOgMed = it.stønadTom.tilTidspunkt(),
+                // 999999999-12 er Infotrygds definisjon av uendelighet, klippes til 9999-12 for å kunne brukes i tidslinje. Kan fjernes når vi ikke lenger har løpende saker i infotrygd
+                tilOgMed = if (it.stønadTom == YearMonth.of(999999999, 12)) YearMonth.of(9999, 12).tilTidspunkt() else it.stønadTom.tilTidspunkt(),
                 innhold = it,
             )
         }.tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -310,12 +310,10 @@ private fun List<BarnetrygdPeriode>.tilTidslinje() =
             Periode(
                 fraOgMed = it.stønadFom.tilTidspunkt(),
                 // 999999999-12 er Infotrygds definisjon av uendelighet, klippes til 9999-12 for å kunne brukes i tidslinje. Kan fjernes når vi ikke lenger har løpende saker i infotrygd
-                tilOgMed = if (it.stønadTom == YearMonth.of(999999999, 12)) YearMonth.of(9999, 12).tilTidspunkt() else it.stønadTom.tilTidspunkt(),
+                tilOgMed = if (it.stønadTom > YearMonth.of(9999, 12)) YearMonth.of(9999, 12).tilTidspunkt() else it.stønadTom.tilTidspunkt(),
                 innhold = it,
             )
         }.tilTidslinje()
-
-private fun List<BarnetrygdPeriode>.fomDatoer(): List<YearMonth> = map { it.stønadFom }
 
 private operator fun BarnetrygdTilPensjon.plus(other: BarnetrygdTilPensjon?): List<BarnetrygdTilPensjon> =
     when {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje
 
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.erEndelig
@@ -11,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somEndelig
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeSiden
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeTil
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom.rangeTo
+import java.time.YearMonth
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.fraOgMed() =
     this.perioder().firstOrNull()?.let {
@@ -57,7 +59,12 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.tidsrom(): Collection<Tidspunkt<T>> =
 fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): Collection<Tidspunkt<T>> {
     val fraOgMed = fraOgMed() ?: return emptyList()
     val tilOgMed = tilOgMed() ?: return emptyList()
-    return (fraOgMed..tilOgMed).toList()
+    // 999999999-12 er løpende dato i infotrygd, skal ikke returnere tidsrom liste.
+    return if (tilOgMed == YearMonth.of(999999999, 12).tilTidspunkt()) {
+        emptyList()
+    } else {
+        (fraOgMed..tilOgMed).toList()
+    }
 }
 
 fun <T : Tidsenhet> tidsrom(vararg tidslinjer: Tidslinje<*, T>) = tidslinjer.toList().tidsrom()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/tidsrom/Tidsrom.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje
 
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.erEndelig
@@ -12,7 +11,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somEndelig
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeSiden
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeTil
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom.rangeTo
-import java.time.YearMonth
 
 fun <I, T : Tidsenhet> Tidslinje<I, T>.fraOgMed() =
     this.perioder().firstOrNull()?.let {
@@ -59,12 +57,7 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.tidsrom(): Collection<Tidspunkt<T>> =
 fun <T : Tidsenhet> Iterable<Tidslinje<*, T>>.tidsrom(): Collection<Tidspunkt<T>> {
     val fraOgMed = fraOgMed() ?: return emptyList()
     val tilOgMed = tilOgMed() ?: return emptyList()
-    // 999999999-12 er løpende dato i infotrygd, skal ikke returnere tidsrom liste.
-    return if (tilOgMed == YearMonth.of(999999999, 12).tilTidspunkt()) {
-        emptyList()
-    } else {
-        (fraOgMed..tilOgMed).toList()
-    }
+    return (fraOgMed..tilOgMed).toList()
 }
 
 fun <T : Tidsenhet> tidsrom(vararg tidslinjer: Tidslinje<*, T>) = tidslinjer.toList().tidsrom()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonServiceIntegrationTest.kt
@@ -136,6 +136,18 @@ class PensjonServiceIntegrationTest : AbstractSpringIntegrationTest() {
     }
 
     @Test
+    fun `skal finne og returnere perioder fra Infotrygd som har infotrygd sin definisjon på uendelighet`() {
+        val søker = tilfeldigPerson()
+        val søkerAktør = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
+
+        mockInfotrygdBarnetrygdResponse(søkerAktør, YearMonth.now(), YearMonth.of(999999999, 12))
+
+        val barnetrygdTilPensjon = pensjonService.hentBarnetrygd(søkerAktør.aktivFødselsnummer(), LocalDate.of(2023, 1, 1))
+        assertThat(barnetrygdTilPensjon).hasSize(1)
+        assertThat(barnetrygdTilPensjon.filter { it.barnetrygdPerioder.all { it.kildesystem == "Infotrygd" } }).hasSize(1)
+    }
+
+    @Test
     fun `skal finne og returnere perioder fra Infotrygd`() {
         val søker = tilfeldigPerson()
         val søkerAktør = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)


### PR DESCRIPTION
På løpende fagsaker operere infotrydg med til datoer som er 999999999-12 dette håndterer ikke tidslinjerammeverket når det forsøker å lage perioder med en slik dato som sluttdato.

Har lagt inn spesialhåndtering av denne datoen slik at tidsrom håndterer denne datoen
