### PR TITLE
Fix: Oppdatere `status` utenfor task slik at endringen ikke rulles tilbake ved feil.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.OPPRETT_AUTOVE
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.OppdaterUtvidetKlassekodeKjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.Status
 import no.nav.familie.ba.sak.task.OpprettTaskService.Companion.overstyrTaskMedNyCallId
 import no.nav.familie.prosessering.util.IdUtils
 import no.nav.familie.unleash.UnleashService
@@ -38,6 +39,7 @@ class OppdaterUtvidetKlassekodeScheduler(
                 logger.info("Oppretter tasker for å migrere fagsak til ny utvidet klassekode på ${it.size} fagsaker.")
             }.forEach { fagsak ->
                 taskRepository.save(overstyrTaskMedNyCallId(IdUtils.generateId()) { OppdaterUtvidetKlassekodeTask.lagTask(fagsak.fagsakId) })
+                oppdaterUtvidetKlassekodeKjøringRepository.oppdaterStatus(fagsakId = fagsak.fagsakId, status = Status.UTFØRES)
             }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
@@ -2,8 +2,6 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD
-import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.OppdaterUtvidetKlassekodeKjøringRepository
-import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.Status
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -21,7 +19,6 @@ import org.springframework.stereotype.Service
 class OppdaterUtvidetKlassekodeTask(
     private val autovedtakOppdaterUtvidetKlassekodeService: AutovedtakOppdaterUtvidetKlassekodeService,
     private val unleashService: UnleashService,
-    private val oppdaterUtvidetKlassekodeKjøringRepository: OppdaterUtvidetKlassekodeKjøringRepository,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         if (!unleashService.isEnabled(KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD)) {
@@ -30,7 +27,6 @@ class OppdaterUtvidetKlassekodeTask(
         }
 
         val fagsakId: Long = objectMapper.readValue(task.payload)
-        oppdaterUtvidetKlassekodeKjøringRepository.oppdaterStatus(fagsakId = fagsakId, status = Status.UTFØRES)
         autovedtakOppdaterUtvidetKlassekodeService.utførMigreringTilOppdatertUtvidetKlassekode(fagsakId = fagsakId)
     }
 


### PR DESCRIPTION
Når vi oppretter `oppdaterUtvidetKlassekodeTask` for en fagsak oppdaterer vi også status-feltet i raden til fagsaken i tabellen `OppdaterUtvidetKlassekodeKjøring`. Fordi selve oppdateringen skjer inne i `oppdaterUtvidetKlassekodeTask` rulles oppdateringen tilbake dersom tasken feiler. Dette ønsker vi ikke, da dette vil medføre at vi oppretter flere tasker for samme fagsak.

Sørger derfor for å oppdatere feltet utenfor tasken etter at tasken er opprettet istedenfor.