### PR TITLE
Satsvalidering ved månedlig valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -103,13 +103,13 @@ class BehandlingsresultatSteg(
 
         if (behandling.erMånedligValutajustering()) {
             BehandlingsresultatValideringUtils.validerIngenEndringTilbakeITid(
-                andelerDenneBehandlingen = tilkjentYtelse.andelerTilkjentYtelse.toList(),
-                andelerForrigeBehandling = andelerForrigeBehandling.toList(),
+                andelerDenneBehandlingen = tilkjentYtelse.andelerTilkjentYtelse,
+                andelerForrigeBehandling = andelerForrigeBehandling,
                 nåMåned = localDateProvider.now().toYearMonth(),
             )
             BehandlingsresultatValideringUtils.validerSatsErUendret(
-                andelerDenneBehandlingen = tilkjentYtelse.andelerTilkjentYtelse.toList(),
-                andelerForrigeBehandling = andelerForrigeBehandling.toList(),
+                andelerDenneBehandlingen = tilkjentYtelse.andelerTilkjentYtelse,
+                andelerForrigeBehandling = andelerForrigeBehandling,
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -76,8 +76,8 @@ object BehandlingsresultatValideringUtils {
     }
 
     fun validerIngenEndringTilbakeITid(
-        andelerDenneBehandlingen: List<AndelTilkjentYtelse>,
-        andelerForrigeBehandling: List<AndelTilkjentYtelse>,
+        andelerDenneBehandlingen: Collection<AndelTilkjentYtelse>,
+        andelerForrigeBehandling: Collection<AndelTilkjentYtelse>,
         nåMåned: YearMonth,
     ) {
         val forrigeMåned = nåMåned.minusMonths(1)
@@ -97,8 +97,8 @@ object BehandlingsresultatValideringUtils {
     }
 
     fun validerSatsErUendret(
-        andelerDenneBehandlingen: List<AndelTilkjentYtelse>,
-        andelerForrigeBehandling: List<AndelTilkjentYtelse>,
+        andelerDenneBehandlingen: Collection<AndelTilkjentYtelse>,
+        andelerForrigeBehandling: Collection<AndelTilkjentYtelse>,
     ) {
         val andelerDenneBehandlingTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType()
         val andelerForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -105,7 +105,7 @@ object BehandlingsresultatValideringUtils {
 
         val endringISatsTidslinjer =
             andelerDenneBehandlingTidslinje.outerJoin(andelerForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
-                if (nyAndel?.sats != gammelAndel?.sats) {
+                if (nyAndel?.sats != gammelAndel?.sats && nyAndel?.kalkulertUtbetalingsbeløp != 0 && gammelAndel?.kalkulertUtbetalingsbeløp != 0) {
                     ErEndringIAndel(andelForrigeBehandling = gammelAndel, andelDenneBehandlingen = nyAndel)
                 } else {
                     IngenEndringIAndel

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -128,7 +128,7 @@ data class AndelTilkjentYtelse(
         )
 
     override fun toString(): String =
-        "AndelTilkjentYtelse(id = $id, behandling = $behandlingId, type = $type, prosent = $prosent, " +
+        "AndelTilkjentYtelse(id = $id, behandling = $behandlingId, type = $type, sats = $sats, prosent = $prosent, " +
             "beløp = $kalkulertUtbetalingsbeløp, stønadFom = $stønadFom, stønadTom = $stønadTom, periodeOffset = $periodeOffset, " +
             "forrigePeriodeOffset = $forrigePeriodeOffset, kildeBehandlingId = $kildeBehandlingId, nasjonaltPeriodebeløp = $nasjonaltPeriodebeløp, " +
             "differanseberegnetBeløp = $differanseberegnetPeriodebeløp, beløpUtenEndretUtbetaling = $beløpUtenEndretUtbetaling)"
@@ -224,12 +224,12 @@ fun Collection<AndelTilkjentYtelse>.tilTidslinjerPerAktørOgType(): Map<Pair<Akt
         andelerTilkjentYtelsePåPerson.tilTidslinje()
     }
 
-fun List<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, Tidslinje<AndelForVedtaksperiode>> =
+fun Collection<AndelTilkjentYtelse>.tilAndelForVedtaksperiodeTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, Tidslinje<AndelForVedtaksperiode>> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
         andelerTilkjentYtelsePåPerson.tilAndelForVedtaksperiodeTidslinje()
     }
 
-fun List<AndelTilkjentYtelse>.tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, Tidslinje<AndelForVedtaksbegrunnelse>> =
+fun Collection<AndelTilkjentYtelse>.tilAndelForVedtaksbegrunnelseTidslinjerPerAktørOgType(): Map<Pair<Aktør, YtelseType>, Tidslinje<AndelForVedtaksbegrunnelse>> =
     groupBy { Pair(it.aktør, it.type) }.mapValues { (_, andelerTilkjentYtelsePåPerson) ->
         andelerTilkjentYtelsePåPerson.tilAndelForVedtaksbegrunnelseTidslinje()
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagPersonResultat
+import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
@@ -211,6 +212,44 @@ internal class BehandlingsresultatValideringUtilsTest {
             BehandlingsresultatValideringUtils.validerSatsErUendret(
                 andelerForrigeBehandling = listOf(originalAndel),
                 andelerDenneBehandlingen = listOf(originalAndel),
+            )
+        }
+    }
+
+    @Test
+    fun `validerSatsErUendret - Skal ikke kaste feil dersom sats endrer seg hvis kalkulertUtbetalingsbeløp er 0`() {
+        val person = tilfeldigPerson()
+        val originalAndel =
+            lagAndelTilkjentYtelse(
+                fom = YearMonth.of(2019, 1),
+                tom = YearMonth.of(2019, 4),
+                sats = 970,
+                kalkulertUtbetalingsbeløp = 0,
+                person = person,
+            )
+
+        val nyeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2019, 1),
+                    tom = YearMonth.of(2019, 2),
+                    sats = 970,
+                    kalkulertUtbetalingsbeløp = 0,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2019, 3),
+                    tom = YearMonth.of(2019, 4),
+                    sats = 1054,
+                    kalkulertUtbetalingsbeløp = 0,
+                    person = person,
+                ),
+            )
+
+        assertDoesNotThrow {
+            BehandlingsresultatValideringUtils.validerSatsErUendret(
+                andelerForrigeBehandling = listOf(originalAndel),
+                andelerDenneBehandlingen = nyeAndeler,
             )
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: (NAV-25377)[https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25377]

Som følge av endringer i #5328 slår vi ikke lenger sammen påfølgende andeler med kalkulert utbetalingsbeløp = 0, som følge av samme endret utbetaling. Dette gjør at andelene er mer riktige, men fører til problemer når validering i månedlig valutajustering gjennomføres.

Endrer valideringen slik at endring i sats kun sjekkes dersom kalkulert utbetalingsbeløp er større enn 0
