### PR TITLE
Legger til callId når vi kaster feil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250219093533_62416e5</prosessering.version>
         <felles.version>3.20250220215513_776c72f</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20250224083824_7fcdc47</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250226115003_49b0dfa</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20241209130157_6873c2d</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250206122712_9ec24df</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -16,12 +16,8 @@ open class Feil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-    var callId: String? = null,
-) : RuntimeException(message) {
-    init {
-        callId = MDC.get(MDCConstants.MDC_CALL_ID)
-    }
-}
+    val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID) // Fetch at declaration for immutability
+) : RuntimeException(message)
 
 open class FunksjonellFeil(
     open val melding: String,
@@ -29,12 +25,8 @@ open class FunksjonellFeil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-    var callId: String? = null,
-) : RuntimeException(melding) {
-    init {
-        callId = MDC.get(MDCConstants.MDC_CALL_ID)
-    }
-}
+    val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID) // Fetch at declaration for immutability
+) : RuntimeException(melding)
 
 class VilkårFeil(
     melding: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -22,6 +22,7 @@ open class Feil(
         callId = MDC.get(MDCConstants.MDC_CALL_ID)
     }
 }
+
 open class FunksjonellFeil(
     open val melding: String,
     open val frontendFeilmelding: String? = melding,
@@ -34,6 +35,7 @@ open class FunksjonellFeil(
         callId = MDC.get(MDCConstants.MDC_CALL_ID)
     }
 }
+
 class VilkårFeil(
     melding: String,
     frontendFeilmelding: String? = melding,

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ba.sak.common
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.SatsendringSvar
+import no.nav.familie.log.mdc.MDCConstants
+import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
 import kotlin.contracts.ExperimentalContracts
@@ -14,16 +16,24 @@ open class Feil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-) : RuntimeException(message)
-
+    var callId: String? = null,
+) : RuntimeException(message) {
+    init {
+        callId = MDC.get(MDCConstants.MDC_CALL_ID)
+    }
+}
 open class FunksjonellFeil(
     open val melding: String,
     open val frontendFeilmelding: String? = melding,
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-) : RuntimeException(melding)
-
+    var callId: String? = null,
+) : RuntimeException(melding) {
+    init {
+        callId = MDC.get(MDCConstants.MDC_CALL_ID)
+    }
+}
 class VilkårFeil(
     melding: String,
     frontendFeilmelding: String? = melding,

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -16,7 +16,7 @@ open class Feil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-    val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID) // Fetch at declaration for immutability
+    open val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID),
 ) : RuntimeException(message)
 
 open class FunksjonellFeil(
@@ -25,7 +25,7 @@ open class FunksjonellFeil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-    val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID) // Fetch at declaration for immutability
+    open val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID),
 ) : RuntimeException(melding)
 
 class VilkårFeil(

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
@@ -90,7 +90,7 @@ object RessursUtils {
             Ressurs.failure(
                 frontendFeilmelding = feil.frontendFeilmelding,
                 errorMessage = feil.message.toString(),
-                callId = feil.callId
+                callId = feil.callId,
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
@@ -90,6 +90,7 @@ object RessursUtils {
             Ressurs.failure(
                 frontendFeilmelding = feil.frontendFeilmelding,
                 errorMessage = feil.message.toString(),
+                callId = feil.callId
             ),
         )
     }


### PR DESCRIPTION
Favorkort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24416

Vi legger til nytt felt callId i Feil, som da propageres videre opp til frontend.