### PR TITLE
Feat/sett enhet til sb enhet ved klage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
         <revision>1</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
-        <prosessering.version>2.20250409144459_df36248</prosessering.version>
+        <prosessering.version>2.20250428110730_a741d1c</prosessering.version>
         <felles.version>3.20250422130733_4d831f9</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250422132745_dfaa902</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20250401151544_aae9e33</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250424145650_af8cea0</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20250422132745_dfaa902</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20250422132745_dfaa902</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250415144931_0dc88d8</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
@@ -67,7 +68,12 @@ class KlageService(
         }
 
         val aktivtFødselsnummer = fagsak.aktør.aktivFødselsnummer()
-        val enhetId = integrasjonClient.hentBehandlendeEnhetForPersonIdentMedRelasjoner(aktivtFødselsnummer).enhetId
+        val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
+        val enhetId =
+            integrasjonClient
+                .hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(saksbehandlerIdent))
+                .first()
+                .enhetsnummer
 
         return klageClient.opprettKlage(
             OpprettKlagebehandlingRequest(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContextTest.kt
@@ -91,6 +91,7 @@ class SaksbehandlerContextTest {
                     fornavn = "fornavn",
                     etternavn = "etternavn",
                     enhet = "enhet",
+                    enhetsnavn = "enhetsnavn",
                 )
 
             every { SikkerhetContext.hentGrupper() } returns emptyList()


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24892)

### 💰 Hva skal gjøres, og hvorfor?
Klagebehandlinger skal ha enhet tilhørende saksbehandleren som opprettet klagen i stedet for enheten med geografisk tilknytning til saken. 
Henter ut saksbehandler her og finner enhet via familie-integrasjoner. 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
