### PR TITLE
Tillater patching av ident hvis gammel og ny fødselsdato begge er over 18

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -61,12 +61,12 @@ internal class HåndterNyIdentServiceTest {
                 personIdentService = personIdentService,
             )
 
-        val gammelFødselsdato = LocalDate.of(2000, 1, 1)
+        val gammelFødselsdato = LocalDate.now().minusYears(1)
         val gammeltFnr = randomFnr(gammelFødselsdato)
         val gammelAktør = tilAktør(gammeltFnr)
         val gammelPerson = lagPerson(aktør = gammelAktør, fødselsdato = gammelFødselsdato)
 
-        val nyFødselsdato = LocalDate.of(2000, 2, 2)
+        val nyFødselsdato = LocalDate.now().minusYears(1).minusMonths(3)
         val nyttFnr = randomFnr(nyFødselsdato)
         val nyAktør = tilAktør(nyttFnr)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fikk inn en identhendelse på en fagsak hvor barnet hadde endret fødselsdato. Saken var gammel og barnet var blitt voksen. Lagt til funksjonalitet for å skippe disse casene
