### PR TITLE
NAV_24505: Legger til egen enum for journalpost behandlingstype som inneholder klage og tilbakekreving

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.erAlfanummeriskPlussKolon
 import no.nav.familie.ba.sak.common.secureLogger
@@ -40,7 +41,7 @@ data class RestJournalføring(
     val dokumenter: List<RestJournalpostDokument>,
     // Saksbehandler sin ident
     val navIdent: String,
-    val nyBehandlingstype: BehandlingType,
+    val nyBehandlingstype: Journalføringsbehandlingstype,
     val nyBehandlingsårsak: BehandlingÅrsak,
     val fagsakType: FagsakType,
     val institusjon: RestInstitusjon? = null,
@@ -92,6 +93,26 @@ data class RestJournalføring(
             // Defaulter til ordinær inntil videre.
             else -> BehandlingUnderkategori.ORDINÆR
         }
+    }
+
+    enum class Journalføringsbehandlingstype {
+        FØRSTEGANGSBEHANDLING,
+        REVURDERING,
+        MIGRERING_FRA_INFOTRYGD,
+        TEKNISK_ENDRING,
+        KLAGE,
+        TILBAKEKREVING,
+        ;
+
+        fun tilBehandingType(): BehandlingType =
+            when (this) {
+                FØRSTEGANGSBEHANDLING -> BehandlingType.FØRSTEGANGSBEHANDLING
+                REVURDERING -> BehandlingType.REVURDERING
+                MIGRERING_FRA_INFOTRYGD -> BehandlingType.MIGRERING_FRA_INFOTRYGD
+                TEKNISK_ENDRING -> BehandlingType.TEKNISK_ENDRING
+                KLAGE -> throw Feil("Klage finnes ikke i ${BehandlingType::class.simpleName}. Behandles i ekstern applikasjon.")
+                TILBAKEKREVING -> throw Feil("Tilbakekreving finnes ikke i ${BehandlingType::class.simpleName}. Behandles i ekstern applikasjon.")
+            }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
@@ -128,7 +128,7 @@ class InnkommendeJournalføringService(
                 opprettBehandlingOgEvtFagsakForJournalføring(
                     personIdent = request.bruker.id,
                     navIdent = request.navIdent,
-                    type = request.nyBehandlingstype,
+                    type = request.nyBehandlingstype.tilBehandingType(),
                     årsak = request.nyBehandlingsårsak,
                     kategori = request.kategori,
                     underkategori = request.underkategori,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceTest.kt
@@ -59,7 +59,7 @@ class InnkommendeJournalføringServiceTest(
 
         val behandling = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId.toLong())
         assertNotNull(behandling)
-        assertEquals(request.nyBehandlingstype, behandling!!.type)
+        assertEquals(request.nyBehandlingstype.tilBehandingType(), behandling!!.type)
         assertEquals(request.nyBehandlingsårsak, behandling.opprettetÅrsak)
 
         val søknadMottattDato = behandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id)

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/JournalpostGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/JournalpostGenerator.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestJournalpostDokument
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.DEFAULT_JOURNALFØRENDE_ENHET
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Sakstype
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
@@ -127,7 +126,7 @@ fun lagMockRestJournalføring(bruker: NavnOgIdent): RestJournalføring =
                 ),
             ),
         navIdent = "09123",
-        nyBehandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+        nyBehandlingstype = RestJournalføring.Journalføringsbehandlingstype.FØRSTEGANGSBEHANDLING,
         nyBehandlingsårsak = BehandlingÅrsak.SØKNAD,
         fagsakType = FagsakType.NORMAL,
     )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Har behvor for å sende inn "Klage"  ved journalføring. Legger det ikke til i `BehandlingType` da klager ikke skal behandles i ba-sak, men i familie-klage. Lager derfor en egen enum som inneholder både "Klage" (og "Tilbakekreving" for senere) slik at vi kan bruke den enumen til å rute til oppretting av klagebehandlinger i familie-klage senere i løypen. 

Har kjørt opp løsningen lokalt og ser ut til å fungere fint.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Koden trenger en større refaktorering, vil heller gjøre det før man skriver tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
