### PR TITLE
kast funksjonell feil når det er feil med brevbegrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -444,7 +444,7 @@ class BrevService(
                         landkoder = integrasjonClient.hentLandkoderISO2(),
                     )
                 } catch (e: BrevBegrunnelseFeil) {
-                    secureLogger.info(
+                    secureLogger.warn(
                         "Brevbegrunnelsefeil for behandling $behandlingId, " +
                             "fagsak ${vedtak.behandling.fagsak.id} " +
                             "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -450,7 +450,7 @@ class BrevService(
                             "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +
                             "\nAutogenerert test:\n" + testVerktøyService.hentBegrunnelsetest(behandlingId),
                     )
-                    throw IllegalStateException(e.message, e)
+                    throw e
                 }
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalService.kt
@@ -23,7 +23,7 @@ class BrevmalService(
 
     fun hentVedtaksbrevmal(behandling: Behandling): Brevmal {
         if (behandling.resultat == Behandlingsresultat.IKKE_VURDERT) {
-            throw Feil("Kan ikke opprette brev. Behandlingen er ikke vurdert.")
+            throw FunksjonellFeil("Kan ikke opprette brev. Behandlingen er ikke vurdert.")
         }
 
         val brevmal =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentGenereringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentGenereringService.kt
@@ -58,7 +58,7 @@ class DokumentGenereringService(
             secureLogger.info("Feil ved dokumentgenerering. Genererer hentVedtaksperioderTest \n ${testVerktøyService.hentVedtaksperioderTest(vedtak.behandling.id)}")
 
             throw Feil(
-                message = "Klarte ikke generere vedtaksbrev på behandling ${vedtak.behandling}: ${feil.message}",
+                message = "Klarte ikke generere vedtaksbrev på fagsak/behandling ${vedtak.behandling.fagsak.id}/${vedtak.behandling.id}: ${feil.message}",
                 frontendFeilmelding = "Det har skjedd en feil, og brevet er ikke sendt. Prøv igjen, og ta kontakt med brukerstøtte hvis problemet vedvarer.",
                 httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
                 throwable = feil,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -71,7 +71,7 @@ class DokumentService(
                 BehandlerRolle.BESLUTTER,
             )
         if (høyesteRolletilgangForInnloggetBruker in funksjonelleRoller && vedtak.stønadBrevPdF == null) {
-            logger.error(
+            logger.warn(
                 "Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}. " +
                     "Innlogget bruker har rolle: $høyesteRolletilgangForInnloggetBruker",
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -71,11 +71,11 @@ class DokumentService(
                 BehandlerRolle.BESLUTTER,
             )
         if (høyesteRolletilgangForInnloggetBruker in funksjonelleRoller && vedtak.stønadBrevPdF == null) {
-            logger.warn(
-                "Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}. " +
-                    "Innlogget bruker har rolle: $høyesteRolletilgangForInnloggetBruker",
+            throw FunksjonellFeil(
+                melding =
+                    "Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}. Innlogget bruker har rolle: $høyesteRolletilgangForInnloggetBruker",
+                frontendFeilmelding = "Det finnes ikke noe vedtaksbrev.",
             )
-            throw FunksjonellFeil("Det finnes ikke noe vedtaksbrev.")
         } else {
             val pdf =
                 vedtak.stønadBrevPdF ?: throw Feil(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -63,10 +63,25 @@ class DokumentService(
     fun hentBrevForVedtak(vedtak: Vedtak): Ressurs<ByteArray> {
         val høyesteRolletilgangForInnloggetBruker = SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker(rolleConfig)
 
-        if (høyesteRolletilgangForInnloggetBruker in listOf(BehandlerRolle.VEILEDER, BehandlerRolle.FORVALTER) && vedtak.stønadBrevPdF == null) {
+        val funksjonelleRoller =
+            listOf(
+                BehandlerRolle.VEILEDER,
+                BehandlerRolle.FORVALTER,
+                BehandlerRolle.SAKSBEHANDLER,
+                BehandlerRolle.BESLUTTER,
+            )
+        if (høyesteRolletilgangForInnloggetBruker in funksjonelleRoller && vedtak.stønadBrevPdF == null) {
+            logger.error(
+                "Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}. " +
+                    "Innlogget bruker har rolle: $høyesteRolletilgangForInnloggetBruker",
+            )
             throw FunksjonellFeil("Det finnes ikke noe vedtaksbrev.")
         } else {
-            val pdf = vedtak.stønadBrevPdF ?: throw Feil("Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}")
+            val pdf =
+                vedtak.stønadBrevPdF ?: throw Feil(
+                    "Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}. " +
+                        "Innlogget bruker har rolle: $høyesteRolletilgangForInnloggetBruker",
+                )
             return Ressurs.success(pdf)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.forrigeMåned
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.common.tilMånedÅr
+import no.nav.familie.ba.sak.integrasjoner.pdl.logger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.erBetaltUtvidetIPeriode
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.erNullPgaDifferanseberegningEllerDeltBosted
@@ -489,7 +490,8 @@ private fun ISanityBegrunnelse.validerBrevbegrunnelse(
     barnasFødselsdatoer: List<LocalDate>,
 ) {
     if (!gjelderSøker && barnasFødselsdatoer.isEmpty() && !this.gjelderSatsendring && !this.erAvslagUregistrerteBarnBegrunnelse()) {
-        throw BrevBegrunnelseFeil("Ingen personer på brevbegrunnelse ${this.apiNavn}")
+        logger.warn("Ingen personer på brevbegrunnelse ${this.apiNavn}")
+        throw BrevBegrunnelseFeil("Begrunnelsen ${this.navnISystem} er ikke gyldig for denne perioden. Kontakt team BAKS hvis du mener det er feil.")
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.brev.brevBegrunnelseProdusent
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.Utils
 import no.nav.familie.ba.sak.common.forrigeMåned
@@ -522,4 +523,4 @@ fun ISanityBegrunnelse.erAvslagUregistrerteBarnBegrunnelse() =
 
 class BrevBegrunnelseFeil(
     melding: String,
-) : IllegalStateException(melding)
+) : FunksjonellFeil(melding)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -163,7 +163,7 @@ class VedtaksperiodeMedBegrunnelserController(
                         "på periode ${vedtaksperiode.fom} - ${vedtaksperiode.tom}. " +
                         "\nAutogenerert test:\n" + testVerktøyService.hentBegrunnelsetest(behandlingId),
                 )
-                throw IllegalStateException(e.message, e)
+                throw e
             }
 
         val begrunnelser =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalServiceTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -42,7 +42,7 @@ internal class BrevmalServiceTest {
         val behandling =
             lagBehandling(årsak = BehandlingÅrsak.KORREKSJON_VEDTAKSBREV, resultat = Behandlingsresultat.IKKE_VURDERT)
 
-        assertThrows<Feil> {
+        assertThrows<FunksjonellFeil> {
             brevmalService.hentVedtaksbrevmal(behandling)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -7,7 +7,6 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
@@ -479,7 +478,7 @@ internal class DokumentServiceTest {
             val feilmelding =
                 assertThrows<FunksjonellFeil> {
                     dokumentService.hentBrevForVedtak(vedtakUtenStønadBrev)
-                }.melding
+                }.frontendFeilmelding
 
             assertThat(feilmelding).isEqualTo("Det finnes ikke noe vedtaksbrev.")
         }
@@ -494,11 +493,11 @@ internal class DokumentServiceTest {
 
             // Act && Assert
             val feilmelding =
-                assertThrows<Feil> {
+                assertThrows<FunksjonellFeil> {
                     dokumentService.hentBrevForVedtak(vedtakUtenStønadBrev)
                 }.message
 
-            assertThat(feilmelding).isEqualTo("Klarte ikke finne vedtaksbrev for vedtak med id ${vedtakUtenStønadBrev.id}")
+            assertThat(feilmelding).isEqualTo("Klarte ikke finne vedtaksbrev for vedtak med id ${vedtakUtenStønadBrev.id}. Innlogget bruker har rolle: $rolle")
         }
 
         @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Kaste funksjonelle feil i stedet for Illegalstate/Feil slik at det blir mindre støy for vakt når saksbehandler bare har valgt feil begrunnelse. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
La til flere roller som funksjonelle, er det riktig? 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testet lokalt
