### PR TITLE
Vi returnerer behandøingrespons ved oppdatering og sletting av tilbakekrevingsvedtak motregning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestUtvidetBehandling.kt
@@ -47,4 +47,5 @@ data class RestUtvidetBehandling(
     val refusjonEøs: List<RestRefusjonEøs>,
     val vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser? = VurderingsstrategiForValutakurser.AUTOMATISK,
     val søknadMottattDato: LocalDateTime?,
+    val tilbakekrevingsvedtakMotregning: RestTilbakekrevingsvedtakMotregning?,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -37,6 +37,8 @@ import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.feilutbetaltValuta.FeilutbetaltValutaService
 import no.nav.familie.ba.sak.kjerne.vedtak.refusjonEøs.RefusjonEøsService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.tilRestTilbakekrevingsvedtakMotregning
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import org.springframework.stereotype.Service
@@ -67,6 +69,7 @@ class UtvidetBehandlingService(
     private val refusjonEøsService: RefusjonEøsService,
     private val vurderingsstrategiForValutakurserRepository: VurderingsstrategiForValutakurserRepository,
     private val behandlingSøknadsinfoService: BehandlingSøknadsinfoService,
+    private val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
 ) {
     fun lagRestUtvidetBehandling(behandlingId: Long): RestUtvidetBehandling {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId)
@@ -105,6 +108,8 @@ class UtvidetBehandlingService(
 
         val brevmottakere = brevmottakerService.hentRestBrevmottakere(behandlingId)
         val søknadMottattDato = behandlingSøknadsinfoService.hentSøknadMottattDato(behandlingId)
+
+        val tilbakekrevingsvedtakMotregning = tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(behandlingId)
 
         return RestUtvidetBehandling(
             behandlingId = behandling.id,
@@ -161,6 +166,7 @@ class UtvidetBehandlingService(
             refusjonEøs = refusjonEøs,
             vurderingsstrategiForValutakurser = vurderingsstrategiForValutakurserRepository.findByBehandlingId(behandling.id)?.vurderingsstrategiForValutakurser,
             søknadMottattDato = søknadMottattDato,
+            tilbakekrevingsvedtakMotregning = tilbakekrevingsvedtakMotregning?.tilRestTilbakekrevingsvedtakMotregning(),
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregningController.kt
@@ -5,7 +5,8 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.ekstern.restDomene.RestOppdaterTilbakekrevingsvedtakMotregning
-import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekrevingsvedtakMotregning
+import no.nav.familie.ba.sak.ekstern.restDomene.RestUtvidetBehandling
+import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -29,22 +30,8 @@ class TilbakekrevingsvedtakMotregningController(
     val tilgangService: TilgangService,
     val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
     val tilbakekrevingsvedtakMotregningBrevService: TilbakekrevingsvedtakMotregningBrevService,
+    val utvidetBehandlingService: UtvidetBehandlingService,
 ) {
-    @GetMapping(
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-    )
-    fun hentTilbakekrevingsvedtakMotregning(
-        @PathVariable behandlingId: Long,
-    ): ResponseEntity<Ressurs<RestTilbakekrevingsvedtakMotregning?>> {
-        tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
-            handling = "Hent TilbakekrevingsvedtakMotregning",
-        )
-        val tilbakekrevingsvedtakMotregning = tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(behandlingId = behandlingId)
-
-        return ResponseEntity.ok(Ressurs.success(tilbakekrevingsvedtakMotregning?.tilRestTilbakekrevingsvedtakMotregning()))
-    }
-
     @PatchMapping(
         produces = [MediaType.APPLICATION_JSON_VALUE],
         consumes = [MediaType.APPLICATION_JSON_VALUE],
@@ -52,30 +39,31 @@ class TilbakekrevingsvedtakMotregningController(
     fun oppdaterTilbakekrevingsvedtakMotregning(
         @PathVariable behandlingId: Long,
         @RequestBody restOppdaterTilbakekrevingsvedtakMotregning: RestOppdaterTilbakekrevingsvedtakMotregning,
-    ): ResponseEntity<Ressurs<RestTilbakekrevingsvedtakMotregning>> {
+    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "Oppdater tilbakekrevingsvedtak motregning",
         )
         tilgangService.validerKanRedigereBehandling(behandlingId)
 
-        val oppdatertTilbakekrevingsvedtakMotregning =
-            tilbakekrevingsvedtakMotregningService.oppdaterTilbakekrevingsvedtakMotregning(
-                behandlingId = behandlingId,
-                samtykke = restOppdaterTilbakekrevingsvedtakMotregning.samtykke,
-                årsakTilFeilutbetaling = restOppdaterTilbakekrevingsvedtakMotregning.årsakTilFeilutbetaling,
-                vurderingAvSkyld = restOppdaterTilbakekrevingsvedtakMotregning.vurderingAvSkyld,
-                varselDato = restOppdaterTilbakekrevingsvedtakMotregning.varselDato,
-                heleBeløpetSkalKrevesTilbake = restOppdaterTilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake,
-            )
+        tilbakekrevingsvedtakMotregningService.oppdaterTilbakekrevingsvedtakMotregning(
+            behandlingId = behandlingId,
+            samtykke = restOppdaterTilbakekrevingsvedtakMotregning.samtykke,
+            årsakTilFeilutbetaling = restOppdaterTilbakekrevingsvedtakMotregning.årsakTilFeilutbetaling,
+            vurderingAvSkyld = restOppdaterTilbakekrevingsvedtakMotregning.vurderingAvSkyld,
+            varselDato = restOppdaterTilbakekrevingsvedtakMotregning.varselDato,
+            heleBeløpetSkalKrevesTilbake = restOppdaterTilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake,
+        )
 
-        return ResponseEntity.ok(Ressurs.success(oppdatertTilbakekrevingsvedtakMotregning.tilRestTilbakekrevingsvedtakMotregning()))
+        val restUtvidetBehandling = utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)
+
+        return ResponseEntity.ok(Ressurs.success(restUtvidetBehandling))
     }
 
     @DeleteMapping
     fun slettTilbakekrevingsvedtakMotregning(
         @PathVariable behandlingId: Long,
-    ): ResponseEntity<Ressurs<String>> {
+    ): ResponseEntity<Ressurs<RestUtvidetBehandling>> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "Slett TilbakekrevingsvedtakMotregning",
@@ -84,7 +72,9 @@ class TilbakekrevingsvedtakMotregningController(
 
         tilbakekrevingsvedtakMotregningService.slettTilbakekrevingsvedtakMotregning(behandlingId)
 
-        return ResponseEntity.ok(Ressurs.success("TilbakekrevingsvedtakMotregning for behandling=$behandlingId slettet OK."))
+        val restUtvidetBehandling = utvidetBehandlingService.lagRestUtvidetBehandling(behandlingId = behandlingId)
+
+        return ResponseEntity.ok(Ressurs.success(restUtvidetBehandling))
     }
 
     @Operation(summary = "Henter eksisterende Tilbakekrevingsvedtak motregning pdf.")


### PR DESCRIPTION
Grunnet hvordan ting er satt opp i frontend og backend, så ser vi det som en bedre løsning å returnere hele behandlingen ved oppdatering og sletting av tilbakekrevingsvedtak motregning.
Dette fordi at det blir mye ekstra kall for å holde ting i sync hvis vi bare får tilbake tilbakekrevingsvedtaket.