### PR TITLE
Status-kolonne i OppdaterUtvidetKlassekodeKjøring-tabell

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/AutovedtakOppdaterUtvidetKlassekodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/AutovedtakOppdaterUtvidetKlassekodeService.kt
@@ -36,7 +36,7 @@ class AutovedtakOppdaterUtvidetKlassekodeService(
 
         if (tilkjentYtelseRepository.harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(fagsakId)) {
             logger.info("Hopper ut av behandling fordi fagsak $fagsakId allerede bruker ny klassekode for utvidet barnetrygd.")
-            oppdaterUtvidetKlassekodeKjøringRepository.settBrukerNyKlassekodeTilTrue(fagsakId)
+            oppdaterUtvidetKlassekodeKjøringRepository.settBrukerNyKlassekodeTilTrueOgStatusTilUtført(fagsakId)
             return
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.task.OpprettTaskService.Companion.overstyrTaskMedNy
 import no.nav.familie.prosessering.util.IdUtils
 import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
-import org.springframework.data.domain.Limit
+import org.springframework.data.domain.PageRequest
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
@@ -33,7 +33,7 @@ class OppdaterUtvidetKlassekodeScheduler(
 
     private fun startAutovedtakOppdaterUtvidetKlassekode(antallFagsaker: Int) {
         oppdaterUtvidetKlassekodeKjøringRepository
-            .findByBrukerNyKlassekodeIsFalse(limit = Limit.of(antallFagsaker))
+            .finnRelevanteOppdaterUtvidetKlassekodeKjøringer(PageRequest.of(0, antallFagsaker))
             .also {
                 logger.info("Oppretter tasker for å migrere fagsak til ny utvidet klassekode på ${it.size} fagsaker.")
             }.forEach { fagsak ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD
+import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.OppdaterUtvidetKlassekodeKjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.Status
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Service
 class OppdaterUtvidetKlassekodeTask(
     private val autovedtakOppdaterUtvidetKlassekodeService: AutovedtakOppdaterUtvidetKlassekodeService,
     private val unleashService: UnleashService,
+    private val oppdaterUtvidetKlassekodeKjøringRepository: OppdaterUtvidetKlassekodeKjøringRepository,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         if (!unleashService.isEnabled(KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD)) {
@@ -27,6 +30,7 @@ class OppdaterUtvidetKlassekodeTask(
         }
 
         val fagsakId: Long = objectMapper.readValue(task.payload)
+        oppdaterUtvidetKlassekodeKjøringRepository.oppdaterStatus(fagsakId = fagsakId, status = Status.UTFØRES)
         autovedtakOppdaterUtvidetKlassekodeService.utførMigreringTilOppdatertUtvidetKlassekode(fagsakId = fagsakId)
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/domene/OppdaterUtvidetKlassekodeKjøring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/domene/OppdaterUtvidetKlassekodeKjøring.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -23,4 +25,13 @@ data class OppdaterUtvidetKlassekodeKjøring(
     val fagsakId: Long,
     @Column(name = "bruker_ny_klassekode", nullable = false)
     val brukerNyKlassekode: Boolean = false,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    val status: Status = Status.IKKE_UTFØRT,
 )
+
+enum class Status {
+    IKKE_UTFØRT,
+    UTFØRES,
+    UTFØRT,
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/domene/OppdaterUtvidetKlassekodeKjøringRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/domene/OppdaterUtvidetKlassekodeKjøringRepository.kt
@@ -1,18 +1,34 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene
 
-import org.springframework.data.domain.Limit
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
 interface OppdaterUtvidetKlassekodeKjøringRepository : JpaRepository<OppdaterUtvidetKlassekodeKjøring, Long> {
-    fun findByBrukerNyKlassekodeIsFalse(limit: Limit = Limit.unlimited()): List<OppdaterUtvidetKlassekodeKjøring>
+    @Query("SELECT oukk FROM OppdaterUtvidetKlassekodeKjøring oukk WHERE oukk.brukerNyKlassekode = false and oukk.status = Status.IKKE_UTFØRT ")
+    fun finnRelevanteOppdaterUtvidetKlassekodeKjøringer(
+        pageable: Pageable,
+    ): Page<OppdaterUtvidetKlassekodeKjøring>
 
+    @Transactional
     @Modifying
-    @Query("UPDATE OppdaterUtvidetKlassekodeKjøring SET brukerNyKlassekode = true WHERE fagsakId = :fagsakId")
-    fun settBrukerNyKlassekodeTilTrue(fagsakId: Long)
+    @Query("UPDATE OppdaterUtvidetKlassekodeKjøring SET brukerNyKlassekode = true, status = Status.UTFØRT WHERE fagsakId = :fagsakId")
+    fun settBrukerNyKlassekodeTilTrueOgStatusTilUtført(
+        fagsakId: Long,
+    )
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE OppdaterUtvidetKlassekodeKjøring SET status = :status WHERE fagsakId = :fagsakId")
+    fun oppdaterStatus(
+        fagsakId: Long,
+        status: Status,
+    )
 
     fun deleteByFagsakId(fagsakId: Long)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/FerdigstillBehandling.kt
@@ -61,7 +61,7 @@ class FerdigstillBehandling(
         }
 
         if (behandling.opprettetÅrsak == BehandlingÅrsak.OPPDATER_UTVIDET_KLASSEKODE) {
-            oppdaterUtvidetKlassekodeKjøringRepository.settBrukerNyKlassekodeTilTrue(behandling.fagsak.id)
+            oppdaterUtvidetKlassekodeKjøringRepository.settBrukerNyKlassekodeTilTrueOgStatusTilUtført(behandling.fagsak.id)
         }
 
         behandlingService.oppdaterStatusPåBehandling(behandlingId = behandling.id, status = BehandlingStatus.AVSLUTTET)

--- a/src/main/resources/db/migration/V269__status_kolonne_utvidet_klassekode_kjoring.sql
+++ b/src/main/resources/db/migration/V269__status_kolonne_utvidet_klassekode_kjoring.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppdater_utvidet_klassekode_kjoring
+    ADD COLUMN status VARCHAR(50) DEFAULT 'IKKE_UTFØRT' NOT NULL;

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockOppdaterUtvidetKlassekodeKjøringRepository.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockOppdaterUtvidetKlassekodeKjøringRepository.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.
 fun mockOppdaterUtvidetKlassekodeKjøringRepository(): OppdaterUtvidetKlassekodeKjøringRepository {
     val oppdaterUtvidetKlassekodeKjøringRepository = mockk<OppdaterUtvidetKlassekodeKjøringRepository>()
 
-    justRun { oppdaterUtvidetKlassekodeKjøringRepository.settBrukerNyKlassekodeTilTrue(any()) }
+    justRun { oppdaterUtvidetKlassekodeKjøringRepository.settBrukerNyKlassekodeTilTrueOgStatusTilUtført(any()) }
     justRun { oppdaterUtvidetKlassekodeKjøringRepository.deleteByFagsakId(any()) }
 
     return oppdaterUtvidetKlassekodeKjøringRepository

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/domene/OppdaterUtvidetKlassekodeKjøringRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/domene/OppdaterUtvidetKlassekodeKjøringRepositoryTest.kt
@@ -1,0 +1,86 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene
+
+import no.nav.familie.ba.sak.common.lagFagsak
+import no.nav.familie.ba.sak.common.randomAktør
+import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+
+class OppdaterUtvidetKlassekodeKjøringRepositoryTest(
+    @Autowired private val oppdaterUtvidetKlassekodeKjøringRepository: OppdaterUtvidetKlassekodeKjøringRepository,
+    @Autowired private val fagsakRepository: FagsakRepository,
+    @Autowired private val aktørIdRepository: AktørIdRepository,
+) : AbstractSpringIntegrationTest() {
+    @Nested
+    inner class FinnRelevanteOppdaterUtvidetKlassekodeKjøringer {
+        @Test
+        fun `skal finne de x antall første radene hvor brukerNyKlassekode er false og status er 'IKKE_UTFØRT'`() {
+            // Arrange
+            val oppdaterUtvidetKlassekodeKjøringer = mutableListOf<OppdaterUtvidetKlassekodeKjøring>()
+            for (index in 1..20) {
+                val aktør = aktørIdRepository.saveAndFlush(randomAktør())
+                val fagsak = fagsakRepository.saveAndFlush(lagFagsak(aktør = aktør))
+                if (index.mod(2) == 0) {
+                    oppdaterUtvidetKlassekodeKjøringer.add(OppdaterUtvidetKlassekodeKjøring(fagsakId = fagsak.id))
+                } else {
+                    oppdaterUtvidetKlassekodeKjøringer.add(OppdaterUtvidetKlassekodeKjøring(fagsakId = fagsak.id, brukerNyKlassekode = true, status = Status.UTFØRT))
+                }
+            }
+            oppdaterUtvidetKlassekodeKjøringRepository.saveAllAndFlush(oppdaterUtvidetKlassekodeKjøringer)
+
+            // Act
+            val relevanteOppdaterUtvidetKlassekodeKjøringer = oppdaterUtvidetKlassekodeKjøringRepository.finnRelevanteOppdaterUtvidetKlassekodeKjøringer(PageRequest.of(0, 20))
+
+            // Assert
+            assertThat(relevanteOppdaterUtvidetKlassekodeKjøringer).hasSize(10)
+            assertThat(relevanteOppdaterUtvidetKlassekodeKjøringer.all { !it.brukerNyKlassekode && it.status == Status.IKKE_UTFØRT }).isTrue
+        }
+    }
+
+    @Nested
+    inner class SettBrukerNyKlassekodeTilTrueOgStatusTilUtført {
+        @Test
+        fun `skal sette brukerNyKlassekode til true og status til utført`() {
+            // Arrange
+            val aktør = aktørIdRepository.saveAndFlush(randomAktør())
+            val fagsak = fagsakRepository.saveAndFlush(lagFagsak(aktør = aktør))
+            oppdaterUtvidetKlassekodeKjøringRepository.saveAndFlush(OppdaterUtvidetKlassekodeKjøring(fagsakId = fagsak.id))
+
+            // Act
+            oppdaterUtvidetKlassekodeKjøringRepository.settBrukerNyKlassekodeTilTrueOgStatusTilUtført(fagsakId = fagsak.id)
+            oppdaterUtvidetKlassekodeKjøringRepository.flush()
+
+            // Assert
+            val oppdaterUtvidetKlassekodeKjøring = oppdaterUtvidetKlassekodeKjøringRepository.findAll().single { it.fagsakId == fagsak.id }
+            assertThat(oppdaterUtvidetKlassekodeKjøring.brukerNyKlassekode).isTrue
+            assertThat(oppdaterUtvidetKlassekodeKjøring.status).isEqualTo(Status.UTFØRT)
+        }
+    }
+
+    @Nested
+    inner class OppdaterStatus {
+        @ParameterizedTest
+        @EnumSource(Status::class, names = ["IKKE_UTFØRT", "UTFØRES", "UTFØRT"], mode = EnumSource.Mode.INCLUDE)
+        fun `skal oppdatere status`(status: Status) {
+            // Arrange
+            val aktør = aktørIdRepository.saveAndFlush(randomAktør())
+            val fagsak = fagsakRepository.saveAndFlush(lagFagsak(aktør = aktør))
+            oppdaterUtvidetKlassekodeKjøringRepository.saveAndFlush(OppdaterUtvidetKlassekodeKjøring(fagsakId = fagsak.id))
+
+            // Act
+            oppdaterUtvidetKlassekodeKjøringRepository.oppdaterStatus(fagsakId = fagsak.id, status = status)
+            oppdaterUtvidetKlassekodeKjøringRepository.flush()
+
+            // Assert
+            val oppdaterUtvidetKlassekodeKjøring = oppdaterUtvidetKlassekodeKjøringRepository.findAll().single { it.fagsakId == fagsak.id }
+            assertThat(oppdaterUtvidetKlassekodeKjøring.status).isEqualTo(status)
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dersom `OppdaterUtvidetKlassekodeTask` feiler eller må vente lenge på å motta status fra oppdrag, risikerer vi at det opprettes duplikate tasker. Altså at vi får flere `opprettUtvidetKlassekodeTask` per fagsak som bruker gammel klassekode. Dette er uheldig og bør ikke skje.

Legger derfor til en `status`-kolonne i tabellen som skal fortelle om tasken er `IKKE_UTFØRT`, `UTFØRES` eller `UTFØRT`, og bruker denne kolonnen til å bestemme hvilke fagsaker vi skal opprette task for.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
