### PR TITLE
Fjerner utfiltrering av OPPDATER_UTVIDET_KLASSEKODE behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/Behandlingutils.kt
@@ -37,8 +37,6 @@ object Behandlingutils {
         behandlingFørFølgende: Behandling,
     ): List<Behandling> =
         iverksatteBehandlinger
-            // Ønsker ikke ta med behandlinger av typen `OPPDATER_UTVIDET_KLASSEKODE` da disse inneholder kunstig splitt i andeler som kan skape 0-utbetalinger mot Oppdrag/Økonomisystemet.
-            .filter { !it.erOppdaterUtvidetKlassekode() }
             .filter { it.aktivertTidspunkt.isBefore(behandlingFørFølgende.aktivertTidspunkt) && it.steg == StegType.BEHANDLING_AVSLUTTET }
 
     fun harBehandlingsårsakAlleredeKjørt(


### PR DESCRIPTION
NAV-

### 💰 Hva skal gjøres, og hvorfor?
Ved første konsistensavstemming etter kjøring av 120 000 `OPPDATER_UTVIDET_KLASSEKODE`-behandlinger fikk vi ca 44 000 avvik. PeriodeId'ene lagret på andelene til behandlingene stemte ikke med det vi har sendt i utbetalingsoppdragene til Oppdrag.

Feilen kommer av at vi ved generering av nytt utbetalingsoppdrag ikke sender inn andelene fra forrige iverksatte behandling, men andelene fra forrige iverksatte behandling som ikke er av typen `OPPDATER_UTVIDET_KLASSEKODE`. Dette fører til at vi setter feil `periodeId` og `forrigePeriodeId` i andelene til den nye behandlingen i mange tilfeller.

Grunnen til at vi "hoppet" over `OPPDATER_UTVIDET_KLASSEKODE`-behandlinger var for å unngå 0-utbetalinger på "Min side" i revurderingsbehandlinger. Men ved å unngå dette, har vi nå mer omfattende problemer relatert til konsistensavstemming. Derfor fjerner vi her denne filtreringen av iverksatte behandlinger.

Konsekvensen av denne endringen, vil være at første revurdering i fagsaker med utvidet barnetrygd vil skape 0-utbetalinger i neste utbetalingsmnd. Dette kan i mange tilfeller bety 0-utbetalinger tilbake til 01.07.23 og frem til datoen revurderingen finner sted.

Det vil finnes noen fagsaker hvor vi allerede har revurdert etter kjøring av `OPPDATER_UTVIDET_KLASSEKODE`, og disse vil fortsatt feile ved neste konsistensavstemming, og må muligens patches på en eller annen måte.