### PR TITLE
Fjern kode relatert til avregning som ikke skal brukes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -39,9 +39,6 @@ enum class FeatureToggle(
 
     BRUK_FUNKSJONALITET_FOR_ULOVFESTET_MOTREGNING("familie-ba-sak.ulovfestet-motregning"),
 
-    // NAV-24534
-    VALIDER_IKKE_AVREGNING("familie-ba-sak.valider-ikke-avregning"),
-
     // Tillatter behandling av klage
     BEHANDLE_KLAGE("familie-ba-sak.klage"),
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingSteg.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.steg
 
-import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -9,7 +7,6 @@ import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 
 @Service
 class VurderTilbakekrevingSteg(
@@ -22,9 +19,6 @@ class VurderTilbakekrevingSteg(
         behandling: Behandling,
         data: RestTilbakekreving?,
     ): StegType {
-        if (unleashService.isEnabled(FeatureToggle.VALIDER_IKKE_AVREGNING)) {
-            validerIkkeAvregning(behandling)
-        }
         if (!tilbakekrevingService.søkerHarÅpenTilbakekreving(behandling.fagsak.id)) {
             tilbakekrevingService.validerRestTilbakekreving(data, behandling.id)
             if (data != null) {
@@ -36,23 +30,4 @@ class VurderTilbakekrevingSteg(
     }
 
     override fun stegType(): StegType = StegType.VURDER_TILBAKEKREVING
-
-    private fun validerIkkeAvregning(behandling: Behandling) {
-        val brukerHarEtterbetaling = simuleringService.hentEtterbetaling(behandling.id) > BigDecimal.ZERO
-        if (brukerHarEtterbetaling) {
-            val brukerHarFeilutbetaling = simuleringService.hentFeilutbetaling(behandling.id) > BigDecimal.ZERO
-
-            val brukerHarÅpenTilbakekreving by lazy {
-                tilbakekrevingService.søkerHarÅpenTilbakekreving(behandling.fagsak.id)
-            }
-
-            if (brukerHarFeilutbetaling || brukerHarÅpenTilbakekreving) {
-                throw FunksjonellFeil(
-                    melding =
-                        "Løsningen i dag legger opp til automatisk avregning der feilutbetalinger trekkes mot etterbetalinger. " +
-                            "Dette har vi ikke hjemmel for. Du må derfor splitte saken for å gå videre.",
-                )
-            }
-        }
-    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.steg
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.ekstern.restDomene.RestTilbakekreving
@@ -13,12 +12,10 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 
 class VurderTilbakekrevingStegTest {
@@ -78,38 +75,5 @@ class VurderTilbakekrevingStegTest {
         assertTrue { stegType == StegType.SEND_TIL_BESLUTTER }
         verify(exactly = 0) { tilbakekrevingService.validerRestTilbakekreving(restTilbakekreving, behandling.id) }
         verify(exactly = 0) { tilbakekrevingService.lagreTilbakekreving(restTilbakekreving, behandling.id) }
-    }
-
-    @Test
-    fun `kaster FunksjonellFeil hvis behandling både har etterbetaling og feilutbetaling`() {
-        every { simuleringService.hentEtterbetaling(any(classifier = Long::class)) } returns BigDecimal(100)
-        every { simuleringService.hentFeilutbetaling(any(classifier = Long::class)) } returns BigDecimal(100)
-
-        val funksjonellFeil =
-            assertThrows<FunksjonellFeil> {
-                vurderTilbakekrevingSteg.utførStegOgAngiNeste(
-                    behandling,
-                    restTilbakekreving,
-                )
-            }
-
-        assertThat(funksjonellFeil.melding).isEqualTo("Løsningen i dag legger opp til automatisk avregning der feilutbetalinger trekkes mot etterbetalinger. Dette har vi ikke hjemmel for. Du må derfor splitte saken for å gå videre.")
-    }
-
-    @Test
-    fun `kaster FunksjonellFeil hvis behandling både har etterbetaling og fagsak har åpen tilbakekreving`() {
-        every { simuleringService.hentEtterbetaling(any(classifier = Long::class)) } returns BigDecimal(100)
-        every { simuleringService.hentFeilutbetaling(any(classifier = Long::class)) } returns BigDecimal.ZERO
-        every { tilbakekrevingService.søkerHarÅpenTilbakekreving(any(classifier = Long::class)) } returns true
-
-        val funksjonellFeil =
-            assertThrows<FunksjonellFeil> {
-                vurderTilbakekrevingSteg.utførStegOgAngiNeste(
-                    behandling,
-                    restTilbakekreving,
-                )
-            }
-
-        assertThat(funksjonellFeil.melding).isEqualTo("Løsningen i dag legger opp til automatisk avregning der feilutbetalinger trekkes mot etterbetalinger. Dette har vi ikke hjemmel for. Du må derfor splitte saken for å gå videre.")
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25282

Fjerner validering relatert til avregning som ikke skal brukes lenger etter at løypen for motregning er ferdig