### PR TITLE
Fjern toggle for å lagre søknadreferanse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -125,7 +125,7 @@ class BehandlingService(
                             behandling = behandling,
                         )
                     }
-                    if (unleashService.isEnabled(FeatureToggle.PREUTFYLLING_VILKÅR) && nyBehandling.søknadsinfo != null) {
+                    if (nyBehandling.søknadsinfo != null) {
                         søknadReferanseService.lagreSøknadReferanse(
                             behandlingId = it.id,
                             journalpostId = nyBehandling.søknadsinfo.journalpostId,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -127,7 +127,6 @@ class BehandlingServiceTest {
             every { loggService.opprettBehandlingLogg(any()) } just runs
             every { taskRepository.save(any()) } returnsArgument 0
             every { unleashService.isEnabled(FeatureToggle.SJEKK_AKTIV_INFOTRYGD_SAK_REPLIKA, true) } returns false
-            every { unleashService.isEnabled(FeatureToggle.PREUTFYLLING_VILKÅR) } returns true
 
             // Act
             val opprettetBehandling = behandlingService.opprettBehandling(nyBehandling)
@@ -179,7 +178,6 @@ class BehandlingServiceTest {
             every { loggService.opprettBehandlingLogg(any()) } just runs
             every { taskRepository.save(any()) } returnsArgument 0
             every { unleashService.isEnabled(FeatureToggle.SJEKK_AKTIV_INFOTRYGD_SAK_REPLIKA, true) } returns false
-            every { unleashService.isEnabled(FeatureToggle.PREUTFYLLING_VILKÅR) } returns true
 
             // Act
             val opprettetBehandling = behandlingService.opprettBehandling(nyBehandling)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25246

Fjerner toggle slik at søknadsreferanse for behandling blir lagret uansett. Sletter ikke toggle, ettersom den blir brukt et annet sted