### PR TITLE
Kast feil hvis til og med-dato er tom for andre årsaker enn ENDRE_MOTTAKER

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
@@ -291,6 +291,9 @@ fun validerTomDato(
     gyldigTomEtterDagensDato: YearMonth?,
     årsak: Årsak?,
 ) {
+    if (årsak != Årsak.ENDRE_MOTTAKER && tomDato == null) {
+        throw FunksjonellFeil(melding = "Til og med-dato kan ikke være tom for årsak ${årsak?.visningsnavn}")
+    }
     val dagensDato = YearMonth.now()
     if (årsak == Årsak.ALLEREDE_UTBETALT && tomDato?.isAfter(dagensDato) == true) {
         val feilmelding =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
@@ -292,7 +292,7 @@ fun validerTomDato(
     årsak: Årsak?,
 ) {
     if (årsak != Årsak.ENDRE_MOTTAKER && tomDato == null) {
-        throw FunksjonellFeil(melding = "Til og med-dato kan ikke være tom for årsak ${årsak?.visningsnavn}")
+        throw FunksjonellFeil(melding = "Til og med-dato kan ikke være tom for årsak '${årsak?.visningsnavn}'")
     }
     val dagensDato = YearMonth.now()
     if (årsak == Årsak.ALLEREDE_UTBETALT && tomDato?.isAfter(dagensDato) == true) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -115,11 +115,11 @@ data class EndretUtbetalingAndel(
 enum class Årsak(
     val visningsnavn: String,
 ) {
-    DELT_BOSTED("Delt bosted"),
-    ETTERBETALING_3ÅR("Etterbetaling 3 år"),
-    ETTERBETALING_3MND("Etterbetaling 3 måneder"),
-    ENDRE_MOTTAKER("Endre mottaker, begge foreldre rett"),
-    ALLEREDE_UTBETALT("Allerede utbetalt"),
+    DELT_BOSTED("Delt bosted"),
+    ETTERBETALING_3ÅR("Etterbetaling 3 år"),
+    ETTERBETALING_3MND("Etterbetaling 3 måneder"),
+    ENDRE_MOTTAKER("Endre mottaker, begge foreldre rett"),
+    ALLEREDE_UTBETALT("Allerede utbetalt"),
     ;
 
     fun førerTilOpphørVed0Prosent() =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -865,6 +865,22 @@ class EndretUtbetalingAndelValideringTest {
         }
     }
 
+    @ParameterizedTest
+    @EnumSource(value = Årsak::class, names = ["ENDRE_MOTTAKER"], mode = EnumSource.Mode.EXCLUDE)
+    fun `Skal kaste feil hvis årsak ikke er ENDRE_MOTTAKER og tom-dato er null`(
+        årsak: Årsak,
+    ) {
+        assertThrows<FunksjonellFeil> {
+            validerTomDato(
+                tomDato = null,
+                årsak = årsak,
+                gyldigTomEtterDagensDato = YearMonth.now(),
+            )
+        }.also {
+            assertThat(it.frontendFeilmelding).startsWith("Til og med-dato kan ikke være tom")
+        }
+    }
+
     @Test
     fun `Skal ikke kaste feil hvis tom-dato er i fremtiden, men lik gyldig dato i fremtiden`() {
         val tom = YearMonth.now().plusMonths(4)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25546

For andre årsaker enn `ENDRE_MOTTAKER` skal saksbehandler få en feilmelding dersom til og med-dato ikke er satt