### PR TITLE
Generering av tidslinjer for utbetalings-kjeder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinje.kt
@@ -25,6 +25,7 @@ class UtbetalingsTidslinje(
                 forrigePeriodeId = it.verdi.forrigePeriodeId,
                 beløp = it.verdi.sats,
                 klassifisering = it.verdi.klassifisering,
+                kildeBehandlingId = it.verdi.behandlingId,
             )
         }
 }
@@ -36,4 +37,5 @@ data class UtbetalingsperiodeDto(
     val forrigePeriodeId: Long?,
     val beløp: BigDecimal,
     val klassifisering: String,
+    val kildeBehandlingId: Long,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinje.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.ba.sak.integrasjoner.økonomi
+
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class UtbetalingsTidslinje(
+    private val utbetalingsperioder: Set<Utbetalingsperiode>,
+    val tidslinje: Tidslinje<Utbetalingsperiode>,
+) {
+    fun erTidslinjeForPeriodeId(periodeId: Long): Boolean =
+        utbetalingsperioder.any { it.periodeId == periodeId }
+
+    fun sisteUtbetalingsperiode(): Utbetalingsperiode =
+        tidslinje.tilPerioderIkkeNull().last().verdi
+
+    fun tilUtbetalingsperioder(): List<UtbetalingsperiodeDto> =
+        tidslinje.tilPerioderIkkeNull().map {
+            UtbetalingsperiodeDto(
+                fom = it.fom,
+                tom = it.tom,
+                periodeId = it.verdi.periodeId,
+                forrigePeriodeId = it.verdi.forrigePeriodeId,
+                beløp = it.verdi.sats,
+                klassifisering = it.verdi.klassifisering,
+            )
+        }
+}
+
+data class UtbetalingsperiodeDto(
+    val fom: LocalDate?,
+    val tom: LocalDate?,
+    val periodeId: Long,
+    val forrigePeriodeId: Long?,
+    val beløp: BigDecimal,
+    val klassifisering: String,
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
@@ -1,0 +1,116 @@
+package no.nav.familie.ba.sak.integrasjoner.økonomi
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.utbetalingsperioder
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.komposisjon.kombiner
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærTilOgMed
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import org.springframework.stereotype.Service
+
+@Service
+class UtbetalingsTidslinjeService(
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+) {
+    fun genererUtbetalingsTidslinjerForFagsak(fagsakId: Long): List<UtbetalingsTidslinje> {
+        val tilkjenteYtelser = tilkjentYtelseRepository.findByFagsak(fagsakId = fagsakId)
+        val utbetalingsperioderPerKjede = genererUtbetalingsperioderPerKjede(tilkjenteYtelser = tilkjenteYtelser)
+        val tidslinjePerKjede = genererTidslinjePerKjede(utbetalingsperioderPerKjede = utbetalingsperioderPerKjede)
+
+        return tidslinjePerKjede.keys.map { sistePeriodeIdIKjede ->
+            val utbetalingsperioder =
+                utbetalingsperioderPerKjede[sistePeriodeIdIKjede]?.flatMap { it.verdi }?.toSet()
+                    ?: throw Feil("Finner ikke perioder tilknyttet periodeId: $sistePeriodeIdIKjede")
+            val tidslinje = tidslinjePerKjede[sistePeriodeIdIKjede] ?: throw Feil("Finner ikke tidslinje tilknyttet periodeId: $sistePeriodeIdIKjede")
+
+            UtbetalingsTidslinje(
+                utbetalingsperioder = utbetalingsperioder,
+                tidslinje = tidslinje,
+            )
+        }
+    }
+
+    fun finnUtbetalingsTidslinjeForPeriodeId(
+        periodeId: Long,
+        utbetalingsTidslinjer: List<UtbetalingsTidslinje>,
+    ): UtbetalingsTidslinje =
+        utbetalingsTidslinjer.single { it.erTidslinjeForPeriodeId(periodeId) }
+
+    private fun genererTidslinjePerKjede(utbetalingsperioderPerKjede: Map<Long, List<Periode<Iterable<Utbetalingsperiode>>>>): Map<Long, Tidslinje<Utbetalingsperiode>> =
+        utbetalingsperioderPerKjede.mapValues { (_, perioder) ->
+            perioder
+                .map { periode ->
+                    Periode(
+                        periode.verdi.maxWith(
+                            compareBy<Utbetalingsperiode> { it.periodeId }
+                                .thenBy { it.opphør != null }
+                                .thenBy { it.opphør?.opphørDatoFom },
+                        ),
+                        periode.fom,
+                        periode.tom,
+                    )
+                }.fold(mutableListOf<Periode<Utbetalingsperiode>>()) { gjeldendePerioder, periode ->
+                    // Fjerner perioder med lavere periodeId enn foregående periode
+                    if (gjeldendePerioder.isEmpty() || periode.verdi.periodeId >= gjeldendePerioder.last().verdi.periodeId) {
+                        val erOpphørsPeriode = periode.verdi.opphør != null
+                        if (erOpphørsPeriode) {
+                            return@fold beskjærPerioderIHenholdTilOpphør(periode, gjeldendePerioder)
+                        }
+                        gjeldendePerioder.add(periode)
+                    }
+                    gjeldendePerioder
+                }.tilTidslinje()
+        }
+
+    private fun genererUtbetalingsperioderPerKjede(tilkjenteYtelser: List<TilkjentYtelse>): Map<Long, List<Periode<Iterable<Utbetalingsperiode>>>> =
+        tilkjenteYtelser
+            .fold(mutableMapOf<Long, List<Tidslinje<Utbetalingsperiode>>>()) { kjederForFagsak, tilkjentYtelse ->
+                val kjederForUtbetalingsperioder =
+                    tilkjentYtelse
+                        .utbetalingsperioder()
+                        .sortedBy { it.periodeId }
+                        .fold(mutableMapOf<Long, MutableList<Periode<Utbetalingsperiode>>>()) { kjeder, utbetalingsperiode ->
+                            kjeder.apply {
+                                // Derom kjede er opphørt forkorter vi perioden til opphørsdato. Ellers bruker vi utbetalingsperiodens vedtakdatoTom
+                                val periodeTom = utbetalingsperiode.opphør?.opphørDatoFom ?: utbetalingsperiode.vedtakdatoTom
+                                val kjede = getOrDefault(utbetalingsperiode.forrigePeriodeId, mutableListOf()) + Periode(utbetalingsperiode, utbetalingsperiode.vedtakdatoFom, periodeTom)
+                                put(utbetalingsperiode.periodeId, kjede.toMutableList())
+                                remove(utbetalingsperiode.forrigePeriodeId)
+                            }
+                        }.mapValues { (_, kjede) ->
+                            val opphørPeriode = kjede.singleOrNull { it.verdi.opphør != null }
+                            val forrigePeriodeId =
+                                opphørPeriode?.verdi?.periodeId ?: kjede.minOfOrNull { it.verdi.forrigePeriodeId ?: -1 }
+                            Pair(kjede.tilTidslinje(), forrigePeriodeId)
+                        }
+                kjederForFagsak.apply {
+                    kjederForUtbetalingsperioder.forEach { periodeId, (tidslinje, forrigePeriodeId) ->
+                        val kjedeForFagsak = kjederForFagsak.getOrDefault(forrigePeriodeId, mutableListOf()) + tidslinje
+                        put(periodeId, kjedeForFagsak.toMutableList())
+                        if (periodeId != forrigePeriodeId) {
+                            remove(forrigePeriodeId)
+                        }
+                    }
+                }
+            }.mapValues { (_, tidslinjerForKjede) ->
+                tidslinjerForKjede.kombiner().tilPerioderIkkeNull()
+            }
+
+    private fun beskjærPerioderIHenholdTilOpphør(
+        opphørsPeriode: Periode<Utbetalingsperiode>,
+        gjeldendePerioder: MutableList<Periode<Utbetalingsperiode>>,
+    ): MutableList<Periode<Utbetalingsperiode>> =
+        (gjeldendePerioder + opphørsPeriode)
+            .tilTidslinje()
+            .beskjærTilOgMed(
+                opphørsPeriode.verdi.opphør!!
+                    .opphørDatoFom
+                    .minusDays(1),
+            ).tilPerioderIkkeNull()
+            .toMutableList()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
@@ -65,7 +65,7 @@ class UtbetalingsTidslinjeService(
                     )
                 }.fold(mutableListOf<Periode<Utbetalingsperiode>>()) { gjeldendePerioder, periode ->
                     // Fjerner perioder med lavere periodeId enn foregående periode
-                    if (gjeldendePerioder.isEmpty() || periode.verdi.periodeId >= gjeldendePerioder.last().verdi.periodeId) {
+                    if (gjeldendePerioder.isEmpty() || periode.verdi.periodeId > gjeldendePerioder.last().verdi.periodeId) {
                         val erOpphørsPeriode = periode.verdi.opphør != null
                         if (erOpphørsPeriode) {
                             return@fold beskjærPerioderIHenholdTilOpphør(periode, gjeldendePerioder)

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -15,6 +15,8 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
 import no.nav.familie.ba.sak.integrasjoner.ecb.ECBService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
+import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsTidslinje
+import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsTidslinjeService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringScheduler
@@ -86,6 +88,7 @@ class ForvalterController(
     private val stønadsstatistikkService: StønadsstatistikkService,
     private val persongrunnlagService: PersongrunnlagService,
     private val hentAlleIdenterTilPsysTask: HentAlleIdenterTilPsysTask,
+    private val utbetalingsTidslinjeService: UtbetalingsTidslinjeService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ForvalterController::class.java)
 
@@ -494,4 +497,9 @@ class ForvalterController(
 
         return ResponseEntity.ok(opprettetTask.id)
     }
+
+    @GetMapping("/hent-utbetalingstidslinjer-for-fagsak/{fagsakId}")
+    fun hentUtbetalingsTidslinjerForFagsak(
+        @PathVariable("fagsakId") fagsakId: Long,
+    ): ResponseEntity<List<UtbetalingsTidslinje>> = ResponseEntity.ok(utbetalingsTidslinjeService.genererUtbetalingsTidslinjerForFagsak(fagsakId))
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -15,8 +15,8 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
 import no.nav.familie.ba.sak.integrasjoner.ecb.ECBService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.oppgave.domene.OppgaveRepository
-import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsTidslinje
 import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsTidslinjeService
+import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsperiodeDto
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringScheduler
@@ -501,5 +501,5 @@ class ForvalterController(
     @GetMapping("/hent-utbetalingstidslinjer-for-fagsak/{fagsakId}")
     fun hentUtbetalingsTidslinjerForFagsak(
         @PathVariable("fagsakId") fagsakId: Long,
-    ): ResponseEntity<List<UtbetalingsTidslinje>> = ResponseEntity.ok(utbetalingsTidslinjeService.genererUtbetalingsTidslinjerForFagsak(fagsakId))
+    ): ResponseEntity<List<List<UtbetalingsperiodeDto>>> = ResponseEntity.ok(utbetalingsTidslinjeService.genererUtbetalingsTidslinjerForFagsak(fagsakId).map { it.tilUtbetalingsperioder() })
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelse.kt
@@ -68,6 +68,6 @@ fun TilkjentYtelse.tilTidslinjeMedAndeler() =
         .values
         .kombiner()
 
-fun TilkjentYtelse.utbetalingsoppdrag(): Utbetalingsoppdrag? = objectMapper.readValue(this.utbetalingsoppdrag, Utbetalingsoppdrag::class.java)
+fun TilkjentYtelse.utbetalingsoppdrag(): Utbetalingsoppdrag? = this.utbetalingsoppdrag?.let { objectMapper.readValue(it, Utbetalingsoppdrag::class.java) }
 
 fun TilkjentYtelse.utbetalingsperioder() = this.utbetalingsoppdrag()?.utbetalingsperiode ?: emptyList()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeServiceTest.kt
@@ -1,0 +1,258 @@
+package no.nav.familie.ba.sak.integrasjoner.økonomi
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppdrag.Opphør
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+
+class UtbetalingsTidslinjeServiceTest {
+    private val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
+
+    private val utbetalingsTidslinjeService = UtbetalingsTidslinjeService(tilkjentYtelseRepository = tilkjentYtelseRepository)
+
+    @Nested
+    inner class GenererUtbetalingsTidslinjerForFagsak {
+        @Test
+        fun `skal generere utbetalingstidslinjer for førstegangsbehandling med 2 kjeder ordinær barnetrygd`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(fagsak)
+            val utbetalingsoppdrag = lagUtbetalingsoppdragFørstegangsbehandling(behandling.id)
+            val tilkjentYtelse = lagTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = objectMapper.writeValueAsString(utbetalingsoppdrag))
+
+            every { tilkjentYtelseRepository.findByFagsak(fagsak.id) } returns listOf(tilkjentYtelse)
+
+            // Act
+            val utbetalingstidslinjer = utbetalingsTidslinjeService.genererUtbetalingsTidslinjerForFagsak(fagsakId = fagsak.id)
+            val førsteTidslinje = utbetalingsTidslinjeService.finnUtbetalingsTidslinjeForPeriodeId(1, utbetalingstidslinjer)
+            val andreTidslinje = utbetalingsTidslinjeService.finnUtbetalingsTidslinjeForPeriodeId(2, utbetalingstidslinjer)
+
+            // Assert
+            assertThat(utbetalingstidslinjer).hasSize(2)
+            assertThat(førsteTidslinje.tidslinje).isNotNull
+            val perioderIFørsteTidslinje = førsteTidslinje.tidslinje.tilPerioderIkkeNull()
+            assertThat(perioderIFørsteTidslinje).hasSize(2)
+            assertThat(perioderIFørsteTidslinje[0].fom).isEqualTo(YearMonth.of(2024, 10).førsteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[0].tom).isEqualTo(YearMonth.of(2025, 1).sisteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[0].verdi.behandlingId).isEqualTo(behandling.id)
+            assertThat(perioderIFørsteTidslinje[0].verdi.periodeId).isEqualTo(0)
+            assertThat(perioderIFørsteTidslinje[0].verdi.forrigePeriodeId).isEqualTo(null)
+            assertThat(perioderIFørsteTidslinje[1].fom).isEqualTo(YearMonth.of(2025, 2).førsteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[1].tom).isEqualTo(YearMonth.of(2040, 9).sisteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[1].verdi.behandlingId).isEqualTo(behandling.id)
+            assertThat(perioderIFørsteTidslinje[1].verdi.periodeId).isEqualTo(1)
+            assertThat(perioderIFørsteTidslinje[1].verdi.forrigePeriodeId).isEqualTo(0)
+
+            assertThat(andreTidslinje.tidslinje).isNotNull
+            val perioderIAndreTidslinje = andreTidslinje.tidslinje.tilPerioderIkkeNull()
+            assertThat(perioderIAndreTidslinje).hasSize(1)
+            assertThat(perioderIAndreTidslinje[0].fom).isEqualTo(YearMonth.of(2023, 4).førsteDagIInneværendeMåned())
+            assertThat(perioderIAndreTidslinje[0].tom).isEqualTo(YearMonth.of(2040, 3).sisteDagIInneværendeMåned())
+            assertThat(perioderIAndreTidslinje[0].verdi.behandlingId).isEqualTo(behandling.id)
+            assertThat(perioderIAndreTidslinje[0].verdi.periodeId).isEqualTo(2)
+            assertThat(perioderIAndreTidslinje[0].verdi.forrigePeriodeId).isEqualTo(null)
+        }
+
+        @Test
+        fun `skal generere utbetalingstidslinjer for revurdering med endring på 1 kjede med ordinær barnetrygd`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val førstegangsbehandling = lagBehandling(fagsak)
+            val revurdering = lagBehandling(fagsak)
+
+            every { tilkjentYtelseRepository.findByFagsak(fagsak.id) } returns
+                listOf(
+                    lagTilkjentYtelse(behandling = førstegangsbehandling, utbetalingsoppdrag = objectMapper.writeValueAsString(lagUtbetalingsoppdragFørstegangsbehandling(førstegangsbehandling.id))),
+                    lagTilkjentYtelse(behandling = revurdering, utbetalingsoppdrag = objectMapper.writeValueAsString(lagUtbetalingsoppdragFørsteRevurdering(revurdering.id))),
+                )
+
+            // Act
+            val utbetalingstidslinjer = utbetalingsTidslinjeService.genererUtbetalingsTidslinjerForFagsak(fagsakId = fagsak.id)
+            val førsteTidslinje = utbetalingsTidslinjeService.finnUtbetalingsTidslinjeForPeriodeId(3, utbetalingstidslinjer)
+            val andreTidslinje = utbetalingsTidslinjeService.finnUtbetalingsTidslinjeForPeriodeId(2, utbetalingstidslinjer)
+
+            // Assert
+            assertThat(utbetalingstidslinjer).hasSize(2)
+            assertThat(førsteTidslinje.tidslinje).isNotNull
+            val perioderIFørsteTidslinje = førsteTidslinje.tidslinje.tilPerioderIkkeNull()
+            assertThat(perioderIFørsteTidslinje).hasSize(2)
+            assertThat(perioderIFørsteTidslinje[0].fom).isEqualTo(YearMonth.of(2024, 10).førsteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[0].tom).isEqualTo(YearMonth.of(2024, 11).sisteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[0].verdi.behandlingId).isEqualTo(førstegangsbehandling.id)
+            assertThat(perioderIFørsteTidslinje[0].verdi.periodeId).isEqualTo(0)
+            assertThat(perioderIFørsteTidslinje[0].verdi.forrigePeriodeId).isEqualTo(null)
+            assertThat(perioderIFørsteTidslinje[1].fom).isEqualTo(YearMonth.of(2024, 12).førsteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[1].tom).isEqualTo(YearMonth.of(2040, 9).sisteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[1].verdi.behandlingId).isEqualTo(revurdering.id)
+            assertThat(perioderIFørsteTidslinje[1].verdi.periodeId).isEqualTo(3)
+            assertThat(perioderIFørsteTidslinje[1].verdi.forrigePeriodeId).isEqualTo(1)
+
+            assertThat(andreTidslinje.tidslinje).isNotNull
+            val perioderIAndreTidslinje = andreTidslinje.tidslinje.tilPerioderIkkeNull()
+            assertThat(perioderIAndreTidslinje).hasSize(1)
+            assertThat(perioderIAndreTidslinje[0].fom).isEqualTo(YearMonth.of(2023, 4).førsteDagIInneværendeMåned())
+            assertThat(perioderIAndreTidslinje[0].tom).isEqualTo(YearMonth.of(2040, 3).sisteDagIInneværendeMåned())
+            assertThat(perioderIAndreTidslinje[0].verdi.behandlingId).isEqualTo(førstegangsbehandling.id)
+            assertThat(perioderIAndreTidslinje[0].verdi.periodeId).isEqualTo(2)
+            assertThat(perioderIAndreTidslinje[0].verdi.forrigePeriodeId).isEqualTo(null)
+        }
+
+        @Test
+        fun `skal generere utbetalingstidslinjer for revurdering med opphør på 1 kjede med ordinær barnetrygd`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val førstegangsbehandling = lagBehandling(fagsak)
+            val revurderingEndring = lagBehandling(fagsak)
+            val revurderingOpphør = lagBehandling(fagsak)
+
+            every { tilkjentYtelseRepository.findByFagsak(fagsak.id) } returns
+                listOf(
+                    lagTilkjentYtelse(behandling = førstegangsbehandling, utbetalingsoppdrag = objectMapper.writeValueAsString(lagUtbetalingsoppdragFørstegangsbehandling(førstegangsbehandling.id))),
+                    lagTilkjentYtelse(behandling = revurderingEndring, utbetalingsoppdrag = objectMapper.writeValueAsString(lagUtbetalingsoppdragFørsteRevurdering(revurderingEndring.id))),
+                    lagTilkjentYtelse(behandling = revurderingOpphør, utbetalingsoppdrag = objectMapper.writeValueAsString(lagUtbetalingsoppdragAndreRevurdering(revurderingOpphør.id))),
+                )
+
+            // Act
+            val utbetalingstidslinjer = utbetalingsTidslinjeService.genererUtbetalingsTidslinjerForFagsak(fagsakId = fagsak.id)
+            val førsteTidslinje = utbetalingsTidslinjeService.finnUtbetalingsTidslinjeForPeriodeId(3, utbetalingstidslinjer)
+            val andreTidslinje = utbetalingsTidslinjeService.finnUtbetalingsTidslinjeForPeriodeId(2, utbetalingstidslinjer)
+
+            // Assert
+            assertThat(utbetalingstidslinjer).hasSize(2)
+            assertThat(førsteTidslinje.tidslinje).isNotNull
+            val perioderIFørsteTidslinje = førsteTidslinje.tidslinje.tilPerioderIkkeNull()
+            assertThat(perioderIFørsteTidslinje).hasSize(2)
+            assertThat(perioderIFørsteTidslinje[0].fom).isEqualTo(YearMonth.of(2024, 10).førsteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[0].tom).isEqualTo(YearMonth.of(2024, 11).sisteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[0].verdi.behandlingId).isEqualTo(førstegangsbehandling.id)
+            assertThat(perioderIFørsteTidslinje[0].verdi.periodeId).isEqualTo(0)
+            assertThat(perioderIFørsteTidslinje[0].verdi.forrigePeriodeId).isEqualTo(null)
+            assertThat(perioderIFørsteTidslinje[1].fom).isEqualTo(YearMonth.of(2024, 12).førsteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[1].tom).isEqualTo(YearMonth.of(2040, 9).sisteDagIInneværendeMåned())
+            assertThat(perioderIFørsteTidslinje[1].verdi.behandlingId).isEqualTo(revurderingEndring.id)
+            assertThat(perioderIFørsteTidslinje[1].verdi.periodeId).isEqualTo(3)
+            assertThat(perioderIFørsteTidslinje[1].verdi.forrigePeriodeId).isEqualTo(1)
+
+            assertThat(andreTidslinje.tidslinje).isNotNull
+            val perioderIAndreTidslinje = andreTidslinje.tidslinje.tilPerioderIkkeNull()
+            assertThat(perioderIAndreTidslinje).hasSize(1)
+            assertThat(perioderIAndreTidslinje[0].fom).isEqualTo(YearMonth.of(2023, 4).førsteDagIInneværendeMåned())
+            assertThat(perioderIAndreTidslinje[0].tom).isEqualTo(YearMonth.of(2025, 1).sisteDagIInneværendeMåned())
+            assertThat(perioderIAndreTidslinje[0].verdi.behandlingId).isEqualTo(revurderingOpphør.id)
+            assertThat(perioderIAndreTidslinje[0].verdi.periodeId).isEqualTo(2)
+            assertThat(perioderIAndreTidslinje[0].verdi.forrigePeriodeId).isEqualTo(null)
+        }
+    }
+}
+
+private fun lagUtbetalingsoppdragFørstegangsbehandling(behandlingId: Long): Utbetalingsoppdrag =
+    lagUtbetalingsoppdrag(
+        avstemmingTidspunkt = LocalDateTime.of(2025, 1, 1, 0, 0, 0),
+        utbetalingsperiode =
+            listOf(
+                lagUtbetalingsperiode(
+                    fom = YearMonth.of(2024, 10).førsteDagIInneværendeMåned(),
+                    tom = YearMonth.of(2025, 1).sisteDagIInneværendeMåned(),
+                    periodeId = 0,
+                    forrigePeriodeId = null,
+                    behandlingId = behandlingId,
+                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
+                    beløp = BigDecimal.valueOf(1000L),
+                ),
+                lagUtbetalingsperiode(
+                    fom = YearMonth.of(2025, 2).førsteDagIInneværendeMåned(),
+                    tom = YearMonth.of(2040, 9).sisteDagIInneværendeMåned(),
+                    periodeId = 1,
+                    forrigePeriodeId = 0,
+                    behandlingId = behandlingId,
+                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
+                    beløp = BigDecimal.valueOf(500L),
+                ),
+                lagUtbetalingsperiode(
+                    fom = YearMonth.of(2023, 4).førsteDagIInneværendeMåned(),
+                    tom = YearMonth.of(2040, 3).sisteDagIInneværendeMåned(),
+                    periodeId = 2,
+                    forrigePeriodeId = null,
+                    behandlingId = behandlingId,
+                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
+                    beløp = BigDecimal.valueOf(1000L),
+                ),
+            ),
+    )
+
+private fun lagUtbetalingsoppdragFørsteRevurdering(behandlingId: Long): Utbetalingsoppdrag =
+    lagUtbetalingsoppdrag(
+        avstemmingTidspunkt = LocalDateTime.of(2025, 2, 1, 0, 0, 0),
+        utbetalingsperiode =
+            listOf(
+                lagUtbetalingsperiode(
+                    fom = YearMonth.of(2024, 12).førsteDagIInneværendeMåned(),
+                    tom = YearMonth.of(2040, 9).sisteDagIInneværendeMåned(),
+                    periodeId = 3,
+                    forrigePeriodeId = 1,
+                    behandlingId = behandlingId,
+                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
+                    beløp = BigDecimal.valueOf(500L),
+                ),
+            ),
+    )
+
+private fun lagUtbetalingsoppdragAndreRevurdering(behandlingId: Long): Utbetalingsoppdrag =
+    lagUtbetalingsoppdrag(
+        avstemmingTidspunkt = LocalDateTime.of(2025, 3, 1, 0, 0, 0),
+        utbetalingsperiode =
+            listOf(
+                lagUtbetalingsperiode(
+                    fom = YearMonth.of(2023, 4).førsteDagIInneværendeMåned(),
+                    tom = YearMonth.of(2040, 3).sisteDagIInneværendeMåned(),
+                    periodeId = 2,
+                    forrigePeriodeId = null,
+                    behandlingId = behandlingId,
+                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
+                    beløp = BigDecimal.valueOf(1000L),
+                    opphør = Opphør(YearMonth.of(2025, 2).førsteDagIInneværendeMåned()),
+                ),
+            ),
+    )
+
+private fun lagUtbetalingsperiode(
+    fom: LocalDate,
+    tom: LocalDate,
+    periodeId: Long,
+    forrigePeriodeId: Long?,
+    behandlingId: Long,
+    klassifisering: String,
+    beløp: BigDecimal,
+    opphør: Opphør? = null,
+) =
+    Utbetalingsperiode(
+        vedtakdatoFom = fom,
+        vedtakdatoTom = tom,
+        erEndringPåEksisterendePeriode = false,
+        periodeId = periodeId,
+        forrigePeriodeId = forrigePeriodeId,
+        behandlingId = behandlingId,
+        datoForVedtak = LocalDate.now(),
+        klassifisering = klassifisering,
+        sats = beløp,
+        satsType = Utbetalingsperiode.SatsType.MND,
+        utbetalesTil = "",
+        opphør = opphør,
+    )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiTestUtils.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiTestUtils.kt
@@ -13,13 +13,16 @@ fun sats(ytelseType: YtelseType) =
         YtelseType.SMÅBARNSTILLEGG -> 660
     }
 
-fun lagUtbetalingsoppdrag(utbetalingsperiode: List<Utbetalingsperiode>) =
+fun lagUtbetalingsoppdrag(
+    utbetalingsperiode: List<Utbetalingsperiode>,
+    avstemmingTidspunkt: LocalDateTime = LocalDateTime.now(),
+) =
     Utbetalingsoppdrag(
         kodeEndring = Utbetalingsoppdrag.KodeEndring.NY,
         fagSystem = "BA",
         saksnummer = "",
         aktoer = UUID.randomUUID().toString(),
         saksbehandlerId = "",
-        avstemmingTidspunkt = LocalDateTime.now(),
+        avstemmingTidspunkt = avstemmingTidspunkt,
         utbetalingsperiode = utbetalingsperiode,
     )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har en del avvik i forbindelse med konsistensavstemming. Mange kommer av problemer ved overgang til ny klassekode for utvidet barnetrygd, men noen avvik stammer fra andre ting. Vi har rundt 150 avvik hver mnd.

Lager her et verktøy for å kunne generere en tidslinje for hver utbetalings-kjede tilknyttet en fagsak, som kun baserer seg på det vi faktisk har sendt til Oppdrag og ikke hvordan andelene ser ut. Tanken er at vi da skal kunne se de ulike utbetalingsperiodene i en fagsak på samme måte som Oppdrag.

Forhåpentligvis vil dette kunne hjelpe oss med å finne ut hvilke andeler som har feil `periodeId` og/eller `kildeBehahandlingId` på vår side, og kan på sikt potensielt brukes ved konsistensavstemming fremfor andelene slik vi gjør i dag.

I første omgang, er tanken å bruke verktøyet for å se om utbetalingstidslinjene på vår side matcher det Oppdrag forventer i de ulike fagsakene vi har fått avvik på.

> NB: Dette er foreløpig kun et "debug/innsikts"-verktøy og endrer ingen eksisterende logikk

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
Tar gjerne en muntlig gjennomgang om noen ønsker det
