### PR TITLE
Fjerner flagget log_rows

### DIFF
--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -54,9 +54,7 @@ spec:
             value: "true"
           - name: pgaudit.log
             value: "write"
-          - name: pgaudit.log_parameter
-            value: "on"
-          - name: pgaudit.log_rows
+          - name: "pgaudit.log_parameter"
             value: "on"
   azure:
     application:


### PR DESCRIPTION
`pgaudit.log_rows` er visstnok ikke støttet i GCP og hindrer også `pgaudit.log_parameter` i å bli skrudd på. Fjerner derfor flagget.

Slack: https://nav-it.slack.com/archives/C5KUST8N6/p1755166322544729