### PR TITLE
Fix for patch av utvidet barnetrygd fagsaker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -28,10 +28,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-<<<<<<< Updated upstream
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
-=======
->>>>>>> Stashed changes
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -28,7 +28,10 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+<<<<<<< Updated upstream
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+=======
+>>>>>>> Stashed changes
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -285,6 +288,7 @@ class ForvalterService(
         logger.info("Fant ${oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.size} behandlinger som er eneste OPPDATER_UTVIDET_KLASSEKODE-behandling i fagsak")
         val resultat = mutableListOf<Pair<Long, List<AndelTilkjentYtelse>>>()
         oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.forEach { behandling ->
+            logger.info("Korrigerer utvidet andeler i behandling ${behandling.id}")
             // Sørger for at behandlingen ble kjørt 17.desember
             if (behandling.opprettetTidspunkt.toLocalDate() != LocalDate.of(2024, 12, 17)) {
                 error("Alle behandlinger må være opprettet 17.desember. Behandling ${behandling.id} ble opprettet ${behandling.opprettetTidspunkt.toLocalDate()}")
@@ -306,7 +310,7 @@ class ForvalterService(
             val behandlingFørOppdaterUtvidetKlassekodeBehandling =
                 behandlingRepository
                     .finnBehandlinger(behandling.fagsak.id)
-                    .filter { it.aktivertTidspunkt < behandling.aktivertTidspunkt }
+                    .filter { it.aktivertTidspunkt < behandling.aktivertTidspunkt && !it.erHenlagt() }
                     .maxBy { it.aktivertTidspunkt }
 
             // Finner utvidet andeler i behandlingen før OPPDATER_UTVIDET_KLASSEKODE behandlingen
@@ -315,6 +319,7 @@ class ForvalterService(
             // Sørger for at vi opprettet splitt i andelene, og korrigerer periodeOffset og forrigePeriodeOffset.
             // Den nye andelen som vil gå fra januar 2025 -> beholder offsets fra andelen vi splitter
             // I den opprinnelige andelen vi nå forkorter oppdaterer vi offsets til å være samme som andelen i forrige behandling.
+            logger.info("Finner tilsvarende andel i forrige behandling blandt utvidet andelene (${utvidetAndelerBehandlingFørOppdaterUtvidetKlassekodeBehandling.map { it.id }})")
             val tilsvarendeAndelIForrigeBehandling = utvidetAndelerBehandlingFørOppdaterUtvidetKlassekodeBehandling.single { utvidetAndel -> utvidetAndel.periodeOffset == utvidetAndelSomOverlapperSplitt.forrigePeriodeOffset }
 
             resultat.add(
@@ -336,6 +341,7 @@ class ForvalterService(
         logger.info("Fant ${oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.size} behandlinger som er eneste OPPDATER_UTVIDET_KLASSEKODE-behandling i fagsak")
         val resultat = mutableListOf<Pair<Long, List<AndelTilkjentYtelse>>>()
         oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.forEach { behandling ->
+            logger.info("Korrigerer utvidet andeler i behandling ${behandling.id}")
             // Sørger for at behandlingen ble kjørt 17.desember
             if (behandling.opprettetTidspunkt.toLocalDate() != LocalDate.of(2024, 12, 17)) {
                 error("Alle behandlinger må være opprettet 17.desember. Behandling ${behandling.id} ble opprettet ${behandling.opprettetTidspunkt.toLocalDate()}")
@@ -358,7 +364,7 @@ class ForvalterService(
             val behandlingFørOppdaterUtvidetKlassekodeBehandling =
                 behandlingRepository
                     .finnBehandlinger(behandling.fagsak.id)
-                    .filter { it.aktivertTidspunkt < behandling.aktivertTidspunkt }
+                    .filter { it.aktivertTidspunkt < behandling.aktivertTidspunkt && !it.erHenlagt() }
                     .maxBy { it.aktivertTidspunkt }
 
             // Finner utvidet andeler i behandlingen før OPPDATER_UTVIDET_KLASSEKODE behandlingen

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -364,9 +364,11 @@ class ForvalterServiceTest {
 
             every { mockedForrigeBehandling.id } returns 2
             every { mockedForrigeBehandling.aktivertTidspunkt } returns LocalDate.of(2024, 8, 1).atStartOfDay()
+            every { mockedForrigeBehandling.erHenlagt() } returns false
 
             every { mockedForrigeBehandling2.id } returns 1
             every { mockedForrigeBehandling2.aktivertTidspunkt } returns LocalDate.of(2022, 8, 1).atStartOfDay()
+            every { mockedForrigeBehandling2.erHenlagt() } returns false
 
             every { behandlingRepository.finnOppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling() } returns listOf(mockedBehandling)
             every {
@@ -476,9 +478,11 @@ class ForvalterServiceTest {
 
             every { mockedForrigeBehandling.id } returns 2
             every { mockedForrigeBehandling.aktivertTidspunkt } returns LocalDate.of(2024, 8, 1).atStartOfDay()
+            every { mockedForrigeBehandling.erHenlagt() } returns false
 
             every { mockedForrigeBehandling2.id } returns 1
             every { mockedForrigeBehandling2.aktivertTidspunkt } returns LocalDate.of(2022, 8, 1).atStartOfDay()
+            every { mockedForrigeBehandling2.erHenlagt() } returns false
 
             every { behandlingRepository.finnOppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling() } returns listOf(mockedBehandling)
             every {


### PR DESCRIPTION
Sørger for at vi filtrerer bort henlagte behandlinger når vi skal finne behandling før `OPPDATER_UTVIDET_KLASSEKODE`-behandling.

Legger også til ekstra logging for å enklere kunne feilsøke.