### PR TITLE
Fjerner toggle for henting av klagebehandlinger fra nytt endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -62,7 +62,4 @@ enum class FeatureToggle(
 
     // NAV-
     SKAL_GENERERE_FINNMARKSTILLEGG("familie-ba-sak.andel-generering-finnmark-nord-troms"),
-
-    // NAv-
-    BRUK_NYTT_ENDEPUNKT_FOR_HENTING_AV_KLAGEBEHANDLINGER("familie-ba-sak.bruk-nytt-endepunkt-for-henting-av-klagebehandlinger"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlageClient.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.klage
 
 import no.nav.familie.ba.sak.common.kallEksternTjenesteRessurs
-import no.nav.familie.ba.sak.config.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenter.kt
@@ -1,8 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.klage
 
-import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.config.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
@@ -13,15 +10,9 @@ import org.springframework.stereotype.Component
 @Component
 class KlagebehandlingHenter(
     private val klageClient: KlageClient,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> {
-        val klagerPåFagsak =
-            if (unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NYTT_ENDEPUNKT_FOR_HENTING_AV_KLAGEBEHANDLINGER)) {
-                klageClient.hentKlagebehandlinger(fagsakId)
-            } else {
-                klageClient.hentKlagebehandlinger(setOf(fagsakId))[fagsakId] ?: throw Feil("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
-            }
+        val klagerPåFagsak = klageClient.hentKlagebehandlinger(fagsakId)
         return klagerPåFagsak.map { it.brukVedtaksdatoFraKlageinstansHvisOversendt() }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingHenterTest.kt
@@ -2,8 +2,6 @@ package no.nav.familie.ba.sak.kjerne.klage
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ba.sak.config.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagKlagebehandlingDto
 import no.nav.familie.ba.sak.datagenerator.lagKlageinstansResultatDto
@@ -12,10 +10,8 @@ import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
 import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDateTime
@@ -23,17 +19,10 @@ import java.util.UUID
 
 class KlagebehandlingHenterTest {
     private val klageClient = mockk<KlageClient>()
-    private val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
     private val klagebehandlingHenter =
         KlagebehandlingHenter(
             klageClient = klageClient,
-            unleashNextMedContextService = unleashNextMedContextService,
         )
-
-    @BeforeEach
-    fun setUp() {
-        every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns true
-    }
 
     @Nested
     inner class HentKlagebehandlingerPåFagsak {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner toggle som styrer hvorvidt vi skal bruke nytt eller gammelt endepunkt for henting av klagebehandlinger fra familie-klage.

Toggle har vært på i prod en stund og nytt endepunkt ser ut til å fungere.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester. 

Ikke relevant

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
