### PR TITLE
NAV-24658: Utivder logikken for relatert behandling id for å ta hensyn til klage, samt legger til relatert behandling fagsystem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <felles.version>3.20250320122046_7ca9dae</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
         <felles-kontrakter.version>3.0_20250324143109_c04b578</felles-kontrakter.version>
-        <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>
+        <familie.kontrakter.saksstatistikk>2.0_20250324193741_10e7868</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20241209130157_6873c2d</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250306084157_636f980</utbetalingsgenerator.version>
         <cucumber.version>7.21.1</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -241,6 +241,8 @@ data class Behandling(
 
     fun erRevurderingKlage() = type == BehandlingType.REVURDERING && opprettetÅrsak in setOf(BehandlingÅrsak.KLAGE, BehandlingÅrsak.IVERKSETTE_KA_VEDTAK)
 
+    fun erRevurderingEllerTekniskEndring() = type == BehandlingType.REVURDERING || type == BehandlingType.TEKNISK_ENDRING
+
     fun erKorrigereVedtak() = opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV
 
     fun kanLeggeTilOgFjerneUtvidetVilkår() = erManuellMigrering() || erTekniskEndring() || erKorrigereVedtak() || erKlage() || erIverksetteKAVedtak()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -239,6 +239,8 @@ data class Behandling(
 
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 
+    fun erRevurderingKlage() = type == BehandlingType.REVURDERING && opprettetÅrsak in setOf(BehandlingÅrsak.KLAGE, BehandlingÅrsak.IVERKSETTE_KA_VEDTAK)
+
     fun erKorrigereVedtak() = opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV
 
     fun kanLeggeTilOgFjerneUtvidetVilkår() = erManuellMigrering() || erTekniskEndring() || erKorrigereVedtak() || erKlage() || erIverksetteKAVedtak()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
@@ -44,6 +44,7 @@ class KlageService(
     private val stegService: StegService,
     private val vedtakService: VedtakService,
     private val tilbakekrevingKlient: TilbakekrevingKlient,
+    private val klagebehandlingHenter: KlagebehandlingHenter,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -80,15 +81,9 @@ class KlageService(
         )
     }
 
-    fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> {
-        val klagebehandligerPerFagsak = klageClient.hentKlagebehandlinger(setOf(fagsakId))
+    fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> = klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
 
-        val klagerPåFagsak =
-            klagebehandligerPerFagsak[fagsakId]
-                ?: throw Feil("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
-
-        return klagerPåFagsak.map { it.brukVedtaksdatoFraKlageinstansHvisOversendt() }
-    }
+    fun hentSisteVedtatteKlagebehandling(fagsakId: Long): KlagebehandlingDto? = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
 
     @Transactional(readOnly = true)
     fun kanOppretteRevurdering(fagsakId: Long): KanOppretteRevurderingResponse {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenter.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ba.sak.kjerne.klage
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
+import org.springframework.stereotype.Component
+
+@Component
+class KlagebehandlingHenter(
+    private val klageClient: KlageClient,
+) {
+    fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> {
+        val klagebehandligerPerFagsak = klageClient.hentKlagebehandlinger(setOf(fagsakId))
+        val klagerPåFagsak = klagebehandligerPerFagsak[fagsakId]
+        if (klagerPåFagsak == null) {
+            throw Feil("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
+        }
+        return klagerPåFagsak.map { it.brukVedtaksdatoFraKlageinstansHvisOversendt() }
+    }
+
+    fun hentSisteVedtatteKlagebehandling(fagsakId: Long): KlagebehandlingDto? =
+        hentKlagebehandlingerPåFagsak(fagsakId)
+            .asSequence()
+            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektStatus(it.status) }
+            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektHenlagtÅrsak(it.henlagtÅrsak) }
+            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektBehandlingResultat(it.resultat) }
+            .filter { it.vedtaksdato != null }
+            .maxByOrNull { it.vedtaksdato!! }
+
+    private object SisteVedtatteKlagebehandlingSjekker {
+        fun harKlagebehandlingKorrektStatus(behandlingStatus: BehandlingStatus) =
+            when (behandlingStatus) {
+                BehandlingStatus.FERDIGSTILT,
+                -> true
+
+                BehandlingStatus.OPPRETTET,
+                BehandlingStatus.UTREDES,
+                BehandlingStatus.VENTER,
+                BehandlingStatus.SATT_PÅ_VENT,
+                -> false
+            }
+
+        fun harKlagebehandlingKorrektHenlagtÅrsak(henlagtÅrsak: HenlagtÅrsak?): Boolean {
+            if (henlagtÅrsak == null) {
+                return true
+            }
+            return when (henlagtÅrsak) {
+                HenlagtÅrsak.TRUKKET_TILBAKE,
+                HenlagtÅrsak.FEILREGISTRERT,
+                -> false
+            }
+        }
+
+        fun harKlagebehandlingKorrektBehandlingResultat(behandlingResultat: BehandlingResultat?): Boolean {
+            if (behandlingResultat == null) {
+                return false
+            }
+            return when (behandlingResultat) {
+                BehandlingResultat.MEDHOLD,
+                BehandlingResultat.IKKE_MEDHOLD,
+                BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
+                -> true
+
+                BehandlingResultat.IKKE_SATT,
+                BehandlingResultat.HENLAGT,
+                -> false
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandling.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ba.sak.statistikk.saksstatistikk
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
+import java.time.LocalDateTime
+
+data class RelatertBehandling(
+    val id: String,
+    val vedtattTidspunkt: LocalDateTime,
+    val fagsystem: Fagsystem,
+) {
+    enum class Fagsystem {
+        BA,
+        KLAGE,
+    }
+
+    companion object Factory {
+        fun fraBarnetrygdbehandling(barnetrygdbehandling: Behandling) =
+            RelatertBehandling(
+                id = barnetrygdbehandling.id.toString(),
+                vedtattTidspunkt = barnetrygdbehandling.aktivertTidspunkt,
+                fagsystem = Fagsystem.BA,
+            )
+
+        fun fraKlagebehandling(klagebehandling: KlagebehandlingDto): RelatertBehandling {
+            val vedtaksdato = klagebehandling.vedtaksdato
+            if (vedtaksdato == null) {
+                throw Feil("Forventer vedtaksdato for klagebehandling ${klagebehandling.id}")
+            }
+            return RelatertBehandling(
+                id = klagebehandling.id.toString(),
+                vedtattTidspunkt = vedtaksdato,
+                fagsystem = Fagsystem.KLAGE,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -1,0 +1,47 @@
+package no.nav.familie.ba.sak.statistikk.saksstatistikk
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.klage.KlageService
+import org.springframework.stereotype.Component
+
+@Component
+class RelatertBehandlingUtleder(
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val klageService: KlageService,
+    private val unleashService: UnleashNextMedContextService,
+) {
+    fun utledRelatertBehandling(behandling: Behandling): RelatertBehandling? {
+        if (!unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false)) {
+            return null
+        }
+        return if (behandling.erRevurderingKlage()) {
+            val sisteVedtatteKlagebehandling = klageService.hentSisteVedtatteKlagebehandling(behandling.fagsak.id)
+            if (sisteVedtatteKlagebehandling == null) {
+                throw Feil("Forventer en vedtatt klagebehandling for behandling ${behandling.id}")
+            }
+            RelatertBehandling.fraKlagebehandling(sisteVedtatteKlagebehandling)
+        } else {
+            behandlingHentOgPersisterService
+                .hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+                ?.takeIf { harBarnetrygdbehandlingKorrektBehandlingType(it) }
+                ?.let { RelatertBehandling.fraBarnetrygdbehandling(it) }
+        }
+    }
+
+    private fun harBarnetrygdbehandlingKorrektBehandlingType(barnetrygdbehandling: Behandling) =
+        when (barnetrygdbehandling.type) {
+            BehandlingType.FØRSTEGANGSBEHANDLING,
+            BehandlingType.MIGRERING_FRA_INFOTRYGD,
+            BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT,
+            -> false
+
+            BehandlingType.REVURDERING,
+            BehandlingType.TEKNISK_ENDRING,
+            -> true
+        }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -5,8 +5,9 @@ import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.klage.KlageService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
@@ -15,29 +16,27 @@ class RelatertBehandlingUtleder(
     private val klageService: KlageService,
     private val unleashService: UnleashNextMedContextService,
 ) {
-    fun utledRelatertBehandling(behandling: Behandling): RelatertBehandling? =
+    private val logger: Logger = LoggerFactory.getLogger(RelatertBehandlingUtleder::class.java)
+
+    fun utledRelatertBehandling(behandling: Behandling): RelatertBehandling? {
         if (behandling.erRevurderingKlage() && unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false)) {
             val sisteVedtatteKlagebehandling = klageService.hentSisteVedtatteKlagebehandling(behandling.fagsak.id)
             if (sisteVedtatteKlagebehandling == null) {
-                throw Feil("Forventer en vedtatt klagebehandling for behandling ${behandling.id}")
+                throw Feil("Forventer en vedtatt klagebehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
             }
-            RelatertBehandling.fraKlagebehandling(sisteVedtatteKlagebehandling)
-        } else {
-            behandlingHentOgPersisterService
-                .hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
-                ?.takeIf { harBarnetrygdbehandlingKorrektBehandlingType(it) }
-                ?.let { RelatertBehandling.fraBarnetrygdbehandling(it) }
+            return RelatertBehandling.fraKlagebehandling(sisteVedtatteKlagebehandling)
         }
 
-    private fun harBarnetrygdbehandlingKorrektBehandlingType(barnetrygdbehandling: Behandling) =
-        when (barnetrygdbehandling.type) {
-            BehandlingType.FØRSTEGANGSBEHANDLING,
-            BehandlingType.MIGRERING_FRA_INFOTRYGD,
-            BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT,
-            -> false
-
-            BehandlingType.REVURDERING,
-            BehandlingType.TEKNISK_ENDRING,
-            -> true
+        if (behandling.erRevurderingEllerTekniskEndring()) {
+            val sisteVedtatteBarnetrygdbehandling =
+                behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+            if (sisteVedtatteBarnetrygdbehandling == null) {
+                logger.warn("Forventer en vedtatt barnetrygdbehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
+                return null
+            }
+            return RelatertBehandling.fraBarnetrygdbehandling(sisteVedtatteBarnetrygdbehandling)
         }
+
+        return null
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -15,11 +15,8 @@ class RelatertBehandlingUtleder(
     private val klageService: KlageService,
     private val unleashService: UnleashNextMedContextService,
 ) {
-    fun utledRelatertBehandling(behandling: Behandling): RelatertBehandling? {
-        if (!unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false)) {
-            return null
-        }
-        return if (behandling.erRevurderingKlage()) {
+    fun utledRelatertBehandling(behandling: Behandling): RelatertBehandling? =
+        if (behandling.erRevurderingKlage() && unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false)) {
             val sisteVedtatteKlagebehandling = klageService.hentSisteVedtatteKlagebehandling(behandling.fagsak.id)
             if (sisteVedtatteKlagebehandling == null) {
                 throw Feil("Forventer en vedtatt klagebehandling for behandling ${behandling.id}")
@@ -31,7 +28,6 @@ class RelatertBehandlingUtleder(
                 ?.takeIf { harBarnetrygdbehandlingKorrektBehandlingType(it) }
                 ?.let { RelatertBehandling.fraBarnetrygdbehandling(it) }
         }
-    }
 
     private fun harBarnetrygdbehandlingKorrektBehandlingType(barnetrygdbehandling: Behandling) =
         when (barnetrygdbehandling.type) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -29,7 +29,7 @@ class RelatertBehandlingUtleder(
 
         if (behandling.erRevurderingEllerTekniskEndring()) {
             val sisteVedtatteBarnetrygdbehandling =
-                behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+                behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
             if (sisteVedtatteBarnetrygdbehandling == null) {
                 logger.warn("Forventer en vedtatt barnetrygdbehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
                 return null

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt
@@ -107,7 +107,7 @@ class SaksstatistikkService(
             // Ikke påkrevde felt
             vedtaksDato = aktivtVedtak?.vedtaksdato?.toLocalDate(),
             relatertBehandlingId = relatertBehandling?.id,
-            // relatertBehandlingFagsystem = relatertBehandling?.fagsystem?.name,
+            relatertBehandlingFagsystem = relatertBehandling?.fagsystem?.name,
             vedtakId = aktivtVedtak?.id?.toString(),
             resultat = behandling.resultat.name,
             behandlingTypeBeskrivelse = behandling.type.visningsnavn,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenterTest.kt
@@ -1,0 +1,261 @@
+package no.nav.familie.ba.sak.kjerne.klage
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.datagenerator.lagKlagebehandlingDto
+import no.nav.familie.ba.sak.datagenerator.lagKlageinstansResultatDto
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDateTime
+
+class KlagebehandlingHenterTest {
+    private val klageClient = mockk<KlageClient>()
+    private val klagebehandlingHenter =
+        KlagebehandlingHenter(
+            klageClient = klageClient,
+        )
+
+    @Nested
+    inner class HentKlagebehandlingerPåFagsak {
+        @Test
+        fun `skal kaste exception om fagsaken ikke finnes i resultatet fra kallet til klageklienten`() {
+            // Arrange
+            val fagsakId = 4L
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    1L to listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto()),
+                    2L to listOf(lagKlagebehandlingDto()),
+                    3L to listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto()),
+                )
+
+            // Act & Assert
+            val exception =
+                assertThrows<Feil> {
+                    klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
+                }
+            assertThat(exception.message).isEqualTo("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
+        }
+
+        @Test
+        fun `skal hente klagebehandlinger på fagsak`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingerForFagsak1 = listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto())
+            val klagebehandlingerForFagsak2 = listOf(lagKlagebehandlingDto())
+            val klagebehandlingerForFagsak3 = listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto())
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to klagebehandlingerForFagsak1,
+                    2L to klagebehandlingerForFagsak2,
+                    3L to klagebehandlingerForFagsak3,
+                )
+
+            // Act
+            val resultat = klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
+
+            // Assert
+            assertThat(resultat).isEqualTo(klagebehandlingerForFagsak1)
+        }
+    }
+
+    @Nested
+    inner class HentSisteVedtatteKlagebehandling {
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["FERDIGSTILT"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal filtrer bort klagebehandlinger som ikke er ferdigstilt`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = behandlingStatus,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = HenlagtÅrsak::class)
+        fun `skal filtrer bort klagebehandlinger med henlagt årsak`(
+            henlagtÅrsak: HenlagtÅrsak,
+        ) {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = henlagtÅrsak,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingResultat::class,
+            names = ["MEDHOLD", "IKKE_MEDHOLD", "IKKE_MEDHOLD_FORMKRAV_AVVIST"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal filtrer bort klagebehandlinger med behandlingsresultat som ikke er korrekt`(
+            behandlingResultat: BehandlingResultat,
+        ) {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = behandlingResultat,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @Test
+        fun `skal filtrer bort klagebehandlinger med behandlingsresultat som er null`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = null,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @Test
+        fun `skal filtrer bort klagebehandlinger med vedtaksdato som er null`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = null,
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.MEDHOLD,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @Test
+        fun `skal hente siste vedtatte klagebehandling med korrekt behandlingsresultat`() {
+            // Arrange
+            val fagsakId = 1L
+            val nåtidspunkt = LocalDateTime.now()
+
+            val klagebehandlingDto1 =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.MEDHOLD,
+                )
+
+            val klagebehandlingDto2 =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt,
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.IKKE_MEDHOLD,
+                    klageinstansResultat =
+                        listOf(
+                            lagKlageinstansResultatDto(
+                                mottattEllerAvsluttetTidspunkt = nåtidspunkt,
+                            ),
+                        ),
+                )
+
+            val klagebehandlingDto3 =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt.minusSeconds(2),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto1, klagebehandlingDto2, klagebehandlingDto3),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isEqualTo(klagebehandlingDto2)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -96,7 +96,7 @@ class RelatertBehandlingUtlederTest {
             // Arrange
             val nåtidspunkt = LocalDateTime.now()
 
-            val revurderingKlage =
+            val revurdering =
                 lagBehandling(
                     behandlingType = BehandlingType.REVURDERING,
                     årsak = behandlingÅrsak,
@@ -105,14 +105,14 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            every { klageService.hentSisteVedtatteKlagebehandling(revurderingKlage.fagsak.id) } returns null
+            every { klageService.hentSisteVedtatteKlagebehandling(revurdering.fagsak.id) } returns null
 
             // Act & assert
             val exception =
                 assertThrows<Feil> {
-                    relatertBehandlingUtleder.utledRelatertBehandling(revurderingKlage)
+                    relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
                 }
-            assertThat(exception.message).isEqualTo("Forventer en vedtatt klagebehandling for fagsak ${revurderingKlage.fagsak.id} og behandling ${revurderingKlage.id}")
+            assertThat(exception.message).isEqualTo("Forventer en vedtatt klagebehandling for fagsak ${revurdering.fagsak.id} og behandling ${revurdering.id}")
             verify { behandlingHentOgPersisterService wasNot called }
         }
 
@@ -128,7 +128,7 @@ class RelatertBehandlingUtlederTest {
             // Arrange
             val nåtidspunkt = LocalDateTime.now()
 
-            val revurderingKlage =
+            val revurdering =
                 lagBehandling(
                     behandlingType = BehandlingType.REVURDERING,
                     årsak = behandlingÅrsak,
@@ -142,10 +142,10 @@ class RelatertBehandlingUtlederTest {
                     vedtaksdato = nåtidspunkt,
                 )
 
-            every { klageService.hentSisteVedtatteKlagebehandling(revurderingKlage.fagsak.id) } returns sisteVedtatteKlagebehandling
+            every { klageService.hentSisteVedtatteKlagebehandling(revurdering.fagsak.id) } returns sisteVedtatteKlagebehandling
 
             // Act
-            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurderingKlage)
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
 
             // Assert
             verify { behandlingHentOgPersisterService wasNot called }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -1,0 +1,291 @@
+package no.nav.familie.ba.sak.statistikk.saksstatistikk
+
+import io.mockk.called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagKlagebehandlingDto
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.klage.KlageService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class RelatertBehandlingUtlederTest {
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val klageService = mockk<KlageService>()
+    private val unleashService = mockk<UnleashNextMedContextService>()
+    private val relatertBehandlingUtleder =
+        RelatertBehandlingUtleder(
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            klageService = klageService,
+            unleashService = unleashService,
+        )
+
+    @BeforeEach
+    fun oppsett() {
+        every { unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false) } returns true
+    }
+
+    @Nested
+    inner class UtledRelatertBehandling {
+        @Test
+        fun `skal returnere null når toggle for å behandle klage er skrudd av`() {
+            // Arrange
+            val behandling = lagBehandling()
+
+            every { unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false) } returns false
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(behandling)
+
+            // Assert
+            assertThat(relatertBehandling).isNull()
+        }
+
+        @Test
+        fun `skal kaste feil om ingen vedtatt klagebehandling finnes når den innsendte behandling er en revurdering med årsak klage`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val revurderingKlage =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.KLAGE,
+                    aktivertTid = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            every { klageService.hentSisteVedtatteKlagebehandling(revurderingKlage.fagsak.id) } returns null
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    relatertBehandlingUtleder.utledRelatertBehandling(revurderingKlage)
+                }
+            assertThat(exception.message).isEqualTo("Forventer en vedtatt klagebehandling for behandling ${revurderingKlage.id}")
+            verify { behandlingHentOgPersisterService wasNot called }
+        }
+
+        @Test
+        fun `skal kaste feil om ingen vedtatt klagebehandling finnes når den innsendte behandling er en revurdering med årsak iverksette ka vedtak`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val revurderingKlage =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+                    aktivertTid = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            every { klageService.hentSisteVedtatteKlagebehandling(revurderingKlage.fagsak.id) } returns null
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    relatertBehandlingUtleder.utledRelatertBehandling(revurderingKlage)
+                }
+            assertThat(exception.message).isEqualTo("Forventer en vedtatt klagebehandling for behandling ${revurderingKlage.id}")
+            verify { behandlingHentOgPersisterService wasNot called }
+        }
+
+        @Test
+        fun `skal utlede relatert behandling med klagebehandlingen som siste vedtatte behandling når den innsendte behandling er en revurdering med årsak klage`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val revurderingKlage =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.KLAGE,
+                    aktivertTid = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            val sisteVedtatteKlagebehandling =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt,
+                )
+
+            every { klageService.hentSisteVedtatteKlagebehandling(revurderingKlage.fagsak.id) } returns sisteVedtatteKlagebehandling
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurderingKlage)
+
+            // Assert
+            verify { behandlingHentOgPersisterService wasNot called }
+            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteKlagebehandling.id.toString())
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KLAGE)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteKlagebehandling.vedtaksdato)
+        }
+
+        @Test
+        fun `skal utlede relatert behandling med klagebehandlingen som siste vedtatte behandling når den innsendte behandling er en revurdering med årsak iverksetter ka vedtak`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val revurderingIverksetteKaVedtak =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+                    aktivertTid = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            val sisteVedtatteKlagebehandling =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt,
+                )
+
+            every { klageService.hentSisteVedtatteKlagebehandling(revurderingIverksetteKaVedtak.fagsak.id) } returns sisteVedtatteKlagebehandling
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurderingIverksetteKaVedtak)
+
+            // Assert
+            verify { behandlingHentOgPersisterService wasNot called }
+            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteKlagebehandling.id.toString())
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KLAGE)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteKlagebehandling.vedtaksdato)
+        }
+
+        @Test
+        fun `skal utlede relatert behandling med barnetrygdbehandlingen som siste vedtatte behandling når den innsendte behandling ikke er en revurdering med årsak klage eller iverksetter ka vedtak`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val revurdering =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                    aktivertTid = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            val sisteVedtatteBarnetrygdbehandling =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    aktivertTid = nåtidspunkt.minusSeconds(2),
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(revurdering.fagsak.id) } returns sisteVedtatteBarnetrygdbehandling
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
+
+            // Assert
+            verify { klageService wasNot called }
+            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteBarnetrygdbehandling.id.toString())
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.BA)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteBarnetrygdbehandling.aktivertTidspunkt)
+        }
+
+        @Test
+        fun `skal utlede relatert behandling med barnetrygdbehandlingen som siste vedtatte behandling når den innsendte behandling ikke er en revurdering`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val behandling =
+                lagBehandling(
+                    behandlingType = BehandlingType.TEKNISK_ENDRING,
+                    årsak = BehandlingÅrsak.TEKNISK_ENDRING,
+                    aktivertTid = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            val sisteVedtatteBarnetrygdbehandling =
+                lagBehandling(
+                    behandlingType = BehandlingType.TEKNISK_ENDRING,
+                    aktivertTid = nåtidspunkt.minusSeconds(2),
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id) } returns sisteVedtatteBarnetrygdbehandling
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(behandling)
+
+            // Assert
+            verify { klageService wasNot called }
+            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteBarnetrygdbehandling.id.toString())
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.BA)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteBarnetrygdbehandling.aktivertTidspunkt)
+        }
+
+        @Test
+        fun `skal ikke utlede relatert behandling når ingen barnetrygdbehandling er vedtatt og den innsendte behandling ikke er en revurdering med årsak klage eller iverksette ka vedtak`() {
+            // Arrange
+            val revurdering =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                    aktivertTid = LocalDateTime.now(),
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(revurdering.fagsak.id) } returns null
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
+
+            // Assert
+            verify { klageService wasNot called }
+            assertThat(relatertBehandling).isNull()
+        }
+
+        @Test
+        fun `skal ikke utlede relatert behandling når kun en førstegangsbehandling for barnetrygd er vedtatt`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val revurdering =
+                lagBehandling(
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                    aktivertTid = nåtidspunkt,
+                    status = BehandlingStatus.UTREDES,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                )
+
+            val sisteVedtatteBarnetrygdbehandling =
+                lagBehandling(
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    aktivertTid = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(revurdering.fagsak.id) } returns sisteVedtatteBarnetrygdbehandling
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
+
+            // Assert
+            verify { klageService wasNot called }
+            assertThat(relatertBehandling).isNull()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -72,7 +72,7 @@ class RelatertBehandlingUtlederTest {
                 )
 
             every { unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false) } returns false
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(revurdering.fagsak.id) } returns sisteVedtatteBarnetrygdbehandling
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(revurdering) } returns sisteVedtatteBarnetrygdbehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
@@ -183,7 +183,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.INNVILGET,
                 )
 
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(revurdering.fagsak.id) } returns sisteVedtatteBarnetrygdbehandling
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(revurdering) } returns sisteVedtatteBarnetrygdbehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
@@ -217,7 +217,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.INNVILGET,
                 )
 
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(tekniskEndring.fagsak.id) } returns sisteVedtatteBarnetrygdbehandling
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(tekniskEndring) } returns sisteVedtatteBarnetrygdbehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(tekniskEndring)
@@ -250,7 +250,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id) } returns null
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling) } returns null
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -176,6 +176,24 @@ internal class SaksstatistikkServiceTest {
     }
 
     @Test
+    fun `Skal ikke mappe relatert behandling til behandlingDVH når relatert behandling er null`() {
+        // Arrange
+        val behandling = lagBehandling(behandlingType = BehandlingType.REVURDERING, årsak = BehandlingÅrsak.KLAGE)
+
+        every { behandlingHentOgPersisterService.hent(any()) } returns behandling
+        every { totrinnskontrollService.hentAktivForBehandling(any()) } returns null
+        every { vedtakService.hentAktivForBehandling(any()) } returns null
+        every { relatertBehandlingUtleder.utledRelatertBehandling(any()) } returns null
+
+        // Act
+        val behandlingDvh = sakstatistikkService.mapTilBehandlingDVH(2)
+
+        // Assert
+        assertThat(behandlingDvh?.relatertBehandlingId).isNull()
+        assertThat(behandlingDvh?.relatertBehandlingFagsystem).isNull()
+    }
+
+    @Test
     fun `Skal mappe til behandlingDVH for Automatisk rute`() {
         val behandling =
             lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE, skalBehandlesAutomatisk = true).also {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkServiceTest.kt
@@ -172,6 +172,7 @@ internal class SaksstatistikkServiceTest {
 
         // Assert
         assertThat(behandlingDvh?.relatertBehandlingId).isEqualTo(behandling.id.toString())
+        assertThat(behandlingDvh?.relatertBehandlingFagsystem).isEqualTo(RelatertBehandling.Fagsystem.BA.name)
     }
 
     @Test

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/KlageGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/KlageGenerator.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ba.sak.datagenerator
+
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.RelatertBehandling
+import no.nav.familie.kontrakter.felles.klage.BehandlingEventType
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
+import no.nav.familie.kontrakter.felles.klage.KlageinstansResultatDto
+import no.nav.familie.kontrakter.felles.klage.KlageinstansUtfall
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+fun lagKlagebehandlingDto(
+    id: UUID = UUID.randomUUID(),
+    fagsakId: UUID = UUID.randomUUID(),
+    status: no.nav.familie.kontrakter.felles.klage.BehandlingStatus = no.nav.familie.kontrakter.felles.klage.BehandlingStatus.FERDIGSTILT,
+    opprettet: LocalDateTime = LocalDateTime.now(),
+    mottattDato: LocalDate = LocalDate.now(),
+    resultat: BehandlingResultat? = BehandlingResultat.MEDHOLD,
+    årsak: no.nav.familie.kontrakter.felles.klage.Årsak? = null,
+    vedtaksdato: LocalDateTime? = LocalDateTime.now(),
+    klageinstansResultat: List<KlageinstansResultatDto> = emptyList(),
+    henlagtÅrsak: HenlagtÅrsak? = null,
+) = KlagebehandlingDto(
+    id = id,
+    fagsakId = fagsakId,
+    status = status,
+    opprettet = opprettet,
+    mottattDato = mottattDato,
+    resultat = resultat,
+    årsak = årsak,
+    vedtaksdato = vedtaksdato,
+    klageinstansResultat = klageinstansResultat,
+    henlagtÅrsak = henlagtÅrsak,
+)
+
+fun lagKlageinstansResultatDto(
+    type: BehandlingEventType = BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET,
+    utfall: KlageinstansUtfall? = KlageinstansUtfall.MEDHOLD,
+    mottattEllerAvsluttetTidspunkt: LocalDateTime = LocalDateTime.now(),
+    journalpostReferanser: List<String> = emptyList(),
+    årsakFeilregistrert: String? = null,
+): KlageinstansResultatDto =
+    KlageinstansResultatDto(
+        type = type,
+        utfall = utfall,
+        mottattEllerAvsluttetTidspunkt = mottattEllerAvsluttetTidspunkt,
+        journalpostReferanser = journalpostReferanser,
+        årsakFeilregistrert = årsakFeilregistrert,
+    )
+
+fun lagRelatertBehandling(
+    id: String = "1",
+    vedtattTidspunkt: LocalDateTime = LocalDateTime.now(),
+    fagsystem: RelatertBehandling.Fagsystem = RelatertBehandling.Fagsystem.BA,
+): RelatertBehandling =
+    RelatertBehandling(
+        id = id,
+        vedtattTidspunkt = vedtattTidspunkt,
+        fagsystem = fagsystem,
+    )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

Ønsker å sende over `relatertBehandlingId` og `relatertBehandlingFagsystem` til DVH for statistikk. `relatertBehandlingId` må kunne peke på både barnetrygdbehandlinger og klagebehandlinger. Hvis man har en behandling av type `REVURDERING` med årsak `KLAGE` eller `IVERKSETTE_VA_VEDTAK` skal man bruke den siste vedtatte klagebehandlingen. I andre tilfeller skal man bruke, om det finnes, den siste vedtatte barnetrygdbehandlingen. Den siste vedtatte barnetrygdbehandlingen må være av type `REVURDERING` eller `TEKNISK_ENDRING` for å bli tatt med som en relatert behandling. Om man har en behandling av type `REVURDERING` med årsak `KLAGE` eller `IVERKSETTE_VA_VEDTAK` og det ikke finnes en vedtatt klagebehandling skal man kaste feil. 

Har deployet til preprod og testet kafka-integrasjonen. Nedenfor ser du bilder fra Kafka Manager. 

Her fra en barnetrygdbehandling som er en revurdering som ikke har årsak klage eller iverksette ka vedtak
![image](https://github.com/user-attachments/assets/caea5e59-a98a-4707-9171-8b88fd5cb6e7)

Her fra en barnetrygdbehandling som er en revurdering med årsak klage
![image](https://github.com/user-attachments/assets/b6da72a1-a0c6-4616-8881-7aa2f346adee)

Relatert PR for KS: https://github.com/navikt/familie-ks-sak/pull/1183

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta om ønskelig
