### PR TITLE
Logger ut periodeId som finnes i flere kjeder samt alle utbetalingsperioder i fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
@@ -57,7 +57,13 @@ class UtbetalingsTidslinjeService(
 
         return tidslinjePerKjede.keys.map { sistePeriodeIdIKjede ->
             Utbetalingstidslinje(
-                utbetalingsperioder = utbetalingsperioderPerKjede.values.single { it.any { utbetalingsperiode -> utbetalingsperiode.periodeId == sistePeriodeIdIKjede } },
+                utbetalingsperioder =
+                    try {
+                        utbetalingsperioderPerKjede.values.single { it.any { utbetalingsperiode -> utbetalingsperiode.periodeId == sistePeriodeIdIKjede } }
+                    } catch (e: Exception) {
+                        secureLogger.error("SistePeriodeIdIKjede=$sistePeriodeIdIKjede finnes i flere forskjellige kjeder. utbetalingsperioderPerKjede=${utbetalingsperioderPerKjede.values}", e)
+                        throw e
+                    },
                 tidslinje = tidslinjePerKjede[sistePeriodeIdIKjede]!!,
             )
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I noen fagsaker feiler generering av utbetalingstidslinjer pga overlapp i periodeId. Legger her til litt logging for å kunne feilsøke hvorfor dette skjer.
