### PR TITLE
Endre frist for å vente på samtykke for ulovfestet motregning til 14 dager

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentUtils.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentÅrsak.AVV
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit.DAYS
 
-const val DAGER_FRIST_FOR_AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING = 5L
+const val DAGER_FRIST_FOR_AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING = 14L
 
 fun validerBehandlingKanSettesPåVent(
     gammelSettPåVent: SettPåVent?,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentServiceTest.kt
@@ -344,7 +344,10 @@ class SettPåVentServiceTest(
                 )
             }
 
-        assertThat(feil.message).isEqualTo("Uventet frist for SettPåVent med årsak AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING for behandling ${behandling.id}. Forventet frist er 5 dager, faktisk frist er 1 dager.")
+        assertThat(feil.message).isEqualTo(
+            "Uventet frist for SettPåVent med årsak AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING for behandling ${behandling.id}. " +
+                "Forventet frist er $DAGER_FRIST_FOR_AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING dager, faktisk frist er 1 dager.",
+        )
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24918

Frist skal være 14 dager, ikke 5 dager

