### PR TITLE
Valider kompetanse litt senere i beløpet, ved behandlingsresultatet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -25,6 +25,9 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValide
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.validerBarnasVilkår
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -58,6 +61,7 @@ class BehandlingsresultatSteg(
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
     private val valutakursRepository: ValutakursRepository,
     private val localDateProvider: LocalDateProvider,
+    private val kompetanseRepository: KompetanseRepository,
 ) : BehandlingSteg<String> {
     override fun preValiderSteg(
         behandling: Behandling,
@@ -89,6 +93,8 @@ class BehandlingsresultatSteg(
                 andelerTilkjentYtelseOgEndreteUtbetalingerService
                     .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
             endreteUtbetalingerMedAndeler.validerEndredeUtbetalingsandeler(tilkjentYtelse, vilkårService.hentVilkårsvurdering(behandling.id))
+
+            validerKompetanse(behandling.id)
         }
 
         if (behandling.erMånedligValutajustering()) {
@@ -241,6 +247,26 @@ class BehandlingsresultatSteg(
 
         if (utenlandskePeriodeBeløp.any { !it.erObligatoriskeFelterSatt() } || valutakurser.any { !it.erObligatoriskeFelterSatt() }) {
             throw FunksjonellFeil("Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder")
+        }
+    }
+
+    private fun validerKompetanse(behandlingId: Long) {
+        val kompetanser = kompetanseRepository.finnFraBehandlingId(behandlingId)
+
+        validerAtAktivitetslandOgBostedIkkeErNorgeHvisNorgeErSekundærland(kompetanser)
+    }
+
+    private fun validerAtAktivitetslandOgBostedIkkeErNorgeHvisNorgeErSekundærland(kompetanser: Collection<Kompetanse>) {
+        kompetanser.forEach { kompetanse ->
+            val erNorgeSekundærland = kompetanse.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND
+
+            if (!erNorgeSekundærland) return@forEach
+
+            if (setOf(kompetanse.søkersAktivitetsland, kompetanse.annenForeldersAktivitetsland, kompetanse.barnetsBostedsland)
+                    .any { it == "NO" }
+            ) {
+                throw FunksjonellFeil("Dersom Norge er sekundærland, må søkers aktivitetsland, annen forelders aktivitetsland eller barnets bostedsland være satt til noe annet enn Norge")
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -15,7 +15,6 @@ import jakarta.persistence.JoinTable
 import jakarta.persistence.ManyToMany
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
-import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.YearMonthConverter
 import no.nav.familie.ba.sak.kjerne.eøs.felles.PeriodeOgBarnSkjemaEntitet
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -281,8 +280,7 @@ fun IUtfyltKompetanse.utbetalingsland(): String {
     return when (utbetalingsland) {
         "NO" ->
             // Unntak. Finner landet som er registrert på kompetansen som ikke er Norge.
-            setOf(this.søkersAktivitetsland, this.annenForeldersAktivitetsland, this.barnetsBostedsland).filterNotNull().singleOrNull { it != "NO" }
-                ?: throw FunksjonellFeil(melding = "Dersom Norge er sekundærland, må søkers aktivitetsland, annen forelders aktivitetsland eller barnets bostedsland være satt til noe annet enn Norge.")
+            setOf(this.søkersAktivitetsland, this.annenForeldersAktivitetsland, this.barnetsBostedsland).filterNotNull().singleOrNull { it != "NO" } ?: utbetalingsland
 
         else -> utbetalingsland
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingStegUtilsKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingStegUtilsKtTest.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ba.sak.kjerne.behandlingsresultat
+
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.somBoolskTidslinje
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.YearMonth
+
+class BehandlingStegUtilsKtTest {
+    @Nested
+    inner class KastFeilVedEndringEtterTest {
+        @Test
+        fun `Skal kaste feil om det er endring etter migreringsdatoen til første behandling`() {
+            val startdato = YearMonth.of(2023, 2)
+            val endringTidslinje = "TTTFFFF".somBoolskTidslinje(startdato)
+
+            assertThrows<FunksjonellFeil> {
+                endringTidslinje.kastFeilVedEndringEtter(startdato, lagBehandling())
+            }
+        }
+
+        @Test
+        fun `Skal ikke kaste feil om det ikke er endring etter migreringsdatoen til første behandling`() {
+            val startdato = YearMonth.of(2023, 2)
+            val treMånederEtterStartdato = startdato.plusMonths(3)
+
+            val endringTidslinje = "TTTFFFF".somBoolskTidslinje(startdato)
+
+           assertDoesNotThrow {
+                endringTidslinje.kastFeilVedEndringEtter(treMånederEtterStartdato, lagBehandling())
+            }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagKompetanse
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.datagenerator.lagValutakurs
@@ -35,6 +36,8 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndr
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
@@ -47,14 +50,15 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Personopplysning
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.EndringerIUtbetalingForBehandlingSteg
 import no.nav.familie.ba.sak.kjerne.steg.StegType
-import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.util.somBoolskTidslinje
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -77,6 +81,7 @@ class BehandlingsresultatStegTest {
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository = mockk()
     private val valutakursRepository: ValutakursRepository = mockk()
     private val valutakursService = mockk<ValutakursService>()
+    private val kompetanseRepository = mockk<KompetanseRepository>()
 
     private val behandlingsresultatSteg: BehandlingsresultatSteg =
         BehandlingsresultatSteg(
@@ -94,6 +99,7 @@ class BehandlingsresultatStegTest {
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             valutakursRepository = valutakursRepository,
             localDateProvider = RealDateProvider(),
+            kompetanseRepository = kompetanseRepository,
         )
 
     private val behandling =
@@ -107,330 +113,496 @@ class BehandlingsresultatStegTest {
         every { simuleringService.oppdaterSimuleringPåBehandling(any()) } returns emptyList()
         every { simuleringService.hentSimuleringPåBehandling(any()) } returns emptyList()
         every { valutakursService.hentValutakurser(any()) } returns emptyList()
+        every { kompetanseRepository.finnFraBehandlingId(any()) } returns emptyList()
     }
 
-    @Test
-    fun `skal kaste exception hvis behandlingsresultat er Avslått for en manuell migrering`() {
-        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.AVSLÅTT
+    @Nested
+    inner class UtførStegOgAngiNesteTest {
+        @Test
+        fun `Skal gå rett fra behandlingsresultat til iverksetting for alle fødselshendelser`() {
+            val fødselshendelseBehandling =
+                behandling.copy(
+                    skalBehandlesAutomatisk = true,
+                    opprettetÅrsak = BehandlingÅrsak.FØDSELSHENDELSE,
+                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                )
+            val vedtak =
+                lagVedtak(
+                    fødselshendelseBehandling,
+                )
+            every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.INNVILGET_OG_ENDRET
+            every { behandlingService.nullstillEndringstidspunkt(fødselshendelseBehandling.id) } just runs
+            every {
+                behandlingService.oppdaterBehandlingsresultat(
+                    any(),
+                    any(),
+                )
+            } returns fødselshendelseBehandling.copy(resultat = Behandlingsresultat.INNVILGET_OG_ENDRET)
+            every {
+                behandlingService.oppdaterStatusPåBehandling(
+                    fødselshendelseBehandling.id,
+                    BehandlingStatus.IVERKSETTER_VEDTAK,
+                )
+            } returns fødselshendelseBehandling.copy(status = BehandlingStatus.IVERKSETTER_VEDTAK)
+            every { vedtakService.hentAktivForBehandlingThrows(fødselshendelseBehandling.id) } returns vedtak
+            every { vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(vedtak) } just runs
+            every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(fødselshendelseBehandling) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(fødselshendelseBehandling.id) } returns emptyList()
+            every { valutakursRepository.finnFraBehandlingId(fødselshendelseBehandling.id) } returns emptyList()
 
-        every {
-            behandlingService.oppdaterBehandlingsresultat(
-                any(),
-                any(),
+            assertEquals(
+                behandlingsresultatSteg.utførStegOgAngiNeste(fødselshendelseBehandling, ""),
+                StegType.IVERKSETT_MOT_OPPDRAG,
             )
-        } returns behandling.copy(resultat = Behandlingsresultat.AVSLÅTT)
+        }
 
-        val exception = assertThrows<RuntimeException> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
-        assertEquals(
-            "Du har fått behandlingsresultatet Avslått. " +
-                "Dette er ikke støttet på migreringsbehandlinger. " +
-                "Meld sak i Porten om du er uenig i resultatet.",
-            exception.message,
-        )
-    }
+        @Test
+        fun `Skal kaste exception hvis behandlingsresultat er Avslått for en manuell migrering`() {
+            every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.AVSLÅTT
 
-    @Test
-    fun `skal kaste exception hvis behandlingsresultat er Delvis Innvilget for en manuell migrering`() {
-        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.DELVIS_INNVILGET
+            every {
+                behandlingService.oppdaterBehandlingsresultat(
+                    any(),
+                    any(),
+                )
+            } returns behandling.copy(resultat = Behandlingsresultat.AVSLÅTT)
 
-        every {
-            behandlingService.oppdaterBehandlingsresultat(
-                any(),
-                any(),
+            val exception = assertThrows<RuntimeException> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
+            assertEquals(
+                "Du har fått behandlingsresultatet Avslått. " +
+                    "Dette er ikke støttet på migreringsbehandlinger. " +
+                    "Meld sak i Porten om du er uenig i resultatet.",
+                exception.message,
             )
-        } returns behandling.copy(resultat = Behandlingsresultat.DELVIS_INNVILGET)
+        }
 
-        val exception = assertThrows<RuntimeException> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
-        assertEquals(
-            "Du har fått behandlingsresultatet Delvis innvilget. " +
-                "Dette er ikke støttet på migreringsbehandlinger. " +
-                "Meld sak i Porten om du er uenig i resultatet.",
-            exception.message,
-        )
-    }
+        @Test
+        fun `Skal kaste exception hvis behandlingsresultat er Delvis Innvilget for en manuell migrering`() {
+            every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.DELVIS_INNVILGET
 
-    @Test
-    fun `skal kaste exception hvis behandlingsresultat er Avslått,Endret og Opphørt for en manuell migrering`() {
-        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT
+            every {
+                behandlingService.oppdaterBehandlingsresultat(
+                    any(),
+                    any(),
+                )
+            } returns behandling.copy(resultat = Behandlingsresultat.DELVIS_INNVILGET)
 
-        every {
-            behandlingService.oppdaterBehandlingsresultat(
-                any(),
-                any(),
+            val exception = assertThrows<RuntimeException> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
+            assertEquals(
+                "Du har fått behandlingsresultatet Delvis innvilget. " +
+                    "Dette er ikke støttet på migreringsbehandlinger. " +
+                    "Meld sak i Porten om du er uenig i resultatet.",
+                exception.message,
             )
-        } returns behandling.copy(resultat = Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT)
+        }
 
-        val exception = assertThrows<RuntimeException> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
-        assertEquals(
-            "Du har fått behandlingsresultatet Avslått, endret og opphørt. " +
-                "Dette er ikke støttet på migreringsbehandlinger. " +
-                "Meld sak i Porten om du er uenig i resultatet.",
-            exception.message,
-        )
-    }
+        @Test
+        fun `Skal kaste exception hvis behandlingsresultat er Avslått,Endret og Opphørt for en manuell migrering`() {
+            every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT
 
-    @Test
-    fun `skal kaste exception dersom det finnes utenlandskperiodebeløp som ikke er fylt ut`() {
-        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.FORTSATT_INNVILGET
+            every {
+                behandlingService.oppdaterBehandlingsresultat(
+                    any(),
+                    any(),
+                )
+            } returns behandling.copy(resultat = Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT)
 
-        every {
-            behandlingService.oppdaterBehandlingsresultat(
-                any(),
-                any(),
+            val exception = assertThrows<RuntimeException> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
+            assertEquals(
+                "Du har fått behandlingsresultatet Avslått, endret og opphørt. " +
+                    "Dette er ikke støttet på migreringsbehandlinger. " +
+                    "Meld sak i Porten om du er uenig i resultatet.",
+                exception.message,
             )
-        } returns behandling.copy(resultat = Behandlingsresultat.FORTSATT_INNVILGET)
+        }
 
-        every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(any()) } returns listOf(lagUtenlandskPeriodebeløp())
-        every { valutakursRepository.finnFraBehandlingId(any()) } returns listOf(lagValutakurs())
+        @Test
+        fun `Skal kaste exception dersom det finnes utenlandskperiodebeløp som ikke er fylt ut`() {
+            every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.FORTSATT_INNVILGET
 
-        val exception = assertThrows<FunksjonellFeil> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
-        assertEquals(
-            "Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder",
-            exception.message,
-        )
-    }
+            every {
+                behandlingService.oppdaterBehandlingsresultat(
+                    any(),
+                    any(),
+                )
+            } returns behandling.copy(resultat = Behandlingsresultat.FORTSATT_INNVILGET)
 
-    @Test
-    fun `skal kaste exception dersom det finnes valutakurser som ikke er fylt ut`() {
-        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.FORTSATT_INNVILGET
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(any()) } returns listOf(lagUtenlandskPeriodebeløp())
+            every { valutakursRepository.finnFraBehandlingId(any()) } returns listOf(lagValutakurs())
 
-        every {
-            behandlingService.oppdaterBehandlingsresultat(
-                any(),
-                any(),
+            val exception = assertThrows<FunksjonellFeil> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
+            assertEquals(
+                "Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder",
+                exception.message,
             )
-        } returns behandling.copy(resultat = Behandlingsresultat.FORTSATT_INNVILGET)
+        }
 
-        every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(any()) } returns
-            listOf(
-                lagUtenlandskPeriodebeløp(
-                    fom = LocalDate.now().toYearMonth(),
-                    beløp = BigDecimal.valueOf(100),
-                    intervall = Intervall.MÅNEDLIG,
-                    valutakode = "SEK",
-                    utbetalingsland = "S",
-                    barnAktører =
-                        setOf(
-                            randomAktør(),
-                        ),
-                ),
+        @Test
+        fun `Skal kaste exception dersom det finnes valutakurser som ikke er fylt ut`() {
+            every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.FORTSATT_INNVILGET
+
+            every {
+                behandlingService.oppdaterBehandlingsresultat(
+                    any(),
+                    any(),
+                )
+            } returns behandling.copy(resultat = Behandlingsresultat.FORTSATT_INNVILGET)
+
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(any()) } returns
+                listOf(
+                    lagUtenlandskPeriodebeløp(
+                        fom = LocalDate.now().toYearMonth(),
+                        beløp = BigDecimal.valueOf(100),
+                        intervall = Intervall.MÅNEDLIG,
+                        valutakode = "SEK",
+                        utbetalingsland = "S",
+                        barnAktører =
+                            setOf(
+                                randomAktør(),
+                            ),
+                    ),
+                )
+            every { valutakursRepository.finnFraBehandlingId(any()) } returns listOf(lagValutakurs())
+
+            val exception = assertThrows<FunksjonellFeil> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
+            assertEquals(
+                "Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder",
+                exception.message,
             )
-        every { valutakursRepository.finnFraBehandlingId(any()) } returns listOf(lagValutakurs())
+        }
 
-        val exception = assertThrows<FunksjonellFeil> { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
-        assertEquals(
-            "Kan ikke fullføre behandlingsresultat-steg før utbetalt i det andre landet og valutakurs er fylt ut for alle barn og perioder",
-            exception.message,
-        )
-    }
+        @Test
+        fun `Skal ikke kaste exception dersom upb og valutakurser er utfylt`() {
+            every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.FORTSATT_INNVILGET
 
-    @Test
-    fun `skal ikke kaste exception dersom upb og valutakurser er utfylt`() {
-        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.FORTSATT_INNVILGET
+            every {
+                behandlingService.oppdaterBehandlingsresultat(
+                    any(),
+                    any(),
+                )
+            } returns behandling.copy(resultat = Behandlingsresultat.FORTSATT_INNVILGET)
 
-        every {
-            behandlingService.oppdaterBehandlingsresultat(
-                any(),
-                any(),
-            )
-        } returns behandling.copy(resultat = Behandlingsresultat.FORTSATT_INNVILGET)
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(any()) } returns
+                listOf(
+                    lagUtenlandskPeriodebeløp(
+                        fom = LocalDate.now().toYearMonth(),
+                        beløp = BigDecimal.valueOf(100),
+                        intervall = Intervall.MÅNEDLIG,
+                        valutakode = "SEK",
+                        utbetalingsland = "S",
+                        barnAktører =
+                            setOf(
+                                randomAktør(),
+                            ),
+                    ),
+                )
+            every { valutakursRepository.finnFraBehandlingId(any()) } returns
+                listOf(
+                    lagValutakurs(
+                        fom = LocalDate.now().toYearMonth(),
+                        valutakode = "SEK",
+                        valutakursdato = LocalDate.now(),
+                        kurs = BigDecimal.valueOf(1.2),
+                        barnAktører =
+                            setOf(
+                                randomAktør(),
+                            ),
+                        vurderingsform = Vurderingsform.MANUELL,
+                    ),
+                )
 
-        every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(any()) } returns
-            listOf(
-                lagUtenlandskPeriodebeløp(
-                    fom = LocalDate.now().toYearMonth(),
-                    beløp = BigDecimal.valueOf(100),
-                    intervall = Intervall.MÅNEDLIG,
-                    valutakode = "SEK",
-                    utbetalingsland = "S",
-                    barnAktører =
-                        setOf(
-                            randomAktør(),
-                        ),
-                ),
-            )
-        every { valutakursRepository.finnFraBehandlingId(any()) } returns
-            listOf(
-                lagValutakurs(
-                    fom = LocalDate.now().toYearMonth(),
-                    valutakode = "SEK",
-                    valutakursdato = LocalDate.now(),
-                    kurs = BigDecimal.valueOf(1.2),
-                    barnAktører =
-                        setOf(
-                            randomAktør(),
-                        ),
-                    vurderingsform = Vurderingsform.MANUELL,
-                ),
-            )
+            every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(any()) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
 
-        every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(any()) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(any()) } returns lagBehandling()
 
-        every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(any()) } returns lagBehandling()
+            every { beregningService.kanAutomatiskIverksetteSmåbarnstilleggEndring(any(), any()) } returns true
 
-        every { beregningService.kanAutomatiskIverksetteSmåbarnstilleggEndring(any(), any()) } returns true
+            every { behandlingService.oppdaterStatusPåBehandling(any(), any()) } returns lagBehandling()
 
-        every { behandlingService.oppdaterStatusPåBehandling(any(), any()) } returns lagBehandling()
-
-        assertDoesNotThrow { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
-    }
-
-    @Test
-    fun `skal kaste feil om det er endring etter migreringsdatoen til første behandling`() {
-        val startdato = YearMonth.of(2023, 2)
-        val endringTidslinje = "TTTFFFF".somBoolskTidslinje(startdato)
-
-        assertThrows<FunksjonellFeil> {
-            endringTidslinje.kastFeilVedEndringEtter(startdato, lagBehandling())
+            assertDoesNotThrow { behandlingsresultatSteg.utførStegOgAngiNeste(behandling, "") }
         }
     }
 
-    @Test
-    fun `skal ikke kaste feil om det ikke er endring etter migreringsdatoen til første behandling`() {
-        val startdato = YearMonth.of(2023, 2)
-        val treMånederEtterStartdato = startdato.plusMonths(3)
+    @Nested
+    inner class PreValiderStegTest {
+        @Test
+        fun `Skal kaste feil dersom det finnes kompetanser der Norge er sekundærland men aktivitetsland eller bosted er satt til Norge`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+            val søker = lagPerson(type = PersonType.SØKER)
+            val barn = lagPerson(type = PersonType.BARN)
+            val personerIBehandling = listOf(barn.tilPersonEnkel(), søker.tilPersonEnkel())
 
-        val endringTidslinje = "TTTFFFF".somBoolskTidslinje(startdato)
+            val personopplysningGrunnlag = mockk<PersonopplysningGrunnlag>()
+            val vikårsvurderings = lagVilkårsvurdering(søkerAktør = søker.aktør, behandling = behandling, resultat = Resultat.OPPFYLT)
+            val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
+            val ugyldigKompetanse =
+                lagKompetanse(
+                    behandlingId = behandling.id,
+                    kompetanseResultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
+                    søkersAktivitetsland = "NO",
+                    barnetsBostedsland = "SE",
+                    annenForeldersAktivitetsland = "SE",
+                    barnAktører = setOf(barn.aktør),
+                )
 
-        assertDoesNotThrow {
-            endringTidslinje.kastFeilVedEndringEtter(treMånederEtterStartdato, lagBehandling())
+            every { vilkårService.hentVilkårsvurderingThrows(behandling.id) } returns vikårsvurderings
+            every { vilkårService.hentVilkårsvurdering(behandling.id) } returns vikårsvurderings
+            every { personopplysningGrunnlag.søker } returns søker
+            every { personopplysningGrunnlag.barna } returns listOf(barn)
+            every { persongrunnlagService.hentBarna(any<Behandling>()) } returns emptyList()
+            every { persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(any()) } returns personerIBehandling
+            every { persongrunnlagService.hentAktivThrows(any()) } returns personopplysningGrunnlag
+            every { beregningService.hentTilkjentYtelseForBehandling(behandling.id) } returns tilkjentYtelse
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id) } returns emptyList()
+            every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) } returns emptyList()
+            every { kompetanseRepository.finnFraBehandlingId(behandling.id) } returns listOf(ugyldigKompetanse)
+
+            // Act & Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    behandlingsresultatSteg.preValiderSteg(behandling)
+                }.melding
+
+            assertThat(feilmelding).isEqualTo("Dersom Norge er sekundærland, må søkers aktivitetsland, annen forelders aktivitetsland eller barnets bostedsland være satt til noe annet enn Norge")
         }
-    }
 
-    @Test
-    fun `skal gå rett fra behandlingsresultat til iverksetting for alle fødselshendelser`() {
-        val fødselshendelseBehandling =
-            behandling.copy(
-                skalBehandlesAutomatisk = true,
-                opprettetÅrsak = BehandlingÅrsak.FØDSELSHENDELSE,
-                type = BehandlingType.FØRSTEGANGSBEHANDLING,
-            )
-        val vedtak =
-            lagVedtak(
-                fødselshendelseBehandling,
-            )
-        every { mockBehandlingsresultatService.utledBehandlingsresultat(any()) } returns Behandlingsresultat.INNVILGET_OG_ENDRET
-        every { behandlingService.nullstillEndringstidspunkt(fødselshendelseBehandling.id) } just runs
-        every {
-            behandlingService.oppdaterBehandlingsresultat(
-                any(),
-                any(),
-            )
-        } returns fødselshendelseBehandling.copy(resultat = Behandlingsresultat.INNVILGET_OG_ENDRET)
-        every {
-            behandlingService.oppdaterStatusPåBehandling(
-                fødselshendelseBehandling.id,
-                BehandlingStatus.IVERKSETTER_VEDTAK,
-            )
-        } returns fødselshendelseBehandling.copy(status = BehandlingStatus.IVERKSETTER_VEDTAK)
-        every { vedtakService.hentAktivForBehandlingThrows(fødselshendelseBehandling.id) } returns vedtak
-        every { vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(vedtak) } just runs
-        every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(fødselshendelseBehandling) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
-        every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(fødselshendelseBehandling.id) } returns emptyList()
-        every { valutakursRepository.finnFraBehandlingId(fødselshendelseBehandling.id) } returns emptyList()
+        @Test
+        fun `Skal kaste ikke feil dersom det ikke finnes kompetanser der Norge er sekundærland men aktivitetsland eller bosted er satt til Norge`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+            val søker = lagPerson(type = PersonType.SØKER)
+            val barn = lagPerson(type = PersonType.BARN)
+            val personerIBehandling = listOf(barn.tilPersonEnkel(), søker.tilPersonEnkel())
 
-        assertEquals(
-            behandlingsresultatSteg.utførStegOgAngiNeste(fødselshendelseBehandling, ""),
-            StegType.IVERKSETT_MOT_OPPDRAG,
-        )
-    }
+            val personopplysningGrunnlag = mockk<PersonopplysningGrunnlag>()
+            val vikårsvurderings = lagVilkårsvurdering(søkerAktør = søker.aktør, behandling = behandling, resultat = Resultat.OPPFYLT)
+            val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
+            val ugyldigKompetanse =
+                lagKompetanse(
+                    behandlingId = behandling.id,
+                    kompetanseResultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
+                    søkersAktivitetsland = "SE",
+                    barnetsBostedsland = "SE",
+                    annenForeldersAktivitetsland = "SE",
+                    barnAktører = setOf(barn.aktør),
+                )
 
-    @Test
-    fun `preValiderSteg - skal validere andeler ved satsendring og ikke kaste feil når endringene i andeler kun er relatert til endring i sats`() {
-        val søker = lagPerson()
-        val barn = lagPerson(type = PersonType.BARN)
-        val forrigeBehandling =
-            lagBehandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING, årsak = BehandlingÅrsak.SØKNAD)
+            every { vilkårService.hentVilkårsvurderingThrows(behandling.id) } returns vikårsvurderings
+            every { vilkårService.hentVilkårsvurdering(behandling.id) } returns vikårsvurderings
+            every { personopplysningGrunnlag.søker } returns søker
+            every { personopplysningGrunnlag.barna } returns listOf(barn)
+            every { persongrunnlagService.hentBarna(any<Behandling>()) } returns emptyList()
+            every { persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(any()) } returns personerIBehandling
+            every { persongrunnlagService.hentAktivThrows(any()) } returns personopplysningGrunnlag
+            every { beregningService.hentTilkjentYtelseForBehandling(behandling.id) } returns tilkjentYtelse
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id) } returns emptyList()
+            every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) } returns emptyList()
+            every { kompetanseRepository.finnFraBehandlingId(behandling.id) } returns listOf(ugyldigKompetanse)
 
-        val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(behandling = forrigeBehandling)
-        forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
-            mutableSetOf(
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 1),
-                    tom = YearMonth.of(2023, 2),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
+            // Act && Assert
+            assertDoesNotThrow { behandlingsresultatSteg.preValiderSteg(behandling) }
+        }
+
+        @Test
+        fun `Skal validere andeler ved satsendring og kaste feil når endringene i andeler er relatert til noe annet enn endring i sats`() {
+            val søker = lagPerson()
+            val barn = lagPerson()
+            val forrigeBehandling =
+                lagBehandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING, årsak = BehandlingÅrsak.SØKNAD)
+            val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(behandling = forrigeBehandling)
+            forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
+                mutableSetOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2023, 2),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                        prosent = BigDecimal(50),
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 3),
+                        tom = YearMonth.of(2033, 1),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                        prosent = BigDecimal(50),
+                    ),
                 ),
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 3),
-                    tom = YearMonth.of(2033, 1),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                ),
-            ),
-        )
-
-        val behandling =
-            lagBehandling(
-                fagsak = forrigeBehandling.fagsak,
-                behandlingType = BehandlingType.REVURDERING,
-                årsak = BehandlingÅrsak.SATSENDRING,
             )
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
-        tilkjentYtelse.andelerTilkjentYtelse.addAll(
-            mutableSetOf(
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 1),
-                    tom = YearMonth.of(2023, 2),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                ),
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 3),
-                    tom = YearMonth.of(2023, 6),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                ),
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 7),
-                    tom = YearMonth.of(2033, 1),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 7).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                ),
-            ),
-        )
-        lagMocksForPreValiderStegSatsendring(
-            behandling = behandling,
-            tilkjentYtelse = tilkjentYtelse,
-            forrigeBehandling = forrigeBehandling,
-            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
-            søker = søker,
-            barn = listOf(barn),
-        )
 
-        behandlingsresultatSteg.preValiderSteg(behandling)
+            val behandling =
+                lagBehandling(
+                    fagsak = forrigeBehandling.fagsak,
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.SATSENDRING,
+                )
+            val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
+            tilkjentYtelse.andelerTilkjentYtelse.addAll(
+                mutableSetOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2023, 2),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                        prosent = BigDecimal(50),
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 3),
+                        tom = YearMonth.of(2023, 6),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                        prosent = BigDecimal(100),
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 7),
+                        tom = YearMonth.of(2033, 1),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 7).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                        prosent = BigDecimal(50),
+                    ),
+                ),
+            )
+            lagMocksForPreValiderStegSatsendring(
+                behandling = behandling,
+                tilkjentYtelse = tilkjentYtelse,
+                forrigeBehandling = forrigeBehandling,
+                forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+                søker = søker,
+                barn = listOf(barn),
+            )
 
-        assertThatCode { behandlingsresultatSteg.preValiderSteg(behandling) }.doesNotThrowAnyException()
+            assertThatThrownBy { behandlingsresultatSteg.preValiderSteg(behandling) }
+                .isInstanceOf(SatsendringFeil::class.java)
+                .hasMessageContaining("Satsendring kan ikke endre på prosenten til en andel")
+        }
+
+        @Test
+        fun `Skal validere andeler ved satsendring og ikke kaste feil når endringene i andeler kun er relatert til endring i sats`() {
+            val søker = lagPerson()
+            val barn = lagPerson(type = PersonType.BARN)
+            val forrigeBehandling =
+                lagBehandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING, årsak = BehandlingÅrsak.SØKNAD)
+
+            val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(behandling = forrigeBehandling)
+            forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
+                mutableSetOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2023, 2),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 3),
+                        tom = YearMonth.of(2033, 1),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                    ),
+                ),
+            )
+
+            val behandling =
+                lagBehandling(
+                    fagsak = forrigeBehandling.fagsak,
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.SATSENDRING,
+                )
+            val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
+            tilkjentYtelse.andelerTilkjentYtelse.addAll(
+                mutableSetOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2023, 2),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 3),
+                        tom = YearMonth.of(2023, 6),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 7),
+                        tom = YearMonth.of(2033, 1),
+                        behandling = forrigeBehandling,
+                        tilkjentYtelse = forrigeTilkjentYtelse,
+                        beløp =
+                            SatsService.finnGjeldendeSatsForDato(
+                                SatsType.ORBA,
+                                YearMonth.of(2023, 7).førsteDagIInneværendeMåned(),
+                            ),
+                        aktør = barn.aktør,
+                    ),
+                ),
+            )
+            lagMocksForPreValiderStegSatsendring(
+                behandling = behandling,
+                tilkjentYtelse = tilkjentYtelse,
+                forrigeBehandling = forrigeBehandling,
+                forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+                søker = søker,
+                barn = listOf(barn),
+            )
+
+            behandlingsresultatSteg.preValiderSteg(behandling)
+
+            assertThatCode { behandlingsresultatSteg.preValiderSteg(behandling) }.doesNotThrowAnyException()
+        }
     }
 
     @Test
@@ -449,108 +621,6 @@ class BehandlingsresultatStegTest {
                 behandlingsresultatSteg.postValiderSteg(behandling)
             }
         }
-    }
-
-    @Test
-    fun `preValiderSteg - skal validere andeler ved satsendring og kaste feil når endringene i andeler er relatert til noe annet enn endring i sats`() {
-        val søker = lagPerson()
-        val barn = lagPerson()
-        val forrigeBehandling =
-            lagBehandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING, årsak = BehandlingÅrsak.SØKNAD)
-        val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(behandling = forrigeBehandling)
-        forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
-            mutableSetOf(
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 1),
-                    tom = YearMonth.of(2023, 2),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                    prosent = BigDecimal(50),
-                ),
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 3),
-                    tom = YearMonth.of(2033, 1),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                    prosent = BigDecimal(50),
-                ),
-            ),
-        )
-
-        val behandling =
-            lagBehandling(
-                fagsak = forrigeBehandling.fagsak,
-                behandlingType = BehandlingType.REVURDERING,
-                årsak = BehandlingÅrsak.SATSENDRING,
-            )
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
-        tilkjentYtelse.andelerTilkjentYtelse.addAll(
-            mutableSetOf(
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 1),
-                    tom = YearMonth.of(2023, 2),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 1).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                    prosent = BigDecimal(50),
-                ),
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 3),
-                    tom = YearMonth.of(2023, 6),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 3).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                    prosent = BigDecimal(100),
-                ),
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2023, 7),
-                    tom = YearMonth.of(2033, 1),
-                    behandling = forrigeBehandling,
-                    tilkjentYtelse = forrigeTilkjentYtelse,
-                    beløp =
-                        SatsService.finnGjeldendeSatsForDato(
-                            SatsType.ORBA,
-                            YearMonth.of(2023, 7).førsteDagIInneværendeMåned(),
-                        ),
-                    aktør = barn.aktør,
-                    prosent = BigDecimal(50),
-                ),
-            ),
-        )
-        lagMocksForPreValiderStegSatsendring(
-            behandling = behandling,
-            tilkjentYtelse = tilkjentYtelse,
-            forrigeBehandling = forrigeBehandling,
-            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
-            søker = søker,
-            barn = listOf(barn),
-        )
-
-        assertThatThrownBy { behandlingsresultatSteg.preValiderSteg(behandling) }
-            .isInstanceOf(SatsendringFeil::class.java)
-            .hasMessageContaining("Satsendring kan ikke endre på prosenten til en andel")
     }
 
     private fun lagMocksForPreValiderStegSatsendring(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseTest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.eøs.kompetanse
 
-import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.datagenerator.lagKompetanse
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
@@ -8,11 +7,10 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.utbetalingsland
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class KompetanseTest {
     @Test
-    fun `tilUtbetalingsland - skal returnere landkode for utbetalingsland dersom kompetanse er utfylt`() {
+    fun `utbetalingsland - skal returnere landkode for utbetalingsland dersom kompetanse er utfylt`() {
         val kompetanse =
             lagKompetanse(
                 barnAktører = setOf(randomAktør()),
@@ -32,7 +30,7 @@ class KompetanseTest {
     }
 
     @Test
-    fun `tilUtbetalingsland - skal returnere null for utbetalingsland dersom kompetanse ikke er utfylt`() {
+    fun `utbetalingsland - skal returnere null for utbetalingsland dersom kompetanse ikke er utfylt`() {
         val kompetanse =
             lagKompetanse()
 
@@ -42,7 +40,7 @@ class KompetanseTest {
     }
 
     @Test
-    fun `tilUtbetalingsland - skal returnere Norge for utbetalingsland dersom kompetanse er utfylt og resultatet er at norge er primærland`() {
+    fun `utbetalingsland - skal returnere Norge for utbetalingsland dersom kompetanse er utfylt og resultatet er at norge er primærland`() {
         val kompetanse =
             lagKompetanse(
                 barnAktører = setOf(randomAktør()),
@@ -62,7 +60,7 @@ class KompetanseTest {
     }
 
     @Test
-    fun `tilUtbetalingsland - skal returnere utbetalingsland ulikt Norge dersom kompetanse er utfylt og hovedregelen fortsatt gir Norge`() {
+    fun `utbetalingsland - skal returnere utbetalingsland ulikt Norge dersom kompetanse er utfylt og hovedregelen fortsatt gir Norge`() {
         val kompetanse =
             lagKompetanse(
                 barnAktører = setOf(randomAktør()),
@@ -79,24 +77,5 @@ class KompetanseTest {
 
         assertThat(utbetalingsland).isNotNull
         assertThat(utbetalingsland).isEqualTo("SE")
-    }
-
-    @Test
-    fun `tilUtbetalingsland - skal kaste feil dersom kompetanse er utfylt og det ikke er registrert noe annet land enn Norge på kompetansen`() {
-        val kompetanse =
-            lagKompetanse(
-                barnAktører = setOf(randomAktør()),
-                søkersAktivitet = KompetanseAktivitet.MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN,
-                søkersAktivitetsland = "NO",
-                annenForeldersAktivitet = KompetanseAktivitet.IKKE_AKTUELT,
-                annenForeldersAktivitetsland = null,
-                barnetsBostedsland = "NO",
-                kompetanseResultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
-                erAnnenForelderOmfattetAvNorskLovgivning = false,
-            )
-
-        val funksjonellFeil = assertThrows<FunksjonellFeil> { kompetanse.utbetalingsland() }
-
-        assertThat(funksjonellFeil.melding).isEqualTo("Dersom Norge er sekundærland, må søkers aktivitetsland, annen forelders aktivitetsland eller barnets bostedsland være satt til noe annet enn Norge.")
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -383,6 +383,7 @@ class CucumberMock(
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             valutakursRepository = valutakursRepository,
             localDateProvider = mockedDateProvider,
+            kompetanseRepository = kompetanseRepository,
         )
 
     val saksbehandlerContext = SaksbehandlerContext("", mockk(), mockUnleashNextMedContextService())


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24435

I Juni 2024 så la vi til ekstra validering på kompetansen ved uthenting av utbetalingslandet - 
valideringen sjekker at dersom Norge er sekundærland, så skal det ikke være mulig å sette søker/annenforelder aktivitetsland til Norge, eller barnets bosted til Norge.

Denne valideringen ble trigget ved generering av utbetalingstabellen + ved justering av utenlandskbeløp.

Valideringen i seg selv er OK, men problemet er at ved revurdering av behandlinger som ble opprettet før denne regelen kom på plass, så vil valideringen skje for tidlig. Den vil skje ved når man trykker neste i vilkårsvurderingen, og der har man ikke mulighet til å korrigere kompetansene ved feil. 

Jeg har derfor:

- Flyttet valideringen slik at den skjer når vi trykker på "Neste" i behandlingsresultat siden
- Lagt til tester på dette, laget nested test klasser siden det var en stor miks i behandlingsresultatsteg test
- Flyttet ut noen tester som ikke hører hjemme i behandlingsresultatsteg test