### PR TITLE
NAV-24505: Legger til Journalføringsbehandlingstype til RestFerdigstillOppgaveKnyttJournalpost, flytter også enumen til domene pakken

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFerdigstillOppgaveKnyttJournalpost.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFerdigstillOppgaveKnyttJournalpost.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
+import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Journalføringsbehandlingstype
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import java.time.LocalDateTime
@@ -12,7 +12,7 @@ data class RestFerdigstillOppgaveKnyttJournalpost(
     val opprettOgKnyttTilNyBehandling: Boolean = false,
     val navIdent: String,
     val bruker: NavnOgIdent,
-    val nyBehandlingstype: BehandlingType,
+    val nyBehandlingstype: Journalføringsbehandlingstype,
     val nyBehandlingsårsak: BehandlingÅrsak,
     val kategori: BehandlingKategori?,
     val underkategori: BehandlingUnderkategori?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
@@ -1,13 +1,12 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.erAlfanummeriskPlussKolon
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Bruker
+import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Journalføringsbehandlingstype
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.OppdaterJournalpostRequest
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
@@ -93,26 +92,6 @@ data class RestJournalføring(
             // Defaulter til ordinær inntil videre.
             else -> BehandlingUnderkategori.ORDINÆR
         }
-    }
-
-    enum class Journalføringsbehandlingstype {
-        FØRSTEGANGSBEHANDLING,
-        REVURDERING,
-        MIGRERING_FRA_INFOTRYGD,
-        TEKNISK_ENDRING,
-        KLAGE,
-        TILBAKEKREVING,
-        ;
-
-        fun tilBehandingType(): BehandlingType =
-            when (this) {
-                FØRSTEGANGSBEHANDLING -> BehandlingType.FØRSTEGANGSBEHANDLING
-                REVURDERING -> BehandlingType.REVURDERING
-                MIGRERING_FRA_INFOTRYGD -> BehandlingType.MIGRERING_FRA_INFOTRYGD
-                TEKNISK_ENDRING -> BehandlingType.TEKNISK_ENDRING
-                KLAGE -> throw Feil("Klage finnes ikke i ${BehandlingType::class.simpleName}. Behandles i ekstern applikasjon.")
-                TILBAKEKREVING -> throw Feil("Tilbakekreving finnes ikke i ${BehandlingType::class.simpleName}. Behandles i ekstern applikasjon.")
-            }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringService.kt
@@ -186,7 +186,7 @@ class InnkommendeJournalføringService(
                 opprettBehandlingOgEvtFagsakForJournalføring(
                     personIdent = request.bruker.id,
                     navIdent = request.navIdent,
-                    type = request.nyBehandlingstype,
+                    type = request.nyBehandlingstype.tilBehandingType(),
                     årsak = request.nyBehandlingsårsak,
                     kategori = request.kategori,
                     underkategori = request.underkategori,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/domene/Journalføringsbehandlingstype.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/domene/Journalføringsbehandlingstype.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ba.sak.integrasjoner.journalføring.domene
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+
+enum class Journalføringsbehandlingstype {
+    FØRSTEGANGSBEHANDLING,
+    REVURDERING,
+    MIGRERING_FRA_INFOTRYGD,
+    TEKNISK_ENDRING,
+    KLAGE,
+    TILBAKEKREVING,
+    ;
+
+    fun tilBehandingType(): BehandlingType =
+        when (this) {
+            FØRSTEGANGSBEHANDLING -> BehandlingType.FØRSTEGANGSBEHANDLING
+            REVURDERING -> BehandlingType.REVURDERING
+            MIGRERING_FRA_INFOTRYGD -> BehandlingType.MIGRERING_FRA_INFOTRYGD
+            TEKNISK_ENDRING -> BehandlingType.TEKNISK_ENDRING
+            KLAGE -> throw Feil("Klage finnes ikke i ${BehandlingType::class.simpleName}. Behandles i ekstern applikasjon.")
+            TILBAKEKREVING -> throw Feil("Tilbakekreving finnes ikke i ${BehandlingType::class.simpleName}. Behandles i ekstern applikasjon.")
+        }
+}

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/JournalpostGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/JournalpostGenerator.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.ekstern.restDomene.NavnOgIdent
 import no.nav.familie.ba.sak.ekstern.restDomene.RestJournalføring
 import no.nav.familie.ba.sak.ekstern.restDomene.RestJournalpostDokument
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.DEFAULT_JOURNALFØRENDE_ENHET
+import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Journalføringsbehandlingstype
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Sakstype
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
@@ -126,7 +127,7 @@ fun lagMockRestJournalføring(bruker: NavnOgIdent): RestJournalføring =
                 ),
             ),
         navIdent = "09123",
-        nyBehandlingstype = RestJournalføring.Journalføringsbehandlingstype.FØRSTEGANGSBEHANDLING,
+        nyBehandlingstype = Journalføringsbehandlingstype.FØRSTEGANGSBEHANDLING,
         nyBehandlingsårsak = BehandlingÅrsak.SØKNAD,
         fagsakType = FagsakType.NORMAL,
     )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Har behvor for å sende inn "Klage"  ved journalføring. Legger det ikke til i `BehandlingType` da klager ikke skal behandles i ba-sak, men i familie-klage. Lager derfor en egen enum som inneholder både "Klage" (og "Tilbakekreving" for senere) slik at vi kan bruke den enumen til å rute til oppretting av klagebehandlinger i familie-klage senere i løypen. 

Har kjørt opp løsningen lokalt og ser ut til å fungere fint.

Relatert PR: https://github.com/navikt/familie-ba-sak/pull/5154

Måtte også legge det til i `RestFerdigstillOppgaveKnyttJournalpost`, valgte derfor å flytte enumen `Journalføringsbehandlingstype` til `domene` pakken. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Trenger en større refaktorering så skriver heller tester etter det. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
