### PR TITLE
Utvidelse av tilgangskontroll for fagsak til å ta med søker for skjermet barn"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -136,7 +136,10 @@ class TilgangService(
                     .hentSøkerOgBarnPåFagsak(fagsakId)
                     ?.map { it.aktør.aktivFødselsnummer() }
                     ?: emptyList()
-            ).ifEmpty { listOf(aktør.aktivFødselsnummer()) }
+            ).ifEmpty {
+                val fagsak = fagsakService.hentPåFagsakId(fagsakId)
+                listOfNotNull(aktør.aktivFødselsnummer(), fagsak.skjermetBarnSøker?.aktør?.aktivFødselsnummer())
+            }
 
         personIdenterIFagsak.forEach { fnr ->
             auditLogger.log(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- **Sørger for at man tar med søkers ident i sjekk for tilgangskontroll for fagsak av typen skjermet_barn**

Tilgangskontroll for barn funker ut av boksen ved fagsaktype SKJERMET_BARN, siden man sjekker tilgangen til fagsaken basert på aktøren på fagsaken. Det samme for behandling. Det er derimot en liten case som ikke var dekket. Det er i de tilfeller hvor: 
- det er en fagsak av type SKJERMET_BARN,
- barnet ikke lenger er kode 6/19
- søker er kode 6/19
- Det er ikke opprettet persongrunnlag for søker og barn siden det ikke er opprettet en behandling



### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
