### PR TITLE
Fix: Patching av `OPPDATER_UTVIDET_KLASSEKODE` behandlinger

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -385,6 +385,11 @@ class ForvalterServiceTest {
                     lagAndelTilkjentYtelse(id = 1, fom = YearMonth.of(2024, 7), tom = YearMonth.of(2035, 5), periodeIdOffset = 2, forrigeperiodeIdOffset = 1, ytelseType = YtelseType.UTVIDET_BARNETRYGD),
                 )
 
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(1) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(id = 1, fom = YearMonth.of(2024, 7), tom = YearMonth.of(2035, 5), periodeIdOffset = 1, forrigeperiodeIdOffset = null, ytelseType = YtelseType.UTVIDET_BARNETRYGD),
+                )
+
             every { andelTilkjentYtelseRepository.save(any()) } answers { firstArg() }
 
             // Act
@@ -479,6 +484,11 @@ class ForvalterServiceTest {
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(2) } returns
                 listOf(
                     lagAndelTilkjentYtelse(id = 1, fom = YearMonth.of(2024, 7), tom = YearMonth.of(2035, 5), periodeIdOffset = 2, forrigeperiodeIdOffset = 1, ytelseType = YtelseType.UTVIDET_BARNETRYGD),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(1) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(id = 1, fom = YearMonth.of(2024, 7), tom = YearMonth.of(2035, 5), periodeIdOffset = 1, forrigeperiodeIdOffset = null, ytelseType = YtelseType.UTVIDET_BARNETRYGD),
                 )
 
             // Act


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I og med at vi ikke alltid iverksetter noe mot økonomi, finnes det behandlinger hvor andelene ikke har `periodeOffset` eller `forrigePeriodeOffset`. Når jeg skal finne korrekt offsets for korrigert andel, må jeg derfor se på alle andeler til tidligere behandlinger for å finne ut hva som blir riktig offsets å korrigere til.
