### PR TITLE
Eeget returobjekt for korrigerte AndelTilkjentYtelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -598,7 +598,7 @@ class ForvalterController(
         summary = "Korrigerer OPPDATER_UTVIDET_KLASSEKODE behandlinger som tilhører fagsak som er opphørt eller avsluttet før 02.2025",
         description = "Korrigerer og legger til andeler i disse behandlingene for å få med splitt som reflekterer det som er sendt til Oppdrag",
     )
-    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlinger(): ResponseEntity<List<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>>> {
+    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlinger(): ResponseEntity<List<Pair<Long, List<RestKorrigertAndelTilkjentYtelseDto>>>> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
             handling = "Korrigere andeler i OPPDATER_UTVIDET_KLASSEKODE behandlinger",
@@ -611,7 +611,7 @@ class ForvalterController(
         summary = "Korrigerer OPPDATER_UTVIDET_KLASSEKODE behandlinger som tilhører fagsak som er opphørt eller avsluttet før 02.2025",
         description = "Korrigerer og legger til andeler i disse behandlingene for å få med splitt som reflekterer det som er sendt til Oppdrag",
     )
-    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlingerDryRun(): ResponseEntity<List<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>>> {
+    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlingerDryRun(): ResponseEntity<List<Pair<Long, List<RestKorrigertAndelTilkjentYtelseDto>>>> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
             handling = "Korrigere andeler i OPPDATER_UTVIDET_KLASSEKODE behandlinger",

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -23,7 +23,6 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.Populer
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
@@ -599,7 +598,7 @@ class ForvalterController(
         summary = "Korrigerer OPPDATER_UTVIDET_KLASSEKODE behandlinger som tilhører fagsak som er opphørt eller avsluttet før 02.2025",
         description = "Korrigerer og legger til andeler i disse behandlingene for å få med splitt som reflekterer det som er sendt til Oppdrag",
     )
-    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlinger(): ResponseEntity<List<Pair<Long, List<AndelTilkjentYtelse>>>> {
+    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlinger(): ResponseEntity<List<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>>> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
             handling = "Korrigere andeler i OPPDATER_UTVIDET_KLASSEKODE behandlinger",
@@ -612,7 +611,7 @@ class ForvalterController(
         summary = "Korrigerer OPPDATER_UTVIDET_KLASSEKODE behandlinger som tilhører fagsak som er opphørt eller avsluttet før 02.2025",
         description = "Korrigerer og legger til andeler i disse behandlingene for å få med splitt som reflekterer det som er sendt til Oppdrag",
     )
-    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlingerDryRun(): ResponseEntity<List<Pair<Long, List<AndelTilkjentYtelse>>>> {
+    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlingerDryRun(): ResponseEntity<List<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>>> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
             handling = "Korrigere andeler i OPPDATER_UTVIDET_KLASSEKODE behandlinger",

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -279,14 +279,14 @@ class ForvalterService(
         }
     }
 
-    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlingerDryRun(): List<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>> {
+    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlingerDryRun(): List<Pair<Long, List<RestKorrigertAndelTilkjentYtelseDto>>> {
         val oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling =
             behandlingRepository
                 .finnOppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling()
                 .filter { it.opprettetTidspunkt.toLocalDate() <= LocalDate.of(2024, 12, 17) }
 
         logger.info("Fant ${oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.size} behandlinger som er eneste OPPDATER_UTVIDET_KLASSEKODE-behandling i fagsak")
-        val resultat = mutableListOf<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>>()
+        val resultat = mutableListOf<Pair<Long, List<RestKorrigertAndelTilkjentYtelseDto>>>()
         oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.forEach { behandling ->
             logger.info("Korrigerer utvidet andeler i behandling ${behandling.id}")
 
@@ -320,7 +320,7 @@ class ForvalterService(
                     listOf(
                         utvidetAndelSomOverlapperSplitt.copy(stønadTom = splittIMnd, periodeOffset = tilsvarendeAndelFraTidligereBehandling.periodeOffset, forrigePeriodeOffset = tilsvarendeAndelFraTidligereBehandling.forrigePeriodeOffset),
                         utvidetAndelSomOverlapperSplitt.copy(id = 0, stønadFom = splittIMnd.plusMonths(1)),
-                    ).map { RestKorrigertAndelTilkjentYtelse(id = it.id, fom = it.stønadFom, tom = it.stønadTom, periodeId = it.periodeOffset, forrigePeriodeId = it.forrigePeriodeOffset) },
+                    ).map { RestKorrigertAndelTilkjentYtelseDto(id = it.id, fom = it.stønadFom, tom = it.stønadTom, periodeId = it.periodeOffset, forrigePeriodeId = it.forrigePeriodeOffset) },
                 ),
             )
         }
@@ -328,14 +328,14 @@ class ForvalterService(
     }
 
     @Transactional
-    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlinger(): List<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>> {
+    fun korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlinger(): List<Pair<Long, List<RestKorrigertAndelTilkjentYtelseDto>>> {
         val oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling =
             behandlingRepository
                 .finnOppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling()
                 .filter { it.opprettetTidspunkt.toLocalDate() <= LocalDate.of(2024, 12, 17) }
 
         logger.info("Fant ${oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.size} behandlinger som er eneste OPPDATER_UTVIDET_KLASSEKODE-behandling i fagsak")
-        val resultat = mutableListOf<Pair<Long, List<RestKorrigertAndelTilkjentYtelse>>>()
+        val resultat = mutableListOf<Pair<Long, List<RestKorrigertAndelTilkjentYtelseDto>>>()
         oppdaterUtvidetKlassekodeBehandlingerIFagsakerHvorDetKunFinnes1SlikBehandling.forEach { behandling ->
             logger.info("Korrigerer utvidet andeler i behandling ${behandling.id}")
 
@@ -370,7 +370,7 @@ class ForvalterService(
                     listOf(
                         andelTilkjentYtelseRepository.save(utvidetAndelSomOverlapperSplitt.copy(stønadTom = splittIMnd, periodeOffset = tilsvarendeAndelFraTidligereBehandling.periodeOffset, forrigePeriodeOffset = tilsvarendeAndelFraTidligereBehandling.forrigePeriodeOffset)),
                         andelTilkjentYtelseRepository.save(utvidetAndelSomOverlapperSplitt.copy(id = 0, stønadFom = splittIMnd.plusMonths(1))),
-                    ).map { RestKorrigertAndelTilkjentYtelse(id = it.id, fom = it.stønadFom, tom = it.stønadTom, periodeId = it.periodeOffset, forrigePeriodeId = it.forrigePeriodeOffset) },
+                    ).map { RestKorrigertAndelTilkjentYtelseDto(id = it.id, fom = it.stønadFom, tom = it.stønadTom, periodeId = it.periodeOffset, forrigePeriodeId = it.forrigePeriodeOffset) },
                 ),
             )
         }
@@ -378,7 +378,7 @@ class ForvalterService(
     }
 }
 
-data class RestKorrigertAndelTilkjentYtelse(
+data class RestKorrigertAndelTilkjentYtelseDto(
     val id: Long,
     val fom: YearMonth,
     val tom: YearMonth,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -400,19 +400,19 @@ class ForvalterServiceTest {
             assertThat(korrigerteAndelerForBehandlinger).hasSize(1)
             val korrigerteAndeler = korrigerteAndelerForBehandlinger.single().second
             assertThat(korrigerteAndeler).hasSize(2)
-            val førsteAndel = korrigerteAndeler.minBy { it.stønadFom }
-            val sisteAndel = korrigerteAndeler.maxBy { it.stønadFom }
+            val førsteAndel = korrigerteAndeler.minBy { it.fom }
+            val sisteAndel = korrigerteAndeler.maxBy { it.fom }
             assertThat(førsteAndel.id).isEqualTo(2)
-            assertThat(førsteAndel.stønadFom).isEqualTo(YearMonth.of(2024, 7))
-            assertThat(førsteAndel.stønadTom).isEqualTo(YearMonth.of(2024, 12))
-            assertThat(førsteAndel.periodeOffset).isEqualTo(2)
-            assertThat(førsteAndel.forrigePeriodeOffset).isEqualTo(1)
+            assertThat(førsteAndel.fom).isEqualTo(YearMonth.of(2024, 7))
+            assertThat(førsteAndel.tom).isEqualTo(YearMonth.of(2024, 12))
+            assertThat(førsteAndel.periodeId).isEqualTo(2)
+            assertThat(førsteAndel.forrigePeriodeId).isEqualTo(1)
 
             assertThat(sisteAndel.id).isEqualTo(0)
-            assertThat(sisteAndel.stønadFom).isEqualTo(YearMonth.of(2025, 1))
-            assertThat(sisteAndel.stønadTom).isEqualTo(YearMonth.of(2035, 5))
-            assertThat(sisteAndel.periodeOffset).isEqualTo(3)
-            assertThat(sisteAndel.forrigePeriodeOffset).isEqualTo(2)
+            assertThat(sisteAndel.fom).isEqualTo(YearMonth.of(2025, 1))
+            assertThat(sisteAndel.tom).isEqualTo(YearMonth.of(2035, 5))
+            assertThat(sisteAndel.periodeId).isEqualTo(3)
+            assertThat(sisteAndel.forrigePeriodeId).isEqualTo(2)
         }
 
         @Test
@@ -498,19 +498,19 @@ class ForvalterServiceTest {
             assertThat(korrigerteAndelerForBehandlinger).hasSize(1)
             val korrigerteAndeler = korrigerteAndelerForBehandlinger.single().second
             assertThat(korrigerteAndeler).hasSize(2)
-            val førsteAndel = korrigerteAndeler.minBy { it.stønadFom }
-            val sisteAndel = korrigerteAndeler.maxBy { it.stønadFom }
+            val førsteAndel = korrigerteAndeler.minBy { it.fom }
+            val sisteAndel = korrigerteAndeler.maxBy { it.fom }
             assertThat(førsteAndel.id).isEqualTo(2)
-            assertThat(førsteAndel.stønadFom).isEqualTo(YearMonth.of(2024, 7))
-            assertThat(førsteAndel.stønadTom).isEqualTo(YearMonth.of(2024, 12))
-            assertThat(førsteAndel.periodeOffset).isEqualTo(2)
-            assertThat(førsteAndel.forrigePeriodeOffset).isEqualTo(1)
+            assertThat(førsteAndel.fom).isEqualTo(YearMonth.of(2024, 7))
+            assertThat(førsteAndel.tom).isEqualTo(YearMonth.of(2024, 12))
+            assertThat(førsteAndel.periodeId).isEqualTo(2)
+            assertThat(førsteAndel.forrigePeriodeId).isEqualTo(1)
 
             assertThat(sisteAndel.id).isEqualTo(0)
-            assertThat(sisteAndel.stønadFom).isEqualTo(YearMonth.of(2025, 1))
-            assertThat(sisteAndel.stønadTom).isEqualTo(YearMonth.of(2035, 5))
-            assertThat(sisteAndel.periodeOffset).isEqualTo(3)
-            assertThat(sisteAndel.forrigePeriodeOffset).isEqualTo(2)
+            assertThat(sisteAndel.fom).isEqualTo(YearMonth.of(2025, 1))
+            assertThat(sisteAndel.tom).isEqualTo(YearMonth.of(2035, 5))
+            assertThat(sisteAndel.periodeId).isEqualTo(3)
+            assertThat(sisteAndel.forrigePeriodeId).isEqualTo(2)
         }
 
         @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Ved kjøring av dry-run for korrigering av andeler ble returobjektet `AndelTilkjentYtelse` alt for stort da vi fikk med alle entiteter `AndelTilkjentYtelse` har relasjoner til. Introduserer her et eget returobjekt for kjøringen.