### PR TITLE
Legg til en bedre feilmelding for saksbehandler og beslutter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -53,7 +53,12 @@ fun AndelTilkjentYtelse.medDifferanseberegning(
             .intValueExact() // Fjern desimaler for å gi fordel til søker
 
     val nyttDifferanseberegnetPeriodebeløp by lazy {
-        (beløpUtenEndretUtbetaling ?: throw FunksjonellFeil("En feil har oppstått. Gå tilbake til vilkårsvurderingen og trykk 'Neste'.")) - avrundetUtenlandskPeriodebeløp
+        (
+            beløpUtenEndretUtbetaling ?: throw FunksjonellFeil(
+                "En feil har oppstått. Gå tilbake til vilkårsvurderingen og trykk 'Neste'." +
+                    "Dersom behandlingen er sendt til totrinnskontroll må behandlingen underkjennes av beslutter slik at saksbehandler kan utføre dette.",
+            )
+        ) - avrundetUtenlandskPeriodebeløp
     }
 
     val nyttKalkulertUtbetalingsbeløp =


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25471

Dersom andeler ikke har beløpUtenEndretUtbetaling satt, ønsker vi at de genereres på nytt.
Men dette er ikke mulig når en sak har ligget på vent lenge, og deretter blitt sendt til totrinnskontroll. 
Generering av nye andeler skjer ikke i totrinnskontroll, så man blir derfor stuck.

Saken som påvirkes av dette i prod er manuelt patchet av meg, men jeg ønsker uansett en litt mer beskrivende feilmelding.