### PR TITLE
Ikke kjør autovedtak finnmarkstillegg for fagsaktype SKJERMET_BARN og INSTITUSJON

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
@@ -15,7 +15,9 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.FINNMARKS
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus.LØPENDE
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.BARN_ENSLIG_MINDREÅRIG
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.NORMAL
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -25,6 +27,8 @@ import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
+val FAGSAKTYPER_DER_FINNMARKSTILLEG_KAN_AUTOVEDTAS = setOf(NORMAL, BARN_ENSLIG_MINDREÅRIG)
 
 @Service
 class AutovedtakFinnmarkstilleggService(
@@ -40,7 +44,10 @@ class AutovedtakFinnmarkstilleggService(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     override fun skalAutovedtakBehandles(behandlingsdata: FinnmarkstilleggData): Boolean {
-        val harLøpendeBarnetrygd by lazy { fagsakService.hentPåFagsakId(behandlingsdata.fagsakId).status == FagsakStatus.LØPENDE }
+        val (fagsaktypeKanBehandles, harLøpendeBarnetrygd) =
+            fagsakService.hentPåFagsakId(behandlingsdata.fagsakId).run {
+                (type in FAGSAKTYPER_DER_FINNMARKSTILLEG_KAN_AUTOVEDTAS) to (status == LØPENDE)
+            }
 
         val sisteIverksatteBehandling =
             behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandlingsdata.fagsakId)
@@ -66,7 +73,9 @@ class AutovedtakFinnmarkstilleggService(
                 }
         }
 
-        return harLøpendeBarnetrygd && (sisteIverksatteBehandlingHarFinnmarkstilleggAndeler || minstÉnAktørHarAdresseSomErRelevanteForFinnmarkstillegg)
+        return fagsaktypeKanBehandles &&
+            harLøpendeBarnetrygd &&
+            (sisteIverksatteBehandlingHarFinnmarkstilleggAndeler || minstÉnAktørHarAdresseSomErRelevanteForFinnmarkstillegg)
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -77,13 +77,18 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
     ): Page<Long>
 
     @Query(
-        value = """SELECT f.id
+        value = """
+            SELECT f.id
             FROM   Fagsak f
             WHERE  NOT EXISTS (
-                    SELECT 1
-                    FROM   finnmarkstillegg_kjoering
-                    WHERE  fk_fagsak_id = f.id
-                ) AND f.status = 'LØPENDE' AND f.arkivert = false""",
+                SELECT 1
+                FROM   finnmarkstillegg_kjoering
+                WHERE  fk_fagsak_id = f.id
+            )
+            AND f.status = 'LØPENDE'
+            AND f.arkivert = false
+            AND f.type IN ('NORMAL', 'BARN_ENSLIG_MINDREÅRIG')
+            """,
         nativeQuery = true,
     )
     fun finnLøpendeFagsakerForFinnmarkstilleggKjøring(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25790

Foreløpig kan vi ikke kjøre autovedtak finnmarkstillegg for fagsaktyper SKJERMET_BARN og INSTITUSJON, så filtrerer bort de i spørringen av fagsaker i scheduleren, og returnerer `false` i `skalBehandles` i autovedtakservicen