### PR TITLE
Overstyr callId ved opprettelse av journalførTilbakekrevingsvedtakMotregningBrev task

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/JournalførTilbakekrevingsvedtakMotregningBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/JournalførTilbakekrevingsvedtakMotregningBrevTask.kt
@@ -20,12 +20,18 @@ import no.nav.familie.ba.sak.kjerne.steg.JournalførVedtaksbrev.Companion.logger
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregning
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.task.JournalførTilbakekrevingsvedtakMotregningBrevTask.Companion.TASK_STEP_TYPE
+import no.nav.familie.ba.sak.task.MånedligValutajusteringTask.Companion
+import no.nav.familie.ba.sak.task.MånedligValutajusteringTask.MånedligValutajusteringTaskDto
+import no.nav.familie.ba.sak.task.OpprettTaskService.Companion.overstyrTaskMedNyCallId
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import no.nav.familie.log.IdUtils
+import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import org.slf4j.MDC
 import org.springframework.stereotype.Service
 
 @Service
@@ -146,9 +152,11 @@ class JournalførTilbakekrevingsvedtakMotregningBrevTask(
         fun opprettTask(
             behandlingId: Long,
         ): Task =
-            Task(
-                TASK_STEP_TYPE,
-                "$behandlingId",
-            )
+            overstyrTaskMedNyCallId(IdUtils.generateId()) {
+                Task(
+                    TASK_STEP_TYPE,
+                    "$behandlingId",
+                )
+            }
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25630

Når vi sender ut tilbakekrevingsvedtak motregningsbrev opprettes det en journalførTilbakekrevingsvedtakMotregningBrev task. Denne ender opp med samme callId som journalførTilJoark tasken.

Siden vi genererer ekstern referanse basert på callId, fagsak, og behandling id, så får disse like ekstern referanse, og ved kall mot joark så funker ikke ting så bra.
Velger derfor å generere separat callId for journalførTilbakekrevingsvedtakMotregningBrev tasken.