### PR TITLE
Sett begrunnelseForManuellKontroll til null når vilkåret oppdateres av SB

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
@@ -113,6 +113,7 @@ data class VilkårResultat(
         oppdaterPekerTilBehandling()
         vurderesEtter = restVilkårResultat.vurderesEtter
         utdypendeVilkårsvurderinger = restVilkårResultat.utdypendeVilkårsvurderinger
+        begrunnelseForManuellKontroll = null
     }
 
     fun kopierMedParent(nyPersonResultat: PersonResultat? = null): VilkårResultat =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25346

Når saksbehandler oppdaterer et vilkår, skal det ikke lenger være markert som at det må manuelt kontrolleres. Setter `begrunnelseManuellKontroll` til `null` i `VilkårResultat::oppdater`.