### PR TITLE
Tilbake: fjern tilbakekrevingsbehandlinger fra minimal fagsak og rest fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsak.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
-import no.nav.familie.ba.sak.kjerne.tilbakekreving.domene.RestTilbakekrevingsbehandling
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Utbetalingsperiode
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -32,7 +31,6 @@ data class RestFagsak(
     override val løpendeUnderkategori: BehandlingUnderkategori?,
     override val gjeldendeUtbetalingsperioder: List<Utbetalingsperiode>,
     val behandlinger: List<RestUtvidetBehandling>,
-    val tilbakekrevingsbehandlinger: List<RestTilbakekrevingsbehandling>,
     override val fagsakType: FagsakType = FagsakType.NORMAL,
 ) : RestBaseFagsak(
         opprettetTidspunkt = opprettetTidspunkt,
@@ -48,7 +46,6 @@ data class RestFagsak(
 
 fun RestBaseFagsak.tilRestFagsak(
     restUtvidetBehandlinger: List<RestUtvidetBehandling>,
-    tilbakekrevingsbehandlinger: List<RestTilbakekrevingsbehandling>,
 ) = RestFagsak(
     opprettetTidspunkt = this.opprettetTidspunkt,
     id = this.id,
@@ -59,7 +56,6 @@ fun RestBaseFagsak.tilRestFagsak(
     løpendeUnderkategori = this.løpendeUnderkategori,
     gjeldendeUtbetalingsperioder = this.gjeldendeUtbetalingsperioder,
     behandlinger = restUtvidetBehandlinger,
-    tilbakekrevingsbehandlinger = tilbakekrevingsbehandlinger,
     fagsakType = this.fagsakType,
 )
 
@@ -73,7 +69,6 @@ data class RestMinimalFagsak(
     override val underBehandling: Boolean,
     override val gjeldendeUtbetalingsperioder: List<Utbetalingsperiode>,
     val behandlinger: List<RestVisningBehandling>,
-    val tilbakekrevingsbehandlinger: List<RestTilbakekrevingsbehandling>,
     val migreringsdato: LocalDate? = null,
     override val fagsakType: FagsakType,
     override val institusjon: RestInstitusjon?,
@@ -92,7 +87,6 @@ data class RestMinimalFagsak(
 
 fun RestBaseFagsak.tilRestMinimalFagsak(
     restVisningBehandlinger: List<RestVisningBehandling>,
-    tilbakekrevingsbehandlinger: List<RestTilbakekrevingsbehandling>,
     migreringsdato: LocalDate?,
 ) = RestMinimalFagsak(
     opprettetTidspunkt = this.opprettetTidspunkt,
@@ -104,7 +98,6 @@ fun RestBaseFagsak.tilRestMinimalFagsak(
     løpendeUnderkategori = this.løpendeUnderkategori,
     gjeldendeUtbetalingsperioder = this.gjeldendeUtbetalingsperioder,
     behandlinger = restVisningBehandlinger,
-    tilbakekrevingsbehandlinger = tilbakekrevingsbehandlinger,
     migreringsdato = migreringsdato,
     fagsakType = this.fagsakType,
     institusjon = this.institusjon,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -28,7 +28,6 @@ import no.nav.familie.ba.sak.kjerne.institusjon.InstitusjonService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
-import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingsbehandlingService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -57,7 +56,6 @@ class FagsakService(
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
     private val skyggesakService: SkyggesakService,
     private val vedtaksperiodeService: VedtaksperiodeService,
-    private val tilbakekrevingsbehandlingService: TilbakekrevingsbehandlingService,
     private val institusjonService: InstitusjonService,
     private val organisasjonService: OrganisasjonService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
@@ -192,8 +190,6 @@ class FagsakService(
     fun lagRestMinimalFagsak(fagsakId: Long): RestMinimalFagsak {
         val restBaseFagsak = lagRestBaseFagsak(fagsakId)
 
-        val tilbakekrevingsbehandlinger =
-            tilbakekrevingsbehandlingService.hentRestTilbakekrevingsbehandlinger((fagsakId))
         val visningsbehandlinger =
             behandlingHentOgPersisterService
                 .hentBehandlinger(fagsakId = fagsakId)
@@ -207,7 +203,6 @@ class FagsakService(
         val migreringsdato = behandlingService.hentMigreringsdatoPåFagsak(fagsakId)
         return restBaseFagsak.tilRestMinimalFagsak(
             restVisningBehandlinger = visningsbehandlinger,
-            tilbakekrevingsbehandlinger = tilbakekrevingsbehandlinger,
             migreringsdato = migreringsdato,
         )
     }
@@ -215,14 +210,12 @@ class FagsakService(
     private fun lagRestFagsak(fagsakId: Long): RestFagsak {
         val restBaseFagsak = lagRestBaseFagsak(fagsakId)
 
-        val tilbakekrevingsbehandlinger =
-            tilbakekrevingsbehandlingService.hentRestTilbakekrevingsbehandlinger((fagsakId))
         val utvidedeBehandlinger =
             behandlingHentOgPersisterService
                 .hentBehandlinger(fagsakId = fagsakId)
                 .map { utvidetBehandlingService.lagRestUtvidetBehandling(it.id) }
 
-        return restBaseFagsak.tilRestFagsak(utvidedeBehandlinger, tilbakekrevingsbehandlinger)
+        return restBaseFagsak.tilRestFagsak(utvidedeBehandlinger)
     }
 
     private fun lagRestBaseFagsak(fagsakId: Long): RestBaseFagsak {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -129,7 +129,7 @@ class BeregningServiceTest {
                     løpendeUnderkategori = null,
                     gjeldendeUtbetalingsperioder = emptyList(),
                     fagsakType = fagsak.type,
-                ).tilRestFagsak(emptyList(), emptyList()),
+                ).tilRestFagsak(emptyList()),
             )
         }
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } answers { emptyList() }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24831

Siste del av oppgaven. Fjerner tilbakekrevingsbehandlinger fra minimal fagsak nå som dette hentes fra eget endepunkt i stedet. Fjerner også tilbakekrevingsbehandlinger fra RestFagsak-objektet som kun brukes i baks-mottak og der er ikke tilbakekrevingsbehandlinger typet opp en gang. Egentlig virker det helt tullete å ha både et RestFagsak og RestMinimalFagsak-objekt da RestFagsak kun brukes i baks-mottak og eneste grunnen til at man ikke kan bytte over til RestMinimalFagsak er fordi behandlingene på fagsaken ikke inneholder steg-property på RestMinimalFagsak... dette er noe vi kan se på senere kanskje? Hadde vært litt spennende å se om vi kunne ha beholdt kun RestMinimalFagsak og da eventuelt ha fjernet "minimal" fra navnet 😊

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Fjerner kode

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
