### PR TITLE
Forsøker å opprette ny andel fremfor å oppdatere eksisterende

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -385,7 +385,6 @@ class ForvalterService(
 
             tilkjentYtelse.andelerTilkjentYtelse.removeAll { it.id == utvidetAndelSomOverlapperSplitt.id }
             tilkjentYtelse.andelerTilkjentYtelse.addAll(oppdatertOgNyAndel)
-            tilkjentYtelseRepository.save(tilkjentYtelse)
 
             resultat.add(
                 Pair(

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -329,7 +329,7 @@ class ForvalterService(
                 Pair(
                     behandling.id,
                     listOf(
-                        utvidetAndelSomOverlapperSplitt.copy(stønadTom = splittIMnd, periodeOffset = tilsvarendeAndelFraTidligereBehandling.periodeOffset, forrigePeriodeOffset = tilsvarendeAndelFraTidligereBehandling.forrigePeriodeOffset),
+                        utvidetAndelSomOverlapperSplitt.copy(id = 0, stønadTom = splittIMnd, periodeOffset = tilsvarendeAndelFraTidligereBehandling.periodeOffset, forrigePeriodeOffset = tilsvarendeAndelFraTidligereBehandling.forrigePeriodeOffset),
                         utvidetAndelSomOverlapperSplitt.copy(id = 0, stønadFom = splittIMnd.plusMonths(1)),
                     ).map { RestKorrigertAndelTilkjentYtelseDto(id = it.id, fom = it.stønadFom, tom = it.stønadTom, periodeId = it.periodeOffset, forrigePeriodeId = it.forrigePeriodeOffset) },
                 ),
@@ -379,7 +379,7 @@ class ForvalterService(
 
             val oppdatertOgNyAndel =
                 listOf(
-                    utvidetAndelSomOverlapperSplitt.copy(stønadTom = splittIMnd, periodeOffset = tilsvarendeAndelFraTidligereBehandling.periodeOffset, forrigePeriodeOffset = tilsvarendeAndelFraTidligereBehandling.forrigePeriodeOffset),
+                    utvidetAndelSomOverlapperSplitt.copy(id = 0, stønadTom = splittIMnd, periodeOffset = tilsvarendeAndelFraTidligereBehandling.periodeOffset, forrigePeriodeOffset = tilsvarendeAndelFraTidligereBehandling.forrigePeriodeOffset),
                     utvidetAndelSomOverlapperSplitt.copy(id = 0, stønadFom = splittIMnd.plusMonths(1)),
                 )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -404,13 +404,12 @@ class ForvalterServiceTest {
             val korrigerteAndelerForBehandlinger = forvalterService.korrigerUtvidetAndelerIOppdaterUtvidetKlassekodeBehandlinger()
 
             // Assert
-            verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
             assertThat(korrigerteAndelerForBehandlinger).hasSize(1)
             val korrigerteAndeler = korrigerteAndelerForBehandlinger.single().second
             assertThat(korrigerteAndeler).hasSize(2)
             val førsteAndel = korrigerteAndeler.minBy { it.fom }
             val sisteAndel = korrigerteAndeler.maxBy { it.fom }
-            assertThat(førsteAndel.id).isEqualTo(2)
+            assertThat(førsteAndel.id).isEqualTo(0)
             assertThat(førsteAndel.fom).isEqualTo(YearMonth.of(2024, 7))
             assertThat(førsteAndel.tom).isEqualTo(YearMonth.of(2024, 12))
             assertThat(førsteAndel.periodeId).isEqualTo(2)
@@ -507,7 +506,7 @@ class ForvalterServiceTest {
             assertThat(korrigerteAndeler).hasSize(2)
             val førsteAndel = korrigerteAndeler.minBy { it.fom }
             val sisteAndel = korrigerteAndeler.maxBy { it.fom }
-            assertThat(førsteAndel.id).isEqualTo(2)
+            assertThat(førsteAndel.id).isEqualTo(0)
             assertThat(førsteAndel.fom).isEqualTo(YearMonth.of(2024, 7))
             assertThat(førsteAndel.tom).isEqualTo(YearMonth.of(2024, 12))
             assertThat(førsteAndel.periodeId).isEqualTo(2)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fortsatt et problem med `StaleObjectStateException` ved lagring av endrede andeler i TilkjentYtelse. Forsøker å fjerne eksisterende og legge til 2 nye andeler fremfor å oppdatere 1 og legge til 1 ny.