### PR TITLE
Refactor test setup to use DatabaseCleanupService.

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.fagsak
 
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.config.DatabaseCleanupService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
 import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
@@ -30,12 +31,11 @@ class FagsakRepositoryTest(
     @Autowired private val behandlingRepository: BehandlingRepository,
     @Autowired private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     @Autowired private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    @Autowired private val databaseCleanupService: DatabaseCleanupService,
 ) : AbstractSpringIntegrationTest() {
     @BeforeEach
     fun beforeEach() {
-        andelTilkjentYtelseRepository.deleteAll()
-        tilkjentYtelseRepository.deleteAll()
-        behandlingRepository.deleteAll()
+        databaseCleanupService.truncate()
     }
 
     @Nested


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Refactor test setup to use DatabaseCleanupService
Replaced manual repository deletions with a call to `databaseCleanupService.truncate()` for cleaner and more maintainable test setup. This improves consistency and reduces duplication in test initialization.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
