### PR TITLE
Rekjøring av månedlig valutajustering ved status FATTER_VEDTAK

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligvalutajustering/AutovedtakMånedligValutajusteringService.kt
@@ -159,7 +159,7 @@ class AutovedtakMånedligValutajusteringService(
 
             BehandlingStatus.FATTER_VEDTAK,
             -> {
-                val klokken6OmTreVirkedager = nesteVirkedag(nesteVirkedag(nesteVirkedag(LocalDate.now()))).atTime(6, 0)
+                val klokken6OmTreVirkedager = (1..3).fold(LocalDate.now()) { acc, _ -> nesteVirkedag(acc) }.atTime(6, 0)
                 throw RekjørSenereException(
                     årsak = "Åpen behandling har status ${åpenBehandling.status}. Prøver igjen klokken 06.00 om tre virkedager",
                     triggerTid = klokken6OmTreVirkedager,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/månedligValutajustering/AutovedtakMånedligValutajusteringServiceTest.kt
@@ -17,7 +17,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Vurderingsform
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.prosessering.error.RekjørSenereException
-import no.nav.familie.util.VirkedagerProvider
+import no.nav.familie.util.VirkedagerProvider.nesteVirkedag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -144,7 +144,7 @@ class AutovedtakMånedligValutajusteringServiceTest {
         val fagsak = defaultFagsak().apply { status = FagsakStatus.LØPENDE }
         val behandling = lagBehandling(fagsak = fagsak, status = BehandlingStatus.AVSLUTTET)
         val åpenBehandling = lagBehandling(fagsak = fagsak, status = BehandlingStatus.FATTER_VEDTAK)
-        val klokkenSeksNesteVirkedag = VirkedagerProvider.nesteVirkedag(LocalDate.now()).atTime(6, 0)
+        val klokkenSeksNesteVirkedag = (1..3).fold(LocalDate.now()) { acc, _ -> nesteVirkedag(acc) }.atTime(6, 0)
 
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns behandling
         every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(any()) } returns åpenBehandling


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Øker tiden det tar før en månedlig valutajustering rekjøres fra én til tre dager, og øker dermed tiden før den settes til manuell oppfølging fra tre til ni virkedager.