### PR TITLE
Legg til enum-klasse for FeatureToggle

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -47,5 +47,3 @@ enum class FeatureToggleConfig(
     // Kjører satsendring lørdag
     SATSENDRING_LØRDAG("familie-ba-sak.satsendring-lordag"),
 }
-
-

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -1,54 +1,6 @@
 package no.nav.familie.ba.sak.config
 
-class FeatureToggleConfig {
-    companion object {
-        // Operasjonelle
-        const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ba-sak.behandling.korreksjon-vedtaksbrev"
-        const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
-        const val TEKNISK_ENDRING = "familie-ba-sak.behandling.teknisk-endring"
-        const val HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD = "familie-ba-sak.hent-identer-til-psys-fra-infotrygd"
-        const val KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK = "familie-ba-sak.kan-kjore-autmatisk-valutajustering-behandling-for-enkelt-sak"
-        const val KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER = "familie-ba-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"
-
-        const val KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK = "familie-ba-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"
-
-        // NAV-21071 lagt bak toggle og kan evt fjernes på sikt hvis man ikke har trengt å skru den på igjen
-        const val SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM = "familie-ba-sak.skalOpprettFremleggsoppgaveDersomEOSMedlem"
-
-        // NAV-23955
-        const val BYTT_VALUTAJUSTERING_DATO = "familie-ba-sak.behandling.valutajustering_dato"
-
-        // NAV-22995
-        const val SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD = "familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd"
-        const val KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD = "familie-ba-sak.kjor-autovedtak-ny-klassekode-for-utvidet-barnetrygd"
-        const val OPPRETT_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_AUTOMATISK = "familie-ba-sak.opprett-autovedtak-ny-klassekode-for-utvidet-barnetrygd-automatisk"
-        const val AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_HØYT_VOLUM = "familie-ba-sak.autovedtak-ny-klassekode-for-utvidet-barnetrygd-hoyt-volum"
-
-        // NAV-23449 - Skrud av/på ny refaktorert logikk for hjemler i brev, skal i teorien produsere det samme resultatet
-        const val BRUK_OMSKRIVING_AV_HJEMLER_I_BREV = "familie-ba-sak.bruk_omskriving_av_hjemler_i_brev"
-
-        // NAV-23733
-        const val BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET = "familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"
-
-        // NAV-23989
-        const val FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE = "familie-ba-sak.sb-navn-i-godkjenne-vedtak-oppgave"
-
-        // satsendring
-        // Oppretter satsendring-tasker for de som ikke har fått ny task
-        const val SATSENDRING_ENABLET: String = "familie-ba-sak.satsendring-enablet"
-
-        // kjører satsendring i arbeidstid med lavt eller høyt volum
-        const val SATSENDRING_HØYT_VOLUM: String = "familie-ba-sak.satsendring-hoyt-volum"
-
-        // Kjører satsendring i utenfor arbeidstid
-        const val SATSENDRING_KVELD: String = "familie-ba-sak.satsendring-kveld"
-
-        // Kjører satsendring lørdag
-        const val SATSENDRING_LØRDAG: String = "familie-ba-sak.satsendring-lordag"
-    }
-}
-
-enum class FeatureToggle(
+enum class FeatureToggleConfig(
     val navn: String,
 ) {
     // Operasjonelle

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -47,3 +47,53 @@ class FeatureToggleConfig {
         const val SATSENDRING_LØRDAG: String = "familie-ba-sak.satsendring-lordag"
     }
 }
+
+enum class FeatureToggle(
+    val navn: String,
+) {
+    // Operasjonelle
+    KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV("familie-ba-sak.behandling.korreksjon-vedtaksbrev"),
+    TEKNISK_VEDLIKEHOLD_HENLEGGELSE("familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"),
+    TEKNISK_ENDRING("familie-ba-sak.behandling.teknisk-endring"),
+    HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD("familie-ba-sak.hent-identer-til-psys-fra-infotrygd"),
+    KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK("familie-ba-sak.kan-kjore-autmatisk-valutajustering-behandling-for-enkelt-sak"),
+    KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER("familie-ba-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"),
+
+    KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ba-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
+
+    // NAV-21071 lagt bak toggle og kan evt fjernes på sikt hvis man ikke har trengt å skru den på igjen
+    SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM("familie-ba-sak.skalOpprettFremleggsoppgaveDersomEOSMedlem"),
+
+    // NAV-23955
+    BYTT_VALUTAJUSTERING_DATO("familie-ba-sak.behandling.valutajustering_dato"),
+
+    // NAV-22995
+    SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD("familie-ba-sak.skal-bruke-ny-klassekode-for-utvidet-barnetrygd"),
+    KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD("familie-ba-sak.kjor-autovedtak-ny-klassekode-for-utvidet-barnetrygd"),
+    OPPRETT_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_AUTOMATISK("familie-ba-sak.opprett-autovedtak-ny-klassekode-for-utvidet-barnetrygd-automatisk"),
+    AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_HØYT_VOLUM("familie-ba-sak.autovedtak-ny-klassekode-for-utvidet-barnetrygd-hoyt-volum"),
+
+    // NAV-23449 - Skrud av/på ny refaktorert logikk for hjemler i brev, skal i teorien produsere det samme resultatet
+    BRUK_OMSKRIVING_AV_HJEMLER_I_BREV("familie-ba-sak.bruk_omskriving_av_hjemler_i_brev"),
+
+    // NAV-23733
+    BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET("familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"),
+
+    // NAV-23989
+    FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE("familie-ba-sak.sb-navn-i-godkjenne-vedtak-oppgave"),
+
+    // satsendring
+    // Oppretter satsendring-tasker for de som ikke har fått ny task
+    SATSENDRING_ENABLET("familie-ba-sak.satsendring-enablet"),
+
+    // kjører satsendring i arbeidstid med lavt eller høyt volum
+    SATSENDRING_HØYT_VOLUM("familie-ba-sak.satsendring-hoyt-volum"),
+
+    // Kjører satsendring i utenfor arbeidstid
+    SATSENDRING_KVELD("familie-ba-sak.satsendring-kveld"),
+
+    // Kjører satsendring lørdag
+    SATSENDRING_LØRDAG("familie-ba-sak.satsendring-lordag"),
+}
+
+

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -50,7 +50,7 @@ class PensjonService(
         fraDato: LocalDate,
     ): List<BarnetrygdTilPensjon> {
         secureLogger.info("Henter data til pensjon for personIdent=$personIdent fraDato=$fraDato")
-        if (envService.erPreprod() && unleashNext.isEnabled(HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD)) {
+        if (envService.erPreprod() && unleashNext.isEnabled(FeatureToggle.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn)) {
             val barnetrygdTilPensjonFraInfotrygdQ = hentBarnetrygdTilPensjonFraInfotrygdQ(personIdent, fraDato)
             if (barnetrygdTilPensjonFraInfotrygdQ.isNotEmpty()) {
                 return barnetrygdTilPensjonFraInfotrygdQ.distinct()
@@ -182,7 +182,7 @@ class PensjonService(
 
     private fun testidenter(
         fraDato: LocalDate,
-    ) = if (unleashNext.isEnabled(HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD)) {
+    ) = if (unleashNext.isEnabled(FeatureToggle.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn)) {
         emptyList() // Skal egentlig ikke kunne havne her, tror jeg, siden hentBarnetrygd() i dette tilfellet skulle returnert på linje 54 for å unngå at det på linje 57 forsøkes å hente data fra pdl på en ident som ikke finnes der i testmiljø
     } else {
         listOfNotNull(

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -50,7 +50,7 @@ class PensjonService(
         fraDato: LocalDate,
     ): List<BarnetrygdTilPensjon> {
         secureLogger.info("Henter data til pensjon for personIdent=$personIdent fraDato=$fraDato")
-        if (envService.erPreprod() && unleashNext.isEnabled(FeatureToggle.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn)) {
+        if (envService.erPreprod() && unleashNext.isEnabled(FeatureToggleConfig.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn)) {
             val barnetrygdTilPensjonFraInfotrygdQ = hentBarnetrygdTilPensjonFraInfotrygdQ(personIdent, fraDato)
             if (barnetrygdTilPensjonFraInfotrygdQ.isNotEmpty()) {
                 return barnetrygdTilPensjonFraInfotrygdQ.distinct()
@@ -182,7 +182,7 @@ class PensjonService(
 
     private fun testidenter(
         fraDato: LocalDate,
-    ) = if (unleashNext.isEnabled(FeatureToggle.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn)) {
+    ) = if (unleashNext.isEnabled(FeatureToggleConfig.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn)) {
         emptyList() // Skal egentlig ikke kunne havne her, tror jeg, siden hentBarnetrygd() i dette tilfellet skulle returnert på linje 54 for å unngå at det på linje 57 forsøkes å hente data fra pdl på en ident som ikke finnes der i testmiljø
     } else {
         listOfNotNull(

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigerer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigerer.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -18,7 +18,7 @@ class KlassifiseringKorrigerer(
     ): BeregnetUtbetalingsoppdragLongId {
         // For fagsaker vi ikke har skrudd på ny klassekode for, returnerer vi det originale utbetalingsoppdraget.
         if (!unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
+                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = behandling.id,
             )
         ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigerer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigerer.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -18,7 +18,7 @@ class KlassifiseringKorrigerer(
     ): BeregnetUtbetalingsoppdragLongId {
         // For fagsaker vi ikke har skrudd på ny klassekode for, returnerer vi det originale utbetalingsoppdraget.
         if (!unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
+                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = behandling.id,
             )
         ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -47,7 +47,7 @@ class UtbetalingsoppdragGenerator(
 
         val skalBrukeNyKlassekodeForUtvidetBarnetrygd =
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
+                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = vedtak.behandling.id,
             )
 
@@ -81,7 +81,7 @@ class UtbetalingsoppdragGenerator(
     ): Map<IdentOgType, AndelDataLongId> {
         val skalBrukeNyKlassekodeForUtvidetBarnetrygd =
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
+                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = behandling.id,
             )
 
@@ -92,7 +92,7 @@ class UtbetalingsoppdragGenerator(
 
         val tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag = tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(behandling.fagsak.id)
 
-        return if (tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag.isNotEmpty() && unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn)) {
+        return if (tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag.isNotEmpty() && unleashNextMedContextService.isEnabled(FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn)) {
             SisteUtvidetAndelOverstyrer.overstyrSisteUtvidetBarnetrygdAndel(
                 sisteAndelPerKjede = sisteAndelPerKjede,
                 tilkjenteYtelserMedOppdatertUtvidetKlassekodeIUtbetalingsoppdrag = tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -47,7 +47,7 @@ class UtbetalingsoppdragGenerator(
 
         val skalBrukeNyKlassekodeForUtvidetBarnetrygd =
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
+                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = vedtak.behandling.id,
             )
 
@@ -81,7 +81,7 @@ class UtbetalingsoppdragGenerator(
     ): Map<IdentOgType, AndelDataLongId> {
         val skalBrukeNyKlassekodeForUtvidetBarnetrygd =
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
+                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = behandling.id,
             )
 
@@ -92,7 +92,7 @@ class UtbetalingsoppdragGenerator(
 
         val tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag = tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(behandling.fagsak.id)
 
-        return if (tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag.isNotEmpty() && unleashNextMedContextService.isEnabled(FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET)) {
+        return if (tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag.isNotEmpty() && unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn)) {
             SisteUtvidetAndelOverstyrer.overstyrSisteUtvidetBarnetrygdAndel(
                 sisteAndelPerKjede = sisteAndelPerKjede,
                 tilkjenteYtelserMedOppdatertUtvidetKlassekodeIUtbetalingsoppdrag = tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
@@ -418,7 +418,7 @@ class ForvalterController(
     fun justerValuta(
         @PathVariable fagsakId: Long,
     ): ResponseEntity<Ressurs<RestMinimalFagsak>> {
-        val erPersonMedTilgangTilÅStarteValutajustering = unleashNextMedContextService.isEnabled(FeatureToggleConfig.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK)
+        val erPersonMedTilgangTilÅStarteValutajustering = unleashNextMedContextService.isEnabled(FeatureToggle.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK.navn)
 
         if (erPersonMedTilgangTilÅStarteValutajustering) {
             autovedtakMånedligValutajusteringService.utførMånedligValutajustering(fagsakId = fagsakId, måned = YearMonth.now())

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
@@ -418,7 +418,7 @@ class ForvalterController(
     fun justerValuta(
         @PathVariable fagsakId: Long,
     ): ResponseEntity<Ressurs<RestMinimalFagsak>> {
-        val erPersonMedTilgangTilÅStarteValutajustering = unleashNextMedContextService.isEnabled(FeatureToggle.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK.navn)
+        val erPersonMedTilgangTilÅStarteValutajustering = unleashNextMedContextService.isEnabled(FeatureToggleConfig.KAN_KJØRE_AUTOMATISK_VALUTAJUSTERING_FOR_ENKELT_SAK.navn)
 
         if (erPersonMedTilgangTilÅStarteValutajustering) {
             autovedtakMånedligValutajusteringService.utførMånedligValutajustering(fagsakId = fagsakId, måned = YearMonth.now())

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilKortString
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
@@ -170,7 +170,7 @@ class AutovedtakFødselshendelseService(
                 )
             taskRepository.save(task)
 
-            if (unleashService.isEnabled(FeatureToggleConfig.SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM, false)) {
+            if (unleashService.isEnabled(FeatureToggle.SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM.navn, false)) {
                 opprettFremleggsoppgaveDersomEØSMedlem(behandling)
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutovedtakFødselshendelseService.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilKortString
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
@@ -170,7 +170,7 @@ class AutovedtakFødselshendelseService(
                 )
             taskRepository.save(task)
 
-            if (unleashService.isEnabled(FeatureToggle.SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM.navn, false)) {
+            if (unleashService.isEnabled(FeatureToggleConfig.SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM.navn, false)) {
                 opprettFremleggsoppgaveDersomEØSMedlem(behandling)
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_HØYT_VOLUM
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.OPPRETT_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_AUTOMATISK
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.OppdaterUtvidetKlassekodeKjøringRepository
@@ -23,8 +22,8 @@ class OppdaterUtvidetKlassekodeScheduler(
 ) {
     @Scheduled(cron = CRON_HVERT_10_MIN_UKEDAG)
     fun triggAutovedtakOppdaterUtvidetKlassekode() {
-        if (leaderClientService.isLeader() && unleashService.isEnabled(OPPRETT_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_AUTOMATISK)) {
-            if (unleashService.isEnabled(AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_HØYT_VOLUM)) {
+        if (leaderClientService.isLeader() && unleashService.isEnabled(FeatureToggle.OPPRETT_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_AUTOMATISK.navn)) {
+            if (unleashService.isEnabled(FeatureToggle.AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_HØYT_VOLUM.navn)) {
                 startAutovedtakOppdaterUtvidetKlassekode(1200)
             } else {
                 startAutovedtakOppdaterUtvidetKlassekode(100)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeScheduler.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode
 
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.domene.OppdaterUtvidetKlassekodeKjøringRepository
@@ -22,8 +22,8 @@ class OppdaterUtvidetKlassekodeScheduler(
 ) {
     @Scheduled(cron = CRON_HVERT_10_MIN_UKEDAG)
     fun triggAutovedtakOppdaterUtvidetKlassekode() {
-        if (leaderClientService.isLeader() && unleashService.isEnabled(FeatureToggle.OPPRETT_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_AUTOMATISK.navn)) {
-            if (unleashService.isEnabled(FeatureToggle.AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_HØYT_VOLUM.navn)) {
+        if (leaderClientService.isLeader() && unleashService.isEnabled(FeatureToggleConfig.OPPRETT_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_AUTOMATISK.navn)) {
+            if (unleashService.isEnabled(FeatureToggleConfig.AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD_HØYT_VOLUM.navn)) {
                 startAutovedtakOppdaterUtvidetKlassekode(1200)
             } else {
                 startAutovedtakOppdaterUtvidetKlassekode(100)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -23,7 +23,7 @@ class OppdaterUtvidetKlassekodeTask(
     private val unleashService: UnleashService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        if (!unleashService.isEnabled(FeatureToggle.KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn)) {
             logger.info("Hopper ut av kjøring av migrering til ny klassekode for utvidet barnetrygd da toggle er skrudd av")
             return
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/oppdaterutvidetklassekode/OppdaterUtvidetKlassekodeTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -23,7 +23,7 @@ class OppdaterUtvidetKlassekodeTask(
     private val unleashService: UnleashService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        if (!unleashService.isEnabled(KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD)) {
+        if (!unleashService.isEnabled(FeatureToggle.KJØR_AUTOVEDTAK_OPPDATER_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn)) {
             logger.info("Hopper ut av kjøring av migrering til ny klassekode for utvidet barnetrygd da toggle er skrudd av")
             return
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
@@ -15,7 +15,7 @@ class AutovedtakSatsendringScheduler(
 ) {
     @Scheduled(cron = CRON_HVERT_10_MIN_UKEDAG)
     fun triggSatsendring() {
-        if (unleashService.isEnabled(FeatureToggle.SATSENDRING_HØYT_VOLUM.navn, false)) {
+        if (unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_HØYT_VOLUM.navn, false)) {
             startSatsendring(1200)
         } else {
             startSatsendring(100)
@@ -24,14 +24,14 @@ class AutovedtakSatsendringScheduler(
 
     @Scheduled(cron = CRON_HVERT_5_MIN_UKEDAG_UTENFOR_ARBEIDSTID)
     fun triggSatsendringUtenforArbeidstid() {
-        if (unleashService.isEnabled(FeatureToggle.SATSENDRING_KVELD.navn, false)) {
+        if (unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_KVELD.navn, false)) {
             startSatsendring(1000)
         }
     }
 
     @Scheduled(cron = CRON_HVERT_5_MIN_LØRDAG)
     fun triggSatsendringLørdag() {
-        if (unleashService.isEnabled(FeatureToggle.SATSENDRING_LØRDAG.navn, false)) {
+        if (unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_LØRDAG.navn, false)) {
             startSatsendring(1000)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringScheduler.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
@@ -15,7 +15,7 @@ class AutovedtakSatsendringScheduler(
 ) {
     @Scheduled(cron = CRON_HVERT_10_MIN_UKEDAG)
     fun triggSatsendring() {
-        if (unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_HØYT_VOLUM, false)) {
+        if (unleashService.isEnabled(FeatureToggle.SATSENDRING_HØYT_VOLUM.navn, false)) {
             startSatsendring(1200)
         } else {
             startSatsendring(100)
@@ -24,14 +24,14 @@ class AutovedtakSatsendringScheduler(
 
     @Scheduled(cron = CRON_HVERT_5_MIN_UKEDAG_UTENFOR_ARBEIDSTID)
     fun triggSatsendringUtenforArbeidstid() {
-        if (unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_KVELD, false)) {
+        if (unleashService.isEnabled(FeatureToggle.SATSENDRING_KVELD.navn, false)) {
             startSatsendring(1000)
         }
     }
 
     @Scheduled(cron = CRON_HVERT_5_MIN_LØRDAG)
     fun triggSatsendringLørdag() {
-        if (unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_LØRDAG, false)) {
+        if (unleashService.isEnabled(FeatureToggle.SATSENDRING_LØRDAG.navn, false)) {
             startSatsendring(1000)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
@@ -35,7 +35,7 @@ class StartSatsendring(
     fun startSatsendring(
         antallFagsaker: Int,
     ) {
-        if (!unleashService.isEnabled(FeatureToggle.SATSENDRING_ENABLET.navn, false)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET.navn, false)) {
             logger.info("Skipper satsendring da toggle er skrudd av.")
             return
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendring.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
@@ -35,7 +35,7 @@ class StartSatsendring(
     fun startSatsendring(
         antallFagsaker: Int,
     ) {
-        if (!unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET, false)) {
+        if (!unleashService.isEnabled(FeatureToggle.SATSENDRING_ENABLET.navn, false)) {
             logger.info("Skipper satsendring da toggle er skrudd av.")
             return
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
@@ -2,8 +2,7 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.TEKNISK_ENDRING
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.TEKNISK_VEDLIKEHOLD_HENLEGGELSE
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerInstitusjon
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
@@ -180,13 +179,13 @@ class BehandlingStegController(
 
         validerhenleggelsestype(
             henleggÅrsak = henleggInfo.årsak,
-            tekniskVedlikeholdToggel = unleashService.isEnabled(TEKNISK_VEDLIKEHOLD_HENLEGGELSE, behandling.id),
+            tekniskVedlikeholdToggel = unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn, behandling.id),
             behandlingId = behandling.id,
         )
 
         validerTilgangTilHenleggelseAvBehandling(
             behandling = behandling,
-            tekniskEndringToggle = unleashService.isEnabled(TEKNISK_ENDRING, behandling.id),
+            tekniskEndringToggle = unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, behandling.id),
         )
 
         validerBehandlingIkkeSendtTilEksterneTjenester(behandling = behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerInstitusjon
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
@@ -179,13 +179,13 @@ class BehandlingStegController(
 
         validerhenleggelsestype(
             henleggÅrsak = henleggInfo.årsak,
-            tekniskVedlikeholdToggel = unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn, behandling.id),
+            tekniskVedlikeholdToggel = unleashService.isEnabled(FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn, behandling.id),
             behandlingId = behandling.id,
         )
 
         validerTilgangTilHenleggelseAvBehandling(
             behandling = behandling,
-            tekniskEndringToggle = unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, behandling.id),
+            tekniskEndringToggle = unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn, behandling.id),
         )
 
         validerBehandlingIkkeSendtTilEksterneTjenester(behandling = behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.Utils.storForbokstavIAlleNavn
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.toLocalDate
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
@@ -473,7 +473,7 @@ class BrevService(
         val refusjonEøs = refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId)
 
         val hjemler =
-            if (unleashService.isEnabled(FeatureToggle.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV.navn, false)) {
+            if (unleashService.isEnabled(FeatureToggleConfig.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV.navn, false)) {
                 hjemmeltekstUtleder.utledHjemmeltekst(
                     behandlingId = behandlingId,
                     vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.common.Utils.storForbokstavIAlleNavn
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.toLocalDate
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
 import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
@@ -473,7 +473,7 @@ class BrevService(
         val refusjonEøs = refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId)
 
         val hjemler =
-            if (unleashService.isEnabled(FeatureToggleConfig.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV, false)) {
+            if (unleashService.isEnabled(FeatureToggle.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV.navn, false)) {
                 hjemmeltekstUtleder.utledHjemmeltekst(
                     behandlingId = behandlingId,
                     vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.rangeTo
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.integrasjoner.ecb.ECBService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.tilSisteVirkedag
@@ -111,7 +111,7 @@ class AutomatiskOppdaterValutakursService(
         endringstidspunkt: YearMonth,
     ) {
         val datoForPraksisEndringAutomatiskValutajustering =
-            if (unleashNextMedContextService.isEnabled(FeatureToggle.BYTT_VALUTAJUSTERING_DATO.navn)) {
+            if (unleashNextMedContextService.isEnabled(FeatureToggleConfig.BYTT_VALUTAJUSTERING_DATO.navn)) {
                 DATO_FOR_PRAKSISENDRING_AUTOMATISK_VALUTAJUSTERING
             } else {
                 YearMonth.of(2023, 1)
@@ -231,7 +231,7 @@ class AutomatiskOppdaterValutakursService(
         behandlingId: BehandlingId,
         nyStrategi: VurderingsstrategiForValutakurser,
     ): VurderingsstrategiForValutakurserDB {
-        if (!unleashNextMedContextService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn)) {
+        if (!unleashNextMedContextService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn)) {
             throw Feil("Relevante toggler for å overstyre vurderingsstrategi for valutakurser er ikke satt.")
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -6,8 +6,7 @@ import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.rangeTo
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.BYTT_VALUTAJUSTERING_DATO
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.TEKNISK_ENDRING
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.integrasjoner.ecb.ECBService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.tilSisteVirkedag
@@ -112,7 +111,7 @@ class AutomatiskOppdaterValutakursService(
         endringstidspunkt: YearMonth,
     ) {
         val datoForPraksisEndringAutomatiskValutajustering =
-            if (unleashNextMedContextService.isEnabled(BYTT_VALUTAJUSTERING_DATO)) {
+            if (unleashNextMedContextService.isEnabled(FeatureToggle.BYTT_VALUTAJUSTERING_DATO.navn)) {
                 DATO_FOR_PRAKSISENDRING_AUTOMATISK_VALUTAJUSTERING
             } else {
                 YearMonth.of(2023, 1)
@@ -232,7 +231,7 @@ class AutomatiskOppdaterValutakursService(
         behandlingId: BehandlingId,
         nyStrategi: VurderingsstrategiForValutakurser,
     ): VurderingsstrategiForValutakurserDB {
-        if (!unleashNextMedContextService.isEnabled(TEKNISK_ENDRING)) {
+        if (!unleashNextMedContextService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn)) {
             throw Feil("Relevante toggler for å overstyre vurderingsstrategi for valutakurser er ikke satt.")
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
@@ -67,15 +67,15 @@ class BeslutteVedtak(
         } else if (behandling.status == BehandlingStatus.AVSLUTTET) {
             throw FunksjonellFeil("Behandlingen er allerede avsluttet")
         } else if (behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-            !unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn, behandling.id)
+            !unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn, behandling.id)
         ) {
             throw FunksjonellFeil(
-                melding = "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og toggle ${FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn} false",
+                melding = "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og toggle ${FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn} false",
                 frontendFeilmelding = "Du har ikke tilgang til å beslutte for denne behandlingen. Ta kontakt med teamet dersom dette ikke stemmer.",
             )
         } else if (behandling.erTekniskEndring() &&
             !unleashService.isEnabled(
-                FeatureToggle.TEKNISK_ENDRING.navn,
+                FeatureToggleConfig.TEKNISK_ENDRING.navn,
                 behandling.id,
             )
         ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
@@ -67,15 +67,15 @@ class BeslutteVedtak(
         } else if (behandling.status == BehandlingStatus.AVSLUTTET) {
             throw FunksjonellFeil("Behandlingen er allerede avsluttet")
         } else if (behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-            !unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV, behandling.id)
+            !unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn, behandling.id)
         ) {
             throw FunksjonellFeil(
-                melding = "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og toggle ${FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV} false",
+                melding = "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og toggle ${FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn} false",
                 frontendFeilmelding = "Du har ikke tilgang til å beslutte for denne behandlingen. Ta kontakt med teamet dersom dette ikke stemmer.",
             )
         } else if (behandling.erTekniskEndring() &&
             !unleashService.isEnabled(
-                FeatureToggleConfig.TEKNISK_ENDRING,
+                FeatureToggle.TEKNISK_ENDRING.navn,
                 behandling.id,
             )
         ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
@@ -82,7 +82,7 @@ class SendTilBeslutter(
                     behandlingId = behandling.id,
                     oppgavetype = Oppgavetype.GodkjenneVedtak,
                     fristForFerdigstillelse = LocalDate.now(),
-                    beskrivelse = if (unleashService.isEnabled(FeatureToggle.FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE.navn)) SikkerhetContext.hentSaksbehandlerNavn() else null,
+                    beskrivelse = if (unleashService.isEnabled(FeatureToggleConfig.FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE.navn)) SikkerhetContext.hentSaksbehandlerNavn() else null,
                 )
             loggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = false)
             taskRepository.save(godkjenneVedtakTask)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.steg
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
@@ -82,7 +82,7 @@ class SendTilBeslutter(
                     behandlingId = behandling.id,
                     oppgavetype = Oppgavetype.GodkjenneVedtak,
                     fristForFerdigstillelse = LocalDate.now(),
-                    beskrivelse = if (unleashService.isEnabled(FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE)) SikkerhetContext.hentSaksbehandlerNavn() else null,
+                    beskrivelse = if (unleashService.isEnabled(FeatureToggle.FYLL_INN_SB_NAVN_I_GODKJENNE_VEDTAK_OPPGAVE.navn)) SikkerhetContext.hentSaksbehandlerNavn() else null,
                 )
             loggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = false)
             taskRepository.save(godkjenneVedtakTask)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.common.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
@@ -156,7 +156,7 @@ class StegService(
     }
 
     fun validerIverksettKAVedtak() {
-        if (!unleashService.isEnabled(KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK.navn)) {
             throw FunksjonellFeil("Det er ikke mulig å opprette behandling med årsak Iverksette KA-vedtak")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegService.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.common.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
@@ -156,7 +156,7 @@ class StegService(
     }
 
     fun validerIverksettKAVedtak() {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK.navn)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK.navn)) {
             throw FunksjonellFeil("Det er ikke mulig å opprette behandling med årsak Iverksette KA-vedtak")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakController.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.sammensattKontrollsak
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestOpprettSammensattKontrollsak
 import no.nav.familie.ba.sak.ekstern.restDomene.RestSammensattKontrollsak
@@ -42,7 +42,7 @@ class SammensattKontrollsakController(
     fun hentSammensattKontrollsak(
         @PathVariable behandlingId: Long,
     ): ResponseEntity<Ressurs<RestSammensattKontrollsak?>> {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 
@@ -62,7 +62,7 @@ class SammensattKontrollsakController(
     fun opprettSammensattKontrollsak(
         @RequestBody restOpprettSammensattKontrollsak: RestOpprettSammensattKontrollsak,
     ): ResponseEntity<Ressurs<RestSammensattKontrollsak>> {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 
@@ -84,7 +84,7 @@ class SammensattKontrollsakController(
     fun oppdaterSammensattKontrollsak(
         @RequestBody restSammensattKontrollsak: RestSammensattKontrollsak,
     ): ResponseEntity<Ressurs<RestSammensattKontrollsak>> {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 
@@ -105,7 +105,7 @@ class SammensattKontrollsakController(
     fun slettSammensattKontrollsak(
         @RequestBody restSammensattKontrollsak: RestSammensattKontrollsak,
     ): ResponseEntity<Ressurs<Long>> {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakController.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.sammensattKontrollsak
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestOpprettSammensattKontrollsak
 import no.nav.familie.ba.sak.ekstern.restDomene.RestSammensattKontrollsak
@@ -42,7 +42,7 @@ class SammensattKontrollsakController(
     fun hentSammensattKontrollsak(
         @PathVariable behandlingId: Long,
     ): ResponseEntity<Ressurs<RestSammensattKontrollsak?>> {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 
@@ -62,7 +62,7 @@ class SammensattKontrollsakController(
     fun opprettSammensattKontrollsak(
         @RequestBody restOpprettSammensattKontrollsak: RestOpprettSammensattKontrollsak,
     ): ResponseEntity<Ressurs<RestSammensattKontrollsak>> {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 
@@ -84,7 +84,7 @@ class SammensattKontrollsakController(
     fun oppdaterSammensattKontrollsak(
         @RequestBody restSammensattKontrollsak: RestSammensattKontrollsak,
     ): ResponseEntity<Ressurs<RestSammensattKontrollsak>> {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 
@@ -105,7 +105,7 @@ class SammensattKontrollsakController(
     fun slettSammensattKontrollsak(
         @RequestBody restSammensattKontrollsak: RestSammensattKontrollsak,
     ): ResponseEntity<Ressurs<Long>> {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/HentAlleIdenterTilPsysTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/HentAlleIdenterTilPsysTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.task
 
 import no.nav.familie.ba.sak.common.EnvService
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.ekstern.pensjon.HentAlleIdenterTilPsysResponseDTO
 import no.nav.familie.ba.sak.ekstern.pensjon.Meldingstype
 import no.nav.familie.ba.sak.ekstern.pensjon.Meldingstype.DATA
@@ -64,7 +64,7 @@ class HentAlleIdenterTilPsysTask(
         logger.info("Starter med å hente alle identer fra Infotrygd for request $requestId")
         val identerFraInfotrygd =
             when {
-                envService.erPreprod() && !unleashNext.isEnabled(HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD) -> emptyList()
+                envService.erPreprod() && !unleashNext.isEnabled(FeatureToggle.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn) -> emptyList()
                 else -> infotrygdBarnetrygdClient.hentPersonerMedBarnetrygdTilPensjon(år)
             }
         logger.info("Ferdig med å hente alle identer fra Infotrygd for request $requestId")

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/HentAlleIdenterTilPsysTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/HentAlleIdenterTilPsysTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.task
 
 import no.nav.familie.ba.sak.common.EnvService
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.ekstern.pensjon.HentAlleIdenterTilPsysResponseDTO
 import no.nav.familie.ba.sak.ekstern.pensjon.Meldingstype
 import no.nav.familie.ba.sak.ekstern.pensjon.Meldingstype.DATA
@@ -64,7 +64,7 @@ class HentAlleIdenterTilPsysTask(
         logger.info("Starter med å hente alle identer fra Infotrygd for request $requestId")
         val identerFraInfotrygd =
             when {
-                envService.erPreprod() && !unleashNext.isEnabled(FeatureToggle.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn) -> emptyList()
+                envService.erPreprod() && !unleashNext.isEnabled(FeatureToggleConfig.HENT_IDENTER_TIL_PSYS_FRA_INFOTRYGD.navn) -> emptyList()
                 else -> infotrygdBarnetrygdClient.hentPersonerMedBarnetrygdTilPensjon(år)
             }
         logger.info("Ferdig med å hente alle identer fra Infotrygd for request $requestId")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigererTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigererTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -42,7 +42,7 @@ class KlassifiseringKorrigererTest {
                 andeler = emptyList(),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD, behandling.id) } returns false
+        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns false
 
         // Act
         val justertUtbetalingsoppdrag =
@@ -75,7 +75,7 @@ class KlassifiseringKorrigererTest {
                 andeler = emptyList(),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD, behandling.id) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
         every { tilkjentYtelseRepository.harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(behandling.fagsak.id) } returns true
 
         // Act
@@ -109,7 +109,7 @@ class KlassifiseringKorrigererTest {
                 andeler = emptyList(),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD, behandling.id) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
         every { tilkjentYtelseRepository.harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(behandling.fagsak.id) } returns false
 
         // Act
@@ -172,7 +172,7 @@ class KlassifiseringKorrigererTest {
                     ),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD, behandling.id) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
         every { tilkjentYtelseRepository.harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(behandling.fagsak.id) } returns false
 
         // Act

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigererTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/KlassifiseringKorrigererTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -42,7 +42,7 @@ class KlassifiseringKorrigererTest {
                 andeler = emptyList(),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns false
+        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns false
 
         // Act
         val justertUtbetalingsoppdrag =
@@ -75,7 +75,7 @@ class KlassifiseringKorrigererTest {
                 andeler = emptyList(),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
         every { tilkjentYtelseRepository.harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(behandling.fagsak.id) } returns true
 
         // Act
@@ -109,7 +109,7 @@ class KlassifiseringKorrigererTest {
                 andeler = emptyList(),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
         every { tilkjentYtelseRepository.harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(behandling.fagsak.id) } returns false
 
         // Act
@@ -172,7 +172,7 @@ class KlassifiseringKorrigererTest {
                     ),
             )
 
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn, behandling.id) } returns true
         every { tilkjentYtelseRepository.harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(behandling.fagsak.id) } returns false
 
         // Act

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -6,7 +6,7 @@ import io.mockk.verify
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -105,14 +105,14 @@ class UtbetalingsoppdragGeneratorTest {
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
+                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = behandling.id,
             )
         } returns true
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
+                toggleId = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
             )
         } returns true
 
@@ -244,14 +244,14 @@ class UtbetalingsoppdragGeneratorTest {
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
+                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = any(),
             )
         } returns true
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
+                toggleId = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
             )
         } returns true
 
@@ -389,14 +389,14 @@ class UtbetalingsoppdragGeneratorTest {
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD,
+                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = any(),
             )
         } returns true
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
+                toggleId = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
             )
         } returns true
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -6,7 +6,7 @@ import io.mockk.verify
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -105,14 +105,14 @@ class UtbetalingsoppdragGeneratorTest {
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
+                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = behandling.id,
             )
         } returns true
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
+                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
             )
         } returns true
 
@@ -244,14 +244,14 @@ class UtbetalingsoppdragGeneratorTest {
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
+                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = any(),
             )
         } returns true
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
+                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
             )
         } returns true
 
@@ -389,14 +389,14 @@ class UtbetalingsoppdragGeneratorTest {
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
+                toggleId = FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn,
                 behandlingId = any(),
             )
         } returns true
 
         every {
             unleashNextMedContextService.isEnabled(
-                toggleId = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
+                toggleId = FeatureToggleConfig.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET.navn,
             )
         } returns true
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring.Companion.SATSENDRINGMÅNED_MARS_2023
@@ -66,7 +66,7 @@ internal class StartSatsendringTest {
 
     @Test
     fun `start satsendring og opprett satsendringtask på sak hvis toggler er på `() {
-        every { unleashService.isEnabled(FeatureToggle.SATSENDRING_ENABLET.navn, false) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET.navn, false) } returns true
 
         val behandling = lagBehandling()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring.Companion.SATSENDRINGMÅNED_MARS_2023
@@ -66,7 +66,7 @@ internal class StartSatsendringTest {
 
     @Test
     fun `start satsendring og opprett satsendringtask på sak hvis toggler er på `() {
-        every { unleashService.isEnabled(FeatureToggleConfig.SATSENDRING_ENABLET, false) } returns true
+        every { unleashService.isEnabled(FeatureToggle.SATSENDRING_ENABLET.navn, false) } returns true
 
         val behandling = lagBehandling()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegControllerTest.kt
@@ -5,7 +5,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -33,10 +33,10 @@ class BehandlingStegControllerTest {
     fun `Skal kaste feil hvis saksbehandler uten teknisk endring-tilgang prøver å henlegge en behandling med årsak=teknisk endring`() {
         val behandling = lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING)
 
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING, behandling.id) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, behandling.id) } returns false
         every {
             unleashService.isEnabled(
-                FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE,
+                FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn,
                 behandling.id,
             )
         } returns false

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegControllerTest.kt
@@ -5,7 +5,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -33,10 +33,10 @@ class BehandlingStegControllerTest {
     fun `Skal kaste feil hvis saksbehandler uten teknisk endring-tilgang prøver å henlegge en behandling med årsak=teknisk endring`() {
         val behandling = lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING)
 
-        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, behandling.id) } returns false
+        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn, behandling.id) } returns false
         every {
             unleashService.isEnabled(
-                FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn,
+                FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn,
                 behandling.id,
             )
         } returns false

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -8,7 +8,7 @@ import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -251,7 +251,7 @@ class BeslutteVedtakTest {
     fun `Skal kaste feil dersom toggle ikke er enabled og årsak er korreksjon vedtaksbrev`() {
         every {
             unleashService.isEnabled(
-                FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn,
+                FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn,
                 any(),
             )
         } returns false
@@ -274,7 +274,7 @@ class BeslutteVedtakTest {
 
     @Test
     fun `Skal kaste feil dersom saksbehandler uten tilgang til teknisk endring prøve å godkjenne en behandling med årsak=teknisk endring`() {
-        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, any()) } returns false
+        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn, any()) } returns false
 
         val behandling = lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING)
         behandling.status = BehandlingStatus.FATTER_VEDTAK

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -8,7 +8,7 @@ import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -251,7 +251,7 @@ class BeslutteVedtakTest {
     fun `Skal kaste feil dersom toggle ikke er enabled og årsak er korreksjon vedtaksbrev`() {
         every {
             unleashService.isEnabled(
-                FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV,
+                FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn,
                 any(),
             )
         } returns false
@@ -274,7 +274,7 @@ class BeslutteVedtakTest {
 
     @Test
     fun `Skal kaste feil dersom saksbehandler uten tilgang til teknisk endring prøve å godkjenne en behandling med årsak=teknisk endring`() {
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING, any()) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, any()) } returns false
 
         val behandling = lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING)
         behandling.status = BehandlingStatus.FATTER_VEDTAK

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -9,7 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.TestClockProvider
 import no.nav.familie.ba.sak.common.toLocalDate
-import no.nav.familie.ba.sak.config.FeatureToggleConfig.Companion.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.cucumber.ValideringUtil.assertSjekkBehandlingIder
 import no.nav.familie.ba.sak.cucumber.domeneparser.Domenebegrep
 import no.nav.familie.ba.sak.cucumber.domeneparser.DomeneparserUtil.groupByBehandlingId
@@ -187,7 +187,7 @@ class OppdragSteg {
         every {
             andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(any())
         } answers {
-            val skalBrukeNyKlassekodeForUtvidetBarnetrygd = toggles[tilkjentYtelse.behandling.id]?.get(SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD) ?: false
+            val skalBrukeNyKlassekodeForUtvidetBarnetrygd = toggles[tilkjentYtelse.behandling.id]?.get(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn) ?: false
             sisteAndelPerIdentNy(tidligereTilkjenteYtelser, skalBrukeNyKlassekodeForUtvidetBarnetrygd).values.toList()
         }
         every {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -9,7 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.TestClockProvider
 import no.nav.familie.ba.sak.common.toLocalDate
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.cucumber.ValideringUtil.assertSjekkBehandlingIder
 import no.nav.familie.ba.sak.cucumber.domeneparser.Domenebegrep
 import no.nav.familie.ba.sak.cucumber.domeneparser.DomeneparserUtil.groupByBehandlingId
@@ -187,7 +187,7 @@ class OppdragSteg {
         every {
             andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(any())
         } answers {
-            val skalBrukeNyKlassekodeForUtvidetBarnetrygd = toggles[tilkjentYtelse.behandling.id]?.get(FeatureToggle.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn) ?: false
+            val skalBrukeNyKlassekodeForUtvidetBarnetrygd = toggles[tilkjentYtelse.behandling.id]?.get(FeatureToggleConfig.SKAL_BRUKE_NY_KLASSEKODE_FOR_UTVIDET_BARNETRYGD.navn) ?: false
             sisteAndelPerIdentNy(tidligereTilkjenteYtelser, skalBrukeNyKlassekodeForUtvidetBarnetrygd).values.toList()
         }
         every {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.verdikjedetester
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.datagenerator.lagMockRestJournalføring
 import no.nav.familie.ba.sak.datagenerator.lagSøknadDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
@@ -242,7 +242,7 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
 
     @Test
     fun `Skal journalføre og behandle utvidet nasjonal sak`() {
-        System.setProperty(FeatureToggle.TEKNISK_ENDRING.navn, "true")
+        System.setProperty(FeatureToggleConfig.TEKNISK_ENDRING.navn, "true")
 
         val scenario =
             RestScenario(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.verdikjedetester
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.datagenerator.lagMockRestJournalføring
 import no.nav.familie.ba.sak.datagenerator.lagSøknadDTO
 import no.nav.familie.ba.sak.ekstern.restDomene.BehandlingUnderkategoriDTO
@@ -242,7 +242,7 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
 
     @Test
     fun `Skal journalføre og behandle utvidet nasjonal sak`() {
-        System.setProperty(FeatureToggleConfig.TEKNISK_ENDRING, "true")
+        System.setProperty(FeatureToggle.TEKNISK_ENDRING.navn, "true")
 
         val scenario =
             RestScenario(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TekniskEndringAvFødselshendelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TekniskEndringAvFødselshendelseTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.verdikjedetester
 
-import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.FeatureToggleConfig
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -41,7 +41,7 @@ class TekniskEndringAvFødselshendelseTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal teknisk opphøre fødselshendelse`() {
-        System.setProperty(FeatureToggle.TEKNISK_ENDRING.navn, "true")
+        System.setProperty(FeatureToggleConfig.TEKNISK_ENDRING.navn, "true")
 
         val scenario =
             RestScenario(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TekniskEndringAvFødselshendelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TekniskEndringAvFødselshendelseTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.verdikjedetester
 
-import no.nav.familie.ba.sak.config.FeatureToggleConfig
+import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.ekstern.restDomene.RestPersonResultat
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
@@ -41,7 +41,7 @@ class TekniskEndringAvFødselshendelseTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal teknisk opphøre fødselshendelse`() {
-        System.setProperty(FeatureToggleConfig.TEKNISK_ENDRING, "true")
+        System.setProperty(FeatureToggle.TEKNISK_ENDRING.navn, "true")
 
         val scenario =
             RestScenario(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23170

Refaktorerer FeatureToggleConfig fra klasse med companion object til enum for bedre typesikring. Fremover kan enums parses direkte i Cucumber-tester, slik at testene kan bruke enum-navnene på samme måte som i koden ellers.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Det ble lagt inn en kommentar på kortet om å fikse defaulting til true/false. Det finnes allerede funksjon i UnleashConfig.kt for å sette default verdi når isEnable() blir kalt. Om ingen verdi bli satt, blir default false - trengs det mer enn dette? 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Finnes eksisterende tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
