### PR TITLE
Fix: Sørger for at ingen keys er null før vi kjører writeValueAsString

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PorteføljejusteringTask.kt
@@ -71,15 +71,15 @@ class PorteføljejusteringTask(
 
     private fun grupperOppgaverEtterSaksreferanseBehandlesAvApplikasjonOgOppgavetype(
         oppgaveGrupperinger: List<OppgaveGruppering>,
-    ): Map<String?, Map<String?, Map<String?, Int>>> =
+    ): Map<String, Map<String, Map<String, Int>>> =
         oppgaveGrupperinger
-            .groupBy { it::class.simpleName }
+            .groupBy { it::class.simpleName ?: "null" }
             .mapValues { (_, oppgaveGrupperinger) ->
                 oppgaveGrupperinger
                     .groupBy {
-                        it.behandlesAvApplikasjon
+                        it.behandlesAvApplikasjon ?: "null"
                     }.mapValues { (_, oppgaveGrupperinger) ->
-                        oppgaveGrupperinger.groupingBy { it.oppgavetype }.eachCount()
+                        oppgaveGrupperinger.groupingBy { it.oppgavetype ?: "null" }.eachCount()
                     }
             }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fikser feil hvor vi forsøker å konvertere et map til JSON og map inneholder null-keys.

`message=Null key for a Map not allowed in JSON `