### PR TITLE
Tydligere feilmelding om hva man trenger å gjøre for en identhendelse med endring i fødselsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -141,17 +141,21 @@ class HåndterNyIdentService(
         }
 
         if (fødselsdatoFraPdl.toYearMonth() != fødselsdatoForrigeBehandling.toYearMonth()) {
+            val introTekstOmFeil =
+                "Fødselsdato er forskjellig fra forrige behandling. \n" +
+                    "   Ny fødselsdato $fødselsdatoFraPdl, forrige fødselsdato $fødselsdatoForrigeBehandling\n" +
+                    "   Fagsak: ${forrigeBehandling.fagsak.id} \n"
             secureLogger.warn(
-                """Fødselsdato er forskjellig fra forrige behandling.
-                    Ny fødselsdato $fødselsdatoFraPdl, forrige fødselsdato $fødselsdatoForrigeBehandling
-                    Fagsak: ${forrigeBehandling.fagsak.id}
-                    Ny ident: ${alleIdenterFraPdl.filter { !it.historisk && it.gruppe == Type.FOLKEREGISTERIDENT.name }.map { it.ident }}
-                    Gamle identer: ${alleIdenterFraPdl.filter { it.historisk && it.gruppe == Type.FOLKEREGISTERIDENT.name }.map { it.ident }}
-                    Send informasjonen beskrevet over til en fagressurs og patch identen manuelt. Se lenke for mer info:
-                    ${LENKE_INFO_OM_MERGING}
-                """.trimMargin(),
+                "$introTekstOmFeil" +
+                    "   Ny ident: ${alleIdenterFraPdl.filter { !it.historisk && it.gruppe == Type.FOLKEREGISTERIDENT.name }.map { it.ident }}\n" +
+                    "   Gamle identer: ${alleIdenterFraPdl.filter { it.historisk && it.gruppe == Type.FOLKEREGISTERIDENT.name }.map { it.ident }}\n",
             )
-            throw Feil("Fødselsdato er forskjellig fra forrige behandling. Kopier tekst fra securelog og send til en fagressurs")
+            throw Feil(
+                "$introTekstOmFeil\n" +
+                    "Du MÅ først patche fnr med PatchMergetIdentTask og etterpå sende saken til en fagressurs.\n" +
+                    "Info om gammel og nytt fnr finner man loggmelding med level WARN i securelogs.\n" +
+                    "${LENKE_INFO_OM_MERGING}",
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentService.kt
@@ -153,7 +153,7 @@ class HåndterNyIdentService(
             throw Feil(
                 "$introTekstOmFeil\n" +
                     "Du MÅ først patche fnr med PatchMergetIdentTask og etterpå sende saken til en fagressurs.\n" +
-                    "Info om gammel og nytt fnr finner man loggmelding med level WARN i securelogs.\n" +
+                    "Info om gammel og nytt fnr finner man i loggmelding med level WARN i securelogs.\n" +
                     "${LENKE_INFO_OM_MERGING}",
             )
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -138,7 +138,15 @@ internal class HåndterNyIdentServiceTest {
                     håndterNyIdentService.håndterNyIdent(PersonIdent(nyttFnr))
                 }
 
-            assertThat(feil.message).startsWith("Fødselsdato er forskjellig fra forrige behandling.")
+            assertThat(feil.message).isEqualTo(
+                """Fødselsdato er forskjellig fra forrige behandling. 
+   Ny fødselsdato 2024-01-23, forrige fødselsdato 2024-04-23
+   Fagsak: 1 
+
+Du MÅ først patche fnr med PatchMergetIdentTask og etterpå sende saken til en fagressurs.
+Info om gammel og nytt fnr finner man loggmelding med level WARN i securelogs.
+Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3%B8r-sak.md#manuell-patching-av-akt%C3%B8r-for-en-behandling for mer info.""",
+            )
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -144,7 +144,7 @@ internal class HåndterNyIdentServiceTest {
    Fagsak: 1 
 
 Du MÅ først patche fnr med PatchMergetIdentTask og etterpå sende saken til en fagressurs.
-Info om gammel og nytt fnr finner man loggmelding med level WARN i securelogs.
+Info om gammel og nytt fnr finner man i loggmelding med level WARN i securelogs.
 Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3%B8r-sak.md#manuell-patching-av-akt%C3%B8r-for-en-behandling for mer info.""",
             )
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tydligere beskjed om hva man må gjøre hvis en aktør endrer ident og fødselsdato. Fagressurser får ikke oppdatert saken før man har patchet identen.

Selve tasken vil nå få melding:
```
Fødselsdato er forskjellig fra forrige behandling. 
   Ny fødselsdato 2024-01-23, forrige fødselsdato 2024-04-23
   Fagsak: 1 

Du MÅ først patche fnr med PatchMergetIdentTask og etterpå sende saken til en fagressurs.
Info om gammel og nytt fnr finner man i loggmelding med level WARN i securelogs.
Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3%B8r-sak.md#manuell-patching-av-akt%C3%B8r-for-en-behandling for mer info.
```


securelogs:
![Screenshot 2025-04-23 at 12 52 28](https://github.com/user-attachments/assets/88e1f59f-ed63-462c-a31c-3440252435a8)
