### PR TITLE
Logger ut fagsak som trigger feil ved generering av utbetalingstidslinjer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi
 
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.integrasjoner.pdl.logger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.utbetalingsoppdrag
@@ -29,12 +31,18 @@ class UtbetalingsTidslinjeService(
     ): List<Periode<Utbetalingsperiode>> {
         val fagsakerIder = behandlingRepository.finnFagsakIderForBehandlinger(behandlinger).toSet()
         return fagsakerIder
-            .flatMap { fagsakId ->
-                genererUtbetalingstidslinjerForFagsak(fagsakId)
-                    .flatMap { utbetalingstidslinje ->
-                        utbetalingstidslinje.tidslinje.beskjærFraOgMed(dato.førsteDagIInneværendeMåned()).tilPerioderIkkeNull()
+                .flatMap { fagsakId ->
+                    try {
+                        genererUtbetalingstidslinjerForFagsak(fagsakId)
+                            .flatMap { utbetalingstidslinje ->
+                                utbetalingstidslinje.tidslinje.beskjærFraOgMed(dato.førsteDagIInneværendeMåned()).tilPerioderIkkeNull()
+                            }
+                    } catch (e: Exception) {
+                        secureLogger.error("Feil ved generering av utbetalingsperioder for fagsak=$fagsakId", e)
+                        throw e
                     }
-            }
+                }
+        }
     }
 
     fun genererUtbetalingstidslinjerForFagsak(fagsakId: Long): List<Utbetalingstidslinje> {


### PR DESCRIPTION
Ved dryrun av konsistensavstemming er det noen tasker som feiler ved generering av utbetalingstidslinjer. Logger her ut fagsakId til fagsak som skaper feil for videre feilsøking.