### PR TITLE
Skipper validering av mer enn 100% utbetalinger for månedlig valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -22,7 +22,7 @@ class TilkjentYtelseValideringService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
 ) {
     fun validerAtIngenUtbetalingerOverstiger100Prosent(behandling: Behandling) {
-        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring()) return
+        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring() || behandling.erMånedligValutajustering()) return
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(behandling.id)
 
         if (totrinnskontroll?.godkjent == true) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Det er en iverksettMotOppdrag-task som feilet for valutajustering. Etter samtale med Anna så skipper man sjekken for mer enn 100% utbetaling for valutajustering. Slik man gjør med blant annet satsendring
