### PR TITLE
Fix: Fjerner tomme utbetalingstidslinjer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
@@ -55,7 +55,7 @@ class UtbetalingsTidslinjeService(
 
         val tidslinjePerKjede = genererTidslinjePerKjede(iverksatteUtbetalingsoppdrag = iverksatteUtbetalingsoppdrag, utbetalingsperioderPerKjede = utbetalingsperioderPerKjede)
 
-        return tidslinjePerKjede.filterValues { it.erTom() }.keys.map { sistePeriodeIdIKjede ->
+        return tidslinjePerKjede.filterValues { !it.erTom() }.keys.map { sistePeriodeIdIKjede ->
             Utbetalingstidslinje(
                 utbetalingsperioder =
                     try {

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/UtbetalingsTidslinjeService.kt
@@ -55,7 +55,7 @@ class UtbetalingsTidslinjeService(
 
         val tidslinjePerKjede = genererTidslinjePerKjede(iverksatteUtbetalingsoppdrag = iverksatteUtbetalingsoppdrag, utbetalingsperioderPerKjede = utbetalingsperioderPerKjede)
 
-        return tidslinjePerKjede.keys.map { sistePeriodeIdIKjede ->
+        return tidslinjePerKjede.filterValues { it.erTom() }.keys.map { sistePeriodeIdIKjede ->
             Utbetalingstidslinje(
                 utbetalingsperioder =
                     try {


### PR DESCRIPTION
Favro: [NAV-24387](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24387)

### 💰 Hva skal gjøres, og hvorfor?
Dersom man har mottatt barnetrygd av en bestemt ytelsetype (Ordinær, utvidet eller småbarnstillegg) tidligere, og deretter mistet retten til alle utbetalinger av den bestemte ytelsetypen vil vi ved generering av alle utbetalingstidslinjer for en fagsak få en tom utbetalingstidslinje for den ytelsetypen. Dette skaper nå feil ved patching av enkelte fagsaker.

Legger her inn filtrering av alle tomme utbetalingstidslinjer.