### PR TITLE
Opprett fagsak skal returnere eksisterende fagsak ved oppretting for institusjon eller skjermet barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -126,9 +126,7 @@ class FagsakService(
                 FagsakType.INSTITUSJON -> {
                     val orgnummer = institusjon?.orgNummer ?: throw FunksjonellFeil("Mangler påkrevd variabel orgnummer for institusjon")
 
-                    fagsakRepository.finnFagsakForInstitusjonOgOrgnummer(aktør, orgnummer)?.also {
-                        throw FunksjonellFeil("Det finnes allerede en institusjon fagsak på denne personen som er koblet til samme organisasjon.")
-                    }
+                    fagsakRepository.finnFagsakForInstitusjonOgOrgnummer(aktør, orgnummer)
                 }
 
                 FagsakType.SKJERMET_BARN -> {
@@ -140,9 +138,7 @@ class FagsakService(
 
                     val søkersAktør = personidentService.hentOgLagreAktør(søkersIdent, true)
 
-                    fagsakRepository.finnFagsakForSkjermetBarnSøker(aktør, søkersAktør)?.also {
-                        throw FunksjonellFeil("Det finnes allerede en skjermet barn fagsak på dette barnet som er koblet til samme søker.")
-                    }
+                    fagsakRepository.finnFagsakForSkjermetBarnSøker(aktør, søkersAktør)
                 }
 
                 else -> fagsakRepository.finnFagsakForAktør(aktør, type)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -277,34 +277,35 @@ class FagsakServiceTest {
 
             assertThat(frontendFeilmelding).isEqualTo("Søker og barn søkt for kan ikke være lik for fagsak type skjermet barn")
         }
+    }
 
-        @Test
-        fun `Skal kaste funksjonell feil dersom man forsøker å lage en fagsak med type skjermet barn men samme kombinasjon av barn og søker finnes allerede`() {
-            // Arrange
-            val barnIdent = randomBarnFnr(alder = 5)
-            val søkerIdent = randomFnr()
-            val barnAktør = randomAktør(barnIdent)
-            val søkerAktør = randomAktør(søkerIdent)
+    // assertThat(frontendFeilmelding).isEqualTo("Det finnes allerede en skjermet barn fagsak på dette barnet som er koblet til samme søker.")
+    // assertThat(frontendFeilmelding).isEqualTo("Det finnes allerede en skjermet barn fagsak på dette barnet som er koblet til samme søker.")
+    @Test
+    fun `Skal kaste funksjonell feil dersom man forsøker å lage en fagsak med type skjermet barn men samme kombinasjon av barn og søker finnes allerede`() {
+        // Arrange
+        val barnIdent = randomBarnFnr(alder = 5)
+        val søkerIdent = randomFnr()
+        val barnAktør = randomAktør(barnIdent)
+        val søkerAktør = randomAktør(søkerIdent)
+        val fagsak = lagFagsak(1, type = FagsakType.SKJERMET_BARN)
 
-            val restSkjermetBarnSøker = RestSkjermetBarnSøker(søkerIdent)
+        val restSkjermetBarnSøker = RestSkjermetBarnSøker(søkerIdent)
 
-            every { unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_FAGSAKTYPE_SKJERMET_BARN) } returns true
-            every { personidentService.hentOgLagreAktør(barnIdent, true) } returns barnAktør
-            every { personidentService.hentOgLagreAktør(søkerIdent, true) } returns søkerAktør
-            every { fagsakRepository.finnFagsakForSkjermetBarnSøker(barnAktør, søkerAktør) } returns mockk()
+        every { unleashService.isEnabled(FeatureToggle.SKAL_BRUKE_FAGSAKTYPE_SKJERMET_BARN) } returns true
+        every { personidentService.hentOgLagreAktør(barnIdent, true) } returns barnAktør
+        every { personidentService.hentOgLagreAktør(søkerIdent, true) } returns søkerAktør
+        every { fagsakRepository.finnFagsakForSkjermetBarnSøker(barnAktør, søkerAktør) } returns fagsak
 
-            // Act && Assert
-            val frontendFeilmelding =
-                assertThrows<FunksjonellFeil> {
-                    fagsakService.hentEllerOpprettFagsak(
-                        personIdent = barnIdent,
-                        skjermetBarnSøker = restSkjermetBarnSøker,
-                        fraAutomatiskBehandling = false,
-                        type = FagsakType.SKJERMET_BARN,
-                    )
-                }.frontendFeilmelding
+        // Act && Assert
+        val returnertFagsak =
+            fagsakService.hentEllerOpprettFagsak(
+                personIdent = barnIdent,
+                skjermetBarnSøker = restSkjermetBarnSøker,
+                fraAutomatiskBehandling = false,
+                type = FagsakType.SKJERMET_BARN,
+            )
 
-            assertThat(frontendFeilmelding).isEqualTo("Det finnes allerede en skjermet barn fagsak på dette barnet som er koblet til samme søker.")
-        }
+        assertThat(returnertFagsak).isEqualTo(fagsak)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -279,10 +279,8 @@ class FagsakServiceTest {
         }
     }
 
-    // assertThat(frontendFeilmelding).isEqualTo("Det finnes allerede en skjermet barn fagsak på dette barnet som er koblet til samme søker.")
-    // assertThat(frontendFeilmelding).isEqualTo("Det finnes allerede en skjermet barn fagsak på dette barnet som er koblet til samme søker.")
     @Test
-    fun `Skal kaste funksjonell feil dersom man forsøker å lage en fagsak med type skjermet barn men samme kombinasjon av barn og søker finnes allerede`() {
+    fun `Skal returnere eksisterende fagsak dersom man forsøker å lage en fagsak med type skjermet barn men samme kombinasjon av barn og søker finnes allerede`() {
         // Arrange
         val barnIdent = randomBarnFnr(alder = 5)
         val søkerIdent = randomFnr()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceIntegrationTest.kt
@@ -703,27 +703,26 @@ class FagsakServiceIntegrationTest(
     }
 
     @Test
-    fun `Skal kaste feil ved forsøk på å opprette institusjon fagsak med org nummer som allerede finnes for person`() {
+    fun `Skal returnere eksisterende fagsak ved forsøk på å opprette institusjon fagsak med org nummer som allerede finnes for person`() {
         // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val institusjon = RestInstitusjon(orgNummer = "123456789", tssEksternId = "testid")
 
-        opprettFagsakForPersonMedStatus(personIdent = barn.aktør.aktivFødselsnummer(), fagsakStatus = FagsakStatus.AVSLUTTET, fagsakType = FagsakType.INSTITUSJON)
+        val fagsak = opprettFagsakForPersonMedStatus(personIdent = barn.aktør.aktivFødselsnummer(), fagsakStatus = FagsakStatus.AVSLUTTET, fagsakType = FagsakType.INSTITUSJON)
 
         // Act && Assert
-        val feilmelding =
-            assertThrows<FunksjonellFeil> {
-                fagsakService.hentEllerOpprettFagsak(
-                    fagsakRequest =
-                        FagsakRequest(
-                            personIdent = barn.aktør.aktivFødselsnummer(),
-                            fagsakType = FagsakType.INSTITUSJON,
-                            institusjon = institusjon,
-                        ),
-                )
-            }.melding
 
-        assertThat(feilmelding).isEqualTo("Det finnes allerede en institusjon fagsak på denne personen som er koblet til samme organisasjon.")
+        val returnertFagsak =
+            fagsakService.hentEllerOpprettFagsak(
+                fagsakRequest =
+                    FagsakRequest(
+                        personIdent = barn.aktør.aktivFødselsnummer(),
+                        fagsakType = FagsakType.INSTITUSJON,
+                        institusjon = institusjon,
+                    ),
+            )
+
+        assertThat(returnertFagsak.data?.id).isEqualTo(fagsak.id)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-25615
Journalføringsløypa for institusjon funker slik at man må først opprette institusjonsfagsak. Så knytter man journalposten til denne fagsaken. 

Inne i kallet for journalførings så kalles hentEllerOpprettFagsak. Den skulle returnert den eksisterende fagsaken, men der hadde det kommet på en unødvedig funksjonell feil hvis det fantes en fagsak. 

Fikset det samme for skjermet barn

![Screenshot 2025-07-04 at 12 42 45](https://github.com/user-attachments/assets/e52f0968-b58e-458a-868d-fa80459739fa)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
