### PR TITLE
Fix: fjern trailing skråstrek for post-endepunkt for å opprette revurdering med årsak klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/EksternKlageController.kt
@@ -47,7 +47,7 @@ class EksternKlageController(
         return Ressurs.success(klageService.kanOppretteRevurdering(fagsakId))
     }
 
-    @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage/")
+    @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage")
     fun opprettRevurderingKlage(
         @PathVariable fagsakId: Long,
     ): Ressurs<OpprettRevurderingResponse> {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._
I test av klageløsningen har Viktor og jeg oppdaget at funksjonalitet for å opprette revurdering med årsak klage ikke funker som det skal. Får feilmeldingen at man ikke finner endepunktet. Vi tror det er pga en skråstrek for mye. Prøver å fjerne og se om funksjonaliteten funker som ønsket.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
