### PR TITLE
Kast funksjonell feil dersom det ikke finnes vedtaksperioder med gitt ID i behandlingen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
@@ -31,6 +31,4 @@ class VedtaksperiodeHentOgPersisterService(
     fun finnVedtaksperioderFor(vedtakId: Long): List<VedtaksperiodeMedBegrunnelser> = vedtaksperiodeRepository.finnVedtaksperioderFor(vedtakId)
 
     fun finnBehandlingIdFor(vedtaksperiodeId: Long): Long? = vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(vedtaksperiodeId)
-
-    fun hentBehandlingIdFor(vedtaksperiodeId: Long): Long = finnBehandlingIdFor(vedtaksperiodeId) ?: throw Feil("Fant ingen behandling tilhørende vedtaksperiode med id $vedtaksperiodeId")
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -92,7 +92,7 @@ class VedtaksperiodeMedBegrunnelserController(
         @RequestBody
         restPutVedtaksperiodeMedFritekster: RestPutVedtaksperiodeMedFritekster,
     ): ResponseEntity<Ressurs<List<RestUtvidetVedtaksperiodeMedBegrunnelser>>> {
-        val behandlingId = vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(vedtaksperiodeId)
+        val behandlingId = vedtaksperiodeHentOgPersisterService.finnBehandlingIdFor(vedtaksperiodeId) ?: throw FunksjonellFeil("Vedtaksperiodene har blitt oppdatert. Oppdater siden og forsøk å legge til fritekst på nytt.")
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.UPDATE)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
@@ -137,7 +137,10 @@ class VedtaksperiodeMedBegrunnelserController(
     fun genererBrevBegrunnelserForPeriode(
         @PathVariable vedtaksperiodeId: Long,
     ): ResponseEntity<Ressurs<Set<String>>> {
-        val behandlingId = vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(vedtaksperiodeId)
+        val behandlingId =
+            vedtaksperiodeHentOgPersisterService.finnBehandlingIdFor(vedtaksperiodeId)
+                ?: throw FunksjonellFeil("Vedtaksperiodene har blitt oppdatert. Oppdater siden og forsøk å legge til begrunnelser på nytt.")
+
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.VEILEDER,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterServiceTest.kt
@@ -39,30 +39,4 @@ class VedtaksperiodeHentOgPersisterServiceTest {
         // Assert
         assertThat(feil.message).isEqualTo("Fant ingen vedtaksperiode med id 1")
     }
-
-    @Test
-    fun `hentBehandlingIdFor skal kaste feil hvis det ikke finnes noe behandling for vedtaksperiode`() {
-        // Arrange && Act
-        every { vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(1) } returns null
-
-        val feil =
-            assertThrows<Feil> {
-                vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(1)
-            }
-
-        // Assert
-        assertThat(feil.message).isEqualTo("Fant ingen behandling tilhørende vedtaksperiode med id 1")
-    }
-
-    @Test
-    fun `hentBehandlingIdFor skal kaste returnere behandlingId hvis det finnes noe behandling for vedtaksperiode`() {
-        // Arrange
-        every { vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(1) } returns 20
-
-        // Act
-        val behandlingIdForVedtaksperiode = vedtaksperiodeHentOgPersisterService.hentBehandlingIdFor(1)
-
-        // Assert
-        assertThat(behandlingIdForVedtaksperiode).isEqualTo(20)
-    }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24988

Vi ønsker å kaste funksjonell feil når det forsøkes å generere perioder + legge til fritekst på perioder som plutselig ikke lenger finnes. Dette kommer mest sannsynlig av saksbehandler har 2 faner, eller det er 2 saksbehandlere som jobber på samme behandling.