### PR TITLE
Fix: Sørger for at det aldri er ok å kun begrunne en vedtaksperiode med en fritekst

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -107,7 +107,7 @@ data class VedtaksperiodeMedBegrunnelser(
         fritekster.addAll(nyeFritekster)
     }
 
-    fun harFriteksterUtenStandardbegrunnelser(): Boolean = (type == Vedtaksperiodetype.OPPHØR || type == Vedtaksperiodetype.AVSLAG) && fritekster.isNotEmpty() && begrunnelser.isEmpty() && eøsBegrunnelser.isEmpty()
+    fun harFriteksterUtenStandardbegrunnelser(): Boolean = fritekster.isNotEmpty() && begrunnelser.isEmpty() && eøsBegrunnelser.isEmpty()
 
     fun erBegrunnet() = !(begrunnelser.isEmpty() && fritekster.isEmpty() && eøsBegrunnelser.isEmpty())
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeValidering.kt
@@ -26,7 +26,7 @@ fun validerSatsendring(
 }
 
 fun validerVedtaksperiodeMedBegrunnelser(vedtaksperiodeMedBegrunnelser: VedtaksperiodeMedBegrunnelser) {
-    if ((vedtaksperiodeMedBegrunnelser.type == Vedtaksperiodetype.OPPHØR || vedtaksperiodeMedBegrunnelser.type == Vedtaksperiodetype.AVSLAG) && vedtaksperiodeMedBegrunnelser.harFriteksterUtenStandardbegrunnelser()) {
+    if (vedtaksperiodeMedBegrunnelser.harFriteksterUtenStandardbegrunnelser()) {
         val fritekstUtenStandardbegrunnelserFeilmelding =
             "Fritekst kan kun brukes i kombinasjon med en eller flere begrunnelser. " + "Legg først til en ny begrunnelse eller fjern friteksten(e)."
         throw FunksjonellFeil(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tidligere validerte vi kun at `OPPHØR`- og `AVSLAG`-perioder ikke kunne lagres dersom de hadde fritekst og ingen valgt begrunnelse. Dette skal gjelde uavhengig av vedtaksperiode-typen.

Konsekvens av denne feilen er at saksbehandler nå har mulighet til å begrunne `UTBETALING`-perioder med kun fritekst.

Fjerner derfor sjekk på type fra valideringen.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
