### PR TITLE
Oppdaterer klassifisering på YtelseType.UTVIDET_BARNETRYGD

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -175,7 +175,7 @@ enum class YtelseType(
     val klassifisering: String,
 ) {
     ORDINÆR_BARNETRYGD("BATR"),
-    UTVIDET_BARNETRYGD("BATR"),
+    UTVIDET_BARNETRYGD("BAUTV-OP"),
     SMÅBARNSTILLEGG("BATRSMA"),
     ;
 


### PR DESCRIPTION
Favro: [NAV-23786](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23786)

### 💰 Hva skal gjøres, og hvorfor?
Endrer `klassifisering` for `YtelseType.UTVIDET_BARNETRYGD` fra `BATR` til `BAUTV-OP`. Ved alle endringer av utvidet barnetrygd vil vi nå gå over til å bruke `BAUTV-OP` mot Oppdrag og det bør derfor også være trygt å endre dette da det kun blir brukt i vedtakene vi sender til Stønadsstatistikk. I og med at vi kun sender endringene i dette vedtaket bør dette fungere også for behandlinger som enda ikke har gått over på ny klassekode.