### PR TITLE
NAV-25025: Setter korrekt type og institusjon for fagsak ved oppretting via journalføring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceV2.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceV2.kt
@@ -89,7 +89,7 @@ class InnkommendeJournalføringServiceV2(
         }
     }
 
-    private fun opprettBehandlingOgEvtFagsakForJournalføring(
+    private fun opprettBehandlingForJournalføring(
         personIdent: String,
         navIdent: String,
         type: BehandlingType,
@@ -121,7 +121,7 @@ class InnkommendeJournalføringServiceV2(
         behandlendeEnhet: String,
         oppgaveId: String,
     ): String {
-        val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent = request.bruker.id)
+        val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent = request.bruker.id, type = request.fagsakType, institusjon = request.institusjon)
         val kanBehandleKlage = unleashService.isEnabled(FeatureToggle.BEHANDLE_KLAGE)
         val tilknyttedeBehandlinger: MutableList<TilknyttetBehandling> = request.tilknyttedeBehandlinger.toMutableList()
         val journalpost = integrasjonClient.hentJournalpost(journalpostId)
@@ -134,7 +134,7 @@ class InnkommendeJournalføringServiceV2(
                 tilknyttedeBehandlinger.add(TilknyttetBehandling(Journalføringsbehandlingstype.KLAGE, klagebehandlingId.toString()))
             } else {
                 val nyBehandling =
-                    opprettBehandlingOgEvtFagsakForJournalføring(
+                    opprettBehandlingForJournalføring(
                         personIdent = request.bruker.id,
                         navIdent = request.navIdent,
                         type = request.nyBehandlingstype.tilBehandingType(),
@@ -210,7 +210,7 @@ class InnkommendeJournalføringServiceV2(
             } else {
                 val brevkode = journalpost.dokumenter?.firstNotNullOfOrNull { it.brevkode }
                 val nyBehandling =
-                    opprettBehandlingOgEvtFagsakForJournalføring(
+                    opprettBehandlingForJournalføring(
                         personIdent = request.bruker.id,
                         navIdent = request.navIdent,
                         type = request.nyBehandlingstype.tilBehandingType(),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-25025](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25025)

Tidligere sendte man med informasjon fra requesten når man opprettet fagsaker, se gammel kode her:
<img width="951" alt="image" src="https://github.com/user-attachments/assets/9b7df336-f815-4f05-96fe-9d7b7b4ed302" />

Ved tilknytning ble ikke type og institusjon brukt. 

Har nå lagt det til ved journalføring. 
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/2fcd4f79-f9b1-440e-8c86-59a265c4aef9" />

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta ved behov.
