### PR TITLE
Endre på startdato finnmarkstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
@@ -46,7 +46,6 @@ object SatsService {
             Sats(SatsType.UTVIDET_BARNETRYGD, 1054, LocalDate.of(2019, 3, 1), LocalDate.of(2023, 2, 28)),
             Sats(SatsType.UTVIDET_BARNETRYGD, 2489, LocalDate.of(2023, 3, 1), LocalDate.of(2023, 6, 30)),
             Sats(SatsType.UTVIDET_BARNETRYGD, 2516, LocalDate.of(2023, 7, 1), LocalDate.MAX),
-
             // TODO: Endre på dato før vi går live tilbake til oktober 2025. Den settes til august siden vi ønsker muligheten til å teste med vedtaksperioder osv nå allerede.
             Sats(SatsType.FINNMARKSTILLEGG, 500, LocalDate.of(2025, 8, 1), LocalDate.MAX),
         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsService.kt
@@ -46,7 +46,9 @@ object SatsService {
             Sats(SatsType.UTVIDET_BARNETRYGD, 1054, LocalDate.of(2019, 3, 1), LocalDate.of(2023, 2, 28)),
             Sats(SatsType.UTVIDET_BARNETRYGD, 2489, LocalDate.of(2023, 3, 1), LocalDate.of(2023, 6, 30)),
             Sats(SatsType.UTVIDET_BARNETRYGD, 2516, LocalDate.of(2023, 7, 1), LocalDate.MAX),
-            Sats(SatsType.FINNMARKSTILLEGG, 500, LocalDate.of(2025, 10, 1), LocalDate.MAX),
+
+            // TODO: Endre på dato før vi går live tilbake til oktober 2025. Den settes til august siden vi ønsker muligheten til å teste med vedtaksperioder osv nå allerede.
+            Sats(SatsType.FINNMARKSTILLEGG, 500, LocalDate.of(2025, 8, 1), LocalDate.MAX),
         )
 
     fun finnSisteSatsFor(satstype: SatsType) = finnAlleSatserFor(satstype).maxBy { it.gyldigTom }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/FinnmarkstilleggGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/FinnmarkstilleggGeneratorTest.kt
@@ -113,7 +113,9 @@ class FinnmarkstilleggGeneratorTest {
 
         // Assert
         val finnmarkstilleggAndel = finnmarkstilleggAndeler.single()
-        assertThat(finnmarkstilleggAndel.stønadFom).isEqualTo(YearMonth.of(2025, 10))
+
+        //TODO: Endre tilbake til oktober 2025 før vi går live
+        assertThat(finnmarkstilleggAndel.stønadFom).isEqualTo(YearMonth.of(2025, 8))
         assertThat(finnmarkstilleggAndel.stønadTom).isEqualTo(YearMonth.of(2025, 12))
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/FinnmarkstilleggGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/FinnmarkstilleggGeneratorTest.kt
@@ -114,7 +114,7 @@ class FinnmarkstilleggGeneratorTest {
         // Assert
         val finnmarkstilleggAndel = finnmarkstilleggAndeler.single()
 
-        //TODO: Endre tilbake til oktober 2025 før vi går live
+        // TODO: Endre tilbake til oktober 2025 før vi går live
         assertThat(finnmarkstilleggAndel.stønadFom).isEqualTo(YearMonth.of(2025, 8))
         assertThat(finnmarkstilleggAndel.stønadTom).isEqualTo(YearMonth.of(2025, 12))
     }


### PR DESCRIPTION
Favrokort:

For å kunne teste at vi får inn riktige vedtaksperioder og annet snacks så må vi få generert andeler for august.
Denne revertes når vi går live.