### PR TITLE
Filtrer bort valutakurser med fremtidig fom eller tom

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TestClockProvider.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TestClockProvider.kt
@@ -1,10 +1,27 @@
 package no.nav.familie.ba.sak
 
 import no.nav.familie.ba.sak.common.ClockProvider
+import no.nav.familie.ba.sak.common.toLocalDate
 import java.time.Clock
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 class TestClockProvider(
-    private val clock: Clock,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) : ClockProvider {
     override fun get(): Clock = clock
+
+    companion object {
+        fun lagClockProviderMedFastTidspunkt(localDateTime: LocalDateTime): TestClockProvider =
+            TestClockProvider(Clock.fixed(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.systemDefault()))
+
+        fun lagClockProviderMedFastTidspunkt(localDate: LocalDate): TestClockProvider =
+            lagClockProviderMedFastTidspunkt(localDate.atStartOfDay())
+
+        fun lagClockProviderMedFastTidspunkt(yearMonth: YearMonth): TestClockProvider =
+            lagClockProviderMedFastTidspunkt(yearMonth.toLocalDate())
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
@@ -3,6 +3,7 @@
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import no.nav.familie.ba.sak.TestClockProvider
 import no.nav.familie.ba.sak.common.MockedDateProvider
 import no.nav.familie.ba.sak.common.lagBehandling
 import no.nav.familie.ba.sak.common.tilfeldigPerson
@@ -37,10 +38,11 @@ import java.time.LocalDate
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AutomatiskOppdaterValutakursServiceTest {
     val dagensDato = LocalDate.of(2020, 9, 15)
+    val clockProvider = TestClockProvider()
 
     val valutakursRepository: PeriodeOgBarnSkjemaRepository<Valutakurs> = mockPeriodeBarnSkjemaRepository()
     val utenlandskPeriodebeløpRepository: PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp> = mockPeriodeBarnSkjemaRepository()
-    val tilpassValutakurserTilUtenlandskePeriodebeløpService = TilpassValutakurserTilUtenlandskePeriodebeløpService(valutakursRepository = valutakursRepository, utenlandskPeriodebeløpRepository, emptyList())
+    val tilpassValutakurserTilUtenlandskePeriodebeløpService = TilpassValutakurserTilUtenlandskePeriodebeløpService(valutakursRepository = valutakursRepository, utenlandskPeriodebeløpRepository, emptyList(), clockProvider)
     val tilpassDifferanseberegningEtterValutakursService = mockk<TilpassDifferanseberegningEtterValutakursService>()
 
     val valutakursService = ValutakursService(valutakursRepository, emptyList())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
@@ -5,8 +5,11 @@ import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.tilpassValutakurserTilUtenlandskePeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.util.UtenlandskPeriodebeløpBuilder
 import no.nav.familie.ba.sak.kjerne.eøs.util.ValutakursBuilder
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.YearMonth
 
 /**
  * Syntaks:
@@ -70,5 +73,30 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
             tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp)
 
         assertEqualsUnordered(forventedeValutakurser, faktiskeValutakurser)
+    }
+
+    @Test
+    fun `test at ikke fremtidige valutakurser genereres`() {
+        val toMånederSiden = MånedTidspunkt.med(YearMonth.now().minusMonths(2))
+
+        val gjeldendeValutakurser =
+            ValutakursBuilder(toMånederSiden)
+                .medKurs("1234", "PLN", barn1)
+                .bygg()
+
+        val utenlandskePeriodebeløp =
+            UtenlandskPeriodebeløpBuilder(toMånederSiden)
+                .medBeløp("1234>", "PLN", "PL", barn1)
+                .bygg()
+
+        val forventedeValutakurser =
+            ValutakursBuilder(toMånederSiden)
+                .medKurs("123>", "PLN", barn1)
+                .bygg()
+
+        val faktiskeValutakurser =
+            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp)
+
+        assertThat(faktiskeValutakurser).isEqualTo(forventedeValutakurser)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
@@ -1,12 +1,13 @@
 package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
 
+import no.nav.familie.ba.sak.TestClockProvider.Companion.lagClockProviderMedFastTidspunkt
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.tilpassValutakurserTilUtenlandskePeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.util.UtenlandskPeriodebeløpBuilder
 import no.nav.familie.ba.sak.kjerne.eøs.util.ValutakursBuilder
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.YearMonth
@@ -19,10 +20,12 @@ import java.time.YearMonth
  * '<siffer>': Skjema har oppgitt kurs og valutakode
  */
 class TilpassValutakursTilUtenlandskePeridebeløpTest {
-    val jan2020 = jan(2020)
-    val barn1 = tilfeldigPerson()
-    val barn2 = tilfeldigPerson()
-    val barn3 = tilfeldigPerson()
+    private val clockProvider = lagClockProviderMedFastTidspunkt(YearMonth.of(2021, 1))
+    private val jan2020 = jan(2020)
+    private val nov2020 = nov(2020)
+    private val barn1 = tilfeldigPerson()
+    private val barn2 = tilfeldigPerson()
+    private val barn3 = tilfeldigPerson()
 
     @Test
     fun `test tilpasning av valutakurser mot kompleks endring av utenlandsk valutabeløp`() {
@@ -47,7 +50,7 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .bygg()
 
         val faktiskeValutakurser =
-            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp)
+            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, clockProvider)
 
         assertEqualsUnordered(forventedeValutakurser, faktiskeValutakurser)
     }
@@ -70,32 +73,30 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .bygg()
 
         val faktiskeValutakurser =
-            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp)
+            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, clockProvider)
 
         assertEqualsUnordered(forventedeValutakurser, faktiskeValutakurser)
     }
 
     @Test
     fun `test at ikke fremtidige valutakurser genereres`() {
-        val toMånederSiden = MånedTidspunkt.med(YearMonth.now().minusMonths(2))
-
         val gjeldendeValutakurser =
-            ValutakursBuilder(toMånederSiden)
-                .medKurs("1234", "PLN", barn1)
+            ValutakursBuilder(nov2020)
+                .medKurs("12345", "PLN", barn1)
                 .bygg()
 
         val utenlandskePeriodebeløp =
-            UtenlandskPeriodebeløpBuilder(toMånederSiden)
-                .medBeløp("1234>", "PLN", "PL", barn1)
+            UtenlandskPeriodebeløpBuilder(nov2020)
+                .medBeløp("12345>", "PLN", "PL", barn1)
                 .bygg()
 
         val forventedeValutakurser =
-            ValutakursBuilder(toMånederSiden)
+            ValutakursBuilder(nov2020)
                 .medKurs("123>", "PLN", barn1)
                 .bygg()
 
         val faktiskeValutakurser =
-            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp)
+            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, clockProvider)
 
         assertThat(faktiskeValutakurser).isEqualTo(forventedeValutakurser)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ba.sak.TestClockProvider
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassValutakurserTilUtenlandskePeriodebeløpService
@@ -28,6 +29,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 internal class ValutakursServiceTest {
+    val clockProvider = TestClockProvider()
     val valutakursRepository: PeriodeOgBarnSkjemaRepository<Valutakurs> = mockPeriodeBarnSkjemaRepository()
     val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository = mockk()
 
@@ -42,6 +44,7 @@ internal class ValutakursServiceTest {
             valutakursRepository,
             utenlandskPeriodebeløpRepository,
             emptyList(),
+            clockProvider,
         )
 
     @BeforeEach

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -3,6 +3,7 @@
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.CoroutineScope
+import no.nav.familie.ba.sak.TestClockProvider.Companion.lagClockProviderMedFastTidspunkt
 import no.nav.familie.ba.sak.common.MockedDateProvider
 import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinition
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockBehandlingMigreringsinfoRepository
@@ -82,6 +83,7 @@ class CucumberMock(
     ecbService: ECBService = mockEcbService(dataFraCucumber),
     scope: CoroutineScope? = null,
 ) {
+    val clockProvider = lagClockProviderMedFastTidspunkt(dataFraCucumber.dagensDato)
     val mockedDateProvider = MockedDateProvider(dataFraCucumber.dagensDato)
     val persongrunnlagService = mockPersongrunnlagService(dataFraCucumber)
     val fagsakService = mockFagsakService(dataFraCucumber)
@@ -264,7 +266,7 @@ class CucumberMock(
 
     val valutakursAbonnenter = listOf(tilpassDifferanseberegningEtterValutakursService, tilbakestillBehandlingFraValutakursEndringService)
 
-    val tilpassValutakurserTilUtenlandskePeriodebeløpService = TilpassValutakurserTilUtenlandskePeriodebeløpService(valutakursRepository = valutakursRepository, utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository, endringsabonnenter = valutakursAbonnenter)
+    val tilpassValutakurserTilUtenlandskePeriodebeløpService = TilpassValutakurserTilUtenlandskePeriodebeløpService(valutakursRepository = valutakursRepository, utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository, endringsabonnenter = valutakursAbonnenter, clockProvider = clockProvider)
 
     val tilbakestillBehandlingFraUtenlandskPeriodebeløpEndringService = TilbakestillBehandlingFraUtenlandskPeriodebeløpEndringService(tilbakestillBehandlingTilBehandlingsresultatService = tilbakestillBehandlingTilBehandlingsresultatService)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22931

Som en følge av en tidligere bug, der saksbehandler kunne legge inn kompetanse frem i tid, er det flere behandlinger som har fått valutakurser frem i tid som saksbehandler ikke har tilgang til å endre.

Fikser problemet ved å:
- Filtrere bort valutakurser som har fom senere enn inneværende måned
- Sette `tom = null` i valutakurser som har tom lik eller senere inneværende måned

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
