### PR TITLE
Splitter ut journalføring av tilbakekrevingsvedtak ved motregning til egen task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250505123518_aa76fed</prosessering.version>
         <felles.version>3.20250505101905_835431d</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250422132745_dfaa902</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20250508110054_895136e</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250508163827_676473b</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20250422132745_dfaa902</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20250422132745_dfaa902</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250415144931_0dc88d8</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/JournalførTilbakekrevingsvedtakMotregningBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/JournalførTilbakekrevingsvedtakMotregningBrevTask.kt
@@ -1,0 +1,154 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.integrasjoner.journalføring.UtgåendeJournalføringService
+import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.brev.DokumentService.Companion.genererEksternReferanseIdForJournalpost
+import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.Bruker
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.Institusjon
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.MottakerInfo
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.tilAvsenderMottaker
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.ba.sak.kjerne.steg.JournalførVedtaksbrev.Companion.logger
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregning
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
+import no.nav.familie.ba.sak.task.JournalførTilbakekrevingsvedtakMotregningBrevTask.Companion.TASK_STEP_TYPE
+import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(taskStepType = TASK_STEP_TYPE, beskrivelse = "Journalfør tilbakekrevingsvedtak ved motregning brev i Joark", maxAntallFeil = 3)
+class JournalførTilbakekrevingsvedtakMotregningBrevTask(
+    private val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val utgåendeJournalføringService: UtgåendeJournalføringService,
+    private val taskRepository: TaskRepositoryWrapper,
+    private val organisasjonService: OrganisasjonService,
+    private val brevmottakerService: BrevmottakerService,
+    private val behandlingService: BehandlingHentOgPersisterService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val behandling = behandlingService.hent(task.payload.toLong())
+        val fagsak = behandling.fagsak
+        val tilbakekrevingsvedtakMotregning = tilbakekrevingsvedtakMotregningService.hentTilbakekrevingsvedtakMotregningEllerKastFunksjonellFeil(behandling.id)
+        val behandlendeEnhet = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id).behandlendeEnhetId
+
+        val mottakere = hentAlleMottakereAvBrevet(fagsak, behandling)
+
+        val journalposterTilDistribusjon =
+            mottakere.associate { mottakerInfo ->
+                val journalpostId =
+                    journalførTilbakekrevingsvedtakMotregningsbrev(
+                        fnr = fagsak.aktør.aktivFødselsnummer(),
+                        fagsakId = fagsak.id,
+                        journalførendeEnhet = behandlendeEnhet,
+                        mottakerInfo = mottakerInfo,
+                        eksternReferanseId = genererEksternReferanseIdForJournalpost(fagsak.id, behandling.id, mottakerInfo),
+                        tilbakekrevingsvedtakMotregning = tilbakekrevingsvedtakMotregning,
+                    )
+                journalpostId to mottakerInfo
+            }
+
+        journalposterTilDistribusjon.forEach {
+            val distribueringTask =
+                DistribuerDokumentTask.opprettDistribuerDokumentTask(
+                    distribuerDokumentDTO =
+                        lagDistribuerDokumentDto(
+                            behandling = behandling,
+                            journalPostId = it.key,
+                            mottakerInfo = it.value,
+                        ),
+                    properties = task.metadata,
+                )
+
+            taskRepository.save(distribueringTask)
+        }
+    }
+
+    private fun hentAlleMottakereAvBrevet(
+        fagsak: Fagsak,
+        behandling: Behandling,
+    ) = if (fagsak.type == FagsakType.INSTITUSJON) {
+        listOf(
+            Institusjon(
+                orgNummer = fagsak.institusjon!!.orgNummer,
+                navn = organisasjonService.hentOrganisasjon(fagsak.institusjon!!.orgNummer).navn,
+            ),
+        )
+    } else {
+        brevmottakerService
+            .hentBrevmottakere(behandling.id)
+            .takeIf { it.isNotEmpty() }
+            ?.map(::ManuellBrevmottaker)
+            ?.let(brevmottakerService::lagMottakereFraBrevMottakere)
+            ?: listOf(Bruker)
+    }
+
+    private fun journalførTilbakekrevingsvedtakMotregningsbrev(
+        fnr: String,
+        fagsakId: Long,
+        tilbakekrevingsvedtakMotregning: TilbakekrevingsvedtakMotregning,
+        journalførendeEnhet: String,
+        mottakerInfo: MottakerInfo,
+        eksternReferanseId: String,
+    ): String {
+        val behandling = tilbakekrevingsvedtakMotregning.behandling
+        val brev =
+            listOf(
+                Dokument(
+                    tilbakekrevingsvedtakMotregning.vedtakPdf!!,
+                    filtype = Filtype.PDFA,
+                    dokumenttype = Dokumenttype.BARNETRYGD_TILBAKEKREVINGSVEDTAK_MOTREGNING,
+                ),
+            )
+
+        logger.info("Journalfører brev for tilbakekrevingsvedtak ved motregning for behandling ${behandling.id}")
+
+        return utgåendeJournalføringService.journalførDokument(
+            fnr = fnr,
+            fagsakId = fagsakId.toString(),
+            journalførendeEnhet = journalførendeEnhet,
+            brev = brev,
+            behandlingId = behandling.id,
+            avsenderMottaker = mottakerInfo.tilAvsenderMottaker(),
+            eksternReferanseId = eksternReferanseId,
+        )
+    }
+
+    private fun lagDistribuerDokumentDto(
+        behandling: Behandling,
+        journalPostId: String,
+        mottakerInfo: MottakerInfo,
+    ) = DistribuerDokumentDTO(
+        fagsakId = behandling.fagsak.id,
+        behandlingId = behandling.id,
+        journalpostId = journalPostId,
+        brevmal = Brevmal.TILBAKEKREVINGSVEDTAK_MOTREGNING,
+        erManueltSendt = false,
+        manuellAdresseInfo = mottakerInfo.manuellAdresseInfo,
+    )
+
+    companion object {
+        const val TASK_STEP_TYPE = "journalførTilbakekrevingsvedtakMotregningBrev"
+
+        fun opprettTask(
+            behandlingId: Long,
+        ): Task =
+            Task(
+                TASK_STEP_TYPE,
+                "$behandlingId",
+            )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -32,10 +32,12 @@ import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
 import no.nav.familie.ba.sak.task.FerdigstillOppgaver
+import no.nav.familie.ba.sak.task.JournalførTilbakekrevingsvedtakMotregningBrevTask
 import no.nav.familie.ba.sak.task.JournalførVedtaksbrevTask
 import no.nav.familie.ba.sak.task.OpprettOppgaveTask
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
@@ -67,6 +69,7 @@ class BeslutteVedtakTest {
     private val simuleringService = mockk<SimuleringService>()
     private val tilbakekrevingService = mockk<TilbakekrevingService>()
     private val brevmottakerService = mockk<BrevmottakerService>()
+    private val mockTilbakekrevingsvedtakMotregningService = mockk<TilbakekrevingsvedtakMotregningService>()
 
     val beslutteVedtak =
         BeslutteVedtak(
@@ -84,6 +87,7 @@ class BeslutteVedtakTest {
             simuleringService = simuleringService,
             tilbakekrevingService = tilbakekrevingService,
             brevmottakerService = brevmottakerService,
+            tilbakekrevingsvedtakMotregningService = mockTilbakekrevingsvedtakMotregningService,
         )
 
     private val randomVilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
@@ -115,6 +119,7 @@ class BeslutteVedtakTest {
         every { tilbakekrevingService.søkerHarÅpenTilbakekreving(any()) } returns false
         every { tilbakekrevingService.hentTilbakekrevingsvalg(any()) } returns null
         every { simuleringService.hentFeilutbetaling(any<Long>()) } returns BigDecimal.ZERO
+        every { mockTilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns null
     }
 
     @Nested
@@ -141,6 +146,35 @@ class BeslutteVedtakTest {
 
             verify(exactly = 1) { FerdigstillOppgaver.opprettTask(behandling.id, Oppgavetype.GodkjenneVedtak) }
             Assertions.assertEquals(StegType.IVERKSETT_MOT_OPPDRAG, nesteSteg)
+        }
+
+        @Test
+        fun `Ved godkjent vedtak og eksisterende tilbakekrevingsvedtak ved motregning brev så skal det opprettes task for å journalføre denne`() {
+            // Arrange
+            val behandling = lagBehandling()
+            behandling.status = BehandlingStatus.FATTER_VEDTAK
+            behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))
+            val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
+
+            every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
+            every { mockTilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns mockk()
+            every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
+            mockkObject(FerdigstillOppgaver.Companion)
+            every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
+            every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
+            mockkObject(JournalførTilbakekrevingsvedtakMotregningBrevTask.Companion)
+            every { JournalførTilbakekrevingsvedtakMotregningBrevTask.opprettTask(behandling.id) } returns mockk()
+            every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+            every { brevmottakerService.hentBrevmottakere(behandling.id) } returns
+                listOf(
+                    lagBrevmottakerDb(behandlingId = behandling.id),
+                )
+
+            // Act
+            beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak)
+
+            // Assert
+            verify(exactly = 1) { JournalførTilbakekrevingsvedtakMotregningBrevTask.opprettTask(any()) }
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/JournalførTilbakekrevingsvedtakMotregningBrevTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/JournalførTilbakekrevingsvedtakMotregningBrevTaskTest.kt
@@ -1,0 +1,92 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagBrevmottakerDb
+import no.nav.familie.ba.sak.integrasjoner.journalføring.UtgåendeJournalføringService
+import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
+import no.nav.familie.ba.sak.kjerne.brev.mottaker.Bruker
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregning
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
+import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class JournalførTilbakekrevingsvedtakMotregningBrevTaskTest {
+    private val mockArbeidsfordelingService = mockk<ArbeidsfordelingService>()
+    private val mockUtgåendeJournalføringService = mockk<UtgåendeJournalføringService>()
+    private val mockTaskRepository = mockk<TaskRepositoryWrapper>()
+    private val mockOrganisasjonService = mockk<OrganisasjonService>()
+    private val mockBrevmottakerService = mockk<BrevmottakerService>()
+    private val mockTilbakekrevingsvedtakMotregningService = mockk<TilbakekrevingsvedtakMotregningService>()
+    private val mockBehandlingService = mockk<BehandlingHentOgPersisterService>()
+
+    private val behandling = lagBehandling()
+    private val arbeidsfordelingPåBehandling = ArbeidsfordelingPåBehandling(behandlingId = behandling.id, behandlendeEnhetNavn = "testNavn", behandlendeEnhetId = "testId")
+
+    private val journalførTilbakekrevingsvedtakMotregningBrevTask =
+        JournalførTilbakekrevingsvedtakMotregningBrevTask(
+            arbeidsfordelingService = mockArbeidsfordelingService,
+            utgåendeJournalføringService = mockUtgåendeJournalføringService,
+            taskRepository = mockTaskRepository,
+            organisasjonService = mockOrganisasjonService,
+            brevmottakerService = mockBrevmottakerService,
+            tilbakekrevingsvedtakMotregningService = mockTilbakekrevingsvedtakMotregningService,
+            behandlingService = mockBehandlingService,
+        )
+
+    @BeforeEach
+    fun setUp() {
+        every { mockBehandlingService.hent(behandling.id) } returns behandling
+        every { mockArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandling.id) } returns arbeidsfordelingPåBehandling
+        every { mockOrganisasjonService.hentOrganisasjon(any()) } returns Organisasjon("orgNummer", "orgNavn")
+        every { mockUtgåendeJournalføringService.journalførDokument(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany listOf("1", "2", "3", "4", "5", "6", "7", "8")
+        every { mockTaskRepository.save(any()) } returnsArgument 0
+    }
+
+    @Test
+    fun `Skal journalføre Tilbakekrevingsvedtak motregning til brevmottakere og lage task for å distribuere dokumentet til alle mottakere`() {
+        // Arrange
+        val tilbakekrevingsvedtakMotregning =
+            TilbakekrevingsvedtakMotregning(
+                id = 1,
+                behandling = behandling,
+                samtykke = true,
+                vedtakPdf = ByteArray(0),
+                heleBeløpetSkalKrevesTilbake = true,
+            )
+
+        every { mockTilbakekrevingsvedtakMotregningService.hentTilbakekrevingsvedtakMotregningEllerKastFunksjonellFeil(behandlingId = behandling.id) } returns tilbakekrevingsvedtakMotregning
+        every { mockBrevmottakerService.hentBrevmottakere(behandling.id) } returns listOf(lagBrevmottakerDb(behandlingId = behandling.id, landkode = "NO"), lagBrevmottakerDb(behandlingId = behandling.id, landkode = "SE"))
+        every { mockBrevmottakerService.lagMottakereFraBrevMottakere(any()) } returns listOf(Bruker, Bruker)
+        every { mockTilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(behandling.id) } returns tilbakekrevingsvedtakMotregning
+
+        // Act
+        journalførTilbakekrevingsvedtakMotregningBrevTask.doTask(
+            JournalførTilbakekrevingsvedtakMotregningBrevTask.opprettTask(behandling.id),
+        )
+
+        // Assert
+        verify(exactly = 2) {
+            mockUtgåendeJournalføringService.journalførDokument(
+                fnr = any(),
+                fagsakId = any(),
+                journalførendeEnhet = any(),
+                brev = any(),
+                vedlegg = any(),
+                førsteside = any(),
+                behandlingId = any(),
+                avsenderMottaker = null,
+                eksternReferanseId = any(),
+            )
+        }
+        verify(exactly = 2) { mockTaskRepository.save(any()) }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
@@ -53,6 +53,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.BegrunnelseMedData
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregning
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.tilUtvidetVedtaksperiodeMedBegrunnelser
@@ -81,6 +82,7 @@ class VedtaksperioderOgBegrunnelserStepDefinition {
     var kompetanser = mutableMapOf<Long, List<Kompetanse>>()
     var valutakurs = mutableMapOf<Long, List<Valutakurs>>()
     var utenlandskPeriodebeløp = mutableMapOf<Long, List<UtenlandskPeriodebeløp>>()
+    var tilbakekrevingsvedtakMotregning = mutableMapOf<Long, TilbakekrevingsvedtakMotregning>()
     var endredeUtbetalinger = mutableMapOf<Long, List<EndretUtbetalingAndel>>()
     var tilkjenteYtelser = mutableMapOf<Long, TilkjentYtelse>()
     var overstyrteEndringstidspunkt = mutableMapOf<Long, LocalDate>()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinition
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockBehandlingMigreringsinfoRepository
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockEcbService
+import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockTilbakekrevingsvedtakMotregningRepository
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockUnleashNextMedContextService
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockUnleashService
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockVurderingsstrategiForValutakurserRepository
@@ -67,12 +68,14 @@ import no.nav.familie.ba.sak.kjerne.steg.RegistrerPersongrunnlag
 import no.nav.familie.ba.sak.kjerne.steg.StatusFraOppdrag
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.steg.TilbakestillBehandlingTilBehandlingsresultatService
+import no.nav.familie.ba.sak.kjerne.steg.TilbakestillBehandlingTilSimuleringService
 import no.nav.familie.ba.sak.kjerne.steg.VilkårsvurderingSteg
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.EøsSkjemaerForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.PersonopplysningGrunnlagForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
@@ -122,6 +125,7 @@ class CucumberMock(
     val kompetanseRepository = mockKompetanseRepository(dataFraCucumber)
     val valutakursRepository = mockValutakursRepository(dataFraCucumber)
     val utenlandskPeriodebeløpRepository = mockUtenlandskPeriodebeløpRepository(dataFraCucumber)
+    val tilbakekrevingsvedtakMotregningRepository = mockTilbakekrevingsvedtakMotregningRepository(dataFraCucumber)
     val endretUtbetalingAndelRepository = mockEndretUtbetalingAndelRepository(dataFraCucumber)
     val simuleringService = mockSimuleringService()
     val startSatsendring = mockStartSatsendring()
@@ -296,6 +300,8 @@ class CucumberMock(
 
     val tilbakestillBehandlingFraUtenlandskPeriodebeløpEndringService = TilbakestillBehandlingFraUtenlandskPeriodebeløpEndringService(tilbakestillBehandlingTilBehandlingsresultatService = tilbakestillBehandlingTilBehandlingsresultatService)
 
+    val tilbakestillBehandlingTilSimuleringService = TilbakestillBehandlingTilSimuleringService(behandlingHentOgPersisterService, behandlingService)
+
     val valutakursService = ValutakursService(valutakursRepository = valutakursRepository, endringsabonnenter = valutakursAbonnenter)
 
     val automatiskOppdaterValutakursService =
@@ -326,6 +332,14 @@ class CucumberMock(
             tilpassDifferanseberegningEtterUtenlandskPeriodebeløpService,
             tilbakestillBehandlingFraUtenlandskPeriodebeløpEndringService,
             tilpassValutakurserTilUtenlandskePeriodebeløpService,
+        )
+
+    val tilbakekrevingsvedtakMotregningService =
+        TilbakekrevingsvedtakMotregningService(
+            tilbakekrevingsvedtakMotregningRepository = tilbakekrevingsvedtakMotregningRepository,
+            loggService = loggService,
+            behandlingService = behandlingHentOgPersisterService,
+            tilbakestillBehandlingTilSimuleringService = tilbakestillBehandlingTilSimuleringService,
         )
 
     val utenlandskPeriodebeløpService =
@@ -567,6 +581,7 @@ class CucumberMock(
             simuleringService = simuleringService,
             tilbakekrevingService = tilbakekrevingService,
             brevmottakerService = brevmottakerService,
+            tilbakekrevingsvedtakMotregningService = tilbakekrevingsvedtakMotregningService,
         )
 
     val stegService =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilbakekrevingsvedtakMotregningRepository.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilbakekrevingsvedtakMotregningRepository.kt
@@ -1,0 +1,17 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock.komponentMocks
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinition
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningRepository
+
+fun mockTilbakekrevingsvedtakMotregningRepository(dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefinition): TilbakekrevingsvedtakMotregningRepository {
+    val tilbakekrevingsvedtakMotregningRepository = mockk<TilbakekrevingsvedtakMotregningRepository>()
+
+    every { tilbakekrevingsvedtakMotregningRepository.finnTilbakekrevingsvedtakMotregningForBehandling(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        dataFraCucumber.tilbakekrevingsvedtakMotregning[behandlingId]
+    }
+
+    return tilbakekrevingsvedtakMotregningRepository
+}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25099

Tidligere så forsøkte vi å gjenbruke JournalførVedtaksbrev steget til å også journalføre våre tilbakekrevingsvedtak ved motregning brev. Men dette viser seg til å ikke fungere helt optimalt fordi:

- Først journalførte man vedtaksbrevet, og deretter tilbakekrevingsvedtaket. Men hvis journalføring av tilbakekrevingsvedtaket feiler, så sliter vi da det ikke finnes noe mekanismer per i dag for å journalføre den alene.
- For å kunne journalføre tilbakekrevingsvedtaket så er man avhengig av at den ordinære vedtaksbrevet blir journalført OK.
- Ved opprettelse av tasken for å distribuere vedtaket ble alltid førstegangsvedtak brevmalen valgt
- Gitt flere brevmottakere som igjen gir flere distribueringstasker, så var det vanskelig å finne ut om noen av disse taskene inneholdt tilbakekrevingsvedtaket.

Jeg har derfor:
- Splittet ut journalføringen av tilbakekrevingsvedtaket til egen task, slik at det blir lettere å se om akkurat denne prosessen kjørte OK. Denne tasken opprettes når vedtaket blir godkjent, og er derfor da helt uavhengig av andre prosesser som skjer etter. Det blir noe duplikat kode, men logikk koblet til akkurat tilbakekrevingsvedtaket blir lettere å justere på.
- Laget tester