### PR TITLE
Henter kun enkel personInfo i OPPDATER_UTVIDET_KLASSEKODE-behandlinger.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -218,7 +218,7 @@ class PersongrunnlagService(
     ): PersonopplysningGrunnlag {
         val personopplysningGrunnlag = lagreOgDeaktiverGammel(PersonopplysningGrunnlag(behandlingId = behandling.id))
 
-        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
+        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering() || behandling.erOppdaterUtvidetKlassekode()
         val søker =
             hentPerson(
                 aktør = aktør,


### PR DESCRIPTION
[NAV-24208](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24208)

### 💰 Hva skal gjøres, og hvorfor?
På lik linje som for satsendringer og månedlige valutajusteringer henter vi kun "enkel" PersonInfo for personer i behandling i `OPPDATER_UTVIDET_KLASSEKODE`-behandlinger.  

https://familie-prosessering.intern.nav.no/service/familie-ba-sak/task/1332204501
