### PR TITLE
Sletter forvalter-endepunkt som ikke har vært i bruk på en stund, som jeg tror man ikke trenger lenger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -21,7 +21,6 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.Månedli
 import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.OppdaterUtvidetKlassekodeTask
 import no.nav.familie.ba.sak.kjerne.autovedtak.oppdaterutvidetklassekode.PopulerOppdaterUtvidetKlassekodeKjøringTask
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
-import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.RestartAvSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -72,7 +71,6 @@ import kotlin.concurrent.thread
 class ForvalterController(
     private val oppgaveRepository: OppgaveRepository,
     private val integrasjonClient: IntegrasjonClient,
-    private val restartAvSmåbarnstilleggService: RestartAvSmåbarnstilleggService,
     private val forvalterService: ForvalterService,
     private val ecbService: ECBService,
     private val testVerktøyService: TestVerktøyService,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -160,26 +160,6 @@ class ForvalterController(
         return ResponseEntity.ok("OK")
     }
 
-    @PostMapping("/kjor-satsendring-uten-validering")
-    @Transactional
-    fun kjørSatsendringFor(
-        @RequestBody fagsakListe: List<Long>,
-    ) {
-        tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
-            handling = "Kjør satsendring uten validering",
-        )
-
-        fagsakListe.parallelStream().forEach { fagsakId ->
-            try {
-                logger.info("Kjører satsendring uten validering for $fagsakId")
-                forvalterService.kjørForenkletSatsendringFor(fagsakId)
-            } catch (e: Exception) {
-                logger.warn("Klarte ikke kjøre satsendring for fagsakId=$fagsakId", e)
-            }
-        }
-    }
-
     @PostMapping("/identifiser-utbetalinger-over-100-prosent")
     fun identifiserUtbetalingerOver100Prosent(): ResponseEntity<Pair<String, String>> {
         tilgangService.verifiserHarTilgangTilHandling(

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -122,25 +122,6 @@ class ForvalterController(
         return ResponseEntity.ok("Ferdigstill oppgaver kjørt. Antall som ikke ble ferdigstilt: $antallFeil")
     }
 
-    @PostMapping(
-        path = ["/start-manuell-restart-av-smaabarnstillegg-jobb/skalOppretteOppgaver/{skalOppretteOppgaver}"],
-        consumes = [MediaType.APPLICATION_JSON_VALUE],
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-    )
-    fun triggManuellStartAvSmåbarnstillegg(
-        @PathVariable skalOppretteOppgaver: Boolean = true,
-    ): ResponseEntity<String> {
-        tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
-            handling = "Trigg manuell start av småbarnstillegg",
-        )
-
-        restartAvSmåbarnstilleggService.finnOgOpprettetOppgaveForSmåbarnstilleggSomSkalRestartesIDenneMåned(
-            skalOppretteOppgaver,
-        )
-        return ResponseEntity.ok("OK")
-    }
-
     private fun ferdigstillOppgave(oppgaveId: Long) {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -190,20 +190,6 @@ class ForvalterController(
         return ResponseEntity.ok(ecbService.hentValutakurs(valuta, dato))
     }
 
-    @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd/{fraÅrMåned}")
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(
-        @PathVariable fraÅrMåned: YearMonth,
-    ): ResponseEntity<List<Pair<Long, String>>> {
-        tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
-            handling = "Finn åpne fagsaker med flere migreringsbehandlinger og løpende sak i infotrygd",
-        )
-        val åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd =
-            forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(fraÅrMåned)
-        logger.info("Følgende fagsaker har flere migreringsbehandlinger og løpende sak i Infotrygd: $åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd")
-        return ResponseEntity.ok(åpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd)
-    }
-
     @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlinger/{fraÅrMåned}")
     fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(
         @PathVariable fraÅrMåned: YearMonth,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -190,21 +190,6 @@ class ForvalterController(
         return ResponseEntity.ok(ecbService.hentValutakurs(valuta, dato))
     }
 
-    @GetMapping("/finnÅpneFagsakerMedFlereMigreringsbehandlinger/{fraÅrMåned}")
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(
-        @PathVariable fraÅrMåned: YearMonth,
-    ): ResponseEntity<List<Pair<Long, String>>> {
-        tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
-            handling = "Finn åpne fagsaker med flere migreringsbehandlinger",
-        )
-
-        val åpneFagsakerMedFlereMigreringsbehandlinger =
-            forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger(fraÅrMåned)
-        logger.info("Følgende fagsaker har flere migreringsbehandlinger og løper i ba-sak: $åpneFagsakerMedFlereMigreringsbehandlinger")
-        return ResponseEntity.ok(åpneFagsakerMedFlereMigreringsbehandlinger)
-    }
-
     @GetMapping(path = ["/behandling/{behandlingId}/begrunnelsetest"])
     fun hentBegrunnelsetestPåBehandling(
         @PathVariable behandlingId: Long,

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -158,17 +158,6 @@ class ForvalterService(
         }
     }
 
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd(fraÅrMåned: YearMonth): List<Pair<Long, String>> {
-        val løpendeFagsakerMedFlereMigreringsbehandlinger =
-            fagsakRepository.finnFagsakerMedFlereMigreringsbehandlinger(
-                fraÅrMåned.førsteDagIInneværendeMåned().atStartOfDay(),
-            )
-
-        return løpendeFagsakerMedFlereMigreringsbehandlinger
-            .filter { infotrygdService.harLøpendeSakIInfotrygd(listOf(it.fødselsnummer)) }
-            .map { Pair(it.fagsakId, it.fødselsnummer) }
-    }
-
     fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(fraÅrMåned: YearMonth): List<Pair<Long, String>> =
         fagsakRepository
             .finnFagsakerMedFlereMigreringsbehandlinger(

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
@@ -40,7 +39,6 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.YearMonth
 
 @Service
 class ForvalterService(
@@ -157,12 +155,6 @@ class ForvalterService(
             }
         }
     }
-
-    fun finnÅpneFagsakerMedFlereMigreringsbehandlinger(fraÅrMåned: YearMonth): List<Pair<Long, String>> =
-        fagsakRepository
-            .finnFagsakerMedFlereMigreringsbehandlinger(
-                fraÅrMåned.førsteDagIInneværendeMåned().atStartOfDay(),
-            ).map { Pair(it.fagsakId, it.fødselsnummer) }
 
     fun settFomPåVilkårTilPersonsFødselsdato(behandlingId: Long): Vilkårsvurdering {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -12,20 +12,14 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
-import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
-import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
-import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
-import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -46,16 +40,10 @@ class ForvalterService(
     private val vedtakService: VedtakService,
     private val beregningService: BeregningService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
-    private val stegService: StegService,
-    private val fagsakService: FagsakService,
-    private val behandlingService: BehandlingService,
-    private val taskRepository: TaskRepositoryWrapper,
-    private val autovedtakService: AutovedtakService,
     private val fagsakRepository: FagsakRepository,
     private val behandlingRepository: BehandlingRepository,
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
-    private val infotrygdService: InfotrygdService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val persongrunnlagService: PersongrunnlagService,
 ) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTask.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.task
 
-import no.nav.familie.ba.sak.internal.ForvalterService
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -14,12 +15,16 @@ import java.time.YearMonth
     maxAntallFeil = 1,
 )
 class FinnSakerMedFlereMigreringsbehandlingerTask(
-    val forvalterService: ForvalterService,
+    val fagsakRepository: FagsakRepository,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val fraOgMedÅrMåned = YearMonth.parse(task.payload)
 
-        val sakerMedFlereMigreringsbehandlinger = forvalterService.finnÅpneFagsakerMedFlereMigreringsbehandlinger(fraOgMedÅrMåned)
+        val sakerMedFlereMigreringsbehandlinger =
+            fagsakRepository
+                .finnFagsakerMedFlereMigreringsbehandlinger(
+                    fraOgMedÅrMåned.førsteDagIInneværendeMåned().atStartOfDay(),
+                ).map { Pair(it.fagsakId, it.fødselsnummer) }
 
         if (sakerMedFlereMigreringsbehandlinger.isNotEmpty()) {
             error("$FEILMELDING fraOgMedÅrMåned=$fraOgMedÅrMåned \n${sakerMedFlereMigreringsbehandlinger.joinToString("\n")}")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -8,29 +8,23 @@ import io.mockk.slot
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrAfter
-import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagVilkårsvurdering
-import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
-import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
-import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
-import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -63,21 +57,6 @@ class ForvalterServiceTest {
     lateinit var behandlingHentOgPersisterService: BehandlingHentOgPersisterService
 
     @MockK
-    lateinit var stegService: StegService
-
-    @MockK
-    lateinit var fagsakService: FagsakService
-
-    @MockK
-    lateinit var behandlingService: BehandlingService
-
-    @MockK
-    lateinit var taskRepository: TaskRepositoryWrapper
-
-    @MockK
-    lateinit var autovedtakService: AutovedtakService
-
-    @MockK
     lateinit var vilkårsvurderingService: VilkårsvurderingService
 
     @MockK
@@ -91,9 +70,6 @@ class ForvalterServiceTest {
 
     @MockK
     lateinit var arbeidsfordelingService: ArbeidsfordelingService
-
-    @MockK
-    lateinit var infotrygdService: InfotrygdService
 
     @InjectMockKs
     lateinit var forvalterService: ForvalterService

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/RolletilgangTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/RolletilgangTest.kt
@@ -218,7 +218,7 @@ class RolletilgangTest(
                 header,
             )
 
-        val response = restTemplate.postForEntity<Ressurs<Any>>(hentUrl("/api/forvalter/kjor-satsendring-uten-validering"), requestEntity)
+        val response = restTemplate.postForEntity<String>(hentUrl("/api/forvalter/ferdigstill-oppgaver"), requestEntity)
 
         assertEquals(HttpStatus.OK, response.statusCode)
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- **Slett forvalter-endepunkt /start-manuell-restart-av-smaabarnstillegg-jobb/skalOppretteOppgaver/{skalOppretteOppgaver}**
- **Slett forvalter-endepunkt for forenklet satsendring**
- **Slett forvalter-endpunkt /finnÅpneFagsakerMedFlereMigreringsbehandlingerOgLøpendeSakIInfotrygd/{fraÅrMåned}**
- **Slett forvalter-endepunkt finnÅpneFagsakerMedFlereMigreringsbehandlinger/{fraÅrMåned}**

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
