### PR TITLE
Generering av andeler ved endret utbetaling med årsak ENDRE_MOTTAKER

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -48,4 +48,6 @@ enum class FeatureToggle(
 
     // NAV-25329
     BRUK_NY_OPPRETT_FAGSAK_MODAL("familie-ba-sak.bruk.ny.opprett.fagsak.modal"),
+
+    SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER("familie-ba-sak.skal-inkludere-aarsak-endre-mottaker-i-initiell-generering-av-andeler"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGenerator.kt
@@ -69,10 +69,17 @@ class TilkjentYtelseGenerator(
 
         val skalBeholdeSplittI0krAndeler = unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING)
 
+        val endretUtbetalingAndelÅrsakerSomSkalInkluderes =
+            if (unleashService.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER)) {
+                listOf(Årsak.ETTERBETALING_3ÅR, Årsak.ETTERBETALING_3MND, Årsak.ENDRE_MOTTAKER)
+            } else {
+                listOf(Årsak.ETTERBETALING_3ÅR, Årsak.ETTERBETALING_3MND)
+            }
+
         val barnasAndelerInkludertEtterbetaling3ÅrEller3MndEndringer =
             lagAndelerMedEndretUtbetalingAndeler(
                 andelTilkjentYtelserUtenEndringer = andelerTilkjentYtelseBarnaUtenEndringer,
-                endretUtbetalingAndeler = endretUtbetalingAndelerBarna.filter { it.årsak in listOf(Årsak.ETTERBETALING_3ÅR, Årsak.ETTERBETALING_3MND) },
+                endretUtbetalingAndeler = endretUtbetalingAndelerBarna.filter { it.årsak in endretUtbetalingAndelÅrsakerSomSkalInkluderes },
                 tilkjentYtelse = tilkjentYtelse,
                 skalBeholdeSplittI0krAndeler = skalBeholdeSplittI0krAndeler,
             )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25230

Dersom et barn har en endret utbetaling med årsak ENDRE_MOTTAKER, har ikke søker rett på utvidet for dette barnet. For å gjenspeile dette i genereringen av andeler, inkluderes nå EndretUtbetalingAndel'er med årsak ENDRE_MOTTAKER i den initielle genereringen av andeler for barn. 

Det gjør at utvidetandeler blir påvirket på følgende måte:
- Dersom alle barna i behandlingen får andeler i en periode satt til 0% som følge av endret utbetaling med årsak ENDRE_MOTTAKER, vil utvidetandeler også bli satt til 0% i samme periode.
- Dersom søker har to barn, ett med 100% utbetaling og ett med 50% utbetaling, og barnet med 100% utbetaling får andeler i en periode satt til 0% som følge av endret utbetaling med årsak ENDRE_MOTTAKER, vil utvidetandeler bli satt til 50% i samme periode.