### PR TITLE
Endrer til intern.dev.nav.no for familie-ba-infotrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/README.md
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/README.md
@@ -12,7 +12,7 @@ Domenemodellen er derfor primært tilpasset ba-sak, med høyere detaljnivå enn 
 
 Pensjon starter med å bestille overlevering av alle identer med barnetrygd innenfor et gitt år ved å kalle endepunktet [/api/ekstern/pensjon/bestill-personer-med-barnetrygd/{år}](https://familie-ba-sak.intern.dev.nav.no/swagger-ui/index.html#/pensjon-controller/bestillPersonerMedBarnetrygdForGitt%C3%85rP%C3%A5Kafka) under [PensjonController](PensjonController.kt), som oppretter en [HentAlleIdenterTilPsysTask](../../task/HentAlleIdenterTilPsysTask.kt)
 
-Denne finner først alle identer fra ba-sak med spørringen gitt av `finnIdenterMedLøpendeBarnetrygdForGittÅr` i [AndelTilkjentYtelseRepository](../../kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt), og deretter alle identer fra Infotrygd via integrasjonen mot [/infotrygd/barnetrygd/pensjon](https://familie-ba-infotrygd.dev.intern.nav.no/swagger-ui/index.html#/pensjon-controller/personerMedBarnetrygd) i [InfotrygdBarnetrygdClient](../../integrasjoner/infotrygd/InfotrygdBarnetrygdClient.kt). Tasken avslutter så med å publisere alle unike ident-forekomster til kafka-topic'en med navn [aapen-familie-ba-sak-identer-med-barnetrygd](../../../../../../../../../../.deploy/nais/kafka/dev/aapen-familie-ba-sak-identer-med-barnetrygd.yaml).
+Denne finner først alle identer fra ba-sak med spørringen gitt av `finnIdenterMedLøpendeBarnetrygdForGittÅr` i [AndelTilkjentYtelseRepository](../../kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt), og deretter alle identer fra Infotrygd via integrasjonen mot [/infotrygd/barnetrygd/pensjon](https://familie-ba-infotrygd.intern.dev.nav.no/swagger-ui/index.html#/pensjon-controller/personerMedBarnetrygd) i [InfotrygdBarnetrygdClient](../../integrasjoner/infotrygd/InfotrygdBarnetrygdClient.kt). Tasken avslutter så med å publisere alle unike ident-forekomster til kafka-topic'en med navn [aapen-familie-ba-sak-identer-med-barnetrygd](../../../../../../../../../../.deploy/nais/kafka/dev/aapen-familie-ba-sak-identer-med-barnetrygd.yaml).
 
 I dev-miljø er det en [funksjonsbryter](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ba-sak.hent-identer-til-psys-fra-infotrygd) som styrer om det skal inkluderes data fra Infotrygd 
 eller ikke. Det er fordi det returneres ekte fødselsnumre derfra, siden `infotrygd_baq` basen stort sett bare er en kopi av `infotrygd_bap`. Den bør helst være avskrudd med mindre Pensjon etterlyser å få teste med bryteren på, siden kjøringer med sensitive data kun gjøres fra et bestemt testmiljø.
@@ -68,7 +68,7 @@ I motsetning til Bisys som kun er interessert i perioder med utvidet barnetrygd,
 
 [Swagger - familie-ba-sak (dev)](https://familie-ba-sak.intern.dev.nav.no/swagger-ui/index.html#/pensjon-controller)
 
-[Swagger - familie-ba-infotrygd (dev)](https://familie-ba-infotrygd.dev.intern.nav.no/swagger-ui/index.html#/pensjon-controller)
+[Swagger - familie-ba-infotrygd (dev)](https://familie-ba-infotrygd.intern.dev.nav.no/swagger-ui/index.html#/pensjon-controller)
 
 [Koden som henter barnetrygd fra ba-sak](PensjonService.kt)
 

--- a/src/test/resources/application-dev-postgres-preprod.yaml
+++ b/src/test/resources/application-dev-postgres-preprod.yaml
@@ -173,7 +173,7 @@ FAMILIE_TILBAKE_API_URL: https://tilbakekreving-backend.intern.dev.nav.no
 FAMILIE_TILBAKE_API_URL_SCOPE: api://dev-gcp.tilbake.tilbakekreving-backend/.default
 FAMILIE_KLAGE_URL: https://familie-klage-backend.intern.dev.nav.no
 FAMILIE_BA_SAK_API_URL: http://localhost:8086/api
-FAMILIE_BA_INFOTRYGD_API_URL: https://familie-ba-infotrygd.dev.intern.nav.no
+FAMILIE_BA_INFOTRYGD_API_URL: https://familie-ba-infotrygd.intern.dev.nav.no
 FAMILIE_BA_INFOTRYGD_SCOPE: api://dev-fss.teamfamilie.familie-ba-infotrygd/.default
 FAMILIE_EF_SAK_API_URL: https://familie-ef-sak.intern.dev.nav.no
 FAMILIE_EF_SAK_API_URL_SCOPE: api://dev-gcp.teamfamilie.familie-ef-sak/.default


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bytter over til intern.dev.nav.no ingressen for familie-ba-infotrygd
