### PR TITLE
filtrer bort identer som ikke har aktiv fødselsnummer ved søk og mapping av relasjoner

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -86,8 +86,14 @@ class PdlRestClient(
                         pdlPerson.person.forelderBarnRelasjon
                             .mapNotNull { relasjon ->
                                 relasjon.relatertPersonsIdent
-                                    ?.let { ident -> personidentService.hentAktørOrNullHvisIkkeAktivFødselsnummer(ident) }
-                                    ?.let { aktør ->
+                                    ?.let { ident ->
+                                        personidentService.hentAktørOrNullHvisIkkeAktivFødselsnummer(ident).run {
+                                            if (this == null) {
+                                                secureLogger.warn("Filtrert bort relasjon som ikke har aktivt fødselsnummer i PDL for ident $ident")
+                                            }
+                                            this
+                                        }
+                                    }?.let { aktør ->
                                         ForelderBarnRelasjon(
                                             aktør = aktør,
                                             relasjonsrolle = relasjon.relatertPersonsRolle,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -85,12 +85,14 @@ class PdlRestClient(
                     PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON -> {
                         pdlPerson.person.forelderBarnRelasjon
                             .mapNotNull { relasjon ->
-                                relasjon.relatertPersonsIdent?.let { ident ->
-                                    ForelderBarnRelasjon(
-                                        aktør = personidentService.hentAktør(ident),
-                                        relasjonsrolle = relasjon.relatertPersonsRolle,
-                                    )
-                                }
+                                relasjon.relatertPersonsIdent
+                                    ?.let { ident -> personidentService.hentAktørOrNullHvisIkkeAktivFødselsnummer(ident) }
+                                    ?.let { aktør ->
+                                        ForelderBarnRelasjon(
+                                            aktør = aktør,
+                                            relasjonsrolle = relasjon.relatertPersonsRolle,
+                                        )
+                                    }
                             }.toSet()
                     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerService.kt
@@ -27,7 +27,7 @@ class PersonopplysningerService(
     fun hentPersoninfoMedRelasjonerOgRegisterinformasjon(aktør: Aktør): PersonInfo {
         val personinfo = hentPersoninfoMedQuery(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON)
         val identerMedAdressebeskyttelse = mutableSetOf<Pair<Aktør, FORELDERBARNRELASJONROLLE>>()
-        val relasjonsidenter = personinfo.forelderBarnRelasjon.map { it.aktør.aktivFødselsnummer() }
+        val relasjonsidenter = personinfo.forelderBarnRelasjon.mapNotNull { it.aktør.aktivFødselsnummer() }
         val tilgangPerIdent = familieIntegrasjonerTilgangskontrollService.sjekkTilgangTilPersoner(relasjonsidenter)
         val forelderBarnRelasjon =
             personinfo.forelderBarnRelasjon

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentIdenterResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentIdenterResponse.kt
@@ -24,6 +24,13 @@ fun List<IdentInformasjon>.hentAktivFødselsnummer(): String =
             throw Error("Finner ikke folkeregisteriden i Pdl")
         }
 
+fun List<IdentInformasjon>.hentAktivFødselsnummerOrNull(): String? =
+    this.singleOrNull { it.gruppe == Type.FOLKEREGISTERIDENT.name && !it.historisk }?.ident.also {
+        if (it == null) {
+            secureLogger.warn("Finner ikke folkeregisterident i liste fra PDL: $this")
+        }
+    }
+
 fun List<IdentInformasjon>.hentAktivAktørId(): String =
     this.singleOrNull { it.gruppe == Type.AKTORID.name && !it.historisk }?.ident
         ?: run {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -324,7 +324,7 @@ class FagsakService(
     fun hentLøpendeFagsaker(): List<Fagsak> = fagsakRepository.finnLøpendeFagsaker()
 
     fun hentFagsakDeltager(personIdent: String): List<RestFagsakDeltager> {
-        val aktør = personidentService.hentAktør(personIdent)
+        val aktør = personidentService.hentAktørOrNullHvisIkkeAktivFødselsnummer(personIdent) ?: return emptyList()
 
         val maskertDeltaker =
             runCatching {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.hentAktivAktørId
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.hentAktivFødselsnummer
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.hentAktivFødselsnummerOrNull
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.person.pdl.aktor.v2.Type
 import org.slf4j.LoggerFactory
@@ -66,6 +67,14 @@ class PersonidentService(
         }
 
         return aktør
+    }
+
+    fun hentAktørOrNullHvisIkkeAktivFødselsnummer(identEllerAktørId: String): Aktør? {
+        if (hentIdenter(identEllerAktørId, false).hentAktivFødselsnummerOrNull() == null) {
+            secureLogger.warn("Fant ikke aktiv fødselsnummer for aktør med id $identEllerAktørId")
+            return null
+        }
+        return hentAktør(identEllerAktørId)
     }
 
     fun hentOgLagreAktør(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentService.kt
@@ -69,13 +69,10 @@ class PersonidentService(
         return aktør
     }
 
-    fun hentAktørOrNullHvisIkkeAktivFødselsnummer(identEllerAktørId: String): Aktør? {
-        if (hentIdenter(identEllerAktørId, false).hentAktivFødselsnummerOrNull() == null) {
-            secureLogger.warn("Fant ikke aktiv fødselsnummer for aktør med id $identEllerAktørId")
-            return null
+    fun hentAktørOrNullHvisIkkeAktivFødselsnummer(identEllerAktørId: String): Aktør? =
+        hentIdenter(identEllerAktørId, false).hentAktivFødselsnummerOrNull()?.let {
+            hentAktør(identEllerAktørId)
         }
-        return hentAktør(identEllerAktørId)
-    }
 
     fun hentOgLagreAktør(
         ident: String,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasj
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClientMock
+import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiKlient
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingKlient
@@ -32,7 +33,7 @@ abstract class AbstractMockkSpringRunner {
     private lateinit var mockPersonopplysningerService: PersonopplysningerService
 
     @Autowired
-    private lateinit var mockPdlIdentRestClient: MockPdlIdentRestClient
+    private lateinit var pdlIdentRestClient: PdlIdentRestClient
 
     @Autowired
     private lateinit var mockIntegrasjonClient: IntegrasjonClient
@@ -105,7 +106,8 @@ abstract class AbstractMockkSpringRunner {
             ClientMocks.clearPdlMocks(mockPersonopplysningerService)
         }
 
-        mockPdlIdentRestClient.reset()
+        val fakePdlIdentRestClient = pdlIdentRestClient as? FakePdlIdentRestClient
+        fakePdlIdentRestClient?.reset()
 
         IntegrasjonClientMock.clearIntegrasjonMocks(mockIntegrasjonClient)
         IntegrasjonClientMock.clearMockFamilieIntegrasjonerTilgangskontrollClient(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasj
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClientMock
-import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiKlient
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingKlient
@@ -33,7 +32,7 @@ abstract class AbstractMockkSpringRunner {
     private lateinit var mockPersonopplysningerService: PersonopplysningerService
 
     @Autowired
-    private lateinit var mockPdlIdentRestClient: PdlIdentRestClient
+    private lateinit var mockPdlIdentRestClient: MockPdlIdentRestClient
 
     @Autowired
     private lateinit var mockIntegrasjonClient: IntegrasjonClient
@@ -106,9 +105,7 @@ abstract class AbstractMockkSpringRunner {
             ClientMocks.clearPdlMocks(mockPersonopplysningerService)
         }
 
-        if (isMockKMock(mockPdlIdentRestClient)) {
-            ClientMocks.clearPdlIdentRestClient(mockPdlIdentRestClient)
-        }
+        mockPdlIdentRestClient.reset()
 
         IntegrasjonClientMock.clearIntegrasjonMocks(mockIntegrasjonClient)
         IntegrasjonClientMock.clearMockFamilieIntegrasjonerTilgangskontrollClient(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/FakePdlIdentRestClient.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/FakePdlIdentRestClient.kt
@@ -13,7 +13,7 @@ import java.net.URI
 @Service
 @Profile("mock-ident-client")
 @Primary
-class MockPdlIdentRestClient(
+class FakePdlIdentRestClient(
     restOperations: RestOperations,
 ) : PdlIdentRestClient(URI("dummy_uri"), restOperations) {
     private val identMap = mutableMapOf<String, List<IdentInformasjon>>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockPdlIdentRestClient.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockPdlIdentRestClient.kt
@@ -16,11 +16,16 @@ import java.net.URI
 class MockPdlIdentRestClient(
     restOperations: RestOperations,
 ) : PdlIdentRestClient(URI("dummy_uri"), restOperations) {
+    private val identMap = mutableMapOf<String, List<IdentInformasjon>>()
+
     override fun hentIdenter(
         personIdent: String,
         historikk: Boolean,
-    ): List<IdentInformasjon> =
-        when {
+    ): List<IdentInformasjon> {
+        // If we have stored identities for this person, return them
+        identMap[personIdent]?.let { return it }
+
+        return when {
             historikk ->
                 listOf(
                     IdentInformasjon(personIdent, historisk = false, gruppe = "FOLKEREGISTERIDENT"),
@@ -41,4 +46,16 @@ class MockPdlIdentRestClient(
                     ),
                 )
         }
+    }
+
+    fun leggTilIdent(
+        personIdent: String,
+        identInformasjon: List<IdentInformasjon>,
+    ) {
+        identMap[personIdent] = identInformasjon
+    }
+
+    fun reset() {
+        identMap.clear()
+    }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
-import no.nav.familie.ba.sak.config.MockPdlIdentRestClient
+import no.nav.familie.ba.sak.config.FakePdlIdentRestClient
 import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
@@ -78,7 +78,7 @@ class FagsakServiceIntegrationTest(
     @Autowired
     private val unleashService: UnleashService,
     @Autowired
-    private val mockPdlIdentRestClient: MockPdlIdentRestClient,
+    private val fakePdlIdentRestClient: FakePdlIdentRestClient,
 ) : AbstractSpringIntegrationTest() {
     @BeforeEach
     fun init() {
@@ -388,7 +388,7 @@ class FagsakServiceIntegrationTest(
     @Test
     fun `Skal returnere tom liste ved søk hvis ident ikke har aktiv fødselsnummer`() {
         val fnr = randomFnr()
-        mockPdlIdentRestClient.leggTilIdent(
+        fakePdlIdentRestClient.leggTilIdent(
             fnr,
             listOf(
                 IdentInformasjon("npid", gruppe = "NPID", historisk = false),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.config.DatabaseCleanupService
+import no.nav.familie.ba.sak.config.MockPdlIdentRestClient
 import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.leggTilPersonInfo
 import no.nav.familie.ba.sak.config.tilAktør
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
@@ -16,6 +17,7 @@ import no.nav.familie.ba.sak.ekstern.restDomene.RestInstitusjon
 import no.nav.familie.ba.sak.ekstern.restDomene.RestSkjermetBarnSøker
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PersonInfo
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandling
@@ -75,6 +77,8 @@ class FagsakServiceIntegrationTest(
     private val mockFamilieIntegrasjonerTilgangskontrollClient: FamilieIntegrasjonerTilgangskontrollClient,
     @Autowired
     private val unleashService: UnleashService,
+    @Autowired
+    private val mockPdlIdentRestClient: MockPdlIdentRestClient,
 ) : AbstractSpringIntegrationTest() {
     @BeforeEach
     fun init() {
@@ -379,6 +383,19 @@ class FagsakServiceIntegrationTest(
             )
         }
         assertEquals(emptyList<RestFagsakDeltager>(), fagsakService.hentFagsakDeltager(randomFnr()))
+    }
+
+    @Test
+    fun `Skal returnere tom liste ved søk hvis ident ikke har aktiv fødselsnummer`() {
+        val fnr = randomFnr()
+        mockPdlIdentRestClient.leggTilIdent(
+            fnr,
+            listOf(
+                IdentInformasjon("npid", gruppe = "NPID", historisk = false),
+                IdentInformasjon("122334343", gruppe = "AKTOERID", historisk = false),
+            ),
+        )
+        assertThat(fagsakService.hentFagsakDeltager(fnr)).hasSize(0)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bedre støtte for NPID. 
- Hvis man henter inn relasjoner for en ident. Som man blant annet gjør ved søk og oppretting så feilet mappingen hvis det er en ident med kun NPID. Lagt til funksjonalitet for å filtrere bort denne identen


Utvidet MockPdlIdentRestClient til å fungere som en fake, slik at man kan gi den verdier man ønsker å få tilbake. I stedet for en hardkodet returnverdi


Dette fikser taskene i NAV-25447
### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
