### PR TITLE
Fiks frist feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.Period
 import java.time.format.DateTimeFormatter
 
 @Service

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -271,9 +271,9 @@ class OppgaveService(
         }
     }
 
-    fun forlengFristÅpneOppgaverPåBehandling(
+    fun settNyFristPåOppgaver(
         behandlingId: Long,
-        forlengelse: Period,
+        nyFrist: LocalDate,
     ) {
         val dbOppgaver = oppgaveRepository.findByBehandlingIdAndIkkeFerdigstilt(behandlingId)
 
@@ -293,7 +293,6 @@ class OppgaveService(
                 }
 
                 else -> {
-                    val nyFrist = LocalDate.parse(gammelOppgave.fristFerdigstillelse!!).plus(forlengelse)
                     val nyOppgave = gammelOppgave.copy(fristFerdigstillelse = nyFrist.toString())
                     logger.info("Oppgave ${dbOppgave.gsakId} endrer frist fra ${gammelOppgave.fristFerdigstillelse} til $nyFrist")
                     integrasjonClient.oppdaterOppgave(nyOppgave.id!!, nyOppgave)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.Period
 
 @Service
 class SettPåVentService(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentService.kt
@@ -52,9 +52,9 @@ class SettPåVentService(
 
         behandling.status = BehandlingStatus.SATT_PÅ_VENT
         behandlingHentOgPersisterService.lagreOgFlush(behandling)
-        oppgaveService.forlengFristÅpneOppgaverPåBehandling(
+        oppgaveService.settNyFristPåOppgaver(
             behandlingId = behandling.id,
-            forlengelse = Period.between(LocalDate.now(), frist),
+            nyFrist = frist,
         )
 
         return settPåVent
@@ -81,14 +81,13 @@ class SettPåVentService(
         )
         logger.info("Oppdater sett på vent behandling $behandlingId med frist $frist og årsak $årsak")
 
-        val gammelFrist = aktivSettPåVent.frist
         aktivSettPåVent.frist = frist
         aktivSettPåVent.årsak = årsak
         val settPåVent = lagreEllerOppdater(aktivSettPåVent)
 
-        oppgaveService.forlengFristÅpneOppgaverPåBehandling(
+        oppgaveService.settNyFristPåOppgaver(
             behandlingId = behandlingId,
-            forlengelse = Period.between(gammelFrist, frist),
+            nyFrist = frist,
         )
 
         return settPåVent


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23748

Når man forlenger frist i dag skjer følgende:

Man finner forskjellX som er dagens dato fram til ny frist.
Man plusser gammelfrist med forskjellX.

Kommer vi da i en situasjon der dagensdato er 30 desember, ny frist er 21 januar, og gammelfrist er 20 desember så vil fristen bli satt til 11 januar. (20 des + 21 dager) selvom ønsket frist er 21 jan.