### PR TITLE
Ta i bruk tidslinje fra familie-felles i VilkårsvurderingTidslinjer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaService.kt
@@ -12,13 +12,12 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjeService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.innholdForTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.verdiPåTidspunkt
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
 import org.springframework.stereotype.Service
-import java.time.YearMonth
+import java.time.LocalDate
 
 @Service
 class BehandlingstemaService(
@@ -87,14 +86,14 @@ class BehandlingstemaService(
             tidslinjer
                 .barnasTidslinjer()
                 .values
-                .map { it.egetRegelverkResultatTidslinje.innholdForTidspunkt(YearMonth.now(clockProvider.get()).tilTidspunkt()) }
+                .map { it.egetRegelverkResultatTidslinje.verdiPåTidspunkt(LocalDate.now(clockProvider.get())) }
 
-        val etBarnHarMinstEnLøpendeEØSPeriode = alleBarnasTidslinjerSomHarLøpendePeriode.any { it.innhold?.regelverk == Regelverk.EØS_FORORDNINGEN }
+        val etBarnHarMinstEnLøpendeEØSPeriode = alleBarnasTidslinjerSomHarLøpendePeriode.any { it?.regelverk == Regelverk.EØS_FORORDNINGEN }
         if (etBarnHarMinstEnLøpendeEØSPeriode) {
             return BehandlingKategori.EØS
         }
 
-        val etBarnHarMinstEnLøpendeNasjonalPeriode = alleBarnasTidslinjerSomHarLøpendePeriode.any { it.innhold?.regelverk == Regelverk.NASJONALE_REGLER }
+        val etBarnHarMinstEnLøpendeNasjonalPeriode = alleBarnasTidslinjerSomHarLøpendePeriode.any { it?.regelverk == Regelverk.NASJONALE_REGLER }
         if (etBarnHarMinstEnLøpendeNasjonalPeriode) {
             return BehandlingKategori.NASJONAL
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatDagTidslinje.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.DagTidspunkt.Companion.tilTidspunktEllerUendeligSent
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.DagTidspunkt.Companion.tilTidspunktEllerUendeligTidlig
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 /**
  * Lager tidslinje av VilkårRegelverkResultat for ett vilkår og én aktør
@@ -36,3 +38,21 @@ fun VilkårResultat.tilPeriode(): Periode<VilkårRegelverkResultat, Dag> {
         ),
     )
 }
+
+fun Iterable<VilkårResultat>.tilVilkårRegelverkResultatTidslinjeFamilieFelles() =
+    this
+        .filter { it.erOppfylt() }
+        .map { it.tilPeriodeNy() }
+        .tilTidslinje()
+
+private fun VilkårResultat.tilPeriodeNy(): FamilieFellesPeriode<VilkårRegelverkResultat> =
+    FamilieFellesPeriode(
+        verdi =
+            VilkårRegelverkResultat(
+                vilkår = vilkårType,
+                regelverkResultat = this.tilRegelverkResultat(),
+                utdypendeVilkårsvurderinger = this.utdypendeVilkårsvurderinger,
+            ),
+        fom = periodeFom,
+        tom = periodeTom,
+    )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinje.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.tilMånedFraMånedsskifteIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.tilMånedFraMånedsskifteIkkeNull
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 /**
  * Extension-funksjon som konverterer en dag-basert tidslinje til en måned-basert tidslinje med VilkårRegelverkResultat
@@ -20,6 +22,12 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.tilMånedFraMåneds
  * Ikke oppfylt | Oppfylt Nasj  -> <Tomt>
  */
 fun Tidslinje<VilkårRegelverkResultat, Dag>.tilMånedsbasertTidslinjeForVilkårRegelverkResultat() =
+    this
+        .tilMånedFraMånedsskifteIkkeNull { sisteDagForrigeMåned, førsteDagDenneMåned ->
+            if (sisteDagForrigeMåned.erOppfylt() && førsteDagDenneMåned.erOppfylt()) førsteDagDenneMåned else null
+        }
+
+fun FamilieFellesTidslinje<VilkårRegelverkResultat>.tilMånedsbasertTidslinjeForVilkårRegelverkResultat() =
     this
         .tilMånedFraMånedsskifteIkkeNull { sisteDagForrigeMåned, førsteDagDenneMåned ->
             if (sisteDagForrigeMåned.erOppfylt() && førsteDagDenneMåned.erOppfylt()) førsteDagDenneMåned else null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -28,9 +28,20 @@ class VilkårsvurderingTidslinjeService(
         )
     }
 
-    fun hentTidslinjer(behandlingId: BehandlingId): VilkårsvurderingTidslinjer? {
+    // TODO: Endre navn til hentTidslinjerThrows når den andre funksjonen er slettet
+    fun hentFamilieFellesTidslinjerThrows(behandlingId: BehandlingId): VilkårsvurderingFamilieFellesTidslinjer {
+        val vilkårsvurdering = vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId = behandlingId.id)!!
+        val søkerOgBarn = persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(behandlingId = behandlingId.id)
+
+        return VilkårsvurderingFamilieFellesTidslinjer(
+            vilkårsvurdering = vilkårsvurdering,
+            søkerOgBarn = søkerOgBarn,
+        )
+    }
+
+    fun hentTidslinjer(behandlingId: BehandlingId): VilkårsvurderingFamilieFellesTidslinjer? {
         return try {
-            hentTidslinjerThrows(behandlingId)
+            hentFamilieFellesTidslinjerThrows(behandlingId)
         } catch (exception: NullPointerException) {
             return null
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Dag
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærEtter
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.kombinerUtenNull
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
@@ -134,21 +133,6 @@ class VilkårsvurderingTidslinjer(
                 .beskjærEtter(søkersTidslinje.regelverkResultatTidslinje)
     }
 }
-
-fun VilkårsvurderingTidslinjer.harBlandetRegelverk(): Boolean =
-    this.søkerHarNasjonalOgFinnesBarnMedEøs() ||
-        søkersTidslinjer().regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
-        barnasTidslinjer().values.any { it.egetRegelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) }
-
-private fun VilkårsvurderingTidslinjer.søkerHarNasjonalOgFinnesBarnMedEøs(): Boolean =
-    barnasTidslinjer().values.any {
-        it.egetRegelverkResultatTidslinje
-            .kombinerMed(søkersTidslinjer().regelverkResultatTidslinje) { barnRegelverk, søkerRegelverk ->
-                barnRegelverk == RegelverkResultat.OPPFYLT_EØS_FORORDNINGEN && søkerRegelverk == RegelverkResultat.OPPFYLT_NASJONALE_REGLER
-            }.inneholder(true)
-    }
-
-fun <I, T : Tidsenhet> Tidslinje<I, T>.inneholder(innhold: I): Boolean = this.perioder().any { it.innhold == innhold }
 
 // TODO: Endre navn til VilkårsvurderingTidslinjer når den andre klassen er slettet
 class VilkårsvurderingFamilieFellesTidslinjer(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/TidslinjeController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/TidslinjeController.kt
@@ -34,7 +34,7 @@ class TidslinjeController(
         )
         return ResponseEntity.ok(
             success(
-                tidslinjeService.hentTidslinjerThrows(BehandlingId(behandlingId)).tilRestTidslinjer(),
+                tidslinjeService.hentFamilieFellesTidslinjerThrows(BehandlingId(behandlingId)).tilRestTidslinjer(),
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/komposisjon/TidslinjeKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/komposisjon/TidslinjeKombinator.kt
@@ -141,3 +141,14 @@ fun <V, R> Collection<Tidslinje<V>>.kombinerNullableKombinator(listeKombinator: 
             is Udefinert -> Udefinert()
         }
     }
+
+fun <V, R> Tidslinje<V>.mapVerdiNullable(mapper: (V?) -> R?): Tidslinje<R> =
+    this.map { periodeVerdi ->
+        when (periodeVerdi) {
+            is Verdi,
+            is Null,
+            -> mapper(periodeVerdi.verdi)?.let { Verdi(it) } ?: Null()
+
+            is Udefinert -> Udefinert()
+        }
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/komposisjon/TidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/komposisjon/TidslinjeUtil.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
+import no.nav.familie.ba.sak.common.isSameOrAfter
+import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
@@ -9,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -45,3 +48,17 @@ fun opprettBooleanTidslinje(
     fraDato: LocalDate,
     tilDato: LocalDate,
 ) = listOf(Periode(verdi = true, fom = fraDato, tom = tilDato)).tilTidslinje()
+
+fun <V> Tidslinje<V>.verdiPåTidspunkt(tidspunkt: LocalDate): V? = this.tilPerioder().verdiForTidspunkt(tidspunkt)
+
+fun <V> Collection<Periode<V>>.verdiForTidspunkt(tidspunkt: LocalDate): V? = this.firstOrNull { it.omfatter(tidspunkt) }?.verdi
+
+private fun <V> Periode<V>.omfatter(tidspunkt: LocalDate) =
+    when {
+        fom == null && tom == null -> true
+        fom == null -> tom!!.isSameOrAfter(tidspunkt)
+        tom == null -> fom!!.isSameOrBefore(tidspunkt)
+        else -> fom!!.isSameOrBefore(tidspunkt) && tom!!.isSameOrAfter(tidspunkt)
+    }
+
+fun <V> Periode<V>.tilTidslinje(): Tidslinje<V> = listOf(this).tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/EndreTid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/EndreTid.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon
 
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.verdiPåTidspunkt
 import no.nav.familie.tidslinje.Null
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.Udefinert
@@ -32,24 +35,14 @@ fun <V> Tidslinje<V>.tilMånedFraMånedsskifteIkkeNull(
     mapper: (innholdSisteDagForrigeMåned: V, innholdFørsteDagDenneMåned: V) -> V?,
 ): Tidslinje<V> =
     this
-        .konverterTilMåned(antallMndBakoverITid = 1) { dato, måneder ->
-            val sisteDagForrigeMåned =
-                måneder
-                    .first()
-                    .lastOrNull()
-                    ?.periodeVerdi
-                    ?.verdi
-            val førsteDagDenneMåned =
-                måneder
-                    .last()
-                    .firstOrNull()
-                    ?.periodeVerdi
-                    ?.verdi
+        .konverterTilMåned { dato, _ ->
+            val verdiForrigeMåned = verdiPåTidspunkt(dato.sisteDagIForrigeMåned())
+            val verdiDenneMåned = verdiPåTidspunkt(dato.førsteDagIInneværendeMåned())
 
-            if (sisteDagForrigeMåned == null || førsteDagDenneMåned == null) {
+            if (verdiForrigeMåned == null || verdiDenneMåned == null) {
                 Null()
             } else {
-                mapper(sisteDagForrigeMåned, førsteDagDenneMåned).tilPeriodeVerdi()
+                mapper(verdiForrigeMåned, verdiDenneMåned).tilPeriodeVerdi()
             }
         }.trim(Null(), Udefinert())
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -6,8 +6,6 @@ import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.ekstern.restDomene.RestVilkårResultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjer
-import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.harBlandetRegelverk
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.søker
@@ -16,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
+import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingFamilieFellesTidslinjer as VilkårsvurderingTidslinjer
 
 val logger = LoggerFactory.getLogger("VilkårsvurderingValidering.kt")
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/behandlingstema/BehandlingstemaServiceTest.kt
@@ -27,7 +27,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjeService
-import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjer
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
@@ -43,6 +42,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.YearMonth
+import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingFamilieFellesTidslinjer as VilkårsvurderingTidslinjer
 
 class BehandlingstemaServiceTest {
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedFamilieFellesTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedFamilieFellesTidslinjeTest.kt
@@ -1,0 +1,147 @@
+package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
+
+import no.nav.familie.ba.sak.datagenerator.ikkeOppfyltVilkår
+import no.nav.familie.ba.sak.datagenerator.lagVilkårResultat
+import no.nav.familie.ba.sak.datagenerator.oppfyltVilkår
+import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.konkatenerTidslinjer
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.tilTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.tilMåned
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.apr
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.feb
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.jul
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.mai
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.mar
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.nov
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.periode
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk.EØS_FORORDNINGEN
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk.NASJONALE_REGLER
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOSATT_I_RIKET
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VilkårsresultatMånedFamilieFellesTidslinjeTest {
+    @Test
+    fun `Virkningstidspunkt fra vilkårsvurdering er måneden etter at normalt vilkår er oppfylt`() {
+        val dagTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), 15.apr(2022), 14.apr(2040)).tilTidslinje()
+        val faktiskMånedTidslinje = dagTidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+        val forventetMånedTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), mai(2022), apr(2040)).tilTidslinje().tilMåned { it.first() }
+
+        assertEquals(forventetMånedTidslinje, faktiskMånedTidslinje)
+    }
+
+    @Test
+    fun `Back to back perioder i månedsskiftet gir sammenhengende perioder`() {
+        val periodeFom = 15.apr(2022)
+        val periodeFom2 = 1.jul(2022)
+        val faktiskMånedTidslinje =
+            listOf(
+                lagVilkårResultat(
+                    vilkårType = BOSATT_I_RIKET,
+                    periodeFom = periodeFom,
+                    periodeTom = periodeFom2.minusDays(1),
+                ),
+                lagVilkårResultat(
+                    vilkårType = BOSATT_I_RIKET,
+                    periodeFom = periodeFom2,
+                    periodeTom = null,
+                ),
+            ).tilVilkårRegelverkResultatTidslinjeFamilieFelles()
+                .tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+
+        val forventetMånedTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), mai(2022), null).tilTidslinje().tilMåned { it.first() }
+
+        assertEquals(forventetMånedTidslinje, faktiskMånedTidslinje)
+    }
+
+    @Test
+    fun `Siste dag fom-måned og første dag i tom-måned gir oppfylt fra neste måned`() {
+        val dagTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), 29.feb(2020), 1.mai(2020)).tilTidslinje()
+        val faktiskMånedstidslinje = dagTidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+        val forventetMånedTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), mar(2020), mai(2020)).tilTidslinje().tilMåned { it.first() }
+
+        assertEquals(forventetMånedTidslinje, faktiskMånedstidslinje)
+    }
+
+    @Test
+    fun `Bytte av regelverk innen en måned skal gi kontinuerlig oppfylt tidslinje`() {
+        val dagvilkårtidslinje =
+            konkatenerTidslinjer(
+                periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), 26.feb(2020), 7.mar(2020)).tilTidslinje(),
+                periode(oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER), 21.mar(2020), 13.mai(2020)).tilTidslinje(),
+            )
+
+        val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+
+        val forventetMånedstidslinje =
+            konkatenerTidslinjer(
+                periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), mar(2020), mar(2020)).tilTidslinje(),
+                periode(oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER), apr(2020), mai(2020)).tilTidslinje(),
+            ).tilMåned { it.first() }
+
+        assertEquals(forventetMånedstidslinje, faktiskMånedstidslinje)
+    }
+
+    @Test
+    fun `Hvis vilkåret er oppfylt siste dag i måneden, skal kun gi oppfylt frem til og med den måneden`() {
+        val dagTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), 15.apr(2022), 30.nov(2022)).tilTidslinje()
+        val faktiskMånedTidslinje = dagTidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+        val forventetMånedTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), mai(2022), nov(2022)).tilTidslinje().tilMåned { it.first() }
+
+        assertEquals(forventetMånedTidslinje, faktiskMånedTidslinje)
+    }
+
+    @Test
+    fun `Hvis regelverk byttes i månedskiftet, skal det være kontinuerlig oppfylt vilkår`() {
+        val dagvilkårtidslinje =
+            konkatenerTidslinjer(
+                periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), null, 31.mar(2020)).tilTidslinje(),
+                periode(oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER), 1.apr(2020), null).tilTidslinje(),
+            )
+
+        val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+
+        val forventetMånedstidslinje =
+            konkatenerTidslinjer(
+                periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), null, mar(2020)).tilTidslinje(),
+                periode(oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER), apr(2020), null).tilTidslinje(),
+            ).tilMåned { it.first() }
+
+        assertEquals(forventetMånedstidslinje, faktiskMånedstidslinje)
+    }
+
+    @Test
+    fun `Hvis det byttes fra oppfylt til ikke oppfylt i månedskiftet, skal kun gi oppfylt til og med denne måneden`() {
+        val dagvilkårtidslinje =
+            konkatenerTidslinjer(
+                periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), null, 31.mar(2020)).tilTidslinje(),
+                periode(ikkeOppfyltVilkår(BOSATT_I_RIKET), 1.apr(2020), null).tilTidslinje(),
+            )
+
+        val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+
+        val forventetMånedstidslinje =
+            periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), null, mar(2020))
+                .tilTidslinje()
+                .tilMåned { it.first() }
+
+        assertEquals(forventetMånedstidslinje, faktiskMånedstidslinje)
+    }
+
+    @Test
+    fun `Hvis regelverk byttes dagen før månedskiftet, skal det være kontinuerlig oppfylt vilkår`() {
+        val dagvilkårtidslinje =
+            konkatenerTidslinjer(
+                periode(oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER), null, 29.apr(2020)).tilTidslinje(),
+                periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), 30.apr(2020), null).tilTidslinje(),
+            )
+
+        val forventetMånedstidslinje =
+            konkatenerTidslinjer(
+                periode(oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER), null, apr(2020)).tilTidslinje(),
+                periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), mai(2020), null).tilTidslinje(),
+            ).tilMåned { it.first() }
+
+        val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+        assertEquals(forventetMånedstidslinje, faktiskMånedstidslinje)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/RestTidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/rest/RestTidslinjerTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.tilPersonEnkelSøkerOgBarn
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
-import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjer
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilInneværendeMåned
@@ -16,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.util.nov
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingFamilieFellesTidslinjer as VilkårsvurderingTidslinjer
 
 internal class RestTidslinjerTest {
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/eksperimentelt/TidslinjeKonkatenering.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/eksperimentelt/TidslinjeKonkatenering.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullOgIkkeTom
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.kombinerUtenNullOgIkkeTom
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 /**
  * Funksjon for å kjede sammen tidslinjer
@@ -11,3 +13,5 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidsenhet
 fun <I, T : Tidsenhet> konkatenerTidslinjer(vararg tidslinje: Tidslinje<I, T>): Tidslinje<I, T> = tidslinje.toList().kombinerUtenNullOgIkkeTom { it.single() }
 
 operator fun <I, T : Tidsenhet> Tidslinje<I, T>.plus(tidslinje: Tidslinje<I, T>): Tidslinje<I, T> = konkatenerTidslinjer(this, tidslinje)
+
+fun <V> konkatenerTidslinjer(vararg tidslinje: FamilieFellesTidslinje<V>): FamilieFellesTidslinje<V> = tidslinje.toList().kombinerUtenNullOgIkkeTom { it.single() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/util/Periode.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/util/Periode.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util
+
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
+import no.nav.familie.tidslinje.Periode
+import java.time.LocalDate
+import java.time.YearMonth
+
+fun <V> periode(
+    verdi: V,
+    fom: LocalDate?,
+    tom: LocalDate?,
+) = Periode(verdi, fom, tom)
+
+fun <V> periode(
+    verdi: V,
+    fom: YearMonth?,
+    tom: YearMonth?,
+) = Periode(verdi, fom?.førsteDagIInneværendeMåned(), tom?.sisteDagIInneværendeMåned())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23270

Bytter ut tidslinje fra ba-sak med tidslinje fra familie-felles enkelte steder.
Holder PR'ene små, så de skal være lette å lese.
Bør leses commit for commit.
Det er noe duplikatkode, men dette vil fjernes i neste PR