### PR TITLE
Bytt rekkefølge på tilpassing av kompetanser og generering av valutakurser i VilkårsvurderingSteg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -86,15 +86,15 @@ class VilkårsvurderingSteg(
 
         beregningService.genererTilkjentYtelseFraVilkårsvurdering(behandling, personopplysningGrunnlag)
 
+        if (!behandling.erSatsendring()) {
+            tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
+        }
+
         if (
             behandling.type in listOf(BehandlingType.REVURDERING, BehandlingType.TEKNISK_ENDRING) &&
             !behandling.skalBehandlesAutomatisk
         ) {
             automatiskOppdaterValutakursService.resettValutakurserOgLagValutakurserEtterEndringstidspunkt(BehandlingId(behandling.id))
-        }
-
-        if (!behandling.erSatsendring()) {
-            tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
         }
 
         if (behandling.erMånedligValutajustering()) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23752

På grunn av en tidligere bug har fagsaker fått EØS-skjemaer med fremtidig fom/tom. Fikset problemet i [denne PR'en](https://github.com/navikt/familie-ba-sak/pull/4973), men i vilkårsvurderingssteget blir valutakursene generert før kompetansene, og feiler.

Fikser problemet ved å bytte rekkefølgen på tilpassing av kompetanser og generering av valutakurser