### PR TITLE
Skipper sjekk av Ny migreringsdato pluss 1 mnd kan ikke være etter første fom i forrige behandling for satsendringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtleder.kt
@@ -26,7 +26,7 @@ class BehandlingsinformasjonUtleder(
     ): Behandlingsinformasjon {
         val behandling = vedtak.behandling
         val fagsak = behandling.fagsak
-        val endretMigreringsdato = endretMigreringsdatoUtleder.utled(fagsak, forrigeTilkjentYtelse)
+        val endretMigreringsdato = endretMigreringsdatoUtleder.utled(fagsak = fagsak, forrigeTilkjentYtelse = forrigeTilkjentYtelse, erSatsendring = behandling.erSatsendring())
         return Behandlingsinformasjon(
             saksbehandlerId = saksbehandlerId,
             behandlingId = behandling.id.toString(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
@@ -21,6 +21,7 @@ class EndretMigreringsdatoUtleder(
     fun utled(
         fagsak: Fagsak,
         forrigeTilkjentYtelse: TilkjentYtelse?,
+        erSatsendring: Boolean = false,
     ): YearMonth? {
         val førsteAndelFomDatoForrigeBehandling = forrigeTilkjentYtelse?.andelerTilkjentYtelse?.minOfOrNull { it.stønadFom } ?: return null
 
@@ -43,7 +44,7 @@ class EndretMigreringsdatoUtleder(
 
         // Plusser på 1 mnd på migreringsdato da barnetrygden kun skal løpe fra BA-sak tidligst mnd etter migrering.
         val migreringsdatoPåFagsakPlussEnMnd = behandlingMigreringsinfo.migreringsdato.plusMonths(1)
-        if (migreringsdatoPåFagsakPlussEnMnd.toYearMonth().isAfter(førsteAndelFomDatoForrigeBehandling)) {
+        if (!erSatsendring && migreringsdatoPåFagsakPlussEnMnd.toYearMonth().isAfter(førsteAndelFomDatoForrigeBehandling)) {
             throw IllegalStateException("Ny migreringsdato pluss 1 mnd kan ikke være etter første fom i forrige behandling")
         }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
En satsendring stoppet iverksetting med Ny migreringsdato pluss 1 mnd kan ikke være etter første fom i forrige behandling. Etter samtale med Anna så ble vi enige om å ikke stoppe iverksetting av disse for Satsendring

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
