### PR TITLE
Sperre preutfylling for EØS-saker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
 import no.nav.familie.ba.sak.config.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import org.springframework.stereotype.Service
 
@@ -12,6 +13,8 @@ class PreutfyllVilkårService(
     private val unleashService: UnleashNextMedContextService,
 ) {
     fun preutfyllVilkår(vilkårsvurdering: Vilkårsvurdering) {
+        if (vilkårsvurdering.behandling.kategori == BehandlingKategori.EØS) return
+
         if (unleashService.isEnabled(FeatureToggle.PREUTFYLLING_VILKÅR)) {
             preutfyllBosattIRiketService.prefutfyllBosattIRiket(vilkårsvurdering)
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
@@ -13,7 +13,6 @@ import no.nav.familie.ba.sak.datagenerator.lagVegadresse
 import no.nav.familie.ba.sak.datagenerator.randomFnr
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlRestClient
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.domene.PersonIdent
@@ -475,37 +474,5 @@ class PreutfyllBosattIRiketServiceTest {
             "Fylt ut automatisk fra registerdata i PDL \n" +
                 "- Bosatt i Norge siden fødsel.",
         )
-    }
-
-    @Test
-    fun `skal preutfylle bosatt i riket vilkår i EØS saker`() {
-        // Arrange
-        val behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS)
-        val persongrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søkerPersonIdent = randomFnr(), barnasIdenter = listOf(randomFnr()))
-        val vilkårsvurdering = lagVilkårsvurdering(persongrunnlagForBehandling = persongrunnlag, behandling = behandling)
-        val personResultat = lagPersonResultat(vilkårsvurdering = vilkårsvurdering)
-
-        every { pdlRestClient.hentStatsborgerskap(personResultat.aktør, historikk = true) } returns
-            listOf(
-                Statsborgerskap("SWE", LocalDate.now().minusYears(10), null, null),
-            )
-
-        every { pdlRestClient.hentBostedsadresserForPerson(any()) } returns
-            listOf(
-                Bostedsadresse(
-                    gyldigFraOgMed = LocalDate.now().minusYears(1),
-                    vegadresse = lagVegadresse(12345L),
-                ),
-            )
-
-        // Act
-        val vilkårResultat = preutfyllBosattIRiketService.genererBosattIRiketVilkårResultat(personResultat = personResultat)
-
-        // Assert
-        assertThat(vilkårResultat).hasSize(1)
-        assertThat(vilkårResultat).allSatisfy {
-            assertThat(it.vilkårType).isEqualTo(Vilkår.BOSATT_I_RIKET)
-            assertThat(it.resultat).isEqualTo(Resultat.OPPFYLT)
-        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -2,15 +2,11 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPersonResultat
-import no.nav.familie.ba.sak.datagenerator.lagVegadresse
 import no.nav.familie.ba.sak.datagenerator.lagVilkårsvurdering
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlRestClient
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
-import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -107,36 +103,5 @@ class PreutfyllLovligOppholdServiceTest {
         assertThat(vilkårResultat).hasSize(1)
         assertThat(vilkårResultat.find { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }?.begrunnelse)
             .isEqualTo("Fylt ut automatisk fra registerdata i PDL \n- Norsk/nordisk statsborgerskap")
-    }
-
-    @Test
-    fun `skal preutfylle bosatt i riket vilkår i EØS saker`() {
-        // Arrange
-        val behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS)
-        val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
-        val personResultat = lagPersonResultat(vilkårsvurdering = vilkårsvurdering)
-
-        every { pdlRestClient.hentStatsborgerskap(personResultat.aktør, historikk = true) } returns
-            listOf(
-                Statsborgerskap("SWE", LocalDate.now().minusYears(10), null, null),
-            )
-
-        every { pdlRestClient.hentBostedsadresserForPerson(any()) } returns
-            listOf(
-                Bostedsadresse(
-                    gyldigFraOgMed = LocalDate.now().minusYears(1),
-                    vegadresse = lagVegadresse(12345L),
-                ),
-            )
-
-        // Act
-        val vilkårResultat = preutfyllLovligOppholdService.genererLovligOppholdVilkårResultat(personResultat = personResultat)
-
-        // Assert
-        assertThat(vilkårResultat).hasSize(1)
-        assertThat(vilkårResultat).allSatisfy {
-            assertThat(it.vilkårType).isEqualTo(Vilkår.LOVLIG_OPPHOLD)
-            assertThat(it.resultat).isEqualTo(Resultat.OPPFYLT)
-        }
     }
 }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25673)

### 💰 Hva skal gjøres, og hvorfor?
På grunn av utdypende vilkårsvurdering må vi sperre for EØS-saker igjen, da dette er komplisert å preutfylle og vi ønsker ikke å fokusere på dette nå. 

