### PR TITLE
Slett melding fra saksstatistikk_mellomlagring etter at den er sendt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/producer/KafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/producer/KafkaProducer.kt
@@ -22,7 +22,6 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 interface KafkaProducer {
     fun sendMessageForTopicVedtakV2(vedtakV2: VedtakDVHV2): Long
@@ -90,9 +89,7 @@ class DefaultKafkaProducer(
         logger.info("$SAKSSTATISTIKK_BEHANDLING_TOPIC -> message sent -> offset=${response.recordMetadata.offset()}")
 
         saksstatistikkBehandlingDvhCounter.increment()
-        melding.offsetVerdi = response.recordMetadata.offset()
-        melding.sendtTidspunkt = LocalDateTime.now()
-        saksstatistikkMellomlagringRepository.save(melding)
+        saksstatistikkMellomlagringRepository.delete(melding)
         return response.recordMetadata.offset()
     }
 
@@ -105,9 +102,7 @@ class DefaultKafkaProducer(
         logger.info("$SAKSSTATISTIKK_SAK_TOPIC -> message sent -> offset=${response.recordMetadata.offset()}")
 
         saksstatistikkSakDvhCounter.increment()
-        melding.offsetVerdi = response.recordMetadata.offset()
-        melding.sendtTidspunkt = LocalDateTime.now()
-        saksstatistikkMellomlagringRepository.save(melding)
+        saksstatistikkMellomlagringRepository.delete(melding)
         return response.recordMetadata.offset()
     }
 
@@ -201,9 +196,7 @@ class MockKafkaProducer(
     override fun sendMessageForTopicBehandling(melding: SaksstatistikkMellomlagring): Long {
         logger.info("Skipper sending av saksstatistikk behandling for ${melding.jsonToBehandlingDVH().behandlingId} fordi kafka ikke er enablet")
         sendteMeldinger["behandling-${melding.jsonToBehandlingDVH().behandlingId}"] = melding.jsonToBehandlingDVH()
-        melding.offsetVerdiOnPrem = 42
-        melding.sendtTidspunkt = LocalDateTime.now()
-        saksstatistikkMellomlagringRepository.save(melding)
+        saksstatistikkMellomlagringRepository.delete(melding)
         return 42
     }
 
@@ -211,9 +204,7 @@ class MockKafkaProducer(
     override fun sendMessageForTopicSak(melding: SaksstatistikkMellomlagring): Long {
         logger.info("Skipper sending av saksstatistikk sak for ${melding.jsonToSakDVH().sakId} fordi kafka ikke er enablet")
         sendteMeldinger["sak-${melding.jsonToSakDVH().sakId}"] = melding.jsonToSakDVH()
-        melding.offsetVerdiOnPrem = 43
-        melding.sendtTidspunkt = LocalDateTime.now()
-        saksstatistikkMellomlagringRepository.save(melding)
+        saksstatistikkMellomlagringRepository.delete(melding)
         return 43
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
@@ -23,7 +23,6 @@ import no.nav.familie.eksterne.kontrakter.saksstatistikk.SakDVH
 import no.nav.familie.log.mdc.MDCConstants
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
@@ -72,7 +71,7 @@ class SaksstatistikkTest(
 
     @Test
     @Tag("integration")
-    fun `Skal lagre saksstatistikk sak til repository og sende meldinger`() {
+    fun `Skal lagre saksstatistikk sak til repository, sende meldinger og slette melding fra mellomlagring etter sending`() {
         val fnr = randomFnr()
         val fagsakId =
             fagsakController
@@ -96,16 +95,14 @@ class SaksstatistikkTest(
             sakstatistikkObjectMapper.readValue(mellomlagredeStatistikkHendelser.first().json, SakDVH::class.java)
 
         saksstatistikkScheduler.sendSaksstatistikk()
-        val oppdatertMellomlagretSaksstatistikkHendelse =
-            saksstatistikkMellomlagringRepository.findByIdOrNull(mellomlagredeStatistikkHendelser.first().id)
 
-        assertNotNull(oppdatertMellomlagretSaksstatistikkHendelse!!.sendtTidspunkt)
+        assertNull(saksstatistikkMellomlagringRepository.findByIdOrNull(mellomlagredeStatistikkHendelser.first().id))
         assertEquals(lagretJsonSomSakDVH, sendteMeldinger["sak-$fagsakId"] as SakDVH)
     }
 
     @Test
     @Tag("integration")
-    fun `Skal lagre saksstatistikk behandling til repository og sende meldinger`() {
+    fun `Skal lagre saksstatistikk behandling til repository, sende meldinger og slette melding fra mellomlagring etter sending`() {
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr, false)
@@ -135,10 +132,8 @@ class SaksstatistikkTest(
             sakstatistikkObjectMapper.readValue(mellomlagretBehandling.last().json, BehandlingDVH::class.java)
 
         saksstatistikkScheduler.sendSaksstatistikk()
-        val oppdatertMellomlagretSaksstatistikkHendelse =
-            saksstatistikkMellomlagringRepository.findByIdOrNull(mellomlagretBehandling.first().id)
 
-        assertNotNull(oppdatertMellomlagretSaksstatistikkHendelse!!.sendtTidspunkt)
+        assertNull(saksstatistikkMellomlagringRepository.findByIdOrNull(mellomlagretBehandling.first().id))
         assertEquals(lagretJsonSomSakDVH, sendteMeldinger["behandling-${behandling.id}"] as BehandlingDVH)
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-24912

Alle meldinger som sendes på kafka i forbindelse med saksstatistikk mellomlagres til en tabell. Det er en scheduled jobb som henter alle meldinger som ikke er sendt og sender de. Raden i tabellen fikk satt sendt_tid og ble liggende til noen™ gadd å manuelt rydd vekk melding

Grunnen til at det er en mellomlagringstabell er at man ønsket å sende de i riktig rekkefølge, og kun sende meldinger på fagsaker og behandlinger som faktisk var committet til basen. Tasker kan ikke garantere rekkefølgen. Samtidig var det nyttig i oppstarten med muligheten til å kunne patche gamle meldinger og da trengte man orginalen.


Det var 2 måter å løse denne på. En med å slette alle meldinger eldre enn en valgt dato med en scheduled jobb,  Den andre er å slette meldingen med engang den er sendt. Tenker at man kan slette med engang etter at melding er sendt. Behovet for patching har ikke vært nødvendig de siste 4 årene. Samt at man bør unngå å patche meldinger sendt uansett fordi det er en komplisert jobb, med stor fare for feil og stort volum



### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
