### PR TITLE
Skipper utbetalinger over 100 prosent validering for OPPDATER_UTVIDET_KLASSEKODE-behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -22,7 +22,7 @@ class TilkjentYtelseValideringService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
 ) {
     fun validerAtIngenUtbetalingerOverstiger100Prosent(behandling: Behandling) {
-        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring()) return
+        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring() || behandling.erOppdaterUtvidetKlassekode()) return
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(behandling.id)
 
         if (totrinnskontroll?.godkjent == true) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har noen `OPPDATER_UTVIDET_KLASSEKODE`-behandlinger som feiler med:

```
 Vi finner utbetalinger som overstiger 100%
```

Som ved satsendringer legger jeg inn at OPPDATER_UTVIDET_KLASSEKODE-behandlinger også skipper denne valideringen.