### PR TITLE
BUG: Fomdato på vilkårresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
@@ -112,7 +112,7 @@ data class VilkårsvurderingForNyBehandlingUtils(
         val eldsteBarnSomVurderesSinFødselsdato =
             personopplysningGrunnlag.barna
                 .filter { !barnaAktørSomAlleredeErVurdert.contains(it.aktør) }
-                .maxByOrNull { it.fødselsdato }
+                .minByOrNull { it.fødselsdato }
                 ?.fødselsdato
                 ?: throw Feil("Finner ingen barn på persongrunnlag")
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårResultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårResultatUtils.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
@@ -22,7 +23,7 @@ object VilkårResultatUtils {
                 vurderFra = eldsteBarnSinFødselsdato,
             )
 
-        val fom = if (eldsteBarnSinFødselsdato >= person.fødselsdato) eldsteBarnSinFødselsdato else person.fødselsdato
+        val fom = if (person.type == PersonType.SØKER) eldsteBarnSinFødselsdato else person.fødselsdato
 
         val tom: LocalDate? =
             if (vilkår == Vilkår.UNDER_18_ÅR) {


### PR DESCRIPTION
Bruk minByOrNull i stedet for maxBy for å finne eldste dato
Kun kutt fomdato til eldste barns fødselsdato på søker sine vilkår

### 💰 Hva skal gjøres, og hvorfor?
To fødselshendelsetasker som feiler i prod fordi det er født tvillinger på hver sin side av midnatt ved månedsskifte. Feilen skyldes at vi kutter fom-datoer ved autogenerering av vilkår på eldste barns fødselsdato, MEN når vi finner eldste barns fødselsdato har vi egentlig funnet yngste barns fordi vi har brukt maxBy og ikke minBy. 

Endret også til å kun kutte søker sine vilkår siden det er mer lettleselig. Man unngår å bli forvirret av om >= på datoer betyr nyere eller eldre dato.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
