### PR TITLE
Vi differanseberegner finnmarkstillegget før vi differanseberegner ordinær andel

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -84,10 +84,11 @@ fun beregnDifferanse(
             aty.oppdaterDifferanseberegning(beløpSomSkalTrekkesFraOrdinærAndel)
         }
 
-    val barnasAndeler = barnasDifferanseberegneteAndelTilkjentYtelseTidslinjer.tilAndelerTilkjentYtelse()
+    val barnasDifferanseberegnetOrdinæreAndeler = barnasDifferanseberegneteAndelTilkjentYtelseTidslinjer.tilAndelerTilkjentYtelse()
+    val barnasDifferanseberegnetFinnmarksAndeler = barnasDifferanseberegneteFinnmarkstilleggAndelTilkjentYtelseTidslinjer.tilAndelerTilkjentYtelse()
     val søkersAndeler = andelerTilkjentYtelse.filter { it.erSøkersAndel() }
 
-    return søkersAndeler + barnasAndeler + barnasDifferanseberegneteFinnmarkstilleggAndelTilkjentYtelseTidslinjer.tilAndelerTilkjentYtelse()
+    return søkersAndeler + barnasDifferanseberegnetOrdinæreAndeler + barnasDifferanseberegnetFinnmarksAndeler
 }
 
 /**

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -52,9 +52,7 @@ fun beregnDifferanse(
         andelerTilkjentYtelse
             .filter { !it.erSøkersAndel() && it.type == YtelseType.ORDINÆR_BARNETRYGD }
 
-    val barnasFinnmarkstilleggAndeler =
-        andelerTilkjentYtelse
-            .filter { !it.erSøkersAndel() && it.type == YtelseType.FINNMARKSTILLEGG }
+    val barnasFinnmarkstilleggAndeler = andelerTilkjentYtelse.filter { it.type == YtelseType.FINNMARKSTILLEGG }
 
     val barnasOrdinæreAndelerTidslinjer = barnasOrdinæreAndeler.tilSeparateTidslinjerForBarna()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/Differanseberegning.kt
@@ -76,7 +76,7 @@ fun beregnDifferanse(
                     finnmarkstilleggAty.differanseberegnetPeriodebeløp
                         ?.let { maxOf(-it, 0) }
                         ?.takeIf { it > 0 }
-                        ?.toBigDecimal() ?: BigDecimal.ZERO
+                        ?.toBigDecimal()
                 } else {
                     beløp
                 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
@@ -91,7 +91,7 @@ class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal håndtere gjentakende endring og differanseberegning på andel tilkjent ytelse`() {
         val aty1 =
-            lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.toBigDecimal())
+            lagVilkårligAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.toBigDecimal())
 
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(-50, aty1?.differanseberegnetPeriodebeløp)
@@ -122,7 +122,7 @@ class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal fjerne desimaler i utenlandskperiodebeløp, effektivt øke den norske ytelsen med inntil én krone`() {
         val aty1 =
-            lagAndelTilkjentYtelse(beløp = 50)
+            lagVilkårligAndelTilkjentYtelse(beløp = 50)
                 .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal()) // Blir til rundet til 100
 
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
@@ -133,7 +133,7 @@ class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal beholde originalt nasjonaltPeriodebeløp når vi oppdatererDifferanseberegning gjentatte ganger`() {
         var aty1 =
-            lagAndelTilkjentYtelse(beløp = 50)
+            lagVilkårligAndelTilkjentYtelse(beløp = 50)
                 .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal())
 
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
@@ -148,7 +148,7 @@ class DifferanseberegningsUtilsTest {
     }
 }
 
-fun lagAndelTilkjentYtelse(beløp: Int) =
+fun lagVilkårligAndelTilkjentYtelse(beløp: Int) =
     lagAndelTilkjentYtelse(
         fom = YearMonth.now(),
         tom = YearMonth.now().plusYears(1),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
@@ -221,6 +221,7 @@ class TilkjentYtelseDifferanseberegningTest {
 
     @Test
     fun `Skal trekke fra finnmarkstillegg andel og ikke ordinær andel ved differanseberegning hvis det er nok med finnmarkstillegget`() {
+        // Arrange
         val barnsFødselsdato = 13.jan(2020)
         val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
 
@@ -268,6 +269,7 @@ class TilkjentYtelseDifferanseberegningTest {
                 ),
             )
 
+        // Act
         val andelerEtterDifferanseBeregning =
             beregnDifferanse(
                 andelerForBarn,
@@ -275,6 +277,7 @@ class TilkjentYtelseDifferanseberegningTest {
                 valutakurser = valutakursIPeriode,
             )
 
+        // Assert
         val ordinærAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.ORDINÆR_BARNETRYGD }
         val finnmarkstilleggAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.FINNMARKSTILLEGG }
 
@@ -284,6 +287,7 @@ class TilkjentYtelseDifferanseberegningTest {
 
     @Test
     fun `Skal trekke videre fra ordinær andel ved differanseberegning hvis det ikke er nok med finnmarkstillegget`() {
+        // Arrange
         val barnsFødselsdato = 13.jan(2020)
         val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
 
@@ -331,6 +335,7 @@ class TilkjentYtelseDifferanseberegningTest {
                 ),
             )
 
+        // Act
         val andelerEtterDifferanseBeregning =
             beregnDifferanse(
                 andelerForBarn,
@@ -338,6 +343,7 @@ class TilkjentYtelseDifferanseberegningTest {
                 valutakurser = valutakursIPeriode,
             )
 
+        // Assert
         val ordinærAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.ORDINÆR_BARNETRYGD }
         val finnmarkstilleggAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.FINNMARKSTILLEGG }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
@@ -1,15 +1,21 @@
 package no.nav.familie.ba.sak.kjerne.eøs.differanseberegning
 
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.eøs.assertEqualsUnordered
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.util.DeltBostedBuilder
 import no.nav.familie.ba.sak.kjerne.eøs.util.TilkjentYtelseBuilder
 import no.nav.familie.ba.sak.kjerne.eøs.util.UtenlandskPeriodebeløpBuilder
 import no.nav.familie.ba.sak.kjerne.eøs.util.ValutakursBuilder
 import no.nav.familie.ba.sak.kjerne.eøs.util.oppdaterTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
+import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Vurderingsform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.VilkårsvurderingBuilder
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.byggTilkjentYtelse
@@ -19,8 +25,12 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOSATT_I_RI
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.GIFT_PARTNERSKAP
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.LOVLIG_OPPHOLD
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.UNDER_18_ÅR
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.YearMonth
 
 /**
  * Merk at operasjoner som tilsynelatende lager en ny instans av TilkjentYtelse, faktisk returner samme.
@@ -207,5 +217,131 @@ class TilkjentYtelseDifferanseberegningTest {
             forventetTilkjentYtelseMedDiff.andelerTilkjentYtelse,
             andelerMedDiffIgjen,
         )
+    }
+
+    @Test
+    fun `Skal trekke fra finnmarkstillegg andel og ikke ordinær andel ved differanseberegning hvis det er nok med finnmarkstillegget`() {
+        val barnsFødselsdato = 13.jan(2020)
+        val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
+
+        val andelerForBarn =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    beløp = 1000,
+                    person = barn,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    beløp = 500,
+                    person = barn,
+                ),
+            )
+
+        val utenlandskPeriodeBeløpIPeriode =
+            listOf(
+                UtenlandskPeriodebeløp(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    barnAktører = setOf(barn.aktør),
+                    beløp = BigDecimal(200),
+                    valutakode = "SEK",
+                    intervall = Intervall.MÅNEDLIG,
+                    utbetalingsland = "NOR",
+                    kalkulertMånedligBeløp = BigDecimal.valueOf(200),
+                ),
+            )
+
+        val valutakursIPeriode =
+            listOf(
+                Valutakurs(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    barnAktører = setOf(barn.aktør),
+                    valutakode = "SEK",
+                    vurderingsform = Vurderingsform.AUTOMATISK,
+                    kurs = BigDecimal(1),
+                ),
+            )
+
+        val andelerEtterDifferanseBeregning =
+            beregnDifferanse(
+                andelerForBarn,
+                utenlandskePeriodebeløp = utenlandskPeriodeBeløpIPeriode,
+                valutakurser = valutakursIPeriode,
+            )
+
+        val ordinærAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.ORDINÆR_BARNETRYGD }
+        val finnmarkstilleggAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.FINNMARKSTILLEGG }
+
+        assertThat(finnmarkstilleggAndel.kalkulertUtbetalingsbeløp).isEqualTo(300)
+        assertThat(ordinærAndel.kalkulertUtbetalingsbeløp).isEqualTo(1000)
+    }
+
+    @Test
+    fun `Skal trekke videre fra ordinær andel ved differanseberegning hvis det ikke er nok med finnmarkstillegget`() {
+        val barnsFødselsdato = 13.jan(2020)
+        val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
+
+        val andelerForBarn =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    beløp = 1000,
+                    person = barn,
+                ),
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    beløp = 500,
+                    person = barn,
+                ),
+            )
+
+        val utenlandskPeriodeBeløpIPeriode =
+            listOf(
+                UtenlandskPeriodebeløp(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    barnAktører = setOf(barn.aktør),
+                    beløp = BigDecimal(700),
+                    valutakode = "SEK",
+                    intervall = Intervall.MÅNEDLIG,
+                    utbetalingsland = "NOR",
+                    kalkulertMånedligBeløp = BigDecimal.valueOf(700),
+                ),
+            )
+
+        val valutakursIPeriode =
+            listOf(
+                Valutakurs(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    barnAktører = setOf(barn.aktør),
+                    valutakode = "SEK",
+                    vurderingsform = Vurderingsform.AUTOMATISK,
+                    kurs = BigDecimal(1),
+                ),
+            )
+
+        val andelerEtterDifferanseBeregning =
+            beregnDifferanse(
+                andelerForBarn,
+                utenlandskePeriodebeløp = utenlandskPeriodeBeløpIPeriode,
+                valutakurser = valutakursIPeriode,
+            )
+
+        val ordinærAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.ORDINÆR_BARNETRYGD }
+        val finnmarkstilleggAndel = andelerEtterDifferanseBeregning.single { it.type == YtelseType.FINNMARKSTILLEGG }
+
+        assertThat(finnmarkstilleggAndel.kalkulertUtbetalingsbeløp).isEqualTo(0)
+        assertThat(ordinærAndel.kalkulertUtbetalingsbeløp).isEqualTo(800)
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25814

Ved differanseberegning ønsker vi først å trekke fra finnmarkstillegget før vi trekker ordinær andel, og så utvidet.

Eksempler

Uten differanseberegning:
<img width="1057" height="397" alt="uten trekk" src="https://github.com/user-attachments/assets/dcfb6835-15b7-42d9-84d4-b4f19cb7c1af" />

Med differanseberegning på 200kr, finnmarkstillegg trekkes først:
<img width="1070" height="767" alt="200kr i trekk" src="https://github.com/user-attachments/assets/adec3ecd-0088-444c-96e6-71ff09fa157f" />

Med differanseberegning på  500kr, finnmarkstillegget trekkes helt, men ordinær ikke påvirket
<img width="1070" height="774" alt="500kr i trekk" src="https://github.com/user-attachments/assets/bc765c15-a197-4021-8f29-61e8d038e4ed" />

Med differanseberegning på 2000kr, finnmarkstillegget trekkes helt, og resten av ordinær
<img width="1067" height="801" alt="2000kr i trekk" src="https://github.com/user-attachments/assets/2a79b4c9-fd69-4963-b74c-e8eeeb7973d1" />

Med differanseberegning på 3000kr, finnmarkstillegget trekkes helt, ordinær trekkes helt, resten av utvidet
<img width="1059" height="798" alt="Med differanseberegning på 3000kr" src="https://github.com/user-attachments/assets/be59d3b2-d44c-4450-8d62-6e15644c3fd8" />

