### PR TITLE
Legger til overlappendePerioderMedAndreFagsaker til simulering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -125,6 +125,7 @@ class AvregningService(
                 tom = it.tom!!,
                 fagsaker =
                     it.verdi.behandlingIds
+                        .distinct()
                         .filter { behandlingId != it }
                         .map { behandlingHentOgPersisterService.hent(it).fagsak.id },
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -18,7 +18,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.INSTITUSJON
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.SKJERMET_BARN
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
-import no.nav.familie.ba.sak.kjerne.simulering.domene.OverlappendePerioderMedAnnenFagsak
+import no.nav.familie.ba.sak.kjerne.simulering.domene.OverlappendePerioderMedAndreFagsaker
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærTilOgMed
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
@@ -102,7 +102,7 @@ class AvregningService(
                 }
             }
 
-    fun hentOverlappendePerioderMedAnnenFagsak(behandlingId: Long): List<OverlappendePerioderMedAnnenFagsak> {
+    fun hentOverlappendePerioderMedAndreFagsaker(behandlingId: Long): List<OverlappendePerioderMedAndreFagsaker> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
 
         val fagsaker =
@@ -120,7 +120,7 @@ class AvregningService(
             ).tilPerioderIkkeNull().filter { it.verdi.erOver100Prosent }
 
         return tidslinjeMedOverlapp.map {
-            OverlappendePerioderMedAnnenFagsak(
+            OverlappendePerioderMedAndreFagsaker(
                 fom = it.fom!!,
                 tom = it.tom!!,
                 fagsaker =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -18,7 +18,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.INSTITUSJON
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.SKJERMET_BARN
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
-import no.nav.familie.ba.sak.kjerne.simulering.domene.OverlappendePeriodePåAnnenFagsak
+import no.nav.familie.ba.sak.kjerne.simulering.domene.OverlappendePerioderMedAnnenFagsak
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærTilOgMed
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
@@ -102,7 +102,7 @@ class AvregningService(
                 }
             }
 
-    fun hentDuplisertePerioderOverFagsak(behandlingId: Long): List<OverlappendePeriodePåAnnenFagsak> {
+    fun hentOverlappendePerioderMedAnnenFagsak(behandlingId: Long): List<OverlappendePerioderMedAnnenFagsak> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
 
         val fagsaker =
@@ -120,7 +120,7 @@ class AvregningService(
             ).tilPerioderIkkeNull().filter { it.verdi.erOver100Prosent }
 
         return tidslinjeMedOverlapp.map {
-            OverlappendePeriodePåAnnenFagsak(
+            OverlappendePerioderMedAnnenFagsak(
                 fom = it.fom!!,
                 tom = it.tom!!,
                 fagsaker =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -18,7 +18,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.INSTITUSJON
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.SKJERMET_BARN
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
-import no.nav.familie.ba.sak.kjerne.simulering.domene.DuplisertePerioderOverFagsak
+import no.nav.familie.ba.sak.kjerne.simulering.domene.OverlappendePeriodePåAnnenFagsak
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærTilOgMed
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
@@ -102,7 +102,7 @@ class AvregningService(
                 }
             }
 
-    fun hentDuplisertePerioderOverFagsak(behandlingId: Long): List<DuplisertePerioderOverFagsak> {
+    fun hentDuplisertePerioderOverFagsak(behandlingId: Long): List<OverlappendePeriodePåAnnenFagsak> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
 
         val fagsaker =
@@ -120,7 +120,7 @@ class AvregningService(
             ).tilPerioderIkkeNull().filter { it.verdi.erOver100Prosent }
 
         return tidslinjeMedOverlapp.map {
-            DuplisertePerioderOverFagsak(
+            OverlappendePeriodePåAnnenFagsak(
                 fom = it.fom!!,
                 tom = it.tom!!,
                 fagsaker =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -119,7 +119,16 @@ class AvregningService(
                 barnsAndelerFraAndreBehandlinger = beregningService.hentRelevanteTilkjentYtelserForBarn(behandling.fagsak.aktør, behandling.fagsak.id).flatMap { it.andelerTilkjentYtelse },
             ).tilPerioderIkkeNull().filter { it.verdi.erOver100Prosent }
 
-        return tidslinjeMedOverlapp.map { DuplisertePerioderOverFagsak(it.fom!!, it.tom!!) }
+        return tidslinjeMedOverlapp.map {
+            DuplisertePerioderOverFagsak(
+                fom = it.fom!!,
+                tom = it.tom!!,
+                fagsaker =
+                    it.verdi.behandlingIds
+                        .filter { behandlingId != it }
+                        .map { behandlingHentOgPersisterService.hent(it).fagsak.id },
+            )
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -7,12 +7,18 @@ import no.nav.familie.ba.sak.config.FeatureToggle.BRUK_FUNKSJONALITET_FOR_ULOVFE
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.lagErOver100ProsentUtbetalingPåYtelseTidslinje
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.BARN_ENSLIG_MINDREÅRIG
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.INSTITUSJON
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.SKJERMET_BARN
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
+import no.nav.familie.ba.sak.kjerne.simulering.domene.DuplisertePerioderOverFagsak
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærTilOgMed
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
@@ -30,6 +36,8 @@ class AvregningService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val clockProvider: ClockProvider,
     private val unleashService: UnleashNextMedContextService,
+    private val fagsakService: FagsakService,
+    private val beregningService: BeregningService,
 ) {
     fun behandlingHarPerioderSomAvregnes(behandlingId: Long): Boolean = hentPerioderMedAvregning(behandlingId).isNotEmpty()
 
@@ -93,6 +101,26 @@ class AvregningService(
                     null
                 }
             }
+
+    fun hentDuplisertePerioderOverFagsak(behandlingId: Long): List<DuplisertePerioderOverFagsak> {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+
+        val fagsaker =
+            when (behandling.fagsak.type) {
+                SKJERMET_BARN, INSTITUSJON, BARN_ENSLIG_MINDREÅRIG -> fagsakService.hentAlleFagsakerForAktør(behandling.fagsak.aktør).filter { it.id != behandling.fagsak.id }
+                else -> return emptyList()
+            }
+
+        if (fagsaker.isEmpty()) return emptyList()
+
+        val tidslinjeMedOverlapp =
+            lagErOver100ProsentUtbetalingPåYtelseTidslinje(
+                andeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id),
+                barnsAndelerFraAndreBehandlinger = beregningService.hentRelevanteTilkjentYtelserForBarn(behandling.fagsak.aktør, behandling.fagsak.id).flatMap { it.andelerTilkjentYtelse },
+            ).tilPerioderIkkeNull().filter { it.verdi.erOver100Prosent }
+
+        return tidslinjeMedOverlapp.map { DuplisertePerioderOverFagsak(it.fom!!, it.tom!!) }
+    }
 }
 
 data class EtterbetalingOgFeilutbetaling(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -300,7 +300,6 @@ object TilkjentYtelseValidering {
             return tomTidslinje()
         }
 
-        // Group andeler by behandlingId
         val andelerPerBehandling = (andeler + barnsAndelerFraAndreBehandlinger).groupBy { it.behandlingId }
 
         // Create a map of behandlingId to timeline of percentages

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValidering.kt
@@ -302,13 +302,11 @@ object TilkjentYtelseValidering {
 
         val andelerPerBehandling = (andeler + barnsAndelerFraAndreBehandlinger).groupBy { it.behandlingId }
 
-        // Create a map of behandlingId to timeline of percentages
         val prosenttidslinjerPerBehandling =
             andelerPerBehandling.mapValues { (_, andelerForBehandling) ->
                 andelerForBehandling.tilProsentAvYtelseUtbetaltTidslinje()
             }
 
-        // Calculate the total percentage timeline
         val totalProsentTidslinje =
             prosenttidslinjerPerBehandling.values
                 .fold(tomTidslinje<BigDecimal>()) { summertProsentTidslinje, prosentTidslinje ->
@@ -317,8 +315,6 @@ object TilkjentYtelseValidering {
                     }
                 }
 
-        // Create a timeline that indicates for each period whether the total percentage exceeds 100%
-        // and which behandlingIds contributed to the overlap
         val erOver100ProsentTidslinje =
             totalProsentTidslinje.mapVerdi { sumProsentForPeriode ->
                 val erOver100Prosent = (sumProsentForPeriode ?: BigDecimal.ZERO) > BigDecimal.valueOf(100)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
@@ -27,13 +27,13 @@ class SimuleringController(
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         val vedtakSimuleringMottaker = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId)
         val avregningsperioder = avregningService.hentPerioderMedAvregning(behandlingId)
-        val overlappendePerioderMedAnnenFagsak = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId)
+        val overlappendePerioderMedAndreFagsaker = avregningService.hentOverlappendePerioderMedAndreFagsaker(behandlingId)
         val simulering =
             vedtakSimuleringMottakereTilRestSimulering(
                 økonomiSimuleringMottakere = vedtakSimuleringMottaker,
             )
 
-        val restSimulering = simulering.tilRestSimulering(avregningsperioder, overlappendePerioderMedAnnenFagsak)
+        val restSimulering = simulering.tilRestSimulering(avregningsperioder, overlappendePerioderMedAndreFagsaker)
         return ResponseEntity.ok(Ressurs.success(restSimulering))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
@@ -27,13 +27,13 @@ class SimuleringController(
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         val vedtakSimuleringMottaker = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId)
         val avregningsperioder = avregningService.hentPerioderMedAvregning(behandlingId)
-        val duplisertePerioderOverFagsak = avregningService.hentDuplisertePerioderOverFagsak(behandlingId)
+        val overlappendePerioderMedAnnenFagsak = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId)
         val simulering =
             vedtakSimuleringMottakereTilRestSimulering(
                 økonomiSimuleringMottakere = vedtakSimuleringMottaker,
             )
 
-        val restSimulering = simulering.tilRestSimulering(avregningsperioder, duplisertePerioderOverFagsak)
+        val restSimulering = simulering.tilRestSimulering(avregningsperioder, overlappendePerioderMedAnnenFagsak)
         return ResponseEntity.ok(Ressurs.success(restSimulering))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
@@ -27,12 +27,13 @@ class SimuleringController(
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         val vedtakSimuleringMottaker = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId)
         val avregningsperioder = avregningService.hentPerioderMedAvregning(behandlingId)
+        val duplisertePerioderOverFagsak = avregningService.hentDuplisertePerioderOverFagsak(behandlingId)
         val simulering =
             vedtakSimuleringMottakereTilRestSimulering(
                 økonomiSimuleringMottakere = vedtakSimuleringMottaker,
             )
 
-        val restSimulering = simulering.tilRestSimulering(avregningsperioder)
+        val restSimulering = simulering.tilRestSimulering(avregningsperioder, duplisertePerioderOverFagsak)
         return ResponseEntity.ok(Ressurs.success(restSimulering))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -16,7 +16,7 @@ data class Simulering(
 ) {
     fun tilRestSimulering(
         avregningsperioder: List<AvregningPeriode>,
-        overlappendePerioderPåAnnenFagsak: List<OverlappendePeriodePåAnnenFagsak>,
+        overlappendePerioderPåAnnenFagsak: List<OverlappendePerioderMedAnnenFagsak>,
     ): RestSimulering =
         RestSimulering(
             perioder = perioder,
@@ -29,7 +29,7 @@ data class Simulering(
             tidSimuleringHentet = tidSimuleringHentet,
             tomSisteUtbetaling = tomSisteUtbetaling,
             avregningsperioder = avregningsperioder,
-            overlappendePerioderPåAnnenFagsak = overlappendePerioderPåAnnenFagsak,
+            overlappendePerioderMedAnnenFagsak = overlappendePerioderPåAnnenFagsak,
         )
 }
 
@@ -56,7 +56,7 @@ data class RestSimulering(
     val tidSimuleringHentet: LocalDate?,
     val tomSisteUtbetaling: LocalDate?,
     val avregningsperioder: List<AvregningPeriode>,
-    val overlappendePerioderPåAnnenFagsak: List<OverlappendePeriodePåAnnenFagsak> = emptyList(),
+    val overlappendePerioderMedAnnenFagsak: List<OverlappendePerioderMedAnnenFagsak> = emptyList(),
 )
 
 data class AvregningPeriode(
@@ -66,7 +66,7 @@ data class AvregningPeriode(
     val totalFeilutbetaling: BigDecimal,
 )
 
-data class OverlappendePeriodePåAnnenFagsak(
+data class OverlappendePerioderMedAnnenFagsak(
     val fom: LocalDate,
     val tom: LocalDate,
     val fagsaker: List<Long>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -16,7 +16,7 @@ data class Simulering(
 ) {
     fun tilRestSimulering(
         avregningsperioder: List<AvregningPeriode>,
-        duplisertePerioderOverFagsak: List<DuplisertePerioderOverFagsak>,
+        overlappendePerioderPåAnnenFagsak: List<OverlappendePeriodePåAnnenFagsak>,
     ): RestSimulering =
         RestSimulering(
             perioder = perioder,
@@ -29,7 +29,7 @@ data class Simulering(
             tidSimuleringHentet = tidSimuleringHentet,
             tomSisteUtbetaling = tomSisteUtbetaling,
             avregningsperioder = avregningsperioder,
-            duplisertePerioderOverFagsak = duplisertePerioderOverFagsak,
+            overlappendePerioderPåAnnenFagsak = overlappendePerioderPåAnnenFagsak,
         )
 }
 
@@ -56,7 +56,7 @@ data class RestSimulering(
     val tidSimuleringHentet: LocalDate?,
     val tomSisteUtbetaling: LocalDate?,
     val avregningsperioder: List<AvregningPeriode>,
-    val duplisertePerioderOverFagsak: List<DuplisertePerioderOverFagsak> = emptyList(),
+    val overlappendePerioderPåAnnenFagsak: List<OverlappendePeriodePåAnnenFagsak> = emptyList(),
 )
 
 data class AvregningPeriode(
@@ -66,7 +66,7 @@ data class AvregningPeriode(
     val totalFeilutbetaling: BigDecimal,
 )
 
-data class DuplisertePerioderOverFagsak(
+data class OverlappendePeriodePåAnnenFagsak(
     val fom: LocalDate,
     val tom: LocalDate,
     val fagsaker: List<Long>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -14,7 +14,10 @@ data class Simulering(
     val tidSimuleringHentet: LocalDate?,
     val tomSisteUtbetaling: LocalDate?,
 ) {
-    fun tilRestSimulering(avregningsperioder: List<AvregningPeriode>): RestSimulering =
+    fun tilRestSimulering(
+        avregningsperioder: List<AvregningPeriode>,
+        duplisertePerioderOverFagsak: List<DuplisertePerioderOverFagsak>,
+    ): RestSimulering =
         RestSimulering(
             perioder = perioder,
             fomDatoNestePeriode = fomDatoNestePeriode,
@@ -26,6 +29,7 @@ data class Simulering(
             tidSimuleringHentet = tidSimuleringHentet,
             tomSisteUtbetaling = tomSisteUtbetaling,
             avregningsperioder = avregningsperioder,
+            duplisertePerioderOverFagsak = duplisertePerioderOverFagsak,
         )
 }
 
@@ -52,6 +56,7 @@ data class RestSimulering(
     val tidSimuleringHentet: LocalDate?,
     val tomSisteUtbetaling: LocalDate?,
     val avregningsperioder: List<AvregningPeriode>,
+    val duplisertePerioderOverFagsak: List<DuplisertePerioderOverFagsak> = emptyList(),
 )
 
 data class AvregningPeriode(
@@ -59,4 +64,10 @@ data class AvregningPeriode(
     val tom: LocalDate,
     val totalEtterbetaling: BigDecimal,
     val totalFeilutbetaling: BigDecimal,
+)
+
+data class DuplisertePerioderOverFagsak(
+    val fom: LocalDate,
+    val tom: LocalDate,
+    val fagsak: Long? = null,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -16,7 +16,7 @@ data class Simulering(
 ) {
     fun tilRestSimulering(
         avregningsperioder: List<AvregningPeriode>,
-        overlappendePerioderPåAnnenFagsak: List<OverlappendePerioderMedAnnenFagsak>,
+        overlappendePerioderMedAnnenFagsak: List<OverlappendePerioderMedAnnenFagsak>,
     ): RestSimulering =
         RestSimulering(
             perioder = perioder,
@@ -29,7 +29,7 @@ data class Simulering(
             tidSimuleringHentet = tidSimuleringHentet,
             tomSisteUtbetaling = tomSisteUtbetaling,
             avregningsperioder = avregningsperioder,
-            overlappendePerioderMedAnnenFagsak = overlappendePerioderPåAnnenFagsak,
+            overlappendePerioderMedAnnenFagsak = overlappendePerioderMedAnnenFagsak,
         )
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -16,7 +16,7 @@ data class Simulering(
 ) {
     fun tilRestSimulering(
         avregningsperioder: List<AvregningPeriode>,
-        overlappendePerioderMedAnnenFagsak: List<OverlappendePerioderMedAnnenFagsak>,
+        overlappendePerioderMedAndreFagsaker: List<OverlappendePerioderMedAndreFagsaker>,
     ): RestSimulering =
         RestSimulering(
             perioder = perioder,
@@ -29,7 +29,7 @@ data class Simulering(
             tidSimuleringHentet = tidSimuleringHentet,
             tomSisteUtbetaling = tomSisteUtbetaling,
             avregningsperioder = avregningsperioder,
-            overlappendePerioderMedAnnenFagsak = overlappendePerioderMedAnnenFagsak,
+            overlappendePerioderMedAndreFagsaker = overlappendePerioderMedAndreFagsaker,
         )
 }
 
@@ -56,7 +56,7 @@ data class RestSimulering(
     val tidSimuleringHentet: LocalDate?,
     val tomSisteUtbetaling: LocalDate?,
     val avregningsperioder: List<AvregningPeriode>,
-    val overlappendePerioderMedAnnenFagsak: List<OverlappendePerioderMedAnnenFagsak> = emptyList(),
+    val overlappendePerioderMedAndreFagsaker: List<OverlappendePerioderMedAndreFagsaker> = emptyList(),
 )
 
 data class AvregningPeriode(
@@ -66,7 +66,7 @@ data class AvregningPeriode(
     val totalFeilutbetaling: BigDecimal,
 )
 
-data class OverlappendePerioderMedAnnenFagsak(
+data class OverlappendePerioderMedAndreFagsaker(
     val fom: LocalDate,
     val tom: LocalDate,
     val fagsaker: List<Long>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/domene/Simulering.kt
@@ -69,5 +69,5 @@ data class AvregningPeriode(
 data class DuplisertePerioderOverFagsak(
     val fom: LocalDate,
     val tom: LocalDate,
-    val fagsak: Long? = null,
+    val fagsaker: List<Long>,
 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/SamhandlerTestConfig.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/SamhandlerTestConfig.kt
@@ -29,6 +29,7 @@ class SamhandlerTestConfig {
         fun clearSamhandlerKlient(samhandlerKlient: SamhandlerKlient) {
             clearMocks(samhandlerKlient)
             every { samhandlerKlient.hentSamhandler(any()) } returns samhandlereInfoMock.first()
+            every { samhandlerKlient.hentSamhandler("312962594") } returns samhandlereInfoMock.last()
             every { samhandlerKlient.søkSamhandlere(any(), any(), any(), any()) } returns
                 SøkSamhandlerInfo(
                     false,
@@ -47,12 +48,12 @@ val samhandlereInfoMock =
                 SamhandlerAdresse(listOf("Instutisjonsnsveien 1"), "0110", "Oslo", "Arbeidsadresse"),
                 SamhandlerAdresse(listOf("Postboks 123"), "0110", "Oslo", "Postadresse"),
             ),
-            orgNummer = "974652269",
+            orgNummer = "312539756",
         ),
         SamhandlerInfo(
             "80000888888",
             "INSTUTISJON 2",
             listOf(SamhandlerAdresse(listOf("Instutisjonsnsveien 2"), "1892", "Degernes", "Arbeidsadresse")),
-            orgNummer = "974652269",
+            orgNummer = "312962594",
         ),
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
@@ -34,6 +35,7 @@ class AvregningServiceTest {
     private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
     private val unleashService = mockk<UnleashNextMedContextService>()
+    private val fagsakService = mockk<FagsakService>()
 
     private val avregningService =
         AvregningService(
@@ -41,6 +43,8 @@ class AvregningServiceTest {
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(mar(2025)),
             unleashService = unleashService,
+            fagsakService = fagsakService,
+            beregningService = mockk(),
         )
 
     @BeforeEach

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -656,7 +656,7 @@ class AvregningServiceTest {
     }
 
     @Nested
-    inner class `hentOverlappendePerioderMedAnnenFagsak` {
+    inner class HentOverlappendePerioderMedAnnenFagsak {
         @Test
         fun `Returner tom liste hvis fagsaktype ikke er SKJERMET_BARN, INSTITUSJON, or BARN_ENSLIG_MINDREÅRIG`() {
             every { behandlingHentOgPersisterService.hent(any()) } returns lagBehandling()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -656,12 +656,12 @@ class AvregningServiceTest {
     }
 
     @Nested
-    inner class HentOverlappendePerioderMedAnnenFagsak {
+    inner class HentOverlappendePerioderMedAndreFagsaker {
         @Test
         fun `Returner tom liste hvis fagsaktype ikke er SKJERMET_BARN, INSTITUSJON, or BARN_ENSLIG_MINDREÅRIG`() {
             every { behandlingHentOgPersisterService.hent(any()) } returns lagBehandling()
 
-            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = inneværendeBehandling.id)
+            val result = avregningService.hentOverlappendePerioderMedAndreFagsaker(behandlingId = inneværendeBehandling.id)
 
             assertThat(result).isEmpty()
         }
@@ -673,7 +673,7 @@ class AvregningServiceTest {
             every { behandlingHentOgPersisterService.hent(any()) } returns lagBehandling(fagsak = fagsakSkjermetBarn)
             every { fagsakService.hentAlleFagsakerForAktør(any()) } returns listOf(fagsakSkjermetBarn)
 
-            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = inneværendeBehandling.id)
+            val result = avregningService.hentOverlappendePerioderMedAndreFagsaker(behandlingId = inneværendeBehandling.id)
 
             assertThat(result).isEmpty()
         }
@@ -715,7 +715,7 @@ class AvregningServiceTest {
                     ),
                 )
 
-            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = behandlingForInstitusjon1.id)
+            val result = avregningService.hentOverlappendePerioderMedAndreFagsaker(behandlingId = behandlingForInstitusjon1.id)
 
             assertThat(result).hasSize(1)
             assertThat(result.first().fagsaker).containsOnly(2)
@@ -760,7 +760,7 @@ class AvregningServiceTest {
                     ),
                 )
 
-            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = behandlingForInstitusjon1.id)
+            val result = avregningService.hentOverlappendePerioderMedAndreFagsaker(behandlingId = behandlingForInstitusjon1.id)
 
             assertThat(result).hasSize(0)
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -3,26 +3,37 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.TestClockProvider
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.INSTITUSJON
 import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.apr
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.jun
+import no.nav.familie.ba.sak.kjerne.tidslinje.util.mai
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.math.BigDecimal
 
 class AvregningServiceTest {
     private val søker = lagPerson()
@@ -36,6 +47,7 @@ class AvregningServiceTest {
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
     private val unleashService = mockk<UnleashNextMedContextService>()
     private val fagsakService = mockk<FagsakService>()
+    private val beregningService = mockk<BeregningService>()
 
     private val avregningService =
         AvregningService(
@@ -44,7 +56,7 @@ class AvregningServiceTest {
             clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(mar(2025)),
             unleashService = unleashService,
             fagsakService = fagsakService,
-            beregningService = mockk(),
+            beregningService = beregningService,
         )
 
     @BeforeEach
@@ -640,6 +652,117 @@ class AvregningServiceTest {
                 )
 
             assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
+        }
+    }
+
+    @Nested
+    inner class `hentOverlappendePerioderMedAnnenFagsak` {
+        @Test
+        fun `Returner tom liste hvis fagsaktype ikke er SKJERMET_BARN, INSTITUSJON, or BARN_ENSLIG_MINDREÅRIG`() {
+            every { behandlingHentOgPersisterService.hent(any()) } returns lagBehandling()
+
+            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = inneværendeBehandling.id)
+
+            assertThat(result).isEmpty()
+        }
+
+        @ParameterizedTest
+        @EnumSource(FagsakType::class, names = ["SKJERMET_BARN", "INSTITUSJON", "BARN_ENSLIG_MINDREÅRIG" ])
+        fun `returner tom liste hvis det ikke finnes noen andre fagsaker på aktøren`(fagsakType: FagsakType) {
+            val fagsakSkjermetBarn = lagFagsak(type = fagsakType)
+            every { behandlingHentOgPersisterService.hent(any()) } returns lagBehandling(fagsak = fagsakSkjermetBarn)
+            every { fagsakService.hentAlleFagsakerForAktør(any()) } returns listOf(fagsakSkjermetBarn)
+
+            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = inneværendeBehandling.id)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `returner overlappende periode med fagsakId på andre fagsaker`() {
+            val fagsakForInstitusjon1 = lagFagsak(id = 1, type = INSTITUSJON)
+            val behandlingForInstitusjon1 = lagBehandling(id = 1, fagsak = fagsakForInstitusjon1)
+            val fagsakForInstitusjon2 = lagFagsak(id = 2, type = INSTITUSJON)
+            val behandlingForInstitusjon2 = lagBehandling(id = 2, fagsak = fagsakForInstitusjon2)
+
+            every { behandlingHentOgPersisterService.hent(behandlingForInstitusjon1.id) } returns behandlingForInstitusjon1
+            every { behandlingHentOgPersisterService.hent(behandlingForInstitusjon2.id) } returns behandlingForInstitusjon2
+
+            every { fagsakService.hentAlleFagsakerForAktør(any()) } returns listOf(fagsakForInstitusjon1, fagsakForInstitusjon2)
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingForInstitusjon1.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        prosent = BigDecimal(100),
+                        behandling = behandlingForInstitusjon1,
+                    ),
+                )
+            every { beregningService.hentRelevanteTilkjentYtelserForBarn(any(), any()) } returns
+                listOf(
+                    lagTilkjentYtelse(
+                        behandling = behandlingForInstitusjon2,
+                        lagAndelerTilkjentYtelse = {
+                            setOf(
+                                lagAndelTilkjentYtelse(
+                                    fom = mar(2025),
+                                    tom = jun(2025),
+                                    prosent = BigDecimal(100),
+                                    behandling = behandlingForInstitusjon2,
+                                ),
+                            )
+                        },
+                    ),
+                )
+
+            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = behandlingForInstitusjon1.id)
+
+            assertThat(result).hasSize(1)
+            assertThat(result.first().fagsaker).containsOnly(2)
+            assertThat(result.first().fom).isEqualTo(mar(2025).førsteDagIInneværendeMåned())
+            assertThat(result.first().tom).isEqualTo(apr(2025).sisteDagIInneværendeMåned())
+        }
+
+        @Test
+        fun `returner tom liste hvis ikke overlappende`() {
+            val fagsakForInstitusjon1 = lagFagsak(id = 1, type = INSTITUSJON)
+            val behandlingForInstitusjon1 = lagBehandling(id = 1, fagsak = fagsakForInstitusjon1)
+            val fagsakForInstitusjon2 = lagFagsak(id = 2, type = INSTITUSJON)
+            val behandlingForInstitusjon2 = lagBehandling(id = 2, fagsak = fagsakForInstitusjon2)
+
+            every { behandlingHentOgPersisterService.hent(behandlingForInstitusjon1.id) } returns behandlingForInstitusjon1
+            every { behandlingHentOgPersisterService.hent(behandlingForInstitusjon2.id) } returns behandlingForInstitusjon2
+
+            every { fagsakService.hentAlleFagsakerForAktør(any()) } returns listOf(fagsakForInstitusjon1, fagsakForInstitusjon2)
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingForInstitusjon1.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = apr(2025),
+                        prosent = BigDecimal(100),
+                        behandling = behandlingForInstitusjon1,
+                    ),
+                )
+            every { beregningService.hentRelevanteTilkjentYtelserForBarn(any(), any()) } returns
+                listOf(
+                    lagTilkjentYtelse(
+                        behandling = behandlingForInstitusjon2,
+                        lagAndelerTilkjentYtelse = {
+                            setOf(
+                                lagAndelTilkjentYtelse(
+                                    fom = mai(2025),
+                                    tom = jun(2025),
+                                    prosent = BigDecimal(100),
+                                    behandling = behandlingForInstitusjon2,
+                                ),
+                            )
+                        },
+                    ),
+                )
+
+            val result = avregningService.hentOverlappendePerioderMedAnnenFagsak(behandlingId = behandlingForInstitusjon1.id)
+
+            assertThat(result).hasSize(0)
         }
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-17161
Utvidelse av simulering. Den inneholder nå et nytt felt:
overlappendePerioderMedAndreFagsaker

I dette feltet vil det vises overlappende perioder for fagsaker hvor barnet er eier av fagsaken. Altså Institusjon, enslig mindreårig og skjermet barn.

Dette feltet er tenkt til å brukes der man må varsle saksbehandler om at det er andre fagsaker som alt har utbetaling i en periode i den behandlingen de jobber med.

Dette fordi i en sak som f.eks. INSTITUSJON. Der kan et barn flytte fra en institusjon til en annen institusjon. Disse fagsakene kan da ha overlappende perioder. Simulering vil da vise data fra begge fagsakene og utbetaling i den ene kan motregnes mot den andre (inntil utbetaling fikser sin bug). Ved å varsel så blir det lettere for en saksbehandler å se at her må noe gjøres slik at de ikke motregnes mot hverandre.

Etter at dette er gjort så kan man etterhvert filtrere bort simulering på fagsaker som ikke tilhører den fagsake man jobber med (https://github.com/navikt/familie-oppdrag/pull/898)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
