### PR TITLE
Sjekker at ident har aktiv fødselsnummer før man sjekker perioder for Bisys, slik at man ikke trigger alarm til vakta

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysService.kt
@@ -9,9 +9,11 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.person.pdl.aktor.v2.Type
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import kotlin.collections.filter
 
 @Service
 class BisysService(
@@ -25,6 +27,12 @@ class BisysService(
         personIdent: String,
         fraDato: LocalDate,
     ): BisysUtvidetBarnetrygdResponse {
+        val identerFraPdl = personidentService.hentIdenter(personIdent, false)
+        if (identerFraPdl.filter { it.gruppe == Type.FOLKEREGISTERIDENT.name }.isEmpty()) {
+            secureLogger.info("Fant ikke gyldig fnr i PDL for $personIdent - $identerFraPdl. Returnerer tom liste til Bisys")
+            return BisysUtvidetBarnetrygdResponse(emptyList())
+        }
+
         val aktør = personidentService.hentAktør(personIdent)
 
         val samledeUtvidetBarnetrygdPerioder = mutableListOf<UtvidetBarnetrygdPeriode>()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bidrag kaller oss noen ganger med NPID. Da har man ikke aktiv fødselsnummer og dermed trigges det en alarm. Legger inn en sjekk om aktiv fødselsnummer og heller returnerer en tom liste hvis dette ikke finnes. Da slipper vi og Bidrag å få feil ved kun NPID ident. Dette fordi vi har ikke saker med NPID.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
