### PR TITLE
Fix: validering av feilutbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.simulering
 import io.micrometer.core.instrument.Metrics
 import jakarta.transaction.Transactional
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.UtbetalingsoppdragGenerator
@@ -141,15 +140,6 @@ class SimuleringService(
     fun hentEtterbetaling(behandlingId: Long): BigDecimal {
         val vedtakSimuleringMottakere = hentSimuleringPåBehandling(behandlingId)
         return hentEtterbetaling(vedtakSimuleringMottakere)
-    }
-
-    fun hentFeilutbetalingTilOgMedForrigeMåned(behandlingId: Long): BigDecimal {
-        val vedtakSimuleringMottakere = hentSimuleringPåBehandling(behandlingId)
-        val feilutbetaling =
-            vedtakSimuleringMottakereTilSimuleringPerioder(vedtakSimuleringMottakere)
-                .filter { it.tom.isBefore(LocalDate.now().førsteDagIInneværendeMåned()) }
-                .sumOf { it.feilutbetaling }
-        return feilutbetaling
     }
 
     fun hentFeilutbetaling(behandlingId: Long): BigDecimal {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -81,7 +81,7 @@ class BeslutteVedtak(
 
         validerBrevmottakere(BehandlingId(behandling.id), data.beslutning.erGodkjent())
 
-        val feilutbetaling by lazy { simuleringService.hentFeilutbetalingTilOgMedForrigeMåned(behandling.id) }
+        val feilutbetaling by lazy { simuleringService.hentFeilutbetaling( behandlingId = behandling.id) }
         val erÅpenTilbakekrevingPåFagsak by lazy { tilbakekrevingService.søkerHarÅpenTilbakekreving(behandling.fagsak.id) }
         val tilbakekrevingsvalg by lazy { tilbakekrevingService.hentTilbakekrevingsvalg(behandling.id) }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -81,7 +81,7 @@ class BeslutteVedtak(
 
         validerBrevmottakere(BehandlingId(behandling.id), data.beslutning.erGodkjent())
 
-        val feilutbetaling by lazy { simuleringService.hentFeilutbetaling( behandlingId = behandling.id) }
+        val feilutbetaling by lazy { simuleringService.hentFeilutbetaling(behandlingId = behandling.id) }
         val erÅpenTilbakekrevingPåFagsak by lazy { tilbakekrevingService.søkerHarÅpenTilbakekreving(behandling.fagsak.id) }
         val tilbakekrevingsvalg by lazy { tilbakekrevingService.hentTilbakekrevingsvalg(behandling.id) }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -3,8 +3,6 @@ package no.nav.familie.ba.sak.kjerne.simulering
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.randomFnr
@@ -30,7 +28,6 @@ import no.nav.familie.kontrakter.felles.simulering.FagOmrådeKode
 import no.nav.familie.kontrakter.felles.simulering.MottakerType
 import no.nav.familie.kontrakter.felles.simulering.PosteringType
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -294,47 +291,6 @@ internal class SimuleringServiceEnhetTest {
             )
 
         assertThrows<Feil> { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) }
-    }
-
-    @Test
-    fun `hentFeilutbetalingTilOgMedForrigeMåned skal summere feilutbetaling for tidligere enn inneværende måned`() {
-        // Arrange
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.REVURDERING,
-                årsak = BehandlingÅrsak.ÅRLIG_KONTROLL,
-            )
-
-        val økonomiSimuleringPostering =
-            listOf(
-                mockVedtakSimuleringPostering(
-                    beløp = 100,
-                    fom = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().minusMonths(2).sisteDagIMåned(),
-                    posteringType = PosteringType.FEILUTBETALING,
-                ),
-                mockVedtakSimuleringPostering(
-                    beløp = 200,
-                    fom = LocalDate.now().minusMonths(1).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().minusMonths(1).sisteDagIMåned(),
-                    posteringType = PosteringType.FEILUTBETALING,
-                ),
-                mockVedtakSimuleringPostering(
-                    beløp = 300,
-                    fom = LocalDate.now().førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().sisteDagIMåned(),
-                    posteringType = PosteringType.FEILUTBETALING,
-                ),
-            )
-
-        every { økonomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns
-            listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = økonomiSimuleringPostering))
-
-        // Act
-        val feilutbetalingTilOgMedForrigeMåned = simuleringService.hentFeilutbetalingTilOgMedForrigeMåned(behandling.id)
-
-        // Assert
-        assertThat(feilutbetalingTilOgMedForrigeMåned, Is(BigDecimal(300)))
     }
 
     private fun mockØkonomiSimuleringMottaker(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import java.math.BigDecimal
 
 class BeslutteVedtakTest {
     private val toTrinnKontrollService = mockk<TotrinnskontrollService>()
@@ -113,6 +114,7 @@ class BeslutteVedtakTest {
         every { automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(any<BehandlingId>()) } just runs
         every { tilbakekrevingService.søkerHarÅpenTilbakekreving(any()) } returns false
         every { tilbakekrevingService.hentTilbakekrevingsvalg(any()) } returns null
+        every { simuleringService.hentFeilutbetaling(any<Long>()) } returns BigDecimal.ZERO
     }
 
     @Nested
@@ -376,6 +378,7 @@ class BeslutteVedtakTest {
                 listOf(
                     lagBrevmottakerDb(behandlingId = behandling.id),
                 )
+            every { simuleringService.hentFeilutbetaling(behandling.id) } returns BigDecimal(10000)
 
             // Act && Assert
             val feilmelding =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import java.math.BigDecimal
 
 class BeslutteVedtakTest {
     private val toTrinnKontrollService = mockk<TotrinnskontrollService>()
@@ -114,7 +113,6 @@ class BeslutteVedtakTest {
         every { automatiskOppdaterValutakursService.oppdaterValutakurserEtterEndringstidspunkt(any<BehandlingId>()) } just runs
         every { tilbakekrevingService.søkerHarÅpenTilbakekreving(any()) } returns false
         every { tilbakekrevingService.hentTilbakekrevingsvalg(any()) } returns null
-        every { simuleringService.hentFeilutbetalingTilOgMedForrigeMåned(any()) } returns BigDecimal.ZERO
     }
 
     @Nested
@@ -378,7 +376,6 @@ class BeslutteVedtakTest {
                 listOf(
                     lagBrevmottakerDb(behandlingId = behandling.id),
                 )
-            every { simuleringService.hentFeilutbetalingTilOgMedForrigeMåned(any()) } returns BigDecimal.valueOf(100000)
 
             // Act && Assert
             val feilmelding =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24806

Vi trenger å se inkludere feilutbetaling i inneværende måned når vi validerer feilutbetaling. Saksbehandler ender opp med å få feil i valideringen når de ikke skulle det, fordi vi dropper å se på inneværende måned. Eksempel:
- SB 1 er på simulering og ser at det er feilutbetaling i inneværende måned. Må da ta stilling til tilbakekreving
- SB 2 skal godkjenne vedtak og vi skal da validere tilbakekrevingen. Nåværende validering ser kun på om det er feilutbetaling før inneværende måned, og da vil ikke tilbakekrevingsvalg og feilutbetaling stemme overens siden det kun er feilutbetaling i inneværende måned. 

Reverterer endringer gjort her i januar: https://github.com/navikt/familie-ba-sak/pull/5036. Har besluttet med Anna at det blir riktig å også se på inneværende måned, og at den bugen som ble fikset i PRen som er lenket er noe vi eventuelt må ta opp på nytt hvis det skjer igjen. Det er mulig det riktige i det tilfelle er å be saksbehandler underkjenne vedtaket og sb 1 må ta stilling til tilbakekreving, i stedet for at vi bare dropper valideringen. Men vi ønsker å vente med å fikse dette til det eventuelt dukker opp ny sak på dette.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tenker det ikke er vits å bruke tid på

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
