### PR TITLE
Fiks EØS opphør begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -428,9 +428,9 @@ private fun hentBarnMedNullutbetalingForrigePeriodeGrunnetEndretUtbetaling(begru
             val endretUtbetalingAndel = begrunnelseGrunnlagForPersonIPeriode.forrigePeriode?.endretUtbetalingAndel
             val endretUtbetalingAndelErSattTil0 = endretUtbetalingAndel?.prosent == BigDecimal.ZERO
 
-            andelerTilkjentYtelse?.isNotEmpty() == true
-                    && andelerTilkjentYtelse.none { it.kalkulertUtbetalingsbeløp > 0 }
-                    && endretUtbetalingAndelErSattTil0
+            andelerTilkjentYtelse?.isNotEmpty() == true &&
+                andelerTilkjentYtelse.none { it.kalkulertUtbetalingsbeløp > 0 } &&
+                endretUtbetalingAndelErSattTil0
         }.keys
 
 private fun hentBarnSomSkalUtbetalesVedDeltBosted(begrunnelsesGrunnlagPerPerson: Map<Person, IBegrunnelseGrunnlagForPeriode>) =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -332,8 +332,8 @@ fun ISanityBegrunnelse.hentBarnasFødselsdatoerForBegrunnelse(
     val barnSomHaddeDeltBostedIForrigePeriodeMenIkkeDenne = hentPersonerMedDeltBostedIForrigePeriodeMenIkkeDenne(begrunnelsesGrunnlagPerPerson).filter { it.type == PersonType.BARN }
     val barnSomNåFårUtbetalingIPeriode = barnMedUtbetaling - barnMedUtbetalingHøyereEnn0IForrigeperiode
 
-    val barnMedNullutbetalingForrigePeriode =
-        hentBarnMedNullutbetalingForrigePeriode(begrunnelsesGrunnlagPerPerson)
+    val barnMedNullutbetalingForrigePeriodeGrunnetEndretUtbetaling =
+        hentBarnMedNullutbetalingForrigePeriodeGrunnetEndretUtbetaling(begrunnelsesGrunnlagPerPerson)
 
     return when {
         this.erAvslagUregistrerteBarnBegrunnelse() -> uregistrerteBarnPåBehandlingen.mapNotNull { it.fødselsdato }
@@ -349,7 +349,7 @@ fun ISanityBegrunnelse.hentBarnasFødselsdatoerForBegrunnelse(
                         barnMedUtbetalingIForrigeperiode = barnMedUtbetalingIForrigeperiode,
                         barnMedOppfylteVilkår = barnMedOppfylteVilkår,
                         barnMistetUtbetalingFraForrigeBehandling = barnMistetUtbetalingFraForrigeBehandling,
-                        barnMedNullutbetalingForrigePeriode = barnMedNullutbetalingForrigePeriode,
+                        barnMedNullutbetalingForrigePeriode = barnMedNullutbetalingForrigePeriodeGrunnetEndretUtbetaling,
                     )
                 }
 
@@ -420,13 +420,17 @@ private fun ISanityBegrunnelse.hentRelevanteBarnVedIkkeInnvilget(
     return relevanteBarn
 }
 
-private fun hentBarnMedNullutbetalingForrigePeriode(begrunnelsesGrunnlagPerPerson: Map<Person, IBegrunnelseGrunnlagForPeriode>) =
+private fun hentBarnMedNullutbetalingForrigePeriodeGrunnetEndretUtbetaling(begrunnelsesGrunnlagPerPerson: Map<Person, IBegrunnelseGrunnlagForPeriode>) =
     begrunnelsesGrunnlagPerPerson
         .filterKeys { it.type == PersonType.BARN }
         .filter { (_, begrunnelseGrunnlagForPersonIPeriode) ->
             val andelerTilkjentYtelse = begrunnelseGrunnlagForPersonIPeriode.forrigePeriode?.andeler?.toList()
+            val endretUtbetalingAndel = begrunnelseGrunnlagForPersonIPeriode.forrigePeriode?.endretUtbetalingAndel
+            val endretUtbetalingAndelErSattTil0 = endretUtbetalingAndel?.prosent == BigDecimal.ZERO
 
-            andelerTilkjentYtelse?.isNotEmpty() == true && andelerTilkjentYtelse.none { it.kalkulertUtbetalingsbeløp > 0 }
+            andelerTilkjentYtelse?.isNotEmpty() == true
+                    && andelerTilkjentYtelse.none { it.kalkulertUtbetalingsbeløp > 0 }
+                    && endretUtbetalingAndelErSattTil0
         }.keys
 
 private fun hentBarnSomSkalUtbetalesVedDeltBosted(begrunnelsesGrunnlagPerPerson: Map<Person, IBegrunnelseGrunnlagForPeriode>) =

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør/opphør-eøs.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/brevBegrunnelser/opphør/opphør-eøs.feature
@@ -186,3 +186,182 @@ Egenskap: Brevbegrunnelser ved opphør for EØS.
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.02.2024 til -
       | Begrunnelse         | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland | Gjelder søker |
       | OPPHØR_EØS_STANDARD | EØS  | 24.03.22             | 1           |         |                  |                           |                       |                                |                     | Ja            |
+
+  Scenario: Ved opphør så skal alle barn trekkes inn i opphørsbegrunnelsen uansett om de har hatt 0 i utbetaling grunnet utenlandsk valuta
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype | Status  |
+      | 1        | NORMAL     | LØPENDE |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak         | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | FORTSATT_INNVILGET  | MÅNEDLIG_VALUTAJUSTERING | Ja                        | EØS                 | AVSLUTTET         |
+      | 2            | 1        | 1                   | OPPHØRT             | NYE_OPPLYSNINGER         | Nei                       | EØS                 | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 13.05.1980  |              |
+      | 1            | 2       | BARN       | 14.04.2008  |              |
+      | 1            | 3       | BARN       | 15.05.2010  |              |
+      | 2            | 1       | SØKER      | 13.05.1980  |              |
+      | 2            | 2       | BARN       | 14.04.2008  |              |
+      | 2            | 3       | BARN       | 15.05.2010  |              |
+    Og dagens dato er 27.06.2025
+    Og med personer fremstilt krav for
+      | BehandlingId | AktørId |
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                      | Utdypende vilkår                | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD,BOSATT_I_RIKET               |                                 | 26.04.2021 | 12.08.2023 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | LOVLIG_OPPHOLD                              |                                 | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET                              | OMFATTET_AV_NORSK_LOVGIVNING    | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | GIFT_PARTNERSKAP                            |                                 | 14.04.2008 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | UNDER_18_ÅR                                 |                                 | 14.04.2008 | 13.04.2026 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOR_MED_SØKER,LOVLIG_OPPHOLD,BOSATT_I_RIKET |                                 | 26.04.2021 | 12.08.2023 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | LOVLIG_OPPHOLD                              |                                 | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER                               | BARN_BOR_ALENE_I_ANNET_EØS_LAND | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOSATT_I_RIKET                              | BARN_BOR_I_EØS                  | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 3       | GIFT_PARTNERSKAP                            |                                 | 15.05.2010 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | UNDER_18_ÅR                                 |                                 | 15.05.2010 | 14.05.2028 | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | LOVLIG_OPPHOLD,BOR_MED_SØKER,BOSATT_I_RIKET |                                 | 26.04.2021 | 25.03.2024 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 3       | LOVLIG_OPPHOLD                              |                                 | 26.03.2024 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | BOSATT_I_RIKET                              | BARN_BOR_I_NORGE                | 26.03.2024 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | BOR_MED_SØKER                               | BARN_BOR_I_NORGE_MED_SØKER      | 26.03.2024 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                                      | Utdypende vilkår                | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD,BOSATT_I_RIKET               |                                 | 26.04.2021 | 12.08.2023 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | LOVLIG_OPPHOLD                              |                                 | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET                              | OMFATTET_AV_NORSK_LOVGIVNING    | 13.08.2023 | 30.06.2025 | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | GIFT_PARTNERSKAP                            |                                 | 14.04.2008 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | UNDER_18_ÅR                                 |                                 | 14.04.2008 | 13.04.2026 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER,LOVLIG_OPPHOLD |                                 | 26.04.2021 | 12.08.2023 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BOSATT_I_RIKET                              | BARN_BOR_I_EØS                  | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER                               | BARN_BOR_ALENE_I_ANNET_EØS_LAND | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | LOVLIG_OPPHOLD                              |                                 | 13.08.2023 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 3       | GIFT_PARTNERSKAP                            |                                 | 15.05.2010 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | UNDER_18_ÅR                                 |                                 | 15.05.2010 | 14.05.2028 | OPPFYLT  | Nei                  |                      |                  |
+      | 3       | LOVLIG_OPPHOLD,BOR_MED_SØKER,BOSATT_I_RIKET |                                 | 26.04.2021 | 25.03.2024 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 3       | BOSATT_I_RIKET                              | BARN_BOR_I_NORGE                | 26.03.2024 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | LOVLIG_OPPHOLD                              |                                 | 26.03.2024 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 3       | BOR_MED_SØKER                               | BARN_BOR_I_NORGE_MED_SØKER      | 26.03.2024 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+    Og med kompetanser
+      | AktørId | Fra dato   | Til dato   | Resultat              | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.09.2023 | 31.03.2024 | NORGE_ER_PRIMÆRLAND   | 1            | ARBEIDER         | I_ARBEID                  | NO                    | NO                             | DK                  |
+      | 2       | 01.04.2024 |            | NORGE_ER_SEKUNDÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | DK                             | DK                  |
+      | 3       | 01.04.2024 |            | NORGE_ER_PRIMÆRLAND   | 1            | ARBEIDER         | I_ARBEID                  | NO                    | DK                             | NO                  |
+      | 2       | 01.09.2023 | 31.03.2024 | NORGE_ER_PRIMÆRLAND   | 2            | ARBEIDER         | I_ARBEID                  | NO                    | NO                             | DK                  |
+      | 2       | 01.04.2024 |            | NORGE_ER_SEKUNDÆRLAND | 2            | ARBEIDER         | I_ARBEID                  | NO                    | DK                             | DK                  |
+      | 3       | 01.04.2024 |            | NORGE_ER_PRIMÆRLAND   | 2            | ARBEIDER         | I_ARBEID                  | NO                    | DK                             | NO                  |
+
+    Og med utenlandsk periodebeløp
+      | AktørId | Fra måned | Til måned | BehandlingId | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 04.2024   | 12.2024   | 1            | 1064  | DKK         | MÅNEDLIG  | DK              |
+      | 2       | 01.2025   |           | 1            | 3297  | DKK         | MÅNEDLIG  | DK              |
+      | 2       | 04.2024   | 12.2024   | 2            | 1064  | DKK         | MÅNEDLIG  | DK              |
+      | 2       | 01.2025   |           | 2            | 3297  | DKK         | MÅNEDLIG  | DK              |
+
+    Og med valutakurser
+      | AktørId | Fra dato   | Til dato   | BehandlingId | Valutakursdato | Valuta kode | Kurs         | Vurderingsform |
+      | 2       | 01.04.2024 | 31.05.2024 | 1            | 2024-05-10     | DKK         | 1.5646655140 | MANUELL        |
+      | 2       | 01.06.2024 | 30.06.2024 | 1            | 2024-05-31     | DKK         | 1.5261168016 | AUTOMATISK     |
+      | 2       | 01.07.2024 | 31.07.2024 | 1            | 2024-06-28     | DKK         | 1.5281930942 | AUTOMATISK     |
+      | 2       | 01.08.2024 | 31.08.2024 | 1            | 2024-07-31     | DKK         | 1.5836694764 | AUTOMATISK     |
+      | 2       | 01.09.2024 | 30.09.2024 | 1            | 2024-08-30     | DKK         | 1.5635013206 | AUTOMATISK     |
+      | 2       | 01.10.2024 | 31.10.2024 | 1            | 2024-09-30     | DKK         | 1.5778567597 | AUTOMATISK     |
+      | 2       | 01.11.2024 | 30.11.2024 | 1            | 2024-10-31     | DKK         | 1.6003136687 | AUTOMATISK     |
+      | 2       | 01.12.2024 | 31.12.2024 | 1            | 2024-11-29     | DKK         | 1.5661915553 | AUTOMATISK     |
+      | 2       | 01.01.2025 | 31.01.2025 | 1            | 2024-12-31     | DKK         | 1.5815656092 | AUTOMATISK     |
+      | 2       | 01.02.2025 | 28.02.2025 | 1            | 2025-01-31     | DKK         | 1.5729850706 | AUTOMATISK     |
+      | 2       | 01.03.2025 | 31.03.2025 | 1            | 2025-02-28     | DKK         | 1.5720070257 | AUTOMATISK     |
+      | 2       | 01.04.2025 | 30.04.2025 | 1            | 2025-03-31     | DKK         | 1.5296262045 | AUTOMATISK     |
+      | 2       | 01.05.2025 | 31.05.2025 | 1            | 2025-04-30     | DKK         | 1.5822123372 | AUTOMATISK     |
+      | 2       | 01.06.2025 |            | 1            | 2025-05-30     | DKK         | 1.5472937643 | AUTOMATISK     |
+      | 2       | 01.04.2024 | 31.05.2024 | 2            | 2024-05-10     | DKK         | 1.5646655140 | MANUELL        |
+      | 2       | 01.06.2024 | 30.06.2024 | 2            | 2024-05-31     | DKK         | 1.5261168016 | AUTOMATISK     |
+      | 2       | 01.07.2024 | 31.07.2024 | 2            | 2024-06-28     | DKK         | 1.5281930942 | AUTOMATISK     |
+      | 2       | 01.08.2024 | 31.08.2024 | 2            | 2024-07-31     | DKK         | 1.5836694764 | AUTOMATISK     |
+      | 2       | 01.09.2024 | 30.09.2024 | 2            | 2024-08-30     | DKK         | 1.5635013206 | AUTOMATISK     |
+      | 2       | 01.10.2024 | 31.10.2024 | 2            | 2024-09-30     | DKK         | 1.5778567597 | AUTOMATISK     |
+      | 2       | 01.11.2024 | 30.11.2024 | 2            | 2024-10-31     | DKK         | 1.6003136687 | AUTOMATISK     |
+      | 2       | 01.12.2024 | 31.12.2024 | 2            | 2024-11-29     | DKK         | 1.5661915553 | AUTOMATISK     |
+      | 2       | 01.01.2025 | 31.01.2025 | 2            | 2024-12-31     | DKK         | 1.5815656092 | AUTOMATISK     |
+      | 2       | 01.02.2025 | 28.02.2025 | 2            | 2025-01-31     | DKK         | 1.5729850706 | AUTOMATISK     |
+      | 2       | 01.03.2025 | 31.03.2025 | 2            | 2025-02-28     | DKK         | 1.5720070257 | AUTOMATISK     |
+      | 2       | 01.04.2025 | 30.04.2025 | 2            | 2025-03-31     | DKK         | 1.5296262045 | AUTOMATISK     |
+      | 2       | 01.05.2025 | 31.05.2025 | 2            | 2025-04-30     | DKK         | 1.5822123372 | AUTOMATISK     |
+      | 2       | 01.06.2025 |            | 2            | 2025-05-30     | DKK         | 1.5472937643 | AUTOMATISK     |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.05.2021 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 1            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 1            | 01.01.2024 | 31.03.2024 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.04.2024 | 31.05.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.06.2024 | 30.06.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.07.2024 | 31.07.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.08.2024 | 31.08.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 1            | 01.09.2024 | 30.09.2024 | 103   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.10.2024 | 31.10.2024 | 88    | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.11.2024 | 30.11.2024 | 64    | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.12.2024 | 31.12.2024 | 100   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.01.2025 | 31.01.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.02.2025 | 28.02.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.03.2025 | 31.03.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.04.2025 | 30.04.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 1            | 01.05.2025 | 31.05.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 2       | 1            | 01.06.2025 | 31.03.2026 | 0     | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 3       | 1            | 01.05.2021 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 3       | 1            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 3       | 1            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 3       | 1            | 01.01.2024 | 31.08.2024 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 3       | 1            | 01.09.2024 | 30.04.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 1            | 01.05.2025 | 30.04.2028 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+
+      | 2       | 2            | 01.05.2021 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 2       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 2       | 2            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 2       | 2            | 01.01.2024 | 31.03.2024 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.04.2024 | 31.05.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.06.2024 | 30.06.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.07.2024 | 31.07.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.08.2024 | 31.08.2024 | 0     | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 2       | 2            | 01.09.2024 | 30.09.2024 | 103   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.10.2024 | 31.10.2024 | 88    | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.11.2024 | 30.11.2024 | 64    | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.12.2024 | 31.12.2024 | 100   | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.01.2025 | 31.01.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.02.2025 | 28.02.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.03.2025 | 31.03.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.04.2025 | 30.04.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 2       | 2            | 01.05.2025 | 31.05.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 2       | 2            | 01.06.2025 | 30.06.2025 | 0     | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 3       | 2            | 01.05.2021 | 28.02.2023 | 1054  | ORDINÆR_BARNETRYGD | 100     | 1054 |
+      | 3       | 2            | 01.03.2023 | 30.06.2023 | 1083  | ORDINÆR_BARNETRYGD | 100     | 1083 |
+      | 3       | 2            | 01.07.2023 | 31.12.2023 | 1310  | ORDINÆR_BARNETRYGD | 100     | 1310 |
+      | 3       | 2            | 01.01.2024 | 31.08.2024 | 1510  | ORDINÆR_BARNETRYGD | 100     | 1510 |
+      | 3       | 2            | 01.09.2024 | 30.04.2025 | 1766  | ORDINÆR_BARNETRYGD | 100     | 1766 |
+      | 3       | 2            | 01.05.2025 | 30.06.2025 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser | Ugyldige begrunnelser |
+      | 01.07.2025 |          | OPPHØR             |                                |                      |                       |
+      | 01.07.2025 |          | OPPHØR             | EØS_FORORDNINGEN               | OPPHØR_EØS_STANDARD  |                       |
+
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato | Standardbegrunnelser | Eøsbegrunnelser     | Fritekster |
+      | 01.07.2025 |          |                      | OPPHØR_EØS_STANDARD |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.07.2025 til -
+      | Begrunnelse         | Type | Barnas fødselsdatoer | Antall barn | Gjelder søker |
+      | OPPHØR_EØS_STANDARD | EØS  | 14.04.08 og 15.05.10 | 2           | Ja            |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25573

I denne pullrequesten https://github.com/navikt/familie-ba-sak/pull/5334, ble det innført ekskludering av barn som ikke har utbetaling i forrige vedtaksperiode pga endret utbetaling ved opphør begrunnelser.
Det mangler en sjekk på endret utbetaling, som fører til at i begrunnelser uten endret utbetaling også får barna ekskludert.

Fikser det + legger til test som sjekker at saken i produksjon er løst.