### PR TITLE
Sett enhet på klagebehandling til saksbehandler sin enhet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
@@ -69,7 +69,7 @@ class KlageService(
 
         val aktivtFødselsnummer = fagsak.aktør.aktivFødselsnummer()
         val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
-        val enhetId =
+        val enhetsnummer =
             integrasjonClient
                 .hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(saksbehandlerIdent))
                 .first()
@@ -82,7 +82,7 @@ class KlageService(
                 eksternFagsakId = fagsak.id.toString(),
                 fagsystem = Fagsystem.BA,
                 klageMottatt = klageMottattDato,
-                behandlendeEnhet = enhetId,
+                behandlendeEnhet = enhetsnummer,
                 behandlingsårsak = Klagebehandlingsårsak.ORDINÆR,
             ),
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
@@ -67,7 +68,12 @@ class KlageService(
         }
 
         val aktivtFødselsnummer = fagsak.aktør.aktivFødselsnummer()
-        val enhetId = integrasjonClient.hentBehandlendeEnhetForPersonIdentMedRelasjoner(aktivtFødselsnummer).enhetId
+        val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
+        val enhetId =
+            integrasjonClient
+                .hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(saksbehandlerIdent))
+                .first()
+                .enhetsnummer
 
         return klageClient.opprettKlage(
             OpprettKlagebehandlingRequest(


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24892)

### 💰 Hva skal gjøres, og hvorfor?
Klagebehandlinger skal ha enhet tilhørende saksbehandleren som opprettet klagen i stedet for enheten med geografisk tilknytning til saken. 
Henter ut saksbehandler her og finner enhet via familie-integrasjoner. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har testet i dev, føler tester gir lite verdi siden vi praksis bare mocker ut svarene vi vil teste.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
