### PR TITLE
Fix: StaleObjectStateException ved patching av andeler 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -383,7 +383,7 @@ class ForvalterService(
                     utvidetAndelSomOverlapperSplitt.copy(id = 0, stønadFom = splittIMnd.plusMonths(1)),
                 )
 
-            tilkjentYtelse.andelerTilkjentYtelse.remove(utvidetAndelSomOverlapperSplitt)
+            tilkjentYtelse.andelerTilkjentYtelse.removeAll { it.id == utvidetAndelSomOverlapperSplitt.id }
             tilkjentYtelse.andelerTilkjentYtelse.addAll(oppdatertOgNyAndel)
             tilkjentYtelseRepository.save(tilkjentYtelse)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
 Problemer med patching av andeler. Får StaleObjectStateException ved lagring av oppdatert `TilkjentYtelse`. Klarte å gjenskape problemet lokalt og ser at `tilkjentYtelse.andelerTilkjentYtelse.remove(andel)` ikke fjernet andelen. Mest sannsynlig pga problem med `equals/hashCode`. Når vi senere la til oppdatertOgNyAndel i lista over andeler lå både gammel og ny versjon av entitet i lista og vi fikk feil. 

Erstatter her `remove()` med `removeAll{}`. 
