### PR TITLE
Bruk Azure AD ved sjekk av enhet sb har tilgang til

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250519094842_e8bd711</prosessering.version>
         <felles.version>3.20250505101905_835431d</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250422132745_dfaa902</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20250513140227_11db730</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250520105353_6584047</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20250422132745_dfaa902</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20250422132745_dfaa902</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250415144931_0dc88d8</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/BarnetrygdEnhet.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/BarnetrygdEnhet.kt
@@ -3,14 +3,15 @@ package no.nav.familie.ba.sak.kjerne.arbeidsfordeling
 enum class BarnetrygdEnhet(
     val enhetsnummer: String,
     val enhetsnavn: String,
+    val gruppenavn: String,
 ) {
-    VIKAFOSSEN("2103", "NAV Vikafossen"),
-    DRAMMEN("4806", "NAV Familie- og pensjonsytelser Drammen"),
-    VADSØ("4820", "NAV Familie- og pensjonsytelser Vadsø"),
-    OSLO("4833", "NAV Familie- og pensjonsytelser Oslo 1"),
-    STORD("4842", "NAV Familie- og pensjonsytelser Stord"),
-    STEINKJER("4817", "NAV Familie- og pensjonsytelser Steinkjer"),
-    MIDLERTIDIG_ENHET("4863", "Midlertidig enhet"),
+    VIKAFOSSEN("2103", "NAV Vikafossen", "0000-GA-ENHET_2103"),
+    DRAMMEN("4806", "NAV Familie- og pensjonsytelser Drammen", "0000-GA-ENHET_4806"),
+    VADSØ("4820", "NAV Familie- og pensjonsytelser Vadsø", "0000-GA-ENHET_4820"),
+    OSLO("4833", "NAV Familie- og pensjonsytelser Oslo 1", "0000-GA-ENHET_4833"),
+    STORD("4842", "NAV Familie- og pensjonsytelser Stord", "0000-GA-ENHET_4842"),
+    STEINKJER("4817", "NAV Familie- og pensjonsytelser Steinkjer", "0000-GA-ENHET_4817"),
+    MIDLERTIDIG_ENHET("4863", "Midlertidig enhet", "0000-GA-ENHET_4863"),
     ;
 
     override fun toString(): String = "$enhetsnavn ($enhetsnummer)"

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/IntegrasjonClientMock.kt
@@ -19,7 +19,6 @@ import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.OppdaterJournal
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
 import no.nav.familie.ba.sak.kjerne.modiacontext.ModiaContext
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
-import no.nav.familie.kontrakter.felles.enhet.Enhet
 import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.kodeverk.BeskrivelseDto
 import no.nav.familie.kontrakter.felles.kodeverk.BetydningDto
@@ -183,7 +182,7 @@ class IntegrasjonClientMock {
                 )
             }
 
-            every { mockIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(any()) } returns BarnetrygdEnhet.entries.map { Enhet(it.enhetsnummer, it.enhetsnavn) }
+            every { mockIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(any()) } returns BarnetrygdEnhet.entries
 
             every { mockIntegrasjonClient.hentModiaContext() } answers {
                 ModiaContext(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClientTest.kt
@@ -38,7 +38,7 @@ class IntegrasjonClientTest {
 
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/enhetstilganger"))
+                .get(WireMock.urlEqualTo("/saksbehandler/1/grupper"))
                 .willReturn(WireMock.okJson(readFile("enheterNavIdentHarTilgangTilResponse.json"))),
         )
 
@@ -52,8 +52,8 @@ class IntegrasjonClientTest {
             assertThat(it.enhetsnavn).isEqualTo(BarnetrygdEnhet.VADSØ.enhetsnavn)
         }
         assertThat(enheter).anySatisfy {
-            assertThat(it.enhetsnummer).isEqualTo(BarnetrygdEnhet.OSLO.enhetsnummer)
-            assertThat(it.enhetsnavn).isEqualTo(BarnetrygdEnhet.OSLO.enhetsnavn)
+            assertThat(it.enhetsnummer).isEqualTo(BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer)
+            assertThat(it.enhetsnavn).isEqualTo(BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClien
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import no.nav.familie.kontrakter.felles.NavIdent
-import no.nav.familie.kontrakter.felles.enhet.Enhet
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -75,9 +74,7 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns emptyList()
 
             // Act & assert
@@ -103,16 +100,9 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns
-                listOf(
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
-                )
+                listOf(BarnetrygdEnhet.VIKAFOSSEN)
 
             // Act
             val tilpassetArbeidsfordelingsenhet =
@@ -141,23 +131,12 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
-                    Enhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil1.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil1.enhetsnavn,
-                    ),
-                    Enhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil2.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil2.enhetsnavn,
-                    ),
+                    BarnetrygdEnhet.VIKAFOSSEN,
+                    BarnetrygdEnhet.OSLO,
+                    BarnetrygdEnhet.DRAMMEN,
                 )
 
             // Act
@@ -208,19 +187,11 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil1.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil1.enhetsnavn,
-                    ),
-                    Enhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil2.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil2.enhetsnavn,
-                    ),
+                    BarnetrygdEnhet.STEINKJER,
+                    BarnetrygdEnhet.VADSØ,
                 )
 
             // Act
@@ -247,20 +218,9 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns
-                listOf(
-                    Enhet(
-                        enhetsnummer = "1234",
-                        enhetsnavn = "Fiktiv enhet",
-                    ),
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
-                )
+                listOf(BarnetrygdEnhet.VIKAFOSSEN)
 
             // Act
             val tilpassetArbeidsfordelingsenhet =
@@ -307,9 +267,7 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns emptyList()
 
             // Act & assert
@@ -335,15 +293,10 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
+                    BarnetrygdEnhet.VIKAFOSSEN,
                 )
 
             // Act
@@ -364,7 +317,6 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
 
             val enhetNavIdentHarTilgangTil1 = BarnetrygdEnhet.OSLO
-            val enhetNavIdentHarTilgangTil2 = BarnetrygdEnhet.DRAMMEN
 
             val arbeidsfordelingsenhet =
                 Arbeidsfordelingsenhet(
@@ -373,23 +325,12 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
-                    Enhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil1.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil1.enhetsnavn,
-                    ),
-                    Enhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil2.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil2.enhetsnavn,
-                    ),
+                    BarnetrygdEnhet.VIKAFOSSEN,
+                    BarnetrygdEnhet.OSLO,
+                    BarnetrygdEnhet.DRAMMEN,
                 )
 
             // Act
@@ -418,23 +359,12 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             every {
-                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
-                    navIdent = navIdent,
-                )
+                mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
             } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                    ),
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
-                    Enhet(
-                        enhetsnummer = arbeidsfordelingEnhet.enhetsnummer,
-                        enhetsnavn = arbeidsfordelingEnhet.enhetsnavn,
-                    ),
+                    BarnetrygdEnhet.MIDLERTIDIG_ENHET,
+                    BarnetrygdEnhet.VIKAFOSSEN,
+                    BarnetrygdEnhet.OSLO,
                 )
 
             // Act
@@ -484,12 +414,7 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
-                listOf(
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
-                )
+                    listOf(BarnetrygdEnhet.VIKAFOSSEN)
 
             // Act
             val tilordnetRessurs =
@@ -510,12 +435,7 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
-                listOf(
-                    Enhet(
-                        enhetsnummer = BarnetrygdEnhet.OSLO.enhetsnummer,
-                        enhetsnavn = BarnetrygdEnhet.OSLO.enhetsnavn,
-                    ),
-                )
+                    listOf(BarnetrygdEnhet.OSLO)
 
             // Act
             val tilordnetRessurs =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
@@ -414,7 +414,7 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
-                    listOf(BarnetrygdEnhet.VIKAFOSSEN)
+                listOf(BarnetrygdEnhet.VIKAFOSSEN)
 
             // Act
             val tilordnetRessurs =
@@ -435,7 +435,7 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
-                    listOf(BarnetrygdEnhet.OSLO)
+                listOf(BarnetrygdEnhet.OSLO)
 
             // Act
             val tilordnetRessurs =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagKlagebehandlingDto
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
@@ -22,7 +23,6 @@ import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
-import no.nav.familie.kontrakter.felles.enhet.Enhet
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.KanIkkeOppretteRevurderingÅrsak
 import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
@@ -277,8 +277,8 @@ class KlageServiceTest {
         fun `skal sette enheten til saksbehandlers enhet ved opprettelse av klage`() {
             // Arrange
             val fagsak = lagFagsak()
-            val forventetEnhet = Enhet("1234", "en")
-            val enhetSomIkkeBurdeVelges = Enhet("2341", "to")
+            val forventetEnhet = BarnetrygdEnhet.OSLO
+            val enhetSomIkkeBurdeVelges = BarnetrygdEnhet.VIKAFOSSEN
             every { integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(any()) } returns
                 listOf(forventetEnhet, enhetSomIkkeBurdeVelges)
 

--- a/src/test/resources/familieintegrasjoner/json/enheterNavIdentHarTilgangTilResponse.json
+++ b/src/test/resources/familieintegrasjoner/json/enheterNavIdentHarTilgangTilResponse.json
@@ -1,14 +1,123 @@
 {
-  "data": [
-    {
-      "enhetsnummer": "4820",
-      "enhetsnavn": "NAV Familie- og pensjonsytelser Vadsø"
-    },
-    {
-      "enhetsnummer": "4833",
-      "enhetsnavn": "NAV Familie- og pensjonsytelser Oslo 1"
-    }
-  ],
+  "data": {
+    "value": [
+      {
+        "id": "93a26831-9866-4410-927b-74ff51a9107c",
+        "displayName": "0000-GA-Barnetrygd-Veileder"
+      },
+      {
+        "id": "9449c153-5a1e-44a7-84c6-7cc7a8867233",
+        "displayName": "0000-GA-Barnetrygd-Beslutter"
+      },
+      {
+        "id": "314fa714-f13c-4cdc-ac5c-e13ce08e241c",
+        "displayName": "0000-GA-Barnetrygd-Superbruker"
+      },
+      {
+        "id": "52fe1bef-224f-49df-a40a-29f92d4520f8",
+        "displayName": "0000-GA-Kontantstotte-Beslutter"
+      },
+      {
+        "id": "c7e0b108-7ae6-432c-9ab4-946174c240c0",
+        "displayName": "0000-GA-Kontantstotte"
+      },
+      {
+        "id": "71f503a2-c28f-4394-a05a-8da263ceca4a",
+        "displayName": "0000-GA-Kontantstotte-Veileder"
+      },
+      {
+        "id": "28e66e77-d879-47f1-8835-fea505cfce9f",
+        "displayName": "0000-GA-GOSYS_MEDLEMSKAP_ENDRER"
+      },
+      {
+        "id": "6c7b1e6e-fd83-400f-9e0d-0f9e1bc24e4f",
+        "displayName": "0000-GA-PERSON-ENDRE_UTENLANDSKID"
+      },
+      {
+        "id": "87ea7c87-08a2-43bc-83d6-0bfeee92185d",
+        "displayName": "0000-GA-GOSYS_KODE6"
+      },
+      {
+        "id": "ea930b6b-9397-44d9-b9e6-f4cf527a632a",
+        "displayName": "0000-GA-Fortrolig_Adresse"
+      },
+      {
+        "id": "69d4a70f-1c83-42a8-8fb8-2f5d54048647",
+        "displayName": "0000-GA-GOSYS_KODE7"
+      },
+      {
+        "id": "5ef775f2-61f8-4283-bf3d-8d03f428aa14",
+        "displayName": "0000-GA-Strengt_Fortrolig_Adresse"
+      },
+      {
+        "id": "90fc4535-ab74-444e-8969-1935b9563e00",
+        "displayName": "0000-GA-GOSYS_LESE_INN_DOKUMENTER"
+      },
+      {
+        "id": "d12fdb94-ea30-452b-ad43-af1a3ab30157",
+        "displayName": "Alle-i-IT"
+      },
+      {
+        "id": "928636f4-fd0d-4149-978e-a6fb68bb19de",
+        "displayName": "0000-GA-STDAPPS"
+      },
+      {
+        "id": "3db683fb-ba0d-4d1a-aa92-153b101d9c88",
+        "displayName": "0000-GA-EnGangIAaret"
+      },
+      {
+        "id": "5044535d-245d-49ef-9a78-2efea67ba0bc",
+        "displayName": "0000-GA-GOSYS_LESE_UT_DOKUMENTER"
+      },
+      {
+        "id": "174bec27-e954-453b-8486-4a80d9fc7636",
+        "displayName": "0000-GA-GOSYS"
+      },
+      {
+        "id": "d2987104-63b2-4110-83ac-20ff6afe24a2",
+        "displayName": "0000-GA-GOSYS_REGIONAL"
+      },
+      {
+        "id": "a9f5ef81-4e81-42e8-b368-0273071b64b9",
+        "displayName": "0000-GA-GOSYS_OPPGAVE_BEHANDLER"
+      },
+      {
+        "id": "dec3ee50-b683-4644-9507-520e8f054ac2",
+        "displayName": "GRP Alle brukere"
+      },
+      {
+        "id": "b81de253-f948-4bdd-9897-a61012e5ebec",
+        "displayName": "0000-GA-GOSYS_Administrer_oppgaver"
+      },
+      {
+        "id": "3e3b7296-c57a-4b2b-9463-177aa1c96dd9",
+        "displayName": "0000-GA-TEMA_BAR"
+      },
+      {
+        "id": "e2cf416e-eb2b-4c86-8b5b-8c5b00385bcf",
+        "displayName": "0000-GA-ENHET_2103"
+      },
+      {
+        "id": "a996c91f-6dd1-466d-bed0-06ddccab87f5",
+        "displayName": "0000-GA-ENHET_4820"
+      },
+      {
+        "id": "cfe01415-0fdb-45cd-a94c-370199fe9956",
+        "displayName": "0000-GA-TEMA_KON"
+      },
+      {
+        "id": "52ca6398-d62b-4e01-bd60-8d3e4708a946",
+        "displayName": "checkpoint_inline_incoming"
+      },
+      {
+        "id": "da471520-ea8f-4590-aca9-579321cfd9ed",
+        "displayName": "All Users"
+      }
+    ]
+  },
   "status": "SUKSESS",
-  "melding": "Fant enheter"
+  "melding": "Hent saksbehandler grupper OK",
+  "frontendFeilmelding": null,
+  "stacktrace": null,
+  "callId": null
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25115

Den 01.10.2025 så legges Axsys ned.
Per i dag bruker vi Axsys til å sjekke om en saksbehandler har tilgang til en enhet før vi eventuelt setter saksbehandleren som tilordnet ressurs i oppgaven som vi oppretter, f.eks BehandleSak oppgaver når behandlinger opprettes.

Ref https://nav-it.slack.com/archives/CDKEM1HC5/p1726835363824219 så har det kommet azure grupper som erstatter axsys:

0000-GA-TEMA_XXX (f.eks. 0000-GA-TEMA_PEN)
0000-GA-ENHET_XXXX (f.eks. 0000-GA-ENHET_4803)

Alle saksbehandlere som hadde fått tilgang gjennom Axsys til enhet 4803 skal nå tilhøre gruppen 0000-GA-ENHET_4803.

Jeg har lagt til et endepunkt i familie-integrasjoner som henter alle grupper til en saksbehandler.
Disse mappes over til barnetrygd enheter i ba-sak, som er da enhetene bruker har tilgang til.