### PR TITLE
Vi justerer på hvordan periodene blir beskrevet i tilbakekrevingsvedtak_motregning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -641,6 +641,15 @@ class BrevService(
 
         val avregningperioderForBehandling = avregningService.hentPerioderMedAvregning(behandling.id)
 
+        val avregningperioderBeskrevet =
+            avregningperioderForBehandling.map { (fom, tom) ->
+                if (fom.toYearMonth() == tom.toYearMonth()) {
+                    fom.tilMånedÅr()
+                } else {
+                    "${fom.tilMånedÅr()} til og med ${tom.tilMånedÅr()}"
+                }
+            }
+
         return TilbakekrevingsvedtakMotregningBrev(
             data =
                 TilbakekrevingsvedtakMotregningBrevData(
@@ -660,7 +669,7 @@ class BrevService(
                             brevOpprettetDato = LocalDate.now(),
                             tilbakekrevingsvedtakMotregning = tilbakekrevingsvedtakMotregning,
                             sumAvFeilutbetaling = Utils.formaterBeløp(avregningperioderForBehandling.sumOf { it.totalFeilutbetaling }.toInt()),
-                            avregningperioder = avregningperioderForBehandling.map { "${it.fom.tilMånedÅr()} til og med ${it.tom.tilMånedÅr()}" },
+                            avregningperioder = avregningperioderBeskrevet,
                         ),
                 ),
             mal = Brevmal.TILBAKEKREVINGSVEDTAK_MOTREGNING,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25099

Ved avregningsperioder der fom == tom så ønsker vi at det listes ut i brevet som f.eks "januar 2025"og ikke "januar 2025 til januar 2025" som det er i dag.