### PR TITLE
Vi bruker dødfødt datoen på barn dersom det finnes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -95,7 +95,8 @@ class PdlRestClient(
 
             pdlPerson.person.let {
                 PersonInfo(
-                    fødselsdato = LocalDate.parse(it.foedselsdato.first().foedselsdato),
+                    // Hvis det ikke finnes fødselsdato på person forsøker vi å bruke dato for barnets død fordi det var et dødfødt barn.
+                    fødselsdato = LocalDate.parse(it.foedselsdato.firstOrNull()?.foedselsdato ?: it.doedfoedtBarn.first().dato),
                     navn = it.navn.firstOrNull()?.fulltNavn(),
                     kjønn = it.kjoenn.firstOrNull()?.kjoenn,
                     forelderBarnRelasjon = forelderBarnRelasjon,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlDødfødtBarnResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlDødfødtBarnResponse.kt
@@ -1,5 +1,5 @@
 package no.nav.familie.ba.sak.integrasjoner.pdl.domene
 
-class PdlDødtfødtBarnResponse(
+class PdlDødfødtBarnResponse(
     val dato: String?,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlDødtfødtBarnResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlDødtfødtBarnResponse.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.ba.sak.integrasjoner.pdl.domene
+
+class PdlDødtfødtBarnResponse(
+    val dato: String?,
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
@@ -27,10 +27,11 @@ data class PdlPersonData(
     val opphold: List<Opphold> = emptyList(),
     val statsborgerskap: List<Statsborgerskap> = emptyList(),
     val doedsfall: List<PdlDødsfallResponse> = emptyList(),
+    val doedfoedtBarn: List<PdlDødtfødtBarnResponse> = emptyList(),
     val kontaktinformasjonForDoedsbo: List<PdlKontaktinformasjonForDødsbo> = emptyList(),
 ) {
     fun validerOmPersonKanBehandlesIFagsystem() {
-        if (foedselsdato.isEmpty()) throw PdlPersonKanIkkeBehandlesIFagsystem("mangler fødselsdato")
+        if (foedselsdato.isEmpty() && doedfoedtBarn.isEmpty()) throw PdlPersonKanIkkeBehandlesIFagsystem("mangler fødselsdato")
         if (folkeregisteridentifikator.firstOrNull()?.status == FolkeregisteridentifikatorStatus.OPPHOERT) {
             throw PdlPersonKanIkkeBehandlesIFagsystem(
                 "er opphørt",

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
@@ -27,7 +27,7 @@ data class PdlPersonData(
     val opphold: List<Opphold> = emptyList(),
     val statsborgerskap: List<Statsborgerskap> = emptyList(),
     val doedsfall: List<PdlDødsfallResponse> = emptyList(),
-    val doedfoedtBarn: List<PdlDødtfødtBarnResponse> = emptyList(),
+    val doedfoedtBarn: List<PdlDødfødtBarnResponse> = emptyList(),
     val kontaktinformasjonForDoedsbo: List<PdlKontaktinformasjonForDødsbo> = emptyList(),
 ) {
     fun validerOmPersonKanBehandlesIFagsystem() {

--- a/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
+++ b/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
@@ -63,6 +63,9 @@ query($ident: ID!) {person: hentPerson(ident: $ident) {
     doedsfall {
         doedsdato
     }
+    doedfoedtBarn {
+        dato
+    }
     kontaktinformasjonForDoedsbo(historikk: false) {
         adresse {
             adresselinje1

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
@@ -159,6 +159,20 @@ class PdlGraphqlTest {
     }
 
     @Test
+    fun testDoedtfodtBarn() {
+        val resp =
+            mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(
+                File(getFile("pdl/pdlDoedfoedtBarnOkResponse.json")),
+            )
+        assertThat(
+            resp.data.person!!
+                .doedfoedtBarn
+                .first()
+                .dato,
+        ).isEqualTo("2024-09-13")
+    }
+
+    @Test
     fun testAdressebeskyttelse() {
         val resp =
             mapper.readValue<PdlBaseResponse<PdlAdressebeskyttelseResponse>>(

--- a/src/test/resources/pdl/pdlDoedfoedtBarnOkResponse.json
+++ b/src/test/resources/pdl/pdlDoedfoedtBarnOkResponse.json
@@ -1,0 +1,52 @@
+{
+  "data": {
+    "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "1234",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
+      "navn": [
+        {
+          "fornavn": "ENGASJERT",
+          "etternavn": "FYR"
+        }
+      ],
+      "foedselsdato": [],
+      "kjoenn": [
+        {
+          "kjoenn": "MANN"
+        }
+      ],
+      "bostedsadresse": [
+        {
+          "ukjentBosted": {
+            "bostedskommune": "Oslo"
+          }
+        }
+      ],
+      "sivilstand": [],
+      "forelderBarnRelasjon": [
+        {
+          "relatertPersonsIdent": "12345678910",
+          "relatertPersonsRolle": "BARN"
+        }
+      ],
+      "adressebeskyttelse": [
+        {
+          "gradering": "UGRADERT"
+        }
+      ],
+      "doedsfall": [],
+      "doedfoedtBarn":
+      [
+        {
+          "dato": "2024-09-13"
+        }
+      ],
+      "kontaktinformasjonForDoedsbo": []
+    }
+  }
+}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23491

Dersom aktør ikke har fødselsnummer, så sjekker vi om aktør har dødfødt objektet med dato på seg.
Hvis så, så betyr det at det er et dødfødt barn, og vi ønsker å bruke datoen barnet døde som fødselsdato.

Verdikjedetester feiler grunnet:
https://github.com/navikt/familie-mock-server/pull/147
