### PR TITLE
Fikser test som sjekker på en måned frem i tid og ikke siste dag i måneden

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
@@ -124,7 +124,7 @@ class VilkårsvurderingForskyvningUtilsTest {
         val fullPeriode = borMedSøkerPerioder.last()
 
         assertEquals(fom.plusMonths(1), deltBostedPeriode.fom)
-        assertEquals(deltBostedTom.plusMonths(1), deltBostedPeriode.tom)
+        assertEquals(deltBostedTom.plusMonths(1).sisteDagIMåned(), deltBostedPeriode.tom)
         assertEquals(deltBostedTom.plusMonths(2).førsteDagIInneværendeMåned(), fullPeriode.fom)
         assertNull(fullPeriode.tom)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Test som feiler pga månedskifte. Fikser testen som sjekker på en måned frem i tid og ikke siste dag i måneden en måned frem i tid
