### PR TITLE
Legg til lyspære på lovlig opphold-vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/BegrunnelseForManuellKontrollAvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/BegrunnelseForManuellKontrollAvVilkår.kt
@@ -6,6 +6,8 @@ enum class BegrunnelseForManuellKontrollAvVilkår(
     private val beskrivelse: String,
 ) {
     INFORMASJON_FRA_SØKNAD("er fylt ut automatisk basert på informasjon fra søknaden"),
+    INFORMASJON_OM_ARBEIDSFORHOLD("er fylt ut automatisk basert på informasjon om arbeidsforhold"),
+    INFORMASJON_OM_OPPHOLDSTILLATELSE("er fylt ut automatisk basert på informasjon om oppholdstillatelse"),
     ;
 
     fun begrunnelse(vilkår: Vilkår) = "Vilkåret '${vilkår.beskrivelse}' $beskrivelse."

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.LOVLIG_OPPHOLD
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.tidslinje.PRAKTISK_TIDLIGSTE_DAG
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
@@ -23,14 +24,10 @@ class PreutfyllLovligOppholdService(
     private val statsborgerskapService: StatsborgerskapService,
     private val integrasjonClient: IntegrasjonClient,
 ) {
-    // Fallback dato siden aareg ikke støtter LocalDate.MIN fordi det er for langt tilbake i tid.
-    // Satt til et vilkårlig tidspunkt i fortiden som ikke brekker validering. Burde utbedres til noe mer fornuftig.
-    private val år0 = LocalDate.of(0, 1, 1)
-
     fun preutfyllLovligOpphold(vilkårsvurdering: Vilkårsvurdering) {
         val søkersResultater = vilkårsvurdering.personResultater.first { it.erSøkersResultater() }
 
-        val datoFørsteBostedadresseNorgeSøker = finnDatoFørsteBostedsadresseINorge(søkersResultater) ?: år0
+        val datoFørsteBostedadresseNorgeSøker = finnDatoFørsteBostedsadresseINorge(søkersResultater) ?: PRAKTISK_TIDLIGSTE_DAG
         val erEØSBorgerOgHarArbeidsforholdTidslinjeSøker = lagErEØSBorgerOgHarArbeidsforholdTidslinje(søkersResultater, datoFørsteBostedadresseNorgeSøker)
 
         vilkårsvurdering.personResultater.forEach { personResultat ->
@@ -38,7 +35,7 @@ class PreutfyllLovligOppholdService(
                 if (personResultat.erSøkersResultater()) {
                     genererLovligOppholdVilkårResultat(personResultat)
                 } else {
-                    val datoFørsteBostedadresseNorgeBarn = finnDatoFørsteBostedsadresseINorge(personResultat) ?: år0
+                    val datoFørsteBostedadresseNorgeBarn = finnDatoFørsteBostedsadresseINorge(personResultat) ?: PRAKTISK_TIDLIGSTE_DAG
                     val erEøsBorgerOgHarArbeidsforholdTidslinjeBarn = erEØSBorgerOgHarArbeidsforholdTidslinjeSøker.beskjærFraOgMed(datoFørsteBostedadresseNorgeBarn)
                     genererLovligOppholdVilkårResultat(personResultat, erEøsBorgerOgHarArbeidsforholdTidslinjeBarn)
                 }
@@ -58,7 +55,7 @@ class PreutfyllLovligOppholdService(
 
         val erBosattINorgeTidslinje = lagErBosattINorgeTidslinje(personResultat)
 
-        val datoFørsteBostedadresse = finnDatoFørsteBostedsadresseINorge(personResultat) ?: år0
+        val datoFørsteBostedadresse = finnDatoFørsteBostedsadresseINorge(personResultat) ?: PRAKTISK_TIDLIGSTE_DAG
 
         val erEØSBorgerOgHarArbeidsforholdTidslinje =
             erEøsBorgerOgHarArbeidsforholdTidslinjeOverride ?: lagErEØSBorgerOgHarArbeidsforholdTidslinje(personResultat, datoFørsteBostedadresse)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.LOVLIG_OPPHOLD
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling.BegrunnelseForManuellKontrollAvVilkår.INFORMASJON_OM_ARBEIDSFORHOLD
 import no.nav.familie.tidslinje.PRAKTISK_TIDLIGSTE_DAG
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
@@ -65,7 +66,7 @@ class PreutfyllLovligOppholdService(
                 .kombinerMed(erNordiskStatsborgerTidslinje, erEØSBorgerOgHarArbeidsforholdTidslinje) { erBosatt, erNordisk, erEøsOgArbeidsforhold ->
                     when {
                         erBosatt == true && erNordisk == true -> OppfyltDelvilkår("- Norsk/nordisk statsborgerskap.")
-                        erBosatt == true && erEøsOgArbeidsforhold == true -> OppfyltDelvilkår("- EØS-borger og har arbeidsforhold i Norge.")
+                        erBosatt == true && erEøsOgArbeidsforhold == true -> OppfyltDelvilkår("- EØS-borger og har arbeidsforhold i Norge.", begrunnelseForManuellKontroll = INFORMASJON_OM_ARBEIDSFORHOLD)
                         else -> IkkeOppfyltDelvilkår
                     }
                 }.beskjærFraOgMed(datoFørsteBostedadresse)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25733

Legger til lyspære på lovlig opphold-vilkåret.
Legger også til `INFORMASJON_OM_OPPHOLDSTILLATELSE`, men den venter på at NAV-25552 skal bli ferdig.

Bytter fra `år0` til `PRAKTISK_TIDLIGSTE_DAG` fra tidslinjerammeverket, da det er samme dato, og den variabelen er brukt flere steder.

<img width="722" height="154" alt="image" src="https://github.com/user-attachments/assets/1676a374-e71c-48a3-a011-273a37ddfbef" />
<img width="248" height="59" alt="image" src="https://github.com/user-attachments/assets/4f0cf41c-ea82-4fab-8443-0687f6341095" />