### PR TITLE
Ekskluder inneværende måned i validering av feilutbetaling i BeslutteVedtak-steget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.simulering
 import io.micrometer.core.instrument.Metrics
 import jakarta.transaction.Transactional
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.UtbetalingsoppdragGenerator
@@ -139,6 +140,15 @@ class SimuleringService(
     fun hentEtterbetaling(behandlingId: Long): BigDecimal {
         val vedtakSimuleringMottakere = hentSimuleringPåBehandling(behandlingId)
         return hentEtterbetaling(vedtakSimuleringMottakere)
+    }
+
+    fun hentFeilutbetalingTilOgMedForrigeMåned(behandlingId: Long): BigDecimal {
+        val vedtakSimuleringMottakere = hentSimuleringPåBehandling(behandlingId)
+        val feilutbetaling =
+            vedtakSimuleringMottakereTilSimuleringPerioder(vedtakSimuleringMottakere)
+                .filter { it.tom.isBefore(LocalDate.now().førsteDagIInneværendeMåned()) }
+                .sumOf { it.feilutbetaling }
+        return feilutbetaling
     }
 
     fun hentFeilutbetaling(behandlingId: Long): BigDecimal {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -86,7 +86,7 @@ class BeslutteVedtak(
 
         validerBrevmottakere(BehandlingId(behandling.id), data.beslutning.erGodkjent())
 
-        val feilutbetaling by lazy { simuleringService.hentFeilutbetaling(behandling.id) }
+        val feilutbetaling by lazy { simuleringService.hentFeilutbetalingTilOgMedForrigeMåned(behandling.id) }
         val erÅpenTilbakekrevingPåFagsak by lazy { tilbakekrevingService.søkerHarÅpenTilbakekreving(behandling.fagsak.id) }
         val tilbakekrevingsvalg by lazy { tilbakekrevingService.hentTilbakekrevingsvalg(behandling.id) }
         val valutakurser by lazy { valutakursRepository.finnFraBehandlingId(behandlingId = behandling.id) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ba.sak.kjerne.simulering
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.randomFnr
@@ -28,9 +30,11 @@ import no.nav.familie.kontrakter.felles.simulering.FagOmrådeKode
 import no.nav.familie.kontrakter.felles.simulering.MottakerType
 import no.nav.familie.kontrakter.felles.simulering.PosteringType
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import java.math.BigDecimal
 import java.time.LocalDate
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -291,6 +295,47 @@ internal class SimuleringServiceEnhetTest {
             )
 
         assertThrows<Feil> { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) }
+    }
+
+    @Test
+    fun `hentFeilutbetalingTilOgMedForrigeMåned skal summere feilutbetaling for tidligere enn inneværende måned`() {
+        // Arrange
+        val behandling =
+            lagBehandling(
+                behandlingType = BehandlingType.REVURDERING,
+                årsak = BehandlingÅrsak.ÅRLIG_KONTROLL,
+            )
+
+        val økonomiSimuleringPostering =
+            listOf(
+                mockVedtakSimuleringPostering(
+                    beløp = 100,
+                    fom = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned(),
+                    tom = LocalDate.now().minusMonths(2).sisteDagIMåned(),
+                    posteringType = PosteringType.FEILUTBETALING,
+                ),
+                mockVedtakSimuleringPostering(
+                    beløp = 200,
+                    fom = LocalDate.now().minusMonths(1).førsteDagIInneværendeMåned(),
+                    tom = LocalDate.now().minusMonths(1).sisteDagIMåned(),
+                    posteringType = PosteringType.FEILUTBETALING,
+                ),
+                mockVedtakSimuleringPostering(
+                    beløp = 300,
+                    fom = LocalDate.now().førsteDagIInneværendeMåned(),
+                    tom = LocalDate.now().sisteDagIMåned(),
+                    posteringType = PosteringType.FEILUTBETALING,
+                ),
+            )
+
+        every { økonomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns
+            listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = økonomiSimuleringPostering))
+
+        // Act
+        val feilutbetalingTilOgMedForrigeMåned = simuleringService.hentFeilutbetalingTilOgMedForrigeMåned(behandling.id)
+
+        // Assert
+        assertThat(feilutbetalingTilOgMedForrigeMåned, Is(BigDecimal(300)))
     }
 
     private fun mockØkonomiSimuleringMottaker(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Saksbehandlere opplever at de ikke får godkjent behandlinger der det er endring i utbetaling inneværende måned.
Dette skyldes en validering av at dersom det eksisterer automatiske valutakurser på behandlingen og det er en feilutbetaling, må det eksistere en tilbakekrevingssak. I tilfellene det er snakk om er ikke utbetalingen skjedd ennå, og det bør være mulig å godkjenne behandlingen med feilutbetaling, selv om det ikke eksisterer en tilbakekrevingssak.

Løser problemet ved å bare validere feilutbetalinger til og med forrige måned.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇