### PR TITLE
Vurderfra til rett fom-dato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingUtils.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårResultatMedNyPeriode
@@ -132,7 +133,7 @@ data class VilkårsvurderingForNyBehandlingUtils(
                         genererVilkårResultatForEtVilkårPåEnPerson(
                             person = person,
                             annenForelder = annenForelder,
-                            eldsteBarnSinFødselsdato = eldsteBarnSomVurderesSinFødselsdato,
+                            fom = if (person.type == PersonType.SØKER) eldsteBarnSomVurderesSinFødselsdato else person.fødselsdato,
                             personResultat = personResultat,
                             vilkår = vilkår,
                         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårResultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårResultatUtils.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering
 
 import no.nav.familie.ba.sak.common.til18ÅrsVilkårsdato
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
@@ -11,7 +10,7 @@ import java.time.LocalDate
 object VilkårResultatUtils {
     fun genererVilkårResultatForEtVilkårPåEnPerson(
         person: Person,
-        eldsteBarnSinFødselsdato: LocalDate,
+        fom: LocalDate,
         personResultat: PersonResultat,
         vilkår: Vilkår,
         annenForelder: Person? = null,
@@ -20,10 +19,8 @@ object VilkårResultatUtils {
             vilkår.vurderVilkår(
                 person = person,
                 annenForelder = annenForelder,
-                vurderFra = eldsteBarnSinFødselsdato,
+                vurderFra = fom,
             )
-
-        val fom = if (person.type == PersonType.SØKER) eldsteBarnSinFødselsdato else person.fødselsdato
 
         val tom: LocalDate? =
             if (vilkår == Vilkår.UNDER_18_ÅR) {


### PR DESCRIPTION
sett vurderFra til riktig dato slik at yngste barns vilkår ikke må være oppfylt fra eldste barns fødselsdato

### 💰 Hva skal gjøres, og hvorfor?
Når vi automatisk fyller ut bosatt i riket for fødselshendelser setter vi ikke-oppfylt dersom vurderFra er før barnets bostedsadresse. Dette blir feil når vurderFra er satt til eldste barns fødselsdato.

Retter opp feilen
