### PR TITLE
Endre når logg for ulovfestet motregning blir oppdatert

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/Logg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/Logg.kt
@@ -96,7 +96,6 @@ enum class LoggType(
     SAMMENSATT_KONTROLLSAK_LAGT_TIL("Sammensatt kontrollsak lagt til"),
     SAMMENSATT_KONTROLLSAK_ENDRET("Sammensatt kontrollsak endret"),
     SAMMENSATT_KONTROLLSAK_FJERNET("Sammensatt kontrollsak fjernet"),
-    TILBAKEKREVINGSVEDTAK_MOTREGNING_OPPRETTET("Tilbakekrevingsvedtak motregning opprettet"),
-    TILBAKEKREVINGSVEDTAK_MOTREGNING_OPPDATERT("Tilbakekrevingsvedtak motregning oppdatert"),
-    TILBAKEKREVINGSVEDTAK_MOTREGNING_SLETTET("Tilbakekrevingsvedtak motregning fjernet"),
+    ULOVFESTET_MOTREGNING_BENYTTET("Ulovfestet motregning er benyttet"),
+    ULOVFESTET_MOTREGNING_ANGRET("Ulovfestet motregning er angret"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggService.kt
@@ -737,11 +737,11 @@ class LoggService(
         ),
     )
 
-    fun loggTilbakekrevingsvedtakMotregningOpprettet(behandlingId: Long) =
+    fun loggUlovfestetMotregningBenyttet(behandlingId: Long) =
         lagre(
             Logg(
                 behandlingId = behandlingId,
-                type = LoggType.TILBAKEKREVINGSVEDTAK_MOTREGNING_OPPRETTET,
+                type = LoggType.ULOVFESTET_MOTREGNING_BENYTTET,
                 rolle =
                     SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
                         rolleConfig,
@@ -750,24 +750,11 @@ class LoggService(
             ),
         )
 
-    fun loggTilbakekrevingsvedtakMotregningOppdatert(behandlingId: Long) =
+    fun loggUlovfestetMotregningAngret(behandlingId: Long) =
         lagre(
             Logg(
                 behandlingId = behandlingId,
-                type = LoggType.TILBAKEKREVINGSVEDTAK_MOTREGNING_OPPDATERT,
-                rolle =
-                    SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
-                        rolleConfig,
-                        BehandlerRolle.SAKSBEHANDLER,
-                    ),
-            ),
-        )
-
-    fun loggTilbakekrevingsvedtakMotregningSlettet(behandlingId: Long) =
-        lagre(
-            Logg(
-                behandlingId = behandlingId,
-                type = LoggType.TILBAKEKREVINGSVEDTAK_MOTREGNING_SLETTET,
+                type = LoggType.ULOVFESTET_MOTREGNING_ANGRET,
                 rolle =
                     SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
                         rolleConfig,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25099

Endrer logging relatert til ulovfestet motregning slik at:
- teksten er endret til _Ulovfestet motregning er benyttet/angret_
- logg om at ulovfestet motregning er benyttet opprettes når `samtykke` blir oppdatert til `true`
- logg om at ulovfestet motregning er angret opprettes når et `TilbakekrevingsvedtakMotregning` der `samtykke` er `true` slettes