### PR TITLE
NAV-24909: Legger til endepunkt for å hente ut barnetrygdbehandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVisningBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVisningBehandling.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Visningsbehandling
 import java.time.LocalDateTime
 
 class RestVisningBehandling(
@@ -21,7 +22,24 @@ class RestVisningBehandling(
     val status: BehandlingStatus,
     val resultat: Behandlingsresultat,
     val vedtaksdato: LocalDateTime?,
-)
+) {
+    companion object Factory {
+        fun opprettFraVisningsbehandling(visningsbehandling: Visningsbehandling) =
+            RestVisningBehandling(
+                behandlingId = visningsbehandling.behandlingId,
+                opprettetTidspunkt = visningsbehandling.opprettetTidspunkt,
+                aktivertTidspunkt = visningsbehandling.aktivertTidspunkt,
+                kategori = visningsbehandling.kategori,
+                underkategori = visningsbehandling.underkategori.tilDto(),
+                aktiv = visningsbehandling.aktiv,
+                årsak = visningsbehandling.opprettetÅrsak,
+                type = visningsbehandling.type,
+                status = visningsbehandling.status,
+                resultat = visningsbehandling.resultat,
+                vedtaksdato = visningsbehandling.vedtaksdato,
+            )
+    }
+}
 
 fun Behandling.tilRestVisningBehandling(vedtaksdato: LocalDateTime?) =
     RestVisningBehandling(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingController.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.ekstern.restDomene.RestVisningBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.behandlingstema.BehandlingstemaService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -46,6 +47,16 @@ class BehandlingController(
     private val utvidetBehandlingService: UtvidetBehandlingService,
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
 ) {
+    @GetMapping(path = ["fagsak/{fagsakId}"])
+    fun hentBehandlinger(
+        @PathVariable fagsakId: Long,
+    ): ResponseEntity<Ressurs<List<RestVisningBehandling>>> {
+        tilgangService.validerTilgangTilFagsak(event = AuditLoggerEvent.ACCESS, fagsakId = fagsakId)
+        tilgangService.verifiserHarTilgangTilHandling(minimumBehandlerRolle = BehandlerRolle.VEILEDER, handling = "hent behandlinger")
+        val behandlinger = behandlingHentOgPersisterService.hentVisningsbehandlinger(fagsakId).map { RestVisningBehandling.opprettFraVisningsbehandling(it) }
+        return ResponseEntity.ok(Ressurs.success(behandlinger))
+    }
+
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun opprettBehandling(
         @RequestBody nyBehandling: NyBehandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Visningsbehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Visningsbehandling.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ba.sak.kjerne.behandling.domene
+
+import java.time.LocalDateTime
+
+data class Visningsbehandling(
+    val behandlingId: Long,
+    val opprettetTidspunkt: LocalDateTime,
+    val aktivertTidspunkt: LocalDateTime,
+    val kategori: BehandlingKategori,
+    val underkategori: BehandlingUnderkategori,
+    val aktiv: Boolean,
+    val opprettetÅrsak: BehandlingÅrsak?,
+    val type: BehandlingType,
+    val status: BehandlingStatus,
+    val resultat: Behandlingsresultat,
+    val vedtaksdato: LocalDateTime?,
+) {
+    companion object Factory {
+        fun opprettFraBehandling(
+            behandling: Behandling,
+            vedtaksdato: LocalDateTime?,
+        ): Visningsbehandling =
+            Visningsbehandling(
+                behandlingId = behandling.id,
+                opprettetTidspunkt = behandling.opprettetTidspunkt,
+                aktivertTidspunkt = behandling.aktivertTidspunkt,
+                kategori = behandling.kategori,
+                underkategori = behandling.underkategori,
+                aktiv = behandling.aktiv,
+                opprettetÅrsak = behandling.opprettetÅrsak,
+                type = behandling.type,
+                status = behandling.status,
+                resultat = behandling.resultat,
+                vedtaksdato = vedtaksdato,
+            )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVisningBehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestVisningBehandlingTest.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.ba.sak.ekstern.restDomene
+
+import no.nav.familie.ba.sak.datagenerator.lagVisningsbehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RestVisningBehandlingTest {
+    @Nested
+    inner class OpprettFraVisningsbehandling {
+        @Test
+        fun `skal opprette rest visningsbehandling fra domene visningsbehandling`() {
+            // Arrange
+            val visningsbehandling = lagVisningsbehandling()
+
+            // Act
+            val restVisningsbehandling = RestVisningBehandling.opprettFraVisningsbehandling(visningsbehandling)
+
+            // Assert
+            assertThat(restVisningsbehandling.behandlingId).isEqualTo(visningsbehandling.behandlingId)
+            assertThat(restVisningsbehandling.opprettetTidspunkt).isEqualTo(visningsbehandling.opprettetTidspunkt)
+            assertThat(restVisningsbehandling.aktivertTidspunkt).isEqualTo(visningsbehandling.aktivertTidspunkt)
+            assertThat(restVisningsbehandling.kategori).isEqualTo(visningsbehandling.kategori)
+            assertThat(restVisningsbehandling.underkategori).isEqualTo(visningsbehandling.underkategori.tilDto())
+            assertThat(restVisningsbehandling.aktiv).isEqualTo(visningsbehandling.aktiv)
+            assertThat(restVisningsbehandling.årsak).isEqualTo(visningsbehandling.opprettetÅrsak)
+            assertThat(restVisningsbehandling.type).isEqualTo(visningsbehandling.type)
+            assertThat(restVisningsbehandling.status).isEqualTo(visningsbehandling.status)
+            assertThat(restVisningsbehandling.resultat).isEqualTo(visningsbehandling.resultat)
+            assertThat(restVisningsbehandling.vedtaksdato).isEqualTo(visningsbehandling.vedtaksdato)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceEnhetstest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceEnhetstest.kt
@@ -1,0 +1,141 @@
+package no.nav.familie.ba.sak.kjerne.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class BehandlingHentOgPersisterServiceEnhetstest {
+    private val behandlingRepository = mockk<BehandlingRepository>()
+    private val saksstatistikkEventPublisher = mockk<SaksstatistikkEventPublisher>()
+    private val vedtakRepository = mockk<VedtakRepository>()
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService =
+        BehandlingHentOgPersisterService(
+            behandlingRepository = behandlingRepository,
+            saksstatistikkEventPublisher = saksstatistikkEventPublisher,
+            vedtakRepository = vedtakRepository,
+        )
+
+    @Nested
+    inner class HentVisningsbehandlinger {
+        @Test
+        fun `skal hente visningsbehandlinger`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val vedtaksdato = LocalDateTime.now()
+
+            val behandling1 =
+                lagBehandling(
+                    fagsak = fagsak,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    årsak = BehandlingÅrsak.SØKNAD,
+                )
+
+            val behandling2 =
+                lagBehandling(
+                    fagsak = fagsak,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                )
+
+            every { vedtakRepository.finnVedtaksdatoForBehandling(any()) } returns vedtaksdato
+
+            every { behandlingRepository.finnBehandlinger(fagsak.id) } returns listOf(behandling1, behandling2)
+
+            // Act
+            val visningsbehandlinger = behandlingHentOgPersisterService.hentVisningsbehandlinger(fagsak.id)
+
+            // Assert
+            assertThat(visningsbehandlinger).hasSize(2)
+            assertThat(visningsbehandlinger).anySatisfy {
+                assertThat(it.behandlingId).isEqualTo(behandling1.id)
+                assertThat(it.opprettetTidspunkt).isEqualTo(behandling1.opprettetTidspunkt)
+                assertThat(it.aktivertTidspunkt).isEqualTo(behandling1.aktivertTidspunkt)
+                assertThat(it.kategori).isEqualTo(behandling1.kategori)
+                assertThat(it.underkategori).isEqualTo(behandling1.underkategori)
+                assertThat(it.aktiv).isEqualTo(behandling1.aktiv)
+                assertThat(it.opprettetÅrsak).isEqualTo(behandling1.opprettetÅrsak)
+                assertThat(it.type).isEqualTo(behandling1.type)
+                assertThat(it.status).isEqualTo(behandling1.status)
+                assertThat(it.resultat).isEqualTo(behandling1.resultat)
+                assertThat(it.vedtaksdato).isEqualTo(vedtaksdato)
+            }
+            assertThat(visningsbehandlinger).anySatisfy {
+                assertThat(it.behandlingId).isEqualTo(behandling2.id)
+                assertThat(it.opprettetTidspunkt).isEqualTo(behandling2.opprettetTidspunkt)
+                assertThat(it.aktivertTidspunkt).isEqualTo(behandling2.aktivertTidspunkt)
+                assertThat(it.kategori).isEqualTo(behandling2.kategori)
+                assertThat(it.underkategori).isEqualTo(behandling2.underkategori)
+                assertThat(it.aktiv).isEqualTo(behandling2.aktiv)
+                assertThat(it.opprettetÅrsak).isEqualTo(behandling2.opprettetÅrsak)
+                assertThat(it.type).isEqualTo(behandling2.type)
+                assertThat(it.status).isEqualTo(behandling2.status)
+                assertThat(it.resultat).isEqualTo(behandling2.resultat)
+                assertThat(it.vedtaksdato).isEqualTo(vedtaksdato)
+            }
+        }
+
+        @Test
+        fun `skal filterer bort behandlinger med oppdatert utvidet klassekode`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val vedtaksdato = LocalDateTime.now()
+
+            val behandling1 =
+                lagBehandling(
+                    fagsak = fagsak,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    årsak = BehandlingÅrsak.SØKNAD,
+                )
+
+            val behandling2 =
+                lagBehandling(
+                    fagsak = fagsak,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.OPPDATER_UTVIDET_KLASSEKODE,
+                )
+
+            every { vedtakRepository.finnVedtaksdatoForBehandling(any()) } returns vedtaksdato
+
+            every { behandlingRepository.finnBehandlinger(fagsak.id) } returns listOf(behandling1, behandling2)
+
+            // Act
+            val visningsbehandlinger = behandlingHentOgPersisterService.hentVisningsbehandlinger(fagsak.id)
+
+            // Assert
+            assertThat(visningsbehandlinger).hasSize(1)
+            assertThat(visningsbehandlinger).anySatisfy {
+                assertThat(it.behandlingId).isEqualTo(behandling1.id)
+                assertThat(it.opprettetTidspunkt).isEqualTo(behandling1.opprettetTidspunkt)
+                assertThat(it.aktivertTidspunkt).isEqualTo(behandling1.aktivertTidspunkt)
+                assertThat(it.kategori).isEqualTo(behandling1.kategori)
+                assertThat(it.underkategori).isEqualTo(behandling1.underkategori)
+                assertThat(it.aktiv).isEqualTo(behandling1.aktiv)
+                assertThat(it.opprettetÅrsak).isEqualTo(behandling1.opprettetÅrsak)
+                assertThat(it.type).isEqualTo(behandling1.type)
+                assertThat(it.status).isEqualTo(behandling1.status)
+                assertThat(it.resultat).isEqualTo(behandling1.resultat)
+                assertThat(it.vedtaksdato).isEqualTo(vedtaksdato)
+            }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
-class BehandlingHentOgPersisterServiceEnhetstest {
+class BehandlingHentOgPersisterServiceTest {
     private val behandlingRepository = mockk<BehandlingRepository>()
     private val saksstatistikkEventPublisher = mockk<SaksstatistikkEventPublisher>()
     private val vedtakRepository = mockk<VedtakRepository>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -22,7 +22,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.YearMonth
 
-class BehandlingServiceEnhetstest {
+class BehandlingServiceTest {
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
 
     private val behandlingstemaService: BehandlingstemaService = mockk()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/VisningsbehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/VisningsbehandlingTest.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.ba.sak.kjerne.behandling.domene
+
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class VisningsbehandlingTest {
+    @Nested
+    inner class OpprettFraBehandling {
+        @Test
+        fun `skal opprette visningsbehandling fra behandling`() {
+            // Arrange
+            val behandling = lagBehandling()
+            val vedtaksdato = LocalDateTime.now()
+
+            // Act
+            val visningsbehandling = Visningsbehandling.opprettFraBehandling(behandling, vedtaksdato)
+
+            // Assert
+            assertThat(visningsbehandling.behandlingId).isEqualTo(behandling.id)
+            assertThat(visningsbehandling.opprettetTidspunkt).isEqualTo(behandling.opprettetTidspunkt)
+            assertThat(visningsbehandling.aktivertTidspunkt).isEqualTo(behandling.aktivertTidspunkt)
+            assertThat(visningsbehandling.kategori).isEqualTo(behandling.kategori)
+            assertThat(visningsbehandling.underkategori).isEqualTo(behandling.underkategori)
+            assertThat(visningsbehandling.aktiv).isEqualTo(behandling.aktiv)
+            assertThat(visningsbehandling.opprettetÅrsak).isEqualTo(behandling.opprettetÅrsak)
+            assertThat(visningsbehandling.type).isEqualTo(behandling.type)
+            assertThat(visningsbehandling.status).isEqualTo(behandling.status)
+            assertThat(visningsbehandling.resultat).isEqualTo(behandling.resultat)
+            assertThat(visningsbehandling.vedtaksdato).isEqualTo(vedtaksdato)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -1,0 +1,168 @@
+package no.nav.familie.ba.sak.kjerne.fagsak
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.datagenerator.lagVisningsbehandling
+import no.nav.familie.ba.sak.ekstern.restDomene.tilDto
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
+import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
+import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.integrasjoner.skyggesak.SkyggesakService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonRepository
+import no.nav.familie.ba.sak.kjerne.institusjon.InstitusjonService
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Utbetalingsperiode
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class FagsakServiceTest {
+    private val fagsakRepository = mockk<FagsakRepository>()
+    private val personRepository = mockk<PersonRepository>()
+    private val andelerTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+    private val personidentService = mockk<PersonidentService>()
+    private val utvidetBehandlingService = mockk<UtvidetBehandlingService>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val familieIntegrasjonerTilgangskontrollService = mockk<FamilieIntegrasjonerTilgangskontrollService>()
+    private val saksstatistikkEventPublisher = mockk<SaksstatistikkEventPublisher>()
+    private val skyggesakService = mockk<SkyggesakService>()
+    private val vedtaksperiodeService = mockk<VedtaksperiodeService>()
+    private val institusjonService = mockk<InstitusjonService>()
+    private val organisasjonService = mockk<OrganisasjonService>()
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val fagsakService =
+        FagsakService(
+            fagsakRepository = fagsakRepository,
+            personRepository = personRepository,
+            andelerTilkjentYtelseRepository = andelerTilkjentYtelseRepository,
+            personidentService = personidentService,
+            utvidetBehandlingService = utvidetBehandlingService,
+            behandlingService = behandlingService,
+            personopplysningerService = personopplysningerService,
+            familieIntegrasjonerTilgangskontrollService = familieIntegrasjonerTilgangskontrollService,
+            saksstatistikkEventPublisher = saksstatistikkEventPublisher,
+            skyggesakService = skyggesakService,
+            vedtaksperiodeService = vedtaksperiodeService,
+            institusjonService = institusjonService,
+            organisasjonService = organisasjonService,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+        )
+
+    @Nested
+    inner class LagRestMinimalFagsak {
+        @Test
+        fun `skal lage rest minimal fagsak`() {
+            // Arrange
+            val fagsak = lagFagsak()
+
+            val visningsbehandling1 =
+                lagVisningsbehandling(
+                    behandlingId = 1L,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+                    aktiv = false,
+                )
+
+            val visningsbehandling2 =
+                lagVisningsbehandling(
+                    behandlingId = 2L,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    type = BehandlingType.REVURDERING,
+                    opprettetÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                    aktiv = false,
+                )
+
+            val sisteBehandlingSomErVedtatt =
+                lagBehandling(
+                    fagsak = fagsak,
+                    id = visningsbehandling2.behandlingId,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    behandlingType = BehandlingType.REVURDERING,
+                    årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                    aktiv = false,
+                )
+
+            val utbetalingsperiode =
+                Utbetalingsperiode(
+                    periodeFom = LocalDate.now().minusYears(1),
+                    periodeTom = LocalDate.now().plusYears(1),
+                    vedtaksperiodetype = Vedtaksperiodetype.UTBETALING,
+                    utbetalingsperiodeDetaljer = emptyList(),
+                    ytelseTyper = listOf(YtelseType.ORDINÆR_BARNETRYGD),
+                    antallBarn = 1,
+                    utbetaltPerMnd = 3000,
+                )
+
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivForFagsak(fagsak.id) } returns null
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns sisteBehandlingSomErVedtatt
+            every { vedtaksperiodeService.hentUtbetalingsperioder(sisteBehandlingSomErVedtatt) } returns listOf(utbetalingsperiode)
+            every { behandlingHentOgPersisterService.hentVisningsbehandlinger(fagsak.id) } returns listOf(visningsbehandling1, visningsbehandling2)
+            every { behandlingService.hentMigreringsdatoPåFagsak(fagsak.id) } returns null
+
+            // Act
+            val restMinimalFagsak = fagsakService.lagRestMinimalFagsak(fagsak.id)
+
+            // Assert
+            assertThat(restMinimalFagsak.opprettetTidspunkt).isNotNull()
+            assertThat(restMinimalFagsak.id).isEqualTo(fagsak.id)
+            assertThat(restMinimalFagsak.søkerFødselsnummer).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(restMinimalFagsak.status).isEqualTo(fagsak.status)
+            assertThat(restMinimalFagsak.løpendeKategori).isEqualTo(sisteBehandlingSomErVedtatt.kategori)
+            assertThat(restMinimalFagsak.løpendeUnderkategori).isEqualTo(sisteBehandlingSomErVedtatt.underkategori)
+            assertThat(restMinimalFagsak.gjeldendeUtbetalingsperioder).hasSize(1)
+            assertThat(restMinimalFagsak.gjeldendeUtbetalingsperioder).containsExactly(utbetalingsperiode)
+            assertThat(restMinimalFagsak.underBehandling).isFalse()
+            assertThat(restMinimalFagsak.migreringsdato).isNull()
+            assertThat(restMinimalFagsak.fagsakType).isEqualTo(FagsakType.NORMAL)
+            assertThat(restMinimalFagsak.institusjon).isNull()
+            assertThat(restMinimalFagsak.behandlinger).hasSize(2)
+            assertThat(restMinimalFagsak.behandlinger).anySatisfy {
+                assertThat(it.behandlingId).isEqualTo(visningsbehandling1.behandlingId)
+                assertThat(it.opprettetTidspunkt).isEqualTo(visningsbehandling1.opprettetTidspunkt)
+                assertThat(it.aktivertTidspunkt).isEqualTo(visningsbehandling1.aktivertTidspunkt)
+                assertThat(it.kategori).isEqualTo(visningsbehandling1.kategori)
+                assertThat(it.underkategori).isEqualTo(visningsbehandling1.underkategori.tilDto())
+                assertThat(it.aktiv).isEqualTo(visningsbehandling1.aktiv)
+                assertThat(it.årsak).isEqualTo(visningsbehandling1.opprettetÅrsak)
+                assertThat(it.type).isEqualTo(visningsbehandling1.type)
+                assertThat(it.status).isEqualTo(visningsbehandling1.status)
+                assertThat(it.resultat).isEqualTo(visningsbehandling1.resultat)
+                assertThat(it.vedtaksdato).isEqualTo(visningsbehandling1.vedtaksdato)
+            }
+            assertThat(restMinimalFagsak.behandlinger).anySatisfy {
+                assertThat(it.behandlingId).isEqualTo(visningsbehandling2.behandlingId)
+                assertThat(it.opprettetTidspunkt).isEqualTo(visningsbehandling2.opprettetTidspunkt)
+                assertThat(it.aktivertTidspunkt).isEqualTo(visningsbehandling2.aktivertTidspunkt)
+                assertThat(it.kategori).isEqualTo(visningsbehandling2.kategori)
+                assertThat(it.underkategori).isEqualTo(visningsbehandling2.underkategori.tilDto())
+                assertThat(it.aktiv).isEqualTo(visningsbehandling2.aktiv)
+                assertThat(it.årsak).isEqualTo(visningsbehandling2.opprettetÅrsak)
+                assertThat(it.type).isEqualTo(visningsbehandling2.type)
+                assertThat(it.status).isEqualTo(visningsbehandling2.status)
+                assertThat(it.resultat).isEqualTo(visningsbehandling2.resultat)
+                assertThat(it.vedtaksdato).isEqualTo(visningsbehandling2.vedtaksdato)
+            }
+        }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
-class BehandlingHentOgPersisterServiceTest(
+class BehandlingHentOgPersisterServiceIntegrationTest(
     @Autowired private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     @Autowired private val fagsakService: FagsakService,
 ) : AbstractSpringIntegrationTest() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceIntegrationTest.kt
@@ -31,7 +31,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Tag("integration")
-class BehandlingServiceTest(
+class BehandlingServiceIntegrationTest(
     @Autowired
     private val fagsakService: FagsakService,
     @Autowired

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
@@ -50,7 +50,7 @@ import org.springframework.web.client.HttpServerErrorException
 import java.time.LocalDate
 import java.time.YearMonth
 
-class FagsakServiceTest(
+class FagsakServiceIntegrationTest(
     @Autowired
     private val fagsakService: FagsakService,
     @Autowired

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/BehandlingGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/BehandlingGenerator.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Visningsbehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.initStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
@@ -123,4 +124,31 @@ fun nyRevurdering(
         underkategori = BehandlingUnderkategori.ORDINÆR,
         søknadMottattDato = LocalDate.now(),
         fagsakId = fagsakId,
+    )
+
+fun lagVisningsbehandling(
+    behandlingId: Long = 0L,
+    opprettetTidspunkt: LocalDateTime = LocalDateTime.now().minusDays(1),
+    aktivertTidspunkt: LocalDateTime = LocalDateTime.now().minusDays(1),
+    kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
+    underkategori: BehandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
+    aktiv: Boolean = true,
+    opprettetÅrsak: BehandlingÅrsak? = BehandlingÅrsak.SØKNAD,
+    type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+    status: BehandlingStatus = BehandlingStatus.AVSLUTTET,
+    resultat: Behandlingsresultat = Behandlingsresultat.INNVILGET,
+    vedtaksdato: LocalDateTime? = LocalDateTime.now(),
+): Visningsbehandling =
+    Visningsbehandling(
+        behandlingId,
+        opprettetTidspunkt,
+        aktivertTidspunkt,
+        kategori,
+        underkategori,
+        aktiv,
+        opprettetÅrsak,
+        type,
+        status,
+        resultat,
+        vedtaksdato,
     )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24909](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24909)

Har lyst til å hente ut barnetrygdbehandlinger fra et eget endepunkt når vi ser på react-query. Introduserer dermed dette endepunkt for å muliggjøre det.

Valgte å introdusere en egen klasse `Visningsbehandling` slik at `BehandlingHentOgPersisterService` ikke trenger å bruke `RestVisningBehandling`. Tanken er at man kan holde domene-laget og api-laget litt adskilt, syns det ble ryddigst slik. `Visningsbehandling` inneholder `vedtaksdato` som ikke et standard `behandling`-objekt gjør. 

Relatert frontend PR: https://github.com/navikt/familie-ba-sak-frontend/pull/3663

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Droppet tester på controller da det ikke ser ut til å være noen verktøy lagt til for å skrive integrasjonstester på lik linje med de som kan bli skrevet i ks-sak.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta ved behov. 
