### PR TITLE
NAV-23449: Refaktorer logikk for hjemler til en egen pakke. Forenkler logikken og skriver enhetstester.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -16,6 +16,9 @@ class FeatureToggleConfig {
         // NAV-22995
         const val SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD = "familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd"
 
+        // NAV-23449 - Skrud av/på ny refaktorert logikk for hjemler i brev, skal i teorien produsere det samme resultatet
+        const val BRUK_OMSKRIVING_AV_HJEMLER_I_BREV = "familie-ba-sak.bruk_omskriving_av_hjemler_i_brev"
+
         // satsendring
         // Oppretter satsendring-tasker for de som ikke har fått ny task
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen883Hjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen883Hjemler.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
+
+fun utledEØSForordningen883Hjemler(
+    sanityEøsBegrunnelser: List<SanityEØSBegrunnelse>,
+) = sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen883 }.distinct()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen987Hjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen987Hjemler.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
+
+fun utledEØSForordningen987Hjemler(
+    sanityEøsBegrunnelser: List<SanityEØSBegrunnelse>,
+    refusjonEøsHjemmelSkalMedIBrev: Boolean,
+): List<String> {
+    val hjemler = mutableListOf<String>()
+
+    hjemler.addAll(sanityEøsBegrunnelser.flatMap { it.hjemlerEØSForordningen987 })
+
+    if (refusjonEøsHjemmelSkalMedIBrev) {
+        hjemler.add("60")
+    }
+
+    return hjemler.distinct()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/FolketrygdlovenHjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/FolketrygdlovenHjemler.kt
@@ -1,0 +1,13 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
+
+fun utledFolketrygdlovenHjemler(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    sanityEøsBegrunnelser: List<SanityEØSBegrunnelse>,
+): List<String> {
+    val hjemlerFolketrygdloven = sanityBegrunnelser.flatMap { it.hjemlerFolketrygdloven }
+    val hjemlerFolketrygdlovenEøs = sanityEøsBegrunnelser.flatMap { it.hjemlerFolketrygdloven }
+    return (hjemlerFolketrygdloven + hjemlerFolketrygdlovenEøs).distinct()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/ForvaltningsloverHjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/ForvaltningsloverHjemler.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+fun utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev: Boolean): List<String> =
+    if (vedtakKorrigertHjemmelSkalMedIBrev) {
+        listOf("35")
+    } else {
+        emptyList()
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemlerKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemlerKombinator.kt
@@ -1,0 +1,101 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.Utils
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+
+fun kombinerHjemler(
+    målform: Målform,
+    separasjonsavtaleStorbritanniaHjemler: List<String>,
+    ordinæreHjemler: List<String>,
+    folketrygdlovenHjemler: List<String>,
+    eøsForordningen883Hjemler: List<String>,
+    eøsForordningen987Hjemler: List<String>,
+    forvaltningslovenHjemler: List<String>,
+): List<String> {
+    val alleHjemlerForBegrunnelser = mutableListOf<String>()
+
+    // Rekkefølgen her er viktig
+    if (separasjonsavtaleStorbritanniaHjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+                when (målform) {
+                    Målform.NB -> "Separasjonsavtalen mellom Storbritannia og Norge artikkel"
+                    Målform.NN -> "Separasjonsavtalen mellom Storbritannia og Noreg artikkel"
+                }
+            } ${
+                Utils.slåSammen(
+                    separasjonsavtaleStorbritanniaHjemler,
+                )
+            }",
+        )
+    }
+
+    if (ordinæreHjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+                when (målform) {
+                    Målform.NB -> "barnetrygdloven"
+                    Målform.NN -> "barnetrygdlova"
+                }
+            } ${
+                hjemlerTilHjemmeltekst(
+                    hjemler = ordinæreHjemler,
+                    lovForHjemmel = "barnetrygdloven",
+                )
+            }",
+        )
+    }
+
+    if (folketrygdlovenHjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+                when (målform) {
+                    Målform.NB -> "folketrygdloven"
+                    Målform.NN -> "folketrygdlova"
+                }
+            } ${
+                hjemlerTilHjemmeltekst(
+                    hjemler = folketrygdlovenHjemler,
+                    lovForHjemmel = "folketrygdloven",
+                )
+            }",
+        )
+    }
+
+    if (eøsForordningen883Hjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add("EØS-forordning 883/2004 artikkel ${Utils.slåSammen(eøsForordningen883Hjemler)}")
+    }
+
+    if (eøsForordningen987Hjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add("EØS-forordning 987/2009 artikkel ${Utils.slåSammen(eøsForordningen987Hjemler)}")
+    }
+
+    if (forvaltningslovenHjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+                when (målform) {
+                    Målform.NB -> "forvaltningsloven"
+                    Målform.NN -> "forvaltningslova"
+                }
+            } ${
+                hjemlerTilHjemmeltekst(
+                    hjemler = forvaltningslovenHjemler,
+                    lovForHjemmel = "forvaltningsloven",
+                )
+            }",
+        )
+    }
+
+    return alleHjemlerForBegrunnelser
+}
+
+private fun hjemlerTilHjemmeltekst(
+    hjemler: List<String>,
+    lovForHjemmel: String,
+): String =
+    when (hjemler.size) {
+        0 -> throw Feil("Kan ikke lage hjemmeltekst for $lovForHjemmel når ingen begrunnelser har hjemler fra $lovForHjemmel knyttet til seg.")
+        1 -> "§ ${hjemler[0]}"
+        else -> "§§ ${Utils.slåSammen(hjemler)}"
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemmeltekstUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemmeltekstUtleder.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
+import no.nav.familie.ba.sak.kjerne.brev.slåSammen
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.refusjonEøs.RefusjonEøsService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import org.springframework.stereotype.Component
+
+@Component
+class HjemmeltekstUtleder(
+    private val vilkårsvurderingService: VilkårsvurderingService,
+    private val sanityService: SanityService,
+    private val persongrunnlagService: PersongrunnlagService,
+    private val refusjonEøsService: RefusjonEøsService,
+) {
+    fun utledHjemmeltekst(
+        behandlingId: Long,
+        vedtakKorrigertHjemmelSkalMedIBrev: Boolean,
+        sorterteVedtaksperioderMedBegrunnelser: List<VedtaksperiodeMedBegrunnelser>,
+    ): String {
+        val vilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandlingId)
+        if (vilkårsvurdering == null) {
+            throw IllegalStateException("Finner ikke vilkårsvurdering ved begrunning av vedtak")
+        }
+
+        val begrunnelseTilSanityBegrunnelse = sanityService.hentSanityBegrunnelser()
+        val eøsBegrunnelseTilSanityEøsBegrunnelse = sanityService.hentSanityEØSBegrunnelser()
+
+        val sanitybegrunnelser =
+            sorterteVedtaksperioderMedBegrunnelser.flatMap { vedtaksperiode ->
+                vedtaksperiode.begrunnelser.mapNotNull { begrunnelse ->
+                    begrunnelseTilSanityBegrunnelse[begrunnelse.standardbegrunnelse]
+                }
+            }
+
+        val sanityEøsBegrunnelser =
+            sorterteVedtaksperioderMedBegrunnelser.flatMap { vedtaksperiode ->
+                vedtaksperiode.eøsBegrunnelser.mapNotNull { eøsBegrunnelse ->
+                    eøsBegrunnelseTilSanityEøsBegrunnelse[eøsBegrunnelse.begrunnelse]
+                }
+            }
+
+        val alleHjemlerForBegrunnelser =
+            kombinerHjemler(
+                målform = persongrunnlagService.hentSøkersMålform(behandlingId = behandlingId),
+                separasjonsavtaleStorbritanniaHjemler = utledSeprasjonsavtaleStorbritanniaHjemler(sanityEøsBegrunnelser = sanityEøsBegrunnelser),
+                ordinæreHjemler =
+                    utledOrdinæreHjemler(
+                        sanityBegrunnelser = sanitybegrunnelser,
+                        sanityEøsBegrunnelser = sanityEøsBegrunnelser,
+                        opplysningspliktHjemlerSkalMedIBrev = !vilkårsvurdering.erOpplysningspliktVilkårOppfylt(),
+                        finnesVedtaksperiodeMedFritekst = sorterteVedtaksperioderMedBegrunnelser.any { it.fritekster.isNotEmpty() },
+                    ),
+                folketrygdlovenHjemler = utledFolketrygdlovenHjemler(sanityBegrunnelser = sanitybegrunnelser, sanityEøsBegrunnelser = sanityEøsBegrunnelser),
+                eøsForordningen883Hjemler = utledEØSForordningen883Hjemler(sanityEøsBegrunnelser = sanityEøsBegrunnelser),
+                eøsForordningen987Hjemler = utledEØSForordningen987Hjemler(sanityEøsBegrunnelser = sanityEøsBegrunnelser, refusjonEøsHjemmelSkalMedIBrev = refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId)),
+                forvaltningslovenHjemler = utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev = vedtakKorrigertHjemmelSkalMedIBrev),
+            )
+
+        return slåSammenHjemlerAvUlikeTyper(alleHjemlerForBegrunnelser)
+    }
+}
+
+private fun slåSammenHjemlerAvUlikeTyper(hjemler: List<String>) =
+    when (hjemler.size) {
+        0 -> throw FunksjonellFeil("Ingen hjemler var knyttet til begrunnelsen(e) som er valgt. Du må velge minst én begrunnelse som er knyttet til en hjemmel.")
+        1 -> hjemler.single()
+        else -> hjemler.slåSammen()
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/OrdinæreHjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/OrdinæreHjemler.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.hjemlerTilhørendeFritekst
+
+fun utledOrdinæreHjemler(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    sanityEøsBegrunnelser: List<SanityEØSBegrunnelse>,
+    opplysningspliktHjemlerSkalMedIBrev: Boolean,
+    finnesVedtaksperiodeMedFritekst: Boolean,
+): List<String> {
+    val ordinæreHjemler = mutableSetOf<String>()
+    ordinæreHjemler.addAll(sanityBegrunnelser.flatMap { it.hjemler })
+    ordinæreHjemler.addAll(sanityEøsBegrunnelser.flatMap { it.hjemler })
+
+    if (opplysningspliktHjemlerSkalMedIBrev) {
+        val hjemlerNårOpplysningspliktIkkeOppfylt = listOf("17", "18")
+        ordinæreHjemler.addAll(hjemlerNårOpplysningspliktIkkeOppfylt)
+    }
+
+    if (finnesVedtaksperiodeMedFritekst) {
+        ordinæreHjemler.addAll(hjemlerTilhørendeFritekst.map { it.toString() })
+    }
+
+    return ordinæreHjemler
+        .map { it.toInt() }
+        .sorted()
+        .map { it.toString() }
+        .distinct()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemler.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityEØSBegrunnelse
+
+fun utledSeprasjonsavtaleStorbritanniaHjemler(sanityEøsBegrunnelser: List<SanityEØSBegrunnelse>) =
+    sanityEøsBegrunnelser
+        .flatMap { it.hjemlerSeperasjonsavtalenStorbritannina }
+        .distinct()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsService.kt
@@ -76,4 +76,6 @@ class RefusjonEøsService(
         refusjonEøs.land = restRefusjonEøs.land
         refusjonEøs.refusjonAvklart = restRefusjonEøs.refusjonAvklart
     }
+
+    fun harRefusjonEøsPåBehandling(behandlingId: Long): Boolean = refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId).isNotEmpty()
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/Vilkårsvurdering.kt
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import no.nav.familie.ba.sak.common.BaseEntitet
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
@@ -83,6 +84,15 @@ data class Vilkårsvurdering(
             .single { it.erSøkersResultater() }
             .andreVurderinger
             .singleOrNull { it.type == AnnenVurderingType.OPPLYSNINGSPLIKT }
+
+    fun erOpplysningspliktVilkårOppfylt(): Boolean {
+        val opplysningspliktVilkår =
+            personResultater
+                .single { it.erSøkersResultater() }
+                .andreVurderinger
+                .singleOrNull { it.type == AnnenVurderingType.OPPLYSNINGSPLIKT }
+        return opplysningspliktVilkår?.resultat == Resultat.OPPFYLT
+    }
 
     fun hentPersonResultaterTil(aktørId: String): List<VilkårResultat> =
         personResultater.find { it.aktør.aktørId == aktørId }?.vilkårResultater?.toList()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -81,6 +81,7 @@ import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.steg.domene.JournalførVedtaksbrevDTO
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
@@ -88,6 +89,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksbegrunnelseFritekst
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.refusjonEøs.RefusjonEøs
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Utbetalingsperiode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.UtbetalingsperiodeDetalj
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
@@ -710,6 +712,108 @@ fun vurderVilkårsvurderingTilInnvilget(
         }
     }
 }
+
+fun lagVilkårsvurdering(
+    id: Long = 0L,
+    behandling: Behandling = lagBehandling(),
+    aktiv: Boolean = true,
+    lagPersonResultater: (vilkårsvurdering: Vilkårsvurdering) -> Set<PersonResultat> = {
+        setOf(
+            lagPersonResultat(
+                vilkårsvurdering = it,
+                aktør = behandling.fagsak.aktør,
+            ),
+        )
+    },
+): Vilkårsvurdering {
+    val vilkårsvurdering =
+        Vilkårsvurdering(
+            id = id,
+            behandling = behandling,
+            aktiv = aktiv,
+        )
+    vilkårsvurdering.personResultater = lagPersonResultater(vilkårsvurdering)
+    return vilkårsvurdering
+}
+
+fun lagPersonResultat(
+    id: Long = 0L,
+    vilkårsvurdering: Vilkårsvurdering,
+    aktør: Aktør = randomAktør(),
+    lagVilkårResultater: (personResultat: PersonResultat) -> Set<VilkårResultat> = {
+        setOf(
+            lagVilkårResultat(
+                behandlingId = vilkårsvurdering.behandling.id,
+                personResultat = it,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = LocalDate.now().minusMonths(1),
+                periodeTom = LocalDate.now().plusYears(2),
+                begrunnelse = "",
+            ),
+            lagVilkårResultat(
+                behandlingId = vilkårsvurdering.behandling.id,
+                personResultat = it,
+                vilkårType = Vilkår.LOVLIG_OPPHOLD,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = LocalDate.now().minusMonths(1),
+                periodeTom = LocalDate.now().plusYears(2),
+                begrunnelse = "",
+            ),
+        )
+    },
+    lagAnnenVurderinger: (personResultat: PersonResultat) -> Set<AnnenVurdering> = {
+        setOf(
+            lagAnnenVurdering(
+                personResultat = it,
+            ),
+        )
+    },
+): PersonResultat {
+    val personResultat =
+        PersonResultat(
+            id = id,
+            vilkårsvurdering = vilkårsvurdering,
+            aktør = aktør,
+        )
+    personResultat.setSortedVilkårResultater(lagVilkårResultater(personResultat))
+    personResultat.andreVurderinger.addAll(lagAnnenVurderinger(personResultat))
+    return personResultat
+}
+
+fun lagAnnenVurdering(
+    id: Long = 0L,
+    personResultat: PersonResultat,
+    resultat: Resultat = Resultat.OPPFYLT,
+    type: AnnenVurderingType = AnnenVurderingType.OPPLYSNINGSPLIKT,
+    begrunnelse: String? = null,
+): AnnenVurdering =
+    AnnenVurdering(
+        id = id,
+        personResultat = personResultat,
+        resultat = resultat,
+        type = type,
+        begrunnelse = begrunnelse,
+    )
+
+fun lagRefusjonEøs(
+    behandlingId: Long = 0L,
+    fom: LocalDate = LocalDate.now().minusMonths(1),
+    tom: LocalDate = LocalDate.now().plusMonths(1),
+    refusjonsbeløp: Int = 0,
+    land: String = "NO",
+    refusjonAvklart: Boolean = true,
+    id: Long = 0L,
+): RefusjonEøs =
+    RefusjonEøs(
+        behandlingId = behandlingId,
+        fom = fom,
+        tom = tom,
+        refusjonsbeløp = refusjonsbeløp,
+        land = land,
+        refusjonAvklart = refusjonAvklart,
+        id = id,
+    )
 
 fun lagVilkårsvurdering(
     søkerAktør: Aktør,
@@ -1498,3 +1602,14 @@ fun lagBrevmottakerDb(
 )
 
 val Number.årSiden: LocalDate get() = LocalDate.now().minusYears(this.toLong())
+
+fun lagEØSBegrunnelse(
+    id: Long = 0L,
+    vedtaksperiodeMedBegrunnelser: VedtaksperiodeMedBegrunnelser = lagVedtaksperiodeMedBegrunnelser(),
+    begrunnelse: EØSStandardbegrunnelse,
+): EØSBegrunnelse =
+    EØSBegrunnelse(
+        id = id,
+        vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+        begrunnelse = begrunnelse,
+    )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -5,14 +5,15 @@ import io.mockk.mockk
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.common.lagBehandling
-import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.brev.hjemler.HjemmeltekstUtleder
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
+import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -25,10 +26,11 @@ import java.time.YearMonth
 class BrevServiceTest {
     val saksbehandlerContext = mockk<SaksbehandlerContext>()
     val brevmalService = mockk<BrevmalService>()
-    val unleashService = mockk<UnleashNextMedContextService>()
+    val unleashService = mockk<UnleashService>()
     val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
     val vedtaksperiodeService = mockk<VedtaksperiodeService>()
     val endretUtbetalingAndelRepository = mockk<EndretUtbetalingAndelRepository>()
+    val hjemmeltekstUtleder = mockk<HjemmeltekstUtleder>()
 
     val brevService =
         BrevService(
@@ -52,12 +54,15 @@ class BrevServiceTest {
             valutakursRepository = mockk(),
             kompetanseRepository = mockk(),
             endretUtbetalingAndelRepository = endretUtbetalingAndelRepository,
+            hjemmeltekstUtleder = hjemmeltekstUtleder,
+            unleashService = unleashService,
         )
 
     @BeforeEach
     fun setUp() {
         every { saksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "saksbehandlerNavn"
         every { unleashService.isEnabled(any()) } returns true
+        every { hjemmeltekstUtleder.utledHjemmeltekst(any(), any(), any()) } returns "Hjemmel 1, 2, 3"
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen883HjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen883HjemlerKtTest.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.common.lagSanityEøsBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EØSForordningen883HjemlerKtTest {
+    @Test
+    fun `skal returnere en tom liste om input er en tom liste`() {
+        // Act
+        val eøsForordningen883Hjemler = utledEØSForordningen883Hjemler(sanityEøsBegrunnelser = emptyList())
+
+        // Assert
+        assertThat(eøsForordningen883Hjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal utlede EØS forordningen 883 hjemler`() {
+        // Arrange
+        val sanityEøsBegrunnelse1 =
+            lagSanityEøsBegrunnelse(
+                hjemlerEØSForordningen883 = listOf("6", "4", "3"),
+            )
+
+        val sanityEøsBegrunnelse2 =
+            lagSanityEøsBegrunnelse(
+                hjemlerEØSForordningen883 = listOf("2", "1", "6"),
+            )
+
+        val sanityEøsBegrunnelser = listOf(sanityEøsBegrunnelse1, sanityEøsBegrunnelse2)
+
+        // Act
+        val eøsForordningen883Hjemler = utledEØSForordningen883Hjemler(sanityEøsBegrunnelser = sanityEøsBegrunnelser)
+
+        // Assert
+        assertThat(eøsForordningen883Hjemler).containsOnly("6", "4", "3", "2", "1")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen987HjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/EØSForordningen987HjemlerKtTest.kt
@@ -1,0 +1,91 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.common.lagSanityEøsBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EØSForordningen987HjemlerKtTest {
+    @Test
+    fun `skal retunere en tom liste om sanity EØS begrunnelsene er en tom liste og refusjon EØS hjemmel ikke skal være med i brevet`() {
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityEøsBegrunnelser = emptyList(),
+                refusjonEøsHjemmelSkalMedIBrev = false,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).isEmpty()
+    }
+
+    @Test
+    fun `skal retunere liste med refusjon EØS hjemmel som eneste innslag da sanity EØS begrunnelser er en tom liste`() {
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityEøsBegrunnelser = emptyList(),
+                refusjonEøsHjemmelSkalMedIBrev = true,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).containsOnly("60")
+    }
+
+    @Test
+    fun `skal retunere en liste av hjemler uten refusjon EØS hjemmel `() {
+        // Arrange
+        val sanityEøsBegrunnelse1 =
+            lagSanityEøsBegrunnelse(
+                hjemlerEØSForordningen987 = listOf("1", "3", "5"),
+            )
+        val sanityEøsBegrunnelse2 =
+            lagSanityEøsBegrunnelse(
+                hjemlerEØSForordningen987 = listOf("4", "3", "6"),
+            )
+
+        val sanityEøsBegrunnelser =
+            listOf(
+                sanityEøsBegrunnelse1,
+                sanityEøsBegrunnelse2,
+            )
+
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityEøsBegrunnelser = sanityEøsBegrunnelser,
+                refusjonEøsHjemmelSkalMedIBrev = false,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).containsOnly("1", "3", "5", "4", "6")
+    }
+
+    @Test
+    fun `skal retunere en liste av hjemler med refusjon EØS hjemmel `() {
+        // Arrange
+        val sanityEøsBegrunnelse1 =
+            lagSanityEøsBegrunnelse(
+                hjemlerEØSForordningen987 = listOf("1", "3", "5"),
+            )
+        val sanityEøsBegrunnelse2 =
+            lagSanityEøsBegrunnelse(
+                hjemlerEØSForordningen987 = listOf("4", "3", "6"),
+            )
+
+        val sanityEøsBegrunnelser =
+            listOf(
+                sanityEøsBegrunnelse1,
+                sanityEøsBegrunnelse2,
+            )
+
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityEøsBegrunnelser = sanityEøsBegrunnelser,
+                refusjonEøsHjemmelSkalMedIBrev = true,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).containsOnly("1", "3", "5", "4", "6", "60")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/FolketrygdlovenHjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/FolketrygdlovenHjemlerKtTest.kt
@@ -1,0 +1,127 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.common.lagSanityBegrunnelse
+import no.nav.familie.ba.sak.common.lagSanityEøsBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FolketrygdlovenHjemlerKtTest {
+    @Test
+    fun `skal returnere en tom liste om både eøs og standard sanity begrunnelser er tom`() {
+        // Act
+        val folketrygdlovenHjemler =
+            utledFolketrygdlovenHjemler(
+                sanityBegrunnelser = emptyList(),
+                sanityEøsBegrunnelser = emptyList(),
+            )
+
+        // Assert
+        assertThat(folketrygdlovenHjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal returnere en liste med hjemler for folketrygdelove uten EØS om kun sanity begrunnelser ikke er tom`() {
+        // Arrange
+        val sanityBegrunnelse1 =
+            lagSanityBegrunnelse(
+                hjemlerFolketrygdloven = listOf("1", "4"),
+            )
+
+        val sanityBegrunnelse2 =
+            lagSanityBegrunnelse(
+                hjemlerFolketrygdloven = listOf("4", "3"),
+            )
+
+        val sanityBegrunnelser =
+            listOf(
+                sanityBegrunnelse1,
+                sanityBegrunnelse2,
+            )
+
+        // Act
+        val folketrygdlovenHjemler =
+            utledFolketrygdlovenHjemler(
+                sanityBegrunnelser = sanityBegrunnelser,
+                sanityEøsBegrunnelser = emptyList(),
+            )
+
+        // Assert
+        assertThat(folketrygdlovenHjemler).containsOnly("1", "4", "3")
+    }
+
+    @Test
+    fun `skal returnere en liste med hjemler for folketrygdelove kun for EØS om kun sanity EØS begrunnelser ikke er tom`() {
+        // Arrange
+        val sanityEøsBegrunnelse1 =
+            lagSanityEøsBegrunnelse(
+                hjemlerFolketrygdloven = listOf("1", "6"),
+            )
+
+        val sanityEøsBegrunnelse2 =
+            lagSanityEøsBegrunnelse(
+                hjemlerFolketrygdloven = listOf("6", "3"),
+            )
+
+        val sanityEøsBegrunnelser =
+            listOf(
+                sanityEøsBegrunnelse1,
+                sanityEøsBegrunnelse2,
+            )
+
+        // Act
+        val folketrygdlovenHjemler =
+            utledFolketrygdlovenHjemler(
+                sanityBegrunnelser = emptyList(),
+                sanityEøsBegrunnelser = sanityEøsBegrunnelser,
+            )
+
+        // Assert
+        assertThat(folketrygdlovenHjemler).containsOnly("1", "6", "3")
+    }
+
+    @Test
+    fun `skal returnere en liste med hjemler for folketrygdelove inkludert de for EØS`() {
+        // Arrange
+        val sanityBegrunnelse1 =
+            lagSanityBegrunnelse(
+                hjemlerFolketrygdloven = listOf("1", "4"),
+            )
+
+        val sanityBegrunnelse2 =
+            lagSanityBegrunnelse(
+                hjemlerFolketrygdloven = listOf("4", "3"),
+            )
+
+        val sanityBegrunnelser =
+            listOf(
+                sanityBegrunnelse1,
+                sanityBegrunnelse2,
+            )
+
+        val sanityEøsBegrunnelse1 =
+            lagSanityEøsBegrunnelse(
+                hjemlerFolketrygdloven = listOf("1", "6"),
+            )
+
+        val sanityEøsBegrunnelse2 =
+            lagSanityEøsBegrunnelse(
+                hjemlerFolketrygdloven = listOf("6", "3"),
+            )
+
+        val sanityEøsBegrunnelser =
+            listOf(
+                sanityEøsBegrunnelse1,
+                sanityEøsBegrunnelse2,
+            )
+
+        // Act
+        val folketrygdlovenHjemler =
+            utledFolketrygdlovenHjemler(
+                sanityBegrunnelser = sanityBegrunnelser,
+                sanityEøsBegrunnelser = sanityEøsBegrunnelser,
+            )
+
+        // Assert
+        assertThat(folketrygdlovenHjemler).containsOnly("1", "4", "6", "3")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/ForvaltningsloverHjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/ForvaltningsloverHjemlerKtTest.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ForvaltningsloverHjemlerKtTest {
+    @Test
+    fun `skal utlede forvaltningslover hjemler om vedtak korrigert hjemmel skal med i brev`() {
+        // Act
+        val forvaltningsloverHjemler = utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev = true)
+
+        // Assert
+        assertThat(forvaltningsloverHjemler).containsOnly("35")
+    }
+
+    @Test
+    fun `skal utlede forvaltningslover hjemler om vedtak korrigert hjemmel ikke skal med i brev`() {
+        // Act
+        val forvaltningsloverHjemler = utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev = false)
+
+        // Assert
+        assertThat(forvaltningsloverHjemler).isEmpty()
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemlerKombinatorKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemlerKombinatorKtTest.kt
@@ -1,0 +1,343 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class HjemlerKombinatorKtTest {
+    @Test
+    fun `skal retunere en tom liste om ingen hjemler blir sendt inn for kombinering`() {
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal kombinere hjemler kun separasjonsavtale storbritannia på bokmål`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("Separasjonsavtalen mellom Storbritannia og Norge artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere hjemler kun separasjonsavtale storbritannia på nynorsk`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun ordinære hjemler på bokmål`() {
+        // Arrange
+        val ordinæreHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = ordinæreHjemler,
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("barnetrygdloven §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun ordinære hjemler på nynorsk`() {
+        // Arrange
+        val ordinæreHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = ordinæreHjemler,
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("barnetrygdlova §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun folketrygdloven hjemler på bokmål`() {
+        // Arrange
+        val folketrygdlovenHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = folketrygdlovenHjemler,
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("folketrygdloven §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun folketrygdloven hjemler på nynorsk`() {
+        // Arrange
+        val folketrygdlovenHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = folketrygdlovenHjemler,
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("folketrygdlova §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 883 hjemler på bokmål`() {
+        // Arrange
+        val eøsForordningen883Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 883/2004 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 883 hjemler på nynorsk`() {
+        // Arrange
+        val eøsForordningen883Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 883/2004 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 987 hjemler på bokmål`() {
+        // Arrange
+        val eøsForordningen987Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 987/2009 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 987 hjemler på nynorsk`() {
+        // Arrange
+        val eøsForordningen987Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 987/2009 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun forvaltningsloven hjemler på bokmål`() {
+        // Arrange
+        val forvaltningslovenHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("forvaltningsloven §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun forvaltningsloven hjemler på nynorsk`() {
+        // Arrange
+        val forvaltningslovenHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                folketrygdlovenHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("forvaltningslova §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere alle hjemler på bokmål`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "12")
+        val ordinæreHjemler = listOf("12")
+        val folketrygdlovenHjemler = listOf("3154", "8", "6")
+        val eøsForordningen883Hjemler = listOf("6")
+        val eøsForordningen987Hjemler = listOf("9000")
+        val forvaltningslovenHjemler = listOf("1337", "322", "644")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = ordinæreHjemler,
+                folketrygdlovenHjemler = folketrygdlovenHjemler,
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsExactly(
+            "Separasjonsavtalen mellom Storbritannia og Norge artikkel 1, 3 og 12",
+            "barnetrygdloven § 12",
+            "folketrygdloven §§ 3154, 8 og 6",
+            "EØS-forordning 883/2004 artikkel 6",
+            "EØS-forordning 987/2009 artikkel 9000",
+            "forvaltningsloven §§ 1337, 322 og 644",
+        )
+    }
+
+    @Test
+    fun `skal kombinere alle hjemler på nynorsk`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "12")
+        val ordinæreHjemler = listOf("12")
+        val folketrygdlovenHjemler = listOf("3154", "8", "6")
+        val eøsForordningen883Hjemler = listOf("6")
+        val eøsForordningen987Hjemler = listOf("9000")
+        val forvaltningslovenHjemler = listOf("1337", "322", "644")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = ordinæreHjemler,
+                folketrygdlovenHjemler = folketrygdlovenHjemler,
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsExactly(
+            "Separasjonsavtalen mellom Storbritannia og Noreg artikkel 1, 3 og 12",
+            "barnetrygdlova § 12",
+            "folketrygdlova §§ 3154, 8 og 6",
+            "EØS-forordning 883/2004 artikkel 6",
+            "EØS-forordning 987/2009 artikkel 9000",
+            "forvaltningslova §§ 1337, 322 og 644",
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemmeltekstUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/HjemmeltekstUtlederTest.kt
@@ -1,0 +1,1156 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagEØSBegrunnelse
+import no.nav.familie.ba.sak.common.lagSanityBegrunnelse
+import no.nav.familie.ba.sak.common.lagSanityEøsBegrunnelse
+import no.nav.familie.ba.sak.common.lagVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.datagenerator.vedtak.lagVedtaksbegrunnelse
+import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksbegrunnelseFritekst
+import no.nav.familie.ba.sak.kjerne.vedtak.refusjonEøs.RefusjonEøsService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class HjemmeltekstUtlederTest {
+    private val vilkårsvurderingService = mockk<VilkårsvurderingService>()
+    private val persongrunnlagService = mockk<PersongrunnlagService>()
+    private val refusjonEøsService = mockk<RefusjonEøsService>()
+    private val sanityService = mockk<SanityService>()
+    private val hjemmeltekstUtleder: HjemmeltekstUtleder =
+        HjemmeltekstUtleder(
+            vilkårsvurderingService = vilkårsvurderingService,
+            sanityService = sanityService,
+            persongrunnlagService = persongrunnlagService,
+            refusjonEøsService = refusjonEøsService,
+        )
+
+    @Test
+    fun `skal kaste exception hvis vilkårsvurdering ikke blir funnet`() {
+        // Arrange
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(1L)
+        } returns null
+
+        // Act & assert
+        val exception =
+            assertThrows<IllegalStateException> {
+                hjemmeltekstUtleder.utledHjemmeltekst(
+                    behandlingId = 1L,
+                    vedtakKorrigertHjemmelSkalMedIBrev = false,
+                    sorterteVedtaksperioderMedBegrunnelser = emptyList(),
+                )
+            }
+        assertThat(exception.message).isEqualTo("Finner ikke vilkårsvurdering ved begrunning av vedtak")
+    }
+
+    @Test
+    fun `skal returnere sorterte hjemler`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                                vedtaksperiodeMedBegrunnelser = lagVedtaksperiodeMedBegrunnelser(),
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                                vedtaksperiodeMedBegrunnelser = lagVedtaksperiodeMedBegrunnelser(),
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4", "2", "10"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns emptyMap()
+
+        // Act
+        val hentHjemmeltekst =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat("barnetrygdloven §§ 2, 4, 10 og 11").isEqualTo(hentHjemmeltekst)
+    }
+
+    @Test
+    fun `skal ikke inkludere hjemmel 17 og 18 hvis opplysningsplikt er oppfylt`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4", "2", "10"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns emptyMap()
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("barnetrygdloven §§ 2, 4, 10 og 11")
+    }
+
+    @Test
+    fun `skal inkludere hjemmel for fritekst`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperiodeMedBegrunnelser =
+            lagVedtaksperiodeMedBegrunnelser(
+                begrunnelser =
+                    mutableSetOf(
+                        lagVedtaksbegrunnelse(
+                            standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                        ),
+                    ),
+            )
+
+        vedtaksperiodeMedBegrunnelser.fritekster.add(
+            VedtaksbegrunnelseFritekst(
+                fritekst = "Dette er en fritekst",
+                vedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelser,
+            ),
+        )
+
+        val vedtaksperioderMedBegrunnelser = listOf(vedtaksperiodeMedBegrunnelser)
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns emptyMap()
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("barnetrygdloven §§ 2, 4, 10 og 11")
+    }
+
+    @Test
+    fun `skal inkludere hjemmel 17 og 18 hvis opplysningsplikt ikke er oppfylt`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.IKKE_OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4", "2", "10"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns emptyMap()
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("barnetrygdloven §§ 2, 4, 10, 11, 17 og 18")
+    }
+
+    @Test
+    fun `skal inkludere EØS-forordning 987 artikkel 60 hvis det eksisterer eøs refusjon på behandlingen`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns true
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns emptyMap()
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns emptyMap()
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = emptyList(),
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("EØS-forordning 987/2009 artikkel 60")
+    }
+
+    @Test
+    fun `skal gi riktig hjemmeltekst ved hjemler både fra barnetrygdloven og folketrygdloven`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SØKER_OG_BARN_FRIVILLIG_MEDLEM,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_SØKER_OG_BARN_FRIVILLIG_MEDLEM to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SØKER_OG_BARN_FRIVILLIG_MEDLEM.sanityApiNavn,
+                        hjemler = listOf("11", "4"),
+                        hjemlerFolketrygdloven = listOf("2-5", "2-8"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns emptyMap()
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("barnetrygdloven §§ 4, 10 og 11 og folketrygdloven §§ 2-5 og 2-8")
+    }
+
+    @Test
+    fun `skal gi riktig formattering ved hjemler fra barnetrygdloven og 2 EØS-forordninger`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns
+            mapOf(
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                        hjemler = listOf("4"),
+                        hjemlerEØSForordningen883 = listOf("11-16"),
+                    ),
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                        hjemler = listOf("11"),
+                        hjemlerEØSForordningen987 = listOf("58", "60"),
+                    ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("barnetrygdloven §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 11-16 og EØS-forordning 987/2009 artikkel 58 og 60")
+    }
+
+    @Test
+    fun `skal gi riktig formattering ved hjemler fra Separasjonsavtale og to EØS-forordninger`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns
+            mapOf(
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                        hjemler = listOf("4"),
+                        hjemlerEØSForordningen883 = listOf("11-16"),
+                        hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                    ),
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                        hjemler = listOf("11"),
+                        hjemlerEØSForordningen987 = listOf("58", "60"),
+                    ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Arrange
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Norge artikkel 29, barnetrygdloven §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 11-16 og EØS-forordning 987/2009 artikkel 58 og 60")
+    }
+
+    @Test
+    fun `skal gi riktig formattering ved nynorsk og hjemler fra Separasjonsavtale og to EØS-forordninger`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns
+            mapOf(
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                        hjemler = listOf("4"),
+                        hjemlerEØSForordningen883 = listOf("11-16"),
+                        hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                    ),
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                        hjemler = listOf("11"),
+                        hjemlerEØSForordningen987 = listOf("58", "60"),
+                    ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, barnetrygdlova §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 11-16 og EØS-forordning 987/2009 artikkel 58 og 60")
+    }
+
+    @Test
+    fun `skal slå sammen hjemlene riktig når det er 3 eller flere hjemler på 'siste' hjemmeltype`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns
+            mapOf(
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                        hjemler = listOf("4"),
+                        hjemlerEØSForordningen883 = listOf("2", "11-16", "67", "68"),
+                        hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                    ),
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                        hjemler = listOf("11"),
+                    ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, barnetrygdlova §§ 4, 10 og 11 og EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68")
+    }
+
+    @Test
+    fun `skal kun ta med en hjemmel 1 gang hvis flere begrunnelser er knyttet til samme hjemmel`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_SATSENDRING,
+                            ),
+                        ),
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            EØSBegrunnelse(
+                                vedtaksperiodeMedBegrunnelser = mockk(),
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4"),
+                    ),
+                Standardbegrunnelse.INNVILGET_SATSENDRING to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                        hjemler = listOf("10"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns
+            mapOf(
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                        hjemler = listOf("4"),
+                        hjemlerEØSForordningen883 = listOf("2", "11-16", "67", "68"),
+                        hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                        hjemlerEØSForordningen987 = listOf("58"),
+                    ),
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                        hjemler = listOf("11"),
+                        hjemlerEØSForordningen883 = listOf("2", "67", "68"),
+                        hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                        hjemlerEØSForordningen987 = listOf("58"),
+                    ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, barnetrygdlova §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68 og EØS-forordning 987/2009 artikkel 58")
+    }
+
+    @Test
+    fun `skal utlede hjemmeltekst for alle hjemler på bokmål`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_MEDLEM_I_FOLKETRYGDEN,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            lagEØSBegrunnelse(
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns true
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_MEDLEM_I_FOLKETRYGDEN to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4", "2", "10"),
+                        hjemlerFolketrygdloven = listOf("644", "322"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns
+            mapOf(
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                        hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                        hjemler = listOf("1"),
+                        hjemlerFolketrygdloven = listOf("1337", "3154"),
+                        hjemlerEØSForordningen883 = listOf("2", "11-16", "67", "68"),
+                        hjemlerEØSForordningen987 = listOf("58"),
+                    ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = true,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo(
+            "Separasjonsavtalen mellom Storbritannia og Norge artikkel 29, " +
+                "barnetrygdloven §§ 1, 2, 4, 10 og 11, " +
+                "folketrygdloven §§ 644, 322, 1337 og 3154, " +
+                "EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68, " +
+                "EØS-forordning 987/2009 artikkel 58 og 60 og forvaltningsloven § 35",
+        )
+    }
+
+    @Test
+    fun `skal utlede hjemmeltekst for alle hjemler på nynorsk`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    begrunnelser =
+                        mutableSetOf(
+                            lagVedtaksbegrunnelse(
+                                standardbegrunnelse = Standardbegrunnelse.INNVILGET_MEDLEM_I_FOLKETRYGDEN,
+                            ),
+                        ),
+                ),
+                lagVedtaksperiodeMedBegrunnelser(
+                    eøsBegrunnelser =
+                        mutableSetOf(
+                            lagEØSBegrunnelse(
+                                begrunnelse = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD,
+                            ),
+                        ),
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns true
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            mapOf(
+                Standardbegrunnelse.INNVILGET_MEDLEM_I_FOLKETRYGDEN to
+                    lagSanityBegrunnelse(
+                        apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
+                        hjemler = listOf("11", "4", "2", "10"),
+                        hjemlerFolketrygdloven = listOf("644", "322"),
+                    ),
+            )
+
+        every {
+            sanityService.hentSanityEØSBegrunnelser()
+        } returns
+            mapOf(
+                EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD to
+                    lagSanityEøsBegrunnelse(
+                        apiNavn = EØSStandardbegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                        hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                        hjemler = listOf("1"),
+                        hjemlerFolketrygdloven = listOf("1337", "3154"),
+                        hjemlerEØSForordningen883 = listOf("2", "11-16", "67", "68"),
+                        hjemlerEØSForordningen987 = listOf("58"),
+                    ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = true,
+                sorterteVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo(
+            "Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, " +
+                "barnetrygdlova §§ 1, 2, 4, 10 og 11, " +
+                "folketrygdlova §§ 644, 322, 1337 og 3154, " +
+                "EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68, " +
+                "EØS-forordning 987/2009 artikkel 58 og 60 og forvaltningslova § 35",
+        )
+    }
+
+    @Test
+    fun `skal kaste exception om ingen hjemmeltekst blir utledet`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { persongrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every { sanityService.hentSanityBegrunnelser() } returns emptyMap()
+        every { sanityService.hentSanityEØSBegrunnelser() } returns emptyMap()
+
+        // Act & assert
+        val exception =
+            assertThrows<FunksjonellFeil> {
+                hjemmeltekstUtleder.utledHjemmeltekst(
+                    behandlingId = behandling.id,
+                    vedtakKorrigertHjemmelSkalMedIBrev = false,
+                    sorterteVedtaksperioderMedBegrunnelser = emptyList(),
+                )
+            }
+        assertThat(exception.message).isEqualTo(
+            "Ingen hjemler var knyttet til begrunnelsen(e) som er valgt. " +
+                "Du må velge minst én begrunnelse som er knyttet til en hjemmel.",
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/OrdinæreHjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/OrdinæreHjemlerKtTest.kt
@@ -1,0 +1,117 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.common.lagSanityBegrunnelse
+import no.nav.familie.ba.sak.common.lagSanityEøsBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OrdinæreHjemlerKtTest {
+    @Test
+    fun `skal utlede en tom liste om ingen hjemler skal inkluderes`() {
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = emptyList(),
+                sanityEøsBegrunnelser = emptyList(),
+                opplysningspliktHjemlerSkalMedIBrev = false,
+                finnesVedtaksperiodeMedFritekst = false,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal utlede ordinære hjemler for sanity begrunnelser`() {
+        // Arrange
+        val sanityBegrunnelse = lagSanityBegrunnelse(hjemler = listOf("1", "3", "2"))
+
+        val sanityBegrunnelser = listOf(sanityBegrunnelse)
+
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = sanityBegrunnelser,
+                sanityEøsBegrunnelser = emptyList(),
+                opplysningspliktHjemlerSkalMedIBrev = false,
+                finnesVedtaksperiodeMedFritekst = false,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("1", "3", "2")
+    }
+
+    @Test
+    fun `skal utlede ordinære hjemler for sanity eøs begrunnelser`() {
+        // Arrange
+        val sanityEøsBegrunnelse = lagSanityEøsBegrunnelse(hjemler = listOf("1", "3", "2"))
+
+        val sanityEøsBegrunnelser = listOf(sanityEøsBegrunnelse)
+
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = emptyList(),
+                sanityEøsBegrunnelser = sanityEøsBegrunnelser,
+                opplysningspliktHjemlerSkalMedIBrev = false,
+                finnesVedtaksperiodeMedFritekst = false,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("1", "3", "2")
+    }
+
+    @Test
+    fun `skal utlede opplysningsplikt hjemmel`() {
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = emptyList(),
+                sanityEøsBegrunnelser = emptyList(),
+                opplysningspliktHjemlerSkalMedIBrev = true,
+                finnesVedtaksperiodeMedFritekst = false,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("17", "18")
+    }
+
+    @Test
+    fun `skal utlede fritekst hjemmeler`() {
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = emptyList(),
+                sanityEøsBegrunnelser = emptyList(),
+                opplysningspliktHjemlerSkalMedIBrev = false,
+                finnesVedtaksperiodeMedFritekst = true,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("2", "4", "11")
+    }
+
+    @Test
+    fun `skal utlede alle ordinære hjemler`() {
+        // Arrange
+        val sanityBegrunnelse = lagSanityBegrunnelse(hjemler = listOf("1", "3", "2"))
+
+        val sanityBegrunnelser = listOf(sanityBegrunnelse)
+
+        val sanityEøsBegrunnelse = lagSanityEøsBegrunnelse(hjemler = listOf("1", "6", "2"))
+
+        val sanityEøsBegrunnelser = listOf(sanityEøsBegrunnelse)
+
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = sanityBegrunnelser,
+                sanityEøsBegrunnelser = sanityEøsBegrunnelser,
+                opplysningspliktHjemlerSkalMedIBrev = true,
+                finnesVedtaksperiodeMedFritekst = true,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("1", "2", "3", "4", "6", "11", "17", "18")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemlerKtTest.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.ba.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ba.sak.common.lagSanityEøsBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SeparasjonsavtaleStorbritanniaHjemlerKtTest {
+    @Test
+    fun `skal returnere en tom liste når sanity eøs begrunnelser er tom`() {
+        // Act
+        val seprasjonsavtaleStorbritanniaHjemler =
+            utledSeprasjonsavtaleStorbritanniaHjemler(
+                sanityEøsBegrunnelser = emptyList(),
+            )
+
+        // Assert
+        assertThat(seprasjonsavtaleStorbritanniaHjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal utlede seprasjonsavtale for storbritannia hjemler`() {
+        // Arrange
+        val sanityEøsBegrunnelse =
+            lagSanityEøsBegrunnelse(
+                hjemlerSeperasjonsavtalenStorbritannina = listOf("1", "4", "3", "4"),
+            )
+
+        val sanityEØSBegrunnelser = listOf(sanityEøsBegrunnelse)
+
+        // Act
+        val seprasjonsavtaleStorbritanniaHjemler =
+            utledSeprasjonsavtaleStorbritanniaHjemler(
+                sanityEøsBegrunnelser = sanityEØSBegrunnelser,
+            )
+
+        // Assert
+        assertThat(seprasjonsavtaleStorbritanniaHjemler).containsOnly("1", "4", "3")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceTest.kt
@@ -1,0 +1,56 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.refusjonEøs
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagRefusjonEøs
+import no.nav.familie.ba.sak.kjerne.logg.LoggService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RefusjonEøsServiceTest {
+    private val refusjonEøsRepository = mockk<RefusjonEøsRepository>()
+    private val loggService = mockk<LoggService>()
+
+    private val refusjonEøsService: RefusjonEøsService =
+        RefusjonEøsService(
+            refusjonEøsRepository = refusjonEøsRepository,
+            loggService = loggService,
+        )
+
+    @Nested
+    inner class HarRefusjonEøsPåBehandlingTest {
+        @Test
+        fun `skal returnere false om refusjon eøs på behandling er tom`() {
+            // Arrange
+            val behandling = lagBehandling()
+
+            every {
+                refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId = behandling.id)
+            } returns emptyList()
+
+            // Act
+            val harRefusjonEøsPåBehandling = refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id)
+
+            // Assert
+            assertThat(harRefusjonEøsPåBehandling).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om refusjon eøs på behandling ikke er tom`() {
+            // Arrange
+            val behandling = lagBehandling()
+
+            every {
+                refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId = behandling.id)
+            } returns listOf(lagRefusjonEøs())
+
+            // Act
+            val harRefusjonEøsPåBehandling = refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id)
+
+            // Assert
+            assertThat(harRefusjonEøsPåBehandling).isTrue()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårsvurderingTest.kt
@@ -1,0 +1,173 @@
+package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene
+
+import no.nav.familie.ba.sak.common.lagAnnenVurdering
+import no.nav.familie.ba.sak.common.lagPersonResultat
+import no.nav.familie.ba.sak.common.lagVilkårResultat
+import no.nav.familie.ba.sak.common.lagVilkårsvurdering
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class VilkårsvurderingTest {
+    @Nested
+    inner class ErOpplysningspliktVilkårOppfyltTest {
+        @Test
+        fun `skal exception om personresultater er tom`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultater = { emptySet() },
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<NoSuchElementException> {
+                    vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+                }
+            assertThat(exception.message).isEqualTo("Collection contains no element matching the predicate.")
+        }
+
+        @Test
+        fun `skal kaste exception om ingen vilkår er for søker`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultater = { vilkårsvurdering ->
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = vilkårsvurdering,
+                                aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagVilkårResultat(
+                                            personResultat = personResultat,
+                                            vilkårType = Vilkår.UNDER_18_ÅR,
+                                        ),
+                                    )
+                                },
+                                lagAnnenVurderinger = { emptySet() },
+                            ),
+                        )
+                    },
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<NoSuchElementException> {
+                    vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+                }
+            assertThat(exception.message).isEqualTo("Collection contains no element matching the predicate.")
+        }
+
+        @Test
+        fun `skal returnere false om annen vurdering er tom`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultater = { vilkårsvurdering ->
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = vilkårsvurdering,
+                                aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagVilkårResultat(
+                                            personResultat = personResultat,
+                                            vilkårType = Vilkår.BOR_MED_SØKER,
+                                        ),
+                                    )
+                                },
+                                lagAnnenVurderinger = { emptySet() },
+                            ),
+                        )
+                    },
+                )
+
+            // Act
+            val erOpplysningspliktVilkårOppfylt = vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+
+            // Assert
+            assertThat(erOpplysningspliktVilkårOppfylt).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om annen vurdering opplysningsplikt ikke er oppfylt`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultater = { vilkårsvurdering ->
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = vilkårsvurdering,
+                                aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagVilkårResultat(
+                                            personResultat = personResultat,
+                                            vilkårType = Vilkår.BOR_MED_SØKER,
+                                        ),
+                                    )
+                                },
+                                lagAnnenVurderinger = {
+                                    setOf(
+                                        lagAnnenVurdering(
+                                            personResultat = it,
+                                            type = AnnenVurderingType.OPPLYSNINGSPLIKT,
+                                            resultat = Resultat.IKKE_OPPFYLT,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            // Act
+            val erOpplysningspliktVilkårOppfylt = vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+
+            // Assert
+            assertThat(erOpplysningspliktVilkårOppfylt).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om annen vurdering opplysningsplikt er oppfylt`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultater = { vilkårsvurdering ->
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = vilkårsvurdering,
+                                aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagVilkårResultat(
+                                            personResultat = personResultat,
+                                            vilkårType = Vilkår.BOR_MED_SØKER,
+                                        ),
+                                    )
+                                },
+                                lagAnnenVurderinger = {
+                                    setOf(
+                                        lagAnnenVurdering(
+                                            personResultat = it,
+                                            type = AnnenVurderingType.OPPLYSNINGSPLIKT,
+                                            resultat = Resultat.OPPFYLT,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            // Act
+            val erOpplysningspliktVilkårOppfylt = vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+
+            // Assert
+            assertThat(erOpplysningspliktVilkårOppfylt).isTrue()
+        }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceIT.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceIT.kt
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.Month
 
-class RefusjonEøsServiceTest(
+class RefusjonEøsServiceIT(
     @Autowired val refusjonEøsService: RefusjonEøsService,
     @Autowired val aktørIdRepository: AktørIdRepository,
     @Autowired val fagsakRepository: FagsakRepository,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23449

Forenkler logikken ved å trekke ut hjemler i en egen pakke. Fordeler logikken ut over flere filer. Skriver enhetstester for den "nye" logikken. Den "nye" logikken skal i teorien produsere samme resultat som den forrige. Hensikten her er utelukkende å gjøre koden mer oversiktlig og lettere å teste. 

Toggle for å skru av/på refaktorert logikk slik at det kan merges uten å testes først. 

Toggle: https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ba-sak.bruk_omskriving_av_hjemler_i_brev

Når toggle fjernes kan man fjerne mye "gammel" kode. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
