### PR TITLE
NAV-25329: Tilpasser unik index på fagsak for skjermet barn

### DIFF
--- a/src/main/resources/db/migration/V285__lag_fagsak_index_for_skjermet_barn.sql
+++ b/src/main/resources/db/migration/V285__lag_fagsak_index_for_skjermet_barn.sql
@@ -1,0 +1,8 @@
+CREATE UNIQUE INDEX IF NOT EXISTS ny_uidx_fagsak_type_aktoer_ikke_arkivert ON fagsak (type, fk_aktoer_id)
+    WHERE fagsak.fk_institusjon_id IS NULL
+        AND fagsak.fk_skjermet_barn_soker_id IS NULL
+        AND arkivert = false;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_fagsak_type_aktoer_skjermet_barn_ikke_arkivert ON fagsak (type, fk_aktoer_id, fk_skjermet_barn_soker_id)
+    WHERE fagsak.fk_skjermet_barn_soker_id IS NOT NULL
+        AND arkivert = false;

--- a/src/main/resources/db/migration/V286__omdoep_fagsak_index_for_skjermet_barn.sql
+++ b/src/main/resources/db/migration/V286__omdoep_fagsak_index_for_skjermet_barn.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS uidx_fagsak_type_aktoer_ikke_arkivert;
+
+ALTER INDEX IF EXISTS ny_uidx_fagsak_type_aktoer_ikke_arkivert RENAME TO uidx_fagsak_type_aktoer_ikke_arkivert;


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-25329](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25329)

Slik som det er nå får man feilmeldingen under når man prøver å opprette en skjermet barn fagsak på et barn som allerede har en skjermet barn fagsak. Det skal være tillatt å opprette en skjermet barn fagsak med forskjellige søkers ident. Endringer her gjør slik at man ikke møter på debbe databasebegresningen. 

> ERROR: duplicate key value violates unique constraint \"uidx_fagsak_type_aktoer_ikke_arkivert\"\n  Detail: Key (type, fk_aktoer_id)=(SKJERMET_BARN, 2045841601491) already exists.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Se kommentar i PR.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
