### PR TITLE
Dersom behandlingskategori er EØS, skal ikke ulovfestet motregning brukes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
 import no.nav.familie.ba.sak.config.FeatureToggle.BRUK_FUNKSJONALITET_FOR_ULOVFESTET_MOTREGNING
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
@@ -38,6 +39,11 @@ class AvregningService(
         }
 
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+
+        if (behandling.kategori == BehandlingKategori.EØS) {
+            return emptyList()
+        }
+
         val sisteIverksatteBehandling =
             behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
                 ?: return emptyList()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22552

Ulovfestet motregning skal ikke brukes for EØS-behandler. Løser dette ved å returnere en tom liste med avregningsperioder for EØS-saker, da det er returverdien til denne funksjonen som trigger løypen for ulovfestet motregning