### PR TITLE
Fjerner toggelen `bruk-oppdatert-logikk-for-tilpass-kompetanser-til-regelverk`

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -46,8 +46,5 @@ enum class FeatureToggle(
     // NAV-24658
     SETT_RELATERT_BEHANDLING_FOR_REVURDERING_KLAGE_I_SAKSSTATISTIKK("familie-ba-sak.sett-relatert-behandling-for-revurdering-klage-i-saksstatistikk"),
 
-    // NAV-24917
-    BRUK_OPPDATERT_LOGIKK_FOR_TILPASS_KOMPETANSER_TIL_REGELVERK("familie-ba-sak.bruk-oppdatert-logikk-for-tilpass-kompetanser-til-regelverk"),
-
     SKAL_BRUKE_NY_DIFFERANSEBEREGNING("familie-ba-sak.skal-bruke-ny-differanseberegning"),
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -52,7 +52,6 @@ internal class KompetanseServiceTest {
     val unleashServiceMock: UnleashNextMedContextService = mockk()
     val tilkjentYtelseGenerator = TilkjentYtelseGenerator(overgangsstønadServiceMock, vilkårsvurderingServiceMock, unleashServiceMock)
     val clockProvider = TestClockProvider()
-    val unleashNextMedContextService: UnleashNextMedContextService = mockk()
 
     val kompetanseService =
         KompetanseService(
@@ -68,7 +67,6 @@ internal class KompetanseServiceTest {
             kompetanseRepository = mockKompetanseRepository,
             endringsabonnenter = emptyList(),
             clockProvider = clockProvider,
-            unleashNextMedContextService = unleashNextMedContextService,
         )
 
     @BeforeEach
@@ -314,7 +312,6 @@ internal class KompetanseServiceTest {
         every { endretUtbetalingAndelHentOgPersisterService.hentForBehandling(behandlingId.id) } returns emptyList()
         every { utbetalingTidslinjeService.hentEndredeUtbetalingsPerioderSomKreverKompetanseTidslinjer(behandlingId, emptyList()) } returns emptyMap()
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_OPPDATERT_LOGIKK_FOR_TILPASS_KOMPETANSER_TIL_REGELVERK, false) } returns true
 
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 
@@ -378,7 +375,6 @@ internal class KompetanseServiceTest {
         every { endretUtbetalingAndelHentOgPersisterService.hentForBehandling(behandlingId.id) } returns emptyList()
         every { utbetalingTidslinjeService.hentEndredeUtbetalingsPerioderSomKreverKompetanseTidslinjer(behandlingId, emptyList()) } returns emptyMap()
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_OPPDATERT_LOGIKK_FOR_TILPASS_KOMPETANSER_TIL_REGELVERK, false) } returns true
 
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 
@@ -437,7 +433,6 @@ internal class KompetanseServiceTest {
         every { endretUtbetalingAndelHentOgPersisterService.hentForBehandling(behandlingId.id) } returns emptyList()
         every { utbetalingTidslinjeService.hentEndredeUtbetalingsPerioderSomKreverKompetanseTidslinjer(behandlingId, emptyList()) } returns emptyMap()
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_OPPDATERT_LOGIKK_FOR_TILPASS_KOMPETANSER_TIL_REGELVERK, false) } returns true
 
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 


### PR DESCRIPTION
Toggelen `bruk-oppdatert-logikk-for-tilpass-kompetanser-til-regelverk` har vært skrudd på i et par uker uten at det er meldt fra om problemer. Fjerner den derfor her.
