### PR TITLE
NAV-25894: Sjekk for løpende andel før man sender utvidet/ordinær ba til Min Side

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.minside
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ba.sak.TestClockProvider
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagFagsak
@@ -30,12 +31,14 @@ class MinSideBarnetrygdServiceTest {
     private val fagsakService = mockk<FagsakService>()
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
     private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
-    private val minSideBarnetrygdService =
+
+    fun lagMinSideBarnetrygdService(clockProvider: TestClockProvider = TestClockProvider()): MinSideBarnetrygdService =
         MinSideBarnetrygdService(
             personidentService = personidentService,
             fagsakService = fagsakService,
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            clockProvider = clockProvider,
         )
 
     @BeforeEach
@@ -50,6 +53,8 @@ class MinSideBarnetrygdServiceTest {
         @Test
         fun `skal returnere tom barnetrygd hvis fagsak er null`() {
             // Arrange
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService()
+
             every { fagsakService.hentFagsakPåPerson(eq(aktør), eq(FagsakType.NORMAL)) } returns null
 
             // Act
@@ -63,6 +68,8 @@ class MinSideBarnetrygdServiceTest {
         @Test
         fun `skal returnere tom barnetrygd hvis behandling er null`() {
             // Arrange
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService()
+
             every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(eq(fagsak.id)) } returns null
 
             // Act
@@ -76,6 +83,8 @@ class MinSideBarnetrygdServiceTest {
         @Test
         fun `skal returnere tom barnetrygd hvis andeler tilkjent ytelser er tom`() {
             // Arrange
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService()
+
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns emptyList()
 
             // Act
@@ -89,6 +98,10 @@ class MinSideBarnetrygdServiceTest {
         @Test
         fun `skal returnere innvilget ordinær og utvidet barnetrygd`() {
             // Arrange
+            val dagensMåned = YearMonth.of(2025, 4)
+            val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensMåned)
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService(clockProvider)
+
             val andeler =
                 listOf(
                     lagAndelTilkjentYtelse(
@@ -134,6 +147,45 @@ class MinSideBarnetrygdServiceTest {
         @Test
         fun `skal returnere innvilget ordinær barnetrygd`() {
             // Arrange
+            val dagensMåned = YearMonth.of(2025, 4)
+            val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensMåned)
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService(clockProvider)
+
+            val andeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2025, 3),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 4),
+                        tom = YearMonth.of(2025, 5),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns andeler
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær?.startmåned).isEqualTo(YearMonth.of(2025, 1))
+            assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal ikke returnere innvilget ordinær barnetrygd da dagens måned er senere enn siste tom dato på andelene`() {
+            // Arrange
+            val dagensMåned = YearMonth.of(2025, 8)
+            val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensMåned)
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService(clockProvider)
+
             val andeler =
                 listOf(
                     lagAndelTilkjentYtelse(
@@ -158,8 +210,155 @@ class MinSideBarnetrygdServiceTest {
             val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
 
             // Assert
+            assertThat(minSideBarnetrygd?.ordinær).isNull()
+            assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal ikke returnere innvilget ordinær eller utvidet barnetrygd da dagens måned er senere enn andelene`() {
+            // Arrange
+            val dagensMåned = YearMonth.of(2025, 8)
+            val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensMåned)
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService(clockProvider)
+
+            val andeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2025, 3),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 4),
+                        tom = YearMonth.of(2025, 7),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 3),
+                        tom = YearMonth.of(2025, 4),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 5),
+                        tom = YearMonth.of(2025, 7),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns andeler
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær).isNull()
+            assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal kun returnere innvilget ordinær barnetrygd da dagens måned er senere enn andelene for utvidet`() {
+            // Arrange
+            val dagensMåned = YearMonth.of(2025, 8)
+            val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensMåned)
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService(clockProvider)
+
+            val andeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2025, 3),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 4),
+                        tom = YearMonth.of(2025, 8),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 3),
+                        tom = YearMonth.of(2025, 4),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 5),
+                        tom = YearMonth.of(2025, 7),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns andeler
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
             assertThat(minSideBarnetrygd?.ordinær?.startmåned).isEqualTo(YearMonth.of(2025, 1))
             assertThat(minSideBarnetrygd?.utvidet).isNull()
+        }
+
+        @Test
+        fun `skal kun returnere innvilget utvidet barnetrygd da dagens måned er senere enn andelene for ordinær`() {
+            // Arrange
+            val dagensMåned = YearMonth.of(2025, 8)
+            val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensMåned)
+            val minSideBarnetrygdService = lagMinSideBarnetrygdService(clockProvider)
+
+            val andeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2025, 3),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 4),
+                        tom = YearMonth.of(2025, 7),
+                        ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 3),
+                        tom = YearMonth.of(2025, 4),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        aktør = aktør,
+                        fom = YearMonth.of(2025, 5),
+                        tom = YearMonth.of(2025, 8),
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(eq(behandling.id)) } returns andeler
+
+            // Act
+            val minSideBarnetrygd = minSideBarnetrygdService.hentMinSideBarnetrygd(fødselsnummer)
+
+            // Assert
+            assertThat(minSideBarnetrygd?.ordinær).isNull()
+            assertThat(minSideBarnetrygd?.utvidet?.startmåned).isEqualTo(YearMonth.of(2025, 3))
         }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
@@ -106,6 +106,9 @@ class MinSideBarnetrygdControllerTest(
         @Test
         fun `skal hente min side barnetrygd`() {
             // Arrange
+            val andelFom = YearMonth.now().minusMonths(5)
+            val andelTom = YearMonth.now().plusMonths(5)
+
             val aktør = aktørIdRepository.save(randomAktør(fnr = fnr))
 
             val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør))
@@ -130,8 +133,8 @@ class MinSideBarnetrygdControllerTest(
                     behandling = behandling,
                     tilkjentYtelse = tilkjentYtelse,
                     aktør = aktør,
-                    fom = YearMonth.of(2025, 1),
-                    tom = YearMonth.of(2025, 6),
+                    fom = andelFom,
+                    tom = andelTom,
                     ytelseType = YtelseType.ORDINÆR_BARNETRYGD,
                 ),
             )
@@ -142,7 +145,7 @@ class MinSideBarnetrygdControllerTest(
             // Assert
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(response.body).isInstanceOfSatisfying(HentMinSideBarnetrygdDto.Suksess::class.java) {
-                assertThat(it.barnetrygd?.ordinær?.startmåned).isEqualTo(YearMonth.of(2025, 1))
+                assertThat(it.barnetrygd?.ordinær?.startmåned).isEqualTo(andelFom)
                 assertThat(it.barnetrygd?.utvidet).isNull()
             }
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25894

Sjekker om løpende tom dato på en andel er lik eller etter dagens måned. Skal ikke vise de som ikke er "løpende". 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
