### PR TITLE
Legger til endepunkt som kan kalles for å opprette minside task for fagsakene uten

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -537,10 +537,35 @@ class ForvalterController(
             ),
         )
     }
+
+    @PostMapping("/opprett-minside-task-for-fagsaker-uten-aktivering")
+    @Operation(
+        summary = "Oppretter task som aktiverer minside for fagsaker som ikke har fått det aktivert enda",
+    )
+    fun opprettMinsideAktiveringTaskForFagsakerUtenAktivering(
+        @RequestBody opprettMinsideAktiveringTaskDto: OpprettMinsideAktiveringTaskDto,
+    ): ResponseEntity<String> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Aktiver",
+        )
+
+        forvalterService.finnFagsakSomSkalHaMinsideAktivertOgLagTask(
+            dryRun = opprettMinsideAktiveringTaskDto.dryRun,
+            antallFagsak = opprettMinsideAktiveringTaskDto.antallFagsaker,
+        )
+
+        return ResponseEntity.ok("Kjørt OK")
+    }
 }
 
 data class FinnOgPatchAndelerRequestDto(
     val fagsaker: Set<Long>,
     val korrigerAndelerFraOgMedDato: LocalDate = LocalDate.of(2025, 2, 1),
+    val dryRun: Boolean = true,
+)
+
+data class OpprettMinsideAktiveringTaskDto(
+    val antallFagsaker: Int,
     val dryRun: Boolean = true,
 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -189,6 +189,24 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
     ): List<Long>
 
     @Query(
+        value = """
+        SELECT * 
+        FROM fagsak f
+        WHERE f.status = 'LØPENDE'
+          AND f.type IN ('NORMAL', 'BARN_ENSLIG_MINDREÅRIG')
+          AND f.arkivert = false
+          AND NOT EXISTS (
+              SELECT 1 
+              FROM minside_aktivering m 
+              WHERE m.fk_aktor_id = f.fk_aktoer_id
+          )
+        ORDER BY f.id
+        """,
+        nativeQuery = true,
+    )
+    fun finnLøpendeFagsakSomIkkeHarFåttMinsideAktivert(pageable: Pageable): Slice<Fagsak>
+
+    @Query(
         """
         SELECT distinct f from Fagsak f
          JOIN Behandling b ON b.fagsak.id = f.id


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25642

Det er ønskelig at alle aktører som har løpende fagsak med type BARN_ENSLIG_MINDREÅRIG / NORMAL skal få minside aktivert. Dette gjøres gjennom eksisterende kode som trigges gjennom AktiverMinSideTask. 

Flyten blir som følges:

1.  Endepunktet kalles med x antall fagsak som ønskes skal bli aktivert
2. Det hentes opp x antall fagsak uten aktivering
3. Det opprettes x antall AktiverMinSideTask for fagsakene
4. For hver gang man kaller endepunktet vil mengden av fagsak bli mindre