### PR TITLE
NAV-23143: Legger til ValutakursRestClientMock for å forhindre at DifferanseberegningIntegrasjonTest går mot det reelle endepunktet

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ValutakursRestClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ValutakursRestClientMock.kt
@@ -1,0 +1,50 @@
+package no.nav.familie.ba.sak.config
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.integrasjoner.ecb.ECBConstants
+import no.nav.familie.valutakurs.ValutakursRestClient
+import no.nav.familie.valutakurs.domene.ExchangeRate
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@TestConfiguration
+class ValutakursRestClientMock {
+    @Bean
+    @Primary
+    fun mockValutakursRestClientMock(): ValutakursRestClient {
+        val valutakursRestClientMock = mockk<ValutakursRestClient>()
+
+        clearMocks(valutakursRestClientMock)
+
+        every {
+            valutakursRestClientMock.hentValutakurs(
+                frequency = any(),
+                currencies = any(),
+                exchangeRateDate = any(),
+            )
+        } answers {
+            val currencies = secondArg<List<String>>()
+            val dagensDato = thirdArg<LocalDate>()
+            val exchangeRates =
+                currencies.map {
+                    ExchangeRate(
+                        currency = it,
+                        exchangeRate = BigDecimal(10),
+                        date = dagensDato,
+                    )
+                }
+            if (ECBConstants.EUR in currencies) {
+                exchangeRates.filter { it.currency == ECBConstants.NOK }
+            } else {
+                exchangeRates
+            }
+        }
+
+        return valutakursRestClientMock
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23143

Forhindrer at den faktiske testen skal gå mot det reelle endepunktet. Slik det er nå vil testen feile om endepunktet er nede. Ved å mock dette forhindrer vi denne avhengigheten. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Ser de andre mockene bruker `clearMocks` men trenger vi egentlig det? 

La inn logikk for å filtrere bort `ExchangeRates` slik at valideringen ikke feilet, men jeg er usikker på om det gir helt mening i forhold til logikken som ligger i `ECBService`. Om noen har en dypere forståelse så kom gjerne med innspill. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
