### PR TITLE
Bug i generering av kompetanser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
@@ -131,8 +131,6 @@ fun tilpassKompetanserTilRegelverk(
                     true -> null // ta bort regelverk dersom det verken utbetales ordinær på barnet eller utvidet for søker
                     else -> regelverk
                 }
-            }.mapValues { (_, tidslinjer) ->
-                tidslinjer.forlengFremtidTilUendelig(tidspunktForUendelighet = inneværendeMåned.sisteDagIInneværendeMåned())
             }
 
     return gjeldendeKompetanser

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/BeskjæreTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/BeskjæreTidslinje.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon
 
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.replaceLast
-import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.tomTidslinje
@@ -93,7 +92,8 @@ fun <T : Any> Tidslinje<T>.forlengFremtidTilUendelig(tidspunktForUendelighet: Lo
         this
             .tilPerioderIkkeNull()
             .filter { it.fom != null && it.fom!! < tidspunktForUendelighet }
-            .replaceLast { Periode(verdi = it.verdi, fom = it.fom, tom = null) }
+            .ifEmpty { return tomTidslinje() }
+            .replaceLast { it.copy(tom = null) }
             .tilTidslinje()
     } else {
         this.tilPerioderIkkeNull().tilTidslinje()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering.RegelverkResultat
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.KompetanseBuilder
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.des
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.sep
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.somBoolskTidslinje
@@ -369,6 +370,24 @@ class TilpassKompetanserTilRegelverkTest {
             KompetanseBuilder(sep2024.tilTidspunkt())
                 .medKompetanse("->", barn1, barn2)
                 .byggKompetanser()
+
+        assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
+    }
+
+    @Test
+    fun `skal ikke generere kompetanser hvis eøs-regelverk er frem i tid`() {
+        val barnaRegelverkTidslinjer =
+            mapOf(barn1.aktør to "EEE".tilRegelverkResultatTidslinje(jan(2025)))
+
+        val faktiskeKompetanser =
+            tilpassKompetanserTilRegelverk(
+                gjeldendeKompetanser = emptyList(),
+                barnaRegelverkTidslinjer = barnaRegelverkTidslinjer,
+                utbetalesIkkeOrdinærEllerUtvidetTidslinjer = emptyMap(),
+                inneværendeMåned = des(2024),
+            )
+
+        val forventedeKompetanser = emptyList<Kompetanse>()
 
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23270

Som en følge av bytte til tidslinjebibliotek fra familie-felles ble det introdusert en bug der man prøver å hente siste element i en tom liste. Dersom listen med perioder er tom returneres `tomTidslinje`.

Fjerner også kode som ikke lenger er nødvendig