### PR TITLE
NAV-25881: Skaffe oversikt over åpne oppgaver for Steinkjær

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -36,6 +36,7 @@ import no.nav.familie.ba.sak.task.OppdaterLøpendeFlagg
 import no.nav.familie.ba.sak.task.OpprettTaskService
 import no.nav.familie.ba.sak.task.PatchFomPåVilkårTilFødselsdato
 import no.nav.familie.ba.sak.task.PatchMergetIdentDto
+import no.nav.familie.ba.sak.task.PorteføljejusteringTask
 import no.nav.familie.ba.sak.task.SlettKompetanserTask
 import no.nav.familie.ba.sak.task.dto.HenleggAutovedtakOgSettBehandlingTilbakeTilVentVedSmåbarnstilleggTask
 import no.nav.familie.ba.sak.task.internkonsistensavstemming.OpprettInternKonsistensavstemmingTaskerTask
@@ -556,6 +557,20 @@ class ForvalterController(
         )
 
         return ResponseEntity.ok("Kjørt OK")
+    }
+
+    @GetMapping("/start-portefoljejustering-task")
+    fun startPorteføljejusteringTask(
+        @RequestParam("antallOppgaver") antallOppgaver: Long,
+    ): ResponseEntity<Long> {
+//        tilgangService.verifiserHarTilgangTilHandling(
+//            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+//            handling = "Start porteføljejustering",
+//        )
+
+        val opprettetTask = taskRepository.save(PorteføljejusteringTask.opprettTask(antallOppgaver = antallOppgaver))
+
+        return ResponseEntity.ok(opprettetTask.id)
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -563,10 +563,10 @@ class ForvalterController(
     fun startPorteføljejusteringTask(
         @RequestParam("antallOppgaver") antallOppgaver: Long,
     ): ResponseEntity<Long> {
-//        tilgangService.verifiserHarTilgangTilHandling(
-//            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
-//            handling = "Start porteføljejustering",
-//        )
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Start porteføljejustering",
+        )
 
         val opprettetTask = taskRepository.save(PorteføljejusteringTask.opprettTask(antallOppgaver = antallOppgaver))
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -1,0 +1,48 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
+import no.nav.familie.ba.sak.task.PorteføljejusteringTask.Companion.TASK_STEP_TYPE
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
+import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+
+@TaskStepBeskrivelse(taskStepType = TASK_STEP_TYPE, beskrivelse = "Finner oppgaver som skal flyttes til ny enhet og oppretter tasker for å oppdatere enhet")
+class PorteføljejusteringTask(
+    private val oppgaveService: OppgaveService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val finnOppgaveRequest =
+            FinnOppgaveRequest(
+                tema = Tema.BAR,
+                enhet = BarnetrygdEnhet.STEINKJER.enhetsnummer,
+                offset = 0,
+                limit = task.payload.toLong(),
+            )
+        val finnOppgaveResponseDto: FinnOppgaveResponseDto = oppgaveService.hentOppgaver(finnOppgaveRequest)
+        val grupperteOppgaver = grupperOppgaverEtterBehandlesAvApplikasjonOgOppgavetype(finnOppgaveResponseDto.oppgaver)
+        secureLogger.info(objectMapper.writeValueAsString(grupperteOppgaver))
+    }
+
+    private fun grupperOppgaverEtterBehandlesAvApplikasjonOgOppgavetype(
+        oppgaver: List<Oppgave>,
+    ): Map<String, Map<String?, Int>> = oppgaver.groupBy { oppgave -> oppgave.behandlesAvApplikasjon ?: "behandlesAvApplikasjonIkkeSatt" }.mapValues { (_, oppgaver) -> oppgaver.groupBy { oppgave -> oppgave.oppgavetype }.mapValues { (_, oppgaver) -> oppgaver.size } }
+
+    companion object {
+        val logger = LoggerFactory.getLogger(PorteføljejusteringTask::class.java)
+        const val TASK_STEP_TYPE = "porteføljejusteringTask"
+
+        fun opprettTask(antallOppgaver: Long): Task =
+            Task(
+                type = TASK_STEP_TYPE,
+                payload = antallOppgaver.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.task
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service
 class PorteføljejusteringTask(
     private val oppgaveService: OppgaveService,
 ) : AsyncTaskStep {
+    @WithSpan
     override fun doTask(task: Task) {
         val finnOppgaveRequest =
             FinnOppgaveRequest(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -32,6 +32,7 @@ class PorteføljejusteringTask(
         val oppgaveGruppereringer = finnOppgaveResponseDto.oppgaver.tilOppgaveGrupperinger()
         val grupperteOppgaver = grupperOppgaverEtterSaksreferanseBehandlesAvApplikasjonOgOppgavetype(oppgaveGruppereringer)
         secureLogger.info(objectMapper.writeValueAsString(grupperteOppgaver))
+        // TODO: Legg inn logikk for å opprette tasker som oppdaterer enhet på oppgavene. Kommer i en senere PR når håndtering av porteføljejustering er ferdig avklart.
     }
 
     private fun List<Oppgave>.tilOppgaveGrupperinger(): List<OppgaveGruppering> =

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -35,7 +35,7 @@ class PorteføljejusteringTask(
 
     private fun grupperOppgaverEtterBehandlesAvApplikasjonOgOppgavetype(
         oppgaver: List<Oppgave>,
-    ): Map<String, Map<String?, Int>> = oppgaver.groupBy { oppgave -> oppgave.behandlesAvApplikasjon ?: "behandlesAvApplikasjonIkkeSatt" }.mapValues { (_, oppgaver) -> oppgaver.groupBy { oppgave -> oppgave.oppgavetype }.mapValues { (_, oppgaver) -> oppgaver.size } }
+    ): Map<String, Map<String, Map<String, Int>>> = oppgaver.groupBy { oppgave -> oppgave.behandlesAvApplikasjon ?: "behandlesAvApplikasjonIkkeSatt" }.mapValues { (_, oppgaver) -> oppgaver.groupBy { oppgave -> oppgave.oppgavetype ?: "manglerOppgavetype" }.mapValues { (_, oppgaver) -> oppgaver.groupBy { oppgave -> oppgave.saksreferanse ?: "ingenSaksreferanse" }.mapValues { (_, oppgaver) -> oppgaver.size } } }
 
     companion object {
         val logger = LoggerFactory.getLogger(PorteføljejusteringTask::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -37,7 +37,7 @@ class PorteføljejusteringTask(
         oppgaver: List<Oppgave>,
     ): Map<String, Map<String, Map<String, Int>>> =
         oppgaver
-            .groupBy { oppgave -> oppgave.behandlesAvApplikasjon ?: "behandlesAvApplikasjonIkkeSatt" }
+            .groupBy { oppgave -> oppgave.behandlesAvApplikasjon ?: oppgave.saksreferanse?.let { if (it.matches(Regex("\\d+[A-Z]\\d+"))) "Infotrygd" else "behandlesAvApplikasjonIkkeSatt" } ?: "behandlesAvApplikasjonIkkeSatt" }
             .mapValues { (_, oppgaver) ->
                 oppgaver
                     .groupBy { oppgave -> oppgave.oppgavetype ?: "manglerOppgavetype" }

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -35,7 +35,18 @@ class PorteføljejusteringTask(
 
     private fun grupperOppgaverEtterBehandlesAvApplikasjonOgOppgavetype(
         oppgaver: List<Oppgave>,
-    ): Map<String, Map<String, Map<String, Int>>> = oppgaver.groupBy { oppgave -> oppgave.behandlesAvApplikasjon ?: "behandlesAvApplikasjonIkkeSatt" }.mapValues { (_, oppgaver) -> oppgaver.groupBy { oppgave -> oppgave.oppgavetype ?: "manglerOppgavetype" }.mapValues { (_, oppgaver) -> oppgaver.groupBy { oppgave -> oppgave.saksreferanse ?: "ingenSaksreferanse" }.mapValues { (_, oppgaver) -> oppgaver.size } } }
+    ): Map<String, Map<String, Map<String, Int>>> =
+        oppgaver
+            .groupBy { oppgave -> oppgave.behandlesAvApplikasjon ?: "behandlesAvApplikasjonIkkeSatt" }
+            .mapValues { (_, oppgaver) ->
+                oppgaver
+                    .groupBy { oppgave -> oppgave.oppgavetype ?: "manglerOppgavetype" }
+                    .mapValues { (_, oppgaver) ->
+                        oppgaver
+                            .groupBy { oppgave -> oppgave.saksreferanse?.let { "medSaksreferanse" } ?: "ingenSaksreferanse" }
+                            .mapValues { (_, oppgaver) -> oppgaver.size }
+                    }
+            }
 
     companion object {
         val logger = LoggerFactory.getLogger(PorteføljejusteringTask::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -13,7 +13,9 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
 
+@Service
 @TaskStepBeskrivelse(taskStepType = TASK_STEP_TYPE, beskrivelse = "Finner oppgaver som skal flyttes til ny enhet og oppretter tasker for å oppdatere enhet")
 class PorteføljejusteringTask(
     private val oppgaveService: OppgaveService,


### PR DESCRIPTION
Favro: [NAV-25881](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25881)

### 💰 Hva skal gjøres, og hvorfor?
For å få en oversikt over alle åpne oppgaver tilordnet enhet 4817 - Steinkjær, legger jeg her til et forvalter-endepunkt som oppretter tasken `PorteføljejusteringTask`. Tasken henter alle åpne oppgaver tilordnet enhet 4817 og deretter kategoriserer og teller opp disse. Da kan vi se hvilke oppgavetyper og hvor mange oppgaver som er tilknyttet hvert fagsystem, samt hvilke oppgavetyper og hvor mange oppgaver som ikke er tilknyttet et fagsystem. 

Da får vi en oversikt som denne:
```
{
  "OppgaveMedSaksreferanse": {
    "familie-ba-sak": {
      "BEH_SAK": 202,
      "GOD_VED": 2,
      "VURD_LIVS": 12,
      "BEH_UND_VED": 1
    },
    "behandlesAvApplikasjonIkkeSatt": {
      "BEH_SED": 21,
      "VURD_LIVS": 99,
      "FREM": 1,
      "BEH_SAK": 36
    },
    "familie-klage": { "BEH_SAK": 1 },
    "familie-tilbake": { "BEH_SAK": 7 },
    "infotrygd": { "BEH_SAK": 3 }
  },
  "OppgaveUtenSaksreferanse": {
    "behandlesAvApplikasjonIkkeSatt": {
      "JFR": 195,
      "BEH_SAK_MK": 1,
      "BEH_SAK": 4,
      "FDR": 251
    }
  }
}
```

> NB: Dette er kode som kun skal brukes for å hente litt statistikk fra Prod for å få en bedre oversikt over omfang før vi starter den faktiske jobben med å skrive kode for å flytte alle oppgaver. Har derfor ikke skrevet noen tester. 
