### PR TITLE
Slett ubrukt felt på RestEndretUtbetalingAndel

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestEndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestEndretUtbetalingAndel.kt
@@ -7,7 +7,6 @@ import java.time.YearMonth
 
 data class RestEndretUtbetalingAndel(
     val id: Long?,
-    val personIdent: String?,
     val personIdenter: List<String>?,
     val prosent: BigDecimal?,
     val fom: YearMonth?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -47,9 +47,8 @@ class EndretUtbetalingAndelService(
     ) {
         val endretUtbetalingAndel = endretUtbetalingAndelRepository.getReferenceById(endretUtbetalingAndelId)
         val personerPåEndretUtbetalingAndel =
-            restEndretUtbetalingAndel.personIdenter
-                ?: restEndretUtbetalingAndel.personIdent?.let { listOf(it) }
-                ?: throw FunksjonellFeil("Endret utbetaling andel må ha minst én person ident")
+            restEndretUtbetalingAndel.personIdenter.takeUnless { it.isNullOrEmpty() }
+                ?: throw FunksjonellFeil("Endret utbetalingsperiode må gjelde minst én person")
 
         val personer =
             persongrunnlagService

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -143,7 +143,6 @@ fun EndretUtbetalingAndel?.skalUtbetales() = this != null && this.prosent != Big
 fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilRestEndretUtbetalingAndel() =
     RestEndretUtbetalingAndel(
         id = this.id,
-        personIdent = this.personIdenter.firstOrNull(),
         personIdenter = this.personIdenter,
         prosent = this.prosent,
         fom = this.fom,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -17,7 +17,6 @@ import no.nav.familie.ba.sak.datagenerator.lagEndretUtbetalingAndelMedAndelerTil
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagPersonResultat
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
-import no.nav.familie.ba.sak.ekstern.restDomene.RestEndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
@@ -38,7 +37,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -216,142 +214,6 @@ class EndretUtbetalingAndelServiceTest {
 
         val slettetEndretUtbetalingAndel = slettetEndretUtbetalingAndelSlot.captured
         assertThat(slettetEndretUtbetalingAndel).isEqualTo(endretUtbetalingAndel.endretUtbetalingAndel)
-    }
-
-    @Test
-    fun `Skal håndtere RestEndretUtbetalingAndel med blanding av nytt og gammelt felt for personIdent(er)`() {
-        // Arrange
-        val behandling = lagBehandling()
-        val barn1 = lagPerson(type = PersonType.BARN)
-        val barn2 = lagPerson(type = PersonType.BARN)
-
-        val endretUtbetalingAndel = EndretUtbetalingAndel(behandlingId = behandling.id)
-
-        val andelerTilkjentYtelse =
-            listOf(
-                lagAndelTilkjentYtelse(
-                    person = barn1,
-                    fom = YearMonth.of(2025, 1),
-                    tom = YearMonth.of(2025, 1),
-                ),
-                lagAndelTilkjentYtelse(
-                    person = barn2,
-                    fom = YearMonth.of(2025, 1),
-                    tom = YearMonth.of(2025, 1),
-                ),
-            )
-
-        val vilkårsvurdering =
-            Vilkårsvurdering(behandling = behandling).apply {
-                personResultater =
-                    setOf(
-                        lagPersonResultat(
-                            vilkårsvurdering = this,
-                            person = barn1,
-                            resultat = Resultat.OPPFYLT,
-                            periodeFom = LocalDate.of(2024, 12, 1),
-                            periodeTom = LocalDate.of(2025, 2, 1),
-                            lagFullstendigVilkårResultat = true,
-                            personType = PersonType.BARN,
-                            vilkårType = Vilkår.BOR_MED_SØKER,
-                        ),
-                        lagPersonResultat(
-                            vilkårsvurdering = this,
-                            person = barn2,
-                            resultat = Resultat.OPPFYLT,
-                            periodeFom = LocalDate.of(2024, 12, 1),
-                            periodeTom = LocalDate.of(2025, 2, 1),
-                            lagFullstendigVilkårResultat = true,
-                            personType = PersonType.BARN,
-                            vilkårType = Vilkår.BOR_MED_SØKER,
-                        ),
-                    )
-            }
-
-        val lagretEndretUtbetalingAndel = slot<EndretUtbetalingAndel>()
-
-        every { mockEndretUtbetalingAndelRepository.getReferenceById(any()) } returns endretUtbetalingAndel
-        every { mockPersongrunnlagService.hentPersonerPåBehandling(any(), behandling) } answers {
-            listOf(barn1, barn2).filter { it.aktør.aktivFødselsnummer() in firstArg<List<String>>() }
-        }
-        every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) } returns
-            lagTestPersonopplysningGrunnlag(behandling.id, barn1, barn2)
-        every { mockAndelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = behandling.id) } returns andelerTilkjentYtelse
-        every { mockEndretUtbetalingAndelHentOgPersisterService.hentForBehandling(behandlingId = behandling.id) } returns listOf(endretUtbetalingAndel)
-        every { mockVilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id) } returns vilkårsvurdering
-        every { mockEndretUtbetalingAndelRepository.saveAndFlush(capture(lagretEndretUtbetalingAndel)) } returns mockk()
-        every { mockBeregningService.oppdaterBehandlingMedBeregning(any(), any(), any()) } returns mockk()
-        every { mockUnleashService.isEnabled(FeatureToggle.SKAL_SPLITTE_ENDRET_UTBETALING_ANDELER) } returns true
-
-        var restEndretUtbetalingAndel =
-            RestEndretUtbetalingAndel(
-                id = 0,
-                personIdent = null,
-                personIdenter = null,
-                prosent = BigDecimal.ZERO,
-                fom = YearMonth.of(2025, 1),
-                tom = YearMonth.of(2025, 1),
-                årsak = Årsak.ALLEREDE_UTBETALT,
-                avtaletidspunktDeltBosted = LocalDate.now(),
-                søknadstidspunkt = LocalDate.now(),
-                begrunnelse = "Test begrunnelse",
-                erTilknyttetAndeler = true,
-            )
-
-        // Act & Assert
-        assertThrows<FunksjonellFeil> {
-            endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
-                behandling = behandling,
-                endretUtbetalingAndelId = 0,
-                restEndretUtbetalingAndel = restEndretUtbetalingAndel,
-            )
-        }
-
-        // Arrange
-        restEndretUtbetalingAndel =
-            restEndretUtbetalingAndel.copy(
-                personIdenter = null,
-                personIdent = barn1.aktør.aktivFødselsnummer(),
-            )
-
-        // Act & Assert
-        assertDoesNotThrow {
-            endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
-                behandling = behandling,
-                endretUtbetalingAndelId = 0,
-                restEndretUtbetalingAndel = restEndretUtbetalingAndel,
-            )
-        }
-
-        // Assert
-        assertThat(lagretEndretUtbetalingAndel.captured).isEqualTo(
-            endretUtbetalingAndel.copy(
-                personer = mutableSetOf(barn1),
-            ),
-        )
-
-        // Arrange
-        restEndretUtbetalingAndel =
-            restEndretUtbetalingAndel.copy(
-                personIdenter = listOf(barn1.aktør.aktivFødselsnummer(), barn2.aktør.aktivFødselsnummer()),
-                personIdent = barn1.aktør.aktivFødselsnummer(),
-            )
-
-        // Act & Assert
-        assertDoesNotThrow {
-            endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
-                behandling = behandling,
-                endretUtbetalingAndelId = 0,
-                restEndretUtbetalingAndel = restEndretUtbetalingAndel,
-            )
-        }
-
-        // Assert
-        assertThat(lagretEndretUtbetalingAndel.captured).isEqualTo(
-            endretUtbetalingAndel.copy(
-                personer = mutableSetOf(barn1, barn2),
-            ),
-        )
     }
 
     @Nested

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelMedUtvidetAndelTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelMedUtvidetAndelTest.kt
@@ -106,7 +106,6 @@ class EndretUtbetalingAndelMedUtvidetAndelTest(
         val restEndretUtbetalingAndelUtvidetBarnetrygd =
             RestEndretUtbetalingAndel(
                 id = null,
-                personIdent = scenario.søker.ident,
                 personIdenter = listOf(scenario.søker.ident),
                 prosent = BigDecimal(0),
                 fom = endretFom,
@@ -126,7 +125,6 @@ class EndretUtbetalingAndelMedUtvidetAndelTest(
         val restEndretUtbetalingAndelOrdinærBarnetrygd =
             RestEndretUtbetalingAndel(
                 id = null,
-                personIdent = scenario.barna.first().ident,
                 personIdenter = listOf(scenario.barna.first().ident),
                 prosent = BigDecimal(0),
                 fom = endretFom,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelTest.kt
@@ -37,7 +37,6 @@ class EndretUtbetalingAndelTest(
         val restEndretUtbetalingAndel =
             RestEndretUtbetalingAndel(
                 id = null,
-                personIdent = scenario.barna.first().ident,
                 personIdenter = listOf(scenario.barna.first().ident),
                 prosent = BigDecimal(0),
                 fom = endretFom,
@@ -92,7 +91,6 @@ class EndretUtbetalingAndelTest(
         val restEndretUtbetalingAndel =
             RestEndretUtbetalingAndel(
                 id = null,
-                personIdent = scenario.barna.first().ident,
                 personIdenter = listOf(scenario.barna.first().ident),
                 prosent = BigDecimal(0),
                 fom = endretFom,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -253,7 +253,6 @@ class RevurderingMedEndredeUtbetalingandelerTest(
                 avtaletidspunktDeltBosted = LocalDate.now().minusYears(3).withDayOfMonth(8),
                 søknadstidspunkt = LocalDate.now().minusYears(3).withDayOfMonth(8),
                 begrunnelse = "begrunnelse",
-                personIdent = barnFnr,
                 personIdenter = listOf(barnFnr),
                 årsak = Årsak.DELT_BOSTED,
                 prosent = BigDecimal.ZERO,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Sletter feltet `personIdent` fra `RestEndretUtbetalingAndel`, da det ikke lenger er i bruk ref denne (PR'en)[https://github.com/navikt/familie-ba-sak-frontend/pull/3793]