### PR TITLE
Tillatt patching av identer som finnes på flere fagsaker så lenge fødesldato er riktig på alle fagsakene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -42,22 +42,30 @@ class HåndterNyIdentService(
 
         val aktørId = identerFraPdl.hentAktivAktørId()
         val aktør = aktørIdRepository.findByAktørIdOrNull(aktørId)
-        val aktuellFagsakVedMerging = hentAktuellFagsakForIdenthendelse(identerFraPdl)
+        val aktuellFagsakerVedMerging = hentAktuellFagsakerForIdenthendelse(identerFraPdl)
+        if (aktuellFagsakerVedMerging.size > 1) {
+            logger.info("Fant mer enn 1 fagsak ved patching av ident")
+        }
 
         return when {
             // Personen er ikke i noen fagsaker
-            aktuellFagsakVedMerging == null -> aktør
+            aktuellFagsakerVedMerging.isNullOrEmpty() -> aktør
 
             // Ny aktørId, nytt fødselsnummer -> begge håndteres i PatchMergetIdentTask
             aktør == null -> {
-                validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, aktuellFagsakVedMerging)
-                opprettMergeIdentTask(aktuellFagsakVedMerging.id, identerFraPdl)
+                aktuellFagsakerVedMerging.forEach { fagsak ->
+                    validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, fagsak)
+                }
+
+                opprettMergeIdentTask(aktuellFagsakerVedMerging.first().id, identerFraPdl)
                 null
             }
 
             // Samme aktørId, nytt fødselsnummer -> legg til fødselsnummer på aktør
             !aktør.harIdent(fødselsnummer = nyIdent.ident) -> {
-                validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, aktuellFagsakVedMerging)
+                aktuellFagsakerVedMerging.forEach { fagsak ->
+                    validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, fagsak)
+                }
                 logger.info("Legger til ny ident")
                 secureLogger.info("Legger til ny ident ${nyIdent.ident} på aktør ${aktør.aktørId}")
                 personIdentService.opprettPersonIdent(aktør, nyIdent.ident, true)
@@ -93,26 +101,15 @@ class HåndterNyIdentService(
         return task
     }
 
-    private fun hentAktuellFagsakForIdenthendelse(alleIdenterFraPdl: List<IdentInformasjon>): Fagsak? {
+    private fun hentAktuellFagsakerForIdenthendelse(alleIdenterFraPdl: List<IdentInformasjon>): List<Fagsak> {
         val aktørerMedAktivPersonident =
             alleIdenterFraPdl
                 .hentAktørIder()
                 .mapNotNull { aktørIdRepository.findByAktørIdOrNull(it) }
                 .filter { aktør -> aktør.personidenter.any { personident -> personident.aktiv } }
 
-        val fagsaker =
-            aktørerMedAktivPersonident
-                .flatMap { aktør -> fagsakService.hentFagsakerPåPerson(aktør) + fagsakService.hentAlleFagsakerForAktør(aktør) }
-
-        if (fagsaker.toSet().size > 1) {
-            secureLogger.warn(
-                "Det eksisterer flere fagsaker på identer som skal merges $fagsaker.\n" +
-                    "Identer: ${alleIdenterFraPdl.filter { it.gruppe == Type.FOLKEREGISTERIDENT.name }}",
-            )
-            throw Feil("Det eksisterer flere fagsaker på identer som skal merges. Patch manuelt. Info om fagsaker og identer ligger i securelog. $LENKE_INFO_OM_MERGING")
-        }
-
-        return fagsaker.firstOrNull()
+        return aktørerMedAktivPersonident
+            .flatMap { aktør -> fagsakService.hentFagsakerPåPerson(aktør) + fagsakService.hentAlleFagsakerForAktør(aktør) }
     }
 
     private fun validerUendretFødselsdatoFraForrigeBehandling(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -42,29 +42,29 @@ class HåndterNyIdentService(
 
         val aktørId = identerFraPdl.hentAktivAktørId()
         val aktør = aktørIdRepository.findByAktørIdOrNull(aktørId)
-        val aktuellFagsakerVedMerging = hentAktuellFagsakerForIdenthendelse(identerFraPdl)
-        if (aktuellFagsakerVedMerging.size > 1) {
+        val aktuelleFagsakerVedMerging = hentAktuelleFagsakerForIdenthendelse(identerFraPdl)
+        if (aktuelleFagsakerVedMerging.size > 1) {
             logger.info("Fant mer enn 1 fagsak ved patching av ident")
         }
 
         return when {
             // Personen er ikke i noen fagsaker
-            aktuellFagsakerVedMerging.isNullOrEmpty() -> aktør
+            aktuelleFagsakerVedMerging.isNullOrEmpty() -> aktør
 
             // Ny aktørId, nytt fødselsnummer -> begge håndteres i PatchMergetIdentTask
             aktør == null -> {
-                aktuellFagsakerVedMerging.forEach { fagsak ->
+                aktuelleFagsakerVedMerging.forEach { fagsak ->
                     validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, fagsak)
                 }
 
                 // patcheendepunktet trenger en fagsak, men samme hvilken fagsak
-                opprettMergeIdentTask(aktuellFagsakerVedMerging.first().id, identerFraPdl)
+                opprettMergeIdentTask(aktuelleFagsakerVedMerging.first().id, identerFraPdl)
                 null
             }
 
             // Samme aktørId, nytt fødselsnummer -> legg til fødselsnummer på aktør
             !aktør.harIdent(fødselsnummer = nyIdent.ident) -> {
-                aktuellFagsakerVedMerging.forEach { fagsak ->
+                aktuelleFagsakerVedMerging.forEach { fagsak ->
                     validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, fagsak)
                 }
                 logger.info("Legger til ny ident")
@@ -102,7 +102,7 @@ class HåndterNyIdentService(
         return task
     }
 
-    private fun hentAktuellFagsakerForIdenthendelse(alleIdenterFraPdl: List<IdentInformasjon>): List<Fagsak> {
+    private fun hentAktuelleFagsakerForIdenthendelse(alleIdenterFraPdl: List<IdentInformasjon>): List<Fagsak> {
         val aktørerMedAktivPersonident =
             alleIdenterFraPdl
                 .hentAktørIder()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -57,6 +57,7 @@ class HåndterNyIdentService(
                     validerUendretFødselsdatoFraForrigeBehandling(identerFraPdl, fagsak)
                 }
 
+                // patcheendepunktet trenger en fagsak, men samme hvilken fagsak
                 opprettMergeIdentTask(aktuellFagsakerVedMerging.first().id, identerFraPdl)
                 null
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -112,7 +112,7 @@ internal class HåndterNyIdentServiceTest {
         }
 
         @Test
-        fun `håndterNyIdent kaster Feil når det eksisterer flere fagsaker for identer`() {
+        fun `håndterNyIdent kaster ikke Feil når det eksisterer flere fagsaker for identer`() {
             // arrange
             every { fagsakService.hentFagsakerPåPerson(any()) } returns
                 listOf(
@@ -121,12 +121,10 @@ internal class HåndterNyIdentServiceTest {
                 )
 
             // act & assert
-            val feil =
-                assertThrows<Feil> {
-                    håndterNyIdentService.håndterNyIdent(PersonIdent(nyttFnr))
-                }
+            val aktør = håndterNyIdentService.håndterNyIdent(PersonIdent(nyttFnr))
 
-            assertThat(feil.message).startsWith("Det eksisterer flere fagsaker på identer som skal merges")
+            assertThat(aktør).isNull()
+            verify(exactly = 1) { opprettTaskService.opprettTaskForÅPatcheMergetIdent(any()) }
         }
 
         @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-24914
Vi har hatt en sjekk ved patching av fagsaker på at det er kun 1 fagsak og de casene som har mer enn 1 har måtte blitt tatt manuelt. Nå har vi patchet flere titalls manuelt og er ganske sikre på at patchescriptet fungere selv om ident finnes på flere fagsaker.

Så denne PR fjerner denne begrensningen og lar de automatisk patches.

https://github.com/navikt/familie-ks-sak/pull/1226

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
