### PR TITLE
Slett toggle

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -41,8 +41,6 @@ enum class FeatureToggle(
     // Tillatter behandling av klage
     BEHANDLE_KLAGE("familie-ba-sak.klage"),
 
-    SKAL_BRUKE_NY_DIFFERANSEBEREGNING("familie-ba-sak.skal-bruke-ny-differanseberegning"),
-
     // NAV-25256
     SKAL_BRUKE_FAGSAKTYPE_SKJERMET_BARN("familie-ba-sak.skjermet-barn"),
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseMedEndretUtbetalingGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseMedEndretUtbetalingGenerator.kt
@@ -26,7 +26,6 @@ object AndelTilkjentYtelseMedEndretUtbetalingGenerator {
         andelTilkjentYtelserUtenEndringer: Collection<AndelTilkjentYtelse>,
         endretUtbetalingAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
         tilkjentYtelse: TilkjentYtelse,
-        skalBeholdeSplittI0krAndeler: Boolean,
     ): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
         if (endretUtbetalingAndeler.isEmpty()) {
             return andelTilkjentYtelserUtenEndringer
@@ -58,7 +57,6 @@ object AndelTilkjentYtelseMedEndretUtbetalingGenerator {
                             andelerAvTypeForPerson = andelerForAktørOgType,
                             endretUtbetalingAndelerForPerson = endringerPerAktør.getOrDefault(aktør, emptyList()),
                             tilkjentYtelse = tilkjentYtelse,
-                            skalBeholdeSplittI0krAndeler = skalBeholdeSplittI0krAndeler,
                         )
                     YtelseType.SMÅBARNSTILLEGG ->
                         throw Feil("Småbarnstillegg kan ikke oppdateres med endret utbetaling andeler i behandling=${tilkjentYtelse.behandling.id}")
@@ -72,7 +70,6 @@ object AndelTilkjentYtelseMedEndretUtbetalingGenerator {
         andelerAvTypeForPerson: List<AndelTilkjentYtelse>,
         endretUtbetalingAndelerForPerson: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
         tilkjentYtelse: TilkjentYtelse,
-        skalBeholdeSplittI0krAndeler: Boolean,
     ): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
         if (endretUtbetalingAndelerForPerson.isEmpty()) {
             return andelerAvTypeForPerson
@@ -110,14 +107,7 @@ object AndelTilkjentYtelseMedEndretUtbetalingGenerator {
                 }
             }
 
-        return if (skalBeholdeSplittI0krAndeler) {
-            andelerMedEndringerTidslinje
-                .tilAndelerTilkjentYtelseMedEndreteUtbetalinger(tilkjentYtelse)
-        } else {
-            andelerMedEndringerTidslinje
-                .slåSammenEtterfølgende0krAndelerPgaSammeEndretAndel()
-                .tilAndelerTilkjentYtelseMedEndreteUtbetalinger(tilkjentYtelse)
-        }
+        return andelerMedEndringerTidslinje.tilAndelerTilkjentYtelseMedEndreteUtbetalinger(tilkjentYtelse)
     }
 
     internal data class AndelMedEndretUtbetalingForTidslinje(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGenerator.kt
@@ -67,8 +67,6 @@ class TilkjentYtelseGenerator(
                     )
                 }
 
-        val skalBeholdeSplittI0krAndeler = unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING)
-
         val endretUtbetalingAndelÅrsakerSomSkalInkluderes =
             if (unleashService.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER)) {
                 listOf(Årsak.ETTERBETALING_3ÅR, Årsak.ETTERBETALING_3MND, Årsak.ENDRE_MOTTAKER)
@@ -81,7 +79,6 @@ class TilkjentYtelseGenerator(
                 andelTilkjentYtelserUtenEndringer = andelerTilkjentYtelseBarnaUtenEndringer,
                 endretUtbetalingAndeler = endretUtbetalingAndelerBarna.filter { it.årsak in endretUtbetalingAndelÅrsakerSomSkalInkluderes },
                 tilkjentYtelse = tilkjentYtelse,
-                skalBeholdeSplittI0krAndeler = skalBeholdeSplittI0krAndeler,
             )
 
         val andelerTilkjentYtelseUtvidetMedAlleEndringer =
@@ -90,7 +87,6 @@ class TilkjentYtelseGenerator(
                 andelerTilkjentYtelseBarnaMedEtterbetaling3ÅrEller3MndEndringer = barnasAndelerInkludertEtterbetaling3ÅrEller3MndEndringer,
                 endretUtbetalingAndelerSøker = endretUtbetalingAndelerSøker,
                 personResultater = vilkårsvurdering.personResultater,
-                skalBeholdeSplittI0krAndeler = skalBeholdeSplittI0krAndeler,
             )
 
         val småbarnstilleggErMulig =
@@ -128,7 +124,6 @@ class TilkjentYtelseGenerator(
                 andelTilkjentYtelserUtenEndringer = andelerTilkjentYtelseBarnaUtenEndringer,
                 endretUtbetalingAndeler = endretUtbetalingAndelerBarna,
                 tilkjentYtelse = tilkjentYtelse,
-                skalBeholdeSplittI0krAndeler = skalBeholdeSplittI0krAndeler,
             )
 
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel } + andelerTilkjentYtelseUtvidetMedAlleEndringer.map { it.andel } + andelerTilkjentYtelseSmåbarnstillegg.map { it.andel })

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtil.kt
@@ -26,7 +26,6 @@ object UtvidetBarnetrygdUtil {
         tilkjentYtelse: TilkjentYtelse,
         endretUtbetalingAndelerSøker: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
         personResultater: Set<PersonResultat>,
-        skalBeholdeSplittI0krAndeler: Boolean,
     ): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
         val andelerTilkjentYtelseUtvidet =
             UtvidetBarnetrygdGenerator(
@@ -42,7 +41,6 @@ object UtvidetBarnetrygdUtil {
             andelTilkjentYtelserUtenEndringer = andelerTilkjentYtelseUtvidet,
             endretUtbetalingAndeler = endretUtbetalingAndelerSøker,
             tilkjentYtelse = tilkjentYtelse,
-            skalBeholdeSplittI0krAndeler = skalBeholdeSplittI0krAndeler,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -44,7 +44,6 @@ fun beregnDifferanse(
     andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
     utenlandskePeriodebeløp: Collection<UtenlandskPeriodebeløp>,
     valutakurser: Collection<Valutakurs>,
-    skalBrukeNyDifferanseberegning: Boolean,
 ): List<AndelTilkjentYtelse> {
     val utenlandskePeriodebeløpTidslinjer = utenlandskePeriodebeløp.tilSeparateTidslinjerForBarna()
     val valutakursTidslinjer = valutakurser.tilSeparateTidslinjerForBarna()
@@ -57,7 +56,7 @@ fun beregnDifferanse(
 
     val barnasDifferanseberegneteAndelTilkjentYtelseTidslinjer =
         andelTilkjentYtelseTidslinjer.outerJoin(barnasUtenlandskePeriodebeløpINorskeKronerTidslinjer) { aty, beløp ->
-            aty.oppdaterDifferanseberegning(beløp, skalBrukeNyDifferanseberegning)
+            aty.oppdaterDifferanseberegning(beløp)
         }
 
     val barnasAndeler = barnasDifferanseberegneteAndelTilkjentYtelseTidslinjer.tilAndelerTilkjentYtelse()
@@ -76,7 +75,6 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
     barna: List<Person>,
     kompetanser: Collection<Kompetanse>,
     personResultater: Set<PersonResultat>,
-    skalBrukeNyDifferanseberegning: Boolean,
 ): List<AndelTilkjentYtelse> {
     // Ta bort eventuell eksisterende differanseberegning, slik at kalkulertUtbetalingsbeløp er nasjonal sats
     // Men behold funksjonelle splitter som er påført tidligere ved å beholde fom og tom på andelene
@@ -125,7 +123,7 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
 
     // Til slutt oppdaterer vi differanseberegningen på utvidet barnetrygd med den utenlandske delen
     val differanseberegnetUtvidetBarnetrygdTidslinje =
-        utvidetBarnetrygdTidslinje.oppdaterDifferanseberegning(utenlandskDelAvUtvidetBarnetrygdTidslinje, skalBrukeNyDifferanseberegning)
+        utvidetBarnetrygdTidslinje.oppdaterDifferanseberegning(utenlandskDelAvUtvidetBarnetrygdTidslinje)
 
     // For hvert barn finner vi ut hvor mye underskudd som gjenstår etter at delen av utvidet barnetrygd er trukket fra
     val barnasGjenståendeUnderskuddTidslinjer =
@@ -160,7 +158,7 @@ fun Collection<AndelTilkjentYtelse>.differanseberegnSøkersYtelser(
 
     // Til slutt oppdaterer vi differanseberegningen på småbarnstillegget med den utenlandske delen
     val differanseberegnetSmåbarnstilleggTidslinje =
-        småbarnstilleggTidslinje.oppdaterDifferanseberegning(utenlandskDelAvSmåbarnstilleggTidslinje, skalBrukeNyDifferanseberegning)
+        småbarnstilleggTidslinje.oppdaterDifferanseberegning(utenlandskDelAvSmåbarnstilleggTidslinje)
 
     // Returner det fulle settet av andeler, både barnas andeler og de potensielt nye andelene for søkers ytelser
     return this.filter { !it.erSøkersAndel() } +

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtils.kt
@@ -31,13 +31,12 @@ fun Intervall.konverterBeløpTilMånedlig(beløp: BigDecimal): BigDecimal =
  */
 fun AndelTilkjentYtelse?.oppdaterDifferanseberegning(
     utenlandskPeriodebeløpINorskeKroner: BigDecimal?,
-    skalBrukeNyDifferanseberegning: Boolean,
 ): AndelTilkjentYtelse? {
     val nyAndelTilkjentYtelse =
         when {
             this == null -> null
             utenlandskPeriodebeløpINorskeKroner == null -> this.utenDifferanseberegning()
-            else -> this.medDifferanseberegning(utenlandskPeriodebeløpINorskeKroner, skalBrukeNyDifferanseberegning)
+            else -> this.medDifferanseberegning(utenlandskPeriodebeløpINorskeKroner)
         }
 
     return nyAndelTilkjentYtelse
@@ -45,7 +44,6 @@ fun AndelTilkjentYtelse?.oppdaterDifferanseberegning(
 
 fun AndelTilkjentYtelse.medDifferanseberegning(
     utenlandskPeriodebeløpINorskeKroner: BigDecimal,
-    skalBrukeNyDifferanseberegning: Boolean,
 ): AndelTilkjentYtelse {
     val avrundetUtenlandskPeriodebeløp =
         utenlandskPeriodebeløpINorskeKroner
@@ -70,12 +68,7 @@ fun AndelTilkjentYtelse.medDifferanseberegning(
     return copy(
         id = 0,
         kalkulertUtbetalingsbeløp = maxOf(nyttKalkulertUtbetalingsbeløp, 0),
-        differanseberegnetPeriodebeløp =
-            if (skalBrukeNyDifferanseberegning) {
-                nyttDifferanseberegnetPeriodebeløp
-            } else {
-                nyttKalkulertUtbetalingsbeløp
-            },
+        differanseberegnetPeriodebeløp = nyttDifferanseberegnetPeriodebeløp,
     )
 }
 
@@ -106,10 +99,9 @@ fun Tidslinje<AndelTilkjentYtelse>.utenDifferanseberegning() =
 
 fun Tidslinje<AndelTilkjentYtelse>.oppdaterDifferanseberegning(
     utenlandskBeløpINorskeKronerTidslinje: Tidslinje<BigDecimal>,
-    skalBrukeNyDifferanseberegning: Boolean,
 ): Tidslinje<AndelTilkjentYtelse> =
     this.kombinerMed(utenlandskBeløpINorskeKronerTidslinje) { andel, utenlandskBeløpINorskeKroner ->
-        andel.oppdaterDifferanseberegning(utenlandskBeløpINorskeKroner, skalBrukeNyDifferanseberegning)
+        andel.oppdaterDifferanseberegning(utenlandskBeløpINorskeKroner)
     }
 
 /**

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilpassDifferanseberegningService.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
-import no.nav.familie.ba.sak.config.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseEndretAbonnent
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -28,7 +26,6 @@ class TilpassDifferanseberegningEtterTilkjentYtelseService(
     private val utenlandskPeriodebeløpRepository: PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp>,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val barnasDifferanseberegningEndretAbonnenter: List<BarnasDifferanseberegningEndretAbonnent>,
-    private val unleashService: UnleashNextMedContextService,
 ) : TilkjentYtelseEndretAbonnent {
     @Transactional
     override fun endretTilkjentYtelse(tilkjentYtelse: TilkjentYtelse) {
@@ -36,14 +33,11 @@ class TilpassDifferanseberegningEtterTilkjentYtelseService(
         val valutakurser = valutakursRepository.finnFraBehandlingId(behandlingId.id)
         val utenlandskePeriodebeløp = utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id)
 
-        val skalBrukeNyDifferanseberegning = unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING)
-
         val oppdaterteAndeler =
             beregnDifferanse(
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse,
                 utenlandskePeriodebeløp = utenlandskePeriodebeløp,
                 valutakurser = valutakurser,
-                skalBrukeNyDifferanseberegning = skalBrukeNyDifferanseberegning,
             )
 
         val oppdatertTilkjentYtelse = tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
@@ -57,7 +51,6 @@ class TilpassDifferanseberegningEtterUtenlandskPeriodebeløpService(
     private val automatiskOppdaterValutakursService: AutomatiskOppdaterValutakursService,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val barnasDifferanseberegningEndretAbonnenter: List<BarnasDifferanseberegningEndretAbonnent>,
-    private val unleashService: UnleashNextMedContextService,
 ) : PeriodeOgBarnSkjemaEndringAbonnent<UtenlandskPeriodebeløp> {
     @Transactional
     override fun skjemaerEndret(
@@ -70,14 +63,11 @@ class TilpassDifferanseberegningEtterUtenlandskPeriodebeløpService(
 
         val valutakurser = valutakursRepository.finnFraBehandlingId(behandlingId.id)
 
-        val skalBrukeNyDifferanseberegning = unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING)
-
         val oppdaterteAndeler =
             beregnDifferanse(
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse,
                 utenlandskePeriodebeløp = utenlandskePeriodebeløp,
                 valutakurser = valutakurser,
-                skalBrukeNyDifferanseberegning = skalBrukeNyDifferanseberegning,
             )
 
         val oppdatertTilkjentYtelse = tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
@@ -90,7 +80,6 @@ class TilpassDifferanseberegningEtterValutakursService(
     private val utenlandskPeriodebeløpRepository: PeriodeOgBarnSkjemaRepository<UtenlandskPeriodebeløp>,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val barnasDifferanseberegningEndretAbonnenter: List<BarnasDifferanseberegningEndretAbonnent>,
-    private val unleashService: UnleashNextMedContextService,
 ) : PeriodeOgBarnSkjemaEndringAbonnent<Valutakurs> {
     @Transactional
     override fun skjemaerEndret(
@@ -100,14 +89,11 @@ class TilpassDifferanseberegningEtterValutakursService(
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandlingOptional(behandlingId.id) ?: return
         val utenlandskePeriodebeløp = utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id)
 
-        val skalBrukeNyDifferanseberegning = unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING)
-
         val oppdaterteAndeler =
             beregnDifferanse(
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse,
                 utenlandskePeriodebeløp = utenlandskePeriodebeløp,
                 valutakurser = valutakurser,
-                skalBrukeNyDifferanseberegning = skalBrukeNyDifferanseberegning,
             )
 
         val oppdatertTilkjentYtelse = tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
@@ -121,17 +107,13 @@ class TilpassDifferanseberegningSøkersYtelserService(
     private val kompetanseRepository: KompetanseRepository,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
-    private val unleashService: UnleashNextMedContextService,
 ) : BarnasDifferanseberegningEndretAbonnent {
     override fun barnasDifferanseberegningEndret(tilkjentYtelse: TilkjentYtelse) {
-        val skalBrukeNyDifferanseberegning = unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING)
-
         val oppdaterteAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = persongrunnlagService.hentBarna(tilkjentYtelse.behandling.id),
                 kompetanser = kompetanseRepository.finnFraBehandlingId(tilkjentYtelse.behandling.id),
                 personResultater = vilkårsvurderingRepository.findByBehandlingAndAktiv(tilkjentYtelse.behandling.id)!!.personResultater,
-                skalBrukeNyDifferanseberegning = skalBrukeNyDifferanseberegning,
             )
         tilkjentYtelseRepository.oppdaterTilkjentYtelse(tilkjentYtelse, oppdaterteAndeler)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.datagenerator.lagEndretUtbetalingAndel
 import no.nav.familie.ba.sak.datagenerator.lagEndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndretUtbetalingGenerator.lagAndelerMedEndretUtbetalingAndeler
-import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndretUtbetalingGenerator.slåSammenEtterfølgende0krAndelerPgaSammeEndretAndel
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndretUtbetalingGenerator.tilAndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.AndelTilkjentYtelseMedEndretUtbetalingGenerator.tilAndelerTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.EndretUtbetalingAndelMedAndelerTilkjentYtelse
@@ -22,7 +21,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
-import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -50,7 +48,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     andelTilkjentYtelserUtenEndringer = emptyList(),
                     endretUtbetalingAndeler = emptyList(),
                     tilkjentYtelse = tilkjentYtelse,
-                    skalBeholdeSplittI0krAndeler = true,
                 )
 
             // Assert
@@ -97,7 +94,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     andelTilkjentYtelserUtenEndringer = listOf(andel1, andel2),
                     endretUtbetalingAndeler = emptyList(),
                     tilkjentYtelse = tilkjentYtelse,
-                    skalBeholdeSplittI0krAndeler = true,
                 )
 
             // Assert
@@ -165,7 +161,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     andelTilkjentYtelserUtenEndringer = listOf(andel1, andel2),
                     endretUtbetalingAndeler = listOf(endretUtbetalingAndelForBarn1),
                     tilkjentYtelse = tilkjentYtelse,
-                    skalBeholdeSplittI0krAndeler = true,
                 )
 
             // Assert
@@ -241,7 +236,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     andelTilkjentYtelserUtenEndringer = listOf(andelBarn, andelUtvidet, andelSmåbarnstillegg),
                     endretUtbetalingAndeler = listOf(endretUtbetalingAndelForSøker),
                     tilkjentYtelse = tilkjentYtelse,
-                    skalBeholdeSplittI0krAndeler = true,
                 )
             }
         }
@@ -294,7 +288,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     andelTilkjentYtelserUtenEndringer = listOf(andel1, andel2),
                     endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
                     tilkjentYtelse = tilkjentYtelse,
-                    skalBeholdeSplittI0krAndeler = true,
                 )
 
             // Assert
@@ -361,7 +354,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     andelTilkjentYtelserUtenEndringer = utbetalingsandeler,
                     endretUtbetalingAndeler = endretUtbetalingAndeler,
                     tilkjentYtelse = utbetalingsandeler.first().tilkjentYtelse,
-                    skalBeholdeSplittI0krAndeler = true,
                 )
 
             assertThat(andelerTilkjentYtelse.size).isEqualTo(1)
@@ -422,7 +414,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     andelTilkjentYtelserUtenEndringer = utbetalingsandeler,
                     endretUtbetalingAndeler = endretUtbetalingAndeler,
                     tilkjentYtelse = utbetalingsandeler.first().tilkjentYtelse,
-                    skalBeholdeSplittI0krAndeler = true,
                 )
 
             assertThat(andelerTilkjentYtelse.size).isEqualTo(2)
@@ -433,249 +424,6 @@ class AndelTilkjentYtelseMedEndretUtbetalingGeneratorTest {
                     it.endreteUtbetalinger.single().id,
                 ).isEqualTo(endretUtbetalingAndel.id)
             }
-        }
-    }
-
-    @Nested
-    inner class SlåSammenEtterfølgendeAndelerTest {
-        @Test
-        fun `skal ikke slå sammen etterfølgende 0kr-andeler hvis de ikke skyldes samme endret utbetaling andel`() {
-            // Arrange
-            val barn = lagPerson(type = PersonType.BARN)
-
-            val periode1 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(9).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().minusMonths(5).sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 0,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1054,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal.ZERO,
-                            endretUtbetalingAndel =
-                                EndretUtbetalingAndelMedAndelerTilkjentYtelse(
-                                    andeler = emptyList(),
-                                    endretUtbetalingAndel =
-                                        lagEndretUtbetalingAndel(
-                                            personer = setOf(barn),
-                                            prosent = BigDecimal.ZERO,
-                                            årsak = Årsak.ETTERBETALING_3MND,
-                                        ),
-                                ),
-                        ),
-                )
-
-            val periode2 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(4).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 0,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1054,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal.ZERO,
-                            endretUtbetalingAndel =
-                                EndretUtbetalingAndelMedAndelerTilkjentYtelse(
-                                    andeler = emptyList(),
-                                    endretUtbetalingAndel =
-                                        lagEndretUtbetalingAndel(
-                                            personer = setOf(barn),
-                                            prosent = BigDecimal.ZERO,
-                                            årsak = Årsak.ALLEREDE_UTBETALT,
-                                        ),
-                                ),
-                        ),
-                )
-
-            val perioderMedAndeler = listOf(periode1, periode2)
-
-            // Act
-            val perioderEtterSammenslåing =
-                perioderMedAndeler.tilTidslinje().slåSammenEtterfølgende0krAndelerPgaSammeEndretAndel().tilPerioderIkkeNull()
-
-            // Assert
-            assertThat(perioderEtterSammenslåing.size).isEqualTo(2)
-            assertThat(perioderEtterSammenslåing[0]).isEqualTo(periode1)
-            assertThat(perioderEtterSammenslåing[1]).isEqualTo(periode2)
-        }
-
-        @Test
-        fun `skal ikke slå sammen 0kr-andeler som har tom periode mellom seg`() {
-            // Arrange
-            val barn = lagPerson(type = PersonType.BARN)
-            val endretUtbetalingAndel =
-                lagEndretUtbetalingAndel(personer = setOf(barn), prosent = BigDecimal.ZERO, årsak = Årsak.ALLEREDE_UTBETALT)
-
-            val periode1 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(9).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().minusMonths(5).sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 0,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1054,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal.ZERO,
-                            endretUtbetalingAndel =
-                                EndretUtbetalingAndelMedAndelerTilkjentYtelse(
-                                    andeler = emptyList(),
-                                    endretUtbetalingAndel = endretUtbetalingAndel,
-                                ),
-                        ),
-                )
-
-            val periode2 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 0,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1054,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal.ZERO,
-                            endretUtbetalingAndel =
-                                EndretUtbetalingAndelMedAndelerTilkjentYtelse(
-                                    andeler = emptyList(),
-                                    endretUtbetalingAndel = endretUtbetalingAndel,
-                                ),
-                        ),
-                )
-            val perioderMedAndeler = listOf(periode1, periode2)
-
-            // Act
-            val perioderEtterSammenslåing =
-                perioderMedAndeler.tilTidslinje().slåSammenEtterfølgende0krAndelerPgaSammeEndretAndel().tilPerioderIkkeNull()
-
-            // Assert
-            assertThat(perioderEtterSammenslåing.size).isEqualTo(2)
-            assertThat(perioderEtterSammenslåing[0]).isEqualTo(periode1)
-            assertThat(perioderEtterSammenslåing[1]).isEqualTo(periode2)
-        }
-
-        @Test
-        fun `skal ikke slå sammen etterfølgende andeler med 100 prosent utbetaling av ulik sats`() {
-            // Arrange
-            val barn = lagPerson(type = PersonType.BARN)
-
-            val periode1 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(9).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().minusMonths(5).sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 1054,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1054,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal(100),
-                            endretUtbetalingAndel = null,
-                        ),
-                )
-
-            val periode2 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(4).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 1766,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1766,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal(100),
-                            endretUtbetalingAndel = null,
-                        ),
-                )
-            val perioderMedAndeler = listOf(periode1, periode2)
-
-            // Act
-            val perioderEtterSammenslåing =
-                perioderMedAndeler.tilTidslinje().slåSammenEtterfølgende0krAndelerPgaSammeEndretAndel().tilPerioderIkkeNull()
-
-            // Assert
-            assertThat(perioderEtterSammenslåing.size).isEqualTo(2)
-            assertThat(perioderEtterSammenslåing[0]).isEqualTo(periode1)
-            assertThat(perioderEtterSammenslåing[1]).isEqualTo(periode2)
-        }
-
-        @Test
-        fun `skal slå sammen etterfølgende 0kr-andeler som skyldes samme endret andel, men er splittet pga satsendring`() {
-            // Arrange
-            val barn = lagPerson(type = PersonType.BARN)
-            val endretUtbetalingAndel =
-                lagEndretUtbetalingAndel(
-                    personer = setOf(barn),
-                    prosent = BigDecimal.ZERO,
-                    årsak = Årsak.ALLEREDE_UTBETALT,
-                    fom = YearMonth.now().minusMonths(9),
-                    tom = YearMonth.now(),
-                )
-
-            val periode1 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(9).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().minusMonths(5).sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 0,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1054,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal.ZERO,
-                            endretUtbetalingAndel =
-                                EndretUtbetalingAndelMedAndelerTilkjentYtelse(
-                                    andeler = emptyList(),
-                                    endretUtbetalingAndel = endretUtbetalingAndel,
-                                ),
-                        ),
-                )
-
-            val periode2 =
-                Periode(
-                    fom = LocalDate.now().minusMonths(4).førsteDagIInneværendeMåned(),
-                    tom = LocalDate.now().sisteDagIMåned(),
-                    verdi =
-                        AndelTilkjentYtelseMedEndretUtbetalingGenerator.AndelMedEndretUtbetalingForTidslinje(
-                            aktør = barn.aktør,
-                            beløp = 0,
-                            beløpUtenEndretUtbetaling = 0,
-                            sats = 1766,
-                            ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
-                            prosent = BigDecimal.ZERO,
-                            endretUtbetalingAndel =
-                                EndretUtbetalingAndelMedAndelerTilkjentYtelse(
-                                    andeler = emptyList(),
-                                    endretUtbetalingAndel = endretUtbetalingAndel,
-                                ),
-                        ),
-                )
-
-            val perioderMedAndeler = listOf(periode1, periode2)
-
-            // Act
-            val perioderEtterSammenslåing =
-                perioderMedAndeler.tilTidslinje().slåSammenEtterfølgende0krAndelerPgaSammeEndretAndel().tilPerioderIkkeNull()
-
-            // Assert
-            assertThat(perioderEtterSammenslåing.size).isEqualTo(1)
-            val periode = perioderEtterSammenslåing.single()
-            assertThat(periode.verdi).isEqualTo(periode1.verdi)
-            assertThat(periode.fom).isEqualTo(periode1.fom)
-            assertThat(periode.tom).isEqualTo(periode2.tom)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest.kt
@@ -375,7 +375,6 @@ private fun VilkårsvurderingBuilder.PersonResultatBuilder.beregnAndelerTilkjent
     every { overgangsstønadServiceMock.hentOgLagrePerioderMedOvergangsstønadForBehandling(any(), any()) } returns mockkObject()
     every { overgangsstønadServiceMock.hentPerioderMedFullOvergangsstønad(any<Behandling>()) } answers { emptyList() }
     every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
-    every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING) } returns true
     every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER) } returns true
 
     return tilkjentYtelseGenerator

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -140,7 +140,6 @@ class BeregningServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } answers { emptyList() }
         every { endretUtbetalingAndelRepository.saveAllAndFlush(any<Collection<EndretUtbetalingAndel>>()) } answers { emptyList() }
         every { andelTilkjentYtelseRepository.saveAllAndFlush(any<Collection<AndelTilkjentYtelse>>()) } answers { emptyList() }
-        every { unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING) } returns true
         every { unleashService.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER) } returns true
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGeneratorTest.kt
@@ -65,7 +65,6 @@ class TilkjentYtelseGeneratorTest {
     fun førHverTest() {
         mockkObject(SatsTidspunkt)
         every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2022, 12, 31)
-        every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING) } returns true
         every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER) } returns true
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsEndretUtbetalingAndelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsEndretUtbetalingAndelTest.kt
@@ -110,7 +110,6 @@ internal class TilkjentYtelseUtilsEndretUtbetalingAndelTest {
                 andelTilkjentYtelserUtenEndringer = (andelTilkjentytelseForBarn1 + andelTilkjentytelseForBarn2),
                 endretUtbetalingAndeler = endretUtbetalingerForBarn1 + endretUtbetalingerForBarn2,
                 tilkjentYtelse = tilkjentYtelse,
-                skalBeholdeSplittI0krAndeler = true,
             )
 
         val andelerTilkjentYtelserEtterEUAList = andelerTilkjentYtelserEtterEUA.map { it.andel }.toList()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -61,7 +61,6 @@ internal class UtvidetBarnetrygdTest {
     fun setup() {
         every { overgangsstønadServiceMock.hentOgLagrePerioderMedOvergangsstønadForBehandling(any(), any()) } returns mockkObject()
         every { overgangsstønadServiceMock.hentPerioderMedFullOvergangsstønad(any<Behandling>()) } answers { emptyList() }
-        every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING) } returns true
         every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER) } returns true
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
@@ -132,7 +132,6 @@ class UtvidetBarnetrygdUtilTest {
                         ),
                     endretUtbetalingAndelerSøker = emptyList(),
                     personResultater = setOf(personResultatBarn, personResultatSøker),
-                    skalBeholdeSplittI0krAndeler = true,
                 )
             }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/VilkårTilTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/VilkårTilTilkjentYtelseTest.kt
@@ -46,7 +46,6 @@ class VilkårTilTilkjentYtelseTest {
     fun førHverTest() {
         mockkObject(SatsTidspunkt)
         every { SatsTidspunkt.senesteSatsTidspunkt } returns LocalDate.of(2022, 12, 31)
-        every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING) } returns true
         every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER) } returns true
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -75,7 +75,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -159,7 +158,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
@@ -201,7 +199,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
@@ -217,7 +214,6 @@ class DifferanseberegningSøkersYtelserTest {
                     barna = emptyList(),
                     kompetanser = emptyList(),
                     personResultater = emptySet(),
-                    skalBrukeNyDifferanseberegning = true,
                 )
 
         assertEquals(emptyList<AndelTilkjentYtelse>(), nyeAndeler)
@@ -278,7 +274,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         // Dette er litt trist. Men selv om andelene er identiske, kan de ikke slås sammen fordi
@@ -344,7 +339,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -392,7 +386,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -447,7 +440,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -503,7 +495,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -563,7 +554,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -624,7 +614,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -685,7 +674,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -753,7 +741,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -826,7 +813,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =
@@ -899,7 +885,6 @@ class DifferanseberegningSøkersYtelserTest {
                 barna = barna,
                 kompetanser = kompetanser,
                 personResultater = personResultater,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         val forventet =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
@@ -91,10 +91,7 @@ class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal håndtere gjentakende endring og differanseberegning på andel tilkjent ytelse`() {
         val aty1 =
-            lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(
-                utenlandskPeriodebeløpINorskeKroner = 100.toBigDecimal(),
-                skalBrukeNyDifferanseberegning = true,
-            )
+            lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.toBigDecimal())
 
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(-50, aty1?.differanseberegnetPeriodebeløp)
@@ -102,10 +99,9 @@ class DifferanseberegningsUtilsTest {
         Assertions.assertEquals(50, aty1?.beløpUtenEndretUtbetaling)
 
         val aty2 =
-            aty1?.copy(nasjonaltPeriodebeløp = 1, beløpUtenEndretUtbetaling = 1).oppdaterDifferanseberegning(
-                utenlandskPeriodebeløpINorskeKroner = 75.toBigDecimal(),
-                skalBrukeNyDifferanseberegning = true,
-            )
+            aty1
+                ?.copy(nasjonaltPeriodebeløp = 1, beløpUtenEndretUtbetaling = 1)
+                .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 75.toBigDecimal())
 
         Assertions.assertEquals(0, aty2?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(-74, aty2?.differanseberegnetPeriodebeløp)
@@ -113,10 +109,9 @@ class DifferanseberegningsUtilsTest {
         Assertions.assertEquals(1, aty2?.beløpUtenEndretUtbetaling)
 
         val aty3 =
-            aty2?.copy(nasjonaltPeriodebeløp = 250, beløpUtenEndretUtbetaling = 250).oppdaterDifferanseberegning(
-                utenlandskPeriodebeløpINorskeKroner = 75.toBigDecimal(),
-                skalBrukeNyDifferanseberegning = true,
-            )
+            aty2
+                ?.copy(nasjonaltPeriodebeløp = 250, beløpUtenEndretUtbetaling = 250)
+                .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 75.toBigDecimal())
 
         Assertions.assertEquals(175, aty3?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(175, aty3?.differanseberegnetPeriodebeløp)
@@ -127,10 +122,8 @@ class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal fjerne desimaler i utenlandskperiodebeløp, effektivt øke den norske ytelsen med inntil én krone`() {
         val aty1 =
-            lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(
-                utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal(),
-                skalBrukeNyDifferanseberegning = true,
-            ) // Blir til rundet til 100
+            lagAndelTilkjentYtelse(beløp = 50)
+                .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal()) // Blir til rundet til 100
 
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(-50, aty1?.differanseberegnetPeriodebeløp)
@@ -140,26 +133,16 @@ class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal beholde originalt nasjonaltPeriodebeløp når vi oppdatererDifferanseberegning gjentatte ganger`() {
         var aty1 =
-            lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(
-                utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal(),
-                skalBrukeNyDifferanseberegning = true,
-            )
+            lagAndelTilkjentYtelse(beløp = 50)
+                .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal())
 
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
 
-        aty1 =
-            aty1.oppdaterDifferanseberegning(
-                utenlandskPeriodebeløpINorskeKroner = 13.6.toBigDecimal(),
-                skalBrukeNyDifferanseberegning = true,
-            )
+        aty1 = aty1.oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 13.6.toBigDecimal())
 
         Assertions.assertEquals(37, aty1?.kalkulertUtbetalingsbeløp)
 
-        aty1 =
-            aty1.oppdaterDifferanseberegning(
-                utenlandskPeriodebeløpINorskeKroner = 49.2.toBigDecimal(),
-                skalBrukeNyDifferanseberegning = true,
-            )
+        aty1 = aty1.oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 49.2.toBigDecimal())
 
         Assertions.assertEquals(1, aty1?.kalkulertUtbetalingsbeløp)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
@@ -102,7 +102,6 @@ class TilkjentYtelseDifferanseberegningTest {
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse,
                 utenlandskePeriodebeløp = utenlandskePeriodebeløp,
                 valutakurser = valutakurser,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         assertEquals(16, andelerMedDifferanse.size)
@@ -170,7 +169,6 @@ class TilkjentYtelseDifferanseberegningTest {
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse,
                 utenlandskePeriodebeløp = utenlandskePeriodebeløp,
                 valutakurser = valutakurser,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         assertEquals(6, andelerMedDiff.size)
@@ -189,7 +187,6 @@ class TilkjentYtelseDifferanseberegningTest {
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse,
                 utenlandskePeriodebeløp = blanktUtenlandskPeridebeløp,
                 valutakurser = valutakurser,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         assertEquals(3, andelerUtenDiff.size)
@@ -203,7 +200,6 @@ class TilkjentYtelseDifferanseberegningTest {
                 andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse,
                 utenlandskePeriodebeløp = utenlandskePeriodebeløp,
                 valutakurser = valutakurser,
-                skalBrukeNyDifferanseberegning = true,
             )
 
         assertEquals(6, andelerMedDiffIgjen.size)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -74,7 +74,6 @@ internal class KompetanseServiceTest {
         mockKompetanseRepository.deleteAll()
         every { overgangsstønadServiceMock.hentOgLagrePerioderMedOvergangsstønadForBehandling(any(), any()) } returns mockkObject()
         every { overgangsstønadServiceMock.hentPerioderMedFullOvergangsstønad(any<Behandling>()) } answers { emptyList() }
-        every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING) } returns true
         every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER) } returns true
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/DeltBostedBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/DeltBostedBuilder.kt
@@ -62,7 +62,6 @@ fun DeltBostedBuilder.oppdaterTilkjentYtelse(): TilkjentYtelse {
             andelTilkjentYtelserUtenEndringer = tilkjentYtelse.andelerTilkjentYtelse.toList(),
             endretUtbetalingAndeler = bygg().tilEndreteUtebetalingAndeler(),
             tilkjentYtelse = tilkjentYtelse,
-            skalBeholdeSplittI0krAndeler = true,
         )
 
     tilkjentYtelse.andelerTilkjentYtelse.clear()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -167,7 +167,6 @@ fun VilkårsvurderingBuilder.byggTilkjentYtelse(): TilkjentYtelse {
     every { overgangsstønadServiceMock.hentOgLagrePerioderMedOvergangsstønadForBehandling(any(), any()) } returns mockkObject()
     every { overgangsstønadServiceMock.hentPerioderMedFullOvergangsstønad(any<Behandling>()) } answers { emptyList() }
     every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
-    every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_BRUKE_NY_DIFFERANSEBEREGNING) } returns true
     every { unleashServiceMock.isEnabled(FeatureToggle.SKAL_INKLUDERE_ÅRSAK_ENDRE_MOTTAKER_I_INITIELL_GENERERING_AV_ANDELER) } returns true
 
     return tilkjentYtelseGenerator.genererTilkjentYtelse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -183,7 +183,6 @@ class CucumberMock(
             kompetanseRepository = kompetanseRepository,
             tilkjentYtelseRepository = tilkjentYtelseRepository,
             vilkårsvurderingRepository = vilkårsvurderingRepository,
-            unleashService = unleashNextMedContextService,
         )
 
     val tilpassDifferanseberegningEtterTilkjentYtelseService =
@@ -192,7 +191,6 @@ class CucumberMock(
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             tilkjentYtelseRepository = tilkjentYtelseRepository,
             barnasDifferanseberegningEndretAbonnenter = listOf(tilpassDifferanseberegningSøkersYtelserService),
-            unleashService = unleashNextMedContextService,
         )
 
     val beregningService =
@@ -295,7 +293,6 @@ class CucumberMock(
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             tilkjentYtelseRepository = tilkjentYtelseRepository,
             barnasDifferanseberegningEndretAbonnenter = listOf(tilpassDifferanseberegningSøkersYtelserService),
-            unleashService = unleashNextMedContextService,
         )
 
     val tilbakestillBehandlingFraValutakursEndringService =
@@ -335,7 +332,6 @@ class CucumberMock(
             tilkjentYtelseRepository = tilkjentYtelseRepository,
             barnasDifferanseberegningEndretAbonnenter = listOf(tilpassDifferanseberegningSøkersYtelserService),
             automatiskOppdaterValutakursService = automatiskOppdaterValutakursService,
-            unleashService = unleashNextMedContextService,
         )
 
     val utenlandskPeriodebeløpEndretAbonnenter =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25575

Sletter toggle som har vært skrudd på i prod lenge.
Sletter også `slåSammenEtterfølgende0krAndelerPgaSammeEndretAndel` med tilhørende tester, da den ikke lenger er i bruk