### PR TITLE
NAV-24639: Legger til MinSide endepunkt

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -66,6 +66,8 @@ spec:
         - "https://familie-ba-sak.intern.dev.nav.no/swagger-ui/oauth2-redirect.html"
         - "http://localhost:8089/swagger-ui/oauth2-redirect.html"
       singlePageApplication: true
+  tokenx:
+    enabled: true
   accessPolicy:
     inbound:
       rules:
@@ -113,6 +115,9 @@ spec:
           cluster: dev-gcp
         - application: logging
           namespace: nais-system
+        - application: familie-ba-minside-frontend
+          namespace: teamfamilie
+          cluster: dev-gcp
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io

--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -94,6 +94,9 @@ spec:
         - application: omsorgsopptjening-start-innlesning-q1
           namespace: pensjonopptjening
           cluster: dev-gcp
+        - application: familie-ba-minside-frontend
+          namespace: teamfamilie
+          cluster: dev-gcp
     outbound:
       rules:
         - application: familie-brev
@@ -115,9 +118,6 @@ spec:
           cluster: dev-gcp
         - application: logging
           namespace: nais-system
-        - application: familie-ba-minside-frontend
-          namespace: teamfamilie
-          cluster: dev-gcp
       external:
         - host: xsrv1mh6.api.sanity.io
         - host: unleash.nais.io

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -72,6 +72,8 @@ spec:
       replyURLs:
         - "https://familie-ba-sak.intern.nav.no/swagger-ui/oauth2-redirect.html"
       singlePageApplication: true
+  tokenx:
+    enabled: true
   accessPolicy:
     inbound:
       rules:
@@ -91,6 +93,9 @@ spec:
           cluster: prod-gcp
         - application: omsorgsopptjening-start-innlesning
           namespace: pensjonopptjening
+          cluster: prod-gcp
+        - application: familie-ba-minside-frontend
+          namespace: teamfamilie
           cluster: prod-gcp
     outbound:
       rules:

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -56,4 +56,7 @@ enum class FeatureToggle(
 
     // NAV-25543
     SKAL_BRUKE_NYTT_FELT_I_EØS_BEGRUNNELSE_DATA_MED_KOMPETANSE("familie-ba-sak.skal-bruke-nytt-felt-i-eos-begrunnelse-data-med-kompetanse"),
+
+    // NAV-24639
+    MIN_SIDE_BARNETRYGD_ENDEPUNKT("familie-ba-sak.min-side-barnetrygd-endepunkt"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/HentMinSideBarnetrygdDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/HentMinSideBarnetrygdDto.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ba.sak.kjerne.minside
+
+sealed class HentMinSideBarnetrygdDto {
+    data class Suksess(
+        var barnetrygd: MinSideBarnetrygd? = null,
+    ) : HentMinSideBarnetrygdDto() {
+        companion object {
+            fun opprettFraDomene(minSideBarnetrygd: MinSideBarnetrygd?) = minSideBarnetrygd?.let { Suksess(it) }
+        }
+    }
+
+    data class Feil(
+        val feilmelding: String,
+    ) : HentMinSideBarnetrygdDto()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygd.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygd.kt
@@ -1,0 +1,16 @@
+package no.nav.familie.ba.sak.kjerne.minside
+
+import java.time.YearMonth
+
+data class MinSideBarnetrygd(
+    val ordinær: Ordinær? = null,
+    val utvidet: Utvidet? = null,
+) {
+    data class Ordinær(
+        val startmåned: YearMonth,
+    )
+
+    data class Utvidet(
+        val startmåned: YearMonth,
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdController.kt
@@ -1,0 +1,77 @@
+package no.nav.familie.ba.sak.kjerne.minside
+
+import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
+import no.nav.familie.sikkerhet.EksternBrukerUtils
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.RequiredIssuers
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/minside/barnetrygd")
+@RequiredIssuers(
+    ProtectedWithClaims(
+        issuer = EksternBrukerUtils.ISSUER_TOKENX,
+        claimMap = ["acr=Level4"],
+    ),
+)
+@Validated
+class MinSideBarnetrygdController(
+    private val minSideBarnetrygdService: MinSideBarnetrygdService,
+    private val unleash: UnleashNextMedContextService,
+) {
+    private val logger = LoggerFactory.getLogger(MinSideBarnetrygdController::class.java)
+
+    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun hentMinSideBarnetrygd(): ResponseEntity<HentMinSideBarnetrygdDto> {
+        if (!unleash.isEnabled(FeatureToggle.MIN_SIDE_BARNETRYGD_ENDEPUNKT)) {
+            return ResponseEntity
+                .status(HttpStatus.NOT_IMPLEMENTED)
+                .body(HentMinSideBarnetrygdDto.Feil("Tjenesten er ikke implementert."))
+        }
+
+        val fnrFraToken: String?
+        try {
+            fnrFraToken = EksternBrukerUtils.hentFnrFraToken()
+        } catch (exception: Exception) {
+            logger.error("Feil ved henting av fnr fra token. Se SecureLogs for detaljer")
+            secureLogger.error("Feil ved henting av fnr fra token.", exception)
+            return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(HentMinSideBarnetrygdDto.Feil("Mangler tilgang."))
+        }
+
+        val fnr: Fødselsnummer?
+        try {
+            fnr = Fødselsnummer(fnrFraToken)
+        } catch (exception: Exception) {
+            logger.error("Ugydlig fnr ved henting av min side barnetrygd. Se SecureLogs for detaljer")
+            secureLogger.error("Ugydlig fnr=$fnrFraToken ved henting av min side barnetrygd", exception)
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(HentMinSideBarnetrygdDto.Feil("Ugydlig fødselsnummer."))
+        }
+
+        try {
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fnr)
+            return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(HentMinSideBarnetrygdDto.Suksess.opprettFraDomene(minSideBarnetrygd))
+        } catch (exception: Exception) {
+            logger.error("Henting av barnetrygd for min side feilet. Se SecureLog for detaljer")
+            secureLogger.error("Henting av barnetrygd for min side feilet for ugyldig fnr=${fnr.verdi}.", exception)
+            return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(HentMinSideBarnetrygdDto.Feil("En ukjent feil oppstod."))
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdService.kt
@@ -1,0 +1,50 @@
+package no.nav.familie.ba.sak.kjerne.minside
+
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
+import org.springframework.stereotype.Service
+
+@Service
+class MinSideBarnetrygdService(
+    private val personidentService: PersonidentService,
+    private val fagsakService: FagsakService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+) {
+    fun hentMinSideBarnetrygd(fødselsnummer: Fødselsnummer): MinSideBarnetrygd? {
+        val aktør = personidentService.hentAktør(fødselsnummer.verdi)
+
+        val fagsak = fagsakService.hentFagsakPåPerson(aktør, FagsakType.NORMAL)
+        if (fagsak == null) {
+            return null
+        }
+
+        val behandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsak.id)
+        if (behandling == null) {
+            return null
+        }
+
+        val andeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
+
+        val ordinær =
+            andeler
+                .filter { it.type == YtelseType.ORDINÆR_BARNETRYGD }
+                .map { it.stønadFom }
+                .minByOrNull { it }
+                ?.let { MinSideBarnetrygd.Ordinær(it) }
+
+        val utvidet =
+            andeler
+                .filter { it.type == YtelseType.UTVIDET_BARNETRYGD }
+                .map { it.stønadFom }
+                .minByOrNull { it }
+                ?.let { MinSideBarnetrygd.Utvidet(it) }
+
+        return MinSideBarnetrygd(ordinær, utvidet)
+    }
+}

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -2,6 +2,9 @@ no.nav.security.jwt:
   issuer.azuread:
     discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
     accepted_audience: ${AZURE_APP_CLIENT_ID}
+  issuer.tokenx:
+    discoveryurl: ${TOKEN_X_WELL_KNOWN_URL}
+    accepted_audience: ${TOKEN_X_CLIENT_ID}
   client:
     registration:
       familie-integrasjoner-onbehalfof:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -2,6 +2,9 @@ no.nav.security.jwt:
   issuer.azuread:
     discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
     accepted_audience: ${AZURE_APP_CLIENT_ID}
+  issuer.tokenx:
+    discoveryurl: ${TOKEN_X_WELL_KNOWN_URL}
+    accepted_audience: ${TOKEN_X_CLIENT_ID}
   client:
     registration:
       familie-integrasjoner-onbehalfof:

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/HentMinSideBarnetrygdDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/HentMinSideBarnetrygdDtoTest.kt
@@ -1,0 +1,53 @@
+package no.nav.familie.ba.sak.kjerne.minside
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class HentMinSideBarnetrygdDtoTest {
+    @Nested
+    inner class FraDomene {
+        @Test
+        fun `skal opprette dto fra domeneobjektet med både ordinær og utvidet`() {
+            // Arrange
+            val minSideBarnetrygd =
+                MinSideBarnetrygd(
+                    ordinær = MinSideBarnetrygd.Ordinær(YearMonth.of(2025, 1)),
+                    utvidet = MinSideBarnetrygd.Utvidet(YearMonth.of(2025, 3)),
+                )
+
+            // Act
+            val dto = HentMinSideBarnetrygdDto.Suksess.opprettFraDomene(minSideBarnetrygd)
+
+            // Assert
+            assertThat(dto?.barnetrygd).isEqualTo(minSideBarnetrygd)
+        }
+
+        @Test
+        fun `skal opprette dto fra domeneobjektet med uten ordinær eller utvidet`() {
+            // Arrange
+            val minSideBarnetrygd =
+                MinSideBarnetrygd(
+                    ordinær = null,
+                    utvidet = null,
+                )
+
+            // Act
+            val dto = HentMinSideBarnetrygdDto.Suksess.opprettFraDomene(minSideBarnetrygd)
+
+            // Assert
+            assertThat(dto?.barnetrygd?.ordinær).isNull()
+            assertThat(dto?.barnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal opprette dto fra domene objektet hvis domeneobjektet er null`() {
+            // Act
+            val dto = HentMinSideBarnetrygdDto.Suksess.opprettFraDomene(null)
+
+            // Assert
+            assertThat(dto).isNull()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdServiceTest.kt
@@ -1,0 +1,165 @@
+package no.nav.familie.ba.sak.kjerne.minside
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.kontrakter.felles.Fødselsnummer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class MinSideBarnetrygdServiceTest {
+    private val fødselsnummer = Fødselsnummer(randomFnr())
+    private val aktør = randomAktør(fnr = fødselsnummer.verdi)
+    private val fagsak = lagFagsak(aktør = aktør)
+    private val behandling = lagBehandling(fagsak = fagsak)
+
+    private val personidentService = mockk<PersonidentService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+    private val minSideBarnetrygdService =
+        MinSideBarnetrygdService(
+            personidentService = personidentService,
+            fagsakService = fagsakService,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+        )
+
+    @BeforeEach
+    fun setup() {
+        every { personidentService.hentAktør(any()) } returns aktør
+        every { fagsakService.hentFagsakPåPerson(eq(aktør), eq(FagsakType.NORMAL)) } returns fagsak
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(eq(fagsak.id)) } returns behandling
+    }
+
+    @Nested
+    inner class HentMinSideBarnetrygd {
+        @Test
+        fun `skal returnere tom barnetrygd hvis fagsak er null`() {
+            // Arrange
+            every { fagsakService.hentFagsakPåPerson(eq(aktør), eq(FagsakType.NORMAL)) } returns null
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær).isNull()
+            assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal returnere tom barnetrygd hvis behandling er null`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(eq(fagsak.id)) } returns null
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær).isNull()
+            assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal returnere tom barnetrygd hvis andeler tilkjent ytelser er tom`() {
+            // Arrange
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns emptyList()
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær).isNull()
+            assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal returnere innvilget ordinær og utvidet barnetrygd`() {
+            // Arrange
+            val andeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2025, 3),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 4),
+                        tom = YearMonth.of(2025, 7),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 3),
+                        tom = YearMonth.of(2025, 4),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 5),
+                        tom = YearMonth.of(2025, 6),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns andeler
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær?.startmåned).isEqualTo(YearMonth.of(2025, 1))
+            assertThat(minSideBarnetrygd?.utvidet?.startmåned).isEqualTo(YearMonth.of(2025, 3))
+        }
+
+        @Test
+        fun `skal returnere innvilget ordinær barnetrygd`() {
+            // Arrange
+            val andeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2025, 3),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 4),
+                        tom = YearMonth.of(2025, 7),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns andeler
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær?.startmåned).isEqualTo(YearMonth.of(2025, 1))
+            assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
@@ -1,0 +1,150 @@
+package no.nav.familie.ba.sak.kjerne.minside
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
+import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
+import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
+import no.nav.familie.sikkerhet.EksternBrukerUtils
+import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import java.time.YearMonth
+
+class MinSideBarnetrygdControllerTest(
+    @Autowired private val minSideBarnetrygdService: MinSideBarnetrygdService,
+    @Autowired private val aktørIdRepository: AktørIdRepository,
+    @Autowired private val fagsakRepository: FagsakRepository,
+    @Autowired private val behandlingRepository: BehandlingRepository,
+    @Autowired private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    @Autowired private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+) : AbstractSpringIntegrationTest() {
+    private val fnr = randomFnr()
+
+    private val unleash = mockk<UnleashNextMedContextService>()
+    private val minSideBarnetrygdController = MinSideBarnetrygdController(minSideBarnetrygdService, unleash)
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(EksternBrukerUtils)
+        every { EksternBrukerUtils.hentFnrFraToken() } returns fnr
+        every { unleash.isEnabled(FeatureToggle.MIN_SIDE_BARNETRYGD_ENDEPUNKT) } returns true
+    }
+
+    @AfterEach
+    fun cleanup() {
+        unmockkObject(EksternBrukerUtils)
+    }
+
+    @Nested
+    inner class HentMinSideBarnetrygd {
+        @Test
+        fun `skal returnere response med feil hvis toggle er disabled`() {
+            // Arrange
+            every { unleash.isEnabled(FeatureToggle.MIN_SIDE_BARNETRYGD_ENDEPUNKT) } returns false
+
+            // Act
+            val response = minSideBarnetrygdController.hentMinSideBarnetrygd()
+
+            // Assert
+            assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_IMPLEMENTED)
+            assertThat(response.body).isInstanceOfSatisfying(HentMinSideBarnetrygdDto.Feil::class.java) {
+                assertThat(it.feilmelding).isEqualTo("Tjenesten er ikke implementert.")
+            }
+        }
+
+        @Test
+        fun `skal returnere response med feil hvis fnr ikke han bli hentet fra token`() {
+            // Arrange
+            every { EksternBrukerUtils.hentFnrFraToken() } throws JwtTokenValidatorException("Finner ikke token.")
+
+            // Act
+            val response = minSideBarnetrygdController.hentMinSideBarnetrygd()
+
+            // Assert
+            assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(response.body).isInstanceOfSatisfying(HentMinSideBarnetrygdDto.Feil::class.java) {
+                assertThat(it.feilmelding).isEqualTo("Mangler tilgang.")
+            }
+        }
+
+        @Test
+        fun `skal returnere response med feil hvis fnr fra token ikke kan konverteres til et fødselsnummer`() {
+            // Arrange
+            every { EksternBrukerUtils.hentFnrFraToken() } returns "12345678903"
+
+            // Act
+            val response = minSideBarnetrygdController.hentMinSideBarnetrygd()
+
+            // Assert
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body).isInstanceOfSatisfying(HentMinSideBarnetrygdDto.Feil::class.java) {
+                assertThat(it.feilmelding).isEqualTo("Ugydlig fødselsnummer.")
+            }
+        }
+
+        @Test
+        fun `skal hente min side barnetrygd`() {
+            // Arrange
+            val aktør = aktørIdRepository.save(randomAktør(fnr = fnr))
+
+            val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør))
+
+            val behandling =
+                behandlingRepository.save(
+                    lagBehandlingUtenId(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.AVSLUTTET,
+                    ),
+                )
+            val tilkjentYtelse =
+                tilkjentYtelseRepository.save(
+                    lagInitiellTilkjentYtelse(
+                        behandling = behandling,
+                        utbetalingsoppdrag = "\"klassifisering\":\"BAUTV-OP\"",
+                    ),
+                )
+
+            andelTilkjentYtelseRepository.save(
+                lagAndelTilkjentYtelse(
+                    behandling = behandling,
+                    tilkjentYtelse = tilkjentYtelse,
+                    aktør = aktør,
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 6),
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                ),
+            )
+
+            // Act
+            val response = minSideBarnetrygdController.hentMinSideBarnetrygd()
+
+            // Assert
+            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(response.body).isInstanceOfSatisfying(HentMinSideBarnetrygdDto.Suksess::class.java) {
+                assertThat(it.barnetrygd?.ordinær?.startmåned).isEqualTo(YearMonth.of(2025, 1))
+                assertThat(it.barnetrygd?.utvidet).isNull()
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24639](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24639)

Introduserer endepunkt for å hente ut informasjon om barnetrygden til den innloggede brukere fra min-side. Bruker `tokenx` og henter fnr fra tokenet. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan at om ønskelig
