### PR TITLE
NAV-25329: Legger til fagsakeier til fagsak dtoene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsak.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestFagsak.kt
@@ -11,6 +11,7 @@ import java.time.LocalDateTime
 open class RestBaseFagsak(
     open val opprettetTidspunkt: LocalDateTime,
     open val id: Long,
+    open val fagsakeier: String,
     open val søkerFødselsnummer: String,
     open val status: FagsakStatus,
     open val underBehandling: Boolean,
@@ -24,6 +25,7 @@ open class RestBaseFagsak(
 data class RestFagsak(
     override val opprettetTidspunkt: LocalDateTime,
     override val id: Long,
+    override val fagsakeier: String,
     override val søkerFødselsnummer: String,
     override val status: FagsakStatus,
     override val underBehandling: Boolean,
@@ -35,6 +37,7 @@ data class RestFagsak(
 ) : RestBaseFagsak(
         opprettetTidspunkt = opprettetTidspunkt,
         id = id,
+        fagsakeier = fagsakeier,
         søkerFødselsnummer = søkerFødselsnummer,
         status = status,
         underBehandling = underBehandling,
@@ -49,6 +52,7 @@ fun RestBaseFagsak.tilRestFagsak(
 ) = RestFagsak(
     opprettetTidspunkt = this.opprettetTidspunkt,
     id = this.id,
+    fagsakeier = this.fagsakeier,
     søkerFødselsnummer = this.søkerFødselsnummer,
     status = this.status,
     underBehandling = this.underBehandling,
@@ -62,6 +66,7 @@ fun RestBaseFagsak.tilRestFagsak(
 data class RestMinimalFagsak(
     override val opprettetTidspunkt: LocalDateTime,
     override val id: Long,
+    override val fagsakeier: String,
     override val søkerFødselsnummer: String,
     override val status: FagsakStatus,
     override val løpendeKategori: BehandlingKategori?,
@@ -75,6 +80,7 @@ data class RestMinimalFagsak(
 ) : RestBaseFagsak(
         opprettetTidspunkt = opprettetTidspunkt,
         id = id,
+        fagsakeier = fagsakeier,
         søkerFødselsnummer = søkerFødselsnummer,
         status = status,
         underBehandling = underBehandling,
@@ -91,6 +97,7 @@ fun RestBaseFagsak.tilRestMinimalFagsak(
 ) = RestMinimalFagsak(
     opprettetTidspunkt = this.opprettetTidspunkt,
     id = this.id,
+    fagsakeier = this.fagsakeier,
     søkerFødselsnummer = this.søkerFødselsnummer,
     status = this.status,
     underBehandling = this.underBehandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -252,6 +252,7 @@ class FagsakService(
         return RestBaseFagsak(
             opprettetTidspunkt = fagsak.opprettetTidspunkt,
             id = fagsak.id,
+            fagsakeier = fagsak.aktør.aktivFødselsnummer(),
             søkerFødselsnummer = hentSøkersFødselsnummer(fagsak),
             status = fagsak.status,
             underBehandling =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -125,6 +125,7 @@ class BeregningServiceTest {
                 RestBaseFagsak(
                     opprettetTidspunkt = fagsak.opprettetTidspunkt,
                     id = fagsak.id,
+                    fagsakeier = fagsak.aktør.aktivFødselsnummer(),
                     søkerFødselsnummer = fagsak.aktør.aktivFødselsnummer(),
                     status = fagsak.status,
                     underBehandling = false,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -139,6 +139,7 @@ class FagsakServiceTest {
             // Assert
             assertThat(restMinimalFagsak.opprettetTidspunkt).isNotNull()
             assertThat(restMinimalFagsak.id).isEqualTo(fagsak.id)
+            assertThat(restMinimalFagsak.fagsakeier).isEqualTo(fagsak.aktør.aktivFødselsnummer())
             assertThat(restMinimalFagsak.søkerFødselsnummer).isEqualTo(fagsak.aktør.aktivFødselsnummer())
             assertThat(restMinimalFagsak.status).isEqualTo(fagsak.status)
             assertThat(restMinimalFagsak.løpendeKategori).isEqualTo(sisteBehandlingSomErVedtatt.kategori)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-25329](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25329)

Har behov for å vite hvem som "eier" fagsaken når søker er satt til skjermet barn da "Opprett fagsak" modalen skal opprette fagsak på "eieren" av den eskisterende skjermet barn fagsaken.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
