### PR TITLE
Sørger for at vi sammenligner tidligere opphørsdato med ny endretMigr…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.felles.utbetalingsgenerator.Utbetalingsgenerator
 import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.springframework.stereotype.Component
@@ -19,6 +20,8 @@ class EndretMigreringsdatoUtleder(
     private val behandlingMigreringsinfoRepository: BehandlingMigreringsinfoRepository,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
 ) {
+    private final val utbetalingsgenerator: Utbetalingsgenerator = TODO("initialize me")
+
     fun utled(
         fagsak: Fagsak,
         forrigeTilkjentYtelse: TilkjentYtelse?,
@@ -59,7 +62,8 @@ class EndretMigreringsdatoUtleder(
                 .findByFagsak(fagsakId = fagsak.id)
                 .filter { it.behandling.aktivertTidspunkt > behandlingMigreringsinfo.endretTidspunkt && it.utbetalingsoppdrag != null }
                 .map { objectMapper.readValue(it.utbetalingsoppdrag, Utbetalingsoppdrag::class.java) }
-                .any { utbetalingsoppdrag -> utbetalingsoppdrag.utbetalingsperiode.any { utbetalingsperiode -> utbetalingsperiode.opphør?.opphørDatoFom == migreringsdatoPåFagsakPlussEnMnd } }
+                // Viktig at vi omgjør til YearMonth før sammenligning her da vi alltid bruker YearhMonth for endretMigreringsdato inn i utbetalingsgenerator
+                .any { utbetalingsoppdrag -> utbetalingsoppdrag.utbetalingsperiode.any { utbetalingsperiode -> utbetalingsperiode.opphør?.opphørDatoFom?.toYearMonth() == migreringsdatoPåFagsakPlussEnMnd.toYearMonth() } }
 
         return if (fagsakOpphørtFraMigreringsdatoIEnAvBehandlingeneEtterMigreringsdatoBleEndret) {
             null

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/EndretMigreringsdatoUtleder.kt
@@ -62,7 +62,7 @@ class EndretMigreringsdatoUtleder(
                 .findByFagsak(fagsakId = fagsak.id)
                 .filter { it.behandling.aktivertTidspunkt > behandlingMigreringsinfo.endretTidspunkt && it.utbetalingsoppdrag != null }
                 .map { objectMapper.readValue(it.utbetalingsoppdrag, Utbetalingsoppdrag::class.java) }
-                // Viktig at vi omgjør til YearMonth før sammenligning her da vi alltid bruker YearhMonth for endretMigreringsdato inn i utbetalingsgenerator
+                // Viktig at vi omgjør til YearMonth før sammenligning her da vi alltid bruker YearMonth for endretMigreringsdato inn i utbetalingsgenerator
                 .any { utbetalingsoppdrag -> utbetalingsoppdrag.utbetalingsperiode.any { utbetalingsperiode -> utbetalingsperiode.opphør?.opphørDatoFom?.toYearMonth() == migreringsdatoPåFagsakPlussEnMnd.toYearMonth() } }
 
         return if (fagsakOpphørtFraMigreringsdatoIEnAvBehandlingeneEtterMigreringsdatoBleEndret) {


### PR DESCRIPTION
[Innmeldt bug i utbetaling-ba kanal på slack.](https://nav-it.slack.com/archives/C01ESUV8V52/p1749542347337119) 

### 💰 Hva skal gjøres, og hvorfor?
Når vi sjekker om vi har opphørt fra den siste endrede migreringsdatoen tidligere, sjekker vi egentlig en spesifikk `LocalDate` mot en `YearMonth` kamuflert som en `LocalDate` hvor dagen alltid er den første i mnd. Dette fører til at vi i fagsaker hvor den endrede migreringsdatoen er noe annet enn den først i mnd alltid opphører fra start, noe som igjen fører til en rekke "0"-utbetalinger på MinSide og unødvendig tunge beregninger for Oppdrag.

Sørger her for at vi konverterer den spesifikke endrede migreringsdatoen til en `YearMonth` før vi sammenligner med tidligere opphørt dato, slik at vi faktisk sammenligner epler med epler.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
