### PR TITLE
NAV-24196: Tillatter å sette Vikafossen hvis det er eneste tilgang saksbehandler har

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/CollectionUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/CollectionUtils.kt
@@ -6,3 +6,15 @@ inline fun <T> Collection<T>.zeroSingleOrThrow(exception: Collection<T>.() -> Ex
     } else {
         throw exception()
     }
+
+fun <T> Collection<T>.containsExactly(vararg elements: T): Boolean {
+    if (this.size != elements.size) {
+        return false
+    }
+    this.forEachIndexed { index, element ->
+        if (element != elements[index]) {
+            return false
+        }
+    }
+    return true
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -28,6 +28,9 @@ enum class FeatureToggle(
     // NAV-23733
     BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET("familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"),
 
+    // NAV-24196
+    TILLAT_OPPRETT_AV_BEHANDLING_PÅ_VIKAFOSSEN("familie-ba-sak.tillatt_opprett_av_behandling_paa_vikafossen"),
+
     // satsendring
     // Oppretter satsendring-tasker for de som ikke har fått ny task
     SATSENDRING_ENABLET("familie-ba-sak.satsendring-enablet"),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/CollectionUtilsKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/CollectionUtilsKtTest.kt
@@ -1,0 +1,202 @@
+package no.nav.familie.ba.sak.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CollectionUtilsKtTest {
+    @Nested
+    inner class ContainsExactlyTest {
+        @Test
+        fun `skal returnere false om en tom liste ikke inneholder det ene ønskede elemente`() {
+            // Arrange
+            val collection = emptyList<String>()
+
+            // Act
+            val containsOnly = collection.containsExactly("A")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om en liste kun inneholder det ene ønskede elemente`() {
+            // Arrange
+            val collection = listOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A")
+
+            // Assert
+            assertThat(containsOnly).isTrue()
+        }
+
+        @Test
+        fun `skal returnere true om en liste kun inneholder de ønskede ulike elemente`() {
+            // Arrange
+            val collection = listOf("A", "B")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "B")
+
+            // Assert
+            assertThat(containsOnly).isTrue()
+        }
+
+        @Test
+        fun `skal returnere true om en liste kun inneholder de ønskede like elemente`() {
+            // Arrange
+            val collection = listOf("A", "A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "A")
+
+            // Assert
+            assertThat(containsOnly).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om en liste kun inneholder de ønskede ulike elemente i forskjellig rekkefølge`() {
+            // Arrange
+            val collection = listOf("A", "B")
+
+            // Act
+            val containsOnly = collection.containsExactly("B", "A")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om en liste med ett element ikke inneholder det ønskede elementet`() {
+            // Arrange
+            val collection = listOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("B")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om en liste med ett element ikke inneholder de ønskede ulike elementene`() {
+            // Arrange
+            val collection = listOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "B")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om en liste med ett element ikke inneholder de ønskede like elementene`() {
+            // Arrange
+            val collection = listOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "A")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om et tomt set ikke inneholder det ene ønskede elemente`() {
+            // Arrange
+            val collection = emptySet<String>()
+
+            // Act
+            val containsOnly = collection.containsExactly("A")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om et set kun inneholder det ene ønskede elemente`() {
+            // Arrange
+            val collection = setOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A")
+
+            // Assert
+            assertThat(containsOnly).isTrue()
+        }
+
+        @Test
+        fun `skal returnere true om et set kun inneholder de ønskede ulike elemente`() {
+            // Arrange
+            val collection = setOf("A", "B")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "B")
+
+            // Assert
+            assertThat(containsOnly).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om et set kun inneholder de ønskede like elemente da et set kun inneholder unike elementer`() {
+            // Arrange
+            val collection = setOf("A", "A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "A")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om et set kun inneholder de ønskede ulike elemente i forskjellig rekkefølge`() {
+            // Arrange
+            val collection = setOf("A", "B")
+
+            // Act
+            val containsOnly = collection.containsExactly("B", "A")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om et set med ett element ikke inneholder det ønskede elementet`() {
+            // Arrange
+            val collection = setOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("B")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om et set med ett element ikke inneholder de ønskede ulike elementene`() {
+            // Arrange
+            val collection = setOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "B")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om et set med ett element ikke inneholder de ønskede like elementene`() {
+            // Arrange
+            val collection = setOf("A")
+
+            // Act
+            val containsOnly = collection.containsExactly("A", "A")
+
+            // Assert
+            assertThat(containsOnly).isFalse()
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24196

Når saksbehandler kun har tilgang til enheten Vikafossen skal det være lovt å opprette behandlinger på Vikafossen enheten. Saksbehandler med Vikafossen tilgang har ofte (alltid?) kun tilgang til Vikafossen.

Har omdøpt de gamle metodene med en "Gammel" suffix. De nye metodene her omtrent lik, men endringer relatert til det som er nevnt over.

Har lagt de nye endringene bak en toggle. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
