### PR TITLE
Automatisk registrering av søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -14,6 +14,7 @@ enum class FeatureToggle(
 
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ba-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
     PREUTFYLLING_VILKÅR("familie-ba-sak.preutfylling-vilkaar"),
+    AUTOMAITSK_REGISTRER_SØKNAD("familie-ba-sak.automatisk-registrer-soknad"),
 
     // NAV-21071 lagt bak toggle og kan evt fjernes på sikt hvis man ikke har trengt å skru den på igjen
     SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM("familie-ba-sak.skalOpprettFremleggsoppgaveDersomEOSMedlem"),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.steg
 
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
 import no.nav.familie.ba.sak.ekstern.restDomene.SøkerMedOpplysninger
@@ -21,8 +22,8 @@ class AutomatiskRegistrerSøknadService(
 ) {
     fun lagRestRegistrerSøknad(behandling: Behandling): RestRegistrerSøknad {
         val søknad =
-            søknadService.hentSøknad(behandling.id)
-                ?: throw IllegalStateException("Fant ikke søknad for behandling med id ${behandling.id}")
+            søknadService.finnSøknad(behandling.id)
+                ?: throw Feil("Fant ikke søknad for behandling med id ${behandling.id}")
 
         val underkategori = søknad.behandlingUnderkategori.tilDto()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
@@ -1,0 +1,59 @@
+package no.nav.familie.ba.sak.kjerne.steg
+
+import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
+import no.nav.familie.ba.sak.ekstern.restDomene.RestRegistrerSøknad
+import no.nav.familie.ba.sak.ekstern.restDomene.SøkerMedOpplysninger
+import no.nav.familie.ba.sak.ekstern.restDomene.SøknadDTO
+import no.nav.familie.ba.sak.ekstern.restDomene.tilDto
+import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ba.sak.kjerne.søknad.SøknadService
+import org.springframework.stereotype.Service
+
+@Service
+class AutomatiskRegistrerSøknadService(
+    private val søknadService: SøknadService,
+    private val persongrunnlagService: PersongrunnlagService,
+    private val personidentService: PersonidentService,
+    private val personopplysningerService: PersonopplysningerService,
+) {
+    fun lagRestRegistrerSøknad(behandling: Behandling): RestRegistrerSøknad {
+        val søknad =
+            søknadService.hentSøknad(behandling.id)
+                ?: throw IllegalStateException("Fant ikke søknad for behandling med id ${behandling.id}")
+
+        val underkategori = søknad.behandlingUnderkategori.tilDto()
+
+        val søker = persongrunnlagService.hentSøker(behandling.id)
+        val søkerMedOpplysninger =
+            SøkerMedOpplysninger(
+                ident = søker.aktør.aktivFødselsnummer(),
+                målform = søknad.målform,
+            )
+
+        val barnaMedOpplysninger =
+            søknad.barn.map {
+                val barnAktør = personidentService.hentOgLagreAktør(it.fnr, true)
+                val barnPersonInfo = personopplysningerService.hentPersoninfoEnkel(barnAktør)
+
+                BarnMedOpplysninger(
+                    ident = barnAktør.aktivFødselsnummer(),
+                    navn = barnPersonInfo.navn ?: "",
+                    fødselsdato = barnPersonInfo.fødselsdato,
+                )
+            }
+
+        return RestRegistrerSøknad(
+            søknad =
+                SøknadDTO(
+                    underkategori = underkategori,
+                    søkerMedOpplysninger = søkerMedOpplysninger,
+                    barnaMedOpplysninger = barnaMedOpplysninger,
+                    endringAvOpplysningerBegrunnelse = "",
+                ),
+            bekreftEndringerViaFrontend = false,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/søknad/SøknadService.kt
@@ -10,7 +10,7 @@ class SøknadService(
     val integrasjonClient: IntegrasjonClient,
     val søknadMapperLookup: SøknadMapper.Lookup,
 ) {
-    fun hentSøknad(behandlingId: Long): Søknad? {
+    fun finnSøknad(behandlingId: Long): Søknad? {
         val søknadReferanse = søknadReferanseService.hentSøknadReferanse(behandlingId) ?: return null
         val versjonertBarnetrygdSøknad = integrasjonClient.hentVersjonertBarnetrygdSøknad(søknadReferanse.journalpostId)
         val søknadMapper = søknadMapperLookup.hentSøknadMapperForVersjon(versjonertBarnetrygdSøknad.barnetrygdSøknad.kontraktVersjon)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceTest.kt
@@ -62,12 +62,14 @@ class StegServiceTest {
             opprettTaskService = opprettTaskService,
             satskjøringRepository = satskjøringRepository,
             unleashService = unleashService,
+            automatiskRegistrerSøknadService = mockk(),
         )
 
     @BeforeEach
     fun setup() {
         every { tilgangService.validerTilgangTilBehandling(any(), any()) } just runs
         every { tilgangService.verifiserHarTilgangTilHandling(any(), any()) } just runs
+        every { unleashService.isEnabled(FeatureToggle.AUTOMAITSK_REGISTRER_SØKNAD) } returns true
     }
 
     @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/søknad/SøknadServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/søknad/SøknadServiceTest.kt
@@ -47,7 +47,7 @@ class SøknadServiceTest {
             every { søknadMapperLookup.hentSøknadMapperForVersjon(versjonertBarnetrygdSøknadV9.barnetrygdSøknad.kontraktVersjon) } returns SøknadMapperV9()
 
             // Act
-            val søknad = søknadService.hentSøknad(behandlingId = behandling.id)
+            val søknad = søknadService.finnSøknad(behandlingId = behandling.id)
 
             // Assert
             assertThat(søknad).isNotNull
@@ -66,7 +66,7 @@ class SøknadServiceTest {
             every { søknadReferanseService.hentSøknadReferanse(behandling.id) } returns null
 
             // Act
-            val søknad = søknadService.hentSøknad(behandlingId = behandling.id)
+            val søknad = søknadService.finnSøknad(behandlingId = behandling.id)
 
             // Assert
             assertThat(søknad).isNull()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -635,6 +635,7 @@ class CucumberMock(
                 opprettTaskService = mockk(),
                 satskjøringRepository = mockk(),
                 unleashService = unleashNextMedContextService,
+                automatiskRegistrerSøknadService = mockk(),
             ),
         )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
@@ -369,6 +369,8 @@ class SøknadGrunnlagTest(
                 ),
             )
 
+        assertThat(behandling.steg).isEqualTo(StegType.VILKÅRSVURDERING)
+
         val søknadGrunnlag = søknadGrunnlagService.hentAktiv(behandling.id)
         assertThat(søknadGrunnlag).isNotNull()
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25246

Legger til funksjonalitet for å automatisk gjennomføre `RegistrereSøknad`-steget, ved å hente søknaden som er knyttet til behandlingen fra `familie-integrasjoner`, og lage `RestRegistrerSøknad` med data fra søknaden. Legger all funksjonaliteten i en `try/catch`, slik at dersom et kall feiler / søknadsreferansen ikke finnes, feiler ikke hele tasken, men søknaden må registreres manuelt av saksbehandler.