### PR TITLE
Bytt til tidslinjebibliotek fra familie-felles

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -235,7 +235,7 @@ internal fun erEndringIVilkårsvurderingForPerson(
             personIForrigeBehandling = personIForrigeBehandling,
         )
 
-    return endringIVilkårsvurderingTidslinje.perioder().any { it.innhold == true }
+    return endringIVilkårsvurderingTidslinje.tilPerioder().any { it.verdi == true }
 }
 
 internal fun erEndringIEndretUtbetalingAndelerForPerson(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
@@ -5,15 +5,15 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 fun List<AndelTilkjentYtelse>.tilTidslinje() = this.map { it.tilPeriode() }.tilTidslinje()
 
 fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinje() =
     this
         .map {
-            FamilieFellesPeriode(
+            Periode(
                 verdi = AndelForVedtaksperiode(it),
                 fom = it.stønadFom.førsteDagIInneværendeMåned(),
                 tom = it.stønadTom.sisteDagIInneværendeMåned(),
@@ -23,7 +23,7 @@ fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinje() =
 fun List<AndelTilkjentYtelse>.tilAndelForVedtaksbegrunnelseTidslinje() =
     this
         .map {
-            FamilieFellesPeriode(
+            Periode(
                 verdi = AndelForVedtaksbegrunnelse(it),
                 fom = it.stønadFom.førsteDagIInneværendeMåned(),
                 tom = it.stønadTom.sisteDagIInneværendeMåned(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
@@ -8,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companio
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
 import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 fun List<AndelTilkjentYtelse>.tilTidslinje() = this.map { it.tilPeriode() }.tilTidslinje()
 
@@ -24,6 +27,16 @@ class AndelTilkjentYtelseForVedtaksperioderTidslinje(
         }
 }
 
+fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinje() =
+    this
+        .map {
+            FamilieFellesPeriode(
+                verdi = AndelForVedtaksperiode(it),
+                fom = it.stønadFom.førsteDagIInneværendeMåned(),
+                tom = it.stønadTom.sisteDagIInneværendeMåned(),
+            )
+        }.tilTidslinje()
+
 class AndelTilkjentYtelseForVedtaksbegrunnelserTidslinje(
     private val andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
 ) : Tidslinje<AndelForVedtaksbegrunnelse, Måned>() {
@@ -36,3 +49,13 @@ class AndelTilkjentYtelseForVedtaksbegrunnelserTidslinje(
             )
         }
 }
+
+fun List<AndelTilkjentYtelse>.tilAndelForVedtaksbegrunnelseTidslinje() =
+    this
+        .map {
+            FamilieFellesPeriode(
+                verdi = AndelForVedtaksbegrunnelse(it),
+                fom = it.stønadFom.førsteDagIInneværendeMåned(),
+                tom = it.stønadTom.sisteDagIInneværendeMåned(),
+            )
+        }.tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseTidslinje.kt
@@ -3,29 +3,12 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 fun List<AndelTilkjentYtelse>.tilTidslinje() = this.map { it.tilPeriode() }.tilTidslinje()
-
-class AndelTilkjentYtelseForVedtaksperioderTidslinje(
-    private val andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-) : Tidslinje<AndelForVedtaksperiode, Måned>() {
-    override fun lagPerioder(): List<Periode<AndelForVedtaksperiode, Måned>> =
-        andelerTilkjentYtelse.map {
-            Periode(
-                fraOgMed = it.stønadFom.tilTidspunkt(),
-                tilOgMed = it.stønadTom.tilTidspunkt(),
-                innhold = AndelForVedtaksperiode(it),
-            )
-        }
-}
 
 fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinje() =
     this
@@ -36,19 +19,6 @@ fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinje() =
                 tom = it.stønadTom.sisteDagIInneværendeMåned(),
             )
         }.tilTidslinje()
-
-class AndelTilkjentYtelseForVedtaksbegrunnelserTidslinje(
-    private val andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
-) : Tidslinje<AndelForVedtaksbegrunnelse, Måned>() {
-    override fun lagPerioder(): List<Periode<AndelForVedtaksbegrunnelse, Måned>> =
-        andelerTilkjentYtelse.map {
-            Periode(
-                fraOgMed = it.stønadFom.tilTidspunkt(),
-                tilOgMed = it.stønadTom.tilTidspunkt(),
-                innhold = AndelForVedtaksbegrunnelse(it),
-            )
-        }
-}
 
 fun List<AndelTilkjentYtelse>.tilAndelForVedtaksbegrunnelseTidslinje() =
     this

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningService.kt
@@ -21,12 +21,12 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.barn
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.steg.EndringerIUtbetalingForBehandlingSteg
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRepository
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tomTidslinje
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 @Service
 class BeregningService(
@@ -127,7 +127,7 @@ class BeregningService(
         return if (endringerIUtbetaling) EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING else EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING
     }
 
-    fun hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomiTidslinje(behandling: Behandling): FamilieFellesTidslinje<Boolean> {
+    fun hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomiTidslinje(behandling: Behandling): Tidslinje<Boolean> {
         val nåværendeAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
         val forrigeAndeler = hentAndelerFraForrigeIverksattebehandling(behandling)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtil.kt
@@ -12,13 +12,13 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvni
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.utvidelser.filtrerIkkeNull
 import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.math.BigDecimal
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 object OrdinærBarnetrygdUtil {
     internal fun beregnAndelerTilkjentYtelseForBarna(
@@ -48,8 +48,8 @@ object OrdinærBarnetrygdUtil {
     }
 
     private fun kombinerProsentOgSatsTidslinjer(
-        tidslinjeMedRettTilProsentForBarn: FamilieFellesTidslinje<BigDecimal>,
-        satsTidslinje: FamilieFellesTidslinje<Int>,
+        tidslinjeMedRettTilProsentForBarn: Tidslinje<BigDecimal>,
+        satsTidslinje: Tidslinje<Int>,
     ) = tidslinjeMedRettTilProsentForBarn
         .kombinerMed(satsTidslinje) { rettTilProsent, sats ->
             when {
@@ -68,7 +68,7 @@ object OrdinærBarnetrygdUtil {
     private fun Set<PersonResultat>.lagTidslinjerMedRettTilProsentPerBarn(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         fagsakType: FagsakType,
-    ): Map<Person, FamilieFellesTidslinje<BigDecimal>> {
+    ): Map<Person, Tidslinje<BigDecimal>> {
         val tidslinjerPerPerson = lagTidslinjerMedRettTilProsentPerPerson(personopplysningGrunnlag, fagsakType)
 
         if (tidslinjerPerPerson.isEmpty()) return emptyMap()
@@ -80,8 +80,8 @@ object OrdinærBarnetrygdUtil {
     }
 
     private fun kombinerSøkerMedHvertBarnSinTidslinje(
-        barnasTidslinjer: Map<Person, FamilieFellesTidslinje<BigDecimal>>,
-        søkerTidslinje: FamilieFellesTidslinje<BigDecimal>,
+        barnasTidslinjer: Map<Person, Tidslinje<BigDecimal>>,
+        søkerTidslinje: Tidslinje<BigDecimal>,
     ) = barnasTidslinjer.mapValues { (_, barnTidslinje) ->
         barnTidslinje
             .kombinerMed(søkerTidslinje) { barnProsent, søkerProsent ->
@@ -110,7 +110,7 @@ object OrdinærBarnetrygdUtil {
     internal fun PersonResultat.tilTidslinjeMedRettTilProsentForPerson(
         person: Person,
         fagsakType: FagsakType,
-    ): FamilieFellesTidslinje<BigDecimal> {
+    ): Tidslinje<BigDecimal> {
         val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(person.fødselsdato)
 
         return tidslinjer.kombiner { it.mapTilProsentEllerNull(person.type, fagsakType) }.slåSammenLikePerioder().filtrerIkkeNull()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companio
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.erUnder6ÅrTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.filtrerMed
-import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.forlengFremtidTilUendelig
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import java.time.LocalDate
@@ -126,8 +125,3 @@ fun lagOrdinærTidslinje(barn: Person): FamilieFellesTidslinje<Int> {
         .kombinerMed(tilleggOrbaTidslinje) { orba, tillegg -> tillegg ?: orba }
         .beskjærFraOgMed(fraOgMed = barn.fødselsdato.førsteDagIInneværendeMåned())
 }
-
-private fun FamilieFellesTidslinje<Int>.klippBortPerioderFørBarnetBleFødt(fødselsdato: LocalDate) =
-    this
-        .beskjærFraOgMed(fraOgMed = fødselsdato.førsteDagIInneværendeMåned())
-        .forlengFremtidTilUendelig(tidspunktForUendelighet = fødselsdato.sisteDagIMåned())

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.Periode
-import no.nav.familie.ba.sak.common.erUnder6ÅrTidslinje
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isBetween
 import no.nav.familie.ba.sak.common.sisteDagIMåned
@@ -10,20 +9,19 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.Sats
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilMånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunktEllerUendeligSent
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunktEllerUendeligTidlig
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjær
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.erUnder6ÅrTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærFraOgMed
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.filtrerMed
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.forlengFremtidTilUendelig
 import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import java.time.LocalDate
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode as TidslinjePeriode
 import no.nav.familie.tidslinje.Periode as FamilieFellesTidslinjePeriode
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 object SatsTidspunkt {
     val senesteSatsTidspunkt: LocalDate = LocalDate.MAX
@@ -121,16 +119,15 @@ fun satstypeFamilieFellesTidslinje(satsType: SatsType) =
             )
         }.tilTidslinje()
 
-fun lagOrdinærTidslinje(barn: Person): Tidslinje<Int, Måned> {
-    val orbaTidslinje = satstypeTidslinje(SatsType.ORBA)
-    val tilleggOrbaTidslinje = satstypeTidslinje(SatsType.TILLEGG_ORBA).filtrerMed(erUnder6ÅrTidslinje(barn))
+fun lagOrdinærTidslinje(barn: Person): FamilieFellesTidslinje<Int> {
+    val orbaTidslinje = satstypeFamilieFellesTidslinje(SatsType.ORBA)
+    val tilleggOrbaTidslinje = satstypeFamilieFellesTidslinje(SatsType.TILLEGG_ORBA).filtrerMed(erUnder6ÅrTidslinje(barn))
     return orbaTidslinje
         .kombinerMed(tilleggOrbaTidslinje) { orba, tillegg -> tillegg ?: orba }
-        .klippBortPerioderFørBarnetBleFødt(fødselsdato = barn.fødselsdato)
+        .beskjærFraOgMed(fraOgMed = barn.fødselsdato.førsteDagIInneværendeMåned())
 }
 
-private fun Tidslinje<Int, Måned>.klippBortPerioderFørBarnetBleFødt(fødselsdato: LocalDate) =
-    this.beskjær(
-        fraOgMed = fødselsdato.tilMånedTidspunkt(),
-        tilOgMed = MånedTidspunkt.uendeligLengeTil(fødselsdato.toYearMonth()),
-    )
+private fun FamilieFellesTidslinje<Int>.klippBortPerioderFørBarnetBleFødt(fødselsdato: LocalDate) =
+    this
+        .beskjærFraOgMed(fraOgMed = fødselsdato.førsteDagIInneværendeMåned())
+        .forlengFremtidTilUendelig(tidspunktForUendelighet = fødselsdato.sisteDagIMåned())

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.beregning
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.Utils.avrundetHeltallAvProsent
-import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.familieFellesTidslinjeFiltrertForPerioderBarnaBorMedSøker
+import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.filtrertForPerioderBarnaBorMedSøker
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -31,7 +31,7 @@ data class UtvidetBarnetrygdGenerator(
         val utvidetVilkårTidslinje = utvidetVilkår.tilForskjøvetTidslinjeForOppfyltVilkårForVoksenPerson(Vilkår.UTVIDET_BARNETRYGD)
 
         val barnasAndelerFiltrertForPerioderBarnaBorMedSøker =
-            andelerBarna.tilSeparateTidslinjerForBarna().familieFellesTidslinjeFiltrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
+            andelerBarna.tilSeparateTidslinjerForBarna().filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
 
         val størsteProsentTidslinje =
             barnasAndelerFiltrertForPerioderBarnaBorMedSøker.values

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
@@ -17,9 +17,9 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvu
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.mapVerdi
 import no.nav.familie.tidslinje.utvidelser.leftJoin
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 object UtvidetBarnetrygdUtil {
     internal fun beregnTilkjentYtelseUtvidet(
@@ -37,7 +37,7 @@ object UtvidetBarnetrygdUtil {
             ).lagUtvidetBarnetrygdAndeler(
                 utvidetVilkår = utvidetVilkår,
                 andelerBarna = andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEller3MndEndringer.map { it.andel },
-                perioderBarnaBorMedSøkerTidslinje = personResultater.tilPerioderBarnaBorMedSøkerFamilieFellesTidslinje(),
+                perioderBarnaBorMedSøkerTidslinje = personResultater.tilPerioderBarnaBorMedSøkerTidslinje(),
             )
 
         return if (skalBrukeNyVersjonAvOppdaterAndelerMedEndringer) {
@@ -54,7 +54,7 @@ object UtvidetBarnetrygdUtil {
         }
     }
 
-    fun Set<PersonResultat>.tilPerioderBarnaBorMedSøkerFamilieFellesTidslinje(): Map<Aktør, FamilieFellesTidslinje<Boolean>> =
+    fun Set<PersonResultat>.tilPerioderBarnaBorMedSøkerTidslinje(): Map<Aktør, Tidslinje<Boolean>> =
         this.associate { personResultat ->
             personResultat.aktør to
                 personResultat.vilkårResultater
@@ -70,7 +70,7 @@ object UtvidetBarnetrygdUtil {
                     }
         }
 
-    fun Map<Aktør, FamilieFellesTidslinje<AndelTilkjentYtelse>>.familieFellesTidslinjeFiltrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje: Map<Aktør, FamilieFellesTidslinje<Boolean>>): Map<Aktør, FamilieFellesTidslinje<AndelTilkjentYtelse>> =
+    fun Map<Aktør, Tidslinje<AndelTilkjentYtelse>>.filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje: Map<Aktør, Tidslinje<Boolean>>): Map<Aktør, Tidslinje<AndelTilkjentYtelse>> =
         this.leftJoin(perioderBarnaBorMedSøkerTidslinje) { andel, barnBorMedSøker ->
             when (barnBorMedSøker) {
                 true -> andel

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndre
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.lagForskjøvetFamilieFellesTidslinjeForOppfylteVilkår
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.lagForskjøvetTidslinjeForOppfylteVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -58,7 +58,7 @@ object UtvidetBarnetrygdUtil {
         this.associate { personResultat ->
             personResultat.aktør to
                 personResultat.vilkårResultater
-                    .lagForskjøvetFamilieFellesTidslinjeForOppfylteVilkår(Vilkår.BOR_MED_SØKER)
+                    .lagForskjøvetTidslinjeForOppfylteVilkår(Vilkår.BOR_MED_SØKER)
                     .mapVerdi { vilkårResultat ->
                         vilkårResultat?.utdypendeVilkårsvurderinger?.none {
                             it in

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -21,16 +21,19 @@ import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.YearMonthConverter
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseForVedtaksbegrunnelserTidslinje
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseForVedtaksperioderTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.tilAndelForVedtaksbegrunnelseTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.tilAndelForVedtaksperiodeTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksperiode
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.Tidslinje
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
@@ -209,21 +212,17 @@ private fun regelverkAvhengigeVilkår() =
         Vilkår.LOVLIG_OPPHOLD,
     )
 
-fun Collection<AndelTilkjentYtelse>.tilTidslinjerPerAktørOgType() =
+fun Collection<AndelTilkjentYtelse>.tilTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, Tidslinje<AndelTilkjentYtelse>> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
         andelerTilkjentYtelsePåPerson.tilTidslinje()
     }
 
-fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseForVedtaksperioderTidslinje> =
+fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, Tidslinje<AndelForVedtaksperiode>> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
-        AndelTilkjentYtelseForVedtaksperioderTidslinje(
-            andelerTilkjentYtelsePåPerson,
-        )
+        andelerTilkjentYtelsePåPerson.tilAndelForVedtaksperiodeTidslinje()
     }
 
-fun List<AndelTilkjentYtelse>.tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, AndelTilkjentYtelseForVedtaksbegrunnelserTidslinje> =
+fun List<AndelTilkjentYtelse>.tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, Tidslinje<AndelForVedtaksbegrunnelse>> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
-        AndelTilkjentYtelseForVedtaksbegrunnelserTidslinje(
-            andelerTilkjentYtelsePåPerson,
-        )
+        andelerTilkjentYtelsePåPerson.tilAndelForVedtaksbegrunnelseTidslinje()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -29,7 +29,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetalingE
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetalingMndEøs
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetalingMndEøsOppsummering
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateFamilieFellesTidslinjerForBarna
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
@@ -120,7 +120,7 @@ fun skalHenteUtbetalingerEøs(
 
     val valutakurserEtterEndringtidspunktet =
         valutakurser
-            .tilSeparateFamilieFellesTidslinjerForBarna()
+            .tilSeparateTidslinjerForBarna()
             .mapValues { (_, valutakursTidslinjeForBarn) -> valutakursTidslinjeForBarn.beskjærFraOgMed(endringstidspunkt.førsteDagIInneværendeMåned()) }
 
     return valutakurserEtterEndringtidspunktet.any { it.value.erIkkeTom() }
@@ -165,8 +165,8 @@ fun hentUtbetalingerPerMndEøs(
     val andelerForVedtaksperioderPerAktørOgTypeAvgrensetTilVedtaksperioder =
         andelerForVedtaksperioderPerAktørOgType.mapValues { (_, andelForVedtaksperiode) -> andelForVedtaksperiode.beskjærFraOgMed(endringstidspunkt.førsteDagIInneværendeMåned()) }
 
-    val utenlandskePeriodebeløpTidslinjerForBarna = utenlandskePeriodebeløp.tilSeparateFamilieFellesTidslinjerForBarna().mapKeys { entry -> Pair(entry.key, YtelseType.ORDINÆR_BARNETRYGD) }
-    val valutakursTidslinjerForBarna = valutakurser.tilSeparateFamilieFellesTidslinjerForBarna().mapKeys { entry -> Pair(entry.key, YtelseType.ORDINÆR_BARNETRYGD) }
+    val utenlandskePeriodebeløpTidslinjerForBarna = utenlandskePeriodebeløp.tilSeparateTidslinjerForBarna().mapKeys { entry -> Pair(entry.key, YtelseType.ORDINÆR_BARNETRYGD) }
+    val valutakursTidslinjerForBarna = valutakurser.tilSeparateTidslinjerForBarna().mapKeys { entry -> Pair(entry.key, YtelseType.ORDINÆR_BARNETRYGD) }
 
     return andelerForVedtaksperioderPerAktørOgTypeAvgrensetTilVedtaksperioder
         // Kombinerer tidslinjene for andeler, utenlandskPeriodebeløp og valutakurser per aktørOgYtelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -17,7 +17,9 @@ import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.YearMonthConverter
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.overlapperHeltEllerDelvisMed
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.ekstern.restDomene.RestEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -25,9 +27,11 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "EndretUtbetalingAndel")
@@ -240,5 +244,15 @@ fun List<IUtfyltEndretUtbetalingAndel>.tilTidslinje() =
                 fraOgMed = betalingAndel.fom.tilTidspunkt(),
                 tilOgMed = betalingAndel.tom.tilTidspunkt(),
                 innhold = betalingAndel,
+            )
+        }.tilTidslinje()
+
+fun List<IUtfyltEndretUtbetalingAndel>.tilFamilieFellesTidslinje() =
+    this
+        .map { betalingAndel ->
+            FamilieFellesPeriode(
+                verdi = betalingAndel,
+                fom = betalingAndel.fom.førsteDagIInneværendeMåned(),
+                tom = betalingAndel.tom.sisteDagIInneværendeMåned(),
             )
         }.tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -24,11 +24,11 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "EndretUtbetalingAndel")
@@ -234,10 +234,10 @@ fun EndretUtbetalingAndel.tilIEndretUtbetalingAndel(): IEndretUtbetalingAndel =
         }
     }
 
-fun List<IUtfyltEndretUtbetalingAndel>.tilFamilieFellesTidslinje() =
+fun List<IUtfyltEndretUtbetalingAndel>.tilTidslinje() =
     this
         .map { betalingAndel ->
-            FamilieFellesPeriode(
+            Periode(
                 verdi = betalingAndel,
                 fom = betalingAndel.fom.førsteDagIInneværendeMåned(),
                 tom = betalingAndel.tom.sisteDagIInneværendeMåned(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -23,9 +23,6 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.ekstern.restDomene.RestEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
@@ -236,16 +233,6 @@ fun EndretUtbetalingAndel.tilIEndretUtbetalingAndel(): IEndretUtbetalingAndel =
             )
         }
     }
-
-fun List<IUtfyltEndretUtbetalingAndel>.tilTidslinje() =
-    this
-        .map { betalingAndel ->
-            Periode(
-                fraOgMed = betalingAndel.fom.tilTidspunkt(),
-                tilOgMed = betalingAndel.tom.tilTidspunkt(),
-                innhold = betalingAndel,
-            )
-        }.tilTidslinje()
 
 fun List<IUtfyltEndretUtbetalingAndel>.tilFamilieFellesTidslinje() =
     this

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
-import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.familieFellesTidslinjeFiltrertForPerioderBarnaBorMedSøker
-import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.tilPerioderBarnaBorMedSøkerFamilieFellesTidslinje
+import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.filtrertForPerioderBarnaBorMedSøker
+import no.nav.familie.ba.sak.kjerne.beregning.UtvidetBarnetrygdUtil.tilPerioderBarnaBorMedSøkerTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.kunAndelerTilOgMed3År
@@ -12,7 +12,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinjeForSøkersYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilKronerPerValutaenhet
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.tilMånedligValutabeløp
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.times
-import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateFamilieFellesTidslinjerForBarna
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat.NORGE_ER_SEKUNDÆRLAND
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
@@ -45,8 +45,8 @@ fun beregnDifferanse(
     utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>,
     valutakurser: Collection<Valutakurs>,
 ): List<AndelTilkjentYtelse> {
-    val utenlandskePeriodebeløpTidslinjer = utenlandskePeriodebeløp.tilSeparateFamilieFellesTidslinjerForBarna()
-    val valutakursTidslinjer = valutakurser.tilSeparateFamilieFellesTidslinjerForBarna()
+    val utenlandskePeriodebeløpTidslinjer = utenlandskePeriodebeløp.tilSeparateTidslinjerForBarna()
+    val valutakursTidslinjer = valutakurser.tilSeparateTidslinjerForBarna()
     val andelTilkjentYtelseTidslinjer = andelerTilkjentYtelse.tilSeparateTidslinjerForBarna()
 
     val barnasUtenlandskePeriodebeløpINorskeKronerTidslinjer =
@@ -90,13 +90,13 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
 
     val barnasAndelerTidslinjer = this.tilSeparateTidslinjerForBarna()
 
-    val perioderBarnaBorMedSøkerTidslinje = personResultater.tilPerioderBarnaBorMedSøkerFamilieFellesTidslinje()
+    val perioderBarnaBorMedSøkerTidslinje = personResultater.tilPerioderBarnaBorMedSøkerTidslinje()
 
     // Finn alle andelene frem til barna er 18 år. Det vil i praksis være ALLE andelene
     // Bruk bare andelene som kvalifiserer for differanseberegning mot søkers ytelser
     val barnasRelevanteAndelerInntil18År =
         barnasAndelerTidslinjer
-            .familieFellesTidslinjeFiltrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
+            .filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
             .kunReneSekundærlandsperioder(kompetanser)
 
     // Lag tidslinjer for hvert barn som inneholder underskuddet fra differanseberegningen på ordinær barnetrygd.
@@ -137,7 +137,7 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
     val barnasRelevanteAndelerInntil3ÅrTidslinjer =
         barnasAndelerTidslinjer
             .kunAndelerTilOgMed3År(barna)
-            .familieFellesTidslinjeFiltrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
+            .filtrertForPerioderBarnaBorMedSøker(perioderBarnaBorMedSøkerTidslinje)
             .kunReneSekundærlandsperioder(kompetanser)
 
     // Vi finner hvor mye hvert barn skal ha som andel av småbarnstillegget på hvert tidspunkt.
@@ -174,7 +174,7 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
 fun Map<Aktør, Tidslinje<AndelTilkjentYtelse>>.kunReneSekundærlandsperioder(
     kompetanser: Collection<Kompetanse>,
 ): Map<Aktør, Tidslinje<AndelTilkjentYtelse>> {
-    val barnasKompetanseTidslinjer = kompetanser.tilSeparateFamilieFellesTidslinjerForBarna()
+    val barnasKompetanseTidslinjer = kompetanser.tilSeparateTidslinjerForBarna()
 
     val barnasErSekundærlandTidslinjer =
         this.leftJoin(barnasKompetanseTidslinjer) { andel, kompetanse ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassKompetanserService.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEndringAbonnent
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaService
-import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateFamilieFellesTidslinjerForBarna
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSkjemaer
 import no.nav.familie.ba.sak.kjerne.eøs.felles.medBehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
@@ -134,7 +134,7 @@ fun tilpassKompetanserTilRegelverk(
             }
 
     return gjeldendeKompetanser
-        .tilSeparateFamilieFellesTidslinjerForBarna()
+        .tilSeparateTidslinjerForBarna()
         .outerJoin(barnasEøsRegelverkTidslinjer) { kompetanse, eøsRegelverk ->
             eøsRegelverk?.let { kompetanse ?: Kompetanse.NULL }
         }.mapValues { (_, value) ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.FinnPeriodeOgBarnSkjemaRepositor
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEndringAbonnent
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaService
-import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateFamilieFellesTidslinjerForBarna
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSkjemaer
 import no.nav.familie.ba.sak.kjerne.eøs.felles.medBehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
@@ -79,11 +79,11 @@ internal fun tilpassUtenlandskePeriodebeløpTilKompetanser(
 ): Collection<UtenlandskPeriodebeløp> {
     val barnasKompetanseTidslinjer =
         gjeldendeKompetanser
-            .tilSeparateFamilieFellesTidslinjerForBarna()
+            .tilSeparateTidslinjerForBarna()
             .filtrerSekundærland()
 
     return forrigeUtenlandskePeriodebeløp
-        .tilSeparateFamilieFellesTidslinjerForBarna()
+        .tilSeparateTidslinjerForBarna()
         .outerJoin(barnasKompetanseTidslinjer) { upb, kompetanse ->
             val utbetalingsland = kompetanse?.utbetalingsland()
             when {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassValutakurserTilUtenlandskePeriodebeløpService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/endringsabonnement/TilpassValutakurserTilUtenlandskePeriodebeløpService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.FinnPeriodeOgBarnSkjemaRepositor
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEndringAbonnent
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaRepository
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaService
-import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateFamilieFellesTidslinjerForBarna
+import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSkjemaer
 import no.nav.familie.ba.sak.kjerne.eøs.felles.medBehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
@@ -70,10 +70,10 @@ internal fun tilpassValutakurserTilUtenlandskePeriodebeløp(
 ): Collection<Valutakurs> {
     val barnasUtenlandskePeriodebeløpTidslinjer =
         gjeldendeUtenlandskePeriodebeløp
-            .tilSeparateFamilieFellesTidslinjerForBarna()
+            .tilSeparateTidslinjerForBarna()
 
     return forrigeValutakurser
-        .tilSeparateFamilieFellesTidslinjerForBarna()
+        .tilSeparateTidslinjerForBarna()
         .outerJoin(barnasUtenlandskePeriodebeløpTidslinjer) { valutakurs, utenlandskPeriodebeløp ->
             when {
                 utenlandskPeriodebeløp == null -> null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SkjemaTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SkjemaTidslinjer.kt
@@ -11,10 +11,10 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunktEllerUendeligSent
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunktEllerUendeligTidlig
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 fun <S : PeriodeOgBarnSkjema<S>> S.tilTidslinje() = listOf(this).tilTidslinje()
 
@@ -29,7 +29,7 @@ internal fun <S : PeriodeOgBarnSkjema<S>> Iterable<S>.tilTidslinje() =
         }
     }
 
-fun <S : PeriodeOgBarnSkjema<S>> Iterable<S>.tilSeparateFamilieFellesTidslinjerForBarna(): Map<Aktør, FamilieFellesTidslinje<S>> {
+fun <S : PeriodeOgBarnSkjema<S>> Iterable<S>.tilSeparateTidslinjerForBarna(): Map<Aktør, Tidslinje<S>> {
     val skjemaer = this
     if (skjemaer.toList().isEmpty()) return emptyMap()
 
@@ -48,12 +48,12 @@ fun <S : PeriodeOgBarnSkjema<S>> Iterable<S>.tilSeparateFamilieFellesTidslinjerF
     }
 }
 
-fun <S : PeriodeOgBarnSkjemaEntitet<S>> Map<Aktør, FamilieFellesTidslinje<S>>.tilSkjemaer() =
+fun <S : PeriodeOgBarnSkjemaEntitet<S>> Map<Aktør, Tidslinje<S>>.tilSkjemaer() =
     this
         .flatMap { (aktør, tidslinjer) -> tidslinjer.tilSkjemaer(aktør) }
         .slåSammen()
 
-private fun <S : PeriodeOgBarnSkjema<S>> FamilieFellesTidslinje<S>.tilSkjemaer(aktør: Aktør) =
+private fun <S : PeriodeOgBarnSkjema<S>> Tidslinje<S>.tilSkjemaer(aktør: Aktør) =
     this.tilPerioder().mapNotNull { periode ->
         periode.verdi?.kopier(
             fom = periode.fom?.toYearMonth(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SkjemaTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SkjemaTidslinjer.kt
@@ -8,9 +8,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.eøs.felles.utenPeriode
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunktEllerUendeligSent
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunktEllerUendeligTidlig
 import no.nav.familie.tidslinje.tilTidslinje
@@ -30,27 +28,6 @@ internal fun <S : PeriodeOgBarnSkjema<S>> Iterable<S>.tilTidslinje() =
             )
         }
     }
-
-fun <S : PeriodeOgBarnSkjema<S>> Iterable<S>.tilSeparateTidslinjerForBarna(): Map<Aktør, Tidslinje<S, Måned>> {
-    val skjemaer = this
-    if (skjemaer.toList().isEmpty()) return emptyMap()
-
-    val alleBarnAktørIder = skjemaer.map { it.barnAktører }.reduce { akk, neste -> akk + neste }
-
-    return alleBarnAktørIder.associateWith { aktør ->
-        tidslinje {
-            skjemaer
-                .filter { it.barnAktører.contains(aktør) }
-                .map {
-                    Periode(
-                        fraOgMed = it.fom.tilTidspunktEllerUendeligTidlig(it.tom),
-                        tilOgMed = it.tom.tilTidspunktEllerUendeligSent(it.fom),
-                        innhold = it.kopier(fom = null, tom = null, barnAktører = setOf(aktør)),
-                    )
-                }
-        }
-    }
-}
 
 fun <S : PeriodeOgBarnSkjema<S>> Iterable<S>.tilSeparateFamilieFellesTidslinjerForBarna(): Map<Aktør, FamilieFellesTidslinje<S>> {
     val skjemaer = this

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -24,10 +24,10 @@ import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import java.time.YearMonth
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "Kompetanse")
@@ -233,10 +233,10 @@ fun Kompetanse.tilIKompetanse(): IKompetanse =
         )
     }
 
-fun List<UtfyltKompetanse>.tilFamilieFellesTidslinje() =
+fun List<UtfyltKompetanse>.tilTidslinje() =
     this
         .map {
-            FamilieFellesPeriode(
+            Periode(
                 verdi = it,
                 fom = it.fom.førsteDagIInneværendeMåned(),
                 tom = it.tom?.sisteDagIInneværendeMåned(),
@@ -254,7 +254,7 @@ fun Collection<Kompetanse>.tilUtfylteKompetanserEtterEndringstidpunktPerAktør(e
     return alleBarnAktørIder.associateWith { aktør ->
         utfylteKompetanser
             .filter { it.barnAktører.contains(aktør) }
-            .tilFamilieFellesTidslinje()
+            .tilTidslinje()
             .beskjærFraOgMed(endringstidspunkt.tilYearMonth().førsteDagIInneværendeMåned())
             .tilPerioder()
             .mapNotNull { it.verdi }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -21,10 +21,7 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.familie.tidslinje.tilTidslinje
@@ -235,16 +232,6 @@ fun Kompetanse.tilIKompetanse(): IKompetanse =
             behandlingId = this.behandlingId,
         )
     }
-
-fun List<UtfyltKompetanse>.tilTidslinje() =
-    this
-        .map {
-            Periode(
-                fraOgMed = it.fom.tilTidspunkt(),
-                tilOgMed = it.tom?.tilTidspunkt() ?: MånedTidspunkt.uendeligLengeTil(),
-                innhold = it,
-            )
-        }.tilTidslinje()
 
 fun List<UtfyltKompetanse>.tilFamilieFellesTidslinje() =
     this

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
@@ -29,10 +29,10 @@ import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
 import java.time.YearMonth
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "UtenlandskPeriodebeløp")
@@ -155,10 +155,10 @@ fun UtenlandskPeriodebeløp.tilIUtenlandskPeriodebeløp(): IUtenlandskPeriodebel
         )
     }
 
-fun List<UtfyltUtenlandskPeriodebeløp>.tilFamilieFellesTidslinje() =
+fun List<UtfyltUtenlandskPeriodebeløp>.tilTidslinje() =
     this
         .map {
-            FamilieFellesPeriode(
+            Periode(
                 verdi = it,
                 fom = it.fom.førsteDagIInneværendeMåned(),
                 tom = it.tom?.sisteDagIInneværendeMåned(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
@@ -28,10 +28,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.times
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
@@ -158,16 +154,6 @@ fun UtenlandskPeriodebeløp.tilIUtenlandskPeriodebeløp(): IUtenlandskPeriodebel
             behandlingId = this.behandlingId,
         )
     }
-
-fun List<UtfyltUtenlandskPeriodebeløp>.tilTidslinje() =
-    this
-        .map {
-            Periode(
-                fraOgMed = it.fom.tilTidspunkt(),
-                tilOgMed = it.tom?.tilTidspunkt() ?: MånedTidspunkt.uendeligLengeTil(),
-                innhold = it,
-            )
-        }.tilTidslinje()
 
 fun List<UtfyltUtenlandskPeriodebeløp>.tilFamilieFellesTidslinje() =
     this

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløp.kt
@@ -17,6 +17,8 @@ import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.YearMonthConverter
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.ekstern.restDomene.tilKalkulertMånedligBeløp
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetaltFraAnnetLand
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
@@ -31,8 +33,10 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
 import java.time.YearMonth
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "UtenlandskPeriodebeløp")
@@ -162,6 +166,16 @@ fun List<UtfyltUtenlandskPeriodebeløp>.tilTidslinje() =
                 fraOgMed = it.fom.tilTidspunkt(),
                 tilOgMed = it.tom?.tilTidspunkt() ?: MånedTidspunkt.uendeligLengeTil(),
                 innhold = it,
+            )
+        }.tilTidslinje()
+
+fun List<UtfyltUtenlandskPeriodebeløp>.tilFamilieFellesTidslinje() =
+    this
+        .map {
+            FamilieFellesPeriode(
+                verdi = it,
+                fom = it.fom.førsteDagIInneværendeMåned(),
+                tom = it.tom?.sisteDagIInneværendeMåned(),
             )
         }.tilTidslinje()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtil.kt
@@ -17,12 +17,12 @@ fun finnFørsteEndringIValutakurs(
         valutakurserDenneBehandling
             .filtrerUtfylteValutakurser()
             .groupBy { it.barnAktører }
-            .mapValues { (_, valutakurser) -> valutakurser.tilFamilieFellesTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
+            .mapValues { (_, valutakurser) -> valutakurser.tilTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
     val valutakurserForrigeBehandlingTidslinje =
         valutakurserForrigeBehandling
             .filtrerUtfylteValutakurser()
             .groupBy { it.barnAktører }
-            .mapValues { (_, valutakurser) -> valutakurser.tilFamilieFellesTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
+            .mapValues { (_, valutakurser) -> valutakurser.tilTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
 
     val erEndringIValutakursTidslinje =
         valutakurserDenneBehandlingTidslinje

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtil.kt
@@ -2,11 +2,11 @@ package no.nav.familie.ba.sak.kjerne.eøs.valutakurs
 
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.outerJoin
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.mapIkkeNull
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.ValutakursForVedtaksperiode
+import no.nav.familie.tidslinje.utvidelser.kombiner
+import no.nav.familie.tidslinje.utvidelser.outerJoin
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import java.time.YearMonth
 
 fun finnFørsteEndringIValutakurs(
@@ -17,12 +17,12 @@ fun finnFørsteEndringIValutakurs(
         valutakurserDenneBehandling
             .filtrerUtfylteValutakurser()
             .groupBy { it.barnAktører }
-            .mapValues { (_, valutakurser) -> valutakurser.tilTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
+            .mapValues { (_, valutakurser) -> valutakurser.tilFamilieFellesTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
     val valutakurserForrigeBehandlingTidslinje =
         valutakurserForrigeBehandling
             .filtrerUtfylteValutakurser()
             .groupBy { it.barnAktører }
-            .mapValues { (_, valutakurser) -> valutakurser.tilTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
+            .mapValues { (_, valutakurser) -> valutakurser.tilFamilieFellesTidslinje().mapIkkeNull { ValutakursForVedtaksperiode(it) } }
 
     val erEndringIValutakursTidslinje =
         valutakurserDenneBehandlingTidslinje
@@ -34,8 +34,8 @@ fun finnFørsteEndringIValutakurs(
             }
 
     return erEndringIValutakursTidslinje
-        .perioder()
-        .firstOrNull { it.innhold == true }
-        ?.fraOgMed
-        ?.tilYearMonth() ?: TIDENES_ENDE.toYearMonth()
+        .tilPerioder()
+        .firstOrNull { it.verdi == true }
+        ?.fom
+        ?.toYearMonth() ?: TIDENES_ENDE.toYearMonth()
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -23,10 +23,6 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
 import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
@@ -154,16 +150,6 @@ fun Valutakurs.tilIValutakurs(): IValutakurs =
             behandlingId = this.behandlingId,
         )
     }
-
-fun List<UtfyltValutakurs>.tilTidslinje() =
-    this
-        .map {
-            Periode(
-                fraOgMed = it.fom.tilTidspunkt(),
-                tilOgMed = it.tom?.tilTidspunkt() ?: MånedTidspunkt.uendeligLengeTil(),
-                innhold = it,
-            )
-        }.tilTidslinje()
 
 fun List<UtfyltValutakurs>.tilFamilieFellesTidslinje() =
     this

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -24,11 +24,11 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "Valutakurs")
@@ -151,10 +151,10 @@ fun Valutakurs.tilIValutakurs(): IValutakurs =
         )
     }
 
-fun List<UtfyltValutakurs>.tilFamilieFellesTidslinje() =
+fun List<UtfyltValutakurs>.tilTidslinje() =
     this
         .map {
-            FamilieFellesPeriode(
+            Periode(
                 verdi = it,
                 fom = it.fom.førsteDagIInneværendeMåned(),
                 tom = it.tom?.sisteDagIInneværendeMåned(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/Valutakurs.kt
@@ -18,6 +18,8 @@ import jakarta.persistence.Table
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.YearMonthConverter
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -26,9 +28,11 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
 import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.tidslinje.tilTidslinje
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 @EntityListeners(RollestyringMotDatabase::class)
 @Entity(name = "Valutakurs")
@@ -158,6 +162,16 @@ fun List<UtfyltValutakurs>.tilTidslinje() =
                 fraOgMed = it.fom.tilTidspunkt(),
                 tilOgMed = it.tom?.tilTidspunkt() ?: MånedTidspunkt.uendeligLengeTil(),
                 innhold = it,
+            )
+        }.tilTidslinje()
+
+fun List<UtfyltValutakurs>.tilFamilieFellesTidslinje() =
+    this
+        .map {
+            FamilieFellesPeriode(
+                verdi = it,
+                fom = it.fom.førsteDagIInneværendeMåned(),
+                tom = it.tom?.sisteDagIInneværendeMåned(),
             )
         }.tilTidslinje()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.eøs.vilkårsvurdering
 
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.lagForskjøvetTidslinjeForOppfylteVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -9,7 +10,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårsvurderingRe
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.mapVerdi
 import org.springframework.stereotype.Service
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.lagForskjøvetFamilieFellesTidslinjeForOppfylteVilkår as lagForskjøvetTidslinjeForOppfylteVilkår
 
 @Service
 class VilkårsvurderingTidslinjeService(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -1,19 +1,18 @@
 package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.kombinerUtenNullMed
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinjeForOppfyltVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.utvidelser.kombiner
 import java.time.YearMonth
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 object EndringIVilkårsvurderingUtil {
     fun lagEndringIVilkårsvurderingTidslinje(
@@ -22,7 +21,7 @@ object EndringIVilkårsvurderingUtil {
         personIBehandling: Person?,
         personIForrigeBehandling: Person?,
         tidligsteRelevanteFomDatoForPersonIVilkårsvurdering: YearMonth,
-    ): Tidslinje<Boolean, Måned> {
+    ): FamilieFellesTidslinje<Boolean> {
         val tidslinjePerVilkår =
             Vilkår.entries.map { vilkår ->
                 val vilkårTidslinje =
@@ -39,7 +38,7 @@ object EndringIVilkårsvurderingUtil {
                         personIBehandling = personIBehandling,
                         personIForrigeBehandling = personIForrigeBehandling,
                     )
-                vilkårTidslinje.beskjærFraOgMed(fraOgMed = tidligsteRelevanteFomDatoForPersonIVilkårsvurdering.tilTidspunkt())
+                vilkårTidslinje.beskjærFraOgMed(fraOgMed = tidligsteRelevanteFomDatoForPersonIVilkårsvurdering.førsteDagIInneværendeMåned())
             }
 
         return tidslinjePerVilkår.kombiner { finnesMinstEnEndringIPeriode(it) }
@@ -59,7 +58,7 @@ object EndringIVilkårsvurderingUtil {
         vilkår: Vilkår,
         personIBehandling: Person?,
         personIForrigeBehandling: Person?,
-    ): Tidslinje<Boolean, Måned> {
+    ): FamilieFellesTidslinje<Boolean> {
         val nåværendeVilkårResultatTidslinje =
             nåværendeOppfylteVilkårResultaterForPerson
                 .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIBehandling?.fødselsdato)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -10,9 +10,9 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.utvidelser.kombiner
 import java.time.YearMonth
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 object EndringIVilkårsvurderingUtil {
     fun lagEndringIVilkårsvurderingTidslinje(
@@ -21,7 +21,7 @@ object EndringIVilkårsvurderingUtil {
         personIBehandling: Person?,
         personIForrigeBehandling: Person?,
         tidligsteRelevanteFomDatoForPersonIVilkårsvurdering: YearMonth,
-    ): FamilieFellesTidslinje<Boolean> {
+    ): Tidslinje<Boolean> {
         val tidslinjePerVilkår =
             Vilkår.entries.map { vilkår ->
                 val vilkårTidslinje =
@@ -58,7 +58,7 @@ object EndringIVilkårsvurderingUtil {
         vilkår: Vilkår,
         personIBehandling: Person?,
         personIForrigeBehandling: Person?,
-    ): FamilieFellesTidslinje<Boolean> {
+    ): Tidslinje<Boolean> {
         val nåværendeVilkårResultatTidslinje =
             nåværendeOppfylteVilkårResultaterForPerson
                 .tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = vilkår, fødselsdato = personIBehandling?.fødselsdato)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/EndreTid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/EndreTid.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon
 
 import no.nav.familie.tidslinje.Null
+import no.nav.familie.tidslinje.PRAKTISK_TIDLIGSTE_DAG
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.TidslinjePeriodeMedDato
 import no.nav.familie.tidslinje.tilPeriodeVerdi
@@ -68,7 +69,11 @@ fun <V> Tidslinje<V>.tilMånedFraMånedsskifte(
                 val verdiForrigeMåned = forrigeMåned.lastOrNull()?.periodeVerdi?.verdi
                 val verdiInneværendeMåned = inneværendeMåned.firstOrNull()?.periodeVerdi?.verdi
 
-                mapper(verdiForrigeMåned, verdiInneværendeMåned).tilPeriodeVerdi()
+                if (dato == PRAKTISK_TIDLIGSTE_DAG) {
+                    verdiInneværendeMåned.tilPeriodeVerdi()
+                } else {
+                    mapper(verdiForrigeMåned, verdiInneværendeMåned).tilPeriodeVerdi()
+                }
             }.trim(Null())
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/EndreTid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tidslinjefamiliefelles/transformasjon/EndreTid.kt
@@ -2,28 +2,31 @@ package no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon
 
 import no.nav.familie.tidslinje.Null
 import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.TidslinjePeriodeMedDato
 import no.nav.familie.tidslinje.tilPeriodeVerdi
+import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.konverterTilMåned
+import no.nav.familie.tidslinje.utvidelser.tilTidslinjePerioderMedDato
 import no.nav.familie.tidslinje.utvidelser.trim
 
 /**
  * Extension-metode for å konvertere fra dag-basert tidslinje til måned-basert tidslinje
- * mapper-funksjonen tar inn listen av alle dagverdiene i én måned, og returner verdien måneden skal ha
+ * [mapper]-funksjonen tar inn listen av alle dagverdiene i én måned, og returner verdien måneden skal ha
  * Dagverdiene kommer i samme rekkefølge som dagene i måneden, og vil ha null-verdi hvis dagen ikke har en verdi
  */
 fun <V> Tidslinje<V>.tilMåned(mapper: (List<V?>) -> V?): Tidslinje<V> =
-    this.konverterTilMåned { dato, månedListe ->
+    this.konverterTilMåned { _, månedListe ->
         val månedVerdier = månedListe.first().map { dag -> dag.periodeVerdi.verdi }
         mapper(månedVerdier).tilPeriodeVerdi()
     }
 
 /**
  * Extention-metode som konverterer en dag-basert tidslinje til en måned-basert tidslinje.
- * <mapper>-funksjonen tar inn verdiene fra de to dagene før og etter månedsskiftet,
+ * [mapper]-funksjonen tar inn verdiene fra de to dagene før og etter månedsskiftet,
  * det vil si verdiene fra siste dag i forrige måned og første dag i inneværemde måned.
- * <mapper>-funksjonen kalles bare dersom begge dagene har en verdi.
+ * [mapper]-funksjonen kalles bare dersom begge dagene har en verdi.
  * Return-verdien er innholdet som blir brukt for inneværende måned.
- * Hvis retur-verdien er <null>, vil den resulterende måneden mangle verdi.
+ * Hvis retur-verdien er null, vil den resulterende måneden mangle verdi.
  * Funksjonen vil bruke månedsskiftene fra måneden før tidslinjen starter frem til og med siste måned i tidslinjen.
  */
 fun <V> Tidslinje<V>.tilMånedFraMånedsskifteIkkeNull(
@@ -35,23 +38,23 @@ fun <V> Tidslinje<V>.tilMånedFraMånedsskifteIkkeNull(
         this
             .konverterTilMåned(antallMndBakoverITid = 1) { _, (forrigeMåned, inneværendeMåned) ->
                 val verdiForrigeMåned = forrigeMåned.lastOrNull()?.periodeVerdi?.verdi
-                val verdiDenneMåned = inneværendeMåned.firstOrNull()?.periodeVerdi?.verdi
+                val verdiInneværendeMåned = inneværendeMåned.firstOrNull()?.periodeVerdi?.verdi
 
-                if (verdiForrigeMåned == null || verdiDenneMåned == null) {
+                if (verdiForrigeMåned == null || verdiInneværendeMåned == null) {
                     Null()
                 } else {
-                    mapper(verdiForrigeMåned, verdiDenneMåned).tilPeriodeVerdi()
+                    mapper(verdiForrigeMåned, verdiInneværendeMåned).tilPeriodeVerdi()
                 }
             }.trim(Null())
     }
 
 /**
  * Extention-metode som konverterer en dag-basert tidslinje til en måned-basert tidslinje.
- * <mapper>-funksjonen tar inn verdiene fra de to dagene før og etter månedsskiftet,
+ * [mapper]-funksjonen tar inn verdiene fra de to dagene før og etter månedsskiftet,
  * det vil si verdiene fra siste dag i forrige måned og første dag i inneværemde måned.
  * Return-verdien er innholdet som blir brukt for inneværende måned.
- * Hvis retur-verdien er <null>, vil den resulterende måneden mangle verdi.
- * Funksjonen vil bruke månedsskiftene fra måneden før tidslinjen starter frem til og med siste måned i tidslinjen.
+ * Hvis retur-verdien er null, vil den resulterende måneden mangle verdi.
+ * Funksjonen vil bruke månedsskiftene fra måneden før tidslinjen starter frem til og med måneden etter tidslinjen slutter.
  */
 fun <V> Tidslinje<V>.tilMånedFraMånedsskifte(
     mapper: (innholdSisteDagForrigeMåned: V?, innholdFørsteDagDenneMåned: V?) -> V?,
@@ -60,10 +63,22 @@ fun <V> Tidslinje<V>.tilMånedFraMånedsskifte(
         this
     } else {
         this
-            .konverterTilMåned(antallMndBakoverITid = 1) { _, (forrigeMåned, inneværendeMåned) ->
+            .forlengTidslinjeMedEnMåned()
+            .konverterTilMåned(antallMndBakoverITid = 1) { dato, (forrigeMåned, inneværendeMåned) ->
                 val verdiForrigeMåned = forrigeMåned.lastOrNull()?.periodeVerdi?.verdi
-                val verdiDenneMåned = inneværendeMåned.firstOrNull()?.periodeVerdi?.verdi
+                val verdiInneværendeMåned = inneværendeMåned.firstOrNull()?.periodeVerdi?.verdi
 
-                mapper(verdiForrigeMåned, verdiDenneMåned).tilPeriodeVerdi()
+                mapper(verdiForrigeMåned, verdiInneværendeMåned).tilPeriodeVerdi()
             }.trim(Null())
+    }
+
+private fun <V> Tidslinje<V>.forlengTidslinjeMedEnMåned(): Tidslinje<V> =
+    if (this.innhold.lastOrNull()?.erUendelig == true) {
+        this
+    } else {
+        val fom = this.kalkulerSluttTidspunkt().plusDays(1)
+        val tom = fom.plusMonths(1)
+        val nyePerioder = this.tilTidslinjePerioderMedDato() + TidslinjePeriodeMedDato<V>(null, fom, tom)
+
+        nyePerioder.tilTidslinje()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/EndringsTidspunktUtil.kt
@@ -12,11 +12,11 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusen
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VedtaksperiodeGrunnlagForPersonVilkårInnvilget
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.erLikUtenomTom
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.utvidelser.outerJoin
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.tidslinje.utvidelser.verdiPåTidspunkt
 import java.time.LocalDate
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 fun utledEndringstidspunkt(
     behandlingsGrunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
@@ -60,8 +60,8 @@ private fun Set<PersonResultat>.beholdKunOppfylteVilkårResultater(): Set<Person
     }.toSet()
 
 private fun loggEndringstidspunktOgEndringer(
-    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>>,
-    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>>,
+    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson>>,
+    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson>>,
     aktørMedFørsteForandring: AktørOgRolleBegrunnelseGrunnlag?,
     datoTidligsteForskjell: LocalDate,
 ) {
@@ -121,7 +121,7 @@ private fun loggEndringstidspunktOgEndringer(
     secureLogger.info("Ved endringstidspunktet $datoTidligsteForskjell er det endring for $aktørMedFørsteForandring")
 }
 
-private fun Map<AktørOgRolleBegrunnelseGrunnlag, FamilieFellesTidslinje<Boolean>>.finnTidligsteForskjell() =
+private fun Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<Boolean>>.finnTidligsteForskjell() =
     this
         .map { (aktørOgRolleForVedtaksgrunnlag, erPeriodeLikTidslinje) ->
             val førsteEndringForAktør =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/BegrunnelseGrunnlagForPersonIPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/BegrunnelseGrunnlagForPersonIPeriode.kt
@@ -3,11 +3,11 @@ package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProd
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilFamilieFellesTidslinje
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilFamilieFellesTidslinje
-import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilFamilieFellesTidslinje
-import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.tilFamilieFellesTidslinje
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilTidslinje
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilTidslinje
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.kombiner
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.mapIkkeNull
@@ -26,6 +26,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusen
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvedeVilkårTidslinjer
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.Companion.hentOrdinæreVilkårFor
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.mapVerdi
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.filtrer
@@ -33,8 +35,6 @@ import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
 import java.math.BigDecimal
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 data class BegrunnelseGrunnlagForPersonIPeriode(
     val person: Person,
@@ -65,11 +65,11 @@ data class BegrunnelseGrunnlagForPersonIPeriode(
     }
 }
 
-fun BehandlingsGrunnlagForVedtaksperioder.lagBegrunnelseGrunnlagTidslinjer(): Map<Person, FamilieFellesTidslinje<BegrunnelseGrunnlagForPersonIPeriode>> = this.persongrunnlag.personer.associateWith { this.lagBegrunnelseGrunnlagForPersonTidslinje(it) }
+fun BehandlingsGrunnlagForVedtaksperioder.lagBegrunnelseGrunnlagTidslinjer(): Map<Person, Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>> = this.persongrunnlag.personer.associateWith { this.lagBegrunnelseGrunnlagForPersonTidslinje(it) }
 
 fun BehandlingsGrunnlagForVedtaksperioder.lagBegrunnelseGrunnlagForPersonTidslinje(
     person: Person,
-): FamilieFellesTidslinje<BegrunnelseGrunnlagForPersonIPeriode> {
+): Tidslinje<BegrunnelseGrunnlagForPersonIPeriode> {
     val vilkårResultaterForPerson =
         this.personResultater.singleOrNull { it.aktør == person.aktør }?.vilkårResultater ?: emptyList()
 
@@ -85,25 +85,25 @@ fun BehandlingsGrunnlagForVedtaksperioder.lagBegrunnelseGrunnlagForPersonTidslin
     val kompetanseTidslinje =
         this.utfylteKompetanser
             .filtrerPåAktør(person.aktør)
-            .tilFamilieFellesTidslinje()
+            .tilTidslinje()
             .mapIkkeNull { KompetanseForVedtaksperiode(it) }
 
     val utenlandskPeriodebeløpTidslinje =
         utfylteUtenlandskPeriodebeløp
             .filtrerPåAktør(person.aktør)
-            .tilFamilieFellesTidslinje()
+            .tilTidslinje()
             .mapIkkeNull { UtenlandskPeriodebeløpForVedtaksperiode(it) }
 
     val valutakursTidslinje =
         utfylteValutakurs
             .filtrerPåAktør(person.aktør)
-            .tilFamilieFellesTidslinje()
+            .tilTidslinje()
             .mapIkkeNull { ValutakursForVedtaksperiode(it) }
 
     val endredeUtbetalingerTidslinje =
         this.utfylteEndredeUtbetalinger
             .filtrerPåAktør(person.aktør)
-            .tilFamilieFellesTidslinje()
+            .tilTidslinje()
             .mapIkkeNull { it.tilEndretUtbetalingAndelForVedtaksperiode() }
 
     val andelerTilkjentYtelseTidslinje =
@@ -151,11 +151,11 @@ fun BehandlingsGrunnlagForVedtaksperioder.lagBegrunnelseGrunnlagForPersonTidslin
 }
 
 private fun lagTidslinjeForEksplisitteAvslag(
-    forskjøvedeVilkårMedPeriode: List<FamilieFellesTidslinje<VilkårResultatForVedtaksperiode>>,
+    forskjøvedeVilkårMedPeriode: List<Tidslinje<VilkårResultatForVedtaksperiode>>,
     generelleAvslag: List<VilkårResultat>,
-): FamilieFellesTidslinje<List<VilkårResultatForVedtaksperiode>> {
+): Tidslinje<List<VilkårResultatForVedtaksperiode>> {
     val forskjøvedeEksplisitteAvslagMedPerioder = forskjøvedeVilkårMedPeriode.map { tidslinje -> tidslinje.filtrer { it?.erEksplisittAvslagPåSøknad == true } }.kombiner { it.toList() }
-    val eksplisitteAvslagUtenPeriode = generelleAvslag.map { genereltAvslag -> FamilieFellesPeriode(genereltAvslag, null, null).tilTidslinje().mapVerdi { it?.let { VilkårResultatForVedtaksperiode(it) } } }.kombiner { it.toList() }
+    val eksplisitteAvslagUtenPeriode = generelleAvslag.map { genereltAvslag -> Periode(genereltAvslag, null, null).tilTidslinje().mapVerdi { it?.let { VilkårResultatForVedtaksperiode(it) } } }.kombiner { it.toList() }
 
     val eksplisitteAvslagTidslinje =
         forskjøvedeEksplisitteAvslagMedPerioder.kombinerMed(eksplisitteAvslagUtenPeriode) { avslagMedPeriode, avslagUtenPeriode ->
@@ -168,7 +168,7 @@ private fun lagTidslinjeForEksplisitteAvslag(
     return eksplisitteAvslagTidslinje
 }
 
-fun List<AndelTilkjentYtelse>.tilAndelerForVedtaksbegrunnelseTidslinje(): FamilieFellesTidslinje<Iterable<AndelForVedtaksbegrunnelse>> =
+fun List<AndelTilkjentYtelse>.tilAndelerForVedtaksbegrunnelseTidslinje(): Tidslinje<Iterable<AndelForVedtaksbegrunnelse>> =
     this
         .tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType()
         .values

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
@@ -37,7 +37,8 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvni
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import no.nav.familie.tidslinje.mapVerdi
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.tomTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
@@ -46,8 +47,6 @@ import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 fun VedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserForPeriode(
     grunnlagForBegrunnelser: GrunnlagForBegrunnelse,
@@ -249,7 +248,7 @@ private fun VedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerson(
         (generelleAvslagsbegrunnelser + avslagsbegrunnelserMedPeriode).toSet()
     }
 
-private fun List<FamilieFellesTidslinje<VilkårResultat>>.filtrerKunEksplisittAvslagsPerioder(): List<FamilieFellesTidslinje<VilkårResultat>> =
+private fun List<Tidslinje<VilkårResultat>>.filtrerKunEksplisittAvslagsPerioder(): List<Tidslinje<VilkårResultat>> =
     this.map { tidslinjeForVilkår ->
         tidslinjeForVilkår
             .tilPerioderIkkeNull()
@@ -566,11 +565,11 @@ fun VedtaksperiodeMedBegrunnelser.finnBegrunnelseGrunnlagPerPerson(
     }
 }
 
-private fun FamilieFellesTidslinje<VedtaksperiodeMedBegrunnelser>.lagTidslinjeGrunnlagDennePeriodenForrigePeriodeOgPeriodeForrigeBehandling(
-    grunnlagTidslinje: FamilieFellesTidslinje<BegrunnelseGrunnlagForPersonIPeriode>,
-    grunnlagTidslinjePerPersonForrigeBehandling: Map<Person, FamilieFellesTidslinje<BegrunnelseGrunnlagForPersonIPeriode>>?,
+private fun Tidslinje<VedtaksperiodeMedBegrunnelser>.lagTidslinjeGrunnlagDennePeriodenForrigePeriodeOgPeriodeForrigeBehandling(
+    grunnlagTidslinje: Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>,
+    grunnlagTidslinjePerPersonForrigeBehandling: Map<Person, Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>>?,
     person: Person,
-): FamilieFellesTidslinje<IBegrunnelseGrunnlagForPeriode> {
+): Tidslinje<IBegrunnelseGrunnlagForPeriode> {
     val grunnlagMedForrigePeriodeTidslinje = grunnlagTidslinje.tilForrigeOgNåværendePeriodeTidslinje(this)
 
     val grunnlagForrigeBehandlingTidslinje = grunnlagTidslinjePerPersonForrigeBehandling?.get(person) ?: tomTidslinje()
@@ -594,9 +593,9 @@ private fun FamilieFellesTidslinje<VedtaksperiodeMedBegrunnelser>.lagTidslinjeGr
     }
 }
 
-private fun VedtaksperiodeMedBegrunnelser.tilTidslinjeForAktuellPeriode(): FamilieFellesTidslinje<VedtaksperiodeMedBegrunnelser> =
+private fun VedtaksperiodeMedBegrunnelser.tilTidslinjeForAktuellPeriode(): Tidslinje<VedtaksperiodeMedBegrunnelser> =
     listOf(
-        FamilieFellesPeriode(
+        Periode(
             verdi = this,
             fom = this.fom?.førsteDagIInneværendeMåned(),
             tom = this.tom?.sisteDagIMåned(),
@@ -608,17 +607,17 @@ data class ForrigeOgDennePerioden(
     val denne: BegrunnelseGrunnlagForPersonIPeriode?,
 )
 
-private fun FamilieFellesTidslinje<BegrunnelseGrunnlagForPersonIPeriode>.tilForrigeOgNåværendePeriodeTidslinje(
-    vedtaksperiodeTidslinje: FamilieFellesTidslinje<VedtaksperiodeMedBegrunnelser>,
-): FamilieFellesTidslinje<ForrigeOgDennePerioden> {
+private fun Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>.tilForrigeOgNåværendePeriodeTidslinje(
+    vedtaksperiodeTidslinje: Tidslinje<VedtaksperiodeMedBegrunnelser>,
+): Tidslinje<ForrigeOgDennePerioden> {
     val grunnlagPerioderSplittetPåVedtaksperiode =
         kombinerMed(vedtaksperiodeTidslinje) { grunnlag, periode ->
             Pair(grunnlag, periode)
-        }.tilPerioder().map { FamilieFellesPeriode(it.verdi?.first, it.fom, it.tom) }
+        }.tilPerioder().map { Periode(it.verdi?.first, it.fom, it.tom) }
 
     return (
         listOf(
-            FamilieFellesPeriode(
+            Periode(
                 verdi = null,
                 fom = YearMonth.now().førsteDagIInneværendeMåned(),
                 tom = YearMonth.now().sisteDagIInneværendeMåned(),
@@ -626,7 +625,7 @@ private fun FamilieFellesTidslinje<BegrunnelseGrunnlagForPersonIPeriode>.tilForr
         ) + grunnlagPerioderSplittetPåVedtaksperiode
     ).zipWithNext { forrige, denne ->
         val innholdForrigePeriode = if (forrige.tom?.nesteMåned() == denne.fom?.toYearMonth()) forrige.verdi else null
-        FamilieFellesPeriode(ForrigeOgDennePerioden(innholdForrigePeriode, denne.verdi), denne.fom, denne.tom)
+        Periode(ForrigeOgDennePerioden(innholdForrigePeriode, denne.verdi), denne.fom, denne.tom)
     }.tilTidslinje()
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
@@ -12,16 +12,16 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksbegrunnel
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.IUtfyltEndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilFamilieFellesTidslinje
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilIEndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilFamilieFellesTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
-import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilFamilieFellesTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilIUtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.UtfyltValutakurs
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.tilIValutakurs
@@ -39,6 +39,8 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvni
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.mapVerdi
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.tomTidslinje
@@ -47,14 +49,12 @@ import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 typealias AktørId = String
 
 data class GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag(
-    val overlappendeGenerelleAvslagVedtaksperiodeGrunnlagForPerson: FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>,
-    val vedtaksperiodeGrunnlagForPerson: FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>,
+    val overlappendeGenerelleAvslagVedtaksperiodeGrunnlagForPerson: Tidslinje<VedtaksperiodeGrunnlagForPerson>,
+    val vedtaksperiodeGrunnlagForPerson: Tidslinje<VedtaksperiodeGrunnlagForPerson>,
 )
 
 data class AktørOgRolleBegrunnelseGrunnlag(
@@ -126,7 +126,7 @@ data class BehandlingsGrunnlagForVedtaksperioder(
                         personResultat,
                     )
 
-                val forskjøvedeVilkårResultaterForPersonsAndeler: FamilieFellesTidslinje<List<VilkårResultat>> =
+                val forskjøvedeVilkårResultaterForPersonsAndeler: Tidslinje<List<VilkårResultat>> =
                     vilkårResultaterUtenGenerelleAvslag.hentForskjøvedeVilkårResultaterForPersonsAndelerTidslinje(
                         person = person,
                         erMinstEttBarnMedUtbetalingTidslinje = erMinstEttBarnMedUtbetalingTidslinje,
@@ -189,9 +189,9 @@ data class BehandlingsGrunnlagForVedtaksperioder(
 
     private fun List<VilkårResultat>.generelleAvslagTilGrunnlagForPersonTidslinje(
         person: Person,
-    ): FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson> =
+    ): Tidslinje<VedtaksperiodeGrunnlagForPerson> =
         this
-            .map { FamilieFellesPeriode(it, null, null).tilTidslinje() }
+            .map { Periode(it, null, null).tilTidslinje() }
             .kombinerUtenNull { it.toList() }
             .mapVerdi { vilkårResultater ->
                 vilkårResultater?.let {
@@ -207,28 +207,28 @@ data class BehandlingsGrunnlagForVedtaksperioder(
                 }
             }
 
-    private fun FamilieFellesTidslinje<List<VilkårResultat>>.tilGrunnlagForPersonTidslinje(
+    private fun Tidslinje<List<VilkårResultat>>.tilGrunnlagForPersonTidslinje(
         person: Person,
         vilkårRolle: PersonType,
         skalSplittePåValutakursendringer: Boolean,
-    ): FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson> {
+    ): Tidslinje<VedtaksperiodeGrunnlagForPerson> {
         val småbarnstilleggTidslinje = andelerTilkjentYtelse.hentErUtbetalingSmåbarnstilleggTidslinje()
         val kompetanseTidslinje =
             utfylteKompetanser
                 .filtrerPåAktør(person.aktør)
-                .tilFamilieFellesTidslinje()
+                .tilTidslinje()
                 .mapIkkeNull { KompetanseForVedtaksperiode(it) }
 
         val utenlandskPeriodebeløpTidslinje =
             utfylteUtenlandskPeriodebeløp
                 .filtrerPåAktør(person.aktør)
-                .tilFamilieFellesTidslinje()
+                .tilTidslinje()
                 .mapIkkeNull { UtenlandskPeriodebeløpForVedtaksperiode(it) }
 
         val endredeUtbetalingerTidslinje =
             utfylteEndredeUtbetalinger
                 .filtrerPåAktør(person.aktør)
-                .tilFamilieFellesTidslinje()
+                .tilTidslinje()
                 .mapIkkeNull { it.tilEndretUtbetalingAndelForVedtaksperiode() }
 
         val overgangsstønadTidslinje =
@@ -309,7 +309,7 @@ private fun List<VilkårResultat>.filtrerVilkårErOrdinærtFor(
 fun hentOrdinæreVilkårForSøkerForskjøvetTidslinje(
     søker: Person,
     personResultater: Set<PersonResultat>,
-): FamilieFellesTidslinje<List<VilkårResultat>> {
+): Tidslinje<List<VilkårResultat>> {
     val søkerPersonResultater = personResultater.single { it.aktør == søker.aktør }
 
     val (_, vilkårResultaterUtenOverlappendeGenerelleAvslag) =
@@ -329,7 +329,7 @@ private fun hentErMinstEttBarnMedUtbetalingTidslinje(
     personResultater: Set<PersonResultat>,
     fagsakType: FagsakType,
     persongrunnlag: PersonopplysningGrunnlag,
-): FamilieFellesTidslinje<Boolean> {
+): Tidslinje<Boolean> {
     val søker = persongrunnlag.søker
     val søkerSineOrdinæreVilkårErOppfyltTidslinje =
         personResultater
@@ -367,12 +367,12 @@ private fun hentErMinstEttBarnMedUtbetalingTidslinje(
 
 private fun List<VilkårResultat>.hentForskjøvedeVilkårResultaterForPersonsAndelerTidslinje(
     person: Person,
-    erMinstEttBarnMedUtbetalingTidslinje: FamilieFellesTidslinje<Boolean>,
-    ordinæreVilkårForSøkerTidslinje: FamilieFellesTidslinje<List<VilkårResultat>>,
+    erMinstEttBarnMedUtbetalingTidslinje: Tidslinje<Boolean>,
+    ordinæreVilkårForSøkerTidslinje: Tidslinje<List<VilkårResultat>>,
     fagsakType: FagsakType,
     vilkårRolle: PersonType,
     bareSøkerOgUregistrertBarn: Boolean,
-): FamilieFellesTidslinje<List<VilkårResultat>> {
+): Tidslinje<List<VilkårResultat>> {
     val forskjøvedeVilkårResultaterForPerson = this.tilForskjøvedeVilkårTidslinjer(person.fødselsdato).kombiner()
 
     return when (vilkårRolle) {
@@ -481,7 +481,7 @@ private fun lagGrunnlagMedOvergangsstønad(
     null -> null
 }
 
-fun List<AndelTilkjentYtelse>.tilAndelerTidslinje(skalSplittePåValutakursendringer: Boolean): FamilieFellesTidslinje<out Iterable<AndelForVedtaksobjekt>> =
+fun List<AndelTilkjentYtelse>.tilAndelerTidslinje(skalSplittePåValutakursendringer: Boolean): Tidslinje<out Iterable<AndelForVedtaksobjekt>> =
     if (skalSplittePåValutakursendringer) {
         this
             .tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType()
@@ -498,16 +498,16 @@ fun List<AndelTilkjentYtelse>.tilAndelerTidslinje(skalSplittePåValutakursendrin
 
 // Vi trenger dette for å kunne begrunne nye perioder med småbarnstillegg som vi ikke hadde i forrige behandling
 fun List<InternPeriodeOvergangsstønad>.tilPeriodeOvergangsstønadForVedtaksperiodeTidslinje(
-    erUtbetalingSmåbarnstilleggTidslinje: FamilieFellesTidslinje<Boolean>,
+    erUtbetalingSmåbarnstilleggTidslinje: Tidslinje<Boolean>,
 ) = this
     .map { OvergangsstønadForVedtaksperiode(it) }
-    .map { FamilieFellesPeriode(it, it.fom.førsteDagIInneværendeMåned(), it.tom.sisteDagIMåned()) }
+    .map { Periode(it, it.fom.førsteDagIInneværendeMåned(), it.tom.sisteDagIMåned()) }
     .tilTidslinje()
     .kombinerMed(erUtbetalingSmåbarnstilleggTidslinje) { overgangsstønad, erUtbetalingSmåbarnstillegg ->
         overgangsstønad.takeIf { erUtbetalingSmåbarnstillegg == true }
     }
 
-private fun FamilieFellesTidslinje<List<VilkårResultat>>.tilVilkårResultaterForVedtaksPeriodeTidslinje() = this.mapVerdi { vilkårResultater -> vilkårResultater?.map { VilkårResultatForVedtaksperiode(it) } }
+private fun Tidslinje<List<VilkårResultat>>.tilVilkårResultaterForVedtaksPeriodeTidslinje() = this.mapVerdi { vilkårResultater -> vilkårResultater?.map { VilkårResultatForVedtaksperiode(it) } }
 
 @JvmName("internPeriodeOvergangsstønaderFiltrerPåAktør")
 fun List<InternPeriodeOvergangsstønad>.filtrerPåAktør(aktør: Aktør) = this.filter { it.personIdent == aktør.aktivFødselsnummer() }
@@ -527,16 +527,16 @@ fun List<UtfyltValutakurs>.filtrerPåAktør(aktør: Aktør) = this.filter { it.b
 @JvmName("utfyltUtenlandskPeriodebeløpFiltrerPåAktør")
 fun List<UtfyltUtenlandskPeriodebeløp>.filtrerPåAktør(aktør: Aktør) = this.filter { it.barnAktører.contains(aktør) }
 
-private fun FamilieFellesPeriode<VedtaksperiodeGrunnlagForPerson>.erInnvilgetEllerEksplisittAvslag(): Boolean {
+private fun Periode<VedtaksperiodeGrunnlagForPerson>.erInnvilgetEllerEksplisittAvslag(): Boolean {
     val erInnvilget = verdi is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
     val erEksplisittAvslag = verdi.vilkårResultaterForVedtaksperiode.any { it.erEksplisittAvslagPåSøknad }
 
     return erInnvilget || erEksplisittAvslag
 }
 
-private fun List<AndelTilkjentYtelse>.hentErUtbetalingSmåbarnstilleggTidslinje(): FamilieFellesTidslinje<Boolean> = this.tilAndelerForVedtaksbegrunnelseTidslinje().hentErUtbetalingSmåbarnstilleggTidslinje()
+private fun List<AndelTilkjentYtelse>.hentErUtbetalingSmåbarnstilleggTidslinje(): Tidslinje<Boolean> = this.tilAndelerForVedtaksbegrunnelseTidslinje().hentErUtbetalingSmåbarnstilleggTidslinje()
 
-fun FamilieFellesTidslinje<Iterable<AndelForVedtaksbegrunnelse>>.hentErUtbetalingSmåbarnstilleggTidslinje() =
+fun Tidslinje<Iterable<AndelForVedtaksbegrunnelse>>.hentErUtbetalingSmåbarnstilleggTidslinje() =
     this.mapIkkeNull { andelerIPeriode ->
         andelerIPeriode.any {
             it.type == YtelseType.SMÅBARNSTILLEGG && it.kalkulertUtbetalingsbeløp > 0

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/BehandlingsGrunnlagForVedtaksperioder.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -10,16 +12,16 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksbegrunnel
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.IUtfyltEndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilFamilieFellesTidslinje
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilIEndretUtbetalingAndel
-import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilFamilieFellesTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
-import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilFamilieFellesTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilIUtenlandskPeriodebeløp
-import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.UtfyltValutakurs
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.tilIValutakurs
@@ -28,32 +30,31 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMedNullable
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNull
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
-import no.nav.familie.ba.sak.kjerne.tidslinje.månedPeriodeAv
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilMånedTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.mapIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.kombiner
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.kombinerUtenNull
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.mapIkkeNull
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.tilAndelerForVedtaksbegrunnelseTidslinje
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvedeVilkårTidslinjer
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilTidslinjeForSplittForPerson
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.mapVerdi
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.tomTidslinje
+import no.nav.familie.tidslinje.utvidelser.filtrerIkkeNull
+import no.nav.familie.tidslinje.utvidelser.kombiner
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 typealias AktørId = String
 
 data class GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag(
-    val overlappendeGenerelleAvslagVedtaksperiodeGrunnlagForPerson: Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned>,
-    val vedtaksperiodeGrunnlagForPerson: Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned>,
+    val overlappendeGenerelleAvslagVedtaksperiodeGrunnlagForPerson: FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>,
+    val vedtaksperiodeGrunnlagForPerson: FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>,
 )
 
 data class AktørOgRolleBegrunnelseGrunnlag(
@@ -125,7 +126,7 @@ data class BehandlingsGrunnlagForVedtaksperioder(
                         personResultat,
                     )
 
-                val forskjøvedeVilkårResultaterForPersonsAndeler: Tidslinje<List<VilkårResultat>, Måned> =
+                val forskjøvedeVilkårResultaterForPersonsAndeler: FamilieFellesTidslinje<List<VilkårResultat>> =
                     vilkårResultaterUtenGenerelleAvslag.hentForskjøvedeVilkårResultaterForPersonsAndelerTidslinje(
                         person = person,
                         erMinstEttBarnMedUtbetalingTidslinje = erMinstEttBarnMedUtbetalingTidslinje,
@@ -188,13 +189,11 @@ data class BehandlingsGrunnlagForVedtaksperioder(
 
     private fun List<VilkårResultat>.generelleAvslagTilGrunnlagForPersonTidslinje(
         person: Person,
-    ): Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned> =
+    ): FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson> =
         this
-            .map {
-                listOf(månedPeriodeAv(null, null, it))
-                    .tilTidslinje()
-            }.kombinerUtenNull { it.toList() }
-            .map { vilkårResultater ->
+            .map { FamilieFellesPeriode(it, null, null).tilTidslinje() }
+            .kombinerUtenNull { it.toList() }
+            .mapVerdi { vilkårResultater ->
                 vilkårResultater?.let {
                     VedtaksperiodeGrunnlagForPersonVilkårIkkeInnvilget(
                         person = person,
@@ -208,28 +207,28 @@ data class BehandlingsGrunnlagForVedtaksperioder(
                 }
             }
 
-    private fun Tidslinje<List<VilkårResultat>, Måned>.tilGrunnlagForPersonTidslinje(
+    private fun FamilieFellesTidslinje<List<VilkårResultat>>.tilGrunnlagForPersonTidslinje(
         person: Person,
         vilkårRolle: PersonType,
         skalSplittePåValutakursendringer: Boolean,
-    ): Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned> {
+    ): FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson> {
         val småbarnstilleggTidslinje = andelerTilkjentYtelse.hentErUtbetalingSmåbarnstilleggTidslinje()
         val kompetanseTidslinje =
             utfylteKompetanser
                 .filtrerPåAktør(person.aktør)
-                .tilTidslinje()
+                .tilFamilieFellesTidslinje()
                 .mapIkkeNull { KompetanseForVedtaksperiode(it) }
 
         val utenlandskPeriodebeløpTidslinje =
             utfylteUtenlandskPeriodebeløp
                 .filtrerPåAktør(person.aktør)
-                .tilTidslinje()
+                .tilFamilieFellesTidslinje()
                 .mapIkkeNull { UtenlandskPeriodebeløpForVedtaksperiode(it) }
 
         val endredeUtbetalingerTidslinje =
             utfylteEndredeUtbetalinger
                 .filtrerPåAktør(person.aktør)
-                .tilTidslinje()
+                .tilFamilieFellesTidslinje()
                 .mapIkkeNull { it.tilEndretUtbetalingAndelForVedtaksperiode() }
 
         val overgangsstønadTidslinje =
@@ -252,19 +251,19 @@ data class BehandlingsGrunnlagForVedtaksperioder(
                         person = person,
                         andeler = andeler,
                     )
-                }.kombinerMedNullable(kompetanseTidslinje) { grunnlagForPerson, kompetanse ->
+                }.kombinerMed(kompetanseTidslinje) { grunnlagForPerson, kompetanse ->
                     lagGrunnlagMedKompetanse(grunnlagForPerson, kompetanse)
-                }.kombinerMedNullable(utenlandskPeriodebeløpTidslinje) { grunnlagForPerson, utenlandskPeriodebeløp ->
+                }.kombinerMed(utenlandskPeriodebeløpTidslinje) { grunnlagForPerson, utenlandskPeriodebeløp ->
                     lagGrunnlagMedUtenlandskPeriodebeløp(grunnlagForPerson, utenlandskPeriodebeløp)
-                }.kombinerMedNullable(endredeUtbetalingerTidslinje) { grunnlagForPerson, endretUtbetalingAndel ->
+                }.kombinerMed(endredeUtbetalingerTidslinje) { grunnlagForPerson, endretUtbetalingAndel ->
                     lagGrunnlagMedEndretUtbetalingAndel(grunnlagForPerson, endretUtbetalingAndel)
-                }.kombinerMedNullable(overgangsstønadTidslinje) { grunnlagForPerson, overgangsstønad ->
+                }.kombinerMed(overgangsstønadTidslinje) { grunnlagForPerson, overgangsstønad ->
                     lagGrunnlagMedOvergangsstønad(grunnlagForPerson, overgangsstønad)
                 }.filtrerIkkeNull()
 
         return grunnlagTidslinje
-            .slåSammenLike()
-            .perioder()
+            .slåSammenLikePerioder()
+            .tilPerioderIkkeNull()
             .dropWhile { !it.erInnvilgetEllerEksplisittAvslag() }
             .tilTidslinje()
     }
@@ -310,7 +309,7 @@ private fun List<VilkårResultat>.filtrerVilkårErOrdinærtFor(
 fun hentOrdinæreVilkårForSøkerForskjøvetTidslinje(
     søker: Person,
     personResultater: Set<PersonResultat>,
-): Tidslinje<List<VilkårResultat>, Måned> {
+): FamilieFellesTidslinje<List<VilkårResultat>> {
     val søkerPersonResultater = personResultater.single { it.aktør == søker.aktør }
 
     val (_, vilkårResultaterUtenOverlappendeGenerelleAvslag) =
@@ -321,7 +320,7 @@ fun hentOrdinæreVilkårForSøkerForskjøvetTidslinje(
     return vilkårResultaterUtenOverlappendeGenerelleAvslag
         .tilForskjøvedeVilkårTidslinjer(søker.fødselsdato)
         .kombiner { vilkårResultater -> vilkårResultater.toList().takeIf { it.isNotEmpty() } }
-        .map { it?.toList()?.filtrerVilkårErOrdinærtFor(søker) }
+        .mapVerdi { it?.toList()?.filtrerVilkårErOrdinærtFor(søker) }
 }
 
 fun VilkårResultat.erGenereltAvslag() = periodeFom == null && periodeTom == null && erEksplisittAvslagPåSøknad == true
@@ -330,15 +329,15 @@ private fun hentErMinstEttBarnMedUtbetalingTidslinje(
     personResultater: Set<PersonResultat>,
     fagsakType: FagsakType,
     persongrunnlag: PersonopplysningGrunnlag,
-): Tidslinje<Boolean, Måned> {
+): FamilieFellesTidslinje<Boolean> {
     val søker = persongrunnlag.søker
-    val søkerSinerOrdinæreVilkårErOppfyltTidslinje =
+    val søkerSineOrdinæreVilkårErOppfyltTidslinje =
         personResultater
             .single { it.aktør == søker.aktør }
             .tilTidslinjeForSplittForPerson(
                 person = søker,
                 fagsakType = fagsakType,
-            ).map { it != null }
+            ).mapVerdi { it != null }
 
     val barnSineVilkårErOppfyltTidslinjer =
         personResultater
@@ -350,7 +349,7 @@ private fun hentErMinstEttBarnMedUtbetalingTidslinje(
                         .tilTidslinjeForSplittForPerson(
                             person = persongrunnlag.personer.single { it.aktør == personResultat.aktør },
                             fagsakType = fagsakType,
-                        ).map { it != null }
+                        ).mapVerdi { it != null }
                 } else {
                     null
                 }
@@ -358,7 +357,7 @@ private fun hentErMinstEttBarnMedUtbetalingTidslinje(
 
     return barnSineVilkårErOppfyltTidslinjer
         .map {
-            it.kombinerMed(søkerSinerOrdinæreVilkårErOppfyltTidslinje) { barnetHarAlleOrdinæreVilkårOppfylt, søkerHarAlleOrdinæreVilkårOppfylt ->
+            it.kombinerMed(søkerSineOrdinæreVilkårErOppfyltTidslinje) { barnetHarAlleOrdinæreVilkårOppfylt, søkerHarAlleOrdinæreVilkårOppfylt ->
                 barnetHarAlleOrdinæreVilkårOppfylt == true && søkerHarAlleOrdinæreVilkårOppfylt == true
             }
         }.kombiner { erOrdinæreVilkårOppfyltForSøkerOgBarn ->
@@ -368,18 +367,18 @@ private fun hentErMinstEttBarnMedUtbetalingTidslinje(
 
 private fun List<VilkårResultat>.hentForskjøvedeVilkårResultaterForPersonsAndelerTidslinje(
     person: Person,
-    erMinstEttBarnMedUtbetalingTidslinje: Tidslinje<Boolean, Måned>,
-    ordinæreVilkårForSøkerTidslinje: Tidslinje<List<VilkårResultat>, Måned>,
+    erMinstEttBarnMedUtbetalingTidslinje: FamilieFellesTidslinje<Boolean>,
+    ordinæreVilkårForSøkerTidslinje: FamilieFellesTidslinje<List<VilkårResultat>>,
     fagsakType: FagsakType,
     vilkårRolle: PersonType,
     bareSøkerOgUregistrertBarn: Boolean,
-): Tidslinje<List<VilkårResultat>, Måned> {
+): FamilieFellesTidslinje<List<VilkårResultat>> {
     val forskjøvedeVilkårResultaterForPerson = this.tilForskjøvedeVilkårTidslinjer(person.fødselsdato).kombiner()
 
     return when (vilkårRolle) {
         PersonType.SØKER ->
             forskjøvedeVilkårResultaterForPerson
-                .map { vilkårResultater ->
+                .mapVerdi { vilkårResultater ->
                     if (bareSøkerOgUregistrertBarn) {
                         vilkårResultater?.toList()?.takeIf { it.isNotEmpty() }
                     } else {
@@ -391,7 +390,7 @@ private fun List<VilkårResultat>.hentForskjøvedeVilkårResultaterForPersonsAnd
 
         PersonType.BARN ->
             if (fagsakType == FagsakType.BARN_ENSLIG_MINDREÅRIG || fagsakType == FagsakType.INSTITUSJON) {
-                forskjøvedeVilkårResultaterForPerson.map { it?.toList() }
+                forskjøvedeVilkårResultaterForPerson.mapVerdi { it?.toList() }
             } else {
                 forskjøvedeVilkårResultaterForPerson
                     .kombinerMed(ordinæreVilkårForSøkerTidslinje) { vilkårResultaterBarn, vilkårResultaterSøker ->
@@ -403,7 +402,7 @@ private fun List<VilkårResultat>.hentForskjøvedeVilkårResultaterForPersonsAnd
             if (this.isNotEmpty()) {
                 throw Feil("Ikke implementert for annenpart")
             } else {
-                emptyList<Periode<List<VilkårResultat>, Måned>>().tilTidslinje()
+                tomTidslinje()
             }
     }
 }
@@ -482,33 +481,33 @@ private fun lagGrunnlagMedOvergangsstønad(
     null -> null
 }
 
-fun List<AndelTilkjentYtelse>.tilAndelerTidslinje(skalSplittePåValutakursendringer: Boolean): Tidslinje<out Iterable<AndelForVedtaksobjekt>, Måned> =
+fun List<AndelTilkjentYtelse>.tilAndelerTidslinje(skalSplittePåValutakursendringer: Boolean): FamilieFellesTidslinje<out Iterable<AndelForVedtaksobjekt>> =
     if (skalSplittePåValutakursendringer) {
         this
             .tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType()
             .values
-            .map { tidslinje -> tidslinje.mapIkkeNull { it }.slåSammenLike() }
+            .map { tidslinje -> tidslinje.mapIkkeNull { it }.slåSammenLikePerioder() }
             .kombiner()
     } else {
         this
             .tilAndelForVedtaksperiodeTidslinjerPerAktørOgType()
             .values
-            .map { tidslinje -> tidslinje.mapIkkeNull { it }.slåSammenLike() }
+            .map { tidslinje -> tidslinje.mapIkkeNull { it }.slåSammenLikePerioder() }
             .kombiner()
     }
 
 // Vi trenger dette for å kunne begrunne nye perioder med småbarnstillegg som vi ikke hadde i forrige behandling
 fun List<InternPeriodeOvergangsstønad>.tilPeriodeOvergangsstønadForVedtaksperiodeTidslinje(
-    erUtbetalingSmåbarnstilleggTidslinje: Tidslinje<Boolean, Måned>,
+    erUtbetalingSmåbarnstilleggTidslinje: FamilieFellesTidslinje<Boolean>,
 ) = this
     .map { OvergangsstønadForVedtaksperiode(it) }
-    .map { Periode(it.fom.tilMånedTidspunkt(), it.tom.tilMånedTidspunkt(), it) }
+    .map { FamilieFellesPeriode(it, it.fom.førsteDagIInneværendeMåned(), it.tom.sisteDagIMåned()) }
     .tilTidslinje()
     .kombinerMed(erUtbetalingSmåbarnstilleggTidslinje) { overgangsstønad, erUtbetalingSmåbarnstillegg ->
         overgangsstønad.takeIf { erUtbetalingSmåbarnstillegg == true }
     }
 
-private fun Tidslinje<List<VilkårResultat>, Måned>.tilVilkårResultaterForVedtaksPeriodeTidslinje() = this.map { vilkårResultater -> vilkårResultater?.map { VilkårResultatForVedtaksperiode(it) } }
+private fun FamilieFellesTidslinje<List<VilkårResultat>>.tilVilkårResultaterForVedtaksPeriodeTidslinje() = this.mapVerdi { vilkårResultater -> vilkårResultater?.map { VilkårResultatForVedtaksperiode(it) } }
 
 @JvmName("internPeriodeOvergangsstønaderFiltrerPåAktør")
 fun List<InternPeriodeOvergangsstønad>.filtrerPåAktør(aktør: Aktør) = this.filter { it.personIdent == aktør.aktivFødselsnummer() }
@@ -528,19 +527,16 @@ fun List<UtfyltValutakurs>.filtrerPåAktør(aktør: Aktør) = this.filter { it.b
 @JvmName("utfyltUtenlandskPeriodebeløpFiltrerPåAktør")
 fun List<UtfyltUtenlandskPeriodebeløp>.filtrerPåAktør(aktør: Aktør) = this.filter { it.barnAktører.contains(aktør) }
 
-private fun Periode<VedtaksperiodeGrunnlagForPerson, Måned>.erInnvilgetEllerEksplisittAvslag(): Boolean {
-    val grunnlagForPerson = innhold ?: return false
-
-    val erInnvilget = grunnlagForPerson is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
-    val erEksplisittAvslag =
-        grunnlagForPerson.vilkårResultaterForVedtaksperiode.any { it.erEksplisittAvslagPåSøknad }
+private fun FamilieFellesPeriode<VedtaksperiodeGrunnlagForPerson>.erInnvilgetEllerEksplisittAvslag(): Boolean {
+    val erInnvilget = verdi is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
+    val erEksplisittAvslag = verdi.vilkårResultaterForVedtaksperiode.any { it.erEksplisittAvslagPåSøknad }
 
     return erInnvilget || erEksplisittAvslag
 }
 
-private fun List<AndelTilkjentYtelse>.hentErUtbetalingSmåbarnstilleggTidslinje(): Tidslinje<Boolean, Måned> = this.tilAndelerForVedtaksbegrunnelseTidslinje().hentErUtbetalingSmåbarnstilleggTidslinje()
+private fun List<AndelTilkjentYtelse>.hentErUtbetalingSmåbarnstilleggTidslinje(): FamilieFellesTidslinje<Boolean> = this.tilAndelerForVedtaksbegrunnelseTidslinje().hentErUtbetalingSmåbarnstilleggTidslinje()
 
-fun Tidslinje<Iterable<AndelForVedtaksbegrunnelse>, Måned>.hentErUtbetalingSmåbarnstilleggTidslinje() =
+fun FamilieFellesTidslinje<Iterable<AndelForVedtaksbegrunnelse>>.hentErUtbetalingSmåbarnstilleggTidslinje() =
     this.mapIkkeNull { andelerIPeriode ->
         andelerIPeriode.any {
             it.type == YtelseType.SMÅBARNSTILLEGG && it.kalkulertUtbetalingsbeløp > 0

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -24,6 +24,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.utledEndringstidspunkt
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.mapVerdi
 import no.nav.familie.tidslinje.omfatter
 import no.nav.familie.tidslinje.tilTidslinje
@@ -35,8 +37,6 @@ import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.time.LocalDate
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
-import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 fun genererVedtaksperioder(
     grunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
@@ -132,7 +132,7 @@ fun finnPerioderSomSkalBegrunnes(
     grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
     endringstidspunkt: LocalDate,
     personerFremstiltKravFor: List<Aktør>,
-): List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
+): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val gjeldendeOgForrigeGrunnlagKombinert =
         kombinerGjeldendeOgForrigeGrunnlag(
             grunnlagTidslinjePerPerson = grunnlagTidslinjePerPerson.mapValues { it.value.vedtaksperiodeGrunnlagForPerson },
@@ -155,10 +155,10 @@ fun finnPerioderSomSkalBegrunnes(
         .leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor)
 }
 
-fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.slåSammenSammenhengendeOpphørsperioder(): List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
+fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.slåSammenSammenhengendeOpphørsperioder(): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val sortertePerioder = this.sortedWith(compareBy({ it.fom }, { it.tom }))
 
-    return sortertePerioder.fold(emptyList()) { acc: List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>, dennePerioden ->
+    return sortertePerioder.fold(emptyList()) { acc: List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>, dennePerioden ->
         val forrigePeriode = acc.lastOrNull()
 
         if (forrigePeriode != null &&
@@ -172,7 +172,7 @@ fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.sl
     }
 }
 
-fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor: List<Aktør>): List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
+fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor: List<Aktør>): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val sortertePerioder = this.sortedWith(compareBy({ it.fom }, { it.tom }))
 
     val sistePeriode = sortertePerioder.lastOrNull()
@@ -187,7 +187,7 @@ fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.le
     }
 }
 
-private fun FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.erPersonMedInnvilgedeVilkårIPeriode() = verdi.any { it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget }
+private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.erPersonMedInnvilgedeVilkårIPeriode() = verdi.any { it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget }
 
 private fun Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>.lagOverlappendeGenerelleAvslagsPerioder() =
     map {
@@ -202,11 +202,11 @@ private fun Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSpl
             }.toList()
     }.tilPerioderIkkeNull()
 
-private fun Collection<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.filtrerPåEndringstidspunkt(
+private fun Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.filtrerPåEndringstidspunkt(
     endringstidspunkt: LocalDate,
 ) = this.filter { (it.tom ?: TIDENES_ENDE).isSameOrAfter(endringstidspunkt) }
 
-private fun List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>>.slåSammenUtenEksplisitteAvslag(personerFremstiltKravFor: List<Aktør>): Collection<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
+private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling>>.slåSammenUtenEksplisitteAvslag(personerFremstiltKravFor: List<Aktør>): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val kombinerteAvslagOgReduksjonsperioder =
         this.map { grunnlagForDenneOgForrigeBehandlingTidslinje ->
             grunnlagForDenneOgForrigeBehandlingTidslinje.filtrerIkkeNull {
@@ -225,7 +225,7 @@ private fun List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>
         }.tilPerioderIkkeNull()
 }
 
-private fun List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>>.utledEksplisitteAvslagsperioder(personerFremstiltKravFor: List<Aktør>): Collection<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
+private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling>>.utledEksplisitteAvslagsperioder(personerFremstiltKravFor: List<Aktør>): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val avslagsperioderPerPerson =
         this
             .map { it.filtrerErAvslagsperiode(personerFremstiltKravFor) }
@@ -240,7 +240,7 @@ private fun List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>
 
     return avslagsperioderMedSammeFomOgTom
         .map { (fomTomPar, avslagMedSammeFomOgTom) ->
-            FamilieFellesPeriode(
+            Periode(
                 verdi = avslagMedSammeFomOgTom.mapNotNull { it.verdi },
                 fom = fomTomPar.first,
                 tom = fomTomPar.second,
@@ -248,14 +248,14 @@ private fun List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>
         }
 }
 
-private fun FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.splittVilkårPerPerson(): List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>> =
+private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.splittVilkårPerPerson(): List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling>> =
     tilPerioderIkkeNull()
         .mapNotNull { it.splittOppTilVilkårPerPerson() }
         .flatten()
         .groupBy({ it.first }, { it.second })
         .map { it.value.tilTidslinje() }
 
-private fun FamilieFellesPeriode<GrunnlagForGjeldendeOgForrigeBehandling>.splittOppTilVilkårPerPerson(): List<Pair<AktørId, FamilieFellesPeriode<GrunnlagForGjeldendeOgForrigeBehandling>>>? {
+private fun Periode<GrunnlagForGjeldendeOgForrigeBehandling>.splittOppTilVilkårPerPerson(): List<Pair<AktørId, Periode<GrunnlagForGjeldendeOgForrigeBehandling>>>? {
     if (verdi.gjeldende == null) return null
 
     val vilkårPerPerson = verdi.gjeldende!!.vilkårResultaterForVedtaksperiode.groupBy { it.aktørId }
@@ -274,7 +274,7 @@ private fun FamilieFellesPeriode<GrunnlagForGjeldendeOgForrigeBehandling>.splitt
     }
 }
 
-private fun FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.filtrerErAvslagsperiode(personerFremstiltKravFor: List<Aktør>) = filtrer { it?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
+private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.filtrerErAvslagsperiode(personerFremstiltKravFor: List<Aktør>) = filtrer { it?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
 
 private fun GrunnlagForGjeldendeOgForrigeBehandling.medVilkårSomHarEksplisitteAvslag(): GrunnlagForGjeldendeOgForrigeBehandling =
     copy(
@@ -292,10 +292,10 @@ private fun GrunnlagForGjeldendeOgForrigeBehandling.medVilkårSomHarEksplisitteA
  * ikke er det.
  **/
 private fun kombinerGjeldendeOgForrigeGrunnlag(
-    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>>,
-    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>>,
+    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson>>,
+    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson>>,
     personerFremstiltKravFor: List<Aktør>,
-): List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>> =
+): List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling>> =
     grunnlagTidslinjePerPerson.map { (aktørId, grunnlagstidslinje) ->
         val grunnlagForrigeBehandling = grunnlagTidslinjePerPersonForrigeBehandling[aktørId]
 
@@ -363,11 +363,11 @@ private fun erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype(
         }
     }
 
-private fun FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.slåSammenSammenhengendeOpphørsperioder(personerFremstiltKravFor: List<Aktør>): FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling> {
+private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.slåSammenSammenhengendeOpphørsperioder(personerFremstiltKravFor: List<Aktør>): Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling> {
     val perioder = this.tilPerioderIkkeNull().sortedBy { it.fom }.toList()
 
     return perioder
-        .fold(emptyList()) { acc: List<FamilieFellesPeriode<GrunnlagForGjeldendeOgForrigeBehandling>>, periode ->
+        .fold(emptyList()) { acc: List<Periode<GrunnlagForGjeldendeOgForrigeBehandling>>, periode ->
             val sistePeriode = acc.lastOrNull()
 
             val erVilkårInnvilgetForrigePeriode = sistePeriode?.verdi?.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
@@ -387,7 +387,7 @@ private fun FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.slå
         }.tilTidslinje()
 }
 
-fun FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.tilVedtaksperiodeMedBegrunnelser(
+fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.tilVedtaksperiodeMedBegrunnelser(
     vedtak: Vedtak,
     personerFremstiltKravFor: List<Aktør>,
 ): VedtaksperiodeMedBegrunnelser =
@@ -427,7 +427,7 @@ private fun VedtaksperiodeGrunnlagForPerson.finnVilkårResultaterSomGjelderPerso
         this.vilkårResultaterForVedtaksperiode.filter { !it.erEksplisittAvslagPåSøknad }
     }
 
-private fun FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
+private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
     val erUtbetalingsperiode = this.verdi.any { it.gjeldende?.erInnvilget() == true }
     val erAvslagsperiode = this.verdi.all { it.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
 
@@ -451,7 +451,7 @@ data class GrupperingskriterierForVedtaksperioder(
     val periodeInneholderInnvilgelse: Boolean,
 )
 
-private fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.slåSammenAvslagOgReduksjonsperioderMedSammeFomOgTom() =
+private fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.slåSammenAvslagOgReduksjonsperioderMedSammeFomOgTom() =
     this
         .groupBy { periode ->
             GrupperingskriterierForVedtaksperioder(
@@ -460,7 +460,7 @@ private fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandli
                 periodeInneholderInnvilgelse = periode.verdi.any { it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget },
             )
         }.map { (grupperingskriterier, verdi) ->
-            FamilieFellesPeriode(
+            Periode(
                 verdi = verdi.map { periode -> periode.verdi }.flatten(),
                 fom = grupperingskriterier.fom,
                 tom = grupperingskriterier.tom,
@@ -484,7 +484,7 @@ fun lagPeriodeForOmregningsbehandling(
     andelTilkjentYtelser: List<AndelTilkjentYtelse>,
     nåDato: LocalDate,
 ): List<VedtaksperiodeMedBegrunnelser> {
-    val andelerTidslinje: FamilieFellesTidslinje<List<AndelForVedtaksperiode>> =
+    val andelerTidslinje: Tidslinje<List<AndelForVedtaksperiode>> =
         andelTilkjentYtelser.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType().values.kombiner { it.toList() }
 
     val nesteEndringITilkjentYtelse =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -13,9 +13,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.ZipPadding
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.filtrerIkkeNull
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.zipMedNeste
@@ -509,7 +506,3 @@ fun lagPeriodeForOmregningsbehandling(
         ),
     )
 }
-
-private fun <T> Periode<T, Måned>.periodeInneholder(
-    nåDato: LocalDate,
-) = this.fraOgMed.tilYearMonth() <= nåDato.toYearMonth() && this.tilOgMed.tilYearMonth() >= nåDato.toYearMonth()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeProdusent.kt
@@ -14,23 +14,11 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.tilAndelForVedtaksperiodeTi
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrer
-import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerMed
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Tidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilDagEllerFørsteDagIPerioden
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilLocalDateEllerNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
-import no.nav.familie.ba.sak.kjerne.tidslinje.tilTidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.ZipPadding
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.map
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.zipMedNeste
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.ZipPadding
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.filtrerIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.zipMedNeste
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
@@ -39,7 +27,19 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.utledEndringstidspunkt
+import no.nav.familie.tidslinje.mapVerdi
+import no.nav.familie.tidslinje.omfatter
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.tomTidslinje
+import no.nav.familie.tidslinje.utvidelser.filtrer
+import no.nav.familie.tidslinje.utvidelser.kombiner
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.time.LocalDate
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
+import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 fun genererVedtaksperioder(
     grunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
@@ -135,7 +135,7 @@ fun finnPerioderSomSkalBegrunnes(
     grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>,
     endringstidspunkt: LocalDate,
     personerFremstiltKravFor: List<Aktør>,
-): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
+): List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val gjeldendeOgForrigeGrunnlagKombinert =
         kombinerGjeldendeOgForrigeGrunnlag(
             grunnlagTidslinjePerPerson = grunnlagTidslinjePerPerson.mapValues { it.value.vedtaksperiodeGrunnlagForPerson },
@@ -158,44 +158,39 @@ fun finnPerioderSomSkalBegrunnes(
         .leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor)
 }
 
-fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.slåSammenSammenhengendeOpphørsperioder(): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
-    val sortertePerioder =
-        this
-            .sortedWith(compareBy({ it.fraOgMed }, { it.tilOgMed }))
+fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.slåSammenSammenhengendeOpphørsperioder(): List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
+    val sortertePerioder = this.sortedWith(compareBy({ it.fom }, { it.tom }))
 
-    return sortertePerioder.fold(emptyList()) { acc: List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>, dennePerioden ->
+    return sortertePerioder.fold(emptyList()) { acc: List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>, dennePerioden ->
         val forrigePeriode = acc.lastOrNull()
 
         if (forrigePeriode != null &&
             !forrigePeriode.erPersonMedInnvilgedeVilkårIPeriode() &&
             !dennePerioden.erPersonMedInnvilgedeVilkårIPeriode()
         ) {
-            acc.dropLast(1) + forrigePeriode.copy(tilOgMed = dennePerioden.tilOgMed)
+            acc.dropLast(1) + forrigePeriode.copy(tom = dennePerioden.tom)
         } else {
             acc + dennePerioden
         }
     }
 }
 
-fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor: List<Aktør>): List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
-    val sortertePerioder =
-        this
-            .sortedWith(compareBy({ it.fraOgMed }, { it.tilOgMed }))
+fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.leggTilUendelighetPåSisteOpphørsPeriode(personerFremstiltKravFor: List<Aktør>): List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
+    val sortertePerioder = this.sortedWith(compareBy({ it.fom }, { it.tom }))
 
     val sistePeriode = sortertePerioder.lastOrNull()
-    val sistePeriodeInneholderEksplisittAvslag =
-        sistePeriode?.innhold?.any { it.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true } == true
+    val sistePeriodeInneholderEksplisittAvslag = sistePeriode?.verdi?.any { it.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true } == true
     return if (sistePeriode != null &&
         !sistePeriode.erPersonMedInnvilgedeVilkårIPeriode() &&
         !sistePeriodeInneholderEksplisittAvslag
     ) {
-        sortertePerioder.dropLast(1) + sistePeriode.copy(tilOgMed = MånedTidspunkt.uendeligLengeTil())
+        sortertePerioder.dropLast(1) + sistePeriode.copy(tom = null)
     } else {
         sortertePerioder
     }
 }
 
-private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.erPersonMedInnvilgedeVilkårIPeriode() = innhold != null && innhold.any { it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget }
+private fun FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.erPersonMedInnvilgedeVilkårIPeriode() = verdi.any { it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget }
 
 private fun Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSplittetPåOverlappendeGenerelleAvslag>.lagOverlappendeGenerelleAvslagsPerioder() =
     map {
@@ -208,15 +203,13 @@ private fun Map<AktørOgRolleBegrunnelseGrunnlag, GrunnlagForPersonTidslinjerSpl
                     false,
                 )
             }.toList()
-    }.perioder()
+    }.tilPerioderIkkeNull()
 
-private fun Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.filtrerPåEndringstidspunkt(
+private fun Collection<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.filtrerPåEndringstidspunkt(
     endringstidspunkt: LocalDate,
-) = this.filter {
-    (it.tilOgMed.tilLocalDateEllerNull() ?: TIDENES_ENDE).isSameOrAfter(endringstidspunkt)
-}
+) = this.filter { (it.tom ?: TIDENES_ENDE).isSameOrAfter(endringstidspunkt) }
 
-private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.slåSammenUtenEksplisitteAvslag(personerFremstiltKravFor: List<Aktør>): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
+private fun List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>>.slåSammenUtenEksplisitteAvslag(personerFremstiltKravFor: List<Aktør>): Collection<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val kombinerteAvslagOgReduksjonsperioder =
         this.map { grunnlagForDenneOgForrigeBehandlingTidslinje ->
             grunnlagForDenneOgForrigeBehandlingTidslinje.filtrerIkkeNull {
@@ -232,52 +225,51 @@ private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.sl�
     return kombinerteAvslagOgReduksjonsperioder
         .kombiner { grunnlagTidslinje ->
             grunnlagTidslinje.toList().takeIf { it.isNotEmpty() }
-        }.perioder()
+        }.tilPerioderIkkeNull()
 }
 
-private fun List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>.utledEksplisitteAvslagsperioder(personerFremstiltKravFor: List<Aktør>): Collection<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>> {
+private fun List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>>.utledEksplisitteAvslagsperioder(personerFremstiltKravFor: List<Aktør>): Collection<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>> {
     val avslagsperioderPerPerson =
         this
             .map { it.filtrerErAvslagsperiode(personerFremstiltKravFor) }
-            .map { tidslinje -> tidslinje.map { it?.medVilkårSomHarEksplisitteAvslag() } }
+            .map { tidslinje -> tidslinje.mapVerdi { it?.medVilkårSomHarEksplisitteAvslag() } }
             .flatMap { it.splittVilkårPerPerson() }
-            .map { it.slåSammenLike() }
+            .map { it.slåSammenLikePerioder() }
 
     val avslagsperioderMedSammeFomOgTom =
         avslagsperioderPerPerson
-            .flatMap { it.perioder() }
-            .groupBy { Pair(it.fraOgMed, it.tilOgMed) }
+            .flatMap { it.tilPerioder() }
+            .groupBy { Pair(it.fom, it.tom) }
 
     return avslagsperioderMedSammeFomOgTom
         .map { (fomTomPar, avslagMedSammeFomOgTom) ->
-            Periode(
-                fraOgMed = fomTomPar.first,
-                tilOgMed = fomTomPar.second,
-                innhold = avslagMedSammeFomOgTom.mapNotNull { it.innhold },
+            FamilieFellesPeriode(
+                verdi = avslagMedSammeFomOgTom.mapNotNull { it.verdi },
+                fom = fomTomPar.first,
+                tom = fomTomPar.second,
             )
         }
 }
 
-private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.splittVilkårPerPerson(): List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>> =
-    perioder()
+private fun FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.splittVilkårPerPerson(): List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>> =
+    tilPerioderIkkeNull()
         .mapNotNull { it.splittOppTilVilkårPerPerson() }
         .flatten()
         .groupBy({ it.first }, { it.second })
         .map { it.value.tilTidslinje() }
 
-private fun Periode<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.splittOppTilVilkårPerPerson(): List<Pair<AktørId, Periode<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>>? {
-    if (innhold?.gjeldende == null) return null
+private fun FamilieFellesPeriode<GrunnlagForGjeldendeOgForrigeBehandling>.splittOppTilVilkårPerPerson(): List<Pair<AktørId, FamilieFellesPeriode<GrunnlagForGjeldendeOgForrigeBehandling>>>? {
+    if (verdi.gjeldende == null) return null
 
-    val vilkårPerPerson =
-        innhold.gjeldende.vilkårResultaterForVedtaksperiode.groupBy { it.aktørId }
+    val vilkårPerPerson = verdi.gjeldende!!.vilkårResultaterForVedtaksperiode.groupBy { it.aktørId }
 
     return vilkårPerPerson.map { (aktørId, vilkårresultaterForPersonIPeriode) ->
         aktørId to
             this.copy(
-                innhold =
-                    this.innhold.copy(
+                verdi =
+                    this.verdi.copy(
                         gjeldende =
-                            innhold.gjeldende.kopier(
+                            verdi.gjeldende!!.kopier(
                                 vilkårResultaterForVedtaksperiode = vilkårresultaterForPersonIPeriode,
                             ),
                     ),
@@ -285,7 +277,7 @@ private fun Periode<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.splittOppTi
     }
 }
 
-private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.filtrerErAvslagsperiode(personerFremstiltKravFor: List<Aktør>) = filtrer { it?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
+private fun FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.filtrerErAvslagsperiode(personerFremstiltKravFor: List<Aktør>) = filtrer { it?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
 
 private fun GrunnlagForGjeldendeOgForrigeBehandling.medVilkårSomHarEksplisitteAvslag(): GrunnlagForGjeldendeOgForrigeBehandling =
     copy(
@@ -303,15 +295,15 @@ private fun GrunnlagForGjeldendeOgForrigeBehandling.medVilkårSomHarEksplisitteA
  * ikke er det.
  **/
 private fun kombinerGjeldendeOgForrigeGrunnlag(
-    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned>>,
-    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, Tidslinje<VedtaksperiodeGrunnlagForPerson, Måned>>,
+    grunnlagTidslinjePerPerson: Map<AktørOgRolleBegrunnelseGrunnlag, FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>>,
+    grunnlagTidslinjePerPersonForrigeBehandling: Map<AktørOgRolleBegrunnelseGrunnlag, FamilieFellesTidslinje<VedtaksperiodeGrunnlagForPerson>>,
     personerFremstiltKravFor: List<Aktør>,
-): List<Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>> =
+): List<FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>> =
     grunnlagTidslinjePerPerson.map { (aktørId, grunnlagstidslinje) ->
         val grunnlagForrigeBehandling = grunnlagTidslinjePerPersonForrigeBehandling[aktørId]
 
         val ytelsestyperInnvilgetForrigeBehandlingTidslinje =
-            grunnlagForrigeBehandling?.map { it?.hentInnvilgedeYtelsestyper() } ?: TomTidslinje()
+            grunnlagForrigeBehandling?.mapVerdi { it?.hentInnvilgedeYtelsestyper() } ?: tomTidslinje()
 
         val grunnlagTidslinjeMedInnvilgedeYtelsestyperForrigeBehandling =
             grunnlagstidslinje.kombinerMed(ytelsestyperInnvilgetForrigeBehandlingTidslinje) { gjeldendePeriode, innvilgedeYtelsestyperForrigeBehandling ->
@@ -323,7 +315,7 @@ private fun kombinerGjeldendeOgForrigeGrunnlag(
 
         grunnlagTidslinjeMedInnvilgedeYtelsestyperForrigeBehandling
             .zipMedNeste(ZipPadding.FØR)
-            .map {
+            .mapVerdi {
                 val forrigePeriode = it?.first
                 val gjeldende = it?.second
 
@@ -374,48 +366,47 @@ private fun erReduksjonFraForrigeBehandlingPåMinstEnYtelsestype(
         }
     }
 
-private fun Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned>.slåSammenSammenhengendeOpphørsperioder(personerFremstiltKravFor: List<Aktør>): Tidslinje<GrunnlagForGjeldendeOgForrigeBehandling, Måned> {
-    val perioder = this.perioder().sortedBy { it.fraOgMed }.toList()
+private fun FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling>.slåSammenSammenhengendeOpphørsperioder(personerFremstiltKravFor: List<Aktør>): FamilieFellesTidslinje<GrunnlagForGjeldendeOgForrigeBehandling> {
+    val perioder = this.tilPerioderIkkeNull().sortedBy { it.fom }.toList()
 
     return perioder
-        .fold(emptyList()) { acc: List<Periode<GrunnlagForGjeldendeOgForrigeBehandling, Måned>>, periode ->
+        .fold(emptyList()) { acc: List<FamilieFellesPeriode<GrunnlagForGjeldendeOgForrigeBehandling>>, periode ->
             val sistePeriode = acc.lastOrNull()
 
-            val erVilkårInnvilgetForrigePeriode =
-                sistePeriode?.innhold?.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
-            val erVilkårInnvilget = periode.innhold?.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
+            val erVilkårInnvilgetForrigePeriode = sistePeriode?.verdi?.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
+            val erVilkårInnvilget = periode.verdi.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget
 
             if (sistePeriode != null &&
                 !erVilkårInnvilgetForrigePeriode &&
                 !erVilkårInnvilget &&
-                periode.innhold?.erReduksjonSidenForrigeBehandling != true &&
-                periode.innhold?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) != true &&
-                sistePeriode.innhold?.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) != true
+                periode.verdi.erReduksjonSidenForrigeBehandling != true &&
+                periode.verdi.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) != true &&
+                sistePeriode.verdi.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) != true
             ) {
-                acc.dropLast(1) + sistePeriode.copy(tilOgMed = periode.tilOgMed)
+                acc.dropLast(1) + sistePeriode.copy(tom = periode.tom)
             } else {
                 acc + periode
             }
         }.tilTidslinje()
 }
 
-fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeMedBegrunnelser(
+fun FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.tilVedtaksperiodeMedBegrunnelser(
     vedtak: Vedtak,
     personerFremstiltKravFor: List<Aktør>,
 ): VedtaksperiodeMedBegrunnelser =
     VedtaksperiodeMedBegrunnelser(
         vedtak = vedtak,
-        fom = fraOgMed.tilDagEllerFørsteDagIPerioden().tilLocalDateEllerNull(),
-        tom = tilOgMed.tilLocalDateEllerNull(),
+        fom = fom,
+        tom = tom,
         type = this.tilVedtaksperiodeType(personerFremstiltKravFor = personerFremstiltKravFor),
     ).let { vedtaksperiode ->
         val begrunnelser =
-            this.innhold
-                ?.flatMap { grunnlagForGjeldendeOgForrigeBehandling ->
+            this.verdi
+                .flatMap { grunnlagForGjeldendeOgForrigeBehandling ->
                     grunnlagForGjeldendeOgForrigeBehandling.gjeldende
                         ?.finnVilkårResultaterSomGjelderPersonIVedtaksperiode(personerFremstiltKravFor)
                         ?.flatMap { it.standardbegrunnelser } ?: emptyList()
-                }?.toSet() ?: emptyList()
+                }.toSet()
 
         vedtaksperiode.begrunnelser.addAll(
             begrunnelser
@@ -439,14 +430,13 @@ private fun VedtaksperiodeGrunnlagForPerson.finnVilkårResultaterSomGjelderPerso
         this.vilkårResultaterForVedtaksperiode.filter { !it.erEksplisittAvslagPåSøknad }
     }
 
-private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
-    val erUtbetalingsperiode =
-        this.innhold != null && this.innhold.any { it.gjeldende?.erInnvilget() == true }
-    val erAvslagsperiode = this.innhold != null && this.innhold.all { it.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
+private fun FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>.tilVedtaksperiodeType(personerFremstiltKravFor: List<Aktør>): Vedtaksperiodetype {
+    val erUtbetalingsperiode = this.verdi.any { it.gjeldende?.erInnvilget() == true }
+    val erAvslagsperiode = this.verdi.all { it.gjeldende?.erEksplisittAvslag(personerFremstiltKravFor) == true }
 
     return when {
         erUtbetalingsperiode ->
-            if (this.innhold?.any { it.erReduksjonSidenForrigeBehandling } == true) {
+            if (this.verdi.any { it.erReduksjonSidenForrigeBehandling }) {
                 Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING
             } else {
                 Vedtaksperiodetype.UTBETALING
@@ -459,24 +449,24 @@ private fun Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>.tilVe
 }
 
 data class GrupperingskriterierForVedtaksperioder(
-    val fom: Tidspunkt<Måned>,
-    val tom: Tidspunkt<Måned>,
+    val fom: LocalDate?,
+    val tom: LocalDate?,
     val periodeInneholderInnvilgelse: Boolean,
 )
 
-private fun List<Periode<List<GrunnlagForGjeldendeOgForrigeBehandling>, Måned>>.slåSammenAvslagOgReduksjonsperioderMedSammeFomOgTom() =
+private fun List<FamilieFellesPeriode<List<GrunnlagForGjeldendeOgForrigeBehandling>>>.slåSammenAvslagOgReduksjonsperioderMedSammeFomOgTom() =
     this
         .groupBy { periode ->
             GrupperingskriterierForVedtaksperioder(
-                fom = periode.fraOgMed,
-                tom = periode.tilOgMed,
-                periodeInneholderInnvilgelse = periode.innhold?.any { it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget } == true,
+                fom = periode.fom,
+                tom = periode.tom,
+                periodeInneholderInnvilgelse = periode.verdi.any { it.gjeldende is VedtaksperiodeGrunnlagForPersonVilkårInnvilget },
             )
         }.map { (grupperingskriterier, verdi) ->
-            Periode(
-                fraOgMed = grupperingskriterier.fom,
-                tilOgMed = grupperingskriterier.tom,
-                innhold = verdi.mapNotNull { periode -> periode.innhold }.flatten(),
+            FamilieFellesPeriode(
+                verdi = verdi.map { periode -> periode.verdi }.flatten(),
+                fom = grupperingskriterier.fom,
+                tom = grupperingskriterier.tom,
             )
         }
 
@@ -497,15 +487,15 @@ fun lagPeriodeForOmregningsbehandling(
     andelTilkjentYtelser: List<AndelTilkjentYtelse>,
     nåDato: LocalDate,
 ): List<VedtaksperiodeMedBegrunnelser> {
-    val andelerTidslinje: Tidslinje<List<AndelForVedtaksperiode>, Måned> =
+    val andelerTidslinje: FamilieFellesTidslinje<List<AndelForVedtaksperiode>> =
         andelTilkjentYtelser.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType().values.kombiner { it.toList() }
 
     val nesteEndringITilkjentYtelse =
         andelerTidslinje
-            .perioder()
-            .singleOrNull { it.periodeInneholder(nåDato) }
-            ?.tilOgMed
-            ?.tilYearMonth()
+            .tilPerioder()
+            .singleOrNull { it.omfatter(nåDato) }
+            ?.tom
+            ?.toYearMonth()
             ?.sisteDagIInneværendeMåned()
 
     return listOf(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -24,22 +24,6 @@ import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
 import java.time.LocalDate
 
 object VilkårsvurderingForskyvningUtils {
-    // TODO: Slett denne, bare brukt i test
-    fun Set<PersonResultat>.tilTidslinjeForSplitt(
-        personerIPersongrunnlag: List<Person>,
-        fagsakType: FagsakType,
-    ): Tidslinje<List<VilkårResultat>> {
-        val tidslinjerPerPerson =
-            this.map { personResultat ->
-                val person =
-                    personerIPersongrunnlag.find { it.aktør == personResultat.aktør }
-                        ?: throw Feil("Finner ikke person med aktørId=${personResultat.aktør.aktørId} i persongrunnlaget ved generering av tidslinje for splitt")
-                personResultat.tilTidslinjeForSplittForPerson(person = person, fagsakType = fagsakType)
-            }
-
-        return tidslinjerPerPerson.kombiner { it.flatten() }.filtrerIkkeNull().slåSammenLikePerioder()
-    }
-
     fun PersonResultat.tilTidslinjeForSplittForPerson(
         person: Person,
         fagsakType: FagsakType,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -1,29 +1,25 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.erUnder18ÅrVilkårTidslinje
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.eksperimentelt.filtrerIkkeNull
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.TomTidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombiner
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.slåSammenLike
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærEtter
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.tilMånedFraMånedsskifte
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.tilMånedFraMånedsskifteIkkeNull
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.erUnder18ÅrVilkårTidslinje
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.tilMånedFraMånedsskifte
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.tilMånedFraMånedsskifteIkkeNull
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilFamilieFellesTidslinje
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.tilTidslinje
+import no.nav.familie.tidslinje.beskjærEtter
+import no.nav.familie.tidslinje.tomTidslinje
+import no.nav.familie.tidslinje.utvidelser.filtrerIkkeNull
+import no.nav.familie.tidslinje.utvidelser.kombiner
+import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
 import java.time.LocalDate
 import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
@@ -31,7 +27,7 @@ object VilkårsvurderingForskyvningUtils {
     fun Set<PersonResultat>.tilTidslinjeForSplitt(
         personerIPersongrunnlag: List<Person>,
         fagsakType: FagsakType,
-    ): Tidslinje<List<VilkårResultat>, Måned> {
+    ): FamilieFellesTidslinje<List<VilkårResultat>> {
         val tidslinjerPerPerson =
             this.map { personResultat ->
                 val person =
@@ -40,13 +36,13 @@ object VilkårsvurderingForskyvningUtils {
                 personResultat.tilTidslinjeForSplittForPerson(person = person, fagsakType = fagsakType)
             }
 
-        return tidslinjerPerPerson.kombiner { it.filterNotNull().flatten() }.filtrerIkkeNull().slåSammenLike()
+        return tidslinjerPerPerson.kombiner { it.flatten() }.filtrerIkkeNull().slåSammenLikePerioder()
     }
 
     fun PersonResultat.tilTidslinjeForSplittForPerson(
         person: Person,
         fagsakType: FagsakType,
-    ): Tidslinje<List<VilkårResultat>, Måned> {
+    ): FamilieFellesTidslinje<List<VilkårResultat>> {
         val tidslinjer = this.vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(person.fødselsdato)
 
         return tidslinjer
@@ -57,19 +53,19 @@ object VilkårsvurderingForskyvningUtils {
                     fagsakType = fagsakType,
                 )
             }.filtrerIkkeNull()
-            .slåSammenLike()
+            .slåSammenLikePerioder()
     }
 
     /**
      * Extention-funksjon som tar inn et sett med vilkårResultater og returnerer en forskjøvet måned-basert tidslinje for hvert vilkår
      * Se readme-fil for utdypende forklaring av logikken for hvert vilkår
      * */
-    fun Collection<VilkårResultat>.tilForskjøvetTidslinjerForHvertOppfylteVilkår(fødselsdato: LocalDate): List<Tidslinje<VilkårResultat, Måned>> =
+    fun Collection<VilkårResultat>.tilForskjøvetTidslinjerForHvertOppfylteVilkår(fødselsdato: LocalDate): List<FamilieFellesTidslinje<VilkårResultat>> =
         this.groupBy { it.vilkårType }.map { (vilkår, vilkårResultater) ->
             vilkårResultater.tilForskjøvetTidslinjeForOppfyltVilkår(vilkår, fødselsdato)
         }
 
-    fun Collection<VilkårResultat>.tilForskjøvedeVilkårTidslinjer(fødselsdato: LocalDate): List<Tidslinje<VilkårResultat, Måned>> =
+    fun Collection<VilkårResultat>.tilForskjøvedeVilkårTidslinjer(fødselsdato: LocalDate): List<FamilieFellesTidslinje<VilkårResultat>> =
         this.groupBy { it.vilkårType }.map { (vilkår, vilkårResultater) ->
             vilkårResultater.tilForskjøvetTidslinje(vilkår, fødselsdato)
         }
@@ -77,8 +73,8 @@ object VilkårsvurderingForskyvningUtils {
     fun Collection<VilkårResultat>.tilForskjøvetTidslinjeForOppfyltVilkår(
         vilkår: Vilkår,
         fødselsdato: LocalDate?,
-    ): Tidslinje<VilkårResultat, Måned> {
-        if (this.isEmpty()) return TomTidslinje()
+    ): FamilieFellesTidslinje<VilkårResultat> {
+        if (this.isEmpty()) return tomTidslinje()
 
         val tidslinje = this.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår)
 
@@ -88,13 +84,13 @@ object VilkårsvurderingForskyvningUtils {
     fun Collection<VilkårResultat>.tilForskjøvetTidslinjeForOppfyltVilkårForVoksenPerson(vilkår: Vilkår): FamilieFellesTidslinje<VilkårResultat> {
         if (vilkår == Vilkår.UNDER_18_ÅR) throw Feil("Funksjonen skal ikke brukes for under 18 vilkåret")
 
-        return this.lagForskjøvetFamilieFellesTidslinjeForOppfylteVilkår(vilkår)
+        return this.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår)
     }
 
-    fun Collection<VilkårResultat>.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår: Vilkår): Tidslinje<VilkårResultat, Måned> =
+    fun Collection<VilkårResultat>.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår: Vilkår): FamilieFellesTidslinje<VilkårResultat> =
         this
             .filter { it.vilkårType == vilkår && it.erOppfylt() }
-            .tilTidslinje()
+            .tilFamilieFellesTidslinje()
             .tilMånedFraMånedsskifteIkkeNull { innholdSisteDagForrigeMåned, innholdFørsteDagDenneMåned ->
                 when {
                     !innholdSisteDagForrigeMåned.erOppfylt() || !innholdFørsteDagDenneMåned.erOppfylt() -> null
@@ -118,16 +114,16 @@ object VilkårsvurderingForskyvningUtils {
     fun Collection<VilkårResultat>.tilForskjøvetTidslinje(
         vilkår: Vilkår,
         fødselsdato: LocalDate,
-    ): Tidslinje<VilkårResultat, Måned> {
+    ): FamilieFellesTidslinje<VilkårResultat> {
         val tidslinje = this.lagForskjøvetTidslinje(vilkår)
 
         return tidslinje.beskjærPå18ÅrHvisUnder18ÅrVilkår(vilkår = vilkår, fødselsdato = fødselsdato)
     }
 
-    private fun Collection<VilkårResultat>.lagForskjøvetTidslinje(vilkår: Vilkår): Tidslinje<VilkårResultat, Måned> =
+    private fun Collection<VilkårResultat>.lagForskjøvetTidslinje(vilkår: Vilkår): FamilieFellesTidslinje<VilkårResultat> =
         this
             .filter { it.vilkårType == vilkår }
-            .tilTidslinje()
+            .tilFamilieFellesTidslinje()
             .tilMånedFraMånedsskifte { innholdSisteDagForrigeMåned, innholdFørsteDagDenneMåned ->
                 if (innholdFørsteDagDenneMåned != null && innholdSisteDagForrigeMåned != null) {
                     when {
@@ -136,8 +132,7 @@ object VilkårsvurderingForskyvningUtils {
                         innholdSisteDagForrigeMåned.erEksplisittAvslagPåSøknad == true && innholdFørsteDagDenneMåned.erOppfylt() -> null
                         else -> innholdFørsteDagDenneMåned
                     }
-                } else if (innholdFørsteDagDenneMåned == null && innholdSisteDagForrigeMåned.erEksplisittAvslagInnenforSammeMåned()
-                ) {
+                } else if (innholdFørsteDagDenneMåned == null && innholdSisteDagForrigeMåned.erEksplisittAvslagInnenforSammeMåned()) {
                     innholdSisteDagForrigeMåned
                 } else {
                     null
@@ -149,17 +144,17 @@ object VilkårsvurderingForskyvningUtils {
             this.periodeFom != null &&
             this.periodeFom!!.toYearMonth() == this.periodeTom?.toYearMonth()
 
-    private fun Tidslinje<VilkårResultat, Måned>.beskjærPå18ÅrHvisUnder18ÅrVilkår(
+    private fun FamilieFellesTidslinje<VilkårResultat>.beskjærPå18ÅrHvisUnder18ÅrVilkår(
         vilkår: Vilkår,
         fødselsdato: LocalDate?,
-    ): Tidslinje<VilkårResultat, Måned> =
+    ): FamilieFellesTidslinje<VilkårResultat> =
         if (vilkår == Vilkår.UNDER_18_ÅR) {
             this.beskjærPå18År(fødselsdato = fødselsdato ?: throw Feil("Mangler fødselsdato, men prøver å beskjære på 18-år vilkåret"))
         } else {
             this
         }
 
-    internal fun Tidslinje<VilkårResultat, Måned>.beskjærPå18År(fødselsdato: LocalDate): Tidslinje<VilkårResultat, Måned> {
+    internal fun FamilieFellesTidslinje<VilkårResultat>.beskjærPå18År(fødselsdato: LocalDate): FamilieFellesTidslinje<VilkårResultat> {
         val erUnder18Tidslinje = erUnder18ÅrVilkårTidslinje(fødselsdato)
         return this.beskjærEtter(erUnder18Tidslinje)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtils.kt
@@ -24,6 +24,7 @@ import java.time.LocalDate
 import no.nav.familie.tidslinje.Tidslinje as FamilieFellesTidslinje
 
 object VilkårsvurderingForskyvningUtils {
+    // TODO: Slett denne, bare brukt i test
     fun Set<PersonResultat>.tilTidslinjeForSplitt(
         personerIPersongrunnlag: List<Person>,
         fagsakType: FagsakType,
@@ -88,18 +89,6 @@ object VilkårsvurderingForskyvningUtils {
     }
 
     fun Collection<VilkårResultat>.lagForskjøvetTidslinjeForOppfylteVilkår(vilkår: Vilkår): FamilieFellesTidslinje<VilkårResultat> =
-        this
-            .filter { it.vilkårType == vilkår && it.erOppfylt() }
-            .tilFamilieFellesTidslinje()
-            .tilMånedFraMånedsskifteIkkeNull { innholdSisteDagForrigeMåned, innholdFørsteDagDenneMåned ->
-                when {
-                    !innholdSisteDagForrigeMåned.erOppfylt() || !innholdFørsteDagDenneMåned.erOppfylt() -> null
-                    vilkår == Vilkår.BOR_MED_SØKER && innholdFørsteDagDenneMåned.erDeltBosted() -> innholdSisteDagForrigeMåned
-                    else -> innholdFørsteDagDenneMåned
-                }
-            }
-
-    fun Collection<VilkårResultat>.lagForskjøvetFamilieFellesTidslinjeForOppfylteVilkår(vilkår: Vilkår): FamilieFellesTidslinje<VilkårResultat> =
         this
             .filter { it.vilkårType == vilkår && it.erOppfylt() }
             .tilFamilieFellesTidslinje()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatTidslinje.kt
@@ -1,27 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene
 
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Dag
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.DagTidspunkt.Companion.tilTidspunktEllerUendeligSent
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.DagTidspunkt.Companion.tilTidspunktEllerUendeligTidlig
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
-
-class VilkårResultatTidslinje(
-    private val vilkårResultater: Collection<VilkårResultat>,
-) : Tidslinje<VilkårResultat, Dag>() {
-    override fun lagPerioder(): List<Periode<VilkårResultat, Dag>> =
-        vilkårResultater.map {
-            Periode(
-                fraOgMed = it.periodeFom.tilTidspunktEllerUendeligTidlig(it.periodeTom),
-                tilOgMed = it.periodeTom.tilTidspunktEllerUendeligSent(it.periodeFom),
-                innhold = it,
-            )
-        }
-}
-
-fun List<VilkårResultat>.tilTidslinje() = VilkårResultatTidslinje(this)
 
 fun Collection<VilkårResultat>.tilFamilieFellesTidslinje() =
     this

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatTidslinje.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene
 
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
-fun Collection<VilkårResultat>.tilFamilieFellesTidslinje() =
+fun Collection<VilkårResultat>.tilTidslinje() =
     this
         .map {
-            FamilieFellesPeriode(
+            Periode(
                 verdi = it,
                 fom = it.periodeFom,
                 tom = it.periodeTom,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtilTest.kt
@@ -13,19 +13,18 @@ import no.nav.familie.ba.sak.kjerne.beregning.OrdinærBarnetrygdUtil.mapTilProse
 import no.nav.familie.ba.sak.kjerne.beregning.OrdinærBarnetrygdUtil.tilTidslinjeMedRettTilProsentForPerson
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.gjelderAlltidFraBarnetsFødselsdato
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 class OrdinærBarnetrygdUtilTest {
     @Test
@@ -98,7 +97,7 @@ class OrdinærBarnetrygdUtilTest {
                 fagsakType = FagsakType.NORMAL,
             )
 
-        val perioder = tidslinje.perioder().toList()
+        val perioder = tidslinje.tilPerioderIkkeNull().toList()
 
         assertEquals(3, perioder.size)
 
@@ -238,10 +237,10 @@ class OrdinærBarnetrygdUtilTest {
         forventetFom: YearMonth,
         forventetTom: YearMonth,
         forventetProsent: BigDecimal,
-        faktisk: Periode<BigDecimal, Måned>,
+        faktisk: FamilieFellesPeriode<BigDecimal>,
     ) {
-        assertEquals(forventetFom, faktisk.fraOgMed.tilYearMonth())
-        assertEquals(forventetTom, faktisk.tilOgMed.tilYearMonth())
-        assertEquals(forventetProsent, faktisk.innhold)
+        assertEquals(forventetFom, faktisk.fom?.toYearMonth())
+        assertEquals(forventetTom, faktisk.tom?.toYearMonth())
+        assertEquals(forventetProsent, faktisk.verdi)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtilTest.kt
@@ -18,13 +18,13 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvu
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.gjelderAlltidFraBarnetsFødselsdato
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
-import no.nav.familie.tidslinje.Periode as FamilieFellesPeriode
 
 class OrdinærBarnetrygdUtilTest {
     @Test
@@ -237,7 +237,7 @@ class OrdinærBarnetrygdUtilTest {
         forventetFom: YearMonth,
         forventetTom: YearMonth,
         forventetProsent: BigDecimal,
-        faktisk: FamilieFellesPeriode<BigDecimal>,
+        faktisk: Periode<BigDecimal>,
     ) {
         assertEquals(forventetFom, faktisk.fom?.toYearMonth())
         assertEquals(forventetTom, faktisk.tom?.toYearMonth())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
@@ -1,10 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.beregning
 
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.årMnd
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonthEllerNull
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -15,7 +16,7 @@ class SatsServiceTest {
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2017, 4, 6))
 
         val ordinærTidslinje = lagOrdinærTidslinje(barn)
-        val ordinærePerioder = ordinærTidslinje.perioder().toList()
+        val ordinærePerioder = ordinærTidslinje.tilPerioderIkkeNull().toList()
 
         Assertions.assertEquals(10, ordinærePerioder.size)
 
@@ -33,17 +34,17 @@ class SatsServiceTest {
 
     private fun assertPeriode(
         forventet: TestKrPeriode,
-        faktisk: no.nav.familie.ba.sak.kjerne.tidslinje.Periode<Int, Måned>,
+        faktisk: Periode<Int>,
     ) {
-        Assertions.assertEquals(forventet.beløp, faktisk.innhold, "Forskjell i beløp")
+        Assertions.assertEquals(forventet.beløp, faktisk.verdi, "Forskjell i beløp")
         Assertions.assertEquals(
             forventet.fom?.let { årMnd(it) },
-            faktisk.fraOgMed.tilYearMonthEllerNull(),
+            faktisk.fom?.toYearMonth(),
             "Forskjell i fra-og-med",
         )
         Assertions.assertEquals(
             forventet.tom?.let { årMnd(it) },
-            faktisk.tilOgMed.tilYearMonthEllerNull(),
+            faktisk.tom?.toYearMonth(),
             "Forskjell i til-og-med",
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
@@ -2,17 +2,10 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
-import no.nav.familie.ba.sak.common.isSameOrBefore
-import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
-import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
-import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagVilkårResultat
-import no.nav.familie.ba.sak.datagenerator.lagVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.nov
@@ -20,7 +13,6 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvni
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinje
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinjeForOppfyltVilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinjerForHvertOppfylteVilkår
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilTidslinjeForSplitt
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -34,7 +26,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.Month
-import java.time.YearMonth
 
 class VilkårsvurderingForskyvningUtilsTest {
     @Test
@@ -444,140 +435,6 @@ class VilkårsvurderingForskyvningUtilsTest {
                 .sisteDagIMåned(),
             under18PerioderEtterBeskjæring.first().tom,
         )
-    }
-
-    @Test
-    fun `Skal lage korrekt tidslinje for splitting av vedtaksperioder`() {
-        val februar2020 = YearMonth.of(2020, 2)
-        val oktober2020 = YearMonth.of(2020, 10)
-        val mars2021 = YearMonth.of(2021, 3)
-        val desember2021 = YearMonth.of(2021, 12)
-        val mai2022 = YearMonth.of(2022, 5)
-
-        val søker = lagPerson(type = PersonType.SØKER)
-        val barn1 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2015, 5, 6))
-        val barn2 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 9, 7))
-
-        val vilkårsvurdering =
-            lagVilkårsvurdering(
-                søkerAktør = søker.aktør,
-                behandling = lagBehandling(),
-                resultat = Resultat.OPPFYLT,
-            )
-
-        val personResultatSøker =
-            PersonResultat(
-                vilkårsvurdering = vilkårsvurdering,
-                aktør = søker.aktør,
-            )
-
-        personResultatSøker.setSortedVilkårResultater(
-            lagVilkårForPerson(
-                personResultat = personResultatSøker,
-                fom = februar2020.førsteDagIInneværendeMåned(),
-                tom = null,
-                generiskeVilkår = listOf(Vilkår.LOVLIG_OPPHOLD, Vilkår.BOSATT_I_RIKET),
-            ),
-        )
-
-        val personResultatBarn1 =
-            PersonResultat(
-                vilkårsvurdering = vilkårsvurdering,
-                aktør = barn1.aktør,
-            )
-
-        personResultatBarn1.setSortedVilkårResultater(
-            lagVilkårForPerson(
-                fom = oktober2020.førsteDagIInneværendeMåned(),
-                tom = null,
-                maksTom = barn1.fødselsdato.til18ÅrsVilkårsdato(),
-                spesielleVilkår =
-                    setOf(
-                        lagVilkårResultat(
-                            periodeFom = oktober2020.førsteDagIInneværendeMåned(),
-                            periodeTom = desember2021.sisteDagIInneværendeMåned(),
-                            vilkårType = Vilkår.BOR_MED_SØKER,
-                            resultat = Resultat.OPPFYLT,
-                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.DELT_BOSTED),
-                        ),
-                        lagVilkårResultat(
-                            periodeFom = desember2021.plusMonths(1).førsteDagIInneværendeMåned(),
-                            periodeTom = null,
-                            vilkårType = Vilkår.BOR_MED_SØKER,
-                            resultat = Resultat.OPPFYLT,
-                        ),
-                    ),
-            ),
-        )
-
-        val personResultatBarn2 =
-            PersonResultat(
-                vilkårsvurdering = vilkårsvurdering,
-                aktør = barn2.aktør,
-            )
-
-        personResultatBarn2.setSortedVilkårResultater(
-            lagVilkårForPerson(
-                fom = oktober2020.førsteDagIInneværendeMåned(),
-                tom = null,
-                maksTom = barn1.fødselsdato.til18ÅrsVilkårsdato(),
-                generiskeVilkår =
-                    listOf(
-                        Vilkår.BOSATT_I_RIKET,
-                        Vilkår.BOR_MED_SØKER,
-                        Vilkår.UNDER_18_ÅR,
-                        Vilkår.GIFT_PARTNERSKAP,
-                    ),
-                spesielleVilkår =
-                    setOf(
-                        lagVilkårResultat(
-                            periodeFom = mars2021.førsteDagIInneværendeMåned(),
-                            periodeTom = mai2022.sisteDagIInneværendeMåned(),
-                            vilkårType = Vilkår.LOVLIG_OPPHOLD,
-                            resultat = Resultat.OPPFYLT,
-                        ),
-                        lagVilkårResultat(
-                            periodeFom = mai2022.plusMonths(1).førsteDagIInneværendeMåned(),
-                            periodeTom = null,
-                            vilkårType = Vilkår.LOVLIG_OPPHOLD,
-                            resultat = Resultat.OPPFYLT,
-                        ),
-                    ),
-            ),
-        )
-
-        val personResultater = setOf(personResultatSøker, personResultatBarn1, personResultatBarn2)
-
-        val tidslinje =
-            personResultater.tilTidslinjeForSplitt(
-                personerIPersongrunnlag = listOf(søker, barn1, barn2),
-                fagsakType = FagsakType.NORMAL,
-            )
-
-        val perioder = tidslinje.tilPerioder()
-
-        val perioderRelevantForTesting = perioder.filter { it.fom!!.toYearMonth().isSameOrBefore(mai2022) }
-
-        assertEquals(4, perioderRelevantForTesting.size)
-
-        val periode1 = perioderRelevantForTesting[0]
-        val periode2 = perioderRelevantForTesting[1]
-        val periode3 = perioderRelevantForTesting[2]
-        val periode4 = perioderRelevantForTesting[3]
-
-        assertPeriode(periode = periode1, forventetFom = februar2020.plusMonths(1), forventetTom = oktober2020)
-        assertPeriode(periode = periode2, forventetFom = oktober2020.plusMonths(1), forventetTom = mars2021)
-        assertPeriode(periode = periode3, forventetFom = mars2021.plusMonths(1), forventetTom = desember2021)
-        assertPeriode(periode = periode4, forventetFom = desember2021.plusMonths(1), forventetTom = mai2022)
-    }
-
-    private fun assertPeriode(
-        periode: Periode<List<VilkårResultat>?>,
-        forventetFom: YearMonth,
-        forventetTom: YearMonth,
-    ) {
-        assertEquals(forventetFom.førsteDagIInneværendeMåned(), periode.fom)
-        assertEquals(forventetTom.sisteDagIInneværendeMåned(), periode.tom)
     }
 
     private fun lagVilkårForPerson(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
@@ -13,14 +14,8 @@ import no.nav.familie.ba.sak.datagenerator.lagVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.tidslinje.Periode
-import no.nav.familie.ba.sak.kjerne.tidslinje.Tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidslinje
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.Måned
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.MånedTidspunkt.Companion.tilMånedTidspunkt
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.neste
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonth
-import no.nav.familie.ba.sak.kjerne.tidslinje.tidspunkt.tilYearMonthEllerNull
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.feb
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.nov
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.beskjærPå18År
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinje
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvetTidslinjeForOppfyltVilkår
@@ -30,7 +25,12 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import org.junit.jupiter.api.Assertions
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.Month
@@ -68,26 +68,26 @@ class VilkårsvurderingForskyvningUtilsTest {
 
         val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
-        Assertions.assertEquals(5, tidslinjer.size)
+        assertEquals(5, tidslinjer.size)
 
         val borMedSøkerTidslinje = tidslinjer.first()
-        val borMedSøkerPerioder = borMedSøkerTidslinje.perioder()
+        val borMedSøkerPerioder = borMedSøkerTidslinje.tilPerioder()
 
-        Assertions.assertEquals(2, borMedSøkerPerioder.size)
+        assertEquals(2, borMedSøkerPerioder.size)
 
         val deltBostedPeriode = borMedSøkerPerioder.first()
         val fullPeriode = borMedSøkerPerioder.last()
 
-        Assertions.assertEquals(fom.plusMonths(1).toYearMonth(), deltBostedPeriode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(deltBostedTom.toYearMonth(), deltBostedPeriode.tilOgMed.tilYearMonth())
-        Assertions.assertEquals(deltBostedTom.plusMonths(1).toYearMonth(), fullPeriode.fraOgMed.tilYearMonth())
-        Assertions.assertNull(fullPeriode.tilOgMed.tilYearMonthEllerNull())
+        assertEquals(fom.plusMonths(1), deltBostedPeriode.fom)
+        assertEquals(deltBostedTom.sisteDagIMåned(), deltBostedPeriode.tom)
+        assertEquals(deltBostedTom.førsteDagINesteMåned(), fullPeriode.fom)
+        assertNull(fullPeriode.tom)
 
         tidslinjer.subList(1, tidslinjer.size).forEach {
-            Assertions.assertEquals(1, it.perioder().size)
-            val periode = it.perioder().first()
-            Assertions.assertEquals(fom.plusMonths(1).toYearMonth(), periode.fraOgMed.tilYearMonth())
-            Assertions.assertNull(fullPeriode.tilOgMed.tilYearMonthEllerNull())
+            assertEquals(1, it.tilPerioder().size)
+            val periode = it.tilPerioder().first()
+            assertEquals(fom.plusMonths(1), periode.fom)
+            assertNull(fullPeriode.tom)
         }
     }
 
@@ -122,26 +122,26 @@ class VilkårsvurderingForskyvningUtilsTest {
 
         val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
-        Assertions.assertEquals(5, tidslinjer.size)
+        assertEquals(5, tidslinjer.size)
 
         val borMedSøkerTidslinje = tidslinjer.first()
-        val borMedSøkerPerioder = borMedSøkerTidslinje.perioder()
+        val borMedSøkerPerioder = borMedSøkerTidslinje.tilPerioder()
 
-        Assertions.assertEquals(2, borMedSøkerPerioder.size)
+        assertEquals(2, borMedSøkerPerioder.size)
 
         val deltBostedPeriode = borMedSøkerPerioder.first()
         val fullPeriode = borMedSøkerPerioder.last()
 
-        Assertions.assertEquals(fom.plusMonths(1).toYearMonth(), deltBostedPeriode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(deltBostedTom.plusMonths(1).toYearMonth(), deltBostedPeriode.tilOgMed.tilYearMonth())
-        Assertions.assertEquals(deltBostedTom.plusMonths(2).toYearMonth(), fullPeriode.fraOgMed.tilYearMonth())
-        Assertions.assertNull(fullPeriode.tilOgMed.tilYearMonthEllerNull())
+        assertEquals(fom.plusMonths(1), deltBostedPeriode.fom)
+        assertEquals(deltBostedTom.plusMonths(1), deltBostedPeriode.tom)
+        assertEquals(deltBostedTom.plusMonths(2).førsteDagIInneværendeMåned(), fullPeriode.fom)
+        assertNull(fullPeriode.tom)
 
         tidslinjer.subList(1, tidslinjer.size).forEach {
-            Assertions.assertEquals(1, it.perioder().size)
-            val periode = it.perioder().first()
-            Assertions.assertEquals(fom.plusMonths(1).toYearMonth(), periode.fraOgMed.tilYearMonth())
-            Assertions.assertNull(fullPeriode.tilOgMed.tilYearMonthEllerNull())
+            assertEquals(1, it.tilPerioder().size)
+            val periode = it.tilPerioder().first()
+            assertEquals(fom.plusMonths(1), periode.fom)
+            assertNull(fullPeriode.tom)
         }
     }
 
@@ -175,26 +175,26 @@ class VilkårsvurderingForskyvningUtilsTest {
 
         val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
-        Assertions.assertEquals(5, tidslinjer.size)
+        assertEquals(5, tidslinjer.size)
 
         val borMedSøkerTidslinje = tidslinjer.first()
-        val borMedSøkerPerioder = borMedSøkerTidslinje.perioder()
+        val borMedSøkerPerioder = borMedSøkerTidslinje.tilPerioder()
 
-        Assertions.assertEquals(2, borMedSøkerPerioder.size)
+        assertEquals(2, borMedSøkerPerioder.size)
 
         val førstePeriode = borMedSøkerPerioder.first()
         val andrePeriode = borMedSøkerPerioder.last()
 
-        Assertions.assertEquals(fom.plusMonths(1).toYearMonth(), førstePeriode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(b2bTom.toYearMonth(), førstePeriode.tilOgMed.tilYearMonth())
-        Assertions.assertEquals(b2bTom.plusMonths(1).toYearMonth(), andrePeriode.fraOgMed.tilYearMonth())
-        Assertions.assertNull(andrePeriode.tilOgMed.tilYearMonthEllerNull())
+        assertEquals(fom.plusMonths(1), førstePeriode.fom)
+        assertEquals(b2bTom.sisteDagIMåned(), førstePeriode.tom)
+        assertEquals(b2bTom.førsteDagINesteMåned(), andrePeriode.fom)
+        assertNull(andrePeriode.tom)
 
         tidslinjer.subList(1, tidslinjer.size).forEach {
-            Assertions.assertEquals(1, it.perioder().size)
-            val periode = it.perioder().first()
-            Assertions.assertEquals(fom.plusMonths(1).toYearMonth(), periode.fraOgMed.tilYearMonth())
-            Assertions.assertNull(andrePeriode.tilOgMed.tilYearMonthEllerNull())
+            assertEquals(1, it.tilPerioder().size)
+            val periode = it.tilPerioder().first()
+            assertEquals(fom.plusMonths(1), periode.fom)
+            assertNull(andrePeriode.tom)
         }
     }
 
@@ -215,19 +215,19 @@ class VilkårsvurderingForskyvningUtilsTest {
         val forskjøvetTidslinje =
             under18VilkårResultat.tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = Vilkår.UNDER_18_ÅR, barn.fødselsdato)
 
-        val forskjøvedePerioder = forskjøvetTidslinje.perioder()
+        val forskjøvedePerioder = forskjøvetTidslinje.tilPerioder()
 
-        Assertions.assertEquals(1, forskjøvedePerioder.size)
+        assertEquals(1, forskjøvedePerioder.size)
 
         val forskjøvetPeriode = forskjøvedePerioder.single()
 
-        Assertions.assertEquals(barn.fødselsdato.plusMonths(1).toYearMonth(), forskjøvetPeriode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(
+        assertEquals(barn.fødselsdato.plusMonths(1), forskjøvetPeriode.fom)
+        assertEquals(
             barn.fødselsdato
                 .plusYears(18)
                 .minusMonths(1)
-                .toYearMonth(),
-            forskjøvetPeriode.tilOgMed.tilYearMonth(),
+                .sisteDagIMåned(),
+            forskjøvetPeriode.tom,
         )
     }
 
@@ -250,14 +250,14 @@ class VilkårsvurderingForskyvningUtilsTest {
         val forskjøvetTidslinje =
             under18VilkårResultat.tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = Vilkår.UNDER_18_ÅR, barn.fødselsdato)
 
-        val forskjøvedePerioder = forskjøvetTidslinje.perioder()
+        val forskjøvedePerioder = forskjøvetTidslinje.tilPerioder()
 
-        Assertions.assertEquals(1, forskjøvedePerioder.size)
+        assertEquals(1, forskjøvedePerioder.size)
 
         val forskjøvetPeriode = forskjøvedePerioder.single()
 
-        Assertions.assertEquals(barn.fødselsdato.plusMonths(1).toYearMonth(), forskjøvetPeriode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(tomDato.toYearMonth(), forskjøvetPeriode.tilOgMed.tilYearMonth())
+        assertEquals(barn.fødselsdato.plusMonths(1), forskjøvetPeriode.fom)
+        assertEquals(tomDato.sisteDagIMåned(), forskjøvetPeriode.tom)
     }
 
     @Test
@@ -269,16 +269,16 @@ class VilkårsvurderingForskyvningUtilsTest {
                 .tilForskjøvetTidslinjeForOppfyltVilkår(
                     vilkår = Vilkår.UNDER_18_ÅR,
                     fødselsdato = barn.fødselsdato,
-                ).perioder()
-        Assertions.assertEquals(forskjøvedeOppfylteVilkårTomListe.size, 0)
+                ).tilPerioder()
+        assertEquals(forskjøvedeOppfylteVilkårTomListe.size, 0)
 
         val forskjøvedeVilkårTomListe =
             emptyList<VilkårResultat>()
                 .tilForskjøvetTidslinje(
                     vilkår = Vilkår.UNDER_18_ÅR,
                     fødselsdato = barn.fødselsdato,
-                ).perioder()
-        Assertions.assertEquals(forskjøvedeVilkårTomListe.size, 0)
+                ).tilPerioder()
+        assertEquals(forskjøvedeVilkårTomListe.size, 0)
     }
 
     @Test
@@ -301,13 +301,13 @@ class VilkårsvurderingForskyvningUtilsTest {
                 .tilForskjøvetTidslinje(
                     vilkår = Vilkår.BOSATT_I_RIKET,
                     fødselsdato = barn.fødselsdato,
-                ).perioder()
+                ).tilPerioderIkkeNull()
 
-        Assertions.assertEquals(1, forskjøvedeVilkår.size)
+        assertEquals(1, forskjøvedeVilkår.size)
 
         val periode = forskjøvedeVilkår.single()
-        Assertions.assertEquals(YearMonth.of(2023, 2), periode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(YearMonth.of(2023, 2), periode.tilOgMed.tilYearMonth())
+        assertEquals(1.feb(2023), periode.fom)
+        assertEquals(28.feb(2023), periode.tom)
     }
 
     @Test
@@ -336,13 +336,13 @@ class VilkårsvurderingForskyvningUtilsTest {
                 .tilForskjøvetTidslinje(
                     vilkår = Vilkår.BOSATT_I_RIKET,
                     fødselsdato = barn.fødselsdato,
-                ).perioder()
+                ).tilPerioderIkkeNull()
 
-        Assertions.assertEquals(2, forskjøvedeVilkår.size)
+        assertEquals(2, forskjøvedeVilkår.size)
 
-        val periode = forskjøvedeVilkår.single { it.innhold?.erEksplisittAvslagPåSøknad == true }
-        Assertions.assertEquals(YearMonth.of(2023, 2), periode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(YearMonth.of(2023, 2), periode.tilOgMed.tilYearMonth())
+        val periode = forskjøvedeVilkår.single { it.verdi.erEksplisittAvslagPåSøknad == true }
+        assertEquals(1.feb(2023), periode.fom)
+        assertEquals(28.feb(2023), periode.tom)
     }
 
     @Test
@@ -365,12 +365,12 @@ class VilkårsvurderingForskyvningUtilsTest {
                 .tilForskjøvetTidslinje(
                     vilkår = Vilkår.BOSATT_I_RIKET,
                     fødselsdato = barn.fødselsdato,
-                ).perioder()
+                ).tilPerioderIkkeNull()
 
-        Assertions.assertEquals(1, forskjøvedeVilkår.size)
+        assertEquals(1, forskjøvedeVilkår.size)
         val periode = forskjøvedeVilkår.single()
-        Assertions.assertEquals(YearMonth.of(2023, 2), periode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(YearMonth.of(2023, 2), periode.tilOgMed.tilYearMonth())
+        assertEquals(1.feb(2023), periode.fom)
+        assertEquals(28.feb(2023), periode.tom)
     }
 
     @Test
@@ -392,9 +392,9 @@ class VilkårsvurderingForskyvningUtilsTest {
                 .tilForskjøvetTidslinje(
                     vilkår = Vilkår.BOSATT_I_RIKET,
                     fødselsdato = barn.fødselsdato,
-                ).perioder()
+                ).tilPerioderIkkeNull()
 
-        Assertions.assertEquals(0, forskjøvedeVilkår.size)
+        assertEquals(0, forskjøvedeVilkår.size)
     }
 
     @Test
@@ -402,53 +402,47 @@ class VilkårsvurderingForskyvningUtilsTest {
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val under18VilkårResultat =
-            listOf(
-                lagVilkårResultat(
-                    periodeFom = barn.fødselsdato,
-                    periodeTom = barn.fødselsdato.plusYears(18).minusDays(1),
-                    vilkårType = Vilkår.UNDER_18_ÅR,
-                    resultat = Resultat.OPPFYLT,
-                ),
+            lagVilkårResultat(
+                periodeFom = barn.fødselsdato,
+                periodeTom = barn.fødselsdato.plusYears(18).minusDays(1),
+                vilkårType = Vilkår.UNDER_18_ÅR,
+                resultat = Resultat.OPPFYLT,
             )
 
-        val under18årVilkårTidslinje: Tidslinje<VilkårResultat, Måned> =
-            tidslinje {
-                under18VilkårResultat.map {
-                    Periode(
-                        fraOgMed = it.periodeFom!!.tilMånedTidspunkt().neste(),
-                        tilOgMed = it.periodeTom!!.tilMånedTidspunkt(),
-                        innhold = it,
-                    )
-                }
-            }
+        val under18årVilkårTidslinje =
+            Periode(
+                verdi = under18VilkårResultat,
+                fom = under18VilkårResultat.periodeFom?.førsteDagINesteMåned(),
+                tom = under18VilkårResultat.periodeTom?.sisteDagIMåned(),
+            ).tilTidslinje()
 
-        val under18PerioderFørBeskjæring = under18årVilkårTidslinje.perioder()
+        val under18PerioderFørBeskjæring = under18årVilkårTidslinje.tilPerioder()
 
-        Assertions.assertEquals(1, under18PerioderFørBeskjæring.size)
-        Assertions.assertEquals(
-            barn.fødselsdato.plusMonths(1).toYearMonth(),
-            under18PerioderFørBeskjæring.first().fraOgMed.tilYearMonth(),
+        assertEquals(1, under18PerioderFørBeskjæring.size)
+        assertEquals(
+            barn.fødselsdato.førsteDagINesteMåned(),
+            under18PerioderFørBeskjæring.first().fom,
         )
-        Assertions.assertEquals(
-            YearMonth.of(2022, Month.NOVEMBER),
-            under18PerioderFørBeskjæring.first().tilOgMed.tilYearMonth(),
+        assertEquals(
+            30.nov(2022),
+            under18PerioderFørBeskjæring.first().tom,
         )
 
         val tidslinjeBeskåret = under18årVilkårTidslinje.beskjærPå18År(barn.fødselsdato)
 
-        val under18PerioderEtterBeskjæring = tidslinjeBeskåret.perioder()
+        val under18PerioderEtterBeskjæring = tidslinjeBeskåret.tilPerioder()
 
-        Assertions.assertEquals(1, under18PerioderEtterBeskjæring.size)
-        Assertions.assertEquals(
-            barn.fødselsdato.plusMonths(1).toYearMonth(),
-            under18PerioderEtterBeskjæring.first().fraOgMed.tilYearMonth(),
+        assertEquals(1, under18PerioderEtterBeskjæring.size)
+        assertEquals(
+            barn.fødselsdato.plusMonths(1),
+            under18PerioderEtterBeskjæring.first().fom,
         )
-        Assertions.assertEquals(
+        assertEquals(
             barn.fødselsdato
                 .plusYears(18)
                 .minusMonths(1)
-                .toYearMonth(),
-            under18PerioderEtterBeskjæring.first().tilOgMed.tilYearMonth(),
+                .sisteDagIMåned(),
+            under18PerioderEtterBeskjæring.first().tom,
         )
     }
 
@@ -560,11 +554,11 @@ class VilkårsvurderingForskyvningUtilsTest {
                 fagsakType = FagsakType.NORMAL,
             )
 
-        val perioder = tidslinje.perioder()
+        val perioder = tidslinje.tilPerioder()
 
-        val perioderRelevantForTesting = perioder.filter { it.fraOgMed.tilYearMonth().isSameOrBefore(mai2022) }
+        val perioderRelevantForTesting = perioder.filter { it.fom!!.toYearMonth().isSameOrBefore(mai2022) }
 
-        Assertions.assertEquals(4, perioderRelevantForTesting.size)
+        assertEquals(4, perioderRelevantForTesting.size)
 
         val periode1 = perioderRelevantForTesting[0]
         val periode2 = perioderRelevantForTesting[1]
@@ -578,12 +572,12 @@ class VilkårsvurderingForskyvningUtilsTest {
     }
 
     private fun assertPeriode(
-        periode: Periode<List<VilkårResultat>, Måned>,
+        periode: Periode<List<VilkårResultat>?>,
         forventetFom: YearMonth,
         forventetTom: YearMonth,
     ) {
-        Assertions.assertEquals(forventetFom, periode.fraOgMed.tilYearMonth())
-        Assertions.assertEquals(forventetTom, periode.tilOgMed.tilYearMonth())
+        assertEquals(forventetFom.førsteDagIInneværendeMåned(), periode.fom)
+        assertEquals(forventetTom.sisteDagIInneværendeMåned(), periode.tom)
     }
 
     private fun lagVilkårForPerson(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23270

Fortsettelse av #5111 
Bytter ut tidslinje fra ba-sak med tidslinje fra familie-felles enkelte steder.
Holder PR'ene små, så de skal være lette å lese.
Bør leses commit for commit, men ble ganske decent å lese alt sammen samtidig også <|:^)
Det er noe duplikatkode, men dette vil fjernes i senere PR'er
