### PR TITLE
Chore: Fjerner toggle `bruk-overstyring-av-fom-siste-andel-utvidet`

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -19,9 +19,6 @@ enum class FeatureToggle(
     // NAV-21071 lagt bak toggle og kan evt fjernes på sikt hvis man ikke har trengt å skru den på igjen
     SKAL_OPPRETTE_FREMLEGGSOPPGAVE_EØS_MEDLEM("familie-ba-sak.skalOpprettFremleggsoppgaveDersomEOSMedlem"),
 
-    // NAV-23733
-    BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET("familie-ba-sak.bruk-overstyring-av-fom-siste-andel-utvidet"),
-
     // NAV-24387
     BRUK_UTBETALINGSTIDSLINJER_VED_GENERERING_AV_PERIODER_TIL_AVSTEMMING("familie-ba-sak.bruk-utbetalingstidslinjer-ved-generering-av-perioder-til-avstemming"),
     SKAL_FINNE_OG_PATCHE_ANDELER_I_FAGAKER_MED_AVVIK("familie-ba-sak.skal-finne-og-patche-andeler-i-fagsaker-med-avvik"),

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
-import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -70,16 +69,7 @@ class UtbetalingsoppdragGenerator(
                 .hentSisteAndelPerIdentOgType(fagsakId = behandling.fagsak.id)
                 .associateBy { IdentOgType(it.aktør.aktivFødselsnummer(), it.type.tilYtelseType()) }
 
-        val tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag = tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(behandling.fagsak.id)
-
-        return if (tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag.isNotEmpty() && unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET)) {
-            SisteUtvidetAndelOverstyrer.overstyrSisteUtvidetBarnetrygdAndel(
-                sisteAndelPerKjede = sisteAndelPerKjede,
-                tilkjenteYtelserMedOppdatertUtvidetKlassekodeIUtbetalingsoppdrag = tilkjenteYtelserMedOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag,
-            )
-        } else {
-            sisteAndelPerKjede.mapValues { it.value.tilAndelDataLongId() }
-        }
+        return sisteAndelPerKjede.mapValues { it.value.tilAndelDataLongId() }
     }
 
     private fun hentForrigeTilkjentYtelse(behandling: Behandling): TilkjentYtelse? =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepository.kt
@@ -32,13 +32,4 @@ interface TilkjentYtelseRepository : JpaRepository<TilkjentYtelse, Long> {
         """,
     )
     fun harFagsakTattIBrukNyKlassekodeForUtvidetBarnetrygd(fagsakId: Long): Boolean
-
-    @Query(
-        """
-        SELECT ty FROM Behandling b
-        JOIN TilkjentYtelse ty ON ty.behandling.id =  b.id
-        WHERE ty.utbetalingsoppdrag IS NOT NULL AND ty.utbetalingsoppdrag like '%"klassifisering":"BAUTV-OP"%' AND b.fagsak.id = :fagsakId 
-    """,
-    )
-    fun findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(fagsakId: Long): List<TilkjentYtelse>
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -6,7 +6,6 @@ import io.mockk.verify
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -101,12 +100,6 @@ class UtbetalingsoppdragGeneratorTest {
             )
 
         every {
-            unleashNextMedContextService.isEnabled(
-                toggle = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
-            )
-        } returns true
-
-        every {
             klassifiseringKorrigerer.korrigerKlassifiseringVedBehov(
                 beregnetUtbetalingsoppdrag = any(),
                 behandling = vedtak.behandling,
@@ -114,8 +107,6 @@ class UtbetalingsoppdragGeneratorTest {
         } answers {
             firstArg()
         }
-
-        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any()) } returns emptyList()
 
         // Act
         val beregnetUtbetalingsoppdragLongId =
@@ -233,12 +224,6 @@ class UtbetalingsoppdragGeneratorTest {
             )
 
         every {
-            unleashNextMedContextService.isEnabled(
-                toggle = FeatureToggle.BRUK_OVERSTYRING_AV_FOM_SISTE_ANDEL_UTVIDET,
-            )
-        } returns true
-
-        every {
             klassifiseringKorrigerer.korrigerKlassifiseringVedBehov(
                 beregnetUtbetalingsoppdrag = any(),
                 behandling = vedtak.behandling,
@@ -246,8 +231,6 @@ class UtbetalingsoppdragGeneratorTest {
         } answers {
             firstArg()
         }
-
-        every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any()) } returns emptyList()
 
         // Act
         val beregnetUtbetalingsoppdragLongId =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -31,7 +31,6 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.Behandlin
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.EndretMigreringsdatoUtleder
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.KlassifiseringKorrigerer
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.UtbetalingsoppdragGenerator
-import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.tilRestUtbetalingsoppdrag
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
@@ -182,9 +181,6 @@ class OppdragSteg {
         every {
             tilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(any())
         } returns tidligereTilkjenteYtelser.lastOrNull()?.copy(utbetalingsoppdrag = objectMapper.writeValueAsString(beregnetUtbetalingsoppdrag[tidligereTilkjenteYtelser.last().behandling.id]?.utbetalingsoppdrag))
-        every {
-            tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any())
-        } returns tidligereTilkjenteYtelser.filter { beregnetUtbetalingsoppdrag[it.behandling.id]?.utbetalingsoppdrag?.utbetalingsperiode?.any { it.klassifisering == YtelsetypeBA.UTVIDET_BARNETRYGD.klassifisering } == true }.map { it.copy(utbetalingsoppdrag = objectMapper.writeValueAsString(beregnetUtbetalingsoppdrag[it.behandling.id]?.utbetalingsoppdrag)) }
         every {
             behandlingHentOgPersisterService.hentBehandlinger(any())
         } returns behandlinger.filter { it.value.fagsak.id == tilkjentYtelse.behandling.fagsak.id }.values.toList()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockTilkjentYtelseRepository.kt
@@ -46,10 +46,5 @@ fun mockTilkjentYtelseRepository(dataFraCucumber: VedtaksperioderOgBegrunnelserS
             .mapNotNull { it.utbetalingsoppdrag }
             .any { it.contains("\"klassifisering\":\"BAUTV-OP\"") }
     }
-
-    every { tilkjentYtelseRepository.findByOppdatertUtvidetBarnetrygdKlassekodeIUtbetalingsoppdrag(any()) } answers {
-        val fagsakId = firstArg<Long>()
-        dataFraCucumber.tilkjenteYtelser.map { it.value }.filter { it.utbetalingsoppdrag != null && it.utbetalingsoppdrag!!.contains("\"klassifisering\":\"BAUTV-OP\"") }
-    }
     return tilkjentYtelseRepository
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I forbindelse med en bug ved overgang til ny klassekode for utvidet barnetrygd trengte vi å overstyre logikken for å bestemme hva som var siste utvidet barnetrygd andel. Toggelen ble skrudd av i slutten av januar 2025 og har ikke blitt skrudd på igjen siden. Fjerner derfor toggelen og tilhørende logikk fra koden.
