### PR TITLE
Fjern fremtidige perioder i EØS-skjemaer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
@@ -114,7 +114,7 @@ fun <K, V, T : Tidsenhet> Map<K, Tidslinje<V, T>>.beskjærTilOgMed(
 ): Map<K, Tidslinje<V, T>> = this.mapValues { (_, tidslinje) -> tidslinje.beskjærTilOgMed(tilOgMed) }
 
 /**
- * Extension-metode for å sette tom dato på en tidslinje til uendelig fra et gitt tidspunkt
+ * Extension-metode for å forlenge fremtid til uendelig for en tidslinje, hvis tilOgMed er senere enn [senesteEndeligeTidspunkt]
  */
 fun <I, T : Tidsenhet> Tidslinje<I, T>.forlengFremtidTilUendelig(senesteEndeligeTidspunkt: Tidspunkt<T>): Tidslinje<I, T> {
     val tilOgMed = this.tilOgMed()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/transformasjon/BeskjæreTidslinje.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon
 
+import no.nav.familie.ba.sak.kjerne.eøs.felles.util.replaceLast
+import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.fraOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
@@ -9,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.erUendeligLengeSiden
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.erUendeligLengeTil
+import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.somUendeligLengeTil
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidsrom.rangeTo
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilOgMed
@@ -109,3 +112,32 @@ fun <I, T : Tidsenhet> Tidslinje<I, T>.beskjærTilOgMed(
 fun <K, V, T : Tidsenhet> Map<K, Tidslinje<V, T>>.beskjærTilOgMed(
     tilOgMed: Tidspunkt<T>,
 ): Map<K, Tidslinje<V, T>> = this.mapValues { (_, tidslinje) -> tidslinje.beskjærTilOgMed(tilOgMed) }
+
+/**
+ * Extension-metode for å sette tom dato på en tidslinje til uendelig fra et gitt tidspunkt
+ */
+fun <I, T : Tidsenhet> Tidslinje<I, T>.forlengFremtidTilUendelig(senesteEndeligeTidspunkt: Tidspunkt<T>): Tidslinje<I, T> {
+    val tilOgMed = this.tilOgMed()
+    return if (tilOgMed != null && tilOgMed > senesteEndeligeTidspunkt) {
+        this.flyttTilOgMed(tilOgMed.somUendeligLengeTil())
+    } else {
+        this
+    }
+}
+
+private fun <I, T : Tidsenhet> Tidslinje<I, T>.flyttTilOgMed(tilTidspunkt: Tidspunkt<T>): Tidslinje<I, T> {
+    val tidslinje = this
+    val fraOgMed = tidslinje.fraOgMed()
+
+    return if (fraOgMed == null || tilTidspunkt < fraOgMed) {
+        TomTidslinje()
+    } else {
+        object : Tidslinje<I, T>() {
+            override fun lagPerioder(): Collection<Periode<I, T>> =
+                tidslinje
+                    .perioder()
+                    .filter { it.fraOgMed <= tilTidspunkt }
+                    .replaceLast { Periode(it.fraOgMed, tilTidspunkt, it.innhold) }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserTest.kt
@@ -6,7 +6,10 @@ import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.tilpassUtenlandskePe
 import no.nav.familie.ba.sak.kjerne.eøs.util.UtenlandskPeriodebeløpBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.KompetanseBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.YearMonth
 
 /**
  * Syntaks:
@@ -16,7 +19,9 @@ import org.junit.jupiter.api.Test
  * '<siffer>': Skjema har oppgitt beløp og valutakode
  */
 class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
+    val inneværendeMåned = YearMonth.of(2021, 1)
     val jan2020 = jan(2020)
+    val nov2020 = nov(2020)
     val barn1 = tilfeldigPerson()
     val barn2 = tilfeldigPerson()
     val barn3 = tilfeldigPerson()
@@ -43,7 +48,7 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .bygg()
 
         val faktiskeUtenlandskePeriodebeløp =
-            tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser)
+            tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser, inneværendeMåned)
 
         assertEqualsUnordered(forventedeUtenlandskePeriodebeløp, faktiskeUtenlandskePeriodebeløp)
     }
@@ -61,7 +66,7 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .byggKompetanser()
 
         val faktiskeUtenlandskePeriodebeløp =
-            tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser)
+            tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser, inneværendeMåned)
 
         val forventedeUtenlandskePeriodebeløp =
             UtenlandskPeriodebeløpBuilder(jan2020)
@@ -69,5 +74,28 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .bygg()
 
         assertEqualsUnordered(forventedeUtenlandskePeriodebeløp, faktiskeUtenlandskePeriodebeløp)
+    }
+
+    @Test
+    fun `test at ikke fremtidige utenlandske periodebeløp genereres`() {
+        val gjeldendeUtenlandskePeriodeBeløp =
+            UtenlandskPeriodebeløpBuilder(nov2020)
+                .medBeløp("12345", "PLN", "PL", barn1)
+                .bygg()
+
+        val kompetanser =
+            KompetanseBuilder(nov2020)
+                .medKompetanse("SSSSS>", barn1, annenForeldersAktivitetsland = "PL")
+                .bygg()
+
+        val forventedeUtenlandskePeriodebeløp =
+            UtenlandskPeriodebeløpBuilder(nov2020)
+                .medBeløp("123>", "PLN", "PL", barn1)
+                .bygg()
+
+        val faktiskeUtenlandskPeriodebeløp =
+            tilpassUtenlandskePeriodebeløpTilKompetanser(gjeldendeUtenlandskePeriodeBeløp, kompetanser, inneværendeMåned)
+
+        assertThat(faktiskeUtenlandskPeriodebeløp).isEqualTo(forventedeUtenlandskePeriodebeløp)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ba.sak.TestClockProvider
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
@@ -39,7 +40,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
             utenlandskPeriodebeløpRepository,
             emptyList(),
             kompetanseRepository,
-            unleashService,
+            TestClockProvider(),
         )
 
     @BeforeEach

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
 
-import no.nav.familie.ba.sak.TestClockProvider.Companion.lagClockProviderMedFastTidspunkt
 import no.nav.familie.ba.sak.common.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.tilpassValutakurserTilUtenlandskePeriodebeløp
@@ -20,7 +19,7 @@ import java.time.YearMonth
  * '<siffer>': Skjema har oppgitt kurs og valutakode
  */
 class TilpassValutakursTilUtenlandskePeridebeløpTest {
-    private val clockProvider = lagClockProviderMedFastTidspunkt(YearMonth.of(2021, 1))
+    private val inneværendeMåned = YearMonth.of(2021, 1)
     private val jan2020 = jan(2020)
     private val nov2020 = nov(2020)
     private val barn1 = tilfeldigPerson()
@@ -50,7 +49,7 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .bygg()
 
         val faktiskeValutakurser =
-            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, clockProvider)
+            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, inneværendeMåned)
 
         assertEqualsUnordered(forventedeValutakurser, faktiskeValutakurser)
     }
@@ -73,7 +72,7 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .bygg()
 
         val faktiskeValutakurser =
-            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, clockProvider)
+            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, inneværendeMåned)
 
         assertEqualsUnordered(forventedeValutakurser, faktiskeValutakurser)
     }
@@ -96,7 +95,7 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .bygg()
 
         val faktiskeValutakurser =
-            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, clockProvider)
+            tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, inneværendeMåned)
 
         assertThat(faktiskeValutakurser).isEqualTo(forventedeValutakurser)
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -335,7 +335,7 @@ class CucumberMock(
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             endringsabonnenter = utenlandskPeriodebeløpEndretAbonnenter,
             kompetanseRepository = kompetanseRepository,
-            unleashService = unleashService,
+            clockProvider = clockProvider,
         )
 
     val endringsabonnenterForKompetanse = listOf(tilpassUtenlandskePeriodebeløpTilKompetanserService, tilbakestillBehandlingFraKompetanseEndringService)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockEcbService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockEcbService.kt
@@ -13,6 +13,10 @@ fun mockEcbService(dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefinition)
         val valuta = firstArg<String>()
         val dato = secondArg<LocalDate>()
 
+        if (dato.isAfter(dataFraCucumber.dagensDato)) {
+            throw IllegalArgumentException("Kan ikke hente valutakurs for dato $dato etter dagens dato ${dataFraCucumber.dagensDato}")
+        }
+
         val valutakurs =
             dataFraCucumber.valutakurs.values
                 .flatten()

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/eøs/tilpass_eøs_skjema.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/eøs/tilpass_eøs_skjema.feature
@@ -1,0 +1,130 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Tilpassing av EØS-skjemaer
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype | Status  |
+      | 1        | NORMAL     | LØPENDE |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak         | Behandlingstype | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus | Behandlingssteg      |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | MÅNEDLIG_VALUTAJUSTERING | REVURDERING     | Ja                        | EØS                 | AVSLUTTET         | BEHANDLING_AVSLUTTET |
+      | 2            | 1        | 1                   | IKKE_VURDERT        | NYE_OPPLYSNINGER         | REVURDERING     | Nei                       | EØS                 | UTREDES           | VILKÅRSVURDERING     |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 27.05.1983  |              |
+      | 1            | 4       | BARN       | 02.07.2015  |              |
+      | 2            | 1       | SØKER      | 27.05.1983  |              |
+      | 2            | 4       | BARN       | 02.07.2015  |              |
+
+  Scenario: Skal fjerne perioder som er fremover i tid
+    Og dagens dato er 01.12.2024
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår             | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD     |                              | 01.08.2018 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET     | OMFATTET_AV_NORSK_LOVGIVNING | 01.08.2018 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 1       | UTVIDET_BARNETRYGD |                              | 26.07.2023 |            | OPPFYLT  | Nei                  |                  |
+
+      | 4       | GIFT_PARTNERSKAP   |                              | 02.07.2015 |            | OPPFYLT  | Nei                  |                  |
+      | 4       | UNDER_18_ÅR        |                              | 02.07.2015 | 01.07.2033 | OPPFYLT  | Nei                  |                  |
+      | 4       | LOVLIG_OPPHOLD     |                              | 01.12.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 4       | BOSATT_I_RIKET     | BARN_BOR_I_NORGE             | 01.12.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 4       | BOR_MED_SØKER      | BARN_BOR_I_NORGE_MED_SØKER   | 01.12.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår             | Utdypende vilkår             | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD     |                              | 01.08.2018 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET     | OMFATTET_AV_NORSK_LOVGIVNING | 01.08.2018 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 1       | UTVIDET_BARNETRYGD |                              | 26.07.2023 |            | OPPFYLT  | Nei                  |                  |
+
+      | 4       | GIFT_PARTNERSKAP   |                              | 02.07.2015 |            | OPPFYLT  | Nei                  |                  |
+      | 4       | UNDER_18_ÅR        |                              | 02.07.2015 | 01.07.2033 | OPPFYLT  | Nei                  |                  |
+      | 4       | BOR_MED_SØKER      | BARN_BOR_I_NORGE_MED_SØKER   | 01.12.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 4       | BOSATT_I_RIKET     | BARN_BOR_I_NORGE             | 01.12.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+      | 4       | LOVLIG_OPPHOLD     |                              | 01.12.2022 |            | OPPFYLT  | Nei                  | EØS_FORORDNINGEN |
+
+    Og med kompetanser
+      | AktørId | Fra dato   | Til dato   | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 4       | 01.01.2023 | 30.09.2027 | NORGE_ER_SEKUNDÆRLAND | 1            | INAKTIV          | I_ARBEID                  | NO                    | SE                             | NO                  |
+      | 4       | 01.10.2027 | 31.10.2030 | NORGE_ER_SEKUNDÆRLAND | 1            | INAKTIV          | I_ARBEID                  | NO                    | SE                             | NO                  |
+      | 4       | 01.11.2030 | 30.06.2033 | NORGE_ER_SEKUNDÆRLAND | 1            | INAKTIV          | I_ARBEID                  | NO                    | SE                             | NO                  |
+
+      | 4       | 01.01.2023 | 30.09.2027 | NORGE_ER_SEKUNDÆRLAND | 2            | INAKTIV          | I_ARBEID                  | NO                    | SE                             | NO                  |
+      | 4       | 01.10.2027 | 31.10.2030 | NORGE_ER_SEKUNDÆRLAND | 2            | INAKTIV          | I_ARBEID                  | NO                    | SE                             | NO                  |
+      | 4       | 01.11.2030 | 30.06.2033 | NORGE_ER_SEKUNDÆRLAND | 2            | INAKTIV          | I_ARBEID                  | NO                    | SE                             | NO                  |
+
+    Og med utenlandsk periodebeløp
+      | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 4       | 01.2023   | 09.2027   | 1            | 1493  | SEK         | MÅNEDLIG  | SE              |
+      | 4       | 10.2027   | 10.2030   | 1            | 1493  | SEK         | MÅNEDLIG  | SE              |
+      | 4       | 11.2030   | 06.2033   | 1            | 1493  | SEK         | MÅNEDLIG  | SE              |
+
+      | 4       | 01.2023   | 09.2027   | 2            | 1493  | SEK         | MÅNEDLIG  | SE              |
+      | 4       | 10.2027   | 10.2030   | 2            | 1493  | SEK         | MÅNEDLIG  | SE              |
+      | 4       | 11.2030   | 06.2033   | 2            | 1493  | SEK         | MÅNEDLIG  | SE              |
+
+    Og med valutakurser
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 4       | 01.01.2023 | 31.05.2024 | 1            | 2023-12-18     | SEK         | 1.0182593091 | MANUELL        |
+      | 4       | 01.06.2024 | 30.06.2024 | 1            | 2024-05-31     | SEK         | 0.9966727957 | AUTOMATISK     |
+      | 4       | 01.07.2024 | 31.07.2024 | 1            | 2024-06-28     | SEK         | 1.0032571856 | AUTOMATISK     |
+      | 4       | 01.08.2024 | 31.08.2024 | 1            | 2024-07-31     | SEK         | 1.0176533907 | AUTOMATISK     |
+      | 4       | 01.09.2024 | 30.09.2024 | 1            | 2024-08-30     | SEK         | 1.0288033170 | AUTOMATISK     |
+      | 4       | 01.10.2024 | 31.10.2024 | 1            | 2024-09-30     | SEK         | 1.0411061947 | AUTOMATISK     |
+      | 4       | 01.11.2024 | 30.11.2024 | 1            | 2024-10-31     | SEK         | 1.0264556178 | AUTOMATISK     |
+      | 4       | 01.12.2024 | 31.12.2024 | 1            | 2024-11-29     | SEK         | 1.0141083521 | AUTOMATISK     |
+      | 4       | 01.01.2025 | 30.09.2027 | 1            | 2024-12-31     | SEK         | 1.0293219304 | AUTOMATISK     |
+      | 4       | 01.10.2027 | 31.10.2030 | 1            | 2023-12-18     | SEK         | 1.0182593091 | MANUELL        |
+      | 4       | 01.11.2030 | 30.06.2033 | 1            | 2023-12-18     | SEK         | 1.0182593091 | MANUELL        |
+
+      | 4       | 01.01.2023 | 31.05.2024 | 2            | 2023-12-18     | SEK         | 1.0182593091 | MANUELL        |
+      | 4       | 01.06.2024 | 30.06.2024 | 2            | 2024-05-31     | SEK         | 0.9966727957 | AUTOMATISK     |
+      | 4       | 01.07.2024 | 31.07.2024 | 2            | 2024-06-28     | SEK         | 1.0032571856 | AUTOMATISK     |
+      | 4       | 01.08.2024 | 31.08.2024 | 2            | 2024-07-31     | SEK         | 1.0176533907 | AUTOMATISK     |
+      | 4       | 01.09.2024 | 30.09.2024 | 2            | 2024-08-30     | SEK         | 1.0288033170 | AUTOMATISK     |
+      | 4       | 01.10.2024 | 31.10.2024 | 2            | 2024-09-30     | SEK         | 1.0411061947 | AUTOMATISK     |
+      | 4       | 01.11.2024 | 30.11.2024 | 2            | 2024-10-31     | SEK         | 1.0264556178 | AUTOMATISK     |
+      | 4       | 01.12.2024 | 30.09.2027 | 2            | 2024-11-29     | SEK         | 1.0141083521 | AUTOMATISK     |
+      | 4       | 01.10.2027 | 31.10.2030 | 2            | 2023-12-18     | SEK         | 1.0182593091 | MANUELL        |
+      | 4       | 01.11.2030 | 30.06.2033 | 2            | 2023-12-18     | SEK         | 1.0182593091 | MANUELL        |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 1       | 1            | 01.08.2023 | 31.12.2023 | 2306  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 1       | 1            | 01.01.2024 | 31.05.2024 | 2506  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 1       | 1            | 01.06.2024 | 31.07.2024 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 1       | 1            | 01.08.2024 | 31.08.2024 | 2507  | UTVIDET_BARNETRYGD | 100     | 2516 |
+      | 1       | 1            | 01.09.2024 | 30.06.2033 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+
+      | 4       | 1            | 01.01.2023 | 28.02.2023 | 0     | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 4       | 1            | 01.03.2023 | 30.06.2023 | 0     | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 4       | 1            | 01.07.2023 | 31.12.2023 | 0     | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 4       | 1            | 01.01.2024 | 31.05.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 4       | 1            | 01.06.2024 | 30.06.2024 | 22    | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 4       | 1            | 01.07.2024 | 31.07.2024 | 13    | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 4       | 1            | 01.08.2024 | 31.08.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 4       | 1            | 01.09.2024 | 30.09.2024 | 230   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 4       | 1            | 01.10.2024 | 31.10.2024 | 212   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 4       | 1            | 01.11.2024 | 30.11.2024 | 234   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 4       | 1            | 01.12.2024 | 31.12.2024 | 252   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 4       | 1            | 01.01.2025 | 30.09.2027 | 230   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 4       | 1            | 01.10.2027 | 30.06.2033 | 246   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+
+    Når vi utfører vilkårsvurderingssteget for behandling 2
+
+    Så forvent følgende valutakurser for behandling 2
+      | BehandlingId | AktørId | Fra dato   | Til dato   | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 2            | 4       | 01.01.2023 | 31.05.2024 | 2023-12-18     | SEK         | 1.0182593091 | MANUELL        |
+      | 2            | 4       | 01.06.2024 | 30.06.2024 | 2024-05-31     | SEK         | 0.9966727957 | AUTOMATISK     |
+      | 2            | 4       | 01.07.2024 | 31.07.2024 | 2024-06-28     | SEK         | 1.0032571856 | AUTOMATISK     |
+      | 2            | 4       | 01.08.2024 | 31.08.2024 | 2024-07-31     | SEK         | 1.0176533907 | AUTOMATISK     |
+      | 2            | 4       | 01.09.2024 | 30.09.2024 | 2024-08-30     | SEK         | 1.0288033170 | AUTOMATISK     |
+      | 2            | 4       | 01.10.2024 | 31.10.2024 | 2024-09-30     | SEK         | 1.0411061947 | AUTOMATISK     |
+      | 2            | 4       | 01.11.2024 | 30.11.2024 | 2024-10-31     | SEK         | 1.0264556178 | AUTOMATISK     |
+      | 2            | 4       | 01.12.2024 |            | 2024-11-29     | SEK         | 1.0141083521 | AUTOMATISK     |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23752

Når behandlinger kopierer EØS-skjemaer fra forrige behandling, der noen av periodene har fom eller tom senere enn inneværende måned, prøver systemet å hente valutakurser med fremtidig dato.

Løser problemet ved å beskjære tidslinjene for kompetanse, utenlandsk periodebeløp og valutakurser på inneværende måned, og sette siste måned som uendelig.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
