### PR TITLE
Legger til HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/domene/ArbeidsfordelingPåBehandlingRepository.kt
@@ -20,6 +20,7 @@ interface ArbeidsfordelingPåBehandlingRepository : JpaRepository<Arbeidsfordeli
              'HENLAGT_FEILAKTIG_OPPRETTET',
              'HENLAGT_SØKNAD_TRUKKET',
              'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+             'HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG',
              'HENLAGT_TEKNISK_VEDLIKEHOLD'
             )   
         ORDER BY b.aktivert_tid DESC

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingStegController.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils.validerBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.Behandlingutils.validerhenleggelsestype
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.fagsak.RestBeslutningPåVedtak
 import no.nav.familie.ba.sak.kjerne.steg.StegService
@@ -230,11 +231,18 @@ enum class HenleggÅrsak(
     TEKNISK_VEDLIKEHOLD("Teknisk vedlikehold"),
     ;
 
-    fun tilBehandlingsresultat() =
+    fun tilBehandlingsresultat(opprettetÅrsak: BehandlingÅrsak) =
         when (this) {
             FEILAKTIG_OPPRETTET -> Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET
+
             SØKNAD_TRUKKET -> Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET
-            AUTOMATISK_HENLAGT -> Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE
+
+            AUTOMATISK_HENLAGT ->
+                when (opprettetÅrsak) {
+                    BehandlingÅrsak.SMÅBARNSTILLEGG, BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID -> Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG
+                    else -> Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE
+                }
+
             TEKNISK_VEDLIKEHOLD -> Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD
         }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -127,6 +127,7 @@ data class Behandling(
         resultat == Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET ||
             resultat == Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET ||
             resultat == Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE ||
+            resultat == Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG ||
             resultat == Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD
 
     fun erVedtatt() = status == BehandlingStatus.AVSLUTTET && !erHenlagt()
@@ -310,7 +311,8 @@ enum class Behandlingsresultat(
     // Henlagt
     HENLAGT_FEILAKTIG_OPPRETTET(displayName = "Henlagt feilaktig opprettet"),
     HENLAGT_SØKNAD_TRUKKET(displayName = "Henlagt søknad trukket"),
-    HENLAGT_AUTOMATISK_FØDSELSHENDELSE(displayName = "Henlagt avslått i automatisk vilkårsvurdering"),
+    HENLAGT_AUTOMATISK_FØDSELSHENDELSE(displayName = "Henlagt avslått i automatisk vilkårsvurdering (fødselshendelse)"),
+    HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG(displayName = "Henlagt avslått i automatisk vilkårsvurdering (småbarnstillegg)"),
     HENLAGT_TEKNISK_VEDLIKEHOLD(displayName = "Henlagt teknisk vedlikehold"),
 
     IKKE_VURDERT(displayName = "Ikke vurdert"),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalService.kt
@@ -85,6 +85,7 @@ class BrevmalService(
                         Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET,
                         Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
                         Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE,
+                        Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG,
                         Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD,
                         Behandlingsresultat.IKKE_VURDERT,
                         -> throw FunksjonellFeil(
@@ -119,6 +120,7 @@ class BrevmalService(
                         Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET,
                         Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
                         Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE,
+                        Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG,
                         Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD,
                         Behandlingsresultat.IKKE_VURDERT,
                         -> throw FunksjonellFeil(
@@ -160,6 +162,7 @@ class BrevmalService(
                         Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET,
                         Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
                         Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE,
+                        Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG,
                         Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD,
                         Behandlingsresultat.IKKE_VURDERT,
                         -> throw FunksjonellFeil(
@@ -197,6 +200,7 @@ class BrevmalService(
                         Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET,
                         Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
                         Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE,
+                        Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG,
                         Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD,
                         Behandlingsresultat.IKKE_VURDERT,
                         -> throw FunksjonellFeil(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -210,6 +210,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
                                                              'HENLAGT_FEILAKTIG_OPPRETTET',
                                                              'HENLAGT_SØKNAD_TRUKKET',
                                                              'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+                                                             'HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG',
                                                              'HENLAGT_TEKNISK_VEDLIKEHOLD'
                                         )
                                       AND b.status = 'AVSLUTTET'
@@ -227,6 +228,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
                                  'HENLAGT_FEILAKTIG_OPPRETTET',
                                  'HENLAGT_SØKNAD_TRUKKET',
                                  'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+                                 'HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG'
                                  'HENLAGT_TEKNISK_VEDLIKEHOLD'
             )
           AND vedtaksdato > :month

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/HenleggBehandling.kt
@@ -69,7 +69,7 @@ class HenleggBehandling(
 
         loggService.opprettHenleggBehandling(behandling, data.årsak.beskrivelse, data.begrunnelse)
 
-        behandling.resultat = data.årsak.tilBehandlingsresultat()
+        behandling.resultat = data.årsak.tilBehandlingsresultat(behandling.opprettetÅrsak)
         behandling.leggTilHenleggStegOmDetIkkeFinnesFraFør()
 
         behandlingHentOgPersisterService.lagreEllerOppdater(behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/HenleggÅrsakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/HenleggÅrsakTest.kt
@@ -1,0 +1,34 @@
+import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class HenleggÅrsakTest {
+    @ParameterizedTest
+    @EnumSource(BehandlingÅrsak::class, names = ["SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID", "SMÅBARNSTILLEGG"])
+    fun `Skal returnere HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG for AUTOMATISK_HENLAGT hvis årsaken er småbarnstillegg relatert`(behandlingÅrsak: BehandlingÅrsak) {
+        val resultat = HenleggÅrsak.AUTOMATISK_HENLAGT.tilBehandlingsresultat(behandlingÅrsak)
+        assertEquals(Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG, resultat)
+    }
+
+    @Test
+    fun `Skal returnere riktig behandlingsresultat for FEILAKTIG_OPPRETTET`() {
+        val resultat = HenleggÅrsak.FEILAKTIG_OPPRETTET.tilBehandlingsresultat(BehandlingÅrsak.FØDSELSHENDELSE)
+        assertEquals(Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET, resultat)
+    }
+
+    @Test
+    fun `Skal returnere riktig behandlingsresultat for SØKNAD_TRUKKET`() {
+        val resultat = HenleggÅrsak.SØKNAD_TRUKKET.tilBehandlingsresultat(BehandlingÅrsak.FØDSELSHENDELSE)
+        assertEquals(Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET, resultat)
+    }
+
+    @Test
+    fun `Skal returnere riktig behandlingsresultat for TEKNISK_VEDLIKEHOLD`() {
+        val resultat = HenleggÅrsak.TEKNISK_VEDLIKEHOLD.tilBehandlingsresultat(BehandlingÅrsak.FØDSELSHENDELSE)
+        assertEquals(Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD, resultat)
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
@@ -98,7 +99,7 @@ class FagsakRepositoryTest(
         @ParameterizedTest
         @EnumSource(
             Behandlingsresultat::class,
-            names = ["HENLAGT_FEILAKTIG_OPPRETTET", "HENLAGT_SØKNAD_TRUKKET", "HENLAGT_AUTOMATISK_FØDSELSHENDELSE", "HENLAGT_TEKNISK_VEDLIKEHOLD"],
+            names = ["HENLAGT_FEILAKTIG_OPPRETTET", "HENLAGT_SØKNAD_TRUKKET", "HENLAGT_AUTOMATISK_FØDSELSHENDELSE", "HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG", "HENLAGT_TEKNISK_VEDLIKEHOLD"],
             mode = EnumSource.Mode.INCLUDE,
         )
         fun `skal ikke finne fagsak dersom alle avsluttede behandlinger er enten avslått eller henlagt`(
@@ -116,6 +117,15 @@ class FagsakRepositoryTest(
                         resultat = Behandlingsresultat.AVSLÅTT,
                         status = BehandlingStatus.AVSLUTTET,
                         aktivertTid = LocalDateTime.of(2025, 2, 11, 0, 0, 0),
+                        aktiv = false,
+                    ),
+                    lagBehandlingUtenId(
+                        fagsak = fagsak,
+                        behandlingType = BehandlingType.REVURDERING,
+                        resultat = Behandlingsresultat.AVSLÅTT,
+                        status = BehandlingStatus.AVSLUTTET,
+                        aktivertTid = LocalDateTime.of(2025, 4, 11, 0, 0, 0),
+                        årsak = BehandlingÅrsak.SMÅBARNSTILLEGG,
                         aktiv = false,
                     ),
                     lagBehandlingUtenId(


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25451

Per nå bruker vi BehandlingResultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE, til og med på småbarnstillegg som er feil. Vi legger til BehandlingResultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG, da dette er ønsket.