### PR TITLE
Satt sluttdato på tilleggsorba i SatsService og skrevet tester

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <prosessering.version>2.20250311132904_6ee7728</prosessering.version>
-        <felles.version>3.20250311182943_dac8027</felles.version>
+        <felles.version>3.20250312114810_5371990</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
         <felles-kontrakter.version>3.0_20250312084645_ae52997</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
@@ -39,7 +39,7 @@ object SatsService {
             Sats(SatsType.TILLEGG_ORBA, 1654, LocalDate.of(2021, 9, 1), LocalDate.of(2021, 12, 31)),
             Sats(SatsType.TILLEGG_ORBA, 1676, LocalDate.of(2022, 1, 1), LocalDate.of(2023, 2, 28)),
             Sats(SatsType.TILLEGG_ORBA, 1723, LocalDate.of(2023, 3, 1), LocalDate.of(2023, 6, 30)),
-            Sats(SatsType.TILLEGG_ORBA, 1766, LocalDate.of(2023, 7, 1), LocalDate.MAX), // Egentlig er tom-dato 2024-08-31, men omskriving skjer senere
+            Sats(SatsType.TILLEGG_ORBA, 1766, LocalDate.of(2023, 7, 1), LocalDate.of(2024, 8, 31)),
             Sats(SatsType.FINN_SVAL, 1054, LocalDate.MIN, LocalDate.of(2014, 3, 31)),
             Sats(SatsType.UTVIDET_BARNETRYGD, 970, LocalDate.MIN, LocalDate.of(2019, 2, 28)),
             Sats(SatsType.UTVIDET_BARNETRYGD, 1054, LocalDate.of(2019, 3, 1), LocalDate.of(2023, 2, 28)),
@@ -100,7 +100,9 @@ fun satstypeTidslinje(satsType: SatsType) =
 
 fun lagOrdinærTidslinje(barn: Person): Tidslinje<Int> {
     val orbaTidslinje = satstypeTidslinje(SatsType.ORBA)
-    val tilleggOrbaTidslinje = satstypeTidslinje(SatsType.TILLEGG_ORBA).filtrerMed(erUnder6ÅrTidslinje(barn))
+    val tilleggOrbaTidslinje =
+        satstypeTidslinje(SatsType.TILLEGG_ORBA)
+            .filtrerMed(erUnder6ÅrTidslinje(barn))
     return orbaTidslinje
         .kombinerMed(tilleggOrbaTidslinje) { orba, tillegg -> tillegg ?: orba }
         .beskjærFraOgMed(fraOgMed = barn.fødselsdato.førsteDagIInneværendeMåned())

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -244,17 +244,19 @@ object TilkjentYtelseValidering {
         val satser = SatsService.hentAllesatser()
         val småbarnsTillegg = satser.filter { it.type == SatsType.SMA }
         val ordinærMedTillegg = satser.filter { it.type == SatsType.TILLEGG_ORBA }
+        val ordinær = satser.filter { it.type == SatsType.ORBA }
         val utvidet = satser.filter { it.type == SatsType.UTVIDET_BARNETRYGD }
         if (småbarnsTillegg.isEmpty() || ordinærMedTillegg.isEmpty() || utvidet.isEmpty()) error("Fant ikke satser ved validering")
         val maksSmåbarnstillegg = småbarnsTillegg.maxByOrNull { it.beløp }!!.beløp
         val maksOrdinærMedTillegg = ordinærMedTillegg.maxByOrNull { it.beløp }!!.beløp
+        val maksOrdinær = ordinær.maxByOrNull { it.beløp }!!.beløp
         val maksUtvidet = utvidet.maxBy { it.beløp }.beløp
 
         return if (fagsakType == FagsakType.BARN_ENSLIG_MINDREÅRIG) {
             maksOrdinærMedTillegg + maksUtvidet
         } else {
             when (personType) {
-                PersonType.BARN -> maksOrdinærMedTillegg
+                PersonType.BARN -> maxOf(maksOrdinær, maksOrdinærMedTillegg)
                 PersonType.SØKER -> maksUtvidet + maksSmåbarnstillegg
                 else -> throw Feil("Ikke støtte for å utbetale til persontype ${personType.name}")
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.YearMonthConverter
+import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
 import no.nav.familie.ba.sak.kjerne.beregning.tilAndelForVedtaksbegrunnelseTidslinje
@@ -189,12 +190,16 @@ enum class YtelseType(
             SMÅBARNSTILLEGG -> YtelsetypeBA.SMÅBARNSTILLEGG
         }
 
+    // FIXME NAV-22043
     fun tilSatsType(
         person: Person,
         ytelseDato: LocalDate,
     ) = when (this) {
         ORDINÆR_BARNETRYGD ->
-            if (ytelseDato.toYearMonth() < person.hentSeksårsdag().toYearMonth()) {
+
+            if (ytelseDato.isSameOrAfter(LocalDate.of(2024, 9, 1))) {
+                SatsType.ORBA
+            } else if (ytelseDato.toYearMonth() < person.hentSeksårsdag().toYearMonth()) {
                 SatsType.TILLEGG_ORBA
             } else {
                 SatsType.ORBA

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -19,9 +19,9 @@ import no.nav.familie.ba.sak.common.BaseEntitet
 import no.nav.familie.ba.sak.common.MånedPeriode
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.YearMonthConverter
-import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
+import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.beregning.tilAndelForVedtaksbegrunnelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.tilAndelForVedtaksperiodeTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
@@ -194,14 +194,16 @@ enum class YtelseType(
         person: Person,
         ytelseDato: LocalDate,
     ) = when (this) {
-        ORDINÆR_BARNETRYGD ->
-            if (ytelseDato.isSameOrAfter(LocalDate.of(2024, 9, 1))) {
+        ORDINÆR_BARNETRYGD -> {
+            val sisteSatsdatoForTilleggsOrba = SatsService.finnSisteSatsFor(SatsType.TILLEGG_ORBA).gyldigTom
+            if (ytelseDato.isAfter(sisteSatsdatoForTilleggsOrba)) {
                 SatsType.ORBA
             } else if (ytelseDato.toYearMonth() < person.hentSeksårsdag().toYearMonth()) {
                 SatsType.TILLEGG_ORBA
             } else {
                 SatsType.ORBA
             }
+        }
 
         UTVIDET_BARNETRYGD -> SatsType.UTVIDET_BARNETRYGD
         SMÅBARNSTILLEGG -> SatsType.SMA

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -190,13 +190,11 @@ enum class YtelseType(
             SMÅBARNSTILLEGG -> YtelsetypeBA.SMÅBARNSTILLEGG
         }
 
-    // FIXME NAV-22043
     fun tilSatsType(
         person: Person,
         ytelseDato: LocalDate,
     ) = when (this) {
         ORDINÆR_BARNETRYGD ->
-
             if (ytelseDato.isSameOrAfter(LocalDate.of(2024, 9, 1))) {
                 SatsType.ORBA
             } else if (ytelseDato.toYearMonth() < person.hentSeksårsdag().toYearMonth()) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
@@ -30,7 +30,7 @@ import java.time.LocalDate
 
 class SatsServiceTest {
     @Test
-    fun `Skal opprette korrekt tidslinje for ordinær barnetrygd for barn`() {
+    fun `Skal opprette korrekt tidslinje for ordinær barnetrygd for barn som ble 6 år mens TILLEGGS_ORBA var aktivt`() {
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2017, 4, 6))
 
         val ordinærTidslinje = lagOrdinærTidslinje(barn)
@@ -48,6 +48,35 @@ class SatsServiceTest {
         assertPeriode(TestKrPeriode(beløp = 1310, fom = "2023-07", tom = "2023-12"), ordinærePerioder[7])
         assertPeriode(TestKrPeriode(beløp = 1510, fom = "2024-01", tom = "2024-08"), ordinærePerioder[8])
         assertPeriode(TestKrPeriode(beløp = 1766, fom = "2024-09", tom = null), ordinærePerioder[9])
+    }
+
+    @Test
+    fun `Skal opprette korrekt tidslinje for ordinær barnetrygd for barn som er født etter at TILLEGGS_ORBA er ferdig`() {
+        val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2025, 1, 6))
+
+        val ordinærTidslinje = lagOrdinærTidslinje(barn)
+        val ordinærePerioder = ordinærTidslinje.tilPerioderIkkeNull().toList()
+
+        assertEquals(1, ordinærePerioder.size)
+
+        assertPeriode(TestKrPeriode(beløp = 1766, fom = "2025-01", tom = null), ordinærePerioder[0])
+    }
+
+    @Test
+    fun `Skal opprette korrekt tidslinje for ordinær barnetrygd for barn som blir 6 år etter at TILLEGGS_ORBA er fjernet`() {
+        val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 12, 6))
+
+        val ordinærTidslinje = lagOrdinærTidslinje(barn)
+        val ordinærePerioder = ordinærTidslinje.tilPerioderIkkeNull().toList()
+
+        assertEquals(6, ordinærePerioder.size)
+
+        assertPeriode(TestKrPeriode(beløp = 1054, fom = "2019-12", tom = "2020-08"), ordinærePerioder[0])
+        assertPeriode(TestKrPeriode(beløp = 1354, fom = "2020-09", tom = "2021-08"), ordinærePerioder[1])
+        assertPeriode(TestKrPeriode(beløp = 1654, fom = "2021-09", tom = "2021-12"), ordinærePerioder[2])
+        assertPeriode(TestKrPeriode(beløp = 1676, fom = "2022-01", tom = "2023-02"), ordinærePerioder[3])
+        assertPeriode(TestKrPeriode(beløp = 1723, fom = "2023-03", tom = "2023-06"), ordinærePerioder[4])
+        assertPeriode(TestKrPeriode(beløp = 1766, fom = "2023-07", tom = null), ordinærePerioder[5])
     }
 
     private fun assertPeriode(
@@ -99,7 +128,7 @@ class SatsServiceTest {
                     (sep(2021)..des(2021)).tilTidslinje { 1654 } +
                     (jan(2022)..feb(2023)).tilTidslinje { 1676 } +
                     (mar(2023)..jun(2023)).tilTidslinje { 1723 } +
-                    (jul(2023)..uendelig).tilTidslinje { 1766 }
+                    (jul(2023)..aug(2024)).tilTidslinje { 1766 }
 
             val faktisk = satstypeTidslinje(TILLEGG_ORBA)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/YtelseTypeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/YtelseTypeTest.kt
@@ -1,34 +1,92 @@
 package no.nav.familie.ba.sak.kjerne.beregning.domene
 
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class YtelseTypeTest {
-    @Test
-    fun `skal mappe ORDINÆR_BARNETRYGD ytelsestype til ORDINÆR_BARNETRYGD ytelsetypeBA`() {
-        // Act
-        val ytelsetypeBA = YtelseType.ORDINÆR_BARNETRYGD.tilYtelseType()
+    @Nested
+    inner class TilYtelseTypeTest {
+        @Test
+        fun `skal mappe ORDINÆR_BARNETRYGD ytelsestype til ORDINÆR_BARNETRYGD ytelsetypeBA`() {
+            // Act
+            val ytelsetypeBA = YtelseType.ORDINÆR_BARNETRYGD.tilYtelseType()
 
-        // Assert
-        assertThat(ytelsetypeBA).isEqualTo(YtelsetypeBA.ORDINÆR_BARNETRYGD)
+            // Assert
+            assertThat(ytelsetypeBA).isEqualTo(YtelsetypeBA.ORDINÆR_BARNETRYGD)
+        }
+
+        @Test
+        fun `skal mappe UTVIDET_BARNETRYGD ytelsestype til UTVIDET_BARNETRYGD ytelsetypeBA`() {
+            // Act
+            val ytelsetypeBA = YtelseType.UTVIDET_BARNETRYGD.tilYtelseType()
+
+            // Assert
+            assertThat(ytelsetypeBA).isEqualTo(YtelsetypeBA.UTVIDET_BARNETRYGD)
+        }
+
+        @Test
+        fun `skal mappe SMÅBARNSTILLEGG ytelsestype til SMÅBARNSTILLEGG ytelsetypeBA`() {
+            // Act
+            val ytelsetypeBA = YtelseType.SMÅBARNSTILLEGG.tilYtelseType()
+
+            // Assert
+            assertThat(ytelsetypeBA).isEqualTo(YtelsetypeBA.SMÅBARNSTILLEGG)
+        }
     }
 
-    @Test
-    fun `skal mappe UTVIDET_BARNETRYGD ytelsestype til UTVIDET_BARNETRYGD ytelsetypeBA`() {
-        // Act
-        val ytelsetypeBA = YtelseType.UTVIDET_BARNETRYGD.tilYtelseType()
+    @Nested
+    inner class TilSatsTypeTest {
+        @Test
+        fun `tilSatsType for ORDINÆR_BARNETRYGD for en som er under 6 år i august 2024 skal returnere TILLEGGS_ORBA`() {
+            val person = lagPerson(fødselsdato = LocalDate.of(2024, 8, 1).minusYears(6).plusMonths(1))
+            val ytelseDato = LocalDate.of(2024, 8, 1)
 
-        // Assert
-        assertThat(ytelsetypeBA).isEqualTo(YtelsetypeBA.UTVIDET_BARNETRYGD)
-    }
+            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDato)
+            assertThat(result).isEqualTo(SatsType.TILLEGG_ORBA)
+        }
 
-    @Test
-    fun `skal mappe SMÅBARNSTILLEGG ytelsestype til SMÅBARNSTILLEGG ytelsetypeBA`() {
-        // Act
-        val ytelsetypeBA = YtelseType.SMÅBARNSTILLEGG.tilYtelseType()
+        @Test
+        fun `tilSatsType for ORDINÆR_BARNETRYGD for en som er under 6 år i september 2024 skal returnere ORBA`() {
+            val person = lagPerson(fødselsdato = LocalDate.of(2024, 9, 1).minusYears(6).plusMonths(1))
+            val ytelseDato = LocalDate.of(2024, 9, 1)
 
-        // Assert
-        assertThat(ytelsetypeBA).isEqualTo(YtelsetypeBA.SMÅBARNSTILLEGG)
+            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDato)
+            assertThat(result).isEqualTo(SatsType.ORBA)
+        }
+
+        @Test
+        fun `tilSatsType for ORDINÆR_BARNETRYGD etter 6 år`() {
+            val person = mockk<Person>()
+            val ytelseDato = LocalDate.of(2026, 1, 1)
+            every { person.hentSeksårsdag() } returns LocalDate.of(2025, 1, 1)
+
+            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDato)
+            assertThat(result).isEqualTo(SatsType.ORBA)
+        }
+
+        @Test
+        fun `tilSatsType for UTVIDET_BARNETRYGD`() {
+            val person = mockk<Person>()
+            val ytelseDato = LocalDate.of(2020, 1, 1)
+
+            val result = YtelseType.UTVIDET_BARNETRYGD.tilSatsType(person, ytelseDato)
+            assertThat(result).isEqualTo(SatsType.UTVIDET_BARNETRYGD)
+        }
+
+        @Test
+        fun `tilSatsType for SMÅBARNSTILLEGG`() {
+            val person = mockk<Person>()
+            val ytelseDato = LocalDate.of(2020, 1, 1)
+
+            val result = YtelseType.SMÅBARNSTILLEGG.tilSatsType(person, ytelseDato)
+            assertThat(result).isEqualTo(SatsType.SMA)
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/util/SatserForTester.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/util/SatserForTester.kt
@@ -7,21 +7,11 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.Sats
 import no.nav.familie.ba.sak.kjerne.beregning.domene.SatsType
 import java.time.LocalDate
 
-fun tilleggOrdinærSatsTilTester(): Int =
-    SatsService
-        .finnAlleSatserFor(SatsType.TILLEGG_ORBA)
-        .findLast {
-            it.gyldigFom <= LocalDate.now().plusDays(1)
-        }!!
-        .beløp
-
 fun sisteUtvidetSatsTilTester(): Int = SatsService.finnSisteSatsFor(SatsType.UTVIDET_BARNETRYGD).beløp
 
 fun sisteSmåbarnstilleggSatsTilTester(): Int = SatsService.finnSisteSatsFor(SatsType.SMA).beløp
 
-fun sisteTilleggOrdinærSats(): Double = SatsService.finnSisteSatsFor(SatsType.TILLEGG_ORBA).beløp.toDouble()
-
-fun tilleggOrdinærSatsNesteMånedTilTester(): Sats =
-    SatsService.finnAlleSatserFor(SatsType.TILLEGG_ORBA).findLast {
+fun ordinærSatsNesteMånedTilTester(): Sats =
+    SatsService.finnAlleSatserFor(SatsType.ORBA).findLast {
         it.gyldigFom.toYearMonth() <= LocalDate.now().nesteMåned()
     }!!

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -40,9 +40,9 @@ import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.RestScenarioPerson
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.stubScenario
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
+import no.nav.familie.ba.sak.util.ordinærSatsNesteMånedTilTester
 import no.nav.familie.ba.sak.util.sisteSmåbarnstilleggSatsTilTester
 import no.nav.familie.ba.sak.util.sisteUtvidetSatsTilTester
-import no.nav.familie.ba.sak.util.tilleggOrdinærSatsTilTester
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.Datakilde
 import no.nav.familie.kontrakter.felles.ef.EksternPeriode
@@ -103,7 +103,7 @@ class BehandleSmåbarnstilleggTest(
     @BeforeEach
     fun førHverTest() {
         mockkObject(SatsTidspunkt)
-        every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2022, 12, 31)
+        every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2024, 9, 1)
     }
 
     @AfterEach
@@ -192,7 +192,7 @@ class BehandleSmåbarnstilleggTest(
             )
 
         assertEquals(
-            tilleggOrdinærSatsTilTester() + sisteUtvidetSatsTilTester() + sisteSmåbarnstilleggSatsTilTester(),
+            ordinærSatsNesteMånedTilTester().beløp + sisteUtvidetSatsTilTester() + sisteSmåbarnstilleggSatsTilTester(),
             hentNåværendeEllerNesteMånedsUtbetaling(
                 behandling = restUtvidetBehandlingEtterBehandlingsResultat.data!!,
             ),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
@@ -19,7 +19,7 @@ import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.RestScenarioPerson
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.stubScenario
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
-import no.nav.familie.ba.sak.util.tilleggOrdinærSatsNesteMånedTilTester
+import no.nav.familie.ba.sak.util.ordinærSatsNesteMånedTilTester
 import no.nav.familie.kontrakter.felles.getDataOrThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -163,14 +163,14 @@ class FødselshendelseFørstegangsbehandlingTest(
         val utbetalingsperioder = aktivBehandling.utbetalingsperioder
         val gjeldendeUtbetalingsperiode =
             utbetalingsperioder.find {
-                it.periodeFom.toYearMonth() >= tilleggOrdinærSatsNesteMånedTilTester().gyldigFom.toYearMonth() &&
-                    it.periodeFom.toYearMonth() <= tilleggOrdinærSatsNesteMånedTilTester().gyldigTom.toYearMonth()
+                it.periodeFom.toYearMonth() >= ordinærSatsNesteMånedTilTester().gyldigFom.toYearMonth() &&
+                    it.periodeFom.toYearMonth() <= ordinærSatsNesteMånedTilTester().gyldigTom.toYearMonth()
             }!!
 
         assertUtbetalingsperiode(
             gjeldendeUtbetalingsperiode,
             2,
-            tilleggOrdinærSatsNesteMånedTilTester().beløp * 2,
+            ordinærSatsNesteMånedTilTester().beløp * 2,
         )
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -65,7 +65,7 @@ class FødselshendelseHenleggelseTest(
     @BeforeEach
     fun førHverTest() {
         mockkObject(SatsTidspunkt)
-        every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2022, 12, 31)
+        every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2024, 9, 1)
     }
 
     @AfterEach

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -35,8 +35,8 @@ import no.nav.familie.ba.sak.kjørbehandling.kjørStegprosessForFGB
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
+import no.nav.familie.ba.sak.util.ordinærSatsNesteMånedTilTester
 import no.nav.familie.ba.sak.util.sisteUtvidetSatsTilTester
-import no.nav.familie.ba.sak.util.tilleggOrdinærSatsNesteMånedTilTester
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
@@ -328,7 +328,7 @@ class FødselshendelseHenleggelseTest(
 
         assertEquals(BehandlingUnderkategori.UTVIDET, behandling.underkategori)
         assertEquals(
-            tilleggOrdinærSatsNesteMånedTilTester().beløp + sisteUtvidetSatsTilTester(),
+            ordinærSatsNesteMånedTilTester().beløp + sisteUtvidetSatsTilTester(),
             hentNåværendeEllerNesteMånedsUtbetaling(
                 behandling = utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandling.id),
             ),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseRevurderingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseRevurderingTest.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.RestScenarioPerson
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.stubScenario
 import no.nav.familie.ba.sak.task.BehandleFødselshendelseTask
-import no.nav.familie.ba.sak.util.tilleggOrdinærSatsNesteMånedTilTester
+import no.nav.familie.ba.sak.util.ordinærSatsNesteMånedTilTester
 import no.nav.familie.kontrakter.felles.getDataOrThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -126,7 +126,7 @@ class FødselshendelseRevurderingTest(
         assertUtbetalingsperiode(
             nesteMånedUtbetalingsperiode,
             2,
-            tilleggOrdinærSatsNesteMånedTilTester().beløp * 2,
+            ordinærSatsNesteMånedTilTester().beløp * 2,
         )
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/JournalførOgBehandleFørstegangssøknadNasjonalTest.kt
@@ -31,8 +31,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.RestScenario
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.RestScenarioPerson
 import no.nav.familie.ba.sak.kjerne.verdikjedetester.scenario.stubScenario
+import no.nav.familie.ba.sak.util.ordinærSatsNesteMånedTilTester
 import no.nav.familie.ba.sak.util.sisteUtvidetSatsTilTester
-import no.nav.familie.ba.sak.util.tilleggOrdinærSatsTilTester
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import org.junit.jupiter.api.AfterEach
@@ -54,7 +54,7 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
     @BeforeEach
     fun førHverTest() {
         mockkObject(SatsTidspunkt)
-        every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2022, 12, 31)
+        every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2024, 9, 1)
     }
 
     @AfterEach
@@ -154,7 +154,7 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
             )
 
         assertEquals(
-            tilleggOrdinærSatsTilTester(),
+            ordinærSatsNesteMånedTilTester().beløp,
             hentNåværendeEllerNesteMånedsUtbetaling(
                 behandling = restUtvidetBehandlingEtterBehandlingsresultat.data!!,
             ),
@@ -350,7 +350,7 @@ class JournalførOgBehandleFørstegangssøknadNasjonalTest(
             )
 
         assertEquals(
-            tilleggOrdinærSatsTilTester() + sisteUtvidetSatsTilTester(),
+            ordinærSatsNesteMånedTilTester().beløp + sisteUtvidetSatsTilTester(),
             hentNåværendeEllerNesteMånedsUtbetaling(
                 behandling = restUtvidetBehandlingEtterBehandlingsresultat.data!!,
             ),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-22043
Satt riktig sluttdato på SatsType TILLEGG_ORBA. Oppdatert kode og tester til å ta hensyn til dette.

Verden ble veldig merkelig hvor satstidspunktet ble rart mocket i kombinasjon med utvidelsen i AndelTilkjentYtelse. Som var et $%#&!! å finne ut av. Løsningen var frustrende enkel å spole frem satstidspunket til siste satsendring.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Noe jeg kan ha glemt?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
