### PR TITLE
NAV-25543: Utvider EØSBegrunnelseDataMedKompetanse med feltet `erAnnenForelderOmfattetAvNorskLovgivning`

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
@@ -111,6 +111,7 @@ fun EØSStandardbegrunnelse.lagBrevBegrunnelse(
                     sokersAktivitet = kompetanse.søkersAktivitet,
                     sokersAktivitetsland = kompetanse.søkersAktivitetsland.tilLandNavn(landkoder).navn,
                     gjelderSoker = gjelderSøker,
+                    erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
                 )
             } else {
                 null

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/Vedtaksbegrunnelse.kt
@@ -116,31 +116,35 @@ data class FritekstBegrunnelse(
     override val type: Begrunnelsetype = Begrunnelsetype.FRITEKST
 }
 
-sealed class EØSBegrunnelseData : BegrunnelseMedData
+sealed interface EØSBegrunnelseData : BegrunnelseMedData {
+    val barnasFodselsdatoer: String
+    val antallBarn: Int
+    val maalform: String
+    val gjelderSoker: Boolean
+}
 
 data class EØSBegrunnelseDataMedKompetanse(
+    override val type: Begrunnelsetype = Begrunnelsetype.EØS_BEGRUNNELSE,
     override val vedtakBegrunnelseType: VedtakBegrunnelseType,
     override val apiNavn: String,
+    override val barnasFodselsdatoer: String,
+    override val antallBarn: Int,
+    override val maalform: String,
+    override val gjelderSoker: Boolean,
+    val erAnnenForelderOmfattetAvNorskLovgivning: Boolean,
     val annenForeldersAktivitet: KompetanseAktivitet,
     val annenForeldersAktivitetsland: String?,
     val barnetsBostedsland: String,
     val sokersAktivitet: KompetanseAktivitet,
     val sokersAktivitetsland: String?,
-    val barnasFodselsdatoer: String,
-    val gjelderSoker: Boolean?,
-    val antallBarn: Int,
-    val maalform: String,
-) : EØSBegrunnelseData() {
-    override val type: Begrunnelsetype = Begrunnelsetype.EØS_BEGRUNNELSE
-}
+) : EØSBegrunnelseData
 
 data class EØSBegrunnelseDataUtenKompetanse(
+    override val type: Begrunnelsetype = Begrunnelsetype.EØS_BEGRUNNELSE,
     override val vedtakBegrunnelseType: VedtakBegrunnelseType,
     override val apiNavn: String,
-    val barnasFodselsdatoer: String,
-    val antallBarn: Int,
-    val maalform: String,
-    val gjelderSoker: Boolean,
-) : EØSBegrunnelseData() {
-    override val type: Begrunnelsetype = Begrunnelsetype.EØS_BEGRUNNELSE
-}
+    override val barnasFodselsdatoer: String,
+    override val antallBarn: Int,
+    override val maalform: String,
+    override val gjelderSoker: Boolean,
+) : EØSBegrunnelseData

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/VedtaksperiodeGrunnlagForPerson.kt
@@ -242,6 +242,7 @@ data class KompetanseForVedtaksperiode(
     val barnetsBostedsland: String,
     val resultat: KompetanseResultat,
     val barnAktører: Set<Aktør>,
+    val erAnnenForelderOmfattetAvNorskLovgivning: Boolean,
 ) {
     constructor(kompetanse: UtfyltKompetanse) : this(
         søkersAktivitet = kompetanse.søkersAktivitet,
@@ -251,6 +252,7 @@ data class KompetanseForVedtaksperiode(
         barnetsBostedsland = kompetanse.barnetsBostedsland,
         resultat = kompetanse.resultat,
         barnAktører = kompetanse.barnAktører,
+        erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
     )
 }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -89,7 +89,7 @@ fun parseStandardBegrunnelse(rad: Tabellrad): BegrunnelseData {
 }
 
 fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
-    val gjelderSoker = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_SØKER, rad)
+    val gjelderSoker = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_SØKER, rad) ?: false
 
     val annenForeldersAktivitet =
         parseValgfriEnum<KompetanseAktivitet>(
@@ -116,6 +116,12 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITETSLAND,
             rad,
         )
+
+    val erAnnenForelderOmfattetAvNorskLovgivning =
+        parseValgfriBoolean(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ER_ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING,
+            rad,
+        ) ?: false
 
     val begrunnelse =
         parseEnum<EØSStandardbegrunnelse>(
@@ -154,6 +160,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseData {
             sokersAktivitet = søkersAktivitet,
             sokersAktivitetsland = søkersAktivitetsland,
             gjelderSoker = gjelderSoker,
+            erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
         )
     } else {
         EØSBegrunnelseDataUtenKompetanse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -73,6 +73,7 @@ object VedtaksperiodeMedBegrunnelserParser {
         ANNEN_FORELDERS_AKTIVITETSLAND("Annen forelders aktivitetsland"),
         BARNETS_BOSTEDSLAND("Barnets bostedsland"),
         RESULTAT("Resultat"),
+        ER_ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING("Annen forelder omfattet av norsk lovgivning"),
     }
 
     enum class DomenebegrepValutakurs(


### PR DESCRIPTION
Favro: [NAV-25543](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25543)

### 💰 Hva skal gjøres, og hvorfor?
Feil tekst flettes inn for `søkersAktivitet` og `annenForeldersAktivitet` dersom annen forelder er omfattet av norsk lovgivning (søker har selvstendig rett).

Utvider her EØSBegrunnelseDataMedKompetanse med feltet `erAnnenForelderOmfattetAvNorskLovgivning` slik at `familie-brev` har nok informasjon til å kunne utlede aktivitets-tekster korrekt dersom annen forelder er omfattet av norsk lovgivning. 

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester. 

Jeg har ikke skrevet tester fordi: Ingen ny logikk, kun lagt til et nytt felt i en dataklasse.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
