### PR TITLE
Ta høyde for at perioder kan overlappe sluttdato for TILLEGGS_ORBA og satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringUtil.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.satsendring
 
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
@@ -30,9 +29,11 @@ private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.erOppdatertForSats(
         .filter { it.stønadTom.isSameOrAfter(fomSisteSatsForSatstype) }
         .filter { andel ->
             val person = personOpplysningGrunnlag.personer.single { it.aktør == andel.aktør }
-            val andelSatsType = andel.type.tilSatsType(person, andel.stønadFom.førsteDagIInneværendeMåned())
+            // Bruker stønadTom siden
 
-            andelSatsType == satstype
+            val andelSatsTyper = andel.type.tilSatsType(person, andel.stønadFom, andel.stønadTom)
+
+            andelSatsTyper.contains(satstype)
         }.filter { it.prosent != BigDecimal.ZERO }
         .all { andelTilkjentYtelse -> andelTilkjentYtelse.sats == SatsService.finnSisteSatsFor(satstype).beløp }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringUtil.kt
@@ -29,7 +29,6 @@ private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.erOppdatertForSats(
         .filter { it.stønadTom.isSameOrAfter(fomSisteSatsForSatstype) }
         .filter { andel ->
             val person = personOpplysningGrunnlag.personer.single { it.aktør == andel.aktør }
-            // Bruker stønadTom siden
 
             val andelSatsTyper = andel.type.tilSatsType(person, andel.stønadFom, andel.stønadTom)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentEØSStandardBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentEØSStandardBegrunnelser.kt
@@ -91,7 +91,7 @@ internal fun hentEØSStandardBegrunnelser(
 
     val filtrertPåHendelser =
         filtrertPåEndretVilkår.filterValues {
-            it.skalFiltreresPåHendelser(begrunnelseGrunnlag, vedtaksperiode.fom)
+            it.skalFiltreresPåHendelser(begrunnelseGrunnlag, vedtaksperiode.fom, vedtaksperiode.tom)
         }
 
     val filtrertPåSkalVisesSelvOmIkkeEndring =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentStandardBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentStandardBegrunnelser.kt
@@ -123,6 +123,7 @@ internal fun hentStandardBegrunnelser(
             it.skalFiltreresPåHendelser(
                 begrunnelseGrunnlag,
                 vedtaksperiode.fom,
+                vedtaksperiode.tom,
             )
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/SatsendringUtilTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
 
 class SatsendringUtilTest {
     private val ugyldigSats = 1000
@@ -41,6 +42,23 @@ class SatsendringUtilTest {
                 }
 
         assertTrue(andelerMedSisteSats.erOppdatertMedSisteSatser(personopplysningGrunnlag))
+    }
+
+    @Test
+    fun `Skal returnere false når andelen overlapper siste dag for TILLEGSORBA og satsendring for ORBA`() {
+        // Arrange
+        val andelerMedSisteSats =
+            listOf(
+                lagAndelTilkjentYtelseMedEndreteUtbetalinger(
+                    fom = YearMonth.of(2023, 7),
+                    tom = YearMonth.of(2030, 1),
+                    sats = 1766,
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    person = person4År,
+                ),
+            )
+        // Act & Assert
+        assertFalse(andelerMedSisteSats.erOppdatertMedSisteSatser(personopplysningGrunnlag))
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/YtelseTypeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/YtelseTypeTest.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ba.sak.kjerne.beregning.domene
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -9,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.YearMonth
 
 class YtelseTypeTest {
     @Nested
@@ -44,48 +47,48 @@ class YtelseTypeTest {
     @Nested
     inner class TilSatsTypeTest {
         @Test
-        fun `tilSatsType for ORDINÆR_BARNETRYGD for en som er under 6 år i august 2024 skal returnere TILLEGGS_ORBA`() {
+        fun `tilSatsType for ORDINÆR_BARNETRYGD for en som er under 6 år i august 2024 skal returnere TILLEGGS_ORBA og ORBA`() {
             val person = lagPerson(fødselsdato = LocalDate.of(2024, 8, 1).minusYears(6).plusMonths(1))
-            val ytelseDato = LocalDate.of(2024, 8, 1)
+            val ytelseDatoFom = YearMonth.of(2024, 8)
 
-            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDato)
-            assertThat(result).isEqualTo(SatsType.TILLEGG_ORBA)
+            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth())
+            assertThat(result).isEqualTo(setOf(SatsType.TILLEGG_ORBA, SatsType.ORBA))
         }
 
         @Test
         fun `tilSatsType for ORDINÆR_BARNETRYGD for en som er under 6 år i september 2024 skal returnere ORBA`() {
             val person = lagPerson(fødselsdato = LocalDate.of(2024, 9, 1).minusYears(6).plusMonths(1))
-            val ytelseDato = LocalDate.of(2024, 9, 1)
+            val ytelseDatoFom = YearMonth.of(2024, 9)
 
-            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDato)
+            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
             assertThat(result).isEqualTo(SatsType.ORBA)
         }
 
         @Test
         fun `tilSatsType for ORDINÆR_BARNETRYGD etter 6 år`() {
             val person = mockk<Person>()
-            val ytelseDato = LocalDate.of(2026, 1, 1)
+            val ytelseDatoFom = YearMonth.of(2026, 1)
             every { person.hentSeksårsdag() } returns LocalDate.of(2025, 1, 1)
 
-            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDato)
+            val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
             assertThat(result).isEqualTo(SatsType.ORBA)
         }
 
         @Test
         fun `tilSatsType for UTVIDET_BARNETRYGD`() {
             val person = mockk<Person>()
-            val ytelseDato = LocalDate.of(2020, 1, 1)
+            val ytelseDatoFom = YearMonth.of(2020, 1)
 
-            val result = YtelseType.UTVIDET_BARNETRYGD.tilSatsType(person, ytelseDato)
+            val result = YtelseType.UTVIDET_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
             assertThat(result).isEqualTo(SatsType.UTVIDET_BARNETRYGD)
         }
 
         @Test
         fun `tilSatsType for SMÅBARNSTILLEGG`() {
             val person = mockk<Person>()
-            val ytelseDato = LocalDate.of(2020, 1, 1)
+            val ytelseDatoFom = YearMonth.of(2020, 1)
 
-            val result = YtelseType.SMÅBARNSTILLEGG.tilSatsType(person, ytelseDato)
+            val result = YtelseType.SMÅBARNSTILLEGG.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
             assertThat(result).isEqualTo(SatsType.SMA)
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Mange fødselshendelsetasker feiler nå pga satsendring. Buggen kommer av at vi får feil satstype når vi prøver å kontrollere at andelene har riktig satstype. 
Dette oppstår siden andelene ikke splittes opp på sluttdatoen for tilleggsorba og dermed i prinsippet har både tillegsorba og orba samtidig. 

tilSatstype() tar når høyde for sluttdatoen på tilleggsorba og gir dermed begge satstypene når det kan være begge. 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
