### PR TITLE
Feilmelding på migreringsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingMigreringsinfoRepository
@@ -45,7 +46,10 @@ class EndretMigreringsdatoUtleder(
         // Plusser på 1 mnd på migreringsdato da barnetrygden kun skal løpe fra BA-sak tidligst mnd etter migrering.
         val migreringsdatoPåFagsakPlussEnMnd = behandlingMigreringsinfo.migreringsdato.plusMonths(1)
         if (!erSatsendring && migreringsdatoPåFagsakPlussEnMnd.toYearMonth().isAfter(førsteAndelFomDatoForrigeBehandling)) {
-            throw IllegalStateException("Ny migreringsdato pluss 1 mnd kan ikke være etter første fom i forrige behandling")
+            throw FunksjonellFeil(
+                "Ny migreringsdato pluss 1 mnd kan ikke være etter første fom i forrige behandling",
+                "Migreringsdato i fagsak er lagt til å være etter en måned med utbetaling fra en behandling som ikke kommer fra infotrygd.",
+            )
         }
 
         // Sjekker om vi har opphørt fra migreringsdato pluss 1 mnd i en av behandlingene etter at migreringsdato sist ble endret.

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtlederTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -217,7 +218,7 @@ class EndretMigreringsdatoUtlederTest {
 
         // Act & assert
         val exception =
-            assertThrows<IllegalStateException> {
+            assertThrows<FunksjonellFeil> {
                 endretMigreringsdatoUtleder.utled(
                     fagsak = fagsak,
                     forrigeTilkjentYtelse = forrigeTilkjentYtelse,


### PR DESCRIPTION
Legger til feilmelding for saksbehandler så de skjønner at det er migreringsdato som er feil i fagsaken og ikke prøver å gjennomføre behandling mange ganger. 

### 💰 Hva skal gjøres, og hvorfor?
Har fått inn en del feil fordi saksbehandler prøver å klikke seg gjennom en behandling som har feil migreringsdato i fagsak. Legger til en feilmelding som forklarer problemet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._
