### PR TITLE
Fikser feilende cucumber-tester

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockUnleashService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockUnleashService.kt
@@ -10,6 +10,7 @@ fun mockUnleashNextMedContextService(): UnleashNextMedContextService {
     val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
     every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns true
     every { unleashNextMedContextService.isEnabled(any<FeatureToggle>(), any<Long>()) } returns true
+    every { unleashNextMedContextService.isEnabled(any<FeatureToggle>(), any<Boolean>()) } returns true
     return unleashNextMedContextService
 }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I noen cucumber-tester kalles `isEnabled()` med default-verdi. Dette var ikke støttet i `MockUnleashService`, og noen få cucumber-tester feilet. Legger her inn støtte for default verdi i `isEnabled`.