### PR TITLE
Service for å utlede avregning i behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import no.nav.familie.ba.sak.common.ClockProvider
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
+import no.nav.familie.ba.sak.config.FeatureToggle.BRUK_FUNKSJONALITET_FOR_ULOVFESTET_MOTREGNING
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -24,8 +26,13 @@ class AvregningService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val clockProvider: ClockProvider,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     fun hentPerioderMedAvregning(behandlingId: Long): List<AvregningPeriode> {
+        if (!unleashService.isEnabled(BRUK_FUNKSJONALITET_FOR_ULOVFESTET_MOTREGNING)) {
+            return emptyList()
+        }
+
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val sisteIverksatteBehandling =
             behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -1,0 +1,94 @@
+package no.nav.familie.ba.sak.kjerne.beregning
+
+import no.nav.familie.ba.sak.common.ClockProvider
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærTilOgMed
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.utvidelser.kombiner
+import no.nav.familie.tidslinje.utvidelser.outerJoin
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class AvregningService(
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val clockProvider: ClockProvider,
+) {
+    fun hentPerioderMedAvregning(behandlingId: Long): List<AvregningPeriode> {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        val sisteIverksatteBehandling =
+            behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
+                ?: return emptyList()
+
+        val andelerInneværendeBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
+        val andelerForrigeBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id)
+
+        val sisteDagIForrigeMåned = LocalDate.now(clockProvider.get()).sisteDagIForrigeMåned()
+
+        val andelerInneværendeBehandlingTidslinjer = andelerInneværendeBehandling.tilTidslinjerPerAktørOgType().beskjærTilOgMed(sisteDagIForrigeMåned)
+        val andelerForrigeBehandlingTidslinjer = andelerForrigeBehandling.tilTidslinjerPerAktørOgType().beskjærTilOgMed(sisteDagIForrigeMåned)
+
+        val tidslinjerMedDifferanser = lagTidslinjerMedDifferanser(andelerInneværendeBehandlingTidslinjer, andelerForrigeBehandlingTidslinjer)
+
+        val perioderMedEtterbetalingerOgFeilutbetalinger =
+            summerEtterbetalingerOgFeilutbetalinger(tidslinjerMedDifferanser)
+                .tilPerioderIkkeNull()
+                .tilAvregningPerioder()
+
+        return perioderMedEtterbetalingerOgFeilutbetalinger
+    }
+
+    private fun lagTidslinjerMedDifferanser(
+        andelerIFortidenInneværendeBehandlingTidslinjer: Map<Pair<Aktør, YtelseType>, Tidslinje<AndelTilkjentYtelse>>,
+        andelerIFortidenForrigeBehandlingTidslinjer: Map<Pair<Aktør, YtelseType>, Tidslinje<AndelTilkjentYtelse>>,
+    ): Collection<Tidslinje<Int>> =
+        andelerIFortidenInneværendeBehandlingTidslinjer
+            .outerJoin(andelerIFortidenForrigeBehandlingTidslinjer) { nyAndel, gammelAndel ->
+                when {
+                    nyAndel == null && gammelAndel == null -> 0
+                    nyAndel == null && gammelAndel != null -> -gammelAndel.kalkulertUtbetalingsbeløp
+                    nyAndel != null && gammelAndel == null -> nyAndel.kalkulertUtbetalingsbeløp
+                    else -> nyAndel!!.kalkulertUtbetalingsbeløp - gammelAndel!!.kalkulertUtbetalingsbeløp
+                }
+            }.values
+
+    private fun summerEtterbetalingerOgFeilutbetalinger(tidslinjerMedDifferanser: Collection<Tidslinje<Int>>): Tidslinje<EtterbetalingOgFeilutbetaling> =
+        tidslinjerMedDifferanser
+            .kombiner { differanser ->
+                val (etterbetaling, feilutbetaling) = differanser.partition { it > 0 }.toList().map { it.sum() }
+                if (etterbetaling != 0 && feilutbetaling != 0) {
+                    EtterbetalingOgFeilutbetaling(
+                        etterbetaling = etterbetaling,
+                        feilutbetaling = -feilutbetaling,
+                    )
+                } else {
+                    null
+                }
+            }
+}
+
+data class EtterbetalingOgFeilutbetaling(
+    val etterbetaling: Int,
+    val feilutbetaling: Int,
+)
+
+private fun List<Periode<EtterbetalingOgFeilutbetaling>>.tilAvregningPerioder(): List<AvregningPeriode> =
+    this.map { periode ->
+        AvregningPeriode(
+            fom = periode.fom ?: throw Feil("Fra og med-dato kan ikke være null"),
+            tom = periode.tom ?: throw Feil("Til og med-dato kan ikke være null"),
+            etterbetaling = periode.verdi.etterbetaling.toBigDecimal(),
+            feilutbetaling = periode.verdi.feilutbetaling.toBigDecimal(),
+        )
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -21,6 +21,7 @@ import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit.MONTHS
+import kotlin.math.absoluteValue
 
 @Service
 class AvregningService(
@@ -78,7 +79,7 @@ class AvregningService(
                 if (etterbetaling != 0 && feilutbetaling != 0) {
                     EtterbetalingOgFeilutbetaling(
                         etterbetaling = etterbetaling,
-                        feilutbetaling = -feilutbetaling,
+                        feilutbetaling = feilutbetaling.absoluteValue,
                     )
                 } else {
                     null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -20,6 +20,7 @@ import no.nav.familie.tidslinje.utvidelser.outerJoin
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit.MONTHS
 
 @Service
 class AvregningService(
@@ -92,10 +93,15 @@ data class EtterbetalingOgFeilutbetaling(
 
 private fun List<Periode<EtterbetalingOgFeilutbetaling>>.tilAvregningPerioder(): List<AvregningPeriode> =
     this.map { periode ->
+        val fom = periode.fom ?: throw Feil("Fra og med-dato kan ikke være null")
+        val tom = periode.tom ?: throw Feil("Til og med-dato kan ikke være null")
+        val antallMåneder = fom.until(tom, MONTHS) + 1 // +1 for å inkludere siste måned
+        val totalEtterbetaling = periode.verdi.etterbetaling * antallMåneder
+        val totalFeilutbetaling = periode.verdi.feilutbetaling * antallMåneder
         AvregningPeriode(
-            fom = periode.fom ?: throw Feil("Fra og med-dato kan ikke være null"),
-            tom = periode.tom ?: throw Feil("Til og med-dato kan ikke være null"),
-            etterbetaling = periode.verdi.etterbetaling.toBigDecimal(),
-            feilutbetaling = periode.verdi.feilutbetaling.toBigDecimal(),
+            fom = fom,
+            tom = tom,
+            totalEtterbetaling = totalEtterbetaling.toBigDecimal(),
+            totalFeilutbetaling = totalFeilutbetaling.toBigDecimal(),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.simulering
 
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
-import no.nav.familie.ba.sak.kjerne.simulering.domene.RestSimulering
+import no.nav.familie.ba.sak.kjerne.simulering.domene.Simulering
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -21,7 +21,7 @@ class SimuleringController(
     @GetMapping(path = ["/{behandlingId}/simulering"])
     fun hentSimulering(
         @PathVariable behandlingId: Long,
-    ): ResponseEntity<Ressurs<RestSimulering>> {
+    ): ResponseEntity<Ressurs<Simulering>> {
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         val vedtakSimuleringMottaker = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId)
         val restSimulering =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.barn
-import no.nav.familie.ba.sak.kjerne.simulering.domene.RestSimulering
+import no.nav.familie.ba.sak.kjerne.simulering.domene.Simulering
 import no.nav.familie.ba.sak.kjerne.simulering.domene.SimuleringsPeriode
 import no.nav.familie.ba.sak.kjerne.simulering.domene.ØkonomiSimuleringMottaker
 import no.nav.familie.ba.sak.kjerne.simulering.domene.ØkonomiSimuleringMottakerRepository
@@ -112,7 +112,7 @@ class SimuleringService(
         }
     }
 
-    private fun simuleringErUtdatert(simulering: RestSimulering) =
+    private fun simuleringErUtdatert(simulering: Simulering) =
         simulering.tidSimuleringHentet == null ||
             (
                 simulering.forfallsdatoNestePeriode != null &&

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -93,6 +93,7 @@ class SimuleringService(
 
     fun hentSimuleringPåBehandling(behandlingId: Long): List<ØkonomiSimuleringMottaker> = økonomiSimuleringMottakerRepository.findByBehandlingId(behandlingId)
 
+    @Transactional
     fun oppdaterSimuleringPåBehandlingVedBehov(behandlingId: Long): List<ØkonomiSimuleringMottaker> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId)
         val behandlingErFerdigBesluttet =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringUtil.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.simulering
 
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.simulering.domene.RestSimulering
+import no.nav.familie.ba.sak.kjerne.simulering.domene.Simulering
 import no.nav.familie.ba.sak.kjerne.simulering.domene.SimuleringsPeriode
 import no.nav.familie.ba.sak.kjerne.simulering.domene.ØkonomiSimuleringMottaker
 import no.nav.familie.ba.sak.kjerne.simulering.domene.ØkonomiSimuleringPostering
@@ -26,7 +26,7 @@ fun filterBortUrelevanteVedtakSimuleringPosteringer(
 
 fun vedtakSimuleringMottakereTilRestSimulering(
     økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>,
-): RestSimulering {
+): Simulering {
     val perioder =
         vedtakSimuleringMottakereTilSimuleringPerioder(
             økonomiSimuleringMottakere,
@@ -43,7 +43,7 @@ fun vedtakSimuleringMottakereTilRestSimulering(
     val tomSisteUtbetaling =
         perioder.filter { nestePeriode == null || it.fom < nestePeriode.fom }.maxOfOrNull { it.tom }
 
-    return RestSimulering(
+    return Simulering(
         perioder = perioder,
         fomDatoNestePeriode = nestePeriode?.fom,
         etterbetaling = hentTotalEtterbetaling(perioder, nestePeriode?.fom),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -13,7 +13,21 @@ data class Simulering(
     val forfallsdatoNestePeriode: LocalDate?,
     val tidSimuleringHentet: LocalDate?,
     val tomSisteUtbetaling: LocalDate?,
-)
+) {
+    fun tilRestSimulering(avregningsperioder: List<AvregningPeriode>): RestSimulering =
+        RestSimulering(
+            perioder = perioder,
+            fomDatoNestePeriode = fomDatoNestePeriode,
+            etterbetaling = etterbetaling,
+            feilutbetaling = feilutbetaling,
+            fom = fom,
+            tomDatoNestePeriode = tomDatoNestePeriode,
+            forfallsdatoNestePeriode = forfallsdatoNestePeriode,
+            tidSimuleringHentet = tidSimuleringHentet,
+            tomSisteUtbetaling = tomSisteUtbetaling,
+            avregningsperioder = avregningsperioder,
+        )
+}
 
 data class SimuleringsPeriode(
     val fom: LocalDate,
@@ -25,6 +39,19 @@ data class SimuleringsPeriode(
     val resultat: BigDecimal,
     val feilutbetaling: BigDecimal,
     val etterbetaling: BigDecimal,
+)
+
+data class RestSimulering(
+    val perioder: List<SimuleringsPeriode>,
+    val fomDatoNestePeriode: LocalDate?,
+    val etterbetaling: BigDecimal,
+    val feilutbetaling: BigDecimal,
+    val fom: LocalDate?,
+    val tomDatoNestePeriode: LocalDate?,
+    val forfallsdatoNestePeriode: LocalDate?,
+    val tidSimuleringHentet: LocalDate?,
+    val tomSisteUtbetaling: LocalDate?,
+    val avregningsperioder: List<AvregningPeriode>,
 )
 
 data class AvregningPeriode(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -57,6 +57,6 @@ data class RestSimulering(
 data class AvregningPeriode(
     val fom: LocalDate,
     val tom: LocalDate,
-    val etterbetaling: BigDecimal,
-    val feilutbetaling: BigDecimal,
+    val totalEtterbetaling: BigDecimal,
+    val totalFeilutbetaling: BigDecimal,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.kjerne.simulering.domene
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class RestSimulering(
+data class Simulering(
     val perioder: List<SimuleringsPeriode>,
     val fomDatoNestePeriode: LocalDate?,
     val etterbetaling: BigDecimal,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -26,3 +26,10 @@ data class SimuleringsPeriode(
     val feilutbetaling: BigDecimal,
     val etterbetaling: BigDecimal,
 )
+
+data class AvregningPeriode(
+    val fom: LocalDate,
+    val tom: LocalDate,
+    val etterbetaling: BigDecimal,
+    val feilutbetaling: BigDecimal,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -153,60 +153,6 @@ class AvregningServiceTest {
             // Assert
             assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
         }
-
-        @Test
-        fun `skal kun returnere perioder til og med forrige måned`() {
-            // Arrange
-            val andelerForrigeBehandling =
-                listOf(
-                    lagAndelTilkjentYtelse(
-                        fom = jan(2025),
-                        tom = apr(2025),
-                        person = barn1,
-                        kalkulertUtbetalingsbeløp = 1000,
-                    ),
-                    lagAndelTilkjentYtelse(
-                        fom = jan(2025),
-                        tom = apr(2025),
-                        person = barn2,
-                        kalkulertUtbetalingsbeløp = 2000,
-                    ),
-                )
-
-            val andelerInneværendeBehandling =
-                listOf(
-                    lagAndelTilkjentYtelse(
-                        fom = jan(2025),
-                        tom = apr(2025),
-                        person = barn1,
-                        kalkulertUtbetalingsbeløp = 2000,
-                    ),
-                    lagAndelTilkjentYtelse(
-                        fom = jan(2025),
-                        tom = apr(2025),
-                        person = barn2,
-                        kalkulertUtbetalingsbeløp = 1000,
-                    ),
-                )
-
-            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
-            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
-
-            // Act
-            val perioderMedEtterbetalingOgFeilutbetaling =
-                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
-
-            // Assert
-            val forventet =
-                AvregningPeriode(
-                    etterbetaling = 1000.toBigDecimal(),
-                    feilutbetaling = 1000.toBigDecimal(),
-                    fom = 1.jan(2025),
-                    tom = 28.feb(2025),
-                )
-
-            assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
-        }
     }
 
     @Nested
@@ -308,8 +254,8 @@ class AvregningServiceTest {
             // Assert
             val forventet =
                 AvregningPeriode(
-                    etterbetaling = 2000.toBigDecimal(),
-                    feilutbetaling = 1000.toBigDecimal(),
+                    totalEtterbetaling = 2000.toBigDecimal(),
+                    totalFeilutbetaling = 1000.toBigDecimal(),
                     fom = 1.jan(2025),
                     tom = 31.jan(2025),
                 )
@@ -368,8 +314,8 @@ class AvregningServiceTest {
             // Assert
             val forventet =
                 AvregningPeriode(
-                    etterbetaling = 1000.toBigDecimal(),
-                    feilutbetaling = 2000.toBigDecimal(),
+                    totalEtterbetaling = 1000.toBigDecimal(),
+                    totalFeilutbetaling = 2000.toBigDecimal(),
                     fom = 1.jan(2025),
                     tom = 31.jan(2025),
                 )
@@ -384,13 +330,13 @@ class AvregningServiceTest {
                 listOf(
                     lagAndelTilkjentYtelse(
                         fom = jan(2025),
-                        tom = jan(2025),
+                        tom = feb(2025),
                         person = barn1,
                         kalkulertUtbetalingsbeløp = 1000,
                     ),
                     lagAndelTilkjentYtelse(
                         fom = jan(2025),
-                        tom = jan(2025),
+                        tom = feb(2025),
                         person = barn2,
                         kalkulertUtbetalingsbeløp = 2000,
                     ),
@@ -399,13 +345,13 @@ class AvregningServiceTest {
                 listOf(
                     lagAndelTilkjentYtelse(
                         fom = jan(2025),
-                        tom = jan(2025),
+                        tom = feb(2025),
                         person = barn1,
                         kalkulertUtbetalingsbeløp = 2000,
                     ),
                     lagAndelTilkjentYtelse(
                         fom = jan(2025),
-                        tom = jan(2025),
+                        tom = feb(2025),
                         person = barn2,
                         kalkulertUtbetalingsbeløp = 1000,
                     ),
@@ -421,10 +367,10 @@ class AvregningServiceTest {
             // Assert
             val forventet =
                 AvregningPeriode(
-                    etterbetaling = 1000.toBigDecimal(),
-                    feilutbetaling = 1000.toBigDecimal(),
+                    totalEtterbetaling = 2000.toBigDecimal(),
+                    totalFeilutbetaling = 2000.toBigDecimal(),
                     fom = 1.jan(2025),
-                    tom = 31.jan(2025),
+                    tom = 28.feb(2025),
                 )
 
             assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
@@ -527,14 +473,14 @@ class AvregningServiceTest {
             val forventet =
                 listOf(
                     AvregningPeriode(
-                        etterbetaling = 1000.toBigDecimal(),
-                        feilutbetaling = 1000.toBigDecimal(),
+                        totalEtterbetaling = 2000.toBigDecimal(),
+                        totalFeilutbetaling = 2000.toBigDecimal(),
                         fom = 1.jan(2024),
                         tom = 29.feb(2024),
                     ),
                     AvregningPeriode(
-                        etterbetaling = 2000.toBigDecimal(),
-                        feilutbetaling = 1000.toBigDecimal(),
+                        totalEtterbetaling = 4000.toBigDecimal(),
+                        totalFeilutbetaling = 2000.toBigDecimal(),
                         fom = 1.mar(2024),
                         tom = 30.apr(2024),
                     ),
@@ -587,6 +533,60 @@ class AvregningServiceTest {
 
             // Assert
             assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
+        }
+
+        @Test
+        fun `skal kun returnere perioder til og med forrige måned`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            val forventet =
+                AvregningPeriode(
+                    totalEtterbetaling = 2000.toBigDecimal(),
+                    totalFeilutbetaling = 2000.toBigDecimal(),
+                    fom = 1.jan(2025),
+                    tom = 28.feb(2025),
+                )
+
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -1,0 +1,541 @@
+package no.nav.familie.ba.sak.kjerne.beregning
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.TestClockProvider
+import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class AvregningServiceTest {
+    private val søker = lagPerson()
+    private val barn1 = lagPerson()
+    private val barn2 = lagPerson()
+
+    private val sisteIverksatteBehandling = lagBehandling()
+    private val inneværendeBehandling = lagBehandling()
+
+    private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+
+    private val avregningService =
+        AvregningService(
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(mar(2025)),
+        )
+
+    @BeforeEach
+    fun setup() {
+        every { behandlingHentOgPersisterService.hent(any()) } returns inneværendeBehandling
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(any()) } returns sisteIverksatteBehandling
+    }
+
+    @Nested
+    inner class `etterbetalingerOgFeilutbetalinger - ett barn` {
+        @Test
+        fun `skal returnere tom liste hvis det ikke finnes andeler`() {
+            // Arrange
+            val andelerForrigeBehandling = emptyList<AndelTilkjentYtelse>()
+            val andelerInneværendeBehandling = emptyList<AndelTilkjentYtelse>()
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere tom liste hvis ingen andeler er endret`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
+        }
+
+        @Test
+        fun `skal ikke returnere perioder med kun feilutbetaling`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling = emptyList<AndelTilkjentYtelse>()
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
+        }
+
+        @Test
+        fun `skal ikke returnere perioder med kun etterbetaling`() {
+            // Arrange
+            val andelerForrigeBehandling = emptyList<AndelTilkjentYtelse>()
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
+        }
+
+        @Test
+        fun `skal kun returnere perioder til og med forrige måned`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            val forventet =
+                AvregningPeriode(
+                    etterbetaling = 1000.toBigDecimal(),
+                    feilutbetaling = 1000.toBigDecimal(),
+                    fom = 1.jan(2025),
+                    tom = 28.feb(2025),
+                )
+
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
+        }
+    }
+
+    @Nested
+    inner class `etterbetalingerOgFeilutbetalinger - to barn` {
+        @Test
+        fun `skal returnere tom liste hvis ingen andeler er endret for flere barn`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
+        }
+
+        @Test
+        fun `skal summere etterbetaling for flere barn`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = søker,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            val forventet =
+                AvregningPeriode(
+                    etterbetaling = 2000.toBigDecimal(),
+                    feilutbetaling = 1000.toBigDecimal(),
+                    fom = 1.jan(2025),
+                    tom = 31.jan(2025),
+                )
+
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
+        }
+
+        @Test
+        fun `skal summere feilutbetaling for flere barn`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = søker,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            val forventet =
+                AvregningPeriode(
+                    etterbetaling = 1000.toBigDecimal(),
+                    feilutbetaling = 2000.toBigDecimal(),
+                    fom = 1.jan(2025),
+                    tom = 31.jan(2025),
+                )
+
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
+        }
+
+        @Test
+        fun `skal returnere feilutbetaling og etterbetaling for flere barn i samme periode`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            val forventet =
+                AvregningPeriode(
+                    etterbetaling = 1000.toBigDecimal(),
+                    feilutbetaling = 1000.toBigDecimal(),
+                    fom = 1.jan(2025),
+                    tom = 31.jan(2025),
+                )
+
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
+        }
+
+        @Test
+        fun `skal returnere tom liste hvis feilutbetaling og etterbetaling er i forskjellige perioder for flere barn`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jul(2024),
+                        tom = jul(2024),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jul(2024),
+                        tom = jul(2024),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = jan(2025),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere to perioder hvis det er forskjellig etterbetaling`() {
+            // Arrange
+            val andelerForrigeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2024),
+                        tom = apr(2024),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2024),
+                        tom = apr(2024),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            val andelerInneværendeBehandling =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2024),
+                        tom = feb(2024),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = mar(2024),
+                        tom = apr(2024),
+                        person = barn1,
+                        kalkulertUtbetalingsbeløp = 3000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2024),
+                        tom = apr(2024),
+                        person = barn2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns andelerForrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(inneværendeBehandling.id) } returns andelerInneværendeBehandling
+
+            // Act
+            val perioderMedEtterbetalingOgFeilutbetaling =
+                avregningService.hentPerioderMedAvregning(behandlingId = inneværendeBehandling.id)
+
+            // Assert
+            val forventet =
+                listOf(
+                    AvregningPeriode(
+                        etterbetaling = 1000.toBigDecimal(),
+                        feilutbetaling = 1000.toBigDecimal(),
+                        fom = 1.jan(2024),
+                        tom = 29.feb(2024),
+                    ),
+                    AvregningPeriode(
+                        etterbetaling = 2000.toBigDecimal(),
+                        feilutbetaling = 1000.toBigDecimal(),
+                        fom = 1.mar(2024),
+                        tom = 30.apr(2024),
+                    ),
+                )
+
+            assertThat(perioderMedEtterbetalingOgFeilutbetaling).isEqualTo(forventet)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -476,7 +476,7 @@ class AvregningServiceTest {
         }
 
         @Test
-        fun `skal returnere to perioder hvis det er forskjellig etterbetaling`() {
+        fun `skal returnere to perioder hvis det er etterbetalingen endres i utbetalingsperioden`() {
             // Arrange
             val andelerForrigeBehandling =
                 listOf(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22661

Vi må utlede hvilke perioder det er avregning i behandlinger. Løser dette ved å se på endringer i andeler per person og ytelsetype mellom forrige iverksatte og inneværende behandling. Avklart med fag at vi bare trenger å se på måneder til og med forrige måned.

Ettersom avregningsperiodene skal brukes i simuleringssteget, og det på en måte er en del av simuleringen, wrappes det sammen med simuleringsdataen, for å minimere hvor ofte vi trenger å utlede og hente dataen.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
