### PR TITLE
Barn med adressebeskyttelse i automatisk registrering av søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ba.sak.ekstern.restDomene.tilRestTotrinnskontroll
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestValutakurs
 import no.nav.familie.ba.sak.ekstern.restDomene.tilRestVedtak
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.filtreringsregler.domene.FødselshendelsefiltreringResultatRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
@@ -70,11 +71,20 @@ class UtvidetBehandlingService(
     private val vurderingsstrategiForValutakurserRepository: VurderingsstrategiForValutakurserRepository,
     private val behandlingSøknadsinfoService: BehandlingSøknadsinfoService,
     private val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
+    private val familieIntegrasjonerTilgangskontrollService: FamilieIntegrasjonerTilgangskontrollService,
 ) {
     fun lagRestUtvidetBehandling(behandlingId: Long): RestUtvidetBehandling {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId = behandlingId)
 
-        val søknadsgrunnlag = søknadGrunnlagService.hentAktiv(behandlingId = behandling.id)
+        val søknadsgrunnlag =
+            søknadGrunnlagService.hentAktiv(behandlingId = behandling.id)?.hentSøknadDto()?.let { søknadDTO ->
+                val barnIdenter = søknadDTO.barnaMedOpplysninger.map { it.ident }
+                val tilganger = familieIntegrasjonerTilgangskontrollService.sjekkTilgangTilPersoner(barnIdenter)
+                søknadDTO.copy(
+                    barnaMedOpplysninger = søknadDTO.barnaMedOpplysninger.filter { barn -> tilganger.getValue(barn.ident).harTilgang },
+                )
+            }
+
         val personopplysningGrunnlag = persongrunnlagService.hentAktiv(behandlingId = behandling.id)
         val personer = personopplysningGrunnlag?.søkerOgBarn
 
@@ -125,7 +135,7 @@ class UtvidetBehandlingService(
             opprettetTidspunkt = behandling.opprettetTidspunkt,
             endretAv = behandling.endretAv,
             arbeidsfordelingPåBehandling = arbeidsfordeling.tilRestArbeidsfordelingPåBehandling(),
-            søknadsgrunnlag = søknadsgrunnlag?.hentSøknadDto(),
+            søknadsgrunnlag = søknadsgrunnlag,
             personer =
                 personer?.map { persongrunnlagService.mapTilRestPersonMedStatsborgerskapLand(it) }
                     ?: emptyList(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.søknad.SøknadService
-import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import org.springframework.stereotype.Service
 
@@ -41,21 +40,13 @@ class AutomatiskRegistrerSøknadService(
                 .hentPersoninfoMedRelasjonerOgRegisterinformasjon(søker.aktør)
                 .forelderBarnRelasjon
                 .filter { it.relasjonsrolle == FORELDERBARNRELASJONROLLE.BARN }
-                .mapNotNull { barn ->
-                    // Filtrer bort barn som har adressebeskyttelse og som ikke er med i søknaden
-                    if (barn.adressebeskyttelseGradering == null ||
-                        barn.adressebeskyttelseGradering == ADRESSEBESKYTTELSEGRADERING.UGRADERT ||
-                        søknad.barn.any { it.fnr == barn.aktør.aktivFødselsnummer() }
-                    ) {
-                        BarnMedOpplysninger(
-                            ident = barn.aktør.aktivFødselsnummer(),
-                            navn = barn.navn ?: "Mangler navn",
-                            fødselsdato = barn.fødselsdato,
-                            inkludertISøknaden = søknad.barn.any { it.fnr == barn.aktør.aktivFødselsnummer() },
-                        )
-                    } else {
-                        null
-                    }
+                .map { barn ->
+                    BarnMedOpplysninger(
+                        ident = barn.aktør.aktivFødselsnummer(),
+                        navn = barn.navn ?: "Mangler navn",
+                        fødselsdato = barn.fødselsdato,
+                        inkludertISøknaden = søknad.barn.any { it.fnr == barn.aktør.aktivFødselsnummer() },
+                    )
                 }
 
         val barnUtenRelasjonFraSøknad =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25246

Inkluder barn med adressebeskyttelse i søknadsgrunnlaget.

Legger også til filtrering av barn når søknadsgrunnlaget hentes til frontend, slik at saksbehandlere uten tilgang til diskresjonskode ikke får opp barn med diskresjonskode