### PR TITLE
Bytt til tidslinjebibliotek fra familie-felles

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingStegUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingStegUtils.kt
@@ -2,24 +2,24 @@ package no.nav.familie.ba.sak.kjerne.behandlingsresultat
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.isSameOrAfter
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import java.time.YearMonth
 
-fun Tidslinje<Boolean, Måned>.kastFeilVedEndringEtter(
+fun Tidslinje<Boolean>.kastFeilVedEndringEtter(
     migreringsdatoForrigeIverksatteBehandling: YearMonth,
     behandling: Behandling,
 ) {
     val endringIUtbetalingEtterDato =
-        perioder()
-            .filter { it.tilOgMed.tilYearMonth().isSameOrAfter(migreringsdatoForrigeIverksatteBehandling) }
+        tilPerioder()
+            .filter { it.tom == null || it.tom!!.toYearMonth().isSameOrAfter(migreringsdatoForrigeIverksatteBehandling) }
 
-    val erEndringIUtbetalingEtterMigreringsdato = endringIUtbetalingEtterDato.any { it.innhold == true }
+    val erEndringIUtbetalingEtterMigreringsdato = endringIUtbetalingEtterDato.any { it.verdi == true }
 
     if (erEndringIUtbetalingEtterMigreringsdato) {
-        BehandlingsresultatSteg.logger.warn("Feil i behandling $behandling.\n\nEndring i måned ${endringIUtbetalingEtterDato.first { it.innhold == true }.fraOgMed.tilYearMonth()}.")
+        BehandlingsresultatSteg.logger.warn("Feil i behandling $behandling.\n\nEndring i måned ${endringIUtbetalingEtterDato.first { it.verdi == true }.fom?.toYearMonth()}.")
         throw FunksjonellFeil(
             "Det finnes endringer i behandlingen som har økonomisk konsekvens for bruker." +
                 "Det skal ikke skje for endre migreringsdatobehandlinger." +

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -5,14 +5,14 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
-import no.nav.familie.ba.sak.kjerne.beregning.EndretUtbetalingAndelTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 
 internal enum class Søknadsresultat {
     INNVILGET,
@@ -94,9 +94,9 @@ object BehandlingsresultatSøknadUtils {
         nåværendeAndelerForPerson: List<AndelTilkjentYtelse>,
         endretUtbetalingAndelerForPerson: List<EndretUtbetalingAndel>,
     ): List<Søknadsresultat> {
-        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndelerForPerson)
-        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndelerForPerson)
-        val endretUtbetalingTidslinje = EndretUtbetalingAndelTidslinje(endretUtbetalingAndelerForPerson)
+        val forrigeTidslinje = forrigeAndelerForPerson.tilTidslinje()
+        val nåværendeTidslinje = nåværendeAndelerForPerson.tilTidslinje()
+        val endretUtbetalingTidslinje = endretUtbetalingAndelerForPerson.tilTidslinje()
 
         val resultatTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje, endretUtbetalingTidslinje) { nåværende, forrige, endretUtbetalingAndel ->
@@ -136,7 +136,7 @@ object BehandlingsresultatSøknadUtils {
                 }
             }
 
-        return resultatTidslinje.perioder().mapNotNull { it.innhold }.distinct()
+        return resultatTidslinje.tilPerioderIkkeNull().map { it.verdi }.distinct()
     }
 
     private fun erEksplisittAvslagPåMinstEnPersonFremstiltKravForEllerSøker(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
@@ -9,19 +9,6 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusen
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
 import no.nav.familie.tidslinje.tilTidslinje
 
-class AndelTilkjentYtelseTidslinje(
-    private val andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-) : Tidslinje<AndelTilkjentYtelse, Måned>() {
-    override fun lagPerioder(): List<Periode<AndelTilkjentYtelse, Måned>> =
-        andelerTilkjentYtelse.map {
-            Periode(
-                fraOgMed = it.stønadFom.tilTidspunkt(),
-                tilOgMed = it.stønadTom.tilTidspunkt(),
-                innhold = it,
-            )
-        }
-}
-
 fun List<AndelTilkjentYtelse>.tilTidslinje() = this.map { it.tilPeriode() }.tilTidslinje()
 
 class AndelTilkjentYtelseForVedtaksperioderTidslinje(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -18,13 +18,13 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Personopplysning
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.barn
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.steg.EndringerIUtbetalingForBehandlingSteg
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
+import no.nav.familie.tidslinje.tomTidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 @Service
 class BeregningService(
@@ -118,17 +118,17 @@ class BeregningService(
     fun hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling: Behandling): EndringerIUtbetalingForBehandlingSteg {
         val endringerIUtbetaling =
             hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomiTidslinje(behandling)
-                .perioder()
-                .any { it.innhold == true }
+                .tilPerioder()
+                .any { it.verdi == true }
 
         return if (endringerIUtbetaling) EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING else EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING
     }
 
-    fun hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomiTidslinje(behandling: Behandling): Tidslinje<Boolean, Måned> {
+    fun hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomiTidslinje(behandling: Behandling): FamilieFellesTidslinje<Boolean> {
         val nåværendeAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
         val forrigeAndeler = hentAndelerFraForrigeIverksattebehandling(behandling)
 
-        if (nåværendeAndeler.isEmpty() && forrigeAndeler.isEmpty()) return TomTidslinje()
+        if (nåværendeAndeler.isEmpty() && forrigeAndeler.isEmpty()) return tomTidslinje()
 
         return EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje(
             nåværendeAndeler = nåværendeAndeler,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndretUtbetalingAndelTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndretUtbetalingAndelTidslinje.kt
@@ -1,34 +1,16 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
-class EndretUtbetalingAndelTidslinje(
-    private val endretUtbetalingAndeler: List<EndretUtbetalingAndel>,
-) : Tidslinje<EndretUtbetalingAndel, Måned>() {
-    override fun lagPerioder(): Collection<Periode<EndretUtbetalingAndel, Måned>> =
-        endretUtbetalingAndeler.map {
-            Periode(
-                fraOgMed = it.fom?.tilTidspunkt() ?: throw Feil("Endret utbetaling andel har ingen fom-dato: $it"),
-                tilOgMed = it.tom?.tilTidspunkt() ?: throw Feil("Endret utbetaling andel har ingen tom-dato: $it"),
-                innhold = it,
-            )
-        }
-}
-
-fun List<EndretUtbetalingAndel>.tilTidslinje(): FamilieFellesTidslinje<EndretUtbetalingAndel> =
+fun List<EndretUtbetalingAndel>.tilTidslinje(): Tidslinje<EndretUtbetalingAndel> =
     this
         .map {
-            FamilieFellesPeriode(
+            Periode(
                 verdi = it,
                 fom = it.fom?.førsteDagIInneværendeMåned(),
                 tom = it.tom?.sisteDagIInneværendeMåned(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndretUtbetalingAndelTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/EndretUtbetalingAndelTidslinje.kt
@@ -1,11 +1,16 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 class EndretUtbetalingAndelTidslinje(
     private val endretUtbetalingAndeler: List<EndretUtbetalingAndel>,
@@ -19,3 +24,13 @@ class EndretUtbetalingAndelTidslinje(
             )
         }
 }
+
+fun List<EndretUtbetalingAndel>.tilTidslinje(): FamilieFellesTidslinje<EndretUtbetalingAndel> =
+    this
+        .map {
+            FamilieFellesPeriode(
+                verdi = it,
+                fom = it.fom?.førsteDagIInneværendeMåned(),
+                tom = it.tom?.sisteDagIInneværendeMåned(),
+            )
+        }.tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtils.kt
@@ -86,7 +86,7 @@ private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.førerTilEndringIUtb
             forrigeAndeler = forrigeAndeler.map { it.andel },
         )
 
-    return endringstidslinje.perioder().any { it.innhold == true }
+    return endringstidslinje.tilPerioder().any { it.verdi == true }
 }
 
 fun hentInnvilgedeOgReduserteAndelerSmåbarnstillegg(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -1,18 +1,17 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
-import no.nav.familie.ba.sak.kjerne.beregning.EndretUtbetalingAndelTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
 
 object EndringIEndretUtbetalingAndelUtil {
     fun lagEndringIEndretUbetalingAndelPerPersonTidslinje(
         nåværendeEndretAndelerForPerson: List<EndretUtbetalingAndel>,
         forrigeEndretAndelerForPerson: List<EndretUtbetalingAndel>,
-    ): Tidslinje<Boolean, Måned> {
-        val nåværendeTidslinje = EndretUtbetalingAndelTidslinje(nåværendeEndretAndelerForPerson)
-        val forrigeTidslinje = EndretUtbetalingAndelTidslinje(forrigeEndretAndelerForPerson)
+    ): Tidslinje<Boolean> {
+        val nåværendeTidslinje = nåværendeEndretAndelerForPerson.tilTidslinje()
+        val forrigeTidslinje = forrigeEndretAndelerForPerson.tilTidslinje()
 
         val endringerTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -1,12 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringUtil.tilFørsteEndringstidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.utvidelser.kombiner
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import java.time.YearMonth
 
 object EndringIUtbetalingUtil {
@@ -26,7 +25,7 @@ object EndringIUtbetalingUtil {
     internal fun lagEndringIUtbetalingTidslinje(
         nåværendeAndeler: List<AndelTilkjentYtelse>,
         forrigeAndeler: List<AndelTilkjentYtelse>,
-    ): Tidslinje<Boolean, Måned> {
+    ): Tidslinje<Boolean> {
         val allePersonerMedAndeler = (nåværendeAndeler.map { it.aktør } + forrigeAndeler.map { it.aktør }).distinct()
 
         val endringstidslinjePerPersonOgType =
@@ -55,9 +54,9 @@ object EndringIUtbetalingUtil {
     private fun lagEndringIUtbetalingForPersonOgTypeTidslinje(
         nåværendeAndeler: List<AndelTilkjentYtelse>,
         forrigeAndeler: List<AndelTilkjentYtelse>,
-    ): Tidslinje<Boolean, Måned> {
-        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndeler)
-        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndeler)
+    ): Tidslinje<Boolean> {
+        val nåværendeTidslinje = nåværendeAndeler.tilTidslinje()
+        val forrigeTidslinje = forrigeAndeler.tilTidslinje()
 
         val endringIBeløpTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
@@ -73,9 +72,9 @@ object EndringIUtbetalingUtil {
     internal fun lagEtterbetalingstidslinjeForPersonOgType(
         nåværendeAndeler: List<AndelTilkjentYtelse>,
         forrigeAndeler: List<AndelTilkjentYtelse>,
-    ): Tidslinje<Boolean, Måned> {
-        val nåværendeTidslinje = AndelTilkjentYtelseTidslinje(nåværendeAndeler)
-        val forrigeTidslinje = AndelTilkjentYtelseTidslinje(forrigeAndeler)
+    ): Tidslinje<Boolean> {
+        val nåværendeTidslinje = nåværendeAndeler.tilTidslinje()
+        val forrigeTidslinje = forrigeAndeler.tilTidslinje()
 
         val etterbetaling =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringUtil.kt
@@ -1,14 +1,15 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 
 object EndringUtil {
-    internal fun Tidslinje<Boolean, Måned>.tilFørsteEndringstidspunkt() =
+    internal fun Tidslinje<Boolean>.tilFørsteEndringstidspunkt() =
         this
-            .perioder()
-            .filter { it.innhold == true }
-            .minOfOrNull { it.fraOgMed }
-            ?.tilYearMonth()
+            .tilPerioder()
+            .filter { it.verdi == true }
+            .mapNotNull { it.fom }
+            .minOfOrNull { it }
+            ?.toYearMonth()
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -47,11 +47,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Personopplysning
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.EndringerIUtbetalingForBehandlingSteg
 import no.nav.familie.ba.sak.kjerne.steg.StegType
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.somBoolskTidslinje
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
@@ -282,10 +278,7 @@ class BehandlingsresultatStegTest {
     @Test
     fun `skal kaste feil om det er endring etter migreringsdatoen til første behandling`() {
         val startdato = YearMonth.of(2023, 2)
-        val endringTidslinje =
-            "TTTFFFF".tilBoolskTidslinje(
-                startdato,
-            )
+        val endringTidslinje = "TTTFFFF".somBoolskTidslinje(startdato)
 
         assertThrows<FunksjonellFeil> {
             endringTidslinje.kastFeilVedEndringEtter(startdato, lagBehandling())
@@ -297,10 +290,7 @@ class BehandlingsresultatStegTest {
         val startdato = YearMonth.of(2023, 2)
         val treMånederEtterStartdato = startdato.plusMonths(3)
 
-        val endringTidslinje =
-            "TTTFFFF".tilBoolskTidslinje(
-                startdato,
-            )
+        val endringTidslinje = "TTTFFFF".somBoolskTidslinje(startdato)
 
         assertDoesNotThrow {
             endringTidslinje.kastFeilVedEndringEtter(treMånederEtterStartdato, lagBehandling())
@@ -602,21 +592,6 @@ class BehandlingsresultatStegTest {
                 .hentAndelerFraForrigeIverksattebehandling(behandling)
         } returns emptyList()
     }
-
-    fun String.tilBoolskTidslinje(startdato: YearMonth): Tidslinje<Boolean, Måned> =
-        tidslinje {
-            this.mapIndexed { index, it ->
-                Periode(
-                    startdato.plusMonths(index.toLong()).tilTidspunkt(),
-                    startdato.plusMonths(index.toLong()).tilTidspunkt(),
-                    when (it) {
-                        'T' -> true
-                        'F' -> false
-                        else -> throw Feil("Klarer ikke å konvertere \"$it\" til Boolean")
-                    },
-                )
-            }
-        }
 
     private fun endretBehandlingsresultat() =
         listOf(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
@@ -101,7 +101,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                     ),
                 personerFremstiltKravFor = listOf(barn1Aktør),
                 endretUtbetalingAndeler = emptyList(),
-            )
+            ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INNVILGET))
@@ -167,7 +167,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                     ),
                 personerFremstiltKravFor = listOf(barn1Aktør),
                 endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
-            )
+            ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INNVILGET))
@@ -209,7 +209,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                     ),
                 personerFremstiltKravFor = listOf(barn1Aktør),
                 endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
-            )
+            ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.AVSLÅTT))
@@ -283,7 +283,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                     ),
                 personerFremstiltKravFor = listOf(barn1Aktør),
                 endretUtbetalingAndeler = emptyList(),
-            )
+            ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INNVILGET))
@@ -336,7 +336,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 nåværendeAndeler = nåværendeAndeler,
                 personerFremstiltKravFor = listOf(barn1Aktør, barn2Aktør),
                 endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
-            )
+            ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
         assertThat(søknadsResultat.size, Is(2))
         assertThat(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
@@ -1,11 +1,12 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.datagenerator.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -38,12 +39,12 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
                     forrigeEndretAndelerForPerson = listOf(forrigeEndretAndel),
                     nåværendeEndretAndelerForPerson = listOf(nåværendeEndretAndel),
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         assertEquals(1, perioderMedEndring.size)
-        assertEquals(jan22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        assertEquals(aug22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
+        assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
     }
 
     @Test
@@ -67,8 +68,8 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
                     forrigeEndretAndelerForPerson = listOf(forrigeEndretAndel),
                     nåværendeEndretAndelerForPerson = listOf(nåværendeEndretAndel),
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         assertTrue(perioderMedEndring.isEmpty())
     }
@@ -106,12 +107,12 @@ class EndringIEndretUtbetalingAndelUtilTest {
                         forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.person == it },
                         nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT)).filter { endretAndel -> endretAndel.person == it },
                     )
-                }.flatMap { it.perioder() }
-                .filter { it.innhold == true }
+                }.flatMap { it.tilPerioder() }
+                .filter { it.verdi == true }
 
         assertEquals(1, perioderMedEndring.size)
-        assertEquals(jan22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        assertEquals(aug22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
+        assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
     }
 
     @Test
@@ -135,12 +136,12 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
                     forrigeEndretAndelerForPerson = listOf(forrigeEndretAndel),
                     nåværendeEndretAndelerForPerson = listOf(nåværendeEndretAndel),
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         assertEquals(1, perioderMedEndring.size)
-        assertEquals(sep22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        assertEquals(des22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        assertEquals(sep22, perioderMedEndring.single().fom?.toYearMonth())
+        assertEquals(des22, perioderMedEndring.single().tom?.toYearMonth())
     }
 
     @Test
@@ -162,11 +163,11 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
                     forrigeEndretAndelerForPerson = emptyList(),
                     nåværendeEndretAndelerForPerson = listOf(nåværendeEndretAndel),
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         assertEquals(1, perioderMedEndring.size)
-        assertEquals(jan22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        assertEquals(aug22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
+        assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtilTest.kt
@@ -1,10 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.YearMonth
@@ -57,12 +58,12 @@ class EndringIUtbetalingUtilTest {
                 .lagEndringIUtbetalingTidslinje(
                     nåværendeAndeler = nåværendeAndeler,
                     forrigeAndeler = forrigeAndeler,
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         Assertions.assertEquals(1, perioderMedEndring.size)
-        Assertions.assertEquals(sep22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        Assertions.assertEquals(des22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        Assertions.assertEquals(sep22, perioderMedEndring.single().fom?.toYearMonth())
+        Assertions.assertEquals(des22, perioderMedEndring.single().tom?.toYearMonth())
 
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
@@ -99,8 +100,8 @@ class EndringIUtbetalingUtilTest {
                 .lagEndringIUtbetalingTidslinje(
                     nåværendeAndeler = andeler,
                     forrigeAndeler = andeler,
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         Assertions.assertTrue(perioderMedEndring.isEmpty())
 
@@ -163,12 +164,12 @@ class EndringIUtbetalingUtilTest {
                 .lagEndringIUtbetalingTidslinje(
                     nåværendeAndeler = nåværendeAndeler,
                     forrigeAndeler = forrigeAndeler,
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         Assertions.assertEquals(1, perioderMedEndring.size)
-        Assertions.assertEquals(mai22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        Assertions.assertEquals(aug22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        Assertions.assertEquals(mai22, perioderMedEndring.single().fom?.toYearMonth())
+        Assertions.assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
 
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
@@ -204,12 +205,12 @@ class EndringIUtbetalingUtilTest {
                 .lagEndringIUtbetalingTidslinje(
                     nåværendeAndeler = listOf(andelBarn2),
                     forrigeAndeler = listOf(andelBarn2, andelBarn1),
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         Assertions.assertEquals(1, perioderMedEndring.size)
-        Assertions.assertEquals(jan22, perioderMedEndring.single().fraOgMed.tilYearMonth())
-        Assertions.assertEquals(aug22, perioderMedEndring.single().tilOgMed.tilYearMonth())
+        Assertions.assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
+        Assertions.assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
 
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
@@ -245,8 +246,8 @@ class EndringIUtbetalingUtilTest {
                 .lagEndringIUtbetalingTidslinje(
                     nåværendeAndeler = listOf(andelBarn2),
                     forrigeAndeler = listOf(andelBarn2, andelBarn1),
-                ).perioder()
-                .filter { it.innhold == true }
+                ).tilPerioder()
+                .filter { it.verdi == true }
 
         Assertions.assertTrue(perioderMedEndring.isEmpty())
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -80,6 +80,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvu
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import java.math.BigDecimal
 import java.time.LocalDate
 import kotlin.random.Random
@@ -529,8 +530,8 @@ private fun skalIverksettesMotOppdrag(
 ): Boolean =
     EndringIUtbetalingUtil
         .lagEndringIUtbetalingTidslinje(nåværendeAndeler, forrigeAndeler)
-        .perioder()
-        .any { it.innhold == true }
+        .tilPerioder()
+        .any { it.verdi == true }
 
 private fun TilkjentYtelse.oppdaterMedUtbetalingsoppdrag(
     dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefinition,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23270

Fortsettelse av #5099 
Bytter ut tidslinje fra ba-sak med tidslinje fra familie-felles enkelte steder.
Holder PR'ene små, så de skal være lette å lese.
Bør leses commit for commit.
Det er noe duplikatkode, men dette vil fjernes i senere PR'er