### PR TITLE
Rydding av warnings ved bygg og oppstart og annet småsnacks

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApplicationConfig.kt
@@ -62,8 +62,8 @@ class ApplicationConfig {
     fun restTemplateBuilder(objectMapper: ObjectMapper): RestTemplateBuilder {
         val jackson2HttpMessageConverter = MappingJackson2HttpMessageConverter(objectMapper)
         return RestTemplateBuilder()
-            .setConnectTimeout(Duration.of(2, ChronoUnit.SECONDS))
-            .setReadTimeout(Duration.of(30, ChronoUnit.SECONDS))
+            .connectTimeout(Duration.of(2, ChronoUnit.SECONDS))
+            .readTimeout(Duration.of(30, ChronoUnit.SECONDS))
             .additionalMessageConverters(listOf(jackson2HttpMessageConverter) + RestTemplate().messageConverters)
     }
 
@@ -78,8 +78,8 @@ class ApplicationConfig {
         RetryOAuth2HttpClient(
             RestClient.create(
                 RestTemplateBuilder()
-                    .setConnectTimeout(Duration.of(2, ChronoUnit.SECONDS))
-                    .setReadTimeout(Duration.of(4, ChronoUnit.SECONDS))
+                    .connectTimeout(Duration.of(2, ChronoUnit.SECONDS))
+                    .readTimeout(Duration.of(4, ChronoUnit.SECONDS))
                     .build(),
             ),
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/RestTemplateConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/RestTemplateConfig.kt
@@ -63,8 +63,8 @@ class RestTemplateConfig {
         bearerTokenClientInterceptor: BearerTokenClientInterceptor,
     ): RestOperations =
         RestTemplateBuilder()
-            .setReadTimeout(Duration.ofMinutes(12L))
-            .setConnectTimeout(Duration.ofMinutes(12L))
+            .readTimeout(Duration.ofMinutes(12L))
+            .connectTimeout(Duration.ofMinutes(12L))
             .interceptors(
                 consumerIdClientInterceptor,
                 bearerTokenClientInterceptor,
@@ -95,8 +95,8 @@ class RestTemplateConfig {
         mdcValuesPropagatingClientInterceptor: MdcValuesPropagatingClientInterceptor,
     ): RestTemplateBuilder =
         RestTemplateBuilder()
-            .setConnectTimeout(Duration.ofSeconds(5))
-            .setReadTimeout(Duration.ofSeconds(5))
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(5))
             .additionalInterceptors(consumerIdClientInterceptor, mdcValuesPropagatingClientInterceptor)
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/VedtaksperioderOgBegrunnelserTestUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/vedtak/VedtaksperioderOgBegrunnelserTestUtil.kt
@@ -97,7 +97,7 @@ private fun lagGenereltTestoppsettForVedtaksperioderOgBegrunnelser(
 # language: no
 # encoding: UTF-8
 
-Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric(10)}
+Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.secure().nextAlphanumeric(10)}
 
   Bakgrunn:""" +
             hentTekstForFagsak(behandling) +
@@ -105,7 +105,7 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
             hentTekstForPersongrunnlag(persongrunnlag, persongrunnlagForrigeBehandling) +
             """
       
-  Scenario: Plassholdertekst for scenario - ${RandomStringUtils.randomAlphanumeric(10)}
+  Scenario: Plassholdertekst for scenario - ${RandomStringUtils.secure().nextAlphanumeric(10)}
     Og dagens dato er ${LocalDate.now().tilddMMyyyy()}""" +
             hentTekstForPersonerFremstiltKravFor(behandling.id, personerFremstiltKravFor) +
             lagPersonresultaterTekst(forrigeBehandling) +

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggService.kt
@@ -58,11 +58,11 @@ class AutovedtakSmåbarnstilleggService(
     private val opprettTaskService: OpprettTaskService,
 ) : AutovedtakBehandlingService<SmåbarnstilleggData> {
     private val antallVedtakOmOvergangsstønad: Counter =
-        Metrics.counter("behandling", "saksbehandling", "hendelse", "smaabarnstillegg", "antall")
+        Metrics.counter("behandling", "saksbehandling", "hendelse", "smaabarnstillegg", "antall", "aarsak", "ikke_relevant", "beskrivelse", "ikke_relevant")
     private val antallVedtakOmOvergangsstønadPåvirkerFagsak: Counter =
-        Metrics.counter("behandling", "saksbehandling", "hendelse", "smaabarnstillegg", "paavirker_fagsak")
+        Metrics.counter("behandling", "saksbehandling", "hendelse", "smaabarnstillegg", "paavirker_fagsak", "aarsak", "ikke_relevant", "beskrivelse", "ikke_relevant")
     private val antallVedtakOmOvergangsstønadPåvirkerIkkeFagsak: Counter =
-        Metrics.counter("behandling", "saksbehandling", "hendelse", "smaabarnstillegg", "paavirker_ikke_fagsak")
+        Metrics.counter("behandling", "saksbehandling", "hendelse", "smaabarnstillegg", "paavirker_ikke_fagsak", "aarsak", "ikke_relevant", "beskrivelse", "ikke_relevant")
 
     enum class TilManuellBehandlingÅrsak(
         val beskrivelse: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -137,11 +137,14 @@ class HåndterNyIdentService(
 
         if (fødselsdatoFraPdl.toYearMonth() != fødselsdatoForrigeBehandling.toYearMonth()) {
             secureLogger.warn(
-                "Fødselsdato er forskjellig fra forrige behandling.\n" +
-                    "Ny fødselsdato $fødselsdatoFraPdl, forrige fødselsdato $fødselsdatoForrigeBehandling\n" +
-                    "Må saksbehandles manuelt. Send til fag: \n" +
-                    "Fagsak: ${forrigeBehandling.fagsak.id} \n" +
-                    "Identer: ${alleIdenterFraPdl.filter { it.gruppe == Type.FOLKEREGISTERIDENT.name }}",
+                """Fødselsdato er forskjellig fra forrige behandling.
+                    Ny fødselsdato $fødselsdatoFraPdl, forrige fødselsdato $fødselsdatoForrigeBehandling
+                    Fagsak: ${forrigeBehandling.fagsak.id}
+                    Ny ident: ${alleIdenterFraPdl.filter { !it.historisk && it.gruppe == Type.FOLKEREGISTERIDENT.name }.map { it.ident }}
+                    Gamle identer: ${alleIdenterFraPdl.filter { it.historisk && it.gruppe == Type.FOLKEREGISTERIDENT.name }.map { it.ident }}
+                    Send informasjonen beskrevet over til en fagressurs og patch identen manuelt. Se lenke for mer info:
+                    ${LENKE_INFO_OM_MERGING}
+                """.trimMargin(),
             )
             throw Feil("Fødselsdato er forskjellig fra forrige behandling. Kopier tekst fra securelog og send til en fagressurs")
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,7 +39,6 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        dialect: "org.hibernate.dialect.PostgreSQLDialect"
         temp:
           use_jdbc_metadata_defaults: false
   flyway:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,8 +39,8 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        temp:
-          use_jdbc_metadata_defaults: false
+        boot:
+          allow_jdbc_metadata_access: true
   flyway:
     enabled: true
     locations: classpath:db/migration,classpath:db/init

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/RestTemplateTestConfig.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/RestTemplateTestConfig.kt
@@ -81,7 +81,7 @@ class RestTemplateTestConfig {
         mdcValuesPropagatingClientInterceptor: MdcValuesPropagatingClientInterceptor,
     ): RestTemplateBuilder =
         RestTemplateBuilder()
-            .setConnectTimeout(Duration.ofSeconds(5))
+            .connectTimeout(Duration.ofSeconds(5))
             .additionalInterceptors(consumerIdClientInterceptor, mdcValuesPropagatingClientInterceptor)
-            .setReadTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(5))
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- Endret beskrivelse på hva man må gjøre for å håndtere en endring av fødselsdato for et barn ved identhendelse
- Bytter vekk fra deprikerte metodene setReadtimeout og setConnectTimout
- Fjerner warning: PostgreSQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
- Fikser warning  og skrur på metadataaccess for å slippe å ha dialect
- Fikser warning med registrering av prometheus metric behandling, fordi den allerede eksisterer og er ulike keys. Prometheus requires that all meters with the same name have the same set of tag keys. There is already an existing meter named 'behandling' containing tag keys [saksbehandling, smaabarnstillegg]. The meter you are attempting to register has keys [aarsak, beskrivelse, saksbehandling, smaabarnstillegg]. Note that subsequent logs will be logged at debug level.
- Tar i bruk secure().nextAlphanumeric(10) i stedet for deprikert metode i java

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
Tester eksisterer alt

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
