### PR TITLE
Vi kaster funksjonell feil ved forsøk på å opprette ny institusjon med samme org nummer på person.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -35,7 +35,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
     ): Fagsak?
 
     @Lock(LockModeType.NONE)
-    @Query(value = "SELECT f FROM Fagsak f WHERE f.aktør = :aktør and f.type = 'INSTITUSJON' and f.status <> 'AVSLUTTET' and f.arkivert = false and f.institusjon.orgNummer = :orgNummer")
+    @Query(value = "SELECT f FROM Fagsak f WHERE f.aktør = :aktør and f.type = 'INSTITUSJON' and f.arkivert = false and f.institusjon.orgNummer = :orgNummer")
     fun finnFagsakForInstitusjonOgOrgnummer(
         aktør: Aktør,
         orgNummer: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -103,7 +103,11 @@ class FagsakService(
             when (type) {
                 FagsakType.INSTITUSJON -> {
                     if (institusjon?.orgNummer == null) throw FunksjonellFeil("Mangler påkrevd variabel orgnummer for institusjon")
-                    fagsakRepository.finnFagsakForInstitusjonOgOrgnummer(aktør, institusjon.orgNummer)
+                    val eksisterendeFagsakPåPersonMedSammeOrgnummer = fagsakRepository.finnFagsakForInstitusjonOgOrgnummer(aktør, institusjon.orgNummer)
+
+                    eksisterendeFagsakPåPersonMedSammeOrgnummer?.let {
+                        throw FunksjonellFeil("Det finnes allerede en institusjon fagsak på denne personen som er koblet til samme organisasjon.")
+                    }
                 }
                 else -> fagsakRepository.finnFagsakForAktør(aktør, type)
             }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23401

Dersom man har en avsluttet institusjon fagsak, og man prøver å opprette ny institusjon fagsak på person med samme org nummer, så vil det kastes SQL feil i dag. Dette fordi at det ikke skal være mulig å opprette ny institusjon fagsak på person med samme org nummer, det ønskes at den avsluttede fagsaken benyttes i dag.

Sånn ser det ut:
<img width="1632" alt="Screenshot 2024-11-23 at 12 18 12" src="https://github.com/user-attachments/assets/bac38431-c682-4c92-9fe9-79604b56efcb">
<img width="726" alt="Screenshot 2024-11-23 at 13 08 01" src="https://github.com/user-attachments/assets/c66e86d8-dc57-4d23-ba5a-84324d4f36e4">


Det er heller ønskelig å gi saksbehandler en ordentlig melding her.
Da slipper vi støy i loggene, og saksbehandler får beskjed at det allerede finnes institusjon fagsak m/ samme orgnummer på person:
<img width="548" alt="Screenshot 2024-11-23 at 13 04 12" src="https://github.com/user-attachments/assets/57546b71-c47c-42fb-84e0-c6e4adcbac00">

Man kunne også bare returnert fagsaken, men dette skjer når SB aktivt prøver å opprette ny institusjon fagsak med samme org nummer, så tenkte det er best å si ifra at det allerede finnes istedenfor å returnere det som finnes.

