### PR TITLE
Fix: Legger til aktørId som key på aktivering/deaktivering-meldinger for minside

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringService.kt
@@ -14,7 +14,7 @@ class MinsideAktiveringService(
         val minsideAktivering = minsideAktiveringRepository.findByAktør(aktør)
         val aktivertMinsideAktivering =
             minsideAktivering?.copy(aktivert = true) ?: MinsideAktivering(aktør = aktør, aktivert = true)
-        minsideAktiveringKafkaProducer.aktiver(aktør.aktivFødselsnummer())
+        minsideAktiveringKafkaProducer.aktiver(aktør)
         return minsideAktiveringRepository.save(aktivertMinsideAktivering)
     }
 
@@ -22,7 +22,7 @@ class MinsideAktiveringService(
         val minsideAktivering = minsideAktiveringRepository.findByAktør(aktør)
         val deaktivertMinsideAktivering =
             minsideAktivering?.copy(aktivert = false) ?: MinsideAktivering(aktør = aktør, aktivert = false)
-        minsideAktiveringKafkaProducer.deaktiver(aktør.aktivFødselsnummer())
+        minsideAktiveringKafkaProducer.deaktiver(aktør)
         return minsideAktiveringRepository.save(deaktivertMinsideAktivering)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringKafkaProducerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringKafkaProducerTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.minside
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ba.sak.datagenerator.randomAktør
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -19,22 +20,22 @@ class MinsideAktiveringKafkaProducerTest {
         @Test
         fun `skal sende aktiveringsmelding for minside via Kafka`() {
             // Arrange
-
-            val personIdent = "12345678901"
+            val aktør = randomAktør("12345678901")
 
             val completableFuture: CompletableFuture<SendResult<String, String>> = mockk()
             val sendResult: SendResult<String, String> = mockk()
 
-            every { kafkaTemplate.send(any(), any()) } returns completableFuture
+            every { kafkaTemplate.send(any(), any(), any()) } returns completableFuture
             every { completableFuture.get(any(), any()) } returns sendResult
 
             // Act
-            minsideAktiveringKafkaProducer.aktiver(personIdent)
+            minsideAktiveringKafkaProducer.aktiver(aktør)
 
             // Assert
             verify {
                 kafkaTemplate.send(
                     "min-side.aapen-microfrontend-v1",
+                    aktør.aktørId,
                     withArg {
                         assertTrue(it.contains("\"@action\":\"enable\""))
                         assertTrue(it.contains("\"ident\":\"12345678901\""))
@@ -52,21 +53,22 @@ class MinsideAktiveringKafkaProducerTest {
         @Test
         fun `skal sende deaktiveringsmelding for minside via Kafka`() {
             // Arrange
-            val personIdent = "12345678901"
+            val aktør = randomAktør("12345678901")
 
             val completableFuture: CompletableFuture<SendResult<String, String>> = mockk()
             val sendResult: SendResult<String, String> = mockk()
 
-            every { kafkaTemplate.send(any(), any()) } returns completableFuture
+            every { kafkaTemplate.send(any(), any(), any()) } returns completableFuture
             every { completableFuture.get(any(), any()) } returns sendResult
 
             // Act
-            minsideAktiveringKafkaProducer.deaktiver(personIdent)
+            minsideAktiveringKafkaProducer.deaktiver(aktør)
 
             // Assert
             verify {
                 kafkaTemplate.send(
                     "min-side.aapen-microfrontend-v1",
+                    aktør.aktørId,
                     withArg {
                         assertTrue(it.contains("\"@action\":\"disable\""))
                         assertTrue(it.contains("\"ident\":\"12345678901\""))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringServiceTest.kt
@@ -47,7 +47,7 @@ class MinsideAktiveringServiceTest {
             val forventetMinsideAktivering = MinsideAktivering(aktør = aktør, aktivert = true)
 
             every { minsideAktiveringRepository.findByAktør(aktør) } returns null
-            every { minsideAktiveringKafkaProducer.aktiver(aktør.aktivFødselsnummer()) } just Runs
+            every { minsideAktiveringKafkaProducer.aktiver(aktør) } just Runs
             every { minsideAktiveringRepository.save(forventetMinsideAktivering) } returns forventetMinsideAktivering
 
             // Act
@@ -65,7 +65,7 @@ class MinsideAktiveringServiceTest {
             val forventetMinsideAktivering = MinsideAktivering(id = 1, aktør = aktør, aktivert = true)
 
             every { minsideAktiveringRepository.findByAktør(aktør) } returns eksisterendeMinsideAktivering
-            every { minsideAktiveringKafkaProducer.aktiver(aktør.aktivFødselsnummer()) } just Runs
+            every { minsideAktiveringKafkaProducer.aktiver(aktør) } just Runs
             every { minsideAktiveringRepository.save(forventetMinsideAktivering) } returns forventetMinsideAktivering
 
             // Act
@@ -85,7 +85,7 @@ class MinsideAktiveringServiceTest {
             val forventetMinsideAktivering = MinsideAktivering(aktør = aktør, aktivert = false)
 
             every { minsideAktiveringRepository.findByAktør(aktør) } returns null
-            every { minsideAktiveringKafkaProducer.deaktiver(aktør.aktivFødselsnummer()) } just Runs
+            every { minsideAktiveringKafkaProducer.deaktiver(aktør) } just Runs
             every { minsideAktiveringRepository.save(forventetMinsideAktivering) } returns forventetMinsideAktivering
 
             // Act
@@ -103,7 +103,7 @@ class MinsideAktiveringServiceTest {
             val forventetMinsideAktivering = MinsideAktivering(id = 1, aktør = aktør, aktivert = false)
 
             every { minsideAktiveringRepository.findByAktør(aktør) } returns eksisterendeMinsideAktivering
-            every { minsideAktiveringKafkaProducer.deaktiver(aktør.aktivFødselsnummer()) } just Runs
+            every { minsideAktiveringKafkaProducer.deaktiver(aktør) } just Runs
             every { minsideAktiveringRepository.save(forventetMinsideAktivering) } returns forventetMinsideAktivering
 
             // Act


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Meldingene vi sendte til Kafka for aktivering av minside har ingen effekt. Etter å ha vært i kontakt med minside-teamet har vi funnet ut at det skyldes at meldingene ikke har noen key. Legger her til key på aktivering/deaktivering-meldinger.

Velger å bruke `aktørId` som key da den ikke er sensitiv og aldri vil endre seg for en person. Dette vil sørge for at alle meldinger som gjelder personen vil havne i samme partisjon. Har fått bekreftet at topicen ikke slår sammen meldinger med samme key (compaction).

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. 
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
