### PR TITLE
Ikke send saksstatistikk ved reaktivering av gammel behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
@@ -53,7 +53,7 @@ class FerdigstillBehandling(
             behandlingHentOgPersisterService.finnAktivForFagsak(behandling.fagsak.id)?.aktiv = false
             behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)?.apply {
                 aktiv = true
-                behandlingHentOgPersisterService.lagreEllerOppdater(this)
+                behandlingHentOgPersisterService.lagreEllerOppdater(this, sendTilDvh = false)
             }
         }
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23573

Dette oppstår fordi:

1. Ved henleggelse av en behandling så ønsker man å sette forrige vedtatte behandling til aktiv. (Dette er fordi at den settes til ikke aktiv når man lager ny behandling, men når ny behandling henlegges ønsker man å gjøre forrige vedtatte behandling tilbake til den aktive)
2. Ved oppdatering av en behandling ( i dette tilfellet, oppdaterer man gammel behandling fordi man har gjort den aktiv) så sender man ny behandlingsstilstand til dvh.
 
3. Ved sending av behandlingsstilstand forsøker man å hente begrunnelser brukt, og dersom det har blitt brukt eldgamle begrunnelser som nå er fjernet, så kastes det en feil.
 
 Vi fikser dette ved å ikke sende oppdatering av behandling til datavarehus for dette caset, da vi uansett ikke sender noe om en behandling er aktiv eller ikke.
 
<img width="911" alt="alertz" src="https://github.com/user-attachments/assets/5f7c8445-37a5-4c09-9bc3-af470904f6b7">

Vi har fikset dette for deaktivering av gammel behandling i:
https://github.com/navikt/familie-ba-sak/pull/4845