### PR TITLE
Legg til begrunnelse type eøs endret utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/EØSStandardbegrunnelse.kt
@@ -756,11 +756,11 @@ enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
         override val sanityApiNavn = "reduksjonSentrumForLivsinteresseSaerkullsbarn"
     },
     ENDRET_UTBETALING_ETTERBETALING_UTVIDET_EØS_INGEN_UTBETALING {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_ENDRET_UTBETALING
         override val sanityApiNavn = "endretUtbetalingEtterbetalingUtvidetEosIngenUtbetaling"
     },
     ENDRET_UTBETALING_ETTERBETALING_UTVIDET_SELVSTENDIG_RETT_EØS_INGEN_UTBETALING {
-        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ENDRET_UTBETALING
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_ENDRET_UTBETALING
         override val sanityApiNavn = "endretUtbetalingEtterbetalingUtvidetSelvstendigRettEosIngenUtbetaling"
     },
     ;

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseType.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/VedtakBegrunnelseType.kt
@@ -18,8 +18,9 @@ enum class VedtakBegrunnelseType(
     FORTSATT_INNVILGET(5),
     EØS_FORTSATT_INNVILGET(5),
     INSTITUSJON_FORTSATT_INNVILGET(5),
-    ENDRET_UTBETALING(7),
     ETTER_ENDRET_UTBETALING(6),
+    ENDRET_UTBETALING(7),
+    EØS_ENDRET_UTBETALING(7),
     ;
 
     fun erInnvilget(): Boolean = this == INNVILGET || this == INSTITUSJON_INNVILGET
@@ -27,4 +28,6 @@ enum class VedtakBegrunnelseType(
     fun erReduksjon(): Boolean = this == REDUKSJON || this == INSTITUSJON_REDUKSJON
 
     fun erAvslag(): Boolean = this == AVSLAG || this == INSTITUSJON_AVSLAG || this == EØS_AVSLAG
+
+    fun erEndretUtbetaling() = this == ENDRET_UTBETALING || this == EØS_ENDRET_UTBETALING
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -41,7 +41,6 @@ import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.domene.EØSBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.tilVedtaksbegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -175,7 +175,7 @@ class VedtaksperiodeService(
         )
 
         if (
-            standardbegrunnelserFraFrontend.any { it.vedtakBegrunnelseType == VedtakBegrunnelseType.ENDRET_UTBETALING }
+            standardbegrunnelserFraFrontend.any { it.vedtakBegrunnelseType.erEndretUtbetaling() }
         ) {
             val andelerTilkjentYtelse =
                 andelerTilkjentYtelseOgEndreteUtbetalingerService

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeValidering.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_MORGEN
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.beregning.SatsService
-import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.VedtakBegrunnelseType
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
 import org.slf4j.Logger

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeValidering.kt
@@ -57,9 +57,9 @@ private fun UtvidetVedtaksperiodeMedBegrunnelser.validerMinstEnEndretUtbetalingb
     fagsakId: Long,
 ) {
     val erMuligÅVelgeEndretUtbetalingBegrunnelse =
-        this.gyldigeBegrunnelser.any { it.vedtakBegrunnelseType == VedtakBegrunnelseType.ENDRET_UTBETALING }
+        this.gyldigeBegrunnelser.any { it.vedtakBegrunnelseType.erEndretUtbetaling() }
     val erValgtEndretUtbetalingBegrunnelse =
-        this.begrunnelser.any { it.standardbegrunnelse.vedtakBegrunnelseType == VedtakBegrunnelseType.ENDRET_UTBETALING }
+        this.begrunnelser.any { it.standardbegrunnelse.vedtakBegrunnelseType.erEndretUtbetaling() }
 
     if (erMuligÅVelgeEndretUtbetalingBegrunnelse && !erValgtEndretUtbetalingBegrunnelse) {
         logger.info("Vedtaksperioden ${this.fom?.tilKortString() ?: ""} - ${this.tom?.tilKortString() ?: ""} mangler endretubetalingsbegrunnelse. Fagsak: $fagsakId, behandling: $behandlingId")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiodetype.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/Vedtaksperiodetype.kt
@@ -12,6 +12,7 @@ enum class Vedtaksperiodetype(
             VedtakBegrunnelseType.FORTSATT_INNVILGET,
             VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING,
             VedtakBegrunnelseType.ENDRET_UTBETALING,
+            VedtakBegrunnelseType.EØS_ENDRET_UTBETALING,
             VedtakBegrunnelseType.INSTITUSJON_INNVILGET,
             VedtakBegrunnelseType.INSTITUSJON_REDUKSJON,
             VedtakBegrunnelseType.INSTITUSJON_FORTSATT_INNVILGET,
@@ -39,6 +40,7 @@ enum class Vedtaksperiodetype(
             VedtakBegrunnelseType.INNVILGET,
             VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING,
             VedtakBegrunnelseType.ENDRET_UTBETALING,
+            VedtakBegrunnelseType.EØS_ENDRET_UTBETALING,
             VedtakBegrunnelseType.INSTITUSJON_REDUKSJON,
             VedtakBegrunnelseType.INSTITUSJON_INNVILGET,
             VedtakBegrunnelseType.EØS_INNVILGET,
@@ -49,6 +51,7 @@ enum class Vedtaksperiodetype(
         setOf(
             VedtakBegrunnelseType.OPPHØR,
             VedtakBegrunnelseType.ENDRET_UTBETALING,
+            VedtakBegrunnelseType.EØS_ENDRET_UTBETALING,
             VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING,
             VedtakBegrunnelseType.INSTITUSJON_OPPHØR,
             VedtakBegrunnelseType.EØS_OPPHØR,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25387

Når vi la inn støtte for at endret utbetaling begrunnelser også kunne trekke inn eøs flettefelter, valgte vi å gjenbruke VedtakBegrunnelseTypen endret utbetaling. Dette hadde uante konsekvenser grunnet følgende kode:


```
fun hentVilkårsbegrunnelser(): Map<VedtakBegrunnelseType, List<RestVedtakBegrunnelseTilknyttetVilkår>> =
   standardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityBegrunnelser(filtrerBortBegrunnelserSomIkkeErIBruk = true)) +
           eøsStandardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityEØSBegrunnelser(filtrerBortBegrunnelserSomIkkeErIBruk = true))
```

Problemet er at dersom endret utbetaling typen finnes i begge mapper som nøkkel, så vil de erstatte hverandre (lik nøkkel) og ikke legge til hverandres value (som er en liste). Dette ble heller ikke oppdaget av testene våres (IT + cucumber) fordi selvom de ble sendt med til frontend som gyldige begrunnelser, så bruker frontend enda et endepunkt for å sjekke om begrunnelsene er gyldige. Dette gjorde det også veldig irriterende å feilsøke 😓 

Vi gjenbruker derfor ikke lenger VedtakBegrunnelseTypen endret utbetaling, men lager en ny en (EØS_ENDRET_UTBETALING).

FrontendPR: https://github.com/navikt/familie-ba-sak-frontend/pull/3788