### PR TITLE
Uavhengig om barn har kompetanse eller ikke så må vi inkludere gjelder søker da det er begrunnelser som er avhengig av dette

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
@@ -99,6 +99,7 @@ fun EØSStandardbegrunnelse.lagBrevBegrunnelse(
                             .tilSanityFormat(),
                     sokersAktivitet = kompetanse.søkersAktivitet,
                     sokersAktivitetsland = kompetanse.søkersAktivitetsland.tilLandNavn(landkoder).navn,
+                    gjelderSoker = gjelderSøker
                 )
             } else {
                 null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
@@ -99,7 +99,7 @@ fun EØSStandardbegrunnelse.lagBrevBegrunnelse(
                             .tilSanityFormat(),
                     sokersAktivitet = kompetanse.søkersAktivitet,
                     sokersAktivitetsland = kompetanse.søkersAktivitetsland.tilLandNavn(landkoder).navn,
-                    gjelderSoker = gjelderSøker
+                    gjelderSoker = gjelderSøker,
                 )
             } else {
                 null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -125,6 +125,7 @@ data class EØSBegrunnelseDataMedKompetanse(
     val sokersAktivitet: KompetanseAktivitet,
     val sokersAktivitetsland: String?,
     val barnasFodselsdatoer: String,
+    val gjelderSoker: Boolean?,
     val antallBarn: Int,
     val maalform: String,
 ) : EØSBegrunnelseData() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -154,6 +154,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             barnetsBostedsland = barnetsBostedsland,
             sokersAktivitet = søkersAktivitet,
             sokersAktivitetsland = søkersAktivitetsland,
+            gjelderSoker = gjelderSoker
         )
     } else {
         EØSBegrunnelseDataUtenKompetanse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -133,14 +133,13 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
 
     val målform = (parseValgfriEnum<Målform>(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅLFORM, rad) ?: Målform.NB).tilSanityFormat()
 
-    return if (gjelderSoker == null) {
-        if (annenForeldersAktivitet == null ||
-            annenForeldersAktivitetsland == null ||
+    return if (annenForeldersAktivitet != null) {
+        if (annenForeldersAktivitetsland == null ||
             barnetsBostedsland == null ||
             søkersAktivitet == null ||
             søkersAktivitetsland == null
         ) {
-            error("For EØS-begrunnelser må enten 'Gjelder søker' eller kompetansefeltene settes")
+            error("Alle kompetanser felter må settes dersom en settes")
         }
 
         EØSBegrunnelseDataMedKompetanse(
@@ -154,7 +153,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             barnetsBostedsland = barnetsBostedsland,
             sokersAktivitet = søkersAktivitet,
             sokersAktivitetsland = søkersAktivitetsland,
-            gjelderSoker = gjelderSoker
+            gjelderSoker = gjelderSoker,
         )
     } else {
         EØSBegrunnelseDataUtenKompetanse(
@@ -163,7 +162,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             barnasFodselsdatoer = barnasFodselsdatoer,
             antallBarn = antallBarn,
             maalform = målform,
-            gjelderSoker = gjelderSoker,
+            gjelderSoker = gjelderSoker ?: false,
         )
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -139,7 +139,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             søkersAktivitet == null ||
             søkersAktivitetsland == null
         ) {
-            error("Alle kompetanser felter må settes dersom en settes")
+            error("Alle felter for kompetanse må fylles ut dersom ett av dem fylles ut.")
         }
 
         EØSBegrunnelseDataMedKompetanse(

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/kompetanser.feature
@@ -46,10 +46,10 @@ Egenskap: Brevbegrunnelser ved endring av kompetanse
       | 01.05.2021 | 31.03.2038 |                      | INNVILGET_SEKUNDÆRLAND_STANDARD                    |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.05.2020 til 30.04.2021
-      | Begrunnelse                                        | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
-      | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE | EØS  | 13.04.20             | 1           | NB      | Norge                          | Norge               | Polen                 | IKKE_AKTUELT              | ARBEIDER         |
+      | Begrunnelse                                        | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet | Gjelder søker |
+      | INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE | EØS  | 13.04.20             | 1           | NB      | Norge                          | Norge               | Polen                 | IKKE_AKTUELT              | ARBEIDER         | Nei           |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.05.2021 til 31.03.2038
-      | Begrunnelse                     | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
-      | INNVILGET_SEKUNDÆRLAND_STANDARD | EØS  | 13.04.20             | 1           | NB      | Norge                          | Polen               | Polen                 | I_ARBEID                  | ARBEIDER         |
+      | Begrunnelse                     | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet | Gjelder søker |
+      | INNVILGET_SEKUNDÆRLAND_STANDARD | EØS  | 13.04.20             | 1           | NB      | Norge                          | Polen               | Polen                 | I_ARBEID                  | ARBEIDER         | Nei           |
 

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/reduksjon.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/reduksjon.feature
@@ -75,8 +75,8 @@ Egenskap: Brevbegrunnelser ved reduksjon
       | 01.04.2023 | 30.06.2023 |                      | REDUKSJON_IKKE_ANSVAR_FOR_BARN |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.04.2023 til 30.06.2023
-      | Begrunnelse                    | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
-      | REDUKSJON_IKKE_ANSVAR_FOR_BARN | EØS  | 09.04.05             | 1           | NB      | Danmark                        | Danmark             | Norge                 | I_ARBEID                  | ARBEIDER         |
+      | Begrunnelse                    | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet | Gjelder søker |
+      | REDUKSJON_IKKE_ANSVAR_FOR_BARN | EØS  | 09.04.05             | 1           | NB      | Danmark                        | Danmark             | Norge                 | I_ARBEID                  | ARBEIDER         | Nei           |
 
 
   Scenario: Reduksjon før fylt 18

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/selvstendig_rett.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevPerioder/selvstendig_rett.feature
@@ -70,5 +70,5 @@ Egenskap: Brevperioder: Selvstendig rett
       | UTBETALING      | september 2022 | til februar 2023 | 1054  | 1                          | 26.01.10            | du                     |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.09.2022 til 28.02.2023
-      | Begrunnelse                                    | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet |
-      | INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_STANDARD | EØS  | 26.01.10             | 1           | NB      | Norge                          | Latvia              | Latvia                | ARBEIDER                  | MOTTAR_PENSJON   |
+      | Begrunnelse                                    | Type | Barnas fødselsdatoer | Antall barn | Målform | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitetsland | Annen forelders aktivitet | Søkers aktivitet | Gjelder søker |
+      | INNVILGET_SELVSTENDIG_RETT_PRIMÆRLAND_STANDARD | EØS  | 26.01.10             | 1           | NB      | Norge                          | Latvia              | Latvia                | ARBEIDER                  | MOTTAR_PENSJON   | Nei           |

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/kompetanser.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/kompetanser.feature
@@ -369,9 +369,9 @@ Egenskap: Gyldige begrunnelser for kompetanser
       | 01.01.2022 | 31.03.2022 |                      | INNVILGET_PRIMÆRLAND_STANDARD |            |
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.01.2022 til 31.03.2022
-      | Begrunnelse                   | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet                     | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
-      | INNVILGET_PRIMÆRLAND_STANDARD | EØS  | 10.08.09             | 1           | NB      | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | INAKTIV                   | Norge                 | Polen                          | Norge               |
-      | INNVILGET_PRIMÆRLAND_STANDARD | EØS  | 07.05.14             | 1           | NB      | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | I_ARBEID                  | Norge                 | Polen                          | Norge               |
+      | Begrunnelse                   | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet                     | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland | Gjelder søker |
+      | INNVILGET_PRIMÆRLAND_STANDARD | EØS  | 10.08.09             | 1           | NB      | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | INAKTIV                   | Norge                 | Polen                          | Norge               | Nei           |
+      | INNVILGET_PRIMÆRLAND_STANDARD | EØS  | 07.05.14             | 1           | NB      | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | I_ARBEID                  | Norge                 | Polen                          | Norge               | Nei           |
 
   Scenario: Skal kunne begrunne nullutbetaling når det er reduksjon i samme måned
     Gitt følgende fagsaker

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/opphør_selvstendig_rett_eøs.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/opphør_selvstendig_rett_eøs.feature
@@ -66,5 +66,5 @@ Egenskap: Gyldige begrunnelser selvstendig rett opphør fra start
       | 01.10.2023 |          |                      | OPPHOR_SELVSTENDIG_RETT_OPPHOR_FRA_START |            |
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.10.2023 til -
-      | Begrunnelse                              | Type | Barnas fødselsdatoer | Antall barn | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
-      | OPPHOR_SELVSTENDIG_RETT_OPPHOR_FRA_START | EØS  | 13.11.07             | 1           | INAKTIV          | ARBEIDER                  | Belgia                | Norge                          | Belgia              |
+      | Begrunnelse                              | Type | Barnas fødselsdatoer | Antall barn | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland | Gjelder søker |
+      | OPPHOR_SELVSTENDIG_RETT_OPPHOR_FRA_START | EØS  | 13.11.07             | 1           | INAKTIV          | ARBEIDER                  | Belgia                | Norge                          | Belgia              | Ja           |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23732

Begrunnelser med og uten kompetanse krever feltet gjelder søker, så inkluderer derfor dette.