### PR TITLE
Sørger for å ta i litt når vi setter id på 'fiktiv/kunstig' andel.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/AndelDataForOppdaterUtvidetKlassekodeBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/AndelDataForOppdaterUtvidetKlassekodeBehandlingUtleder.kt
@@ -45,7 +45,7 @@ class AndelDataForOppdaterUtvidetKlassekodeBehandlingUtleder(
                     listOf(
                         // Sørger for at første AndelData etter splitt får en unik id. Dette sørger for at utbetalingsgenerator ikke kaster feil.
                         // Andelen skal ikke trigge en endring som fører til nytt kjedeelement, og vil på sett og vis bli ignorert. (Fordrer at vi finner en tilsvarende AndelData blandt forrigeAndeler)
-                        andelData.copy(fom = it.stønadFom, tom = inneværendeMåned, id = it.id + tilkjentYtelse.andelerTilkjentYtelse.size),
+                        andelData.copy(fom = it.stønadFom, tom = inneværendeMåned, id = it.id + (tilkjentYtelse.andelerTilkjentYtelse.size * 1000)),
                         // Siste AndelData etter splitt får id som samsvarer med AndelTilkjentYtelse slik at periodeId og forrigePeriodeId skal oppdateres på riktig andel.
                         andelData.copy(fom = inneværendeMåned.plusMonths(1), tom = it.stønadTom),
                     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/AndelDataForOppdaterUtvidetKlassekodeBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/AndelDataForOppdaterUtvidetKlassekodeBehandlingUtlederTest.kt
@@ -148,7 +148,7 @@ class AndelDataForOppdaterUtvidetKlassekodeBehandlingUtlederTest {
             assertThat(førsteUtvidetAndelData.fom).isEqualTo(utvidetAndel.stønadFom)
             assertThat(førsteUtvidetAndelData.tom).isEqualTo(denneMåned)
             // Id til første utvidet andel ved split gir vi en falsk id som er lik id + antall andeler.
-            assertThat(førsteUtvidetAndelData.id).isEqualTo(utvidetAndel.id + tilkjentYtelse.andelerTilkjentYtelse.size)
+            assertThat(førsteUtvidetAndelData.id).isEqualTo(utvidetAndel.id + (tilkjentYtelse.andelerTilkjentYtelse.size * 1000))
             assertThat(førsteUtvidetAndelData.beløp).isEqualTo(utvidetAndel.kalkulertUtbetalingsbeløp)
             assertThat(førsteUtvidetAndelData.type).isEqualTo(YtelsetypeBA.UTVIDET_BARNETRYGD)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi splitter opp "nye"-andeler før generering av utbetalingsoppdrag. I den forbindelse må vi sette en kunstig id på den ene andelen. Tidligere satte vi id = (id til andel + antall andeler), men dette fører noen ganger til at vi får duplikate id'er. Sørger her for at vi tar i litt når vi setter id til denne kunstige andelen. Id'en brukes ikke til noe spesielt, men kan altså ikke være lik en av de andre andelene vi sender inn til generatoren.
