### PR TITLE
Sjekk tidligere behandlinger på fagsak ved fastsettelse av behandlene enhet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -142,7 +142,6 @@ class OppgaveService(
         oppgavetype: Oppgavetype,
         fristForFerdigstillelse: LocalDate,
         beskrivelse: String,
-        enhetsnummer: String?,
     ): String {
         val opprettOppgave =
             OpprettOppgaveRequest(
@@ -153,7 +152,7 @@ class OppgaveService(
                 beskrivelse = beskrivelse,
                 saksId = null,
                 behandlingstema = null,
-                enhetsnummer = enhetsnummer,
+                enhetsnummer = null,
             )
         val opprettetOppgaveId = integrasjonClient.opprettOppgave(opprettOppgave).oppgaveId.toString()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -84,9 +84,13 @@ class ArbeidsfordelingService(
 
         val oppdatertArbeidsfordelingPåBehandling =
             if (behandling.erAutomatiskOgHarTidligereBehandling()) {
-                sisteBehandlingSomErIverksatt ?: throw Feil("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.")
+                if (aktivArbeidsfordelingPåBehandling != null) {
+                    aktivArbeidsfordelingPåBehandling
+                } else {
+                    sisteBehandlingSomErIverksatt ?: throw Feil("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.")
 
-                fastsettArbeidsfordelingsenhetUtIfraTidligereBehandlingerPåFagsak(behandling.id, behandling.fagsak.id)
+                    fastsettArbeidsfordelingsenhetUtIfraTidligereBehandlingerPåFagsak(behandling.id, behandling.fagsak.id)
+                }
             } else {
                 val arbeidsfordelingsenhet = hentArbeidsfordelingsenhet(behandling)
                 val tilpassetArbeidsfordelingsenhet =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -23,6 +23,7 @@ import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -83,11 +84,9 @@ class ArbeidsfordelingService(
 
         val oppdatertArbeidsfordelingPåBehandling =
             if (behandling.erAutomatiskOgHarTidligereBehandling()) {
-                fastsettArbeidsfordelingsenhetUtIfraForrigeBehandling(
-                    behandling,
-                    sisteBehandlingSomErIverksatt,
-                    aktivArbeidsfordelingPåBehandling,
-                )
+                sisteBehandlingSomErIverksatt ?: throw Feil("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.")
+
+                fastsettArbeidsfordelingsenhetUtIfraTidligereBehandlingerPåFagsak(behandling.id, behandling.fagsak.id)
             } else {
                 val arbeidsfordelingsenhet = hentArbeidsfordelingsenhet(behandling)
                 val tilpassetArbeidsfordelingsenhet =
@@ -129,28 +128,26 @@ class ArbeidsfordelingService(
         )
     }
 
-    private fun fastsettArbeidsfordelingsenhetUtIfraForrigeBehandling(
-        behandling: Behandling,
-        sisteBehandlingSomErIverksatt: Behandling?,
-        aktivArbeidsfordelingPåBehandling: ArbeidsfordelingPåBehandling?,
+    private fun fastsettArbeidsfordelingsenhetUtIfraTidligereBehandlingerPåFagsak(
+        behandlingId: Long,
+        fagsakId: Long,
     ): ArbeidsfordelingPåBehandling {
-        if (aktivArbeidsfordelingPåBehandling != null) return aktivArbeidsfordelingPåBehandling
+        val sisteGyldigeArbeidsfordeling = arbeidsfordelingPåBehandlingRepository.finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(fagsakId)
 
-        sisteBehandlingSomErIverksatt ?: throw Feil("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.")
-
-        val forrigeIverksattesBehandlingArbeidsfordelingsenhet =
-            arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(
-                sisteBehandlingSomErIverksatt.id,
-            ) ?: throw Feil("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke arbeidsfordelingsenhet på forrige iverksatte behandling.")
-
-        if (forrigeIverksattesBehandlingArbeidsfordelingsenhet.behandlendeEnhetId == BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer) {
-            throw Feil("Kan ikke fastsette arbeidsfordelingsenhet. Forrige behandlende enhet er MIDLERTIDIG_ENHET")
+        if (sisteGyldigeArbeidsfordeling == null) {
+            return arbeidsfordelingPåBehandlingRepository.save(
+                ArbeidsfordelingPåBehandling(
+                    behandlingId = behandlingId,
+                    behandlendeEnhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
+                    behandlendeEnhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
+                ),
+            )
         }
 
         return arbeidsfordelingPåBehandlingRepository.save(
-            forrigeIverksattesBehandlingArbeidsfordelingsenhet.copy(
+            sisteGyldigeArbeidsfordeling.copy(
                 id = 0,
-                behandlingId = behandling.id,
+                behandlingId = behandlingId,
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -22,7 +22,6 @@ import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublis
 import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import org.slf4j.LoggerFactory
-import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -21,7 +21,6 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
-import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
 import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.stereotype.Service
@@ -38,7 +37,6 @@ class ArbeidsfordelingService(
     private val personopplysningerService: PersonopplysningerService,
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
-    private val unleashService: UnleashService,
 ) {
     @Transactional
     fun manueltOppdaterBehandlendeEnhet(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/MidlertidigEnhetIAutomatiskBehandlingFeil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/MidlertidigEnhetIAutomatiskBehandlingFeil.kt
@@ -1,5 +1,0 @@
-package no.nav.familie.ba.sak.kjerne.arbeidsfordeling
-
-class MidlertidigEnhetIAutomatiskBehandlingFeil(
-    melding: String,
-) : RuntimeException(melding)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
@@ -51,9 +51,6 @@ class TilpassArbeidsfordelingService(
         if (navIdent == null) {
             throw Feil("Kan ikke håndtere ${BarnetrygdEnhet.MIDLERTIDIG_ENHET} om man mangler NAV-ident")
         }
-        if (navIdent.erSystemIdent()) {
-            throw MidlertidigEnhetIAutomatiskBehandlingFeil("Kan ikke håndtere ${BarnetrygdEnhet.MIDLERTIDIG_ENHET} i automatiske behandlinger")
-        }
         val enheterNavIdentHarTilgangTil =
             integrasjonClient
                 .hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
@@ -15,13 +15,13 @@ interface ArbeidsfordelingPåBehandlingRepository : JpaRepository<Arbeidsfordeli
         JOIN Behandling b ON apb.behandlingId = b.id
         WHERE b.fagsak.id = :fagsakId
           AND apb.behandlendeEnhetId != '4863'
-          AND b.endretTidspunkt NOT IN (
+          AND b.resultat NOT IN (
                  'HENLAGT_FEILAKTIG_OPPRETTET',
                  'HENLAGT_SØKNAD_TRUKKET',
                  'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
                  'HENLAGT_TEKNISK_VEDLIKEHOLD'
             )
-        ORDER BY b.endretTidspunkt DESC
+        ORDER BY b.aktivertTidspunkt DESC
         LIMIT 1
         """,
         nativeQuery = true,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
@@ -10,18 +10,19 @@ interface ArbeidsfordelingPåBehandlingRepository : JpaRepository<Arbeidsfordeli
 
     @Query(
         """
-        SELECT apb
-        FROM ArbeidsfordelingPåBehandling apb
-        JOIN Behandling b ON apb.behandlingId = b.id
-        WHERE b.fagsak.id = :fagsakId
-          AND apb.behandlendeEnhetId != '4863'
+        SELECT apb.*
+        FROM arbeidsfordeling_pa_behandling apb
+            JOIN behandling b ON apb.fk_behandling_id = b.id
+        WHERE b.fk_fagsak_id = :fagsakId
+          AND apb.behandlende_enhet_id != '4863'
+          AND b.status = 'AVSLUTTET'
           AND b.resultat NOT IN (
-                 'HENLAGT_FEILAKTIG_OPPRETTET',
-                 'HENLAGT_SØKNAD_TRUKKET',
-                 'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
-                 'HENLAGT_TEKNISK_VEDLIKEHOLD'
-            )
-        ORDER BY b.aktivertTidspunkt DESC
+             'HENLAGT_FEILAKTIG_OPPRETTET',
+             'HENLAGT_SØKNAD_TRUKKET',
+             'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+             'HENLAGT_TEKNISK_VEDLIKEHOLD'
+            )   
+        ORDER BY b.aktivert_tid DESC
         LIMIT 1
         """,
         nativeQuery = true,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
@@ -7,6 +7,28 @@ import org.springframework.data.jpa.repository.Query
 interface ArbeidsfordelingPåBehandlingRepository : JpaRepository<ArbeidsfordelingPåBehandling, Long> {
     @Query(value = "SELECT apb FROM ArbeidsfordelingPåBehandling apb WHERE apb.behandlingId = :behandlingId")
     fun finnArbeidsfordelingPåBehandling(behandlingId: Long): ArbeidsfordelingPåBehandling?
+
+    @Query(
+        """
+        SELECT apb
+        FROM ArbeidsfordelingPåBehandling apb
+        JOIN Behandling b ON apb.behandlingId = b.id
+        WHERE b.fagsak.id = :fagsakId
+          AND apb.behandlendeEnhetId != '4863'
+          AND b.endretTidspunkt NOT IN (
+                 'HENLAGT_FEILAKTIG_OPPRETTET',
+                 'HENLAGT_SØKNAD_TRUKKET',
+                 'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+                 'HENLAGT_TEKNISK_VEDLIKEHOLD'
+            )
+        ORDER BY b.endretTidspunkt DESC
+        LIMIT 1
+        """,
+        nativeQuery = true,
+    )
+    fun finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(
+        fagsakId: Long,
+    ): ArbeidsfordelingPåBehandling?
 }
 
 // Extension-function fordi default methods for JPA ikke er støttet uten @JvmDefaultWithCompatibility

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/BehandleFødselshendelseTask.kt
@@ -6,8 +6,6 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdFeedService
-import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
-import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.MidlertidigEnhetIAutomatiskBehandlingFeil
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.FagsystemRegelVurdering
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.VelgFagSystemService
@@ -88,20 +86,15 @@ class BehandleFødselshendelseTask(
                     infotrygdFeedService.sendTilInfotrygdFeed(nyBehandling.barnasIdenter)
                 }
             }
-        } catch (e: Exception) {
-            if (e::class in setOf(FunksjonellFeil::class, MidlertidigEnhetIAutomatiskBehandlingFeil::class)) {
-                val aktør = personidentService.hentAktør(nyBehandling.morsIdent)
-                taskRepositoryWrapper.save(
-                    OpprettVurderFødselshendelseKonsekvensForYtelseOppgave.opprettTask(
-                        aktør = aktør,
-                        oppgavetype = Oppgavetype.VurderLivshendelse,
-                        beskrivelse = "Saksbehandler må vurdere konsekvens for ytelse fordi fødselshendelsen ikke kunne håndteres automatisk",
-                        enhetsnummer = if (e is MidlertidigEnhetIAutomatiskBehandlingFeil) BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer else null,
-                    ),
-                )
-            } else {
-                throw e
-            }
+        } catch (e: FunksjonellFeil) {
+            val aktør = personidentService.hentAktør(nyBehandling.morsIdent)
+            taskRepositoryWrapper.save(
+                OpprettVurderFødselshendelseKonsekvensForYtelseOppgave.opprettTask(
+                    aktør = aktør,
+                    oppgavetype = Oppgavetype.VurderLivshendelse,
+                    beskrivelse = "Saksbehandler må vurdere konsekvens for ytelse fordi fødselshendelsen ikke kunne håndteres automatisk",
+                ),
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettVurderFødselshendelseKonsekvensForYtelseOppgave.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettVurderFødselshendelseKonsekvensForYtelseOppgave.kt
@@ -28,7 +28,6 @@ class OpprettVurderFødselshendelseKonsekvensForYtelseOppgave(
                 oppgavetype = opprettVurderFødselshendelseKonsekvensForYtelseOppgaveTaskDTO.oppgavetype,
                 fristForFerdigstillelse = LocalDate.now(),
                 beskrivelse = opprettVurderFødselshendelseKonsekvensForYtelseOppgaveTaskDTO.beskrivelse,
-                enhetsnummer = opprettVurderFødselshendelseKonsekvensForYtelseOppgaveTaskDTO.enhetsnummer,
             )
     }
 
@@ -39,7 +38,6 @@ class OpprettVurderFødselshendelseKonsekvensForYtelseOppgave(
             aktør: Aktør,
             oppgavetype: Oppgavetype,
             beskrivelse: String,
-            enhetsnummer: String? = null,
         ): Task =
             Task(
                 type = TASK_STEP_TYPE,
@@ -49,7 +47,6 @@ class OpprettVurderFødselshendelseKonsekvensForYtelseOppgave(
                             aktør.aktørId,
                             oppgavetype,
                             beskrivelse,
-                            enhetsnummer,
                         ),
                     ),
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettVurderFødselshendelseKonsekvensForYtelseOppgaveTaskDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/dto/OpprettVurderFødselshendelseKonsekvensForYtelseOppgaveTaskDTO.kt
@@ -8,5 +8,4 @@ data class OpprettVurderFødselshendelseKonsekvensForYtelseOppgaveTaskDTO(
     val ident: AktørId, // Dette er aktørId (string) og ikke fnr
     val oppgavetype: Oppgavetype,
     val beskrivelse: String,
-    val enhetsnummer: String?,
 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/DataGenerator.kt
@@ -216,6 +216,7 @@ fun lagBehandling(
     aktivertTid: LocalDateTime = LocalDateTime.now(),
     id: Long = nesteBehandlingId(),
     endretTidspunkt: LocalDateTime = LocalDateTime.now(),
+    aktiv: Boolean = true,
 ) = Behandling(
     id = id,
     fagsak = fagsak,
@@ -227,6 +228,7 @@ fun lagBehandling(
     resultat = resultat,
     status = status,
     aktivertTidspunkt = aktivertTid,
+    aktiv = aktiv,
 ).also {
     it.endretTidspunkt = endretTidspunkt
     val tidligereSteg =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -22,7 +22,6 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.NavIdent
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -120,7 +119,7 @@ class ArbeidsfordelingServiceTest {
                 assertThrows<Feil> {
                     arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, null)
                 }
-            assertEquals("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.", exception.message)
+            assertThat(exception.message).isEqualTo("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.")
         }
 
         @ParameterizedTest

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.lagPersonEnkel
-import no.nav.familie.ba.sak.datagenerator.oppgave.lagArbeidsfordelingPåBehandling
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
@@ -121,52 +120,6 @@ class ArbeidsfordelingServiceTest {
                     arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, null)
                 }
             assertEquals("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.", exception.message)
-        }
-
-        @Test
-        fun `fastsettBehandlendeEnhet skal kaste Feil hvis arbeidsfordeling på forrige behandling mangler`() {
-            // Arrange
-            val behandling = lagBehandling(årsak = BehandlingÅrsak.SMÅBARNSTILLEGG)
-            val forrigeBehandling = lagBehandling(årsak = BehandlingÅrsak.SMÅBARNSTILLEGG)
-
-            every {
-                arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(any())
-            } returns null
-
-            // Act & Assert
-            val exception =
-                assertThrows<Feil> {
-                    arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, forrigeBehandling)
-                }
-            assertEquals("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke arbeidsfordelingsenhet på forrige iverksatte behandling.", exception.message)
-        }
-
-        @Test
-        fun `fastsettBehandlendeEnhet skal kaste Feil hvis systembruker er satt som enhet i arbeidsfordeling på forrige behandling`() {
-            // Arrange
-            val behandling = lagBehandling(årsak = BehandlingÅrsak.SMÅBARNSTILLEGG)
-            val forrigeBehandling = lagBehandling(årsak = BehandlingÅrsak.SMÅBARNSTILLEGG)
-            val arbeidsfordelingPåForrigeBehandling =
-                lagArbeidsfordelingPåBehandling(
-                    behandlingId = forrigeBehandling.id,
-                    behandlendeEnhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    behandlendeEnhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
-
-            every {
-                arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id)
-            } returns null
-
-            every {
-                arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(forrigeBehandling.id)
-            } returns arbeidsfordelingPåForrigeBehandling
-
-            // Act & Assert
-            val exception =
-                assertThrows<Feil> {
-                    arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, forrigeBehandling)
-                }
-            assertThat(exception.message).isEqualTo("Kan ikke fastsette arbeidsfordelingsenhet. Forrige behandlende enhet er MIDLERTIDIG_ENHET")
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.arbeidsfordeling
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.lagPersonEnkel
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
@@ -20,12 +21,13 @@ import no.nav.familie.ba.sak.kjerne.simulering.lagBehandling
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.NavIdent
-import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 class ArbeidsfordelingServiceTest {
     private val arbeidsfordelingPåBehandlingRepository: ArbeidsfordelingPåBehandlingRepository = mockk()
@@ -37,7 +39,6 @@ class ArbeidsfordelingServiceTest {
     private val personopplysningerService: PersonopplysningerService = mockk()
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher = mockk()
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService = mockk()
-    private val unleashService: UnleashService = mockk()
 
     private val arbeidsfordelingService: ArbeidsfordelingService =
         ArbeidsfordelingService(
@@ -50,7 +51,6 @@ class ArbeidsfordelingServiceTest {
             personopplysningerService = personopplysningerService,
             saksstatistikkEventPublisher = saksstatistikkEventPublisher,
             tilpassArbeidsfordelingService = tilpassArbeidsfordelingService,
-            unleashService = unleashService,
         )
 
     @Nested
@@ -105,10 +105,11 @@ class ArbeidsfordelingServiceTest {
             assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetNavn).isEqualTo(BarnetrygdEnhet.OSLO.enhetsnavn)
         }
 
-        @Test
-        fun `fastsettBehandlendeEnhet skal kaste Feil hvis forrige behandling er null`() {
+        @ParameterizedTest
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        fun `fastsettBehandlendeEnhet skal kaste Feil hvis forrige behandling er null for automatiske behandlinger som skal ha tidligere behandlinger`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
-            val behandling = lagBehandling(årsak = BehandlingÅrsak.SMÅBARNSTILLEGG)
+            val behandling = lagBehandling(årsak = behandlingÅrsak)
 
             every {
                 arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(any())
@@ -120,6 +121,85 @@ class ArbeidsfordelingServiceTest {
                     arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, null)
                 }
             assertEquals("Kan ikke fastsette arbeidsfordelingsenhet. Finner ikke tidligere behandling.", exception.message)
+        }
+
+        @ParameterizedTest
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        fun `fastsettBehandlendeEnhet skal sette 4863 til behandlende enhet dersom ingen av de tidligere behandlingene har hatt en annen behandlende enhet enn 4863`(behandlingÅrsak: BehandlingÅrsak) {
+            // Arrange
+            val forrigeBehandling = lagBehandling()
+            val behandling = lagBehandling(årsak = behandlingÅrsak)
+
+            val arbeidsfordelingPåBehandlingSlot = slot<ArbeidsfordelingPåBehandling>()
+
+            every {
+                arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(any())
+            } returns null
+
+            every {
+                arbeidsfordelingPåBehandlingRepository.finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(behandling.fagsak.id)
+            } returns null
+
+            every { arbeidsfordelingPåBehandlingRepository.save(capture(arbeidsfordelingPåBehandlingSlot)) } answers { firstArg() }
+
+            // Act
+            arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, forrigeBehandling)
+
+            // Assert
+            val arbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingSlot.captured
+            assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetId).isEqualTo(BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer)
+            assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetNavn).isEqualTo(BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn)
+            assertThat(arbeidsfordelingPåBehandling.behandlingId).isEqualTo(behandling.id)
+            assertThat(arbeidsfordelingPåBehandling.id).isEqualTo(0)
+        }
+
+        @ParameterizedTest
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        fun `fastsettBehandlendeEnhet skal sette behandlende enhet til en gyldig enhet dersom en av de tidligere behandlingene har hatt en annen behandlende enhet enn 4863`(behandlingÅrsak: BehandlingÅrsak) {
+            // Arrange
+            val forrigeBehandling = lagBehandling()
+            val behandling = lagBehandling(årsak = behandlingÅrsak)
+
+            val arbeidsfordelingPåBehandlingSlot = slot<ArbeidsfordelingPåBehandling>()
+
+            every {
+                arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(any())
+            } returns null
+
+            every {
+                arbeidsfordelingPåBehandlingRepository.finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(behandling.fagsak.id)
+            } returns ArbeidsfordelingPåBehandling(behandlingId = forrigeBehandling.id, behandlendeEnhetId = BarnetrygdEnhet.OSLO.enhetsnummer, behandlendeEnhetNavn = BarnetrygdEnhet.OSLO.enhetsnavn)
+
+            every { arbeidsfordelingPåBehandlingRepository.save(capture(arbeidsfordelingPåBehandlingSlot)) } answers { firstArg() }
+
+            // Act
+            arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, forrigeBehandling)
+
+            // Assert
+            val arbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingSlot.captured
+            assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetId).isEqualTo(BarnetrygdEnhet.OSLO.enhetsnummer)
+            assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetNavn).isEqualTo(BarnetrygdEnhet.OSLO.enhetsnavn)
+            assertThat(arbeidsfordelingPåBehandling.behandlingId).isEqualTo(behandling.id)
+            assertThat(arbeidsfordelingPåBehandling.id).isEqualTo(0)
+        }
+
+        @ParameterizedTest
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        fun `fastsettBehandlendeEnhet skal ikke gjøre noe dersom aktiv behandlende enhet finnes`(behandlingÅrsak: BehandlingÅrsak) {
+            // Arrange
+            val forrigeBehandling = lagBehandling()
+            val behandling = lagBehandling(årsak = behandlingÅrsak)
+
+            every {
+                arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(any())
+            } returns ArbeidsfordelingPåBehandling(behandlingId = forrigeBehandling.id, behandlendeEnhetId = BarnetrygdEnhet.OSLO.enhetsnummer, behandlendeEnhetNavn = BarnetrygdEnhet.OSLO.enhetsnavn)
+
+            // Act
+            arbeidsfordelingService.fastsettBehandlendeEnhet(behandling, forrigeBehandling)
+
+            // Assert
+            verify(exactly = 0) { loggService.opprettBehandlendeEnhetEndret(any(), any(), any(), any(), any()) }
+            verify(exactly = 0) { oppgaveService.endreTilordnetEnhetPåOppgaverForBehandling(any(), any()) }
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
@@ -42,26 +42,6 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal kaste midlertidigEnhetIAutomatiskBehandlingFeil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident er systembruker`() {
-            // Arrange
-            val arbeidsfordelingPåBehandling =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
-
-            // Act & assert
-            val exception =
-                assertThrows<MidlertidigEnhetIAutomatiskBehandlingFeil> {
-                    tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(
-                        arbeidsfordelingsenhet = arbeidsfordelingPåBehandling,
-                        navIdent = NavIdent(SYSTEM_FORKORTELSE),
-                    )
-                }
-            assertThat(exception.message).isEqualTo("Kan ikke håndtere ${BarnetrygdEnhet.MIDLERTIDIG_ENHET} i automatiske behandlinger")
-        }
-
-        @Test
         fun `skal kaste feil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident ikke har tilgang til noen andre enheter enn 4863 og 2103`() {
             // Arrange
             val navIdent = NavIdent("1")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepositoryTest.kt
@@ -1,15 +1,29 @@
 package no.nav.familie.ba.sak.kjerne.arbeidsfordeling.domene
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.lagBehandling
+import no.nav.familie.ba.sak.common.lagFagsak
+import no.nav.familie.ba.sak.common.randomAktør
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.datagenerator.oppgave.lagArbeidsfordelingPåBehandling
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
+import java.time.LocalDateTime
 
 class ArbeidsfordelingPåBehandlingRepositoryTest(
+    @Autowired private val aktørIdRepository: AktørIdRepository,
+    @Autowired private val fagsakRepository: FagsakRepository,
+    @Autowired private val behandlingRepository: BehandlingRepository,
     @Autowired private val arbeidsfordelingPåBehandlingRepository: ArbeidsfordelingPåBehandlingRepository,
 ) : AbstractSpringIntegrationTest() {
     @Nested
@@ -27,8 +41,7 @@ class ArbeidsfordelingPåBehandlingRepositoryTest(
             arbeidsfordelingPåBehandlingRepository.save(arbeidsfordelingPåBehandling)
 
             // Act
-            val lagretArbeidsfordelingPåBehandling =
-                arbeidsfordelingPåBehandlingRepository.hentArbeidsfordelingPåBehandling(behandlingId)
+            val lagretArbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingRepository.hentArbeidsfordelingPåBehandling(behandlingId)
 
             // Assert
             assertThat(lagretArbeidsfordelingPåBehandling).isEqualTo(arbeidsfordelingPåBehandling)
@@ -42,6 +55,104 @@ class ArbeidsfordelingPåBehandlingRepositoryTest(
                     arbeidsfordelingPåBehandlingRepository.hentArbeidsfordelingPåBehandling(1L)
                 }
             assertThat(exception.message).isEqualTo("Finner ikke tilknyttet arbeidsfordelingsenhet på behandling 1")
+        }
+    }
+
+    @Nested
+    inner class FinnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak {
+        @Test
+        fun `skal ikke hente arbeidsfordelingPåBehandling med behandlende enhet er midlertidig enhet`() {
+            // Arrange
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak = fagsakRepository.save(lagFagsak(aktør = aktør))
+            val behandling = behandlingRepository.save(lagBehandling(fagsak = fagsak, status = BehandlingStatus.AVSLUTTET))
+
+            arbeidsfordelingPåBehandlingRepository.save(
+                lagArbeidsfordelingPåBehandling(
+                    behandlingId = behandling.id,
+                    behandlendeEnhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
+                ),
+            )
+
+            // Act
+            val lagretArbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingRepository.finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(fagsak.id)
+
+            // Assert
+            assertThat(lagretArbeidsfordelingPåBehandling).isNull()
+        }
+
+        @Test
+        fun `skal ikke hente arbeidsfordeling på behandling som ikke har status AVSLUTTET`() {
+            // Arrange
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak = fagsakRepository.save(lagFagsak(aktør = aktør))
+            val behandling = behandlingRepository.save(lagBehandling(fagsak = fagsak, status = BehandlingStatus.FATTER_VEDTAK, aktivertTid = LocalDateTime.now()))
+
+            arbeidsfordelingPåBehandlingRepository.save(lagArbeidsfordelingPåBehandling(behandlingId = behandling.id))
+
+            // Act
+            val lagretArbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingRepository.finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(fagsak.id)
+
+            // Assert
+            assertThat(lagretArbeidsfordelingPåBehandling).isNull()
+        }
+
+        @Test
+        fun `skal ikke hente arbeidsfordeling på behandling som har resultat HENLAGT`() {
+            // Arrange
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak = fagsakRepository.save(lagFagsak(aktør = aktør))
+            val behandling =
+                behandlingRepository.save(
+                    lagBehandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.AVSLUTTET,
+                        resultat = Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET,
+                        aktivertTid = LocalDateTime.now(),
+                    ),
+                )
+
+            arbeidsfordelingPåBehandlingRepository.save(lagArbeidsfordelingPåBehandling(behandlingId = behandling.id))
+
+            // Act
+            val lagretArbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingRepository.finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(fagsak.id)
+
+            // Assert
+            assertThat(lagretArbeidsfordelingPåBehandling).isNull()
+        }
+
+        @Test
+        fun `skal hente nyeste arbeidsfordeling på behandling`() {
+            // Arrange
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak = fagsakRepository.save(lagFagsak(aktør = aktør))
+
+            val nyBehandling =
+                behandlingRepository.save(
+                    lagBehandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.AVSLUTTET,
+                        aktivertTid = LocalDateTime.now(),
+                    ),
+                )
+            val gammelBehandling =
+                behandlingRepository.save(
+                    lagBehandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.AVSLUTTET,
+                        aktivertTid = LocalDateTime.now().minusDays(10),
+                        aktiv = false,
+                    ),
+                )
+
+            val arbeidsfordelingNy = arbeidsfordelingPåBehandlingRepository.save(lagArbeidsfordelingPåBehandling(behandlingId = nyBehandling.id))
+            arbeidsfordelingPåBehandlingRepository.save(lagArbeidsfordelingPåBehandling(behandlingId = gammelBehandling.id))
+
+            // Act
+            val lagretArbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingRepository.finnSisteGyldigeArbeidsfordelingPåBehandlingIFagsak(fagsak.id)
+
+            // Assert
+            assertThat(lagretArbeidsfordelingPåBehandling).isEqualTo(arbeidsfordelingNy)
         }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepositoryTest.kt
@@ -16,6 +16,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import java.time.LocalDateTime
@@ -97,8 +99,9 @@ class ArbeidsfordelingPåBehandlingRepositoryTest(
             assertThat(lagretArbeidsfordelingPåBehandling).isNull()
         }
 
-        @Test
-        fun `skal ikke hente arbeidsfordeling på behandling som har resultat HENLAGT`() {
+        @ParameterizedTest
+        @EnumSource(Behandlingsresultat::class, names = ["HENLAGT_FEILAKTIG_OPPRETTET", "HENLAGT_SØKNAD_TRUKKET", "HENLAGT_AUTOMATISK_FØDSELSHENDELSE", "HENLAGT_TEKNISK_VEDLIKEHOLD"], mode = EnumSource.Mode.INCLUDE)
+        fun `skal ikke hente arbeidsfordeling på behandling som har resultat HENLAGT`(behandlingsResultat: Behandlingsresultat) {
             // Arrange
             val aktør = aktørIdRepository.save(randomAktør())
             val fagsak = fagsakRepository.save(lagFagsak(aktør = aktør))
@@ -107,7 +110,7 @@ class ArbeidsfordelingPåBehandlingRepositoryTest(
                     lagBehandling(
                         fagsak = fagsak,
                         status = BehandlingStatus.AVSLUTTET,
-                        resultat = Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET,
+                        resultat = behandlingsResultat,
                         aktivertTid = LocalDateTime.now(),
                     ),
                 )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
@@ -247,7 +247,6 @@ class FødselshendelseFørstegangsbehandlingTest(
                 aktør = Aktør(scenario.søker.aktørId!!),
                 oppgavetype = Oppgavetype.VurderLivshendelse,
                 beskrivelse = "Saksbehandler må vurdere konsekvens for ytelse fordi fødselshendelsen ikke kunne håndteres automatisk",
-                enhetsnummer = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
             )
         }
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
@@ -1,20 +1,15 @@
 package no.nav.familie.ba.sak.kjerne.verdikjedetester
 
 import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.verify
 import no.nav.familie.ba.sak.common.LocalDateService
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
-import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
-import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.brev.BrevmalService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
@@ -24,11 +19,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.mockserver.domene.RestScenarioPerson
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
-import no.nav.familie.ba.sak.task.OpprettVurderFødselshendelseKonsekvensForYtelseOppgave
 import no.nav.familie.ba.sak.util.tilleggOrdinærSatsNesteMånedTilTester
 import no.nav.familie.kontrakter.felles.getDataOrThrow
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -46,20 +38,6 @@ class FødselshendelseFørstegangsbehandlingTest(
     @Autowired private val brevmalService: BrevmalService,
     @Autowired private val integrasjonClient: IntegrasjonClient,
 ) : AbstractVerdikjedetest() {
-    @AfterEach
-    fun cleanUp() {
-        // Gå tilbake til default mock.
-        every {
-            integrasjonClient.hentBehandlendeEnhet(any())
-        } returns
-            listOf(
-                Arbeidsfordelingsenhet(
-                    BarnetrygdEnhet.OSLO.enhetsnummer,
-                    BarnetrygdEnhet.OSLO.enhetsnavn,
-                ),
-            )
-    }
-
     @Test
     fun `Skal innvilge fødselshendelse på mor med 1 barn født november 2021 og behandles desember 2021 uten utbetalinger`() {
         // Behandler desember 2021 for å få med automatisk begrunnelse av satsendring januar 2022
@@ -199,55 +177,5 @@ class FødselshendelseFørstegangsbehandlingTest(
             2,
             tilleggOrdinærSatsNesteMånedTilTester().beløp * 2,
         )
-    }
-
-    @Test
-    fun `Skal opprette VurderLivshendelse task hvis man ikke kan fastsette behandlende enhet`() {
-        mockkObject(OpprettVurderFødselshendelseKonsekvensForYtelseOppgave)
-        every { integrasjonClient.hentBehandlendeEnhet(any()) } returns
-            listOf(
-                Arbeidsfordelingsenhet(
-                    BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                ),
-            )
-
-        val scenario =
-            mockServerKlient().lagScenario(
-                RestScenario(
-                    søker = RestScenarioPerson(fødselsdato = "2000-01-01", fornavn = "Mor", etternavn = "Søker"),
-                    barna =
-                        listOf(
-                            RestScenarioPerson(
-                                fødselsdato = LocalDate.of(2024, 1, 1).toString(),
-                                fornavn = "Barn",
-                                etternavn = "Barnesen",
-                            ),
-                        ),
-                ),
-            )
-
-        behandleFødselshendelse(
-            nyBehandlingHendelse =
-                NyBehandlingHendelse(
-                    morsIdent = scenario.søker.ident!!,
-                    barnasIdenter = listOf(scenario.barna.first().ident!!),
-                ),
-            behandleFødselshendelseTask = behandleFødselshendelseTask,
-            fagsakService = fagsakService,
-            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
-            vedtakService = vedtakService,
-            stegService = stegService,
-            personidentService = personidentService,
-            brevmalService = brevmalService,
-        )
-
-        verify(exactly = 1) {
-            OpprettVurderFødselshendelseKonsekvensForYtelseOppgave.opprettTask(
-                aktør = Aktør(scenario.søker.aktørId!!),
-                oppgavetype = Oppgavetype.VurderLivshendelse,
-                beskrivelse = "Saksbehandler må vurdere konsekvens for ytelse fordi fødselshendelsen ikke kunne håndteres automatisk",
-            )
-        }
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-23353

Reverserer tidligere endringer som aggressivt kastet feil hvis man ikke kan fastsette behandlende enhet. Tidligere sjekket den forrige behandling, men nå sjekker den alle tidligere behandlinger på gitt fagsak.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
