### PR TITLE
Fiks gyldige begrunnelser ved perioder etter endret utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/IEndretUtbetalingAndelForVedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/IEndretUtbetalingAndelForVedtaksperiode.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.UtfyltEndretUtbetali
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
 
 sealed interface IEndretUtbetalingAndelForVedtaksperiode {
     val prosent: BigDecimal
@@ -16,6 +17,8 @@ data class EndretUtbetalingAndelForVedtaksperiode(
     override val prosent: BigDecimal,
     override val årsak: Årsak,
     override val søknadstidspunkt: LocalDate,
+    val fom: YearMonth,
+    val tom: YearMonth,
 ) : IEndretUtbetalingAndelForVedtaksperiode
 
 data class EndretUtbetalingAndelForVedtaksperiodeDeltBosted(
@@ -38,5 +41,7 @@ fun IUtfyltEndretUtbetalingAndel.tilEndretUtbetalingAndelForVedtaksperiode(): IE
             prosent = this.prosent,
             årsak = this.årsak,
             søknadstidspunkt = this.søknadstidspunkt,
+            fom = this.fom,
+            tom = this.tom,
         )
     }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/etter_endret_utbetaling.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/gyldigeBegrunnelser/etter_endret_utbetaling.feature
@@ -67,9 +67,130 @@ Egenskap: Gyldige begrunnelser for etter endret utbetaling, en mor med ett barn
 
     Så forvent at følgende begrunnelser er gyldige
       | Fra dato   | Til dato   | VedtaksperiodeType | Gyldige begrunnelser                          | Ugyldige begrunnelser |
-      | 01.05.2020 | 31.01.2021 | OPPHØR             |                                               |                          |
-      | 01.02.2021 | 31.03.2038 | UTBETALING         | ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_AAR |                          |
-      | 01.04.2038 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR                            |                          |
+      | 01.05.2020 | 31.01.2021 | OPPHØR             |                                               |                       |
+      | 01.02.2021 | 31.03.2038 | UTBETALING         | ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_AAR |                       |
+      | 01.04.2038 |            | OPPHØR             | OPPHØR_UNDER_18_ÅR                            |                       |
 
+  Scenario: Vilkår som ble utgjørende i forrige periode men ikke blir begrunnet grunnet endret utbetaling skal kunne begrunnes neste periode
 
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype | Status    |
+      | 1        | NORMAL     | AVSLUTTET |
 
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat        | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | AVSLÅTT                    | SØKNAD           | Nei                       | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | DELVIS_INNVILGET_OG_ENDRET | SØKNAD           | Nei                       | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 18.02.1990  |              |
+      | 1            | 2       | BARN       | 27.07.2016  |              |
+      | 1            | 3       | BARN       | 15.01.2019  |              |
+      | 1            | 4       | BARN       | 07.07.2020  |              |
+      | 1            | 5       | BARN       | 28.06.2023  |              |
+      | 2            | 1       | SØKER      | 18.02.1990  |              |
+      | 2            | 2       | BARN       | 27.07.2016  |              |
+      | 2            | 3       | BARN       | 15.01.2019  |              |
+      | 2            | 4       | BARN       | 07.07.2020  |              |
+      | 2            | 5       | BARN       | 28.06.2023  |              |
+
+    Og dagens dato er 11.05.2025
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+      | 2            | 5       |
+      | 2            | 4       |
+      | 2            | 3       |
+      | 2            | 2       |
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser        | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD               |                  | 02.08.2019 |            | OPPFYLT      | Nei                  |                             | NASJONALE_REGLER |
+      | 1       | BOSATT_I_RIKET               |                  | 25.11.2020 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_BOSATT_I_RIKET_SØKER | NASJONALE_REGLER |
+
+      | 2       | GIFT_PARTNERSKAP             |                  | 27.07.2016 |            | OPPFYLT      | Nei                  |                             |                  |
+      | 2       | BOR_MED_SØKER                |                  | 27.07.2016 |            | OPPFYLT      | Nei                  |                             | NASJONALE_REGLER |
+      | 2       | UNDER_18_ÅR                  |                  | 27.07.2016 | 26.07.2034 | OPPFYLT      | Nei                  |                             |                  |
+      | 2       | LOVLIG_OPPHOLD               |                  | 02.08.2019 |            | OPPFYLT      | Nei                  |                             | NASJONALE_REGLER |
+      | 2       | BOSATT_I_RIKET               |                  | 25.11.2020 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_BOSATT_I_RIKET       | NASJONALE_REGLER |
+
+      | 3       | LOVLIG_OPPHOLD,BOR_MED_SØKER |                  | 15.01.2019 |            | OPPFYLT      | Nei                  |                             | NASJONALE_REGLER |
+      | 3       | UNDER_18_ÅR                  |                  | 15.01.2019 | 14.01.2037 | OPPFYLT      | Nei                  |                             |                  |
+      | 3       | GIFT_PARTNERSKAP             |                  | 15.01.2019 |            | OPPFYLT      | Nei                  |                             |                  |
+      | 3       | BOSATT_I_RIKET               |                  | 25.11.2020 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_BOSATT_I_RIKET       | NASJONALE_REGLER |
+
+      | 4       | GIFT_PARTNERSKAP             |                  | 07.07.2020 |            | OPPFYLT      | Nei                  |                             |                  |
+      | 4       | LOVLIG_OPPHOLD,BOR_MED_SØKER |                  | 07.07.2020 |            | OPPFYLT      | Nei                  |                             | NASJONALE_REGLER |
+      | 4       | UNDER_18_ÅR                  |                  | 07.07.2020 | 06.07.2038 | OPPFYLT      | Nei                  |                             |                  |
+      | 4       | BOSATT_I_RIKET               |                  | 25.11.2020 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_BOSATT_I_RIKET       | NASJONALE_REGLER |
+
+      | 5       | LOVLIG_OPPHOLD,BOR_MED_SØKER |                  | 28.06.2023 |            | OPPFYLT      | Nei                  |                             | NASJONALE_REGLER |
+      | 5       | BOSATT_I_RIKET               |                  | 28.06.2023 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_BOSATT_I_RIKET       | NASJONALE_REGLER |
+      | 5       | UNDER_18_ÅR                  |                  | 28.06.2023 | 27.06.2041 | OPPFYLT      | Nei                  |                             |                  |
+      | 5       | GIFT_PARTNERSKAP             |                  | 28.06.2023 |            | OPPFYLT      | Nei                  |                             |                  |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår   | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD               |                    | 02.08.2019 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | BOSATT_I_RIKET               | VURDERT_MEDLEMSKAP | 16.08.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 2       | UNDER_18_ÅR                  |                    | 27.07.2016 | 26.07.2034 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOR_MED_SØKER                |                    | 27.07.2016 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | GIFT_PARTNERSKAP             |                    | 27.07.2016 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | LOVLIG_OPPHOLD               |                    | 02.08.2019 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BOSATT_I_RIKET               | VURDERT_MEDLEMSKAP | 16.08.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 3       | BOR_MED_SØKER,LOVLIG_OPPHOLD |                    | 15.01.2019 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 3       | UNDER_18_ÅR                  |                    | 15.01.2019 | 14.01.2037 | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | GIFT_PARTNERSKAP             |                    | 15.01.2019 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | BOSATT_I_RIKET               | VURDERT_MEDLEMSKAP | 16.08.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 4       | GIFT_PARTNERSKAP             |                    | 07.07.2020 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 4       | LOVLIG_OPPHOLD,BOR_MED_SØKER |                    | 07.07.2020 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 4       | UNDER_18_ÅR                  |                    | 07.07.2020 | 06.07.2038 | OPPFYLT  | Nei                  |                      |                  |
+      | 4       | BOSATT_I_RIKET               | VURDERT_MEDLEMSKAP | 16.08.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 5       | UNDER_18_ÅR                  |                    | 28.06.2023 | 27.06.2041 | OPPFYLT  | Nei                  |                      |                  |
+      | 5       | GIFT_PARTNERSKAP             |                    | 28.06.2023 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 5       | LOVLIG_OPPHOLD,BOR_MED_SØKER |                    | 28.06.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 5       | BOSATT_I_RIKET               | VURDERT_MEDLEMSKAP | 16.08.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+    Og med endrede utbetalinger
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak              | Prosent | Søknadstidspunkt | Avtaletidspunkt delt bosted |
+      | 5       | 2            | 01.09.2023 | 30.11.2024 | ETTERBETALING_3MND | 0       | 20.03.2025       |                             |
+      | 3       | 2            | 01.09.2023 | 30.11.2024 | ETTERBETALING_3MND | 0       | 20.03.2025       |                             |
+      | 4       | 2            | 01.09.2023 | 30.11.2024 | ETTERBETALING_3MND | 0       | 20.03.2025       |                             |
+      | 2       | 2            | 01.09.2023 | 30.11.2024 | ETTERBETALING_3MND | 0       | 20.03.2025       |                             |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+
+      | 2       | 2            | 01.09.2023 | 30.11.2024 | 0     | ORDINÆR_BARNETRYGD | 0       | 1310 |
+      | 2       | 2            | 01.12.2024 | 30.04.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.05.2025 | 30.06.2034 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 3       | 2            | 01.09.2023 | 30.11.2024 | 0     | ORDINÆR_BARNETRYGD | 0       | 1766 |
+      | 3       | 2            | 01.12.2024 | 30.04.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 2            | 01.05.2025 | 31.12.2036 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 4       | 2            | 01.09.2023 | 30.11.2024 | 0     | ORDINÆR_BARNETRYGD | 0       | 1766 |
+      | 4       | 2            | 01.12.2024 | 30.04.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 4       | 2            | 01.05.2025 | 30.06.2038 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 5       | 2            | 01.09.2023 | 30.11.2024 | 0     | ORDINÆR_BARNETRYGD | 0       | 1766 |
+      | 5       | 2            | 01.12.2024 | 30.04.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 5       | 2            | 01.05.2025 | 31.05.2041 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                 | Ugyldige begrunnelser |
+      | 01.09.2023 | 30.11.2024 | OPPHØR             |                                |                                      |                       |
+      | 01.12.2024 | 30.04.2025 | UTBETALING         |                                | INNVILGET_HELE_FAMILIEN_TRYGDEAVTALE |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser                 | Eøsbegrunnelser | Fritekster |
+      | 01.12.2024 | 30.04.2025 | INNVILGET_HELE_FAMILIEN_TRYGDEAVTALE |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.12.2024 til 30.04.2025
+      | Begrunnelse                          | Type     | Gjelder søker | Barnas fødselsdatoer                     | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet | Avtaletidspunkt delt bosted |
+      | INNVILGET_HELE_FAMILIEN_TRYGDEAVTALE | STANDARD |               | 27.07.16, 15.01.19, 07.07.20 og 28.06.23 | 4           | november 2024                        |         | 7 064 |                  |                         |                             |


### PR DESCRIPTION
Favrokort:  https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25092

I denne barnetrygd saken har vedkommende og familien kommet til norge.
Måneden etter er de innvilget barnetrygd, men pga etterbetaling 3 måneder regelen så får de ikke utbetalt de første 3 månedene de skulle ha betaling for.

Det opprettes derfor 2 vedtaksperioder, en for den første perioden de ikke får utbetaling, og en for perioden etter.
Det er ønskelig å benytte innvilgelse begrunnelser på den siste perioden, men det er ikke mulig.
Dette er fordi at når vilkår blir utgjørende, forventer vi at man skal begrunne dem i samme periode (i dette tilfellet, i den første perioden). 

Jeg har derfor justert på koden slik at hvis man i den forrige perioden hadde endret utbetaling andeler som startet samtidig som en vilkår ble gyldig og den var utgjørende, skal man kunne bruke innvilgelses begrunnelser i samme periode som endret utbetaling andelen ender.