### PR TITLE
Valider tilbakekrevingsvalg når det besluttes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -171,7 +171,7 @@ class BeslutteVedtak(
             throw FunksjonellFeil("Det er en feilutbetaling som saksbehandler ikke har tatt stilling til. Saken må underkjennes og sendes tilbake til saksbehandler for ny vurdering.")
         }
 
-        if (feilutbetaling == BigDecimal.ZERO && tilbakekrevingsvalg !in listOf(null, Tilbakekrevingsvalg.IGNORER_TILBAKEKREVING)) {
+        if (feilutbetaling == BigDecimal.ZERO && tilbakekrevingsvalg in listOf(Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL, Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK, Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_UTEN_VARSEL)) {
             throw FunksjonellFeil("Det er valgt å opprette tilbakekrevingssak men det er ikke lenger feilutbetalt beløp. Behandlingen må underkjennes, og saksbehandler må gå tilbake til behandlingsresultatet og trykke neste og fullføre behandlingen på nytt.")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -17,8 +17,6 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerValidering
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
-import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
-import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Vurderingsform
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
@@ -53,7 +51,6 @@ class BeslutteVedtak(
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val saksbehandlerContext: SaksbehandlerContext,
     private val automatiskBeslutningService: AutomatiskBeslutningService,
-    private val valutakursRepository: ValutakursRepository,
     private val simuleringService: SimuleringService,
     private val tilbakekrevingService: TilbakekrevingService,
     private val brevmottakerService: BrevmottakerService,
@@ -66,9 +63,7 @@ class BeslutteVedtak(
             throw FunksjonellFeil("Behandlingen er allerede sendt til oppdrag og venter på kvittering")
         } else if (behandling.status == BehandlingStatus.AVSLUTTET) {
             throw FunksjonellFeil("Behandlingen er allerede avsluttet")
-        } else if (behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-            !unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV, behandling.id)
-        ) {
+        } else if (behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV && !unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV, behandling.id)) {
             throw FunksjonellFeil(
                 melding = "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og toggle ${FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn} false",
                 frontendFeilmelding = "Du har ikke tilgang til å beslutte for denne behandlingen. Ta kontakt med teamet dersom dette ikke stemmer.",
@@ -89,15 +84,11 @@ class BeslutteVedtak(
         val feilutbetaling by lazy { simuleringService.hentFeilutbetalingTilOgMedForrigeMåned(behandling.id) }
         val erÅpenTilbakekrevingPåFagsak by lazy { tilbakekrevingService.søkerHarÅpenTilbakekreving(behandling.fagsak.id) }
         val tilbakekrevingsvalg by lazy { tilbakekrevingService.hentTilbakekrevingsvalg(behandling.id) }
-        val valutakurser by lazy { valutakursRepository.finnFraBehandlingId(behandlingId = behandling.id) }
 
-        val behandlingSkalAutomatiskBesluttes =
-            automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)
+        val behandlingSkalAutomatiskBesluttes = automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)
 
-        val beslutter =
-            if (behandlingSkalAutomatiskBesluttes) SikkerhetContext.SYSTEM_NAVN else saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
-        val beslutterId =
-            if (behandlingSkalAutomatiskBesluttes) SikkerhetContext.SYSTEM_FORKORTELSE else SikkerhetContext.hentSaksbehandler()
+        val beslutter = if (behandlingSkalAutomatiskBesluttes) SikkerhetContext.SYSTEM_NAVN else saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+        val beslutterId = if (behandlingSkalAutomatiskBesluttes) SikkerhetContext.SYSTEM_FORKORTELSE else SikkerhetContext.hentSaksbehandler()
 
         val totrinnskontroll =
             totrinnskontrollService.besluttTotrinnskontroll(
@@ -115,14 +106,11 @@ class BeslutteVedtak(
         )
 
         return if (data.beslutning.erGodkjent()) {
-            val erAutomatiskeValutakurserPåBehandling = valutakurser.any { it.vurderingsform == Vurderingsform.AUTOMATISK }
-            if (erAutomatiskeValutakurserPåBehandling && !erÅpenTilbakekrevingPåFagsak) {
+            if (!erÅpenTilbakekrevingPåFagsak) {
                 validerErTilbakekrevingHvisFeilutbetaling(feilutbetaling, tilbakekrevingsvalg)
             }
 
-            val vedtak =
-                vedtakService.hentAktivForBehandling(behandlingId = behandling.id)
-                    ?: error("Fant ikke aktivt vedtak på behandling ${behandling.id}")
+            val vedtak = vedtakService.hentAktivForBehandling(behandlingId = behandling.id) ?: error("Fant ikke aktivt vedtak på behandling ${behandling.id}")
 
             vedtakService.oppdaterVedtaksdatoOgBrev(vedtak)
 
@@ -153,9 +141,7 @@ class BeslutteVedtak(
             }
             nesteSteg
         } else {
-            val vilkårsvurdering =
-                vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)
-                    ?: throw Feil("Fant ikke vilkårsvurdering på behandling")
+            val vilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id) ?: throw Feil("Fant ikke vilkårsvurdering på behandling")
             val kopiertVilkårsVurdering = vilkårsvurdering.kopier(inkluderAndreVurderinger = true)
             vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = kopiertVilkårsVurdering)
 
@@ -184,6 +170,10 @@ class BeslutteVedtak(
         if (feilutbetaling != BigDecimal.ZERO && tilbakekrevingsvalg == null) {
             throw FunksjonellFeil("Det er en feilutbetaling som saksbehandler ikke har tatt stilling til. Saken må underkjennes og sendes tilbake til saksbehandler for ny vurdering.")
         }
+
+        if (feilutbetaling == BigDecimal.ZERO && tilbakekrevingsvalg !in listOf(null, Tilbakekrevingsvalg.IGNORER_TILBAKEKREVING)) {
+            throw FunksjonellFeil("Det er valgt å opprette tilbakekrevingssak men det er ikke lenger feilutbetalt beløp. Behandlingen må underkjennes, og saksbehandler må gå tilbake til behandlingsresultatet og trykke neste og fullføre behandlingen på nytt.")
+        }
     }
 
     override fun postValiderSteg(behandling: Behandling) {
@@ -193,8 +183,7 @@ class BeslutteVedtak(
     override fun stegType(): StegType = StegType.BESLUTTE_VEDTAK
 
     private fun sjekkOmBehandlingSkalIverksettesOgHentNesteSteg(behandling: Behandling): StegType {
-        val endringerIUtbetaling =
-            beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling)
+        val endringerIUtbetaling = beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling)
 
         return hentNesteStegGittEndringerIUtbetaling(behandling, endringerIUtbetaling)
     }
@@ -221,8 +210,7 @@ class BeslutteVedtak(
         )
 
         if (!behandling.erManuellMigrering() || !behandlingErAutomatiskBesluttet) {
-            val ferdigstillGodkjenneVedtakTask =
-                FerdigstillOppgaver.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak)
+            val ferdigstillGodkjenneVedtakTask = FerdigstillOppgaver.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak)
             taskRepository.save(ferdigstillGodkjenneVedtakTask)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.math.BigDecimal
 
 class BeslutteVedtakTest {
@@ -326,8 +328,9 @@ class BeslutteVedtakTest {
             assertThat(exception.message).isEqualTo("Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket")
         }
 
-        @Test
-        fun `Skal kaste feil dersom feilutbetaling ikke lenger finnes og det er valgt å opprette en `() {
+        @ParameterizedTest
+        @EnumSource(Tilbakekrevingsvalg::class, names = ["OPPRETT_TILBAKEKREVING_MED_VARSEL", "OPPRETT_TILBAKEKREVING_UTEN_VARSEL", "OPPRETT_TILBAKEKREVING_AUTOMATISK"], mode = EnumSource.Mode.INCLUDE)
+        fun `Skal kaste feil dersom feilutbetaling ikke lenger finnes og det er valgt å opprette en tilbakekrevingssak`(tilbakekrevingsvalg: Tilbakekrevingsvalg) {
             // Arrange
             val behandling = lagBehandling()
             behandling.status = BehandlingStatus.FATTER_VEDTAK
@@ -345,7 +348,7 @@ class BeslutteVedtakTest {
                 listOf(
                     lagBrevmottakerDb(behandlingId = behandling.id),
                 )
-            every { tilbakekrevingService.hentTilbakekrevingsvalg(behandling.id) } returns Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL
+            every { tilbakekrevingService.hentTilbakekrevingsvalg(behandling.id) } returns tilbakekrevingsvalg
 
             // Act && Assert
             val feilmelding =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -553,7 +553,6 @@ class CucumberMock(
             tilkjentYtelseValideringService = tilkjentYtelseValideringService,
             saksbehandlerContext = saksbehandlerContext,
             automatiskBeslutningService = automatiskBeslutningService,
-            valutakursRepository = valutakursRepository,
             simuleringService = simuleringService,
             tilbakekrevingService = tilbakekrevingService,
             brevmottakerService = brevmottakerService,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24502

Vi har fått en sak i produksjon der det eksisterte feilutbetaling på brukeren når saken ble sendt til godkjenning.
Men i mellomtiden så har det feilutbetalte beløpet blitt slettet hos økonomi, også har beslutter godkjent vedtaket.

Dette fører til en ugyldig state for behandlingen, og vi ønsker å forhindre dette.

Jeg har derfor:

- Lagt til en ekstra validering når det besluttes at hvis det feilutbetalte beløpet er 0, og man har aktivt valgt å opprette en tilbakekrevingssak så skal det nå kastes en feil som ber SB1 å gå tilbake til behandlingsresultatet og gå videre.
- Fjernet kravet om at det må være månedlig valutajustering før man validerer tilbakekrevingsvalget
- Lagt til tester på gammel validering da det ikke fantes fra før, lagt til tester på ny validering.