### PR TITLE
Endre hvordan fritekst blir sendt med i ForenkletTilbakekrevingsvedtakBrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -655,8 +655,8 @@ class BrevService(
                             navn = navn,
                             fodselsnummer = mottakerIdent,
                             brevOpprettetDato = LocalDate.now(),
-                            forenkletTilbakekrevingsvedtakTekst = forenkletTilbakekrevingsvedtak.fritekst,
                         ),
+                    fritekst = forenkletTilbakekrevingsvedtak.fritekst,
                 ),
             mal = Brevmal.FORENKLET_TILBAKEKREVINGSVEDTAK,
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForenkletTilbakekrevingsvedtakBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/ForenkletTilbakekrevingsvedtakBrev.kt
@@ -11,23 +11,21 @@ data class ForenkletTilbakekrevingsvedtakBrev(
 data class ForenkletTilbakekrevingsvedtakBrevData(
     override val delmalData: DelmalData,
     override val flettefelter: Flettefelter,
+    val fritekst: String,
 ) : BrevData {
     data class Flettefelter(
         override val navn: Flettefelt,
         override val fodselsnummer: Flettefelt,
         override val brevOpprettetDato: Flettefelt = flettefelt(LocalDate.now().tilDagMånedÅr()),
-        val forenkletTilbakekrevingsvedtakTekst: Flettefelt,
     ) : FlettefelterForDokument {
         constructor(
             navn: String,
             fodselsnummer: String,
             brevOpprettetDato: LocalDate,
-            forenkletTilbakekrevingsvedtakTekst: String,
         ) : this(
             navn = flettefelt(navn),
             fodselsnummer = flettefelt(fodselsnummer),
             brevOpprettetDato = flettefelt(brevOpprettetDato.tilDagMånedÅr()),
-            forenkletTilbakekrevingsvedtakTekst = flettefelt(forenkletTilbakekrevingsvedtakTekst),
         )
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24929

Saksbehandler skal fylle inn en fritekst som skal legges til i brevet for `ForenkletTilbakekrevingsvedtakBrev`. Brevet var laget med et flettefelt `forenkletTilbakekrevingsvedtakTekst`, men endrer måten det sendes til familie-brev så det er likere fritekstfelter i andre brev