### PR TITLE
Unngå kall mot PDL etter iverksetting mot oppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdragTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdragTask.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask.Companion.TASK_STEP_TYPE
@@ -23,7 +22,6 @@ import java.util.Properties
 class IverksettMotOppdragTask(
     private val stegService: StegService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
-    private val personidentService: PersonidentService,
     private val taskRepository: TaskRepositoryWrapper,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
@@ -36,7 +34,11 @@ class IverksettMotOppdragTask(
 
     override fun onCompletion(task: Task) {
         val iverksettingTask = objectMapper.readValue(task.payload, IverksettingTaskDTO::class.java)
-        val personIdent = personidentService.hentAktør(iverksettingTask.personIdent).aktivFødselsnummer()
+        val personIdent =
+            behandlingHentOgPersisterService
+                .hent(iverksettingTask.behandlingsId)
+                .fagsak.aktør
+                .aktivFødselsnummer()
         val statusFraOppdragTask =
             Task(
                 type = StatusFraOppdragTask.TASK_STEP_TYPE,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -617,7 +617,7 @@ class CucumberMock(
             opprettTaskService = opprettTaskService,
             stegService = stegService,
         )
-    val iverksettMotOppdragTask = IverksettMotOppdragTask(stegService, behandlingHentOgPersisterService, personidentService, taskRepository)
+    val iverksettMotOppdragTask = IverksettMotOppdragTask(stegService, behandlingHentOgPersisterService, taskRepository)
     val ferdigstillBehandlingTask = FerdigstillBehandlingTask(stegService = stegService, behandlingHentOgPersisterService = behandlingHentOgPersisterService)
     val statusFraOppdragTask = StatusFraOppdragTask(stegService, behandlingHentOgPersisterService, personidentService, taskRepository)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi hadde en forskjell mellom utbetalingsoppdraget i familie-oppdrag og utbetalingsoppdraget i tilkjent_ytelse. Dette skjedde fordi PDL var nede da man forsøkte å lage neste task. Dette skjedde etter at oppdraget var iverksatt. Da feilet tasken og når den ble rekjørt, så forsøkte den å iverksette på nytt. Dette utbetalingsoppdraget hadde forskjellig oppbygging av periodeId. Så neste revurdering på fagsaken feilet mot oppdrag

Denne oppgaven er en del av favro NAV-24177 for robustgjøring av tasken, siden man ikke trenger å gjøre kall mot PDL her.

Dette for å unngå at iverksettingstasken feiler hvis PDL er nede.
### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
