### PR TITLE
Utbedre generering av informasjonsbrev på fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -50,4 +50,7 @@ enum class FeatureToggle(
 
     // Tillatter behandling av klage
     BEHANDLE_KLAGE("familie-ba-sak.klage"),
+
+    // Skrur på informasjonsbrev for klage, inkluderer ny måte å generere brev for institusjon på fagsak.
+    INNHENTE_OPPLYSNINGER_KLAGE_BREV("familie-ba-sak.innhente-opplysninger-klage-brev"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentController.kt
@@ -2,13 +2,17 @@ package no.nav.familie.ba.sak.kjerne.brev
 
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
+import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestMinimalFagsak
 import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.integrasjoner.pdl.PdlRestClient
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.byggMottakerdataFraBehandling
+import no.nav.familie.ba.sak.kjerne.brev.domene.byggMottakerdataFraFagsak
 import no.nav.familie.ba.sak.kjerne.brev.domene.leggTilEnhet
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -44,6 +48,8 @@ class DokumentController(
     private val arbeidsfordelingService: ArbeidsfordelingService,
     private val utvidetBehandlingService: UtvidetBehandlingService,
     private val dokumentDistribueringService: DokumentDistribueringService,
+    private val unleashNext: UnleashNextMedContextService,
+    private val pdlRestClient: PdlRestClient,
 ) {
     @PostMapping(path = ["vedtaksbrev/{vedtakId}"])
     fun genererVedtaksbrev(
@@ -159,9 +165,20 @@ class DokumentController(
         )
 
         val fagsak = fagsakService.hentPåFagsakId(fagsakId)
+
+        val oppdatertManueltBrevRequest =
+            if (unleashNext.isEnabled(FeatureToggle.INNHENTE_OPPLYSNINGER_KLAGE_BREV)) {
+                manueltBrevRequest.byggMottakerdataFraFagsak(fagsak, arbeidsfordelingService, pdlRestClient)
+            } else {
+                manueltBrevRequest.leggTilEnhet(
+                    fagsak.aktør.aktivFødselsnummer(),
+                    arbeidsfordelingService,
+                )
+            }
+
         return dokumentGenereringService
             .genererManueltBrev(
-                manueltBrevRequest = manueltBrevRequest.leggTilEnhet(fagsak.aktør.aktivFødselsnummer(), arbeidsfordelingService),
+                manueltBrevRequest = oppdatertManueltBrevRequest,
                 erForhåndsvisning = true,
                 fagsak = fagsak,
             ).let { Ressurs.success(it) }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
@@ -38,6 +38,8 @@ class DokumentControllerTest(
             arbeidsfordelingService = mockk(relaxed = true),
             utvidetBehandlingService = mockk(relaxed = true),
             dokumentDistribueringService = mockk(relaxed = true),
+            pdlRestClient = mockk(relaxed = true),
+            unleashNext = mockk(relaxed = true),
         )
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fortsettelse av: NAV-24768. Det viste seg at å hente person via PersonRepostory ikke er robust nok. Derfor brukes heller PDL. Denne gangen legges det bak toggle :^)

Målform blir skrudd tilbake til at saksbehandler setter det, siden dette ikke er informasjon PDL sitter på.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
