### PR TITLE
Håndterer opphør gjennom overskriving av tidligere periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.utbetalingsoppdrag
 import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærTilOgMed
+import no.nav.familie.ba.sak.kjerne.tidslinjefamiliefelles.transformasjon.beskjærTilOgMedEtter
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import no.nav.familie.tidslinje.Periode
@@ -87,7 +88,11 @@ class UtbetalingsTidslinjeService(
                     }
                 kjederForFagsak.apply {
                     kjederForUtbetalingsperioder.forEach { periodeId, (tidslinje, forrigePeriodeId, opphørsperiode) ->
-                        val gjeldendeTidslinje = kjederForFagsak.getOrDefault(forrigePeriodeId, tomTidslinje()).beskjærOgKorrigerPerioderVedOpphør(opphørsperiode)
+                        val gjeldendeTidslinje =
+                            kjederForFagsak
+                                .getOrDefault(forrigePeriodeId, tomTidslinje())
+                                .beskjærOgKorrigerPerioderVedOpphør(opphørsperiode)
+                                .beskjærTilOgMedEtterIkkeTomTidslinje(tidslinje)
 
                         // Sørger for at vi alltid tar med den siste perioden dersom det er overlapp.
                         val nyGjeldendeTidslinje =
@@ -125,4 +130,11 @@ class UtbetalingsTidslinjeService(
                 // Beskjærer tidslinje slik at alt etter opphørsdato forsvinner
                 .beskjærTilOgMed(opphørsperiode.opphør!!.opphørDatoFom.minusDays(1))
         }
+
+    private fun Tidslinje<Utbetalingsperiode>.beskjærTilOgMedEtterIkkeTomTidslinje(tidslinje: Tidslinje<Utbetalingsperiode>): Tidslinje<Utbetalingsperiode> {
+        if (tidslinje.erTom()) {
+            return this
+        }
+        return this.beskjærTilOgMedEtter(tidslinje)
+    }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Etter litt testing i prod oppdaget jeg at `UtbetalingsTidslinjeService` ikke håndterer opphør ved overskriving av tidligere periode.

Gitt en periode som løper fra 01.09.24 -> 01.09.35, skal en ny periode 01.09.24 -> 28.02.25 føre til at det det ikke løper noe fra og med 01.03.25.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester. 
