### PR TITLE
Legger til nye endepunkter som tar imot ident i requestbody istedenfor

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonController.kt
@@ -40,6 +40,7 @@ class PersonController(
     private val tilgangService: TilgangService,
 ) {
     @GetMapping
+    @Deprecated("Slettes etter overgang til POST endepunkter m/ requestbody")
     fun hentPerson(
         @RequestHeader personIdent: String,
         @Valid
@@ -56,7 +57,26 @@ class PersonController(
         return ResponseEntity.ok(Ressurs.success(personinfo))
     }
 
+    @PostMapping
+    fun hentPerson(
+        @Valid @RequestBody personIdentDto: PersonIdent,
+    ): ResponseEntity<Ressurs<RestPersonInfo>> {
+        val personIdent = personIdentDto.ident
+
+        // Valider personIdent
+        Fødselsnummer(personIdent)
+
+        val aktør = personidentService.hentAktør(personIdent)
+        val personinfo =
+            familieIntegrasjonerTilgangskontrollService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
+                ?: personopplysningerService
+                    .hentPersoninfoMedRelasjonerOgRegisterinformasjon(aktør)
+                    .tilRestPersonInfo(personIdent)
+        return ResponseEntity.ok(Ressurs.success(personinfo))
+    }
+
     @GetMapping(path = ["/enkel"])
+    @Deprecated("Slettes etter overgang til POST endepunkter m/ requestbody")
     fun hentPersonEnkel(
         @RequestHeader personIdent: String,
         @Valid
@@ -74,10 +94,47 @@ class PersonController(
         return ResponseEntity.ok(Ressurs.success(personinfo))
     }
 
+    @PostMapping(path = ["/enkel"])
+    fun hentPersonEnkel(
+        @Valid @RequestBody personIdentDto: PersonIdent,
+    ): ResponseEntity<Ressurs<RestPersonInfo>> {
+        val personIdent = personIdentDto.ident
+
+        // Valider personIdent
+        Fødselsnummer(personIdent)
+
+        val aktør = personidentService.hentAktør(personIdent)
+        val personinfo =
+            familieIntegrasjonerTilgangskontrollService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
+                ?: personopplysningerService
+                    .hentPersoninfoEnkel(aktør)
+                    .tilRestPersonInfo(personIdent)
+        return ResponseEntity.ok(Ressurs.success(personinfo))
+    }
+
     @GetMapping(path = ["/adresse"])
+    @Deprecated("Slettes etter overgang til POST endepunkter m/ requestbody")
     fun hentPersonAdresse(
         @RequestHeader personIdent: String,
     ): ResponseEntity<Ressurs<RestPersonInfo>> {
+        // For validering
+        Fødselsnummer(personIdent)
+
+        val aktør = personidentService.hentAktør(personIdent)
+        val personinfo =
+            familieIntegrasjonerTilgangskontrollService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
+                ?: personopplysningerService
+                    .hentPersoninfoNavnOgAdresse(aktør)
+                    .tilRestPersonInfoMedNavnOgAdresse(personIdent)
+        return ResponseEntity.ok(Ressurs.success(personinfo))
+    }
+
+    @PostMapping(path = ["/adresse"])
+    fun hentPersonAdresse(
+        @Valid @RequestBody personIdentDto: PersonIdent,
+    ): ResponseEntity<Ressurs<RestPersonInfo>> {
+        val personIdent = personIdentDto.ident
+
         // For validering
         Fødselsnummer(personIdent)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageClient.kt
@@ -26,7 +26,7 @@ class KlageClient(
                 .build()
                 .toUri()
 
-        return kallEksternTjenesteRessurs<UUID>(
+        return kallEksternTjenesteRessurs(
             tjeneste = "klage",
             uri = uri,
             formål = "Opprett klagebehandling",


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24650

Bytter til POST fra GET ved henting av personer.
Da unngår vi å måtte legge personident i header, men heller i body mtp sensitiv info i headers.

Frontend PR: https://github.com/navikt/familie-ba-sak-frontend/pull/3611