### PR TITLE
Tilbakestill behandling til simuleringsteg når heleBeløpetSkalKrevesTilbake oppdateres

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingTilSimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingTilSimuleringService.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.ba.sak.kjerne.steg
+
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TilbakestillBehandlingTilSimuleringService(
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val behandlingService: BehandlingService,
+) {
+    @Transactional
+    fun tilbakestillBehandlingTilSimuering(behandlingId: Long): Behandling {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+
+        if (behandling.erTilbakestiltTilSimulering()) {
+            return behandling
+        }
+
+        return behandlingService.leggTilStegPåBehandlingOgSettTidligereStegSomUtført(
+            behandlingId = behandlingId,
+            steg = StegType.VURDER_TILBAKEKREVING,
+        )
+    }
+}
+
+private fun Behandling.erTilbakestiltTilSimulering(): Boolean {
+    val gjeldendeSteg = this.behandlingStegTilstand.last()
+    return gjeldendeSteg.behandlingSteg == StegType.VURDER_TILBAKEKREVING &&
+        gjeldendeSteg.behandlingStegStatus == BehandlingStegStatus.IKKE_UTFØRT
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregningService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
+import no.nav.familie.ba.sak.kjerne.steg.TilbakestillBehandlingTilSimuleringService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -12,6 +13,7 @@ class TilbakekrevingsvedtakMotregningService(
     private val tilbakekrevingsvedtakMotregningRepository: TilbakekrevingsvedtakMotregningRepository,
     private val loggService: LoggService,
     private val behandlingService: BehandlingHentOgPersisterService,
+    private val tilbakestillBehandlingTilSimuleringService: TilbakestillBehandlingTilSimuleringService,
 ) {
     fun finnTilbakekrevingsvedtakMotregning(behandlingId: Long) = tilbakekrevingsvedtakMotregningRepository.finnTilbakekrevingsvedtakMotregningForBehandling(behandlingId)
 
@@ -60,6 +62,7 @@ class TilbakekrevingsvedtakMotregningService(
                 }
                 heleBeløpetSkalKrevesTilbake?.let {
                     this.heleBeløpetSkalKrevesTilbake = it
+                    tilbakestillBehandlingTilSimuleringService.tilbakestillBehandlingTilSimuering(behandlingId)
                 }
             }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25099

Når `heleBeløpetSkalKrevesTilbake`oppdateres, ønsker vi å tilbakestille behandlingen til simuleringssteget, slik at man ikke havner i en uønsket state i frontend