### PR TITLE
Endre refusjoneøs tekst til å vise per mnd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -626,17 +626,17 @@ class VedtaksperiodeService(
                 when (målform) {
                     NN -> {
                         if (avklart) {
-                            "Frå $fom til $tom blir etterbetaling på $beløp kroner utbetalt til myndighetene i $land."
+                            "Frå $fom til $tom blir etterbetaling på $beløp kroner per måned utbetalt til myndighetene i $land."
                         } else {
-                            "Frå $fom til $tom blir ikkje etterbetaling på $beløp kroner utbetalt no sidan det er utbetalt barnetrygd i $land."
+                            "Frå $fom til $tom blir ikkje etterbetaling på $beløp kroner per måned utbetalt no sidan det er utbetalt barnetrygd i $land."
                         }
                     }
 
                     else -> {
                         if (avklart) {
-                            "Fra $fom til $tom blir etterbetaling på $beløp kroner utbetalt til myndighetene i $land."
+                            "Fra $fom til $tom blir etterbetaling på $beløp kroner per måned utbetalt til myndighetene i $land."
                         } else {
-                            "Fra $fom til $tom blir ikke etterbetaling på $beløp kroner utbetalt nå siden det er utbetalt barnetrygd i $land."
+                            "Fra $fom til $tom blir ikke etterbetaling på $beløp kroner per måned utbetalt nå siden det er utbetalt barnetrygd i $land."
                         }
                     }
                 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -219,7 +219,7 @@ class VedtaksperiodeServiceTest {
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = true)
 
         assertThat(perioder?.size).isEqualTo(1)
-        assertThat(perioder?.single()).isEqualTo("Fra januar 2020 til januar 2022 blir etterbetaling på 200 kroner utbetalt til myndighetene i Norge.")
+        assertThat(perioder?.single()).isEqualTo("Fra januar 2020 til januar 2022 blir etterbetaling på 200 kroner per måned utbetalt til myndighetene i Norge.")
     }
 
     @Test
@@ -247,6 +247,6 @@ class VedtaksperiodeServiceTest {
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = false)
 
         assertThat(perioder?.size).isEqualTo(1)
-        assertThat(perioder?.single()).isEqualTo("Fra januar 2020 til januar 2022 blir ikke etterbetaling på 200 kroner utbetalt nå siden det er utbetalt barnetrygd i Norge.")
+        assertThat(perioder?.single()).isEqualTo("Fra januar 2020 til januar 2022 blir ikke etterbetaling på 200 kroner per måned utbetalt nå siden det er utbetalt barnetrygd i Norge.")
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24701

NFP skal innføre ny felles rutine for refusjon EØS, og i den anledning ber de om at vi endrer tekst i periodevisningen, til beløp per måned. Det er fordi NØS vil ha beløp oppgitt per måned i den manuelle oppgaven som sendes via Gosys.

Teksten var opprinnelig satt opp som månedsbeløp. Dette ble endret når vi innførte automatisk valutajustering, fordi det ville medføre at saksbehandler må legge inn veldig mange perioder i skjema siden beløpet endrer seg for hver måned. Dette mener NFP ikke lenger blir et problem, og ønsker derfor at dette endres tilbake.

NFP venter med å lansere den nye rutinen til vi har lagt inn endringen i systemet.