### PR TITLE
NAV-24773: Fritekst på alle begrunnelser i revurderinger med årsak klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/EØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/EØSBegrunnelse.kt
@@ -49,11 +49,10 @@ class EØSBegrunnelse(
     fun tilRestVedtaksbegrunnelse(
         sanityBegrunnelser: List<ISanityBegrunnelse>,
         alleBegrunnelserSkalStøtteFritekst: Boolean,
-    ) =
-        RestVedtaksbegrunnelse(
-            standardbegrunnelse = this.begrunnelse.enumnavnTilString(),
-            vedtakBegrunnelseType = this.begrunnelse.vedtakBegrunnelseType,
-            vedtakBegrunnelseSpesifikasjon = this.begrunnelse.enumnavnTilString(),
-            støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.begrunnelse.støtterFritekst(sanityBegrunnelser),
-        )
+    ) = RestVedtaksbegrunnelse(
+        standardbegrunnelse = this.begrunnelse.enumnavnTilString(),
+        vedtakBegrunnelseType = this.begrunnelse.vedtakBegrunnelseType,
+        vedtakBegrunnelseSpesifikasjon = this.begrunnelse.enumnavnTilString(),
+        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.begrunnelse.støtterFritekst(sanityBegrunnelser),
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/EØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/domene/EØSBegrunnelse.kt
@@ -46,11 +46,14 @@ class EØSBegrunnelse(
             begrunnelse = this.begrunnelse,
         )
 
-    fun tilRestVedtaksbegrunnelse(sanityBegrunnelser: List<ISanityBegrunnelse>) =
+    fun tilRestVedtaksbegrunnelse(
+        sanityBegrunnelser: List<ISanityBegrunnelse>,
+        alleBegrunnelserSkalStøtteFritekst: Boolean,
+    ) =
         RestVedtaksbegrunnelse(
             standardbegrunnelse = this.begrunnelse.enumnavnTilString(),
             vedtakBegrunnelseType = this.begrunnelse.vedtakBegrunnelseType,
             vedtakBegrunnelseSpesifikasjon = this.begrunnelse.enumnavnTilString(),
-            støtterFritekst = this.begrunnelse.støtterFritekst(sanityBegrunnelser),
+            støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.begrunnelse.støtterFritekst(sanityBegrunnelser),
         )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -53,13 +53,12 @@ class Vedtaksbegrunnelse(
 fun Vedtaksbegrunnelse.tilRestVedtaksbegrunnelse(
     sanityBegrunnelser: List<SanityBegrunnelse>,
     alleBegrunnelserSkalStøtteFritekst: Boolean,
-) =
-    RestVedtaksbegrunnelse(
-        standardbegrunnelse = this.standardbegrunnelse.enumnavnTilString(),
-        vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
-        vedtakBegrunnelseSpesifikasjon = this.standardbegrunnelse.enumnavnTilString(),
-        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.standardbegrunnelse.støtterFritekst(sanityBegrunnelser),
-    )
+) = RestVedtaksbegrunnelse(
+    standardbegrunnelse = this.standardbegrunnelse.enumnavnTilString(),
+    vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
+    vedtakBegrunnelseSpesifikasjon = this.standardbegrunnelse.enumnavnTilString(),
+    støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.standardbegrunnelse.støtterFritekst(sanityBegrunnelser),
+)
 
 enum class Begrunnelsetype {
     STANDARD_BEGRUNNELSE,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -50,12 +50,15 @@ class Vedtaksbegrunnelse(
     override fun toString(): String = "Vedtaksbegrunnelse(id=$id, standardbegrunnelse=$standardbegrunnelse)"
 }
 
-fun Vedtaksbegrunnelse.tilRestVedtaksbegrunnelse(sanityBegrunnelser: List<SanityBegrunnelse>) =
+fun Vedtaksbegrunnelse.tilRestVedtaksbegrunnelse(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    alleBegrunnelserSkalStøtteFritekst: Boolean,
+) =
     RestVedtaksbegrunnelse(
         standardbegrunnelse = this.standardbegrunnelse.enumnavnTilString(),
         vedtakBegrunnelseType = this.standardbegrunnelse.vedtakBegrunnelseType,
         vedtakBegrunnelseSpesifikasjon = this.standardbegrunnelse.enumnavnTilString(),
-        støtterFritekst = this.standardbegrunnelse.støtterFritekst(sanityBegrunnelser),
+        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.standardbegrunnelse.støtterFritekst(sanityBegrunnelser),
     )
 
 enum class Begrunnelsetype {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -410,7 +410,7 @@ class VedtaksperiodeService(
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser().values.toList()
         val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser().values.toList()
 
-        // For revurderinger med årsak klage skal fritekst legges til på alle begrunnelser
+        // For revurderinger med årsak klage skal fritekst støttes på alle begrunnelser
         val alleBegrunnelserSkalStøtteFritekst = behandling.type == BehandlingType.REVURDERING && behandling.erKlage()
 
         val vedtaksperioder =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.integrasjoner.sanity.SanityService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -409,6 +410,9 @@ class VedtaksperiodeService(
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser().values.toList()
         val sanityEØSBegrunnelser = sanityService.hentSanityEØSBegrunnelser().values.toList()
 
+        // For revurderinger med årsak klage skal fritekst legges til på alle begrunnelser
+        val alleBegrunnelserSkalStøtteFritekst = behandling.type == BehandlingType.REVURDERING && behandling.erKlage()
+
         val vedtaksperioder =
             if (behandling.status != BehandlingStatus.AVSLUTTET) {
                 val utvidetVedtaksperiodeMedBegrunnelser =
@@ -418,7 +422,13 @@ class VedtaksperiodeService(
                     )
                 utvidetVedtaksperiodeMedBegrunnelser
                     .sorter()
-                    .map { it.tilRestUtvidetVedtaksperiodeMedBegrunnelser(sanityBegrunnelser, sanityEØSBegrunnelser) }
+                    .map {
+                        it.tilRestUtvidetVedtaksperiodeMedBegrunnelser(
+                            sanityBegrunnelser = sanityBegrunnelser,
+                            sanityEØSBegrunnelser = sanityEØSBegrunnelser,
+                            alleBegrunnelserSkalStøtteFritekst = alleBegrunnelserSkalStøtteFritekst,
+                        )
+                    }
             } else {
                 emptyList()
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/RestUtvidetVedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/domene/RestUtvidetVedtaksperiodeMedBegrunnelser.kt
@@ -21,13 +21,26 @@ data class RestUtvidetVedtaksperiodeMedBegrunnelser(
 fun UtvidetVedtaksperiodeMedBegrunnelser.tilRestUtvidetVedtaksperiodeMedBegrunnelser(
     sanityBegrunnelser: List<SanityBegrunnelse>,
     sanityEØSBegrunnelser: List<SanityEØSBegrunnelse>,
+    alleBegrunnelserSkalStøtteFritekst: Boolean,
 ): RestUtvidetVedtaksperiodeMedBegrunnelser =
     RestUtvidetVedtaksperiodeMedBegrunnelser(
         id = this.id,
         fom = this.fom,
         tom = this.tom,
         type = this.type,
-        begrunnelser = this.begrunnelser.map { it.tilRestVedtaksbegrunnelse(sanityBegrunnelser) } + this.eøsBegrunnelser.map { it.tilRestVedtaksbegrunnelse(sanityEØSBegrunnelser) },
+        begrunnelser =
+            this.begrunnelser.map {
+                it.tilRestVedtaksbegrunnelse(
+                    sanityBegrunnelser = sanityBegrunnelser,
+                    alleBegrunnelserSkalStøtteFritekst = alleBegrunnelserSkalStøtteFritekst,
+                )
+            } +
+                this.eøsBegrunnelser.map {
+                    it.tilRestVedtaksbegrunnelse(
+                        sanityBegrunnelser = sanityEØSBegrunnelser,
+                        alleBegrunnelserSkalStøtteFritekst = alleBegrunnelserSkalStøtteFritekst,
+                    )
+                },
         fritekster = this.fritekster,
         utbetalingsperiodeDetaljer = this.utbetalingsperiodeDetaljer,
         gyldigeBegrunnelser = this.gyldigeBegrunnelser.map { it.enumnavnTilString() },


### PR DESCRIPTION
Favro: [NAV-24773](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24773)

### 💰 Hva skal gjøres, og hvorfor?
Sørger for at saksbehandler kan legge til fritekst på alle begrunnelser uavhengig av type for alle revurderinger med `opprettetÅrsak` = `KLAGE`.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

![image](https://github.com/user-attachments/assets/19d7937a-d0aa-44f1-9fa8-12d267fd5159)
