### PR TITLE
NAV-25324: Nytt endepunkt i `EksternKlageController`for å kunne sjekke om saksbehandler har tilgang til fagsak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250728105838_1f618e2</prosessering.version>
         <felles.version>3.20250616113100_41d23f2</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250730094950_2d4dd59</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20250730094742_b263f30</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250804135212_2b83ee2</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20250730094950_2d4dd59</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20250730094950_2d4dd59</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250415144931_0dc88d8</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/klage/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/klage/EksternKlageController.kt
@@ -11,6 +11,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
 import no.nav.familie.kontrakter.felles.klage.KanOppretteRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
+import no.nav.familie.kontrakter.felles.tilgangskontroll.FagsakTilgang
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -94,20 +95,15 @@ class EksternKlageController(
     @GetMapping("fagsak/{fagsakId}/tilgang")
     fun hentTilgangTilFagsak(
         @PathVariable fagsakId: Long,
-    ): Ressurs<FagsakTilgangDto> {
-        val fagsakTilgangDto: FagsakTilgangDto =
+    ): Ressurs<FagsakTilgang> {
+        val fagsakTilgang: FagsakTilgang =
             try {
                 tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
-                FagsakTilgangDto(harTilgang = true)
+                FagsakTilgang(harTilgang = true)
             } catch (e: RolleTilgangskontrollFeil) {
-                FagsakTilgangDto(harTilgang = false, begrunnelse = e.frontendFeilmelding)
+                FagsakTilgang(harTilgang = false, begrunnelse = e.frontendFeilmelding)
             }
 
-        return Ressurs.success(fagsakTilgangDto)
+        return Ressurs.success(fagsakTilgang)
     }
 }
-
-data class FagsakTilgangDto(
-    val harTilgang: Boolean,
-    val begrunnelse: String? = null
-)

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/klage/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/klage/EksternKlageController.kt
@@ -1,6 +1,7 @@
-package no.nav.familie.ba.sak.ekstern
+package no.nav.familie.ba.sak.ekstern.klage
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.RolleTilgangskontrollFeil
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.kjerne.klage.KlageService
@@ -89,4 +90,24 @@ class EksternKlageController(
 
         return Ressurs.success(klageService.hentFagsystemVedtak(fagsakId))
     }
+
+    @GetMapping("fagsak/{fagsakId}/tilgang")
+    fun hentTilgangTilFagsak(
+        @PathVariable fagsakId: Long,
+    ): Ressurs<FagsakTilgangDto> {
+        val fagsakTilgangDto: FagsakTilgangDto =
+            try {
+                tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+                FagsakTilgangDto(harTilgang = true)
+            } catch (e: RolleTilgangskontrollFeil) {
+                FagsakTilgangDto(harTilgang = false, begrunnelse = e.frontendFeilmelding)
+            }
+
+        return Ressurs.success(fagsakTilgangDto)
+    }
 }
+
+data class FagsakTilgangDto(
+    val harTilgang: Boolean,
+    val begrunnelse: String? = null
+)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/EksternKlageControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/EksternKlageControllerTest.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
 import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.ekstern.klage.EksternKlageController
-import no.nav.familie.ba.sak.ekstern.klage.FagsakTilgangDto
 import no.nav.familie.ba.sak.kjerne.behandling.EksternBehandlingRelasjonRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
@@ -24,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.tilgangskontroll.FagsakTilgang
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -113,7 +113,7 @@ class EksternKlageControllerTest(
             every { tilgangService.validerTilgangTilFagsak(fagsak.id, any()) } just runs
 
             // Act
-            val response: Ressurs<FagsakTilgangDto> = eksternKlageController.hentTilgangTilFagsak(fagsak.id)
+            val response: Ressurs<FagsakTilgang> = eksternKlageController.hentTilgangTilFagsak(fagsak.id)
 
             // Assert
             assertThat(response.data?.harTilgang).isTrue()
@@ -124,11 +124,11 @@ class EksternKlageControllerTest(
             // Arrange
             val aktør = aktørIdRepository.save(randomAktør())
             val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør))
-            
+
             every { tilgangService.validerTilgangTilFagsak(fagsak.id, any()) } throws RolleTilgangskontrollFeil("Ingen tilgang")
 
             // Act
-            val response = eksternKlageController.hentTilgangTilFagsak(fagsak.id)
+            val response: Ressurs<FagsakTilgang> = eksternKlageController.hentTilgangTilFagsak(fagsak.id)
 
             // Assert
             assertThat(response.data?.harTilgang).isFalse()


### PR DESCRIPTION
Favro: [NAV-25324](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25324)

### 💰 Hva skal gjøres, og hvorfor?
Legger til endepunktet `fagsak/{fagsakId}/tilgang` i `EksternKlageController`, som sjekker om saksbehandler har tilgang til fagsak med id = `fagsakId` og returnerer et `FagsakTilgang`-objekt med info om saksbehandler har tilgang eller ikke.

Dette legges til for å sikre at saksbehandlere som har tilgang til en fagsak i `ba-sak` også skal ha tilgang til tilknyttet klage-behandling i `familie-klage`. Når en saksbehandler forsøker å åpne en klage-behandling kalles dette nye endepunktet, og responsen avgjør om saksbehandler får tilgang eller ikke.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
