### PR TITLE
Endre feilmelding i differanseberegning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
-import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.del
 import no.nav.familie.ba.sak.common.multipliser
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -53,7 +53,7 @@ fun AndelTilkjentYtelse.medDifferanseberegning(
             .intValueExact() // Fjern desimaler for å gi fordel til søker
 
     val nyttDifferanseberegnetPeriodebeløp by lazy {
-        (beløpUtenEndretUtbetaling ?: throw Feil("beløpUtenEndretUtbetaling kan ikke være null")) - avrundetUtenlandskPeriodebeløp
+        (beløpUtenEndretUtbetaling ?: throw FunksjonellFeil("En feil har oppstått. Gå tilbake til vilkårsvurderingen og trykk 'Neste'")) - avrundetUtenlandskPeriodebeløp
     }
 
     val nyttKalkulertUtbetalingsbeløp =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

For å unngå unødvendige henvendelser fra saksbehandlere, kastes det en `FunksjonellFeil` i stedet for en `Feil` med beskrivelse på hva de kan gjøre for å fikse problemet