### PR TITLE
Overstyre sisteAndelPerKjede for utvidet barnetrygd dersom fagsak er over på ny klassekode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -24,6 +24,9 @@ class FeatureToggleConfig {
         // NAV-23449 - Skrud av/på ny refaktorert logikk for hjemler i brev, skal i teorien produsere det samme resultatet
         const val BRUK_OMSKRIVING_AV_HJEMLER_I_BREV = "familie-ba-sak.bruk_omskriving_av_hjemler_i_brev"
 
+        // NAV-23733
+        const val BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET = "familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"
+
         // satsendring
         // Oppretter satsendring-tasker for de som ikke har fått ny task
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtleder.kt
@@ -1,11 +1,11 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
 import no.nav.familie.ba.sak.common.ClockProvider
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
+import no.nav.familie.felles.utbetalingsgenerator.domain.AndelDataLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import org.springframework.stereotype.Component
@@ -21,7 +21,7 @@ class BehandlingsinformasjonUtleder(
         saksbehandlerId: String,
         vedtak: Vedtak,
         forrigeTilkjentYtelse: TilkjentYtelse?,
-        sisteAndelPerKjede: Map<IdentOgType, AndelTilkjentYtelse>,
+        sisteAndelPerKjede: Map<IdentOgType, AndelDataLongId>,
         erSimulering: Boolean,
     ): Behandlingsinformasjon {
         val behandling = vedtak.behandling
@@ -43,7 +43,7 @@ class BehandlingsinformasjonUtleder(
 
     private fun finnOpphørsdatoForAlleKjeder(
         forrigeTilkjentYtelse: TilkjentYtelse?,
-        sisteAndelPerKjede: Map<IdentOgType, AndelTilkjentYtelse>,
+        sisteAndelPerKjede: Map<IdentOgType, AndelDataLongId>,
         endretMigreringsdato: YearMonth?,
     ): YearMonth? =
         if (forrigeTilkjentYtelse == null || sisteAndelPerKjede.isEmpty()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -1,7 +1,9 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.integrasjoner.pdl.logger
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -14,6 +16,8 @@ import no.nav.familie.felles.utbetalingsgenerator.Utbetalingsgenerator
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelDataLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.objectMapper
 import org.springframework.stereotype.Component
 
 @Component
@@ -72,7 +76,7 @@ class UtbetalingsoppdragGenerator(
                 behandlingsinformasjon = behandlingsinformasjon,
                 forrigeAndeler = forrigeAndeler,
                 nyeAndeler = nyeAndeler,
-                sisteAndelPerKjede = sisteAndelPerKjede.mapValues { it.value.tilAndelDataLongId(skalBrukeNyKlassekodeForUtvidetBarnetrygd) },
+                sisteAndelPerKjede = sisteAndelPerKjede,
             )
 
         return klassifiseringKorrigerer.korrigerKlassifiseringVedBehov(
@@ -81,15 +85,46 @@ class UtbetalingsoppdragGenerator(
         )
     }
 
-    private fun hentSisteAndelTilkjentYtelse(behandling: Behandling): Map<IdentOgType, AndelTilkjentYtelse> {
+    private fun hentSisteAndelTilkjentYtelse(
+        behandling: Behandling,
+    ): Map<IdentOgType, AndelDataLongId> {
         val skalBrukeNyKlassekodeForUtvidetBarnetrygd =
             unleashNextMedContextService.isEnabled(
                 toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
                 behandlingId = behandling.id,
             )
-        return andelTilkjentYtelseRepository
-            .hentSisteAndelPerIdentOgType(fagsakId = behandling.fagsak.id)
-            .associateBy { IdentOgType(it.aktør.aktivFødselsnummer(), it.type.tilYtelseType(skalBrukeNyKlassekodeForUtvidetBarnetrygd)) }
+
+        val sisteAndelPerKjede =
+            andelTilkjentYtelseRepository
+                .hentSisteAndelPerIdentOgType(fagsakId = behandling.fagsak.id)
+                .associateBy { IdentOgType(it.aktør.aktivFødselsnummer(), it.type.tilYtelseType(skalBrukeNyKlassekodeForUtvidetBarnetrygd)) }
+
+        val tilkjenteYtelserHvorUtbetalingsoppdragInneholderOppdatertKlassekodeForUtvidetBarnetrygd = tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(behandling.fagsak.id)
+
+        return sisteAndelPerKjede.mapValues {
+            if (tilkjenteYtelserHvorUtbetalingsoppdragInneholderOppdatertKlassekodeForUtvidetBarnetrygd.isNotEmpty() && it.key.type == YtelsetypeBA.UTVIDET_BARNETRYGD && unleashNextMedContextService.isEnabled(FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET)) {
+                // Finner siste utbetalingsoppdraget som innehold kjedelementer med oppdatert utvidet klassekode
+                val sistOversendteUtbetalingsoppdragMedUtvidetBarnetrygd = tilkjenteYtelserHvorUtbetalingsoppdragInneholderOppdatertKlassekodeForUtvidetBarnetrygd.maxBy { tilkjentYtelse -> tilkjentYtelse.behandling.aktivertTidspunkt }.utbetalingsoppdrag
+
+                // Finner det siste kjedelementet med oppdatert utvidet klassekode
+                val sistOversendteUtvidetBarnetrygdKjedeelement =
+                    objectMapper
+                        .readValue(sistOversendteUtbetalingsoppdragMedUtvidetBarnetrygd, Utbetalingsoppdrag::class.java)
+                        .utbetalingsperiode
+                        .filter { utbetalingsperiode -> utbetalingsperiode.klassifisering == YtelsetypeBA.UTVIDET_BARNETRYGD.klassifisering }
+                        .maxByOrNull { utvidetPeriode -> utvidetPeriode.vedtakdatoFom }!!
+
+                if (it.value.stønadFom != sistOversendteUtvidetBarnetrygdKjedeelement.vedtakdatoFom.toYearMonth()) {
+                    logger.warn("Overstyrer vedtakFom i andelDataLongId da fom til siste andel per kjede ikke stemmer overens med siste kjedelement oversendt til Oppdrag")
+                    // Oppdaterer fom i AndelDataLongId til samme fom som sist oversendte, da det ikke er 1-1 mellom fom på siste andel og fom på siste kjedelement oversendt til Oppdrag.
+                    it.value.tilAndelDataLongId(skalBrukeNyKlassekodeForUtvidetBarnetrygd).copy(fom = sistOversendteUtvidetBarnetrygdKjedeelement.vedtakdatoFom.toYearMonth())
+                } else {
+                    it.value.tilAndelDataLongId(skalBrukeNyKlassekodeForUtvidetBarnetrygd)
+                }
+            } else {
+                it.value.tilAndelDataLongId(skalBrukeNyKlassekodeForUtvidetBarnetrygd)
+            }
+        }
     }
 
     private fun hentForrigeTilkjentYtelse(behandling: Behandling): TilkjentYtelse? =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
@@ -37,5 +37,5 @@ interface TilkjentYtelseRepository : JpaRepository<TilkjentYtelse, Long> {
         WHERE ty.utbetalingsoppdrag IS NOT NULL AND ty.utbetalingsoppdrag like '%"klassifisering":"BAUTV-OP"%' AND b.fagsak.id = :fagsakId 
     """,
     )
-    fun findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(fagsakId: Long): List<TilkjentYtelse>
+    fun findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(fagsakId: Long): List<TilkjentYtelse>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
@@ -29,4 +29,13 @@ interface TilkjentYtelseRepository : JpaRepository<TilkjentYtelse, Long> {
         """,
     )
     fun harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(fagsakId: Long): Boolean
+
+    @Query(
+        """
+        SELECT ty FROM Behandling b
+        JOIN TilkjentYtelse ty ON ty.behandling.id =  b.id
+        WHERE ty.utbetalingsoppdrag IS NOT NULL AND ty.utbetalingsoppdrag like '%"klassifisering":"BAUTV-OP"%' AND b.fagsak.id = :fagsakId 
+    """,
+    )
+    fun finnUtbetalingsoppdragMedUtvidetBarnetrygd(fagsakId: Long): List<TilkjentYtelse>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
@@ -37,5 +37,5 @@ interface TilkjentYtelseRepository : JpaRepository<TilkjentYtelse, Long> {
         WHERE ty.utbetalingsoppdrag IS NOT NULL AND ty.utbetalingsoppdrag like '%"klassifisering":"BAUTV-OP"%' AND b.fagsak.id = :fagsakId 
     """,
     )
-    fun finnUtbetalingsoppdragMedUtvidetBarnetrygd(fagsakId: Long): List<TilkjentYtelse>
+    fun findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(fagsakId: Long): List<TilkjentYtelse>
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtlederTest.kt
@@ -240,7 +240,7 @@ class BehandlingsinformasjonUtlederTest {
 
         val sisteAndelPerKjede =
             mapOf(
-                IdentOgType("1", YtelsetypeBA.ORDINÆR_BARNETRYGD) to lagAndelTilkjentYtelse,
+                IdentOgType("1", YtelsetypeBA.ORDINÆR_BARNETRYGD) to lagAndelTilkjentYtelse.tilAndelDataLongId(true),
             )
 
         every {
@@ -311,7 +311,7 @@ class BehandlingsinformasjonUtlederTest {
 
         val sisteAndelPerKjede =
             mapOf(
-                IdentOgType("1", YtelsetypeBA.ORDINÆR_BARNETRYGD) to lagAndelTilkjentYtelse,
+                IdentOgType("1", YtelsetypeBA.ORDINÆR_BARNETRYGD) to lagAndelTilkjentYtelse.tilAndelDataLongId(true),
             )
 
         every {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -112,6 +112,12 @@ class UtbetalingsoppdragGeneratorTest {
         } returns true
 
         every {
+            unleashNextMedContextService.isEnabled(
+                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
+            )
+        } returns true
+
+        every {
             klassifiseringKorrigerer.korrigerKlassifiseringVedBehov(
                 beregnetUtbetalingsoppdrag = any(),
                 behandling = vedtak.behandling,
@@ -233,6 +239,12 @@ class UtbetalingsoppdragGeneratorTest {
             unleashNextMedContextService.isEnabled(
                 toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
                 behandlingId = any(),
+            )
+        } returns true
+
+        every {
+            unleashNextMedContextService.isEnabled(
+                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
             )
         } returns true
 
@@ -360,6 +372,12 @@ class UtbetalingsoppdragGeneratorTest {
             unleashNextMedContextService.isEnabled(
                 toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
                 behandlingId = any(),
+            )
+        } returns true
+
+        every {
+            unleashNextMedContextService.isEnabled(
+                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
             )
         } returns true
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -120,7 +120,7 @@ class UtbetalingsoppdragGeneratorTest {
             firstArg()
         }
 
-        every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } returns emptyList()
+        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } returns emptyList()
 
         // Act
         val beregnetUtbetalingsoppdragLongId =
@@ -245,7 +245,7 @@ class UtbetalingsoppdragGeneratorTest {
             firstArg()
         }
 
-        every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } returns emptyList()
+        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } returns emptyList()
 
         // Act
         val beregnetUtbetalingsoppdragLongId =
@@ -388,7 +388,7 @@ class UtbetalingsoppdragGeneratorTest {
                 ),
             )
 
-        every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } returns emptyList()
+        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } returns emptyList()
         // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -120,6 +120,8 @@ class UtbetalingsoppdragGeneratorTest {
             firstArg()
         }
 
+        every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } returns emptyList()
+
         // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
@@ -242,6 +244,8 @@ class UtbetalingsoppdragGeneratorTest {
         } answers {
             firstArg()
         }
+
+        every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } returns emptyList()
 
         // Act
         val beregnetUtbetalingsoppdragLongId =
@@ -383,6 +387,8 @@ class UtbetalingsoppdragGeneratorTest {
                     kildeBehandlingId = null,
                 ),
             )
+
+        every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } returns emptyList()
         // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -126,7 +126,7 @@ class UtbetalingsoppdragGeneratorTest {
             firstArg()
         }
 
-        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } returns emptyList()
+        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any()) } returns emptyList()
 
         // Act
         val beregnetUtbetalingsoppdragLongId =
@@ -257,7 +257,7 @@ class UtbetalingsoppdragGeneratorTest {
             firstArg()
         }
 
-        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } returns emptyList()
+        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any()) } returns emptyList()
 
         // Act
         val beregnetUtbetalingsoppdragLongId =
@@ -406,7 +406,7 @@ class UtbetalingsoppdragGeneratorTest {
                 ),
             )
 
-        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } returns emptyList()
+        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any()) } returns emptyList()
         // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -178,7 +178,7 @@ class OppdragSteg {
             tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(any())
         } returns tidligereTilkjenteYtelser.lastOrNull()?.copy(utbetalingsoppdrag = objectMapper.writeValueAsString(beregnetUtbetalingsoppdrag[tidligereTilkjenteYtelser.last().behandling.id]?.utbetalingsoppdrag))
         every {
-            tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any())
+            tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any())
         } returns tidligereTilkjenteYtelser.filter { beregnetUtbetalingsoppdrag[it.behandling.id]?.utbetalingsoppdrag?.utbetalingsperiode?.any { it.klassifisering == YtelsetypeBA.UTVIDET_BARNETRYGD.klassifisering } == true }.map { it.copy(utbetalingsoppdrag = objectMapper.writeValueAsString(beregnetUtbetalingsoppdrag[it.behandling.id]?.utbetalingsoppdrag)) }
         every {
             behandlingHentOgPersisterService.hentBehandlinger(any())

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -178,7 +178,7 @@ class OppdragSteg {
             tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(any())
         } returns tidligereTilkjenteYtelser.lastOrNull()?.copy(utbetalingsoppdrag = objectMapper.writeValueAsString(beregnetUtbetalingsoppdrag[tidligereTilkjenteYtelser.last().behandling.id]?.utbetalingsoppdrag))
         every {
-            tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any())
+            tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any())
         } returns tidligereTilkjenteYtelser.filter { beregnetUtbetalingsoppdrag[it.behandling.id]?.utbetalingsoppdrag?.utbetalingsperiode?.any { it.klassifisering == YtelsetypeBA.UTVIDET_BARNETRYGD.klassifisering } == true }.map { it.copy(utbetalingsoppdrag = objectMapper.writeValueAsString(beregnetUtbetalingsoppdrag[it.behandling.id]?.utbetalingsoppdrag)) }
         every {
             behandlingHentOgPersisterService.hentBehandlinger(any())

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
@@ -46,5 +46,10 @@ fun mockTilkjentYtelseRepository(dataFraCucumber: VedtaksperioderOgBegrunnelserS
             .mapNotNull { it.utbetalingsoppdrag }
             .any { it.contains("\"klassifisering\":\"BAUTV-OP\"") }
     }
+
+    every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } answers {
+        val fagsakId = firstArg<Long>()
+        dataFraCucumber.tilkjenteYtelser.map { it.value }.filter { it.utbetalingsoppdrag != null && it.utbetalingsoppdrag!!.contains("\"klassifisering\":\"BAUTV-OP\"") }
+    }
     return tilkjentYtelseRepository
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
@@ -47,7 +47,7 @@ fun mockTilkjentYtelseRepository(dataFraCucumber: VedtaksperioderOgBegrunnelserS
             .any { it.contains("\"klassifisering\":\"BAUTV-OP\"") }
     }
 
-    every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } answers {
+    every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any()) } answers {
         val fagsakId = firstArg<Long>()
         dataFraCucumber.tilkjenteYtelser.map { it.value }.filter { it.utbetalingsoppdrag != null && it.utbetalingsoppdrag!!.contains("\"klassifisering\":\"BAUTV-OP\"") }
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
@@ -47,7 +47,7 @@ fun mockTilkjentYtelseRepository(dataFraCucumber: VedtaksperioderOgBegrunnelserS
             .any { it.contains("\"klassifisering\":\"BAUTV-OP\"") }
     }
 
-    every { tilkjentYtelseRepository.finnUtbetalingsoppdragMedUtvidetBarnetrygd(any()) } answers {
+    every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdIUtbetalingsoppdrag(any()) } answers {
         val fagsakId = firstArg<Long>()
         dataFraCucumber.tilkjenteYtelser.map { it.value }.filter { it.utbetalingsoppdrag != null && it.utbetalingsoppdrag!!.contains("\"klassifisering\":\"BAUTV-OP\"") }
     }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/opphoerEtterOppdaterUtvidetKlassekodeBehandling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/opphoerEtterOppdaterUtvidetKlassekodeBehandling.feature
@@ -1,0 +1,27 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Utbetalingsoppdrag: Opphør/simulering etter OppdaterUtvidetKlassekode-behandling
+
+  Scenario: Opphør alle kjeder
+
+    Gitt følgende feature toggles
+      | BehandlingId | FeatureToggleId                                                | Er togglet på |
+      | 1            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Nei           |
+      | 2            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+      | 3            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Uten andeler | Fra dato | Til dato | Beløp | Ytelse             | Behandlingsårsak            | Behandlingstype |
+      | 1            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             |                 |
+      | 2            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD | OPPDATER_UTVIDET_KLASSEKODE | REVURDERING     |
+      | 3            | Ja           |          |          | 700   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Ytelse                    |
+      | 1            | 07.2023  | 05.2034  |             | 700   | NY           | Nei        | 0          |                    | UTVIDET_BARNETRYGD_GAMMEL |
+      | 2            | 01.2025  | 05.2034  |             | 700   | ENDR         | Nei        | 1          | 0                  | UTVIDET_BARNETRYGD        |
+      | 3            | 01.2025  | 05.2034  | 07.2023     | 700   | ENDR         | Ja         | 1          | 0                  | UTVIDET_BARNETRYGD        |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/opphoerEtterOppdaterUtvidetKlassekodeBehandling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/oppdrag/opphoerEtterOppdaterUtvidetKlassekodeBehandling.feature
@@ -3,7 +3,7 @@
 
 Egenskap: Utbetalingsoppdrag: Opphør/simulering etter OppdaterUtvidetKlassekode-behandling
 
-  Scenario: Opphør alle kjeder
+  Scenario: Opphør av utvidet barnetrygd etter behandling med årsak OPPDATER_UTVIDET_KLASSEKODE
 
     Gitt følgende feature toggles
       | BehandlingId | FeatureToggleId                                                | Er togglet på |
@@ -18,6 +18,8 @@ Egenskap: Utbetalingsoppdrag: Opphør/simulering etter OppdaterUtvidetKlassekode
       | 2            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD | OPPDATER_UTVIDET_KLASSEKODE | REVURDERING     |
       | 3            | Ja           |          |          | 700   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
 
+    Og inneværende måned er 12.2024
+
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
@@ -25,3 +27,93 @@ Egenskap: Utbetalingsoppdrag: Opphør/simulering etter OppdaterUtvidetKlassekode
       | 1            | 07.2023  | 05.2034  |             | 700   | NY           | Nei        | 0          |                    | UTVIDET_BARNETRYGD_GAMMEL |
       | 2            | 01.2025  | 05.2034  |             | 700   | ENDR         | Nei        | 1          | 0                  | UTVIDET_BARNETRYGD        |
       | 3            | 01.2025  | 05.2034  | 07.2023     | 700   | ENDR         | Ja         | 1          | 0                  | UTVIDET_BARNETRYGD        |
+
+
+  Scenario: Endring av utvidet barnetrygd etter behandling med årsak OPPDATER_UTVIDET_KLASSEKODE
+
+    Gitt følgende feature toggles
+      | BehandlingId | FeatureToggleId                                                | Er togglet på |
+      | 1            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Nei           |
+      | 2            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+      | 3            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Uten andeler | Fra dato | Til dato | Beløp | Ytelse             | Behandlingsårsak            | Behandlingstype |
+      | 1            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             |                 |
+      | 2            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD | OPPDATER_UTVIDET_KLASSEKODE | REVURDERING     |
+      | 3            |              | 07.2023  | 05.2026  | 750   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
+
+    Og inneværende måned er 12.2024
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Ytelse                    |
+      | 1            | 07.2023  | 05.2034  |             | 700   | NY           | Nei        | 0          |                    | UTVIDET_BARNETRYGD_GAMMEL |
+      | 2            | 01.2025  | 05.2034  |             | 700   | ENDR         | Nei        | 1          | 0                  | UTVIDET_BARNETRYGD        |
+      | 3            | 07.2023  | 05.2026  |             | 750   | ENDR         | Nei        | 2          | 1                  | UTVIDET_BARNETRYGD        |
+
+
+  Scenario: Opphør av utvidet barnetrygd 2 behandlinger etter behandling med årsak OPPDATER_UTVIDET_KLASSEKODE
+
+    Gitt følgende feature toggles
+      | BehandlingId | FeatureToggleId                                                | Er togglet på |
+      | 1            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Nei           |
+      | 2            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+      | 3            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Uten andeler | Fra dato | Til dato | Beløp | Ytelse             | Behandlingsårsak            | Behandlingstype |
+      | 1            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             |                 |
+      | 2            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD | OPPDATER_UTVIDET_KLASSEKODE | REVURDERING     |
+      | 3            |              | 07.2023  | 05.2026  | 500   | ORDINÆR_BARNETRYGD |                             | REVURDERING     |
+      | 3            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
+      | 4            |              | 07.2023  | 05.2026  | 400   | ORDINÆR_BARNETRYGD |                             | REVURDERING     |
+      | 4            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
+      | 5            |              | 07.2023  | 05.2026  | 400   | ORDINÆR_BARNETRYGD |                             | REVURDERING     |
+
+    Og inneværende måned er 12.2024
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Ytelse                    |
+      | 1            | 07.2023  | 05.2034  |             | 700   | NY           | Nei        | 0          |                    | UTVIDET_BARNETRYGD_GAMMEL |
+      | 2            | 01.2025  | 05.2034  |             | 700   | ENDR         | Nei        | 1          | 0                  | UTVIDET_BARNETRYGD        |
+      | 3            | 07.2023  | 05.2026  |             | 500   | ENDR         | Nei        | 2          |                    | ORDINÆR_BARNETRYGD        |
+      | 4            | 07.2023  | 05.2026  |             | 400   | ENDR         | Nei        | 3          | 2                  | ORDINÆR_BARNETRYGD        |
+      | 5            | 01.2025  | 05.2034  | 07.2023     | 700   | ENDR         | Ja         | 1          | 0                  | UTVIDET_BARNETRYGD        |
+
+  Scenario: Opphør/forkorting av utvidet barnetrygd 2 behandlinger etter behandling med årsak OPPDATER_UTVIDET_KLASSEKODE
+
+    Gitt følgende feature toggles
+      | BehandlingId | FeatureToggleId                                                | Er togglet på |
+      | 1            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Nei           |
+      | 2            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+      | 3            | familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd | Ja            |
+
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Uten andeler | Fra dato | Til dato | Beløp | Ytelse             | Behandlingsårsak            | Behandlingstype |
+      | 1            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             |                 |
+      | 2            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD | OPPDATER_UTVIDET_KLASSEKODE | REVURDERING     |
+      | 3            |              | 07.2023  | 05.2026  | 500   | ORDINÆR_BARNETRYGD |                             | REVURDERING     |
+      | 3            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
+      | 4            |              | 07.2023  | 05.2026  | 400   | ORDINÆR_BARNETRYGD |                             | REVURDERING     |
+      | 4            |              | 07.2023  | 05.2034  | 700   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
+      | 5            |              | 07.2023  | 05.2026  | 400   | ORDINÆR_BARNETRYGD |                             | REVURDERING     |
+      | 5            |              | 07.2023  | 05.2030  | 700   | UTVIDET_BARNETRYGD |                             | REVURDERING     |
+
+    Og inneværende måned er 12.2024
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Ytelse                    |
+      | 1            | 07.2023  | 05.2034  |             | 700   | NY           | Nei        | 0          |                    | UTVIDET_BARNETRYGD_GAMMEL |
+      | 2            | 01.2025  | 05.2034  |             | 700   | ENDR         | Nei        | 1          | 0                  | UTVIDET_BARNETRYGD        |
+      | 3            | 07.2023  | 05.2026  |             | 500   | ENDR         | Nei        | 2          |                    | ORDINÆR_BARNETRYGD        |
+      | 4            | 07.2023  | 05.2026  |             | 400   | ENDR         | Nei        | 3          | 2                  | ORDINÆR_BARNETRYGD        |
+      | 5            | 01.2025  | 05.2034  | 06.2030     | 700   | ENDR         | Ja         | 1          | 0                  | UTVIDET_BARNETRYGD        |


### PR DESCRIPTION
Favro: [NAV-23733](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23733)

### 💰 Hva skal gjøres, og hvorfor?
I revurderinger i fagsaker vi har kjørt `OppdaterUtvidetKlassekodeTask` for, kommer ikke saksbehandler seg videre fra vilkårsvurdering pga feilende simulering mot Oppdrag. Dette skyldes hvordan vi utleder `sisteAndelPerKjede` og at vi etter `OppdaterUtvidetKlassekodeTask` ikke lenger har ett 1-1 forhold mellom andeler og kjedeelementer for utvidet barnetrygd. 

Andelen i en utvidet barnetrygd behandling strekker seg eksempelvis fra 01.07.23 -> 01.07.33, mens det siste kjedeelementet vi faktisk sendte til Oppdrag i autovedtaket strakk seg fra 01.01.25 -> 01.07.33. Oppdrag klager da når vi forsøker å opphøre (som vi alltid gjør i simulering) på at den ikke kjenner igjen kjedeelementet 01.07.23 -> 01.07.33, fordi den forventer det siste vi sendte som var 01.01.25 -> 01.07.33. 

Som en midlertidig løsning for å ikke hindre saksbehandlere fra å gjøre revurderinger i fagsaker vi har kjørt jobben `OppdaterUtvidetKlassekodeTask` for, legger vi her til logikk for å overstyre den siste andelen for utvidet kjeden med korrekt fom-dato. Dette gjøres ved å sjekke alle tidligere utbetalingsoppdrag til fagsak og finne det siste utbetalingsoppdraget som inneholdt den nye klassekoden for utvidet. Deretter velger vi ut det siste kjedeelementet for utvidet barnetrygd fra utbetalingsoppdraget basert på `fom`, og bruker denne `fom`-en i den siste andelen for utvidet kjeden.

> Gjenskapte feilen i preprod og testet at jeg fikk revurdert etter å ha rullet ut disse endringene

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Selv om dette vil fungere i lang tid, tror jeg det er lurt å tenkte litt nytt på den automatiske jobben vi kjører for å få fagsaker over på ny klassekode. Det lureste vil nok være å faktisk opprette en splitt i andelene slik at vi får tilbake 1-1 forholdet mellom andeler og kjedeelementer.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
Tar gjerne en muntlig gjennomgang dersom det er enklere.
