### PR TITLE
prioriter navn og kjønn som kommer fra PDL og ikke Freg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -15,6 +15,8 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlUtenlandskAdressseRespo
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlVergeResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.VergemaalEllerFremtidsfullmakt
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.filtrerKjønnPåKilde
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.filtrerNavnPåKilde
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.http.client.AbstractRestClient
@@ -97,8 +99,8 @@ class PdlRestClient(
                 PersonInfo(
                     // Hvis det ikke finnes fødselsdato på person forsøker vi å bruke dato for barnets død fordi det var et dødfødt barn.
                     fødselsdato = LocalDate.parse(it.foedselsdato.firstOrNull()?.foedselsdato ?: it.doedfoedtBarn.first().dato),
-                    navn = it.navn.firstOrNull()?.fulltNavn(),
-                    kjønn = it.kjoenn.firstOrNull()?.kjoenn,
+                    navn = it.navn.filtrerNavnPåKilde()?.fulltNavn(),
+                    kjønn = it.kjoenn.filtrerKjønnPåKilde()?.kjoenn,
                     forelderBarnRelasjon = forelderBarnRelasjon,
                     adressebeskyttelseGradering = it.adressebeskyttelse.firstOrNull()?.gradering,
                     bostedsadresser = it.bostedsadresse,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.integrasjoner.pdl.domene
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.familie.ba.sak.common.PdlPersonKanIkkeBehandlesIFagSystemÅrsak
 import no.nav.familie.ba.sak.common.PdlPersonKanIkkeBehandlesIFagsystem
-import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.kontrakter.felles.personopplysning.Adressebeskyttelse
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
@@ -89,38 +88,18 @@ data class PdlMetadata(
 fun List<PdlNavn>.filtrerNavnPåKilde(): PdlNavn? {
     val funksjonelleNavn = this.filter { it.metadata.historisk == false }
 
-    return when (funksjonelleNavn.size) {
-        0 -> null
-        1 -> this.first()
-        else ->
-            this.find {
-                it.metadata.master == PdlMaster.PDL.navn
-            } ?: run {
-                secureLogger.error("Fikk flere navn fra PDL med samme master / kilde: $funksjonelleNavn")
-                throw IllegalStateException("Fikk flere navn fra PDL med samme master / kilde. Se securelogs for detaljer.")
-            }
-    }
+    return funksjonelleNavn.minByOrNull { PdlMaster.valueOf(it.metadata.master.uppercase()).prioritet }
 }
 
 fun List<PdlKjoenn>.filtrerKjønnPåKilde(): PdlKjoenn? {
     val funksjoneltKjønn = this.filter { it.metadata.historisk == false }
 
-    return when (funksjoneltKjønn.size) {
-        0 -> null
-        1 -> this.first()
-        else ->
-            this.find {
-                it.metadata.master == PdlMaster.PDL.navn
-            } ?: run {
-                secureLogger.error("Fikk flere kjønn fra PDL med samme master / kilde: $funksjoneltKjønn")
-                throw IllegalStateException("Fikk flere kjønn fra PDL med samme master / kilde. Se securelogs for detaljer.")
-            }
-    }
+    return funksjoneltKjønn.minByOrNull { PdlMaster.valueOf(it.metadata.master.uppercase()).prioritet }
 }
 
 enum class PdlMaster(
-    val navn: String,
+    val prioritet: Int,
 ) {
-    PDL(navn = "PDL"),
-    FREG(navn = "Freg"),
+    PDL(1),
+    FREG(2),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
@@ -85,17 +85,17 @@ data class PdlMetadata(
     val historisk: Boolean,
 )
 
-fun List<PdlNavn>.filtrerNavnPåKilde(): PdlNavn? {
-    val funksjonelleNavn = this.filter { it.metadata.historisk == false }
+// Filtrer på historisk slik at ikke-historiske alltid får prioritet
+fun List<PdlNavn>.filtrerNavnPåKilde(): PdlNavn? =
+    this
+        .filter { it.metadata.historisk == false }
+        .minByOrNull { PdlMaster.valueOf(it.metadata.master.uppercase()).prioritet }
 
-    return funksjonelleNavn.minByOrNull { PdlMaster.valueOf(it.metadata.master.uppercase()).prioritet }
-}
-
-fun List<PdlKjoenn>.filtrerKjønnPåKilde(): PdlKjoenn? {
-    val funksjoneltKjønn = this.filter { it.metadata.historisk == false }
-
-    return funksjoneltKjønn.minByOrNull { PdlMaster.valueOf(it.metadata.master.uppercase()).prioritet }
-}
+// Filtrer på historisk slik at ikke-historiske alltid får prioritet
+fun List<PdlKjoenn>.filtrerKjønnPåKilde(): PdlKjoenn? =
+    this
+        .filter { it.metadata.historisk == false }
+        .minByOrNull { PdlMaster.valueOf(it.metadata.master.uppercase()).prioritet }
 
 enum class PdlMaster(
     val prioritet: Int,

--- a/src/main/resources/pdl/hentperson-enkel.graphql
+++ b/src/main/resources/pdl/hentperson-enkel.graphql
@@ -11,9 +11,17 @@ query($ident: ID!) {person: hentPerson(ident: $ident) {
         fornavn
         mellomnavn
         etternavn
+        metadata {
+            master
+            historisk
+        }
     }
     kjoenn {
         kjoenn
+        metadata {
+            master
+            historisk
+        }
     }
     adressebeskyttelse {
         gradering

--- a/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
+++ b/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
@@ -11,9 +11,17 @@ query($ident: ID!) {person: hentPerson(ident: $ident) {
         fornavn
         mellomnavn
         etternavn
+        metadata {
+            master
+            historisk
+        }
     }
     kjoenn {
         kjoenn
+        metadata {
+            master
+            historisk
+        }
     }
     forelderBarnRelasjon {
         relatertPersonsIdent,

--- a/src/main/resources/pdl/hentperson-navn-og-adresse.graphql
+++ b/src/main/resources/pdl/hentperson-navn-og-adresse.graphql
@@ -3,6 +3,10 @@ query($ident: ID!) {person: hentPerson(ident: $ident) {
         fornavn
         mellomnavn
         etternavn
+        metadata {
+            master
+            historisk
+        }
     }
     bostedsadresse(historikk: false) {
         gyldigTilOgMed

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
@@ -5,7 +5,12 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlAdressebeskyttelseRespo
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBaseResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentPersonRelasjonerResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentPersonResponse
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlMaster
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlMetadata
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlNavn
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.filtrerKjønnPåKilde
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.filtrerNavnPåKilde
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
@@ -35,6 +40,13 @@ class PdlGraphqlTest {
                 .first()
                 .fornavn,
         ).isEqualTo("ENGASJERT")
+        assertThat(
+            resp.data.person!!
+                .navn
+                .first()
+                .metadata
+                .master,
+        ).isEqualTo(PdlMaster.PDL.navn)
         assertThat(
             resp.data.person!!
                 .kjoenn
@@ -209,10 +221,57 @@ class PdlGraphqlTest {
 
     @Test
     fun testFulltNavn() {
-        assertThat(PdlNavn(fornavn = "For", mellomnavn = "Mellom", etternavn = "Etter").fulltNavn())
-            .isEqualTo("For Mellom Etter")
-        assertThat(PdlNavn(fornavn = "For", etternavn = "Etter").fulltNavn())
-            .isEqualTo("For Etter")
+        assertThat(
+            PdlNavn(
+                fornavn = "For",
+                mellomnavn = "Mellom",
+                etternavn = "Etter",
+                metadata = PdlMetadata(master = "kilde", historisk = false),
+            ).fulltNavn(),
+        ).isEqualTo("For Mellom Etter")
+        assertThat(
+            PdlNavn(
+                fornavn = "For",
+                etternavn = "Etter",
+                metadata = PdlMetadata(master = "kilde", historisk = false),
+            ).fulltNavn(),
+        ).isEqualTo("For Etter")
+    }
+
+    @Test
+    fun testDeserialiseringAvResponsMedToNavn() {
+        val resp =
+            mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlMedToNavnOgToKjonn.json")))
+        assertThat(
+            resp.data.person!!
+                .navn
+                .filtrerNavnPåKilde()
+                ?.etternavn,
+        ).isEqualTo("NATUR")
+    }
+
+    @Test
+    fun testDeserialiseringAvResponsMedToKjønn() {
+        val resp =
+            mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlMedToNavnOgToKjonn.json")))
+        assertThat(
+            resp.data.person!!
+                .kjoenn
+                .filtrerKjønnPåKilde()
+                ?.kjoenn,
+        ).isEqualTo(Kjønn.KVINNE)
+    }
+
+    @Test
+    fun testDeserialiseringAvResponsMedUgyldigeKilder() {
+        val resp =
+            mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlMedToNavnOgToKjonn.json")))
+        assertThat(
+            resp.data.person!!
+                .kjoenn
+                .filtrerKjønnPåKilde()
+                ?.kjoenn,
+        ).isEqualTo(Kjønn.KVINNE)
     }
 
     private fun getFile(name: String): String = javaClass.classLoader?.getResource(name)?.file ?: error("Testkonfigurasjon feil")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlAdressebeskyttelseRespo
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBaseResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentPersonRelasjonerResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentPersonResponse
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlMaster
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlMetadata
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlNavn
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.filtrerKjønnPåKilde
@@ -47,7 +46,7 @@ class PdlGraphqlTest {
                 .metadata
                 .master
                 .uppercase(),
-        ).isEqualTo(PdlMaster.PDL.name)
+        ).isEqualTo("PDL")
         assertThat(
             resp.data.person!!
                 .kjoenn

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
@@ -45,8 +45,9 @@ class PdlGraphqlTest {
                 .navn
                 .first()
                 .metadata
-                .master,
-        ).isEqualTo(PdlMaster.PDL.navn)
+                .master
+                .uppercase(),
+        ).isEqualTo(PdlMaster.PDL.name)
         assertThat(
             resp.data.person!!
                 .kjoenn

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/scenario/StubsForVerdikjedetester.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/scenario/StubsForVerdikjedetester.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentIdenterResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentPersonResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlIdenter
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlKjoenn
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlMetadata
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlNavn
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonData
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonRequest
@@ -202,9 +203,10 @@ private fun enkelPdlHentPersonResponse(scenarioPerson: RestScenarioPerson): PdlP
                     fornavn = scenarioPerson.fornavn,
                     mellomnavn = null,
                     etternavn = scenarioPerson.etternavn,
+                    metadata = PdlMetadata(master = "kilde", historisk = false),
                 ),
             ),
-        kjoenn = listOf(PdlKjoenn(kjoenn = Kjønn.KVINNE)),
+        kjoenn = listOf(PdlKjoenn(kjoenn = Kjønn.KVINNE, metadata = PdlMetadata(master = "kilde", historisk = false))),
         adressebeskyttelse = emptyList(),
         sivilstand = listOf(Sivilstand(type = SIVILSTANDTYPE.UGIFT)),
         bostedsadresse = scenarioPerson.bostedsadresser,

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarn.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarn.json
@@ -20,7 +20,11 @@
       "navn": [
         {
           "fornavn": "BARN",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -30,7 +34,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedAdressebeskyttelse.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedAdressebeskyttelse.json
@@ -20,7 +20,11 @@
       "navn": [
         {
           "fornavn": "REAL",
-          "etternavn": "RUNDINGSBØYE"
+          "etternavn": "RUNDINGSBØYE",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -30,7 +34,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedOpphørtStatus.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnMedOpphørtStatus.json
@@ -20,7 +20,11 @@
       "navn": [
         {
           "fornavn": "BARN",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -30,7 +34,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnUtenFødselsdato.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForBarnUtenFødselsdato.json
@@ -20,13 +20,21 @@
       "navn": [
         {
           "fornavn": "BARN",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForDødMor.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForDødMor.json
@@ -20,7 +20,11 @@
       "navn": [
         {
           "fornavn": "MOR",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -30,7 +34,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "KVINNE"
+          "kjoenn": "KVINNE",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMor3Barn1Opphørt1UtenFødselsdato.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMor3Barn1Opphørt1UtenFødselsdato.json
@@ -20,7 +20,11 @@
       "navn": [
         {
           "fornavn": "MOR",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -30,7 +34,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "KVINNE"
+          "kjoenn": "KVINNE",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedTomtStatsborgerskap.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedTomtStatsborgerskap.json
@@ -30,7 +30,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -40,7 +44,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "KVINNE"
+          "kjoenn": "KVINNE",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedUkjentStatsborgerskap.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedUkjentStatsborgerskap.json
@@ -30,7 +30,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -40,7 +44,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "KVINNE"
+          "kjoenn": "KVINNE",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedXXXStatsborgerskap.json
+++ b/src/test/resources/pdl/PdlIntegrasjon/personinfoResponseForMorMedXXXStatsborgerskap.json
@@ -30,7 +30,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -40,7 +44,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "KVINNE"
+          "kjoenn": "KVINNE",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/pdlDoedfoedtBarnOkResponse.json
+++ b/src/test/resources/pdl/pdlDoedfoedtBarnOkResponse.json
@@ -11,13 +11,21 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [
@@ -40,8 +48,7 @@
         }
       ],
       "doedsfall": [],
-      "doedfoedtBarn":
-      [
+      "doedfoedtBarn": [
         {
           "dato": "2024-09-13"
         }

--- a/src/test/resources/pdl/pdlManglerFoedselResponse.json
+++ b/src/test/resources/pdl/pdlManglerFoedselResponse.json
@@ -11,7 +11,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -21,8 +25,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
-        }
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }        }
       ],
       "bostedsadresse": [],
       "sivilstand": [

--- a/src/test/resources/pdl/pdlMatrikkelAdresseOkResponse.json
+++ b/src/test/resources/pdl/pdlMatrikkelAdresseOkResponse.json
@@ -11,7 +11,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -21,7 +25,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/pdlMedToNavnMedIngenFraPdl.json
+++ b/src/test/resources/pdl/pdlMedToNavnMedIngenFraPdl.json
@@ -24,7 +24,7 @@
           "mellomnavn": null,
           "etternavn": "NATUR",
           "metadata": {
-            "master": "PDL",
+            "master": "Freg",
             "historisk": false
           }
         },

--- a/src/test/resources/pdl/pdlMedToNavnMedIngenFraPdl.json
+++ b/src/test/resources/pdl/pdlMedToNavnMedIngenFraPdl.json
@@ -33,7 +33,7 @@
           "mellomnavn": null,
           "etternavn": "BYKJERNE",
           "metadata": {
-            "master": "Freg",
+            "master": "RandomUkjentKilde",
             "historisk": false
           }
         }
@@ -49,7 +49,7 @@
         {
           "kjoenn": "MANN",
           "metadata": {
-            "master": "Freg",
+            "master": "RandomUkjentKilde",
             "historisk": false
           }
         }

--- a/src/test/resources/pdl/pdlMedToNavnMedIngenFraPdl.json
+++ b/src/test/resources/pdl/pdlMedToNavnMedIngenFraPdl.json
@@ -1,0 +1,86 @@
+{
+  "data": {
+    "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "26528903613",
+          "status": "I_BRUK",
+          "type": "FNR"
+        },
+        {
+          "identifikasjonsnummer": "26528903613",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
+      "foedselsdato": [
+        {
+          "foedselsdato": "1989-12-26"
+        }
+      ],
+      "navn": [
+        {
+          "fornavn": "UFUNKSJONELL",
+          "mellomnavn": null,
+          "etternavn": "NATUR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
+        },
+        {
+          "fornavn": "FUNKSJONELL",
+          "mellomnavn": null,
+          "etternavn": "BYKJERNE",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false
+          }
+        }
+      ],
+      "kjoenn": [
+        {
+          "kjoenn": "KVINNE",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false
+          }
+        },
+        {
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false
+          }
+        }
+      ],
+      "adressebeskyttelse": [],
+      "bostedsadresse": [
+        {
+          "angittFlyttedato": "1989-12-26",
+          "gyldigTilOgMed": null,
+          "vegadresse": {
+            "matrikkelId": 212261815,
+            "husnummer": "963",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "adressenavn": "Østsideveien",
+            "kommunenummer": "1573",
+            "tilleggsnavn": "Vikan",
+            "postnummer": "6570"
+          },
+          "matrikkeladresse": null,
+          "ukjentBosted": null
+        }
+      ],
+      "sivilstand": [
+        {
+          "gyldigFraOgMed": "1989-12-26",
+          "type": "UGIFT"
+        }
+      ],
+      "doedsfall": [],
+      "kontaktinformasjonForDoedsbo": []
+    }
+  }
+}

--- a/src/test/resources/pdl/pdlMedToNavnOgToKjonn.json
+++ b/src/test/resources/pdl/pdlMedToNavnOgToKjonn.json
@@ -1,0 +1,86 @@
+{
+  "data": {
+    "person": {
+      "folkeregisteridentifikator": [
+        {
+          "identifikasjonsnummer": "26528903613",
+          "status": "I_BRUK",
+          "type": "FNR"
+        },
+        {
+          "identifikasjonsnummer": "26528903613",
+          "status": "I_BRUK",
+          "type": "FNR"
+        }
+      ],
+      "foedselsdato": [
+        {
+          "foedselsdato": "1989-12-26"
+        }
+      ],
+      "navn": [
+        {
+          "fornavn": "UFUNKSJONELL",
+          "mellomnavn": null,
+          "etternavn": "NATUR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
+        },
+        {
+          "fornavn": "FUNKSJONELL",
+          "mellomnavn": null,
+          "etternavn": "BYKJERNE",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false
+          }
+        }
+      ],
+      "kjoenn": [
+        {
+          "kjoenn": "KVINNE",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
+        },
+        {
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false
+          }
+        }
+      ],
+      "adressebeskyttelse": [],
+      "bostedsadresse": [
+        {
+          "angittFlyttedato": "1989-12-26",
+          "gyldigTilOgMed": null,
+          "vegadresse": {
+            "matrikkelId": 212261815,
+            "husnummer": "963",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "adressenavn": "Østsideveien",
+            "kommunenummer": "1573",
+            "tilleggsnavn": "Vikan",
+            "postnummer": "6570"
+          },
+          "matrikkeladresse": null,
+          "ukjentBosted": null
+        }
+      ],
+      "sivilstand": [
+        {
+          "gyldigFraOgMed": "1989-12-26",
+          "type": "UGIFT"
+        }
+      ],
+      "doedsfall": [],
+      "kontaktinformasjonForDoedsbo": []
+    }
+  }
+}

--- a/src/test/resources/pdl/pdlOkResponse.json
+++ b/src/test/resources/pdl/pdlOkResponse.json
@@ -11,7 +11,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -21,7 +25,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/pdlOkResponseEnkel.json
+++ b/src/test/resources/pdl/pdlOkResponseEnkel.json
@@ -4,7 +4,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -14,7 +18,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [

--- a/src/test/resources/pdl/pdlTomAdresseOkResponse.json
+++ b/src/test/resources/pdl/pdlTomAdresseOkResponse.json
@@ -11,7 +11,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -21,7 +25,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [],

--- a/src/test/resources/pdl/pdlUkjentBostedAdresseOkResponse.json
+++ b/src/test/resources/pdl/pdlUkjentBostedAdresseOkResponse.json
@@ -11,7 +11,11 @@
       "navn": [
         {
           "fornavn": "ENGASJERT",
-          "etternavn": "FYR"
+          "etternavn": "FYR",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "foedselsdato": [
@@ -21,7 +25,11 @@
       ],
       "kjoenn": [
         {
-          "kjoenn": "MANN"
+          "kjoenn": "MANN",
+          "metadata": {
+            "master": "PDL",
+            "historisk": false
+          }
         }
       ],
       "bostedsadresse": [


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24082)

Ref [pdl-doc](https://pdl-docs.ansatt.nav.no/ekstern/index.html#_navn) så ønsker vi å bruke PDL som master og ikke Freg når vi får verdier fra begge. 

Velger derfor å ta med metadata, master og historisk for å kunne filtrere ut når det er flere kilder til navn/kjønn. 

[Dokumentasjon om metadata og kilder](https://pdl-docs.ansatt.nav.no/ekstern/index.html#felles)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
