### PR TITLE
Send med saksbehandler id til frontend

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestTotrinnskontroll.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestTotrinnskontroll.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 
 data class RestTotrinnskontroll(
     val saksbehandler: String,
+    val saksbehandlerId: String,
     val beslutter: String? = null,
     val godkjent: Boolean = false,
     val opprettetTidspunkt: LocalDateTime,
@@ -16,4 +17,5 @@ fun Totrinnskontroll.tilRestTotrinnskontroll() =
         beslutter = this.beslutter,
         godkjent = this.godkjent,
         opprettetTidspunkt = this.opprettetTidspunkt,
+        saksbehandlerId = this.saksbehandlerId,
     )


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24574

Når vi nå sjekker om saksbehandler er på sitt vedtak så sammenligner vi displayname (Etternavn, Fornavn), med det som ligger i vedtaksbrevet som signatur (Fornavn Mellomnavn Etternavn). Denne sjekken feiler etter at vi endret signatur på vedtaksbrevet.

Jeg synes uansett at denne sjekken bør sjekke på NAVIdent istedenfor, som er mer sikkert mtp at flere kan ha samme navn. Endrer det derfor til SB ident. Tilbakemeldinger tas imot med glede! :D

FrontendPR for å sjekke på SB ID: https://github.com/navikt/familie-ba-sak-frontend/pull/3591