### PR TITLE
Håndtere arbeidsfordeling i `OPPDATER_UTVIDET_KLASSEKODE`-behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -227,7 +227,9 @@ data class Behandling(
 
     fun erSatsendringEllerMånedligValutajustering() = erSatsendring() || erMånedligValutajustering()
 
-    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsendringEllerMånedligValutajustering() || erSmåbarnstillegg() || erOmregning()
+    fun erOppdaterUtvidetKlassekode() = this.opprettetÅrsak == BehandlingÅrsak.OPPDATER_UTVIDET_KLASSEKODE
+
+    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsendringEllerMånedligValutajustering() || erSmåbarnstillegg() || erOmregning() || erOppdaterUtvidetKlassekode()
 
     fun erManuellMigreringForEndreMigreringsdato() =
         erMigrering() &&

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -105,7 +105,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "OPPDATER_UTVIDET_KLASSEKODE"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal kaste Feil hvis forrige behandling er null for automatiske behandlinger som skal ha tidligere behandlinger`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val behandling = lagBehandling(årsak = behandlingÅrsak)
@@ -123,7 +123,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "OPPDATER_UTVIDET_KLASSEKODE"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal sette 4863 til behandlende enhet dersom ingen av de tidligere behandlingene har hatt en annen behandlende enhet enn 4863`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()
@@ -153,7 +153,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "OPPDATER_UTVIDET_KLASSEKODE"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal sette behandlende enhet til en gyldig enhet dersom en av de tidligere behandlingene har hatt en annen behandlende enhet enn 4863`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()
@@ -183,7 +183,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "OPPDATER_UTVIDET_KLASSEKODE"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal ikke gjøre noe dersom aktiv behandlende enhet finnes`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Behandlinger med årsak `OPPDATER_UTVIDET_KLASSEKODE` faller inn i kategorien av automatiske behandlinger med tidligere behandlinger. Altså skal vi også her bruke enhet fra tidligere behandling ulik 4863 dersom denne finnes.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
