### PR TITLE
Legg til støtte i Cucumber for autovedtak Finnmarkstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -166,6 +166,7 @@ data class Behandling(
             skalBehandlesAutomatisk && erSatsendring() && erEndringFraForrigeBehandlingSendtTilØkonomi -> true
             skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID && this.resultat == Behandlingsresultat.FORTSATT_INNVILGET -> true
             skalBehandlesAutomatisk && erMånedligValutajustering() -> true
+            skalBehandlesAutomatisk && erFinnmarkstillegg() -> true
             else -> false
         }
 
@@ -223,6 +224,8 @@ data class Behandling(
     fun erSatsendring() = this.opprettetÅrsak == BehandlingÅrsak.SATSENDRING
 
     fun erMånedligValutajustering() = this.opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING
+
+    fun erFinnmarkstillegg() = this.opprettetÅrsak == BehandlingÅrsak.FINNMARKSTILLEGG
 
     fun erSatsendringEllerMånedligValutajustering() = erSatsendring() || erMånedligValutajustering()
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
@@ -369,21 +369,15 @@ fun hentNesteSteg(
                 REGISTRERE_PERSONGRUNNLAG -> VILKÅRSVURDERING
                 VILKÅRSVURDERING -> BEHANDLINGSRESULTAT
                 BEHANDLINGSRESULTAT -> {
-                    if (!behandling.skalBehandlesAutomatisk) {
-                        VURDER_TILBAKEKREVING
-                    } else if (behandling.skalBehandlesAutomatisk && behandling.status == BehandlingStatus.IVERKSETTER_VEDTAK) {
+                    if (endringerIUtbetaling == EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING) {
                         IVERKSETT_MOT_OPPDRAG
                     } else {
-                        VURDER_TILBAKEKREVING
+                        FERDIGSTILLE_BEHANDLING
                     }
                 }
 
-                VURDER_TILBAKEKREVING -> SEND_TIL_BESLUTTER
-                SEND_TIL_BESLUTTER -> BESLUTTE_VEDTAK
-                BESLUTTE_VEDTAK -> hentNesteStegTypeBasertPåOmDetErEndringIUtbetaling(endringerIUtbetaling)
                 IVERKSETT_MOT_OPPDRAG -> VENTE_PÅ_STATUS_FRA_ØKONOMI
-                VENTE_PÅ_STATUS_FRA_ØKONOMI -> IVERKSETT_MOT_FAMILIE_TILBAKE
-                IVERKSETT_MOT_FAMILIE_TILBAKE -> JOURNALFØR_VEDTAKSBREV
+                VENTE_PÅ_STATUS_FRA_ØKONOMI -> JOURNALFØR_VEDTAKSBREV
                 JOURNALFØR_VEDTAKSBREV -> DISTRIBUER_VEDTAKSBREV
                 DISTRIBUER_VEDTAKSBREV -> FERDIGSTILLE_BEHANDLING
                 FERDIGSTILLE_BEHANDLING -> BEHANDLING_AVSLUTTET

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
@@ -92,7 +92,8 @@ data class VilkårResultat(
             "periodeFom=$periodeFom, " +
             "periodeTom=$periodeTom, " +
             "resultat=$resultat, " +
-            "evalueringÅrsaker=$evalueringÅrsaker" +
+            "evalueringÅrsaker=$evalueringÅrsaker, " +
+            "utdypendeVilkårsvurderinger=$utdypendeVilkårsvurderinger" +
             ")"
 
     fun nullstill() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperiodeUtil.kt
@@ -198,9 +198,20 @@ fun leggTilVilkårResultatPåPersonResultat(
     behandlingId: Long,
 ) = personResultatForBehandling
     .map { personResultat ->
-        personResultat.vilkårResultater.clear()
+        personResultat.apply {
+            vilkårResultater.clear()
+            val nyeVilkårResultater = parseVilkårResultaterForAktør(vilkårResultaterPerPerson[aktør.aktørId]!!, behandlingId, personResultat)
+            vilkårResultater.addAll(nyeVilkårResultater)
+        }
+    }.toSet()
 
-        vilkårResultaterPerPerson[personResultat.aktør.aktørId]?.forEach { rad ->
+fun parseVilkårResultaterForAktør(
+    vilkårResultatRaderForAktør: List<MutableMap<String, String>>,
+    behandlingId: Long,
+    personResultat: PersonResultat? = null,
+): Set<VilkårResultat> =
+    vilkårResultatRaderForAktør
+        .flatMap { rad ->
             val vilkårForÉnRad =
                 parseEnumListe<Vilkår>(
                     VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.VILKÅR,
@@ -243,10 +254,8 @@ fun leggTilVilkårResultatPåPersonResultat(
                         standardbegrunnelser = hentStandardBegrunnelser(rad),
                     )
                 }
-            personResultat.vilkårResultater.addAll(vilkårResultaterForÉnRad)
-        }
-        personResultat
-    }.toSet()
+            vilkårResultaterForÉnRad
+        }.toSet()
 
 private fun hentStandardBegrunnelser(rad: MutableMap<String, String>): List<IVedtakBegrunnelse> {
     val standardbegrunnelser: List<IVedtakBegrunnelse> =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/AdresseParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/AdresseParser.kt
@@ -1,0 +1,96 @@
+package no.nav.familie.ba.sak.cucumber.domeneparser
+
+import io.cucumber.datatable.DataTable
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.DomenebegrepAdresse.ADRESSETYPE
+import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.DomenebegrepAdresse.KOMMUNENUMMER
+import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.AKTØR_ID
+import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.parseAktørId
+import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.parseAktørIdListe
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
+import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
+import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
+import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
+
+fun parseAdresser(
+    dataTable: DataTable,
+    persongrunnlag: Map<Long, PersonopplysningGrunnlag>,
+): Map<String, PdlBostedsadresseOgDeltBostedPerson> =
+    dataTable
+        .asMaps()
+        .flatMap {
+            parseAktørIdListe(it).map { aktørId ->
+                it.toMutableMap().apply { put(AKTØR_ID.nøkkel, aktørId) }
+            }
+        }.groupBy { parseAktørId(it) }
+        .map { (aktørId, rader) ->
+            val (bostedsadresseRader, deltBostedRader) =
+                rader.partition { rad ->
+                    val adressetype = parseValgfriString(ADRESSETYPE, rad) ?: "Bostedsadresse"
+                    if (adressetype !in setOf("Bostedsadresse", "Delt bosted")) {
+                        throw Feil("Adressetype må være 'Bostedsadresse' eller 'Delt bosted'")
+                    }
+                    adressetype == "Bostedsadresse"
+                }
+
+            val bostedsadresser =
+                bostedsadresseRader.map { rad ->
+                    val fraDato = parseDato(Domenebegrep.FRA_DATO, rad)
+                    val tilDato = parseValgfriDato(Domenebegrep.TIL_DATO, rad)
+                    val kommunenummer = parseString(KOMMUNENUMMER, rad)
+
+                    Bostedsadresse(
+                        gyldigFraOgMed = fraDato,
+                        gyldigTilOgMed = tilDato,
+                        vegadresse =
+                            Vegadresse(
+                                matrikkelId = null,
+                                husnummer = null,
+                                husbokstav = null,
+                                bruksenhetsnummer = null,
+                                adressenavn = null,
+                                kommunenummer = kommunenummer,
+                                tilleggsnavn = null,
+                                postnummer = null,
+                            ),
+                    )
+                }
+
+            val deltBosted =
+                deltBostedRader.map { rad ->
+                    val fraDato = parseDato(Domenebegrep.FRA_DATO, rad)
+                    val tilDato = parseValgfriDato(Domenebegrep.TIL_DATO, rad)
+                    val kommunenummer = parseString(KOMMUNENUMMER, rad)
+
+                    DeltBosted(
+                        startdatoForKontrakt = fraDato,
+                        sluttdatoForKontrakt = tilDato,
+                        vegadresse =
+                            Vegadresse(
+                                matrikkelId = null,
+                                husnummer = null,
+                                husbokstav = null,
+                                bruksenhetsnummer = null,
+                                adressenavn = null,
+                                kommunenummer = kommunenummer,
+                                tilleggsnavn = null,
+                                postnummer = null,
+                            ),
+                    )
+                }
+
+            val ident =
+                persongrunnlag
+                    .values
+                    .flatMap { it.personer }
+                    .first { it.aktør.aktørId == aktørId }
+                    .aktør
+                    .aktivFødselsnummer()
+
+            ident to
+                PdlBostedsadresseOgDeltBostedPerson(
+                    bostedsadresse = bostedsadresser,
+                    deltBosted = deltBosted,
+                )
+        }.toMap()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -106,4 +106,11 @@ object VedtaksperiodeMedBegrunnelserParser {
     ) : Domenenøkkel {
         YTELSE_TYPE("Ytelse type"),
     }
+
+    enum class DomenebegrepAdresse(
+        override val nøkkel: String,
+    ) : Domenenøkkel {
+        ADRESSETYPE("Adressetype"),
+        KOMMUNENUMMER("Kommunenummer"),
+    }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinitio
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockBehandlingMigreringsinfoRepository
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockBehandlingSøknadsinfoRepository
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockEcbService
+import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockSystemOnlyPdlRestClient
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockTilbakekrevingsvedtakMotregningRepository
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockUnleashNextMedContextService
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockUnleashService
@@ -80,6 +81,8 @@ import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.Tilba
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling.PreutfyllBosattIRiketService
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling.PreutfyllVilkårService
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
 import no.nav.familie.ba.sak.task.FerdigstillBehandlingTask
 import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
@@ -147,6 +150,7 @@ class CucumberMock(
     val patchetAndelTilkjentYtelseRepository = mockk<PatchetAndelTilkjentYtelseRepository>()
     val eksternBehandlingRelasjonService = mockk<EksternBehandlingRelasjonService>()
     val behandlingSøknadsinfoRepository = mockBehandlingSøknadsinfoRepository()
+    val systemOnlyPdlRestClient = mockSystemOnlyPdlRestClient(dataFraCucumber)
 
     init {
         dataFraCucumber.toggles.forEach { (behandlingId, togglesForBehandling) ->
@@ -539,6 +543,20 @@ class CucumberMock(
             unleashService = unleashNextMedContextService,
         )
 
+    val preutfyllBosattIRiketService =
+        PreutfyllBosattIRiketService(
+            pdlRestClient = systemOnlyPdlRestClient,
+            søknadService = mockk(),
+            persongrunnlagService = persongrunnlagService,
+        )
+
+    val preutfyllVilkårService =
+        PreutfyllVilkårService(
+            preutfyllLovligOppholdService = mockk(),
+            preutfyllBosattIRiketService = preutfyllBosattIRiketService,
+            unleashService = unleashNextMedContextService,
+        )
+
     val vilkårsvurderingForNyBehandlingService =
         VilkårsvurderingForNyBehandlingService(
             vilkårsvurderingService = vilkårsvurderingService,
@@ -548,7 +566,7 @@ class CucumberMock(
             endretUtbetalingAndelService = endretUtbetalingAndelService,
             vilkårsvurderingMetrics = mockk(),
             andelerTilkjentYtelseRepository = andelTilkjentYtelseRepository,
-            preutfyllVilkårService = mockk(),
+            preutfyllVilkårService = preutfyllVilkårService,
         )
 
     val registrerPersongrunnlag =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockAutovedtakFinnmarkstilleggService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockAutovedtakFinnmarkstilleggService.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ba.sak.cucumber.mock.komponentMocks
+
+import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinition
+import no.nav.familie.ba.sak.cucumber.mock.CucumberMock
+import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+
+fun mockAutovedtakFinnmarkstilleggService(
+    dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefinition,
+    fagsakId: Long,
+    nyBehanldingId: Long,
+): AutovedtakFinnmarkstilleggService {
+    val forrigeBehandling =
+        dataFraCucumber.behandlinger.values
+            .filter { it.fagsak.id == fagsakId && it.status == BehandlingStatus.AVSLUTTET }
+            .maxByOrNull { it.id }
+
+    dataFraCucumber.behandlingTilForrigeBehandling.put(nyBehanldingId, forrigeBehandling?.id)
+
+    val cucumberMock =
+        CucumberMock(
+            dataFraCucumber = dataFraCucumber,
+            nyBehandlingId = nyBehanldingId,
+            forrigeBehandling = forrigeBehandling,
+        )
+
+    return AutovedtakFinnmarkstilleggService(
+        behandlingHentOgPersisterService = cucumberMock.behandlingHentOgPersisterService,
+        autovedtakService = cucumberMock.autovedtakService,
+        behandlingService = cucumberMock.behandlingService,
+        fagsakService = cucumberMock.fagsakService,
+        taskService = cucumberMock.taskService,
+        persongrunnlagService = cucumberMock.persongrunnlagService,
+        beregningService = cucumberMock.beregningService,
+        simuleringService = cucumberMock.simuleringService,
+        pdlRestClient = cucumberMock.systemOnlyPdlRestClient,
+    )
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockFagsakService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockFagsakService.kt
@@ -24,5 +24,11 @@ fun mockFagsakService(dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefiniti
         fagsak.status = nyStatus
         fagsak
     }
+    every { fagsakService.hentAktør(any()) } answers {
+        val fagsakId = firstArg<Long>()
+        dataFraCucumber.fagsaker.values
+            .single { it.id == fagsakId }
+            .aktør
+    }
     return fagsakService
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSystemOnlyPdlRestClient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSystemOnlyPdlRestClient.kt
@@ -1,0 +1,56 @@
+package no.nav.familie.ba.sak.cucumber.mock.komponentMocks
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinition
+import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
+import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
+import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
+
+fun mockSystemOnlyPdlRestClient(
+    dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefinition,
+): SystemOnlyPdlRestClient =
+    mockk<SystemOnlyPdlRestClient> {
+        every { hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
+            val identer = firstArg<List<String>>()
+            val vegadresseIOslo = Vegadresse(null, null, null, null, null, "0301", null, null)
+            identer.associateWith { ident ->
+                val fødselsdato =
+                    dataFraCucumber.persongrunnlag
+                        .flatMap { it.value.personer }
+                        .first { it.aktør.aktivFødselsnummer() == ident }
+                        .fødselsdato
+
+                val eksisterendeAdresser = dataFraCucumber.adresser[ident]
+                if (eksisterendeAdresser == null || eksisterendeAdresser.bostedsadresse.isEmpty()) {
+                    PdlBostedsadresseOgDeltBostedPerson(
+                        bostedsadresse = listOf(Bostedsadresse(gyldigFraOgMed = fødselsdato, vegadresse = vegadresseIOslo)),
+                        deltBosted = eksisterendeAdresser?.deltBosted ?: emptyList(),
+                    )
+                } else {
+                    eksisterendeAdresser
+                }
+            }
+        }
+
+        every { hentStatsborgerskap(any(), any()) } answers {
+            val aktør = firstArg<Aktør>()
+            val fødselsdato =
+                dataFraCucumber.persongrunnlag
+                    .flatMap { it.value.personer }
+                    .first { it.aktør == aktør }
+                    .fødselsdato
+
+            listOf(
+                Statsborgerskap(
+                    land = "NOR",
+                    gyldigFraOgMed = fødselsdato,
+                    gyldigTilOgMed = null,
+                    bekreftelsesdato = fødselsdato,
+                ),
+            )
+        }
+    }

--- a/src/test/resources/no/nav/familie/ba/sak/cucumber/finnmarkstillegg/finnmarkstillegg.feature
+++ b/src/test/resources/no/nav/familie/ba/sak/cucumber/finnmarkstillegg/finnmarkstillegg.feature
@@ -1,0 +1,61 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Finnmarkstillegg autovedtak
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | Behandlingsresultat | Behandlingsårsak | Behandlingsstatus |
+      | 1            | 1        | INNVILGET           | SØKNAD           | AVSLUTTET         |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 01.01.2000  |
+      | 1            | 2       | BARN       | 01.01.2025  |
+
+  Scenario: Skal oppdatere vilkårresultater og generere andeler når autovedtak finnmarkstillegg kjøres
+    Og dagens dato er 01.09.2025
+
+    Og lag personresultater for behandling 1
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                                        | Fra dato   | Til dato   | Resultat |
+      | 1       | BOSATT_I_RIKET, LOVLIG_OPPHOLD                | 01.01.2025 |            | OPPFYLT  |
+
+      | 2       | UNDER_18_ÅR                                   | 01.01.2025 | 31.12.2042 | OPPFYLT  |
+      | 2       | GIFT_PARTNERSKAP                              | 01.01.2025 |            | OPPFYLT  |
+      | 2       | BOSATT_I_RIKET, BOR_MED_SØKER, LOVLIG_OPPHOLD | 01.01.2025 |            | OPPFYLT  |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Prosent | Ytelse type        |
+      | 2       | 1            | 01.02.2025 | 30.04.2025 | 1766  | 100     | ORDINÆR_BARNETRYGD |
+      | 2       | 1            | 01.05.2025 | 31.12.2042 | 1968  | 100     | ORDINÆR_BARNETRYGD |
+
+    Og med bostedskommuner
+      | AktørId | Fra dato   | Til dato | Kommunenummer |
+      | 1       | 01.01.2000 |          | 0301          |
+      | 2       | 01.01.2025 |          | 0301          |
+      | 1, 2    | 01.05.2025 |          | 5601          |
+
+    Når vi lager automatisk behandling med id 2 på fagsak 1 på grunn av finnmarkstillegg
+
+    Så forvent følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                        | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
+      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
+      | 1       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 1       | LOVLIG_OPPHOLD                | 01.01.2025 |            | OPPFYLT  |                              |
+
+      | 2       | UNDER_18_ÅR                   | 01.01.2025 | 31.12.2042 | OPPFYLT  |                              |
+      | 2       | GIFT_PARTNERSKAP              | 01.01.2025 |            | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 2       | BOR_MED_SØKER, LOVLIG_OPPHOLD | 01.01.2025 |            | OPPFYLT  |                              |
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Prosent | Ytelse type        |
+      | 2       | 2            | 01.02.2025 | 30.04.2025 | 1766  | 100     | ORDINÆR_BARNETRYGD |
+      | 2       | 2            | 01.05.2025 | 31.12.2042 | 1968  | 100     | ORDINÆR_BARNETRYGD |
+      | 2       | 2            | 01.08.2025 | 31.12.2042 | 500   | 100     | FINNMARKSTILLEGG   |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25926

Legger til funksjoner i Cucumber-riggen for å kunne:
- legge til bostedskommune for aktører
- kjøre autovedtak Finnmarkstillegg
- sjekke om vilkårresultater på en behandling er som forventet

Legger også med en enkel test for å sjekke om de nye testfunksjonene funker, og noe småplukk som ble avdekket under kjøring av test