### PR TITLE
Fjern gamle toggles

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -17,13 +17,9 @@ enum class FeatureToggle(
     // NAV-21071 lagt bak toggle og kan evt fjernes på sikt hvis man ikke har trengt å skru den på igjen
     SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM("familie-ba-sak.skalOpprettFremleggsoppgaveDersomEOSMedlem"),
 
-    // NAV-23955
-    BYTT_VALUTAJUSTERING_DATO("familie-ba-sak.behandling.valutajustering_dato"),
-
     // NAV-23733
     BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET("familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"),
 
-    BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR("familie-ba-sak.bruk-ny-saksbehandler-navn-format-i-signatur"),
 
     // NAV-24387
     BRUK_UTBETALINGSTIDSLINJER_VED_GENERERING_AV_PERIODER_TIL_AVSTEMMING("familie-ba-sak.bruk-utbetalingstidslinjer-ved-generering-av-perioder-til-avstemming"),

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -23,7 +23,6 @@ enum class FeatureToggle(
     // NAV-23733
     BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET("familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"),
 
-    // NAV-24034
     BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR("familie-ba-sak.bruk-ny-saksbehandler-navn-format-i-signatur"),
 
     // NAV-24387

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -20,7 +20,6 @@ enum class FeatureToggle(
     // NAV-23733
     BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET("familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"),
 
-
     // NAV-24387
     BRUK_UTBETALINGSTIDSLINJER_VED_GENERERING_AV_PERIODER_TIL_AVSTEMMING("familie-ba-sak.bruk-utbetalingstidslinjer-ved-generering-av-perioder-til-avstemming"),
     SKAL_FINNE_OG_PATCHE_ANDELER_I_FAGAKER_MED_AVVIK("familie-ba-sak.skal-finne-og-patche-andeler-i-fagsaker-med-avvik"),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursService.kt
@@ -111,12 +111,7 @@ class AutomatiskOppdaterValutakursService(
         utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>,
         endringstidspunkt: YearMonth,
     ) {
-        val datoForPraksisEndringAutomatiskValutajustering =
-            if (unleashNextMedContextService.isEnabled(FeatureToggle.BYTT_VALUTAJUSTERING_DATO)) {
-                DATO_FOR_PRAKSISENDRING_AUTOMATISK_VALUTAJUSTERING
-            } else {
-                YearMonth.of(2023, 1)
-            }
+        val datoForPraksisEndringAutomatiskValutajustering = DATO_FOR_PRAKSISENDRING_AUTOMATISK_VALUTAJUSTERING
 
         if (behandling.erMigrering() || behandling.opprettetÅrsak.erManuellMigreringsårsak()) return
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContext.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContext.kt
@@ -23,10 +23,6 @@ class SaksbehandlerContext(
         } else {
             val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
 
-            if (!unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR)) {
-                return SikkerhetContext.hentSaksbehandlerNavn()
-            }
-
             return try {
                 val saksbehandler = integrasjonClient.hentSaksbehandler(saksbehandlerIdent)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContext.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContext.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.sikkerhet
 
-import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import org.slf4j.LoggerFactory

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
@@ -89,7 +89,6 @@ class AutomatiskOppdaterValutakursServiceTest {
             dato.month.value.toBigDecimal()
         }
         every { vurderingsstrategiForValutakurserRepository.findByBehandlingId(any()) } returns null
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.BYTT_VALUTAJUSTERING_DATO) } returns true
         valutakursRepository.deleteAll()
         utenlandskPeriodebeløpRepository.deleteAll()
         justRun { tilpassDifferanseberegningEtterValutakursService.skjemaerEndret(any(), any()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursServiceTest.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ba.sak.TestClockProvider
 import no.nav.familie.ba.sak.common.MockedDateProvider
 import no.nav.familie.ba.sak.common.toLocalDate
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagØkonomiSimuleringMottaker

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContextTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
-import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SaksbehandlerContextTest.kt
@@ -39,7 +39,6 @@ class SaksbehandlerContextTest {
         fun `skal returnere tom streng dersom SB har kode6 gruppen`() {
             // Arrange
             every { SikkerhetContext.hentGrupper() } returns listOf(kode6GruppeId)
-            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns true
 
             // Act
             val saksbehandlerSignatur = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
@@ -53,23 +52,6 @@ class SaksbehandlerContextTest {
             // Arrange
             every { SikkerhetContext.hentGrupper() } returns emptyList()
             every { mockIntegrasjonClient.hentSaksbehandler(any()) } throws Exception()
-            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns true
-            every { SikkerhetContext.hentSaksbehandlerNavn() } returns "Etternavn, Fornavn"
-
-            // Act
-            val saksbehandlerSignatur = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
-
-            // Assert
-            assertThat(saksbehandlerSignatur).isEqualTo("Etternavn, Fornavn")
-
-            verify(exactly = 1) { SikkerhetContext.hentSaksbehandlerNavn() }
-        }
-
-        @Test
-        fun `skal returnere navn fra token dersom feature toggle er skrudd av`() {
-            // Arrange
-            every { SikkerhetContext.hentGrupper() } returns emptyList()
-            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns false
             every { SikkerhetContext.hentSaksbehandlerNavn() } returns "Etternavn, Fornavn"
 
             // Act
@@ -96,7 +78,6 @@ class SaksbehandlerContextTest {
 
             every { SikkerhetContext.hentGrupper() } returns emptyList()
             every { mockIntegrasjonClient.hentSaksbehandler(any()) } returns saksbehandler
-            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns true
 
             // Act
             val saksbehandlerSignatur = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()


### PR DESCRIPTION
Fjerner disse to togglene:

familie-ba-sak.behandling.valutajustering_dato
amilie-ba-sak.bruk-ny-saksbehandler-navn-format-i-signatur