### PR TITLE
Feat: saksbehandlers navn i beskrivelsen til godkjenne vedtak-oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -27,6 +27,9 @@ class FeatureToggleConfig {
         // NAV-23733
         const val BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET = "familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"
 
+        // NAV-23989
+        const val FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE = "familie-ba-sak.sb-navn-i-godkjenne-vedtak-oppgave"
+
         // satsendring
         // Oppretter satsendring-tasker for de som ikke har fått ny task
         const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -82,7 +82,7 @@ class SendTilBeslutter(
                     behandlingId = behandling.id,
                     oppgavetype = Oppgavetype.GodkjenneVedtak,
                     fristForFerdigstillelse = LocalDate.now(),
-                    beskrivelse = if (unleashService.isEnabled(FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE)) SikkerhetContext.hentSaksbehandlerNavn() else null
+                    beskrivelse = if (unleashService.isEnabled(FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE)) SikkerhetContext.hentSaksbehandlerNavn() else null,
                 )
             loggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = false)
             taskRepository.save(godkjenneVedtakTask)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
@@ -19,9 +20,11 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.validerPerioderInnehol
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.FerdigstillLagVedtakOppgaver
 import no.nav.familie.ba.sak.task.OpprettOppgaveTask
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -36,6 +39,7 @@ class SendTilBeslutter(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val automatiskBeslutningService: AutomatiskBeslutningService,
     private val validerBrevmottakerService: ValiderBrevmottakerService,
+    private val unleashService: UnleashService,
 ) : BehandlingSteg<String> {
     override fun preValiderSteg(
         behandling: Behandling,
@@ -78,6 +82,7 @@ class SendTilBeslutter(
                     behandlingId = behandling.id,
                     oppgavetype = Oppgavetype.GodkjenneVedtak,
                     fristForFerdigstillelse = LocalDate.now(),
+                    beskrivelse = if (unleashService.isEnabled(FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE)) SikkerhetContext.hentSaksbehandlerNavn() else null
                 )
             loggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = false)
             taskRepository.save(godkjenneVedtakTask)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
+import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -40,6 +41,7 @@ class SendTilBeslutterTest {
     private val mockVedtaksperiodeService = mockk<VedtaksperiodeService>()
     private val mockAutomatiskBeslutningService = mockk<AutomatiskBeslutningService>()
     private val mockValiderBrevmottakerService = mockk<ValiderBrevmottakerService>()
+    private val mockUnleashService = mockk<UnleashService>()
 
     private val totrinnskontrollService = TotrinnskontrollService(mockBehandlingService, mockTotrinnskontrollRepository, mockSaksbehandlerContext)
 
@@ -54,6 +56,7 @@ class SendTilBeslutterTest {
             vedtaksperiodeService = mockVedtaksperiodeService,
             automatiskBeslutningService = mockAutomatiskBeslutningService,
             validerBrevmottakerService = mockValiderBrevmottakerService,
+            unleashService = mockUnleashService,
         )
 
     @Nested
@@ -73,6 +76,7 @@ class SendTilBeslutterTest {
             every { mockVedtakService.hentAktivForBehandlingThrows(behandlingId = behandling.id) } returns vedtak
             every { mockVedtakService.oppdaterVedtakMedStønadsbrev(vedtak) } returns vedtak
             every { mockBehandlingService.sendBehandlingTilBeslutter(behandling) } just runs
+            every { mockUnleashService.isEnabled(any()) } returns true
 
             // Act
             sendTilBeslutter.utførStegOgAngiNeste(behandling, "")
@@ -102,6 +106,7 @@ class SendTilBeslutterTest {
             every { mockLoggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = true) } just runs
             every { mockTaskRepository.save(any()) } returnsArgument 0
             every { mockBehandlingService.sendBehandlingTilBeslutter(behandling) } just runs
+            every { mockUnleashService.isEnabled(any()) } returns true
 
             // Act
             sendTilBeslutter.utførStegOgAngiNeste(behandling, "")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23989

Fyller ut saksbehandler sitt navn i beskrivelsen til godkjenne vedtak-oppgaven hvis toggle er på. Dette er i dag en manuell prosess som saksbehandlerne bruker mye tid på, men som er en veldig liten fiks. Legger bak toggle så Dorota kan teste før vi prodsetter.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det gir mening å bruke tid på, finnes ingen eksisterende tester som tester task. Men kom med innspill om noen er uenig!

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
