### PR TITLE
NAV-25500: Fjerner deprecated kode for oppretting av revurdering klage.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/EksternKlageController.kt
@@ -48,29 +48,6 @@ class EksternKlageController(
         return Ressurs.success(klageService.kanOppretteRevurdering(fagsakId))
     }
 
-    @Deprecated(message = "Erstattet av metoden 'opprettRevurderingKlage'")
-    @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage")
-    fun opprettRevurderingKlageGammel(
-        @PathVariable fagsakId: Long,
-    ): Ressurs<OpprettRevurderingResponse> {
-        tilgangService.validerTilgangTilHandlingOgFagsak(
-            fagsakId = fagsakId,
-            handling = "Opprett revurdering med årask klage på fagsak=$fagsakId",
-            event = AuditLoggerEvent.CREATE,
-            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
-        )
-
-        if (!SikkerhetContext.kallKommerFraKlage()) {
-            throw Feil("Kallet utføres ikke av en autorisert klient")
-        }
-        return Ressurs.success(
-            klageService.validerOgOpprettRevurderingKlage(
-                fagsakId = fagsakId,
-                klagebehandlingId = null,
-            ),
-        )
-    }
-
     @PostMapping("fagsak/{fagsakId}/klagebehandling/{klagebehandlingId}/opprett-revurdering-klage")
     fun opprettRevurderingKlage(
         @PathVariable fagsakId: Long,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageService.kt
@@ -109,7 +109,7 @@ class KlageService(
     @Transactional
     fun validerOgOpprettRevurderingKlage(
         fagsakId: Long,
-        klagebehandlingId: UUID?,
+        klagebehandlingId: UUID,
     ): OpprettRevurderingResponse {
         val fagsak = fagsakService.hentPåFagsakId(fagsakId)
 
@@ -122,7 +122,7 @@ class KlageService(
 
     private fun opprettRevurderingKlage(
         fagsak: Fagsak,
-        klagebehandlingId: UUID?,
+        klagebehandlingId: UUID,
     ) = try {
         val forrigeBehandling =
             behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = fagsak.id)
@@ -139,7 +139,7 @@ class KlageService(
                 // barnasIdenter hentes fra forrige behandling i håndterNyBehandling() ved revurdering
                 barnasIdenter = emptyList(),
                 fagsakId = forrigeBehandling.fagsak.id,
-                nyEksternBehandlingRelasjon = klagebehandlingId?.let { NyEksternBehandlingRelasjon.opprettForKlagebehandling(it) },
+                nyEksternBehandlingRelasjon = NyEksternBehandlingRelasjon.opprettForKlagebehandling(klagebehandlingId),
             )
 
         val revurdering = stegService.håndterNyBehandling(nyBehandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageServiceTest.kt
@@ -109,45 +109,6 @@ class KlageServiceTest {
     @Nested
     inner class OpprettRevurderingKlage {
         @Test
-        fun `kan opprette revurdering hvis det finnes en ferdigstilt behandling`() {
-            // Arrange
-            val aktør = randomAktør()
-            val fagsak = Fagsak(aktør = aktør)
-            val forrigeBehandling =
-                lagBehandling(
-                    behandlingKategori = BehandlingKategori.EØS,
-                    underkategori = BehandlingUnderkategori.UTVIDET,
-                    fagsak = fagsak,
-                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                    årsak = BehandlingÅrsak.OMREGNING_SMÅBARNSTILLEGG,
-                    status = BehandlingStatus.AVSLUTTET,
-                )
-
-            every { fagsakService.hentPåFagsakId(any()) } returns fagsak
-            every { behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(any()) } returns false
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns forrigeBehandling
-
-            val nyBehandling =
-                NyBehandling(
-                    kategori = forrigeBehandling.kategori,
-                    underkategori = forrigeBehandling.underkategori,
-                    søkersIdent = forrigeBehandling.fagsak.aktør.aktivFødselsnummer(),
-                    behandlingType = BehandlingType.REVURDERING,
-                    behandlingÅrsak = BehandlingÅrsak.KLAGE,
-                    navIdent = SikkerhetContext.hentSaksbehandler(),
-                    barnasIdenter = emptyList(),
-                    fagsakId = forrigeBehandling.fagsak.id,
-                    nyEksternBehandlingRelasjon = null,
-                )
-
-            // Act
-            klageService.validerOgOpprettRevurderingKlage(fagsakId = fagsak.id, klagebehandlingId = null)
-
-            // Assert
-            verify { stegService.håndterNyBehandling(nyBehandling) }
-        }
-
-        @Test
         fun `kan opprette revurdering med ekstern behandling relasjon hvis det finnes en ferdigstilt behandling`() {
             // Arrange
             val klagebehandlingId = UUID.randomUUID()
@@ -201,7 +162,7 @@ class KlageServiceTest {
             every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns lagBehandling(status = BehandlingStatus.UTREDES)
 
             // Act
-            val result = klageService.validerOgOpprettRevurderingKlage(fagsakId = 0L, klagebehandlingId = null)
+            val result = klageService.validerOgOpprettRevurderingKlage(fagsakId = 0L, klagebehandlingId = UUID.randomUUID())
 
             // Assert
             assertThat(result.opprettetBehandling).isFalse()
@@ -215,7 +176,7 @@ class KlageServiceTest {
             every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns null
 
             // Act
-            val result = klageService.validerOgOpprettRevurderingKlage(fagsakId = 0L, klagebehandlingId = null)
+            val result = klageService.validerOgOpprettRevurderingKlage(fagsakId = 0L, klagebehandlingId = UUID.randomUUID())
 
             // Assert
             assertThat(result.opprettetBehandling).isFalse()
@@ -272,7 +233,7 @@ class KlageServiceTest {
     }
 
     @Nested
-    inner class SettRiktigEnhetVedOpprettelseAvKlage {
+    inner class OpprettKlage {
         @Test
         fun `skal sette enheten til saksbehandlers enhet ved opprettelse av klage`() {
             // Arrange


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-25500](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25500)

Fjerner endepunkt som ikke er i bruk lengre. Erstatte av [dette](https://github.com/navikt/familie-ba-sak/blob/main/src/main/kotlin/no/nav/familie/ba/sak/ekstern/EksternKlageController.kt#L74) endepunktet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
