### PR TITLE
Øker minne i Maven på GHA

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -60,7 +60,7 @@ jobs:
 
   integrasjonstester:
     name: Integrasjonstester
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4
@@ -70,7 +70,7 @@ jobs:
           cache: 'maven'
       - name: Kjør integrasjonstester
         env:
-          MAVEN_OPTS: "-Xmx6g -Dmaven.artifact.threads=10"
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -70,7 +70,7 @@ jobs:
           cache: 'maven'
       - name: Kjør integrasjonstester
         env:
-          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
+          MAVEN_OPTS: "-Xmx6g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -60,7 +60,7 @@ jobs:
 
   integrasjonstester:
     name: Integrasjonstester
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -44,7 +44,7 @@ jobs:
           cache: 'maven'
       - name: Kjør enhetstester
         env:
-          MAVEN_OPTS: -Xss1024M -Xmx2048M
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -70,7 +70,7 @@ jobs:
           cache: 'maven'
       - name: Kjør integrasjonstester
         env:
-          MAVEN_OPTS: -Xss1024M -Xmx2048M
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -116,7 +116,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Kjør Sonar
         env:
-          MAVEN_OPTS: -Xss1024M -Xmx2048M
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -159,7 +159,7 @@ jobs:
           cache: 'maven'
       - name: Kjør verdikjedetester m/ feature toggles slått på
         env:
-          MAVEN_OPTS: -Xss1024M -Xmx2048M
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -42,7 +42,7 @@ jobs:
           cache: 'maven'
       - name: Kjør integrasjonstester
         env:
-          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
+          MAVEN_OPTS: "-Xmx6g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,7 +32,7 @@ jobs:
 
   integrasjonstester:
     name: Integrasjonstester
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4
@@ -42,7 +42,7 @@ jobs:
           cache: 'maven'
       - name: Kjør integrasjonstester
         env:
-          MAVEN_OPTS: -Xss1024M -Xmx2048M
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,7 +32,7 @@ jobs:
 
   integrasjonstester:
     name: Integrasjonstester
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4
@@ -42,7 +42,7 @@ jobs:
           cache: 'maven'
       - name: Kjør integrasjonstester
         env:
-          MAVEN_OPTS: "-Xmx6g -Dmaven.artifact.threads=10"
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -17,7 +17,7 @@ jobs:
           cache: 'maven'
       - name: Kjør enhetstester
         env:
-          MAVEN_OPTS: -Xss1024M -Xmx2048M
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,7 @@
                     <excludedGroups>${excludedGroups}</excludedGroups>
                     <threadCount>1</threadCount>
                     <runOrder>random</runOrder>
+                    <argLine>-Xmx2g</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-24974
Øker minne maven kan bruke på GHA for å se om det hjelper jacoco som dør. ubuntu-latest skal ha 7GB tilgjengelig og ubuntu-latest-4-cores har 16GB. 

Øker maven.artifact.threads fra default 5 til 10 tråder for å sjekke om ting går litt raskere.
