### PR TITLE
Generering av PDF for tilbakekrevingsvedtak ved motregning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtak.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningBrevService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
@@ -57,6 +58,7 @@ class BeslutteVedtak(
     private val tilbakekrevingService: TilbakekrevingService,
     private val brevmottakerService: BrevmottakerService,
     private val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
+    private val tilbakekrevingsvedtakMotregningBrevService: TilbakekrevingsvedtakMotregningBrevService,
 ) : BehandlingSteg<RestBeslutningPåVedtak> {
     override fun utførStegOgAngiNeste(
         behandling: Behandling,
@@ -120,6 +122,10 @@ class BeslutteVedtak(
             }
 
             vedtakService.oppdaterVedtaksdatoOgBrev(vedtak)
+
+            tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(behandling.id)?.let {
+                tilbakekrevingsvedtakMotregningBrevService.opprettOgLagreTilbakekrevingsvedtakMotregningPdf(behandling.id)
+            }
 
             val nesteSteg = sjekkOmBehandlingSkalIverksettesOgHentNesteSteg(behandling)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -11,9 +11,12 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.tilstand.BehandlingStegTilstand
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatSteg
+import no.nav.familie.ba.sak.kjerne.beregning.AvregningService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.validerPerioderInneholderBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
@@ -37,6 +40,8 @@ class SendTilBeslutter(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val automatiskBeslutningService: AutomatiskBeslutningService,
     private val validerBrevmottakerService: ValiderBrevmottakerService,
+    private val avregningService: AvregningService,
+    private val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
 ) : BehandlingSteg<String> {
     override fun preValiderSteg(
         behandling: Behandling,
@@ -64,6 +69,12 @@ class SendTilBeslutter(
                 behandlingId = behandling.id,
                 fagsakId = behandling.fagsak.id,
             )
+        }
+
+        if (avregningService.behandlingHarPerioderSomAvregnes(behandling.id)) {
+            tilbakekrevingsvedtakMotregningService
+                .hentTilbakekrevingsvedtakMotregningEllerKastFunksjonellFeil(behandling.id)
+                .validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter()
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutter.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.AvregningService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningBrevService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
@@ -42,6 +43,7 @@ class SendTilBeslutter(
     private val validerBrevmottakerService: ValiderBrevmottakerService,
     private val avregningService: AvregningService,
     private val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
+    private val tilbakekrevingsvedtakMotregningBrevService: TilbakekrevingsvedtakMotregningBrevService,
 ) : BehandlingSteg<String> {
     override fun preValiderSteg(
         behandling: Behandling,
@@ -103,6 +105,10 @@ class SendTilBeslutter(
         if (!behandling.skalBehandlesAutomatisk) {
             val vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId = behandling.id)
             vedtakService.oppdaterVedtakMedStønadsbrev(vedtak)
+        }
+
+        tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(behandling.id)?.let {
+            tilbakekrevingsvedtakMotregningBrevService.opprettOgLagreTilbakekrevingsvedtakMotregningPdf(behandling.id)
         }
 
         behandlingService.sendBehandlingTilBeslutter(behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregning.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import no.nav.familie.ba.sak.common.BaseEntitet
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekrevingsvedtakMotregning
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
@@ -55,3 +56,21 @@ fun TilbakekrevingsvedtakMotregning.tilRestTilbakekrevingsvedtakMotregning() =
         samtykke = this.samtykke,
         heleBeløpetSkalKrevesTilbake = this.heleBeløpetSkalKrevesTilbake,
     )
+
+fun TilbakekrevingsvedtakMotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter() {
+    if (!samtykke) {
+        throw FunksjonellFeil("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter hvis samtykke ikke er bekreftet.")
+    }
+    if (!heleBeløpetSkalKrevesTilbake) {
+        throw FunksjonellFeil("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter hvis ikke hele beløpet skal kreves tilbake.")
+    }
+    if (varselDato.isAfter(LocalDate.now())) {
+        throw FunksjonellFeil("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter med fremtidig varseldato.")
+    }
+    if (årsakTilFeilutbetaling.isNullOrBlank()) {
+        throw FunksjonellFeil("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter uten årsak til feilutbetaling.")
+    }
+    if (vurderingAvSkyld.isNullOrBlank()) {
+        throw FunksjonellFeil("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter uten vurdering av skyld.")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -161,6 +161,7 @@ class BeslutteVedtakTest {
 
             every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
             every { tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns mockk()
+            every { tilbakekrevingsvedtakMotregningBrevService.opprettOgLagreTilbakekrevingsvedtakMotregningPdf(any()) } returns mockk()
             every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
             mockkObject(FerdigstillOppgaver.Companion)
             every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningBrevService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
@@ -69,7 +70,8 @@ class BeslutteVedtakTest {
     private val simuleringService = mockk<SimuleringService>()
     private val tilbakekrevingService = mockk<TilbakekrevingService>()
     private val brevmottakerService = mockk<BrevmottakerService>()
-    private val mockTilbakekrevingsvedtakMotregningService = mockk<TilbakekrevingsvedtakMotregningService>()
+    private val tilbakekrevingsvedtakMotregningService = mockk<TilbakekrevingsvedtakMotregningService>()
+    private val tilbakekrevingsvedtakMotregningBrevService = mockk<TilbakekrevingsvedtakMotregningBrevService>()
 
     val beslutteVedtak =
         BeslutteVedtak(
@@ -87,7 +89,8 @@ class BeslutteVedtakTest {
             simuleringService = simuleringService,
             tilbakekrevingService = tilbakekrevingService,
             brevmottakerService = brevmottakerService,
-            tilbakekrevingsvedtakMotregningService = mockTilbakekrevingsvedtakMotregningService,
+            tilbakekrevingsvedtakMotregningService = tilbakekrevingsvedtakMotregningService,
+            tilbakekrevingsvedtakMotregningBrevService = tilbakekrevingsvedtakMotregningBrevService,
         )
 
     private val randomVilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
@@ -119,7 +122,7 @@ class BeslutteVedtakTest {
         every { tilbakekrevingService.søkerHarÅpenTilbakekreving(any()) } returns false
         every { tilbakekrevingService.hentTilbakekrevingsvalg(any()) } returns null
         every { simuleringService.hentFeilutbetaling(any<Long>()) } returns BigDecimal.ZERO
-        every { mockTilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns null
+        every { tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns null
     }
 
     @Nested
@@ -157,7 +160,7 @@ class BeslutteVedtakTest {
             val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
 
             every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
-            every { mockTilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns mockk()
+            every { tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns mockk()
             every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
             mockkObject(FerdigstillOppgaver.Companion)
             every { FerdigstillOppgaver.opprettTask(any(), any()) } returns Task(FerdigstillOppgaver.TASK_STEP_TYPE, "")
@@ -421,6 +424,29 @@ class BeslutteVedtakTest {
                 }.melding
 
             assertThat(feilmelding).isEqualTo("Det er en feilutbetaling som saksbehandler ikke har tatt stilling til. Saken må underkjennes og sendes tilbake til saksbehandler for ny vurdering.")
+        }
+
+        @Test
+        fun `Skal oppdatere vedtaksbrev for tilbakekrevingsvedtak motregning`() {
+            // Arrange
+            val behandling = lagBehandling()
+
+            every { brevmottakerService.hentBrevmottakere(any()) } returns emptyList()
+            every { automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(any()) } returns false
+            every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
+            every { beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(any()) } returns EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING
+            every { tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(any()) } returns mockk()
+            every { tilbakekrevingsvedtakMotregningBrevService.opprettOgLagreTilbakekrevingsvedtakMotregningPdf(any()) } returns mockk()
+
+            // Act
+            beslutteVedtak.utførStegOgAngiNeste(behandling, RestBeslutningPåVedtak(Beslutning.GODKJENT))
+
+            // Assert
+            verify(exactly = 1) {
+                tilbakekrevingsvedtakMotregningBrevService.opprettOgLagreTilbakekrevingsvedtakMotregningPdf(
+                    behandling.id,
+                )
+            }
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/SendTilBeslutterTest.kt
@@ -193,7 +193,7 @@ class SendTilBeslutterTest {
 
             // Act
             val feil =
-                assertThrows<Feil> {
+                assertThrows<FunksjonellFeil> {
                     sendTilBeslutter.preValiderSteg(behandling, stegService)
                 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/tilbakekrevingsvedtakmotregning/TilbakekrevingsvedtakMotregningServiceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -474,11 +473,11 @@ class TilbakekrevingsvedtakMotregningServiceTest {
 
             // Act & Assert
             val feil =
-                assertThrows<Feil> {
+                assertThrows<FunksjonellFeil> {
                     tilbakekrevingsvedtakMotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter()
                 }
 
-            assertThat(feil.message).isEqualTo("Kan ikke sende tilbakekrevingsvedtak motregning til beslutter hvis samtykke ikke er bekreftet.")
+            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter hvis samtykke ikke er bekreftet.")
         }
 
         @Test
@@ -493,11 +492,11 @@ class TilbakekrevingsvedtakMotregningServiceTest {
 
             // Act & Assert
             val feil =
-                assertThrows<Feil> {
+                assertThrows<FunksjonellFeil> {
                     tilbakekrevingsvedtakMotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter()
                 }
 
-            assertThat(feil.message).isEqualTo("Kan ikke sende tilbakekrevingsvedtak motregning til beslutter hvis ikke hele beløpet skal kreves tilbake.")
+            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter hvis ikke hele beløpet skal kreves tilbake.")
         }
 
         @Test
@@ -517,7 +516,7 @@ class TilbakekrevingsvedtakMotregningServiceTest {
                     tilbakekrevingsvedtakMotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter()
                 }
 
-            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak motregning til beslutter med fremtidig varseldato.")
+            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter med fremtidig varseldato.")
         }
 
         @Test
@@ -538,7 +537,7 @@ class TilbakekrevingsvedtakMotregningServiceTest {
                     tilbakekrevingsvedtakMotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter()
                 }
 
-            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak motregning til beslutter uten årsak til feilutbetaling.")
+            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter uten årsak til feilutbetaling.")
         }
 
         @Test
@@ -560,7 +559,7 @@ class TilbakekrevingsvedtakMotregningServiceTest {
                     tilbakekrevingsvedtakMotregning.validerAtTilbakekrevingsvedtakMotregningKanSendesTilBeslutter()
                 }
 
-            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak motregning til beslutter uten vurdering av skyld.")
+            assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke sende tilbakekrevingsvedtak ved motregning til beslutter uten vurdering av skyld.")
         }
 
         @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -75,6 +75,7 @@ import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.Personopplysnin
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningBrevService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
@@ -342,6 +343,12 @@ class CucumberMock(
             tilbakestillBehandlingTilSimuleringService = tilbakestillBehandlingTilSimuleringService,
         )
 
+    val tilbakekrevingsvedtakMotregningBrevService =
+        TilbakekrevingsvedtakMotregningBrevService(
+            tilbakekrevingsvedtakMotregningRepository = tilbakekrevingsvedtakMotregningRepository,
+            dokumentGenereringService = dokumentGenereringService,
+        )
+
     val utenlandskPeriodebeløpService =
         UtenlandskPeriodebeløpService(
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
@@ -582,6 +589,7 @@ class CucumberMock(
             tilbakekrevingService = tilbakekrevingService,
             brevmottakerService = brevmottakerService,
             tilbakekrevingsvedtakMotregningService = tilbakekrevingsvedtakMotregningService,
+            tilbakekrevingsvedtakMotregningBrevService = tilbakekrevingsvedtakMotregningBrevService,
         )
 
     val stegService =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25099

Sånn koden er nå er vi avhengig av at saksbehandler og beslutter forhåndsviser vedtaksbrevet for at det skal bli generert, men vi trenger at brevet blir generert uavhengig av om de ser på det eller ikke.

- Legger til validering på at `TilbakekrevingsvedtakMotregning` er riktig utfylt i `SendTilBeslutter::preValiderSteg`
- Legger til generering av brev i `SendTilBeslutter::utførStegOgAngiNeste`
- Legger til generering av brev i `BeslutteVedtak::utførStegOgAngiNeste`