### PR TITLE
Lagre i SøknadDTO om søknaden ble automatisk registrert

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/SøknadDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/SøknadDTO.kt
@@ -15,6 +15,7 @@ data class SøknadDTO(
     val søkerMedOpplysninger: SøkerMedOpplysninger,
     val barnaMedOpplysninger: List<BarnMedOpplysninger>,
     val endringAvOpplysningerBegrunnelse: String,
+    val erAutomatiskRegistrert: Boolean = false,
 )
 
 fun SøknadDTO.writeValueAsString(): String = objectMapper.writeValueAsString(this)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/AutomatiskRegistrerSøknadService.kt
@@ -74,6 +74,7 @@ class AutomatiskRegistrerSøknadService(
                     søkerMedOpplysninger = søkerMedOpplysninger,
                     barnaMedOpplysninger = barnaMedOpplysninger,
                     endringAvOpplysningerBegrunnelse = "",
+                    erAutomatiskRegistrert = true,
                 ),
             bekreftEndringerViaFrontend = false,
         )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagTest.kt
@@ -447,4 +447,29 @@ class SøknadGrunnlagTest(
         assertThat(persongrunnlag!!.søker.aktør.aktivFødselsnummer()).isEqualTo(søkerIdent)
         assertThat(persongrunnlag.barna).isEmpty()
     }
+
+    @Test
+    fun `Skal defaulte erAutomatiskRegistrert til false hvis feltet ikke finnes`() {
+        val søknadDTOTekst =
+            """
+            {
+                "underkategori": "ORDINÆR",
+                "søkerMedOpplysninger": {
+                    "ident": "${randomFnr()}",
+                    "målform": "NB"
+                },
+                "barnaMedOpplysninger": [],
+                "endringAvOpplysningerBegrunnelse": ""
+            }
+            """.trimIndent()
+        val søknadGrunnlag =
+            SøknadGrunnlag(
+                behandlingId = 0,
+                søknad = søknadDTOTekst,
+            )
+
+        val søknadDTO = søknadGrunnlag.hentSøknadDto()
+
+        assertThat(søknadDTO.erAutomatiskRegistrert).isFalse()
+    }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25346

Lagre i `SøknadDTO` om søknaden er automatisk registrert. Default til `false`, slik at eksisterende `SøknadDTO`'er uten feltet satt blir `false`