### PR TITLE
Fikser problem med å opprette klagebehandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageClient.kt
@@ -26,7 +26,7 @@ class KlageClient(
                 .build()
                 .toUri()
 
-        return kallEksternTjenesteRessurs<UUID>(
+        return kallEksternTjenesteRessurs(
             tjeneste = "klage",
             uri = uri,
             formål = "Opprett klagebehandling",


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Dropper å gjøre om data fra klageløsningen direkte til UUID, da det fører til feilen:
```
Caused by: org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Cannot construct instance of `no.nav.familie.kontrakter.felles.Ressurs` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value
```
Dette er også sånn det er løst 99% av andre stedene i koden hvor man kaller på ekstern tjeneste som returnerer ressurs.

Takk til @UyQuangNguyen for god hjelp 🤝

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
