### PR TITLE
Graceful shutdown på skyggesak, satsendring og saksstatistikkscheduler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakScheduler.kt
@@ -1,75 +1,33 @@
 package no.nav.familie.ba.sak.integrasjoner.skyggesak
 
-import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.LeaderClientService
-import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
-import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
-import no.nav.familie.log.mdc.MDCConstants
-import org.slf4j.LoggerFactory
-import org.slf4j.MDC
-import org.springframework.data.domain.Pageable
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ContextClosedEvent
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
-import java.util.UUID
 
 @Component
 class SkyggesakScheduler(
-    val skyggesakRepository: SkyggesakRepository,
-    val fagsakRepository: FagsakRepository,
-    val integrasjonClient: IntegrasjonClient,
     val leaderClientService: LeaderClientService,
-) {
+    val skyggesakService: SkyggesakService,
+) : ApplicationListener<ContextClosedEvent> {
+    @Volatile private var isShuttingDown = false
+
     @Scheduled(fixedDelay = 60000)
     fun opprettSkyggesaker() {
-        if (leaderClientService.isLeader()) {
-            sendSkyggesaker()
+        if (!isShuttingDown && leaderClientService.isLeader()) {
+            skyggesakService.sendSkyggesaker()
         }
     }
 
     @Scheduled(cron = "0 0 6 * * *")
     fun ryddOppISendteSkyggesaker() {
         if (leaderClientService.isLeader()) {
-            fjernGamleSkyggesakInnslag()
+            skyggesakService.fjernGamleSkyggesakInnslag()
         }
     }
 
-    @Transactional
-    fun sendSkyggesaker() {
-        val skyggesaker = skyggesakRepository.finnSkyggesakerKlareForSending(Pageable.ofSize(400))
-
-        for (skyggesak in skyggesaker) {
-            try {
-                MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
-                val fagsak = fagsakRepository.finnFagsak(skyggesak.fagsakId)!!
-                logger.info("Opprettet skyggesak for fagsak ${fagsak.id}")
-                integrasjonClient.opprettSkyggesak(fagsak.aktør, fagsak.id)
-                skyggesakRepository.save(skyggesak.copy(sendtTidspunkt = LocalDateTime.now()))
-            } catch (e: Exception) {
-                logger.warn("Kunne ikke opprette skyggesak for fagsak ${skyggesak.fagsakId}")
-                secureLogger.warn("Kunne ikke opprette skyggesak for fagsak ${skyggesak.fagsakId}", e)
-            } finally {
-                MDC.clear()
-            }
-        }
-    }
-
-    @Transactional
-    fun fjernGamleSkyggesakInnslag() {
-        skyggesakRepository
-            .finnSkyggesakerSomErSendt()
-            .filter { it.sendtTidspunkt!!.isBefore(LocalDateTime.now().minusDays(SKYGGESAK_RETENTION.toLong())) }
-            .run {
-                logger.info("Fjerner ${this.size} rader fra Skyggesak, sendt for mer enn $SKYGGESAK_RETENTION dager siden")
-                secureLogger.info("Fjerner følgende rader eldre enn $SKYGGESAK_RETENTION fra Skyggesak:\n$this ")
-                skyggesakRepository.deleteAll(this)
-            }
-    }
-
-    companion object {
-        private const val SKYGGESAK_RETENTION = 14
-
-        private val logger = LoggerFactory.getLogger(SkyggesakScheduler::class.java)
+    override fun onApplicationEvent(event: ContextClosedEvent) {
+        isShuttingDown = true
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakService.kt
@@ -1,13 +1,63 @@
 package no.nav.familie.ba.sak.integrasjoner.skyggesak
 
+import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.log.mdc.MDCConstants
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
 
 @Service
 class SkyggesakService(
     private val skyggesakRepository: SkyggesakRepository,
+    val fagsakRepository: FagsakRepository,
+    val integrasjonClient: IntegrasjonClient,
 ) {
+    @Transactional
+    fun sendSkyggesaker() {
+        val skyggesaker = skyggesakRepository.finnSkyggesakerKlareForSending(Pageable.ofSize(400))
+
+        for (skyggesak in skyggesaker) {
+            try {
+                MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
+                val fagsak = fagsakRepository.finnFagsak(skyggesak.fagsakId)!!
+                logger.info("Opprettet skyggesak for fagsak ${fagsak.id}")
+                integrasjonClient.opprettSkyggesak(fagsak.aktør, fagsak.id)
+                skyggesakRepository.save(skyggesak.copy(sendtTidspunkt = LocalDateTime.now()))
+            } catch (e: Exception) {
+                logger.warn("Kunne ikke opprette skyggesak for fagsak ${skyggesak.fagsakId}")
+                secureLogger.warn("Kunne ikke opprette skyggesak for fagsak ${skyggesak.fagsakId}", e)
+            } finally {
+                MDC.clear()
+            }
+        }
+    }
+
+    @Transactional
+    fun fjernGamleSkyggesakInnslag() {
+        skyggesakRepository
+            .finnSkyggesakerSomErSendt()
+            .filter { it.sendtTidspunkt!!.isBefore(LocalDateTime.now().minusDays(SKYGGESAK_RETENTION.toLong())) }
+            .run {
+                logger.info("Fjerner ${this.size} rader fra Skyggesak, sendt for mer enn $SKYGGESAK_RETENTION dager siden")
+                secureLogger.info("Fjerner følgende rader eldre enn $SKYGGESAK_RETENTION fra Skyggesak:\n$this ")
+                skyggesakRepository.deleteAll(this)
+            }
+    }
+
     fun opprettSkyggesak(fagsak: Fagsak) {
         skyggesakRepository.save(Skyggesak(fagsakId = fagsak.id))
+    }
+
+    companion object {
+        private const val SKYGGESAK_RETENTION = 14
+
+        private val logger = LoggerFactory.getLogger(SkyggesakScheduler::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakService.kt
@@ -27,7 +27,7 @@ class SkyggesakService(
             try {
                 MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
                 val fagsak = fagsakRepository.finnFagsak(skyggesak.fagsakId)!!
-                logger.info("Opprettet skyggesak for fagsak ${fagsak.id}")
+                logger.info("Oppretter skyggesak for fagsak ${fagsak.id}")
                 integrasjonClient.opprettSkyggesak(fagsak.aktør, fagsak.id)
                 skyggesakRepository.save(skyggesak.copy(sendtTidspunkt = LocalDateTime.now()))
             } catch (e: Exception) {
@@ -43,10 +43,10 @@ class SkyggesakService(
     fun fjernGamleSkyggesakInnslag() {
         skyggesakRepository
             .finnSkyggesakerSomErSendt()
-            .filter { it.sendtTidspunkt!!.isBefore(LocalDateTime.now().minusDays(SKYGGESAK_RETENTION.toLong())) }
+            .filter { it.sendtTidspunkt!!.isBefore(LocalDateTime.now().minusDays(SKYGGESAK_RETENTION_DAGER.toLong())) }
             .run {
-                logger.info("Fjerner ${this.size} rader fra Skyggesak, sendt for mer enn $SKYGGESAK_RETENTION dager siden")
-                secureLogger.info("Fjerner følgende rader eldre enn $SKYGGESAK_RETENTION fra Skyggesak:\n$this ")
+                logger.info("Fjerner ${this.size} rader fra Skyggesak, sendt for mer enn $SKYGGESAK_RETENTION_DAGER dager siden")
+                secureLogger.info("Fjerner følgende rader eldre enn $SKYGGESAK_RETENTION_DAGER fra Skyggesak:\n$this ")
                 skyggesakRepository.deleteAll(this)
             }
     }
@@ -56,8 +56,8 @@ class SkyggesakService(
     }
 
     companion object {
-        private const val SKYGGESAK_RETENTION = 14
+        private const val SKYGGESAK_RETENTION_DAGER = 14
 
-        private val logger = LoggerFactory.getLogger(SkyggesakScheduler::class.java)
+        private val logger = LoggerFactory.getLogger(SkyggesakService::class.java)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tiltak for å minske antall errors når leader-sidecaren blir tatt ned før appen. Hentet fra familie-prosessering-backend, som ikke kjører nye tasker når man får SIGTERM. På samme måte sjekker man ikke leader for de Scheduled jobbene som kjører ofte det er sendt en melding om at appen stenger ned.

Også flytte noe kode fra skyggesak-scheduler til serviceklassen siden at Transactional-proxien ikke funker om det er i samme klasse.

ref: https://nav-it.slack.com/archives/C01G9BA8JKZ/p1740747402744669

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
