### PR TITLE
Refaktorer preutfylling lovlig opphold

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -3,12 +3,14 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.PdlRestClient
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Medlemskap
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.StatsborgerskapService
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.LOVLIG_OPPHOLD
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.tidslinje.PRAKTISK_TIDLIGSTE_DAG
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
@@ -22,22 +24,17 @@ class PreutfyllLovligOppholdService(
     private val pdlRestClient: PdlRestClient,
     private val statsborgerskapService: StatsborgerskapService,
     private val integrasjonClient: IntegrasjonClient,
+    private val persongrunnlagService: PersongrunnlagService,
 ) {
     fun preutfyllLovligOpphold(vilkårsvurdering: Vilkårsvurdering) {
         val søkersResultater = vilkårsvurdering.personResultater.first { it.erSøkersResultater() }
 
-        val datoFørsteBostedadresseNorgeSøker = finnDatoFørsteBostedsadresseINorge(søkersResultater) ?: LocalDate.MIN
-        val erEØSBorgerOgHarArbeidsforholdTidslinjeSøker = lagErEØSBorgerOgHarArbeidsforholdTidslinje(søkersResultater, datoFørsteBostedadresseNorgeSøker)
+        val fomDatoForBeskjæring = finnFomDatoForBeskjæring(søkersResultater, vilkårsvurdering) ?: PRAKTISK_TIDLIGSTE_DAG
+        val erEØSBorgerOgHarArbeidsforholdTidslinjeSøker = lagErEØSBorgerOgHarArbeidsforholdTidslinje(søkersResultater, fomDatoForBeskjæring)
 
         vilkårsvurdering.personResultater.forEach { personResultat ->
             val lovligOppholdVilkårResultat =
-                if (personResultat.erSøkersResultater()) {
-                    genererLovligOppholdVilkårResultat(personResultat)
-                } else {
-                    val datoFørsteBostedadresseNorgeBarn = finnDatoFørsteBostedsadresseINorge(personResultat) ?: LocalDate.MIN
-                    val erEøsBorgerOgHarArbeidsforholdTidslinjeBarn = erEØSBorgerOgHarArbeidsforholdTidslinjeSøker.beskjærFraOgMed(datoFørsteBostedadresseNorgeBarn)
-                    genererLovligOppholdVilkårResultat(personResultat, erEøsBorgerOgHarArbeidsforholdTidslinjeBarn)
-                }
+                genererLovligOppholdVilkårResultat(personResultat, erEØSBorgerOgHarArbeidsforholdTidslinjeSøker)
 
             if (lovligOppholdVilkårResultat.isNotEmpty()) {
                 personResultat.vilkårResultater.removeIf { it.vilkårType == LOVLIG_OPPHOLD }
@@ -46,28 +43,25 @@ class PreutfyllLovligOppholdService(
         }
     }
 
-    fun genererLovligOppholdVilkårResultat(
+    private fun genererLovligOppholdVilkårResultat(
         personResultat: PersonResultat,
-        erEøsBorgerOgHarArbeidsforholdTidslinjeOverride: Tidslinje<Boolean>? = null,
+        erEøsBorgerOgHarArbeidsforholdTidslinjeOverride: Tidslinje<Boolean>,
     ): Set<VilkårResultat> {
         val erNordiskStatsborgerTidslinje = pdlRestClient.lagErNordiskStatsborgerTidslinje(personResultat)
 
-        val erBosattINorgeTidslinje = lagErBosattINorgeTidslinje(personResultat)
+        val fomDatoForBeskjæring = finnFomDatoForBeskjæring(personResultat, personResultat.vilkårsvurdering) ?: PRAKTISK_TIDLIGSTE_DAG
 
-        val datoFørsteBostedadresse = finnDatoFørsteBostedsadresseINorge(personResultat) ?: LocalDate.MIN
-
-        val erEØSBorgerOgHarArbeidsforholdTidslinje =
-            erEøsBorgerOgHarArbeidsforholdTidslinjeOverride ?: lagErEØSBorgerOgHarArbeidsforholdTidslinje(personResultat, datoFørsteBostedadresse)
+        val erEØSBorgerOgHarArbeidsforholdTidslinje = erEøsBorgerOgHarArbeidsforholdTidslinjeOverride
 
         val harLovligOppholdTidslinje =
-            erBosattINorgeTidslinje
-                .kombinerMed(erNordiskStatsborgerTidslinje, erEØSBorgerOgHarArbeidsforholdTidslinje) { erBosatt, erNordisk, erEøsOgArbeidsforhold ->
+            erNordiskStatsborgerTidslinje
+                .kombinerMed(erEØSBorgerOgHarArbeidsforholdTidslinje) { erNordisk, erEøsOgArbeidsforhold ->
                     when {
-                        erBosatt == true && erNordisk == true -> OppfyltDelvilkår("- Norsk/nordisk statsborgerskap.")
-                        erBosatt == true && erEøsOgArbeidsforhold == true -> OppfyltDelvilkår("- EØS-borger og har arbeidsforhold i Norge.")
+                        erNordisk == true -> OppfyltDelvilkår("- Norsk/nordisk statsborgerskap.")
+                        erEøsOgArbeidsforhold == true -> OppfyltDelvilkår("- EØS-borger og har arbeidsforhold i Norge.")
                         else -> IkkeOppfyltDelvilkår
                     }
-                }.beskjærFraOgMed(datoFørsteBostedadresse)
+                }.beskjærFraOgMed(fomDatoForBeskjæring)
 
         return harLovligOppholdTidslinje
             .tilPerioderIkkeNull()
@@ -86,38 +80,32 @@ class PreutfyllLovligOppholdService(
             }.toSet()
     }
 
-    private fun lagErBosattINorgeTidslinje(personResultat: PersonResultat): Tidslinje<Boolean> {
-        val alleBostedsadresserForPerson =
+    private fun finnFomDatoForBeskjæring(
+        personResultat: PersonResultat,
+        vilkårsvurdering: Vilkårsvurdering,
+    ): LocalDate? {
+        val førsteBostedFomDato =
             pdlRestClient
                 .hentBostedsadresserForPerson(fødselsnummer = personResultat.aktør.aktivFødselsnummer())
-                .sortedBy { it.gyldigFraOgMed }
+                .filter { it.vegadresse != null || it.matrikkeladresse != null || it.ukjentBosted != null }
+                .mapNotNull { it.gyldigFraOgMed }
+                .minByOrNull { it }
 
-        return alleBostedsadresserForPerson
-            .windowed(size = 2, step = 1, partialWindows = true) {
-                val denne = it.first()
-                val neste = it.getOrNull(1)
+        val barna = persongrunnlagService.hentAktivThrows(vilkårsvurdering.behandling.id).barna
 
-                Periode(
-                    verdi = denne.vegadresse != null || denne.matrikkeladresse != null || denne.ukjentBosted != null,
-                    fom = denne.gyldigFraOgMed,
-                    tom = denne.gyldigTilOgMed ?: neste?.gyldigFraOgMed?.minusDays(1),
-                )
-            }.tilTidslinje()
+        return førsteBostedFomDato ?: if (personResultat.erSøkersResultater()) {
+            barna.minOfOrNull { it.fødselsdato }
+        } else {
+            barna.find { it.aktør.aktørId == personResultat.aktør.aktørId }?.fødselsdato
+        }
     }
-
-    private fun finnDatoFørsteBostedsadresseINorge(personResultat: PersonResultat?): LocalDate? =
-        pdlRestClient
-            .hentBostedsadresserForPerson(fødselsnummer = personResultat!!.aktør.aktivFødselsnummer())
-            .filter { it.vegadresse != null || it.matrikkeladresse != null || it.ukjentBosted != null }
-            .mapNotNull { it.gyldigFraOgMed }
-            .minByOrNull { it }
 
     private fun lagErEØSBorgerOgHarArbeidsforholdTidslinje(
         personResultat: PersonResultat,
-        datoFørsteBostedadresse: LocalDate,
+        fomDatoForBeskjæring: LocalDate,
     ): Tidslinje<Boolean> =
         lagErEØSBorgerTidslinje(personResultat)
-            .kombinerMed(lagHarArbeidsforholdTidslinje(personResultat, datoFørsteBostedadresse)) { erEøs, harArbeidsforhold ->
+            .kombinerMed(lagHarArbeidsforholdTidslinje(personResultat, fomDatoForBeskjæring)) { erEøs, harArbeidsforhold ->
                 erEøs == true && harArbeidsforhold == true
             }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -365,50 +365,5 @@ class PreutfyllLovligOppholdServiceTest {
             assertThat(lovligOppholdResultater.begrunnelse)
                 .isEqualTo("Fylt ut automatisk fra registerdata i PDL\n- EØS-borger og har arbeidsforhold i Norge.")
         }
-
-//        @Test
-//        fun `skal preutfylle oppfylt lovlig vilkår hvis EØS borger og arbeidsforhold, med ikke oppfylt periode uten norsk bostedadresse`() {
-//            // Arrange
-//            val vilkårsvurdering = lagVilkårsvurdering()
-//            val personResultat = lagPersonResultat(vilkårsvurdering = vilkårsvurdering)
-//
-//            every { pdlRestClient.hentStatsborgerskap(personResultat.aktør, historikk = true) } returns
-//                listOf(
-//                    Statsborgerskap("BE", LocalDate.now().minusYears(20), null, null),
-//                )
-//
-//            every { pdlRestClient.hentBostedsadresserForPerson(any()) } returns
-//                listOf(
-//                    Bostedsadresse(
-//                        gyldigFraOgMed = LocalDate.now().minusYears(5),
-//                        gyldigTilOgMed = LocalDate.now().minusYears(3),
-//                        vegadresse = lagVegadresse(12345L),
-//                    ),
-//                    Bostedsadresse(
-//                        gyldigFraOgMed = LocalDate.now().minusYears(1),
-//                        vegadresse = lagVegadresse(54321L),
-//                    ),
-//                )
-//            every { statsborgerskapService.hentSterkesteMedlemskap(Statsborgerskap("BE", LocalDate.now().minusYears(20), null, null)) } returns Medlemskap.EØS
-//
-//            every { integrasjonClient.hentArbeidsforhold(any(), LocalDate.now().minusYears(5)) } returns
-//                listOf(Arbeidsforhold(arbeidsgiver = null, ansettelsesperiode = Ansettelsesperiode(Periode(LocalDate.now().minusYears(5), null))))
-//
-//            // Act
-//            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
-//
-//            // Assert
-//            assertThat(personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }).hasSize(3)
-//            assertThat(personResultat.vilkårResultater.first().periodeFom).isEqualTo(LocalDate.now().minusYears(5))
-//            assertThat(personResultat.vilkårResultater.first().periodeTom).isEqualTo(LocalDate.now().minusYears(3))
-//            assertThat(personResultat.vilkårResultater.first().resultat).isEqualTo(Resultat.OPPFYLT)
-//
-//            assertThat(personResultat.vilkårResultater.find { it.resultat == Resultat.IKKE_OPPFYLT }!!.periodeFom).isEqualTo(LocalDate.now().minusYears(3).plusDays(1))
-//            assertThat(personResultat.vilkårResultater.find { it.resultat == Resultat.IKKE_OPPFYLT }!!.periodeTom).isEqualTo(LocalDate.now().minusYears(1).minusDays(1))
-//
-//            assertThat(personResultat.vilkårResultater.last().periodeFom).isEqualTo(LocalDate.now().minusYears(1))
-//            assertThat(personResultat.vilkårResultater.last().periodeTom).isNull()
-//            assertThat(personResultat.vilkårResultater.last().resultat).isEqualTo(Resultat.OPPFYLT)
-//        }
     }
 }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25551) 

### 💰 Hva skal gjøres, og hvorfor?
Fjerner erBosattINorgeTidslinje da man ikke trenger å ha bostedsadresse i Norge for Lovlig opphold. Legger til beskjæring på eldste barn om bostedadresse ikke finnes.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
