### PR TITLE
Fjerner den ene verdikjedetestene som bruker familie-ba-infotrygd

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
@@ -19,7 +19,6 @@ class VerdikjedetesterPropertyOverrideContextInitializer : ApplicationContextIni
     override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
         TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
             configurableApplicationContext,
-            "FAMILIE_BA_INFOTRYGD_API_URL: http://localhost:1337/rest/api/infotrygd/ba",
             "PDL_URL: http://localhost:1337/rest/api/pdl",
         )
         val brukLokalMockserver = System.getProperty("brukLokalMockserver")?.toBoolean() ?: false
@@ -54,6 +53,7 @@ class VerdikjedetesterPropertyOverrideContextInitializer : ApplicationContextIni
     "mock-task-service",
     "mock-sanity-client",
     "mock-unleash",
+    "mock-infotrygd-barnetrygd",
 )
 @ContextConfiguration(initializers = [VerdikjedetesterPropertyOverrideContextInitializer::class])
 @Tag("verdikjedetest")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -34,16 +34,13 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
-import no.nav.familie.ba.sak.util.sisteTilleggOrdinærSats
 import no.nav.familie.ba.sak.util.sisteUtvidetSatsTilTester
 import no.nav.familie.ba.sak.util.tilleggOrdinærSatsNesteMånedTilTester
-import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -73,63 +70,6 @@ class FødselshendelseHenleggelseTest(
     @AfterEach
     fun etterHverTest() {
         unmockkObject(SatsTidspunkt)
-    }
-
-    @Test
-    fun `Skal ikke starte behandling i ba-sak fordi det finnes saker i infotrygd (velg fagsystem)`() {
-        val scenario =
-            mockServerKlient().lagScenario(
-                RestScenario(
-                    søker =
-                        RestScenarioPerson(
-                            fødselsdato = "1982-01-12",
-                            fornavn = "Mor",
-                            etternavn = "Søker",
-                            infotrygdSaker =
-                                InfotrygdSøkResponse(
-                                    bruker =
-                                        listOf(
-                                            lagInfotrygdSak(
-                                                sisteTilleggOrdinærSats(),
-                                                listOf("1234"),
-                                                "OR",
-                                                "OS",
-                                            ),
-                                        ),
-                                    barn = emptyList(),
-                                ),
-                        ),
-                    barna =
-                        listOf(
-                            RestScenarioPerson(
-                                fødselsdato = now().minusMonths(2).toString(),
-                                fornavn = "Barn",
-                                etternavn = "Barnesen",
-                            ),
-                        ),
-                ),
-            )
-
-        val behandling =
-            behandleFødselshendelse(
-                nyBehandlingHendelse =
-                    NyBehandlingHendelse(
-                        morsIdent = scenario.søker.ident!!,
-                        barnasIdenter = listOf(scenario.barna.first().ident!!),
-                    ),
-                behandleFødselshendelseTask = behandleFødselshendelseTask,
-                fagsakService = fagsakService,
-                behandlingHentOgPersisterService = behandlingHentOgPersisterService,
-                vedtakService = vedtakService,
-                stegService = stegService,
-                personidentService = personidentService,
-                brevmalService = brevmalService,
-            )
-        assertNull(behandling)
-
-        verify(exactly = 1) {
-            opprettTaskService.opprettSendFeedTilInfotrygdTask(scenario.barna.map { it.ident!! })
-        }
     }
 
     @Test


### PR DESCRIPTION
Vi ser sjansen for at denne testen plukker opp noe som liten og det forenkler oppsettet av verdikjedetestene.

### 💰 Hva skal gjøres, og hvorfor?
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert. Ta med en **lenke til Favro** og
skriv en kort beskrivelse av hvorfor endringen skal gjøres._

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
