### PR TITLE
Bug: Patch ident på fagsak som ikke har behandllinger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <properties>
         <java.version>21</java.version>
         <kotlin.version>2.1.0</kotlin.version>
-        <kotlin.compiler.languageVersion>2.0</kotlin.compiler.languageVersion>
-        <kotlin.compiler.apiVersion>2.0</kotlin.compiler.apiVersion>
+        <kotlin.compiler.languageVersion>2.1</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
         <revision>1</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -41,7 +41,7 @@ class HåndterNyIdentService(
 
         val aktørId = identerFraPdl.hentAktivAktørId()
         val aktør = aktørIdRepository.findByAktørIdOrNull(aktørId)
-        val aktuellFagsakVedMerging = hentAktuellFagsak(identerFraPdl)
+        val aktuellFagsakVedMerging = hentAktuellFagsakForIdenthendelse(identerFraPdl)
 
         return when {
             // Personen er ikke i noen fagsaker
@@ -92,7 +92,7 @@ class HåndterNyIdentService(
         return task
     }
 
-    private fun hentAktuellFagsak(alleIdenterFraPdl: List<IdentInformasjon>): Fagsak? {
+    private fun hentAktuellFagsakForIdenthendelse(alleIdenterFraPdl: List<IdentInformasjon>): Fagsak? {
         val aktørerMedAktivPersonident =
             alleIdenterFraPdl
                 .hentAktørIder()
@@ -101,7 +101,7 @@ class HåndterNyIdentService(
 
         val fagsaker =
             aktørerMedAktivPersonident
-                .flatMap { aktør -> fagsakService.hentFagsakerPåPerson(aktør) }
+                .flatMap { aktør -> fagsakService.hentFagsakerPåPerson(aktør) + fagsakService.hentAlleFagsakerForAktør(aktør) }
 
         if (fagsaker.toSet().size > 1) {
             secureLogger.warn(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Identhendelser på en aktør hvor aktøren har en Fagsak, men ikke en behandling har blitt ignorert. Siden query for å finne fagsaker gjør en join på behandling, men man ønsker å patche aktøren selv om den kun har en behandling. Legger til logikk hvor man også søker etter fagsaker som aktøren eier. Og kombinerer resultatet av disse.

- **Endrer kotlinkodestil til 2.1**
- **Støtte for å patche ident på fagsaker som ikke har behandling**

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
