### PR TITLE
NAV-24658: Henter ut forrige vedtatte klagebehandling basert på innsendt behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
@@ -83,7 +83,7 @@ class KlageService(
 
     fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> = klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
 
-    fun hentSisteVedtatteKlagebehandling(fagsakId: Long): KlagebehandlingDto? = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+    fun hentForrigeVedtatteKlagebehandling(behandling: Behandling): KlagebehandlingDto? = klagebehandlingHenter.hentForrigeVedtatteKlagebehandling(behandling)
 
     @Transactional(readOnly = true)
     fun kanOppretteRevurdering(fagsakId: Long): KanOppretteRevurderingResponse {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenter.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.klage
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
 import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
@@ -20,16 +21,17 @@ class KlagebehandlingHenter(
         return klagerPåFagsak.map { it.brukVedtaksdatoFraKlageinstansHvisOversendt() }
     }
 
-    fun hentSisteVedtatteKlagebehandling(fagsakId: Long): KlagebehandlingDto? =
-        hentKlagebehandlingerPåFagsak(fagsakId)
+    fun hentForrigeVedtatteKlagebehandling(behandling: Behandling): KlagebehandlingDto? =
+        hentKlagebehandlingerPåFagsak(behandling.fagsak.id)
             .asSequence()
-            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektStatus(it.status) }
-            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektHenlagtÅrsak(it.henlagtÅrsak) }
-            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektBehandlingResultat(it.resultat) }
+            .filter { ForrigeVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektStatus(it.status) }
+            .filter { ForrigeVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektHenlagtÅrsak(it.henlagtÅrsak) }
+            .filter { ForrigeVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektBehandlingResultat(it.resultat) }
             .filter { it.vedtaksdato != null }
+            .filter { it.vedtaksdato!!.isBefore(behandling.aktivertTidspunkt) }
             .maxByOrNull { it.vedtaksdato!! }
 
-    private object SisteVedtatteKlagebehandlingSjekker {
+    private object ForrigeVedtatteKlagebehandlingSjekker {
         fun harKlagebehandlingKorrektStatus(behandlingStatus: BehandlingStatus) =
             when (behandlingStatus) {
                 BehandlingStatus.FERDIGSTILT,

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -20,21 +20,20 @@ class RelatertBehandlingUtleder(
 
     fun utledRelatertBehandling(behandling: Behandling): RelatertBehandling? {
         if (behandling.erRevurderingKlage() && unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false)) {
-            val sisteVedtatteKlagebehandling = klageService.hentSisteVedtatteKlagebehandling(behandling.fagsak.id)
-            if (sisteVedtatteKlagebehandling == null) {
+            val forrigeVedtatteKlagebehandling = klageService.hentForrigeVedtatteKlagebehandling(behandling)
+            if (forrigeVedtatteKlagebehandling == null) {
                 throw Feil("Forventer en vedtatt klagebehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
             }
-            return RelatertBehandling.fraKlagebehandling(sisteVedtatteKlagebehandling)
+            return RelatertBehandling.fraKlagebehandling(forrigeVedtatteKlagebehandling)
         }
 
         if (behandling.erRevurderingEllerTekniskEndring()) {
-            val sisteVedtatteBarnetrygdbehandling =
-                behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
-            if (sisteVedtatteBarnetrygdbehandling == null) {
+            val forrigeVedtatteBarnetrygdbehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+            if (forrigeVedtatteBarnetrygdbehandling == null) {
                 logger.warn("Forventer en vedtatt barnetrygdbehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
                 return null
             }
-            return RelatertBehandling.fraBarnetrygdbehandling(sisteVedtatteBarnetrygdbehandling)
+            return RelatertBehandling.fraBarnetrygdbehandling(forrigeVedtatteBarnetrygdbehandling)
         }
 
         return null

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageServiceTest.kt
@@ -175,11 +175,11 @@ class KlageServiceTest {
     }
 
     @Nested
-    inner class HentSisteVedtatteKlagebehandling {
+    inner class HentForrigeVedtatteKlagebehandling {
         @Test
-        fun `skal hente siste vedtatte klagebehandling`() {
+        fun `skal hente forrige vedtatte klagebehandling`() {
             // Arrange
-            val fagsakId = 1L
+            val behandling = lagBehandling()
 
             val klagebehandlingDto =
                 lagKlagebehandlingDto(
@@ -189,13 +189,13 @@ class KlageServiceTest {
                     resultat = BehandlingResultat.MEDHOLD,
                 )
 
-            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandlingDto
+            every { klagebehandlingHenter.hentForrigeVedtatteKlagebehandling(behandling) } returns klagebehandlingDto
 
             // Act
-            val sisteVedtatteKlagebehandling = klageService.hentSisteVedtatteKlagebehandling(fagsakId)
+            val forrigeVedtatteKlagebehandling = klageService.hentForrigeVedtatteKlagebehandling(behandling)
 
             // Assert
-            assertThat(sisteVedtatteKlagebehandling).isEqualTo(klagebehandlingDto)
+            assertThat(forrigeVedtatteKlagebehandling).isEqualTo(klagebehandlingDto)
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -48,7 +48,7 @@ class RelatertBehandlingUtlederTest {
             names = ["KLAGE", "IVERKSETTE_KA_VEDTAK"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede relatert behandling med barnetrygdbehandling som siste vedtatte behandling selv for revurdering med årsak klage eller årsak iverksette ka vedtak når toggle er skrudd av`(
+        fun `skal utlede relatert behandling med barnetrygdbehandling som forrige vedtatte behandling selv for revurdering med årsak klage eller årsak iverksette ka vedtak når toggle er skrudd av`(
             behandlingÅrsak: BehandlingÅrsak,
         ) {
             // Arrange
@@ -63,7 +63,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            val sisteVedtatteBarnetrygdbehandling =
+            val forrigeVedtatteBarnetrygdbehandling =
                 lagBehandling(
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                     aktivertTid = nåtidspunkt.minusSeconds(2),
@@ -72,16 +72,16 @@ class RelatertBehandlingUtlederTest {
                 )
 
             every { unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE, false) } returns false
-            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(revurdering) } returns sisteVedtatteBarnetrygdbehandling
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(revurdering) } returns forrigeVedtatteBarnetrygdbehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
 
             // Assert
             verify { klageService wasNot called }
-            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteBarnetrygdbehandling.id.toString())
+            assertThat(relatertBehandling?.id).isEqualTo(forrigeVedtatteBarnetrygdbehandling.id.toString())
             assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.BA)
-            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteBarnetrygdbehandling.aktivertTidspunkt)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(forrigeVedtatteBarnetrygdbehandling.aktivertTidspunkt)
         }
 
         @ParameterizedTest
@@ -105,7 +105,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            every { klageService.hentSisteVedtatteKlagebehandling(revurdering.fagsak.id) } returns null
+            every { klageService.hentForrigeVedtatteKlagebehandling(revurdering) } returns null
 
             // Act & assert
             val exception =
@@ -122,7 +122,7 @@ class RelatertBehandlingUtlederTest {
             names = ["KLAGE", "IVERKSETTE_KA_VEDTAK"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede relatert behandling med klagebehandlingen som siste vedtatte behandling når den innsendte behandling er en revurdering med årsak klage eller årsak iverksette ka vedtak`(
+        fun `skal utlede relatert behandling med klagebehandlingen som forrige vedtatte behandling når den innsendte behandling er en revurdering med årsak klage eller årsak iverksette ka vedtak`(
             behandlingÅrsak: BehandlingÅrsak,
         ) {
             // Arrange
@@ -137,21 +137,21 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            val sisteVedtatteKlagebehandling =
+            val forrigeVedtatteKlagebehandling =
                 lagKlagebehandlingDto(
                     vedtaksdato = nåtidspunkt,
                 )
 
-            every { klageService.hentSisteVedtatteKlagebehandling(revurdering.fagsak.id) } returns sisteVedtatteKlagebehandling
+            every { klageService.hentForrigeVedtatteKlagebehandling(revurdering) } returns forrigeVedtatteKlagebehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
 
             // Assert
             verify { behandlingHentOgPersisterService wasNot called }
-            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteKlagebehandling.id.toString())
+            assertThat(relatertBehandling?.id).isEqualTo(forrigeVedtatteKlagebehandling.id.toString())
             assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KLAGE)
-            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteKlagebehandling.vedtaksdato)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(forrigeVedtatteKlagebehandling.vedtaksdato)
         }
 
         @ParameterizedTest
@@ -160,7 +160,7 @@ class RelatertBehandlingUtlederTest {
             names = ["KLAGE", "IVERKSETTE_KA_VEDTAK"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `skal utlede relatert behandling med barnetrygdbehandlingen som siste vedtatte behandling når den innsendte behandling er en revurdering som ikke har årsak klage eller iverksetter ka vedtak`(
+        fun `skal utlede relatert behandling med barnetrygdbehandlingen som forrige vedtatte behandling når den innsendte behandling er en revurdering som ikke har årsak klage eller iverksetter ka vedtak`(
             behandlingÅrsak: BehandlingÅrsak,
         ) {
             // Arrange
@@ -175,7 +175,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            val sisteVedtatteBarnetrygdbehandling =
+            val forrigeVedtatteBarnetrygdbehandling =
                 lagBehandling(
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                     aktivertTid = nåtidspunkt.minusSeconds(2),
@@ -183,20 +183,20 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.INNVILGET,
                 )
 
-            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(revurdering) } returns sisteVedtatteBarnetrygdbehandling
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(revurdering) } returns forrigeVedtatteBarnetrygdbehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
 
             // Assert
             verify { klageService wasNot called }
-            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteBarnetrygdbehandling.id.toString())
+            assertThat(relatertBehandling?.id).isEqualTo(forrigeVedtatteBarnetrygdbehandling.id.toString())
             assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.BA)
-            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteBarnetrygdbehandling.aktivertTidspunkt)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(forrigeVedtatteBarnetrygdbehandling.aktivertTidspunkt)
         }
 
         @Test
-        fun `skal utlede relatert behandling med barnetrygdbehandlingen som siste vedtatte behandling når den innsendte behandling er en teknisk endring`() {
+        fun `skal utlede relatert behandling med barnetrygdbehandlingen som forrige vedtatte behandling når den innsendte behandling er en teknisk endring`() {
             // Arrange
             val nåtidspunkt = LocalDateTime.now()
 
@@ -209,7 +209,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            val sisteVedtatteBarnetrygdbehandling =
+            val forrigeVedtatteBarnetrygdbehandling =
                 lagBehandling(
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                     aktivertTid = nåtidspunkt.minusSeconds(2),
@@ -217,16 +217,16 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.INNVILGET,
                 )
 
-            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(tekniskEndring) } returns sisteVedtatteBarnetrygdbehandling
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(tekniskEndring) } returns forrigeVedtatteBarnetrygdbehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(tekniskEndring)
 
             // Assert
             verify { klageService wasNot called }
-            assertThat(relatertBehandling?.id).isEqualTo(sisteVedtatteBarnetrygdbehandling.id.toString())
+            assertThat(relatertBehandling?.id).isEqualTo(forrigeVedtatteBarnetrygdbehandling.id.toString())
             assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.BA)
-            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(sisteVedtatteBarnetrygdbehandling.aktivertTidspunkt)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(forrigeVedtatteBarnetrygdbehandling.aktivertTidspunkt)
         }
 
         @ParameterizedTest


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

Ønsker kun å se på klagebehandlinger som er vedtatt før behandlingen ble opprettet.  

Eksempel:
Klage 2: - Kl. 12.02
Revurdering Klage - Kl. 12.01
Klage 1 - Kl. 12:00  <-- Velg denne når man sender inne revurdering klage behandlingen
 
### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
