### PR TITLE
bedre logging når vi ikke finner en ident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentIdenterResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentIdenterResponse.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner.pdl.domene
 
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.person.pdl.aktor.v2.Type
 
 class PdlHentIdenterResponse(
@@ -18,10 +19,16 @@ data class IdentInformasjon(
 
 fun List<IdentInformasjon>.hentAktivFødselsnummer(): String =
     this.singleOrNull { it.gruppe == Type.FOLKEREGISTERIDENT.name && !it.historisk }?.ident
-        ?: throw Error("Finner ikke aktørId i Pdl")
+        ?: run {
+            secureLogger.error("Finner ikke folkeregisterident i liste fra PDL: $this")
+            throw Error("Finner ikke folkeregisteriden i Pdl")
+        }
 
 fun List<IdentInformasjon>.hentAktivAktørId(): String =
     this.singleOrNull { it.gruppe == Type.AKTORID.name && !it.historisk }?.ident
-        ?: throw Error("Finner ikke aktørId i Pdl")
+        ?: run {
+            secureLogger.error("Finner ikke folkeregisterident i liste fra PDL: $this")
+            throw Error("Finner ikke aktørId i Pdl")
+        }
 
 fun List<IdentInformasjon>.hentAktørIder(): List<String> = filter { it.gruppe == Type.AKTORID.name }.map { it.ident }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når vi ikke finner noen ident logges det ikke hva det er søkt etter. Det gjør det vanskelig å feilsøke. Legger ved logging i securelogging av tilhørende identer.

[Feil i sentry](https://sentry.gc.nav.no/organizations/nav/issues/603545/?environment=prod&project=112&query=is%3Aunresolved&referrer=issue-stream)
