### PR TITLE
NAV-24943: Oppretter alltid fagsak ved journalføring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceV2.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceV2.kt
@@ -25,7 +25,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.klage.KlageService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
@@ -122,23 +121,11 @@ class InnkommendeJournalføringServiceV2(
         behandlendeEnhet: String,
         oppgaveId: String,
     ): String {
+        val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent = request.bruker.id)
         val kanBehandleKlage = unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE)
         val tilknyttedeBehandlinger: MutableList<TilknyttetBehandling> = request.tilknyttedeBehandlinger.toMutableList()
         val journalpost = integrasjonClient.hentJournalpost(journalpostId)
         val brevkode = journalpost.dokumenter?.firstNotNullOfOrNull { it.brevkode }
-
-        val fagsak =
-            if (request.fagsakId != null) {
-                fagsakService.hentPåFagsakId(request.fagsakId)
-            } else if (request.opprettOgKnyttTilNyBehandling) {
-                fagsakService.hentEllerOpprettFagsak(
-                    personIdent = request.bruker.id,
-                    type = FagsakType.NORMAL,
-                    institusjon = null,
-                )
-            } else {
-                throw Feil("Forventet en fagsak ved journalføring for journalpostId $journalpostId og oppgaveId $oppgaveId.")
-            }
 
         if (request.opprettOgKnyttTilNyBehandling) {
             if (kanBehandleKlage && request.nyBehandlingstype == Journalføringsbehandlingstype.KLAGE) {
@@ -210,23 +197,10 @@ class InnkommendeJournalføringServiceV2(
         request: RestFerdigstillOppgaveKnyttJournalpost,
         oppgaveId: Long,
     ): String {
+        val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent = request.bruker.id)
         val kanBehandleKlage = unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE)
         val tilknyttedeBehandlinger: MutableList<TilknyttetBehandling> = request.tilknyttedeBehandlinger.toMutableList()
-
         val journalpost = hentJournalpost(request.journalpostId)
-
-        val fagsak =
-            if (request.fagsakId != null) {
-                fagsakService.hentPåFagsakId(request.fagsakId)
-            } else if (request.opprettOgKnyttTilNyBehandling) {
-                fagsakService.hentEllerOpprettFagsak(
-                    personIdent = request.bruker.id,
-                    type = FagsakType.NORMAL,
-                    institusjon = null,
-                )
-            } else {
-                throw Feil("Forventet en fagsak ved ferdigstilling av oppgave med oppgaveId $oppgaveId for journalpostId ${request.journalpostId}.")
-            }
 
         if (request.opprettOgKnyttTilNyBehandling) {
             if (kanBehandleKlage && request.nyBehandlingstype == Journalføringsbehandlingstype.KLAGE) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceV2Test.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceV2Test.kt
@@ -76,6 +76,6 @@ class InnkommendeJournalføringServiceV2Test {
         val journalposterForBruker = innkommendeJournalføringServiceV2.hentJournalposterForBruker(brukerId)
 
         // Assert
-        assertThat(journalposterForBruker.first { it.journalpost.journalpostId === journalpostId }.journalpostTilgang.harTilgang).isTrue
+        assertThat(journalposterForBruker.first { it.journalpost.journalpostId === journalpostId }.journalpostTilgang.harTilgang).isTrue()
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24943](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24943)

Etter en prat med Anna kom vi fram til at vi alltid skal opprette en fagsak på bruker.id når det journalføres. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei, men kan ta hvis det er behov.
