### PR TITLE
Automatisk begrunn vedtaksperioder i finnmarkstillegg saker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseService.kt
@@ -1,0 +1,61 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
+import org.springframework.stereotype.Service
+
+@Service
+class AutovedtakFinnmarkstilleggBegrunnelseService(
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val beregningService: BeregningService,
+    private val vedtaksperiodeService: VedtaksperiodeService,
+    private val vedtakService: VedtakService,
+    private val vedtaksperiodeHentOgPersisterService: VedtaksperiodeHentOgPersisterService,
+) {
+    fun begrunnAutovedtakForFinnmarkstillegg(
+        behandlingEtterBehandlingsresultat: Behandling,
+    ) {
+        val sistIverksatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId = behandlingEtterBehandlingsresultat.fagsak.id) ?: throw Feil("Finner ikke siste iverksatte behandling")
+        val forrigeAndeler = beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandlingId = sistIverksatteBehandling.id)
+        val nåværendeAndeler = beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandlingId = behandlingEtterBehandlingsresultat.id)
+
+        val (innvilgetMånedTidspunkt, redusertMånedTidspunkt) =
+            finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+                forrigeAndeler = forrigeAndeler,
+                nåværendeAndeler = nåværendeAndeler,
+            )
+
+        if (innvilgetMånedTidspunkt.isEmpty() && redusertMånedTidspunkt.isEmpty()) {
+            throw Feil("Det er forsøkt å begrunne autovedtak men det ble ikke funnet noen perioder med innvilgelse eller reduksjon.")
+        }
+
+        val vedtaksperioder =
+            vedtaksperiodeService.hentPersisterteVedtaksperioder(
+                vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId = behandlingEtterBehandlingsresultat.id),
+            )
+
+        innvilgetMånedTidspunkt.forEach {
+            leggTilBegrunnelseIVedtaksperiode(
+                vedtaksperiodeStartDato = it,
+                standardbegrunnelse = Standardbegrunnelse.INNVILGET_FINNMARKSTLLEGG,
+                vedtaksperioder = vedtaksperioder,
+            )
+        }
+
+        redusertMånedTidspunkt.forEach {
+            leggTilBegrunnelseIVedtaksperiode(
+                vedtaksperiodeStartDato = it,
+                standardbegrunnelse = Standardbegrunnelse.REDUKSJON_FINNMARKSTILLEGG,
+                vedtaksperioder = vedtaksperioder,
+            )
+        }
+
+        vedtaksperiodeHentOgPersisterService.lagre(vedtaksperioder)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseUtil.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.tilAndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -18,16 +19,18 @@ fun finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
     forrigeAndeler: List<AndelTilkjentYtelse>,
     nåværendeAndeler: List<AndelTilkjentYtelse>,
 ): Pair<Set<YearMonth>, Set<YearMonth>> {
+    val forrigeFinnmarkstilleggAndeler = forrigeAndeler.filter { it.erFinnmarkstillegg() }
+    val nåværendeFinnmarkstilleggAndeler = nåværendeAndeler.filter { it.erFinnmarkstillegg() }
+
     val relevanteBarn =
-        (forrigeAndeler + nåværendeAndeler)
-            .filter { it.erFinnmarkstillegg() }
+        (forrigeFinnmarkstilleggAndeler + nåværendeFinnmarkstilleggAndeler)
             .map { it.aktør }
             .toSet()
 
     val innvilgedeOgReduserteFinnmarkstilleggPerioder =
         relevanteBarn.fold<Aktør, Pair<Set<YearMonth>, Set<YearMonth>>>(emptySet<YearMonth>() to emptySet()) { (nyePerioder, reduksjonsPerioder), barn ->
-            val forrigeFinnmarkstilleggsAndelerTidslinje = forrigeAndeler.filter { it.aktør == barn }.tilTidslinje()
-            val nåværendeFinnmarkstilleggAndelerTidslinje = nåværendeAndeler.filter { it.aktør == barn }.tilTidslinje()
+            val forrigeFinnmarkstilleggsAndelerTidslinje = forrigeFinnmarkstilleggAndeler.filter { it.aktør == barn }.tilTidslinje()
+            val nåværendeFinnmarkstilleggAndelerTidslinje = nåværendeFinnmarkstilleggAndeler.filter { it.aktør == barn }.tilTidslinje()
 
             val nyeAndeler = forrigeFinnmarkstilleggsAndelerTidslinje.kombinerMed(nåværendeFinnmarkstilleggAndelerTidslinje) { gammel, ny -> ny.takeIf { gammel == null } }
             val fjernetAndeler = forrigeFinnmarkstilleggsAndelerTidslinje.kombinerMed(nåværendeFinnmarkstilleggAndelerTidslinje) { gammel, ny -> gammel.takeIf { ny == null } }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseUtil.kt
@@ -1,0 +1,70 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilAndelTilkjentYtelse
+import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.Vedtaksbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
+import java.time.YearMonth
+
+fun finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+    forrigeAndeler: List<AndelTilkjentYtelse>,
+    nåværendeAndeler: List<AndelTilkjentYtelse>,
+): Pair<Set<YearMonth>, Set<YearMonth>> {
+    val relevanteBarn =
+        (forrigeAndeler + nåværendeAndeler)
+            .filter { it.erFinnmarkstillegg() }
+            .map { it.aktør }
+            .toSet()
+
+    val innvilgedeOgReduserteFinnmarkstilleggPerioder =
+        relevanteBarn.fold<Aktør, Pair<Set<YearMonth>, Set<YearMonth>>>(emptySet<YearMonth>() to emptySet()) { (nyePerioder, reduksjonsPerioder), barn ->
+            val forrigeFinnmarkstilleggsAndelerTidslinje = forrigeAndeler.filter { it.aktør == barn }.tilTidslinje()
+            val nåværendeFinnmarkstilleggAndelerTidslinje = nåværendeAndeler.filter { it.aktør == barn }.tilTidslinje()
+
+            val nyeAndeler = forrigeFinnmarkstilleggsAndelerTidslinje.kombinerMed(nåværendeFinnmarkstilleggAndelerTidslinje) { gammel, ny -> ny.takeIf { gammel == null } }
+            val fjernetAndeler = forrigeFinnmarkstilleggsAndelerTidslinje.kombinerMed(nåværendeFinnmarkstilleggAndelerTidslinje) { gammel, ny -> gammel.takeIf { ny == null } }
+
+            (nyePerioder + nyeAndeler.tilAndelTilkjentYtelse().map { it.stønadFom } to reduksjonsPerioder + fjernetAndeler.tilAndelTilkjentYtelse().map { it.stønadFom })
+        }
+
+    return innvilgedeOgReduserteFinnmarkstilleggPerioder
+}
+
+internal fun leggTilBegrunnelseIVedtaksperiode(
+    vedtaksperiodeStartDato: YearMonth,
+    standardbegrunnelse: Standardbegrunnelse,
+    vedtaksperioder: List<VedtaksperiodeMedBegrunnelser>,
+) {
+    val vedtaksperiode =
+        vedtaksperioder.find {
+            it.type == Vedtaksperiodetype.UTBETALING &&
+                it.fom?.toYearMonth() == vedtaksperiodeStartDato
+        } ?: run {
+            secureLogger.info(
+                "Finner ikke aktuell periode å begrunne ved autovedtak finnmarkstillegg. " +
+                    "Periode: $vedtaksperiodeStartDato. " +
+                    "Perioder: ${vedtaksperioder.map { "Periode(type=${it.type}, fom=${it.fom}, tom=${it.tom})" }}",
+            )
+            throw Feil(
+                "Finner ikke aktuell periode å begrunne ved autovedtak finnmarkstillegg. Se securelogger for detaljer.",
+            )
+        }
+
+    vedtaksperiode.settBegrunnelser(
+        (
+            vedtaksperiode.begrunnelser +
+                Vedtaksbegrunnelse(
+                    vedtaksperiodeMedBegrunnelser = vedtaksperiode,
+                    standardbegrunnelse = standardbegrunnelse,
+                )
+        ).toList(),
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
@@ -43,6 +43,7 @@ class AutovedtakFinnmarkstilleggService(
     private val behandlingService: BehandlingService,
     private val beregningService: BeregningService,
     private val simuleringService: SimuleringService,
+    private val autovedtakFinnmarkstilleggBegrunnelseService: AutovedtakFinnmarkstilleggBegrunnelseService,
 ) : AutovedtakBehandlingService<FinnmarkstilleggData> {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -101,6 +102,8 @@ class AutovedtakFinnmarkstilleggService(
         if (feilutbetaling > BigDecimal.ZERO) {
             throw Feil("Det er oppdaget feilutbetaling ved kjøring av finnmarkstillegg for fagsakId=${behandlingsdata.fagsakId}. Automatisk kjøring stoppes.")
         }
+
+        autovedtakFinnmarkstilleggBegrunnelseService.begrunnAutovedtakForFinnmarkstillegg(behandlingEtterBehandlingsresultat)
 
         val opprettetVedtak =
             autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.BARN_ENSLIG_MINDREÅRIG
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.NORMAL
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
+import no.nav.familie.ba.sak.kjerne.steg.IverksettMotOppdrag
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.FerdigstillBehandlingTask
@@ -44,6 +45,7 @@ class AutovedtakFinnmarkstilleggService(
     private val beregningService: BeregningService,
     private val simuleringService: SimuleringService,
     private val autovedtakFinnmarkstilleggBegrunnelseService: AutovedtakFinnmarkstilleggBegrunnelseService,
+    private val iverksettMotOppdrag: IverksettMotOppdrag,
 ) : AutovedtakBehandlingService<FinnmarkstilleggData> {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -103,7 +105,11 @@ class AutovedtakFinnmarkstilleggService(
             throw Feil("Det er oppdaget feilutbetaling ved kjøring av finnmarkstillegg for fagsakId=${behandlingsdata.fagsakId}. Automatisk kjøring stoppes.")
         }
 
-        autovedtakFinnmarkstilleggBegrunnelseService.begrunnAutovedtakForFinnmarkstillegg(behandlingEtterBehandlingsresultat)
+        if (behandlingEtterBehandlingsresultat.steg == StegType.IVERKSETT_MOT_OPPDRAG) {
+            autovedtakFinnmarkstilleggBegrunnelseService.begrunnAutovedtakForFinnmarkstillegg(
+                behandlingEtterBehandlingsresultat,
+            )
+        }
 
         val opprettetVedtak =
             autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggService.kt
@@ -45,7 +45,6 @@ class AutovedtakFinnmarkstilleggService(
     private val beregningService: BeregningService,
     private val simuleringService: SimuleringService,
     private val autovedtakFinnmarkstilleggBegrunnelseService: AutovedtakFinnmarkstilleggBegrunnelseService,
-    private val iverksettMotOppdrag: IverksettMotOppdrag,
 ) : AutovedtakBehandlingService<FinnmarkstilleggData> {
     private val logger = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -139,6 +139,8 @@ data class AndelTilkjentYtelse(
 
     fun erSmåbarnstillegg() = this.type == YtelseType.SMÅBARNSTILLEGG
 
+    fun erFinnmarkstillegg() = this.type == YtelseType.FINNMARKSTILLEGG
+
     fun erSøkersAndel() = erUtvidet() || erSmåbarnstillegg()
 
     fun erLøpende(): Boolean = this.stønadTom > YearMonth.now()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -793,6 +793,10 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
         override val sanityApiNavn = "reduksjonBarnBorIInstitusjon"
     },
+    REDUKSJON_FINNMARKSTILLEGG {
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.REDUKSJON
+        override val sanityApiNavn = "reduksjonFinnmarkstillegg"
+    },
     AVSLAG_BOSATT_I_RIKET {
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
         override val sanityApiNavn = "avslagBosattIRiket"

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseServiceTest.kt
@@ -1,0 +1,237 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.datagenerator.defaultFagsak
+import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.datagenerator.lagVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.YearMonth
+
+class AutovedtakFinnmarkstilleggBegrunnelseServiceTest {
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val beregningService = mockk<BeregningService>()
+    private val vedtaksperiodeService = mockk<VedtaksperiodeService>()
+    private val vedtakService = mockk<VedtakService>()
+    private val vedtaksperiodeHentOgPersisterService = mockk<VedtaksperiodeHentOgPersisterService>()
+
+    private val autovedtakFinnmarkstilleggBegrunnelseService =
+        AutovedtakFinnmarkstilleggBegrunnelseService(
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            beregningService = beregningService,
+            vedtaksperiodeService = vedtaksperiodeService,
+            vedtakService = vedtakService,
+            vedtaksperiodeHentOgPersisterService = vedtaksperiodeHentOgPersisterService,
+        )
+
+    private val fagsak = defaultFagsak()
+    private val forrigeBehandling = lagBehandling(fagsak = fagsak, id = 0)
+    private val behandling = lagBehandling(fagsak = fagsak, id = 1)
+    private val barn = lagPerson(type = PersonType.BARN)
+    private val barn2 = lagPerson(type = PersonType.BARN)
+
+    @Test
+    fun `Skal kaste feil dersom det ikke finnes noen perioder å begrunne`() {
+        // Arrange
+        val forrigeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 11),
+                    tom = YearMonth.of(2025, 12),
+                    person = barn,
+                    behandling = forrigeBehandling,
+                    beløp = 500,
+                    sats = 500,
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                ),
+            )
+
+        val nåværendeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 11),
+                    tom = YearMonth.of(2025, 12),
+                    person = barn,
+                    behandling = behandling,
+                    beløp = 500,
+                    sats = 500,
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                ),
+            )
+
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsak.id) } returns forrigeBehandling
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(forrigeBehandling.id) } returns forrigeAndeler
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandling.id) } returns nåværendeAndeler
+
+        // Act && Assert
+        val feilmelding =
+            assertThrows<Feil> {
+                autovedtakFinnmarkstilleggBegrunnelseService.begrunnAutovedtakForFinnmarkstillegg(behandling)
+            }.message
+
+        assertThat(feilmelding).isEqualTo("Det er forsøkt å begrunne autovedtak men det ble ikke funnet noen perioder med innvilgelse eller reduksjon.")
+    }
+
+    @Test
+    fun `Skal lagre vedtaksperiode med innvilgesebegrunnelse dersom det finnes perioder med innvilgelse`() {
+        // Arrange
+        val nåværendeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 11),
+                    tom = YearMonth.of(2025, 12),
+                    person = barn,
+                    behandling = behandling,
+                    beløp = 500,
+                    sats = 500,
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                ),
+            )
+
+        val oppdaterteVedtaksperioderSlot = slot<List<VedtaksperiodeMedBegrunnelser>>()
+
+        val vedtaksperiode =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    fom = LocalDate.of(2025, 11, 1),
+                    type = Vedtaksperiodetype.UTBETALING,
+                    begrunnelser = mutableSetOf(),
+                ),
+            )
+
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsak.id) } returns forrigeBehandling
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(forrigeBehandling.id) } returns emptyList()
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandling.id) } returns nåværendeAndeler
+        every { vedtaksperiodeService.hentPersisterteVedtaksperioder(any()) } returns vedtaksperiode
+        every { vedtakService.hentAktivForBehandlingThrows(behandling.id) } returns mockk()
+        every { vedtaksperiodeHentOgPersisterService.lagre(capture(oppdaterteVedtaksperioderSlot)) } answers { firstArg() }
+
+        // Act
+        autovedtakFinnmarkstilleggBegrunnelseService.begrunnAutovedtakForFinnmarkstillegg(behandling)
+
+        val oppdaterteVedtaksperioder = oppdaterteVedtaksperioderSlot.captured
+
+        assertThat(oppdaterteVedtaksperioder.size).isEqualTo(1)
+        assertThat(oppdaterteVedtaksperioder[0].begrunnelser.map { it.standardbegrunnelse }[0]).isEqualTo(Standardbegrunnelse.INNVILGET_FINNMARKSTLLEGG)
+    }
+
+    @Test
+    fun `Skal lagre vedtaksperiode med reduksjonsbegrunnelse dersom det finnes perioder med reduksjon`() {
+        // Arrange
+        val forrigeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 11),
+                    tom = YearMonth.of(2025, 12),
+                    person = barn,
+                    behandling = forrigeBehandling,
+                    beløp = 500,
+                    sats = 500,
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                ),
+            )
+
+        val oppdaterteVedtaksperioderSlot = slot<List<VedtaksperiodeMedBegrunnelser>>()
+
+        val vedtaksperiode =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    fom = LocalDate.of(2025, 11, 1),
+                    type = Vedtaksperiodetype.UTBETALING,
+                    begrunnelser = mutableSetOf(),
+                ),
+            )
+
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsak.id) } returns forrigeBehandling
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(forrigeBehandling.id) } returns forrigeAndeler
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandling.id) } returns emptyList()
+        every { vedtaksperiodeService.hentPersisterteVedtaksperioder(any()) } returns vedtaksperiode
+        every { vedtakService.hentAktivForBehandlingThrows(behandling.id) } returns mockk()
+        every { vedtaksperiodeHentOgPersisterService.lagre(capture(oppdaterteVedtaksperioderSlot)) } answers { firstArg() }
+
+        // Act
+        autovedtakFinnmarkstilleggBegrunnelseService.begrunnAutovedtakForFinnmarkstillegg(behandling)
+
+        val oppdaterteVedtaksperioder = oppdaterteVedtaksperioderSlot.captured
+
+        assertThat(oppdaterteVedtaksperioder.size).isEqualTo(1)
+        assertThat(oppdaterteVedtaksperioder[0].begrunnelser.map { it.standardbegrunnelse }[0]).isEqualTo(Standardbegrunnelse.REDUKSJON_FINNMARKSTILLEGG)
+    }
+
+    @Test
+    fun `Skal lagre vedtaksperiode med både reduksjon og innvilgelse begrunnelse dersom det finnes perioder med begge`() {
+        // Arrange
+        val forrigeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    person = barn,
+                    behandling = forrigeBehandling,
+                    beløp = 500,
+                    sats = 500,
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                ),
+            )
+
+        val nåværendeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 10),
+                    tom = YearMonth.of(2025, 12),
+                    person = barn2,
+                    behandling = behandling,
+                    beløp = 500,
+                    sats = 500,
+                    ytelseType = YtelseType.FINNMARKSTILLEGG,
+                ),
+            )
+
+        val oppdaterteVedtaksperioderSlot = slot<List<VedtaksperiodeMedBegrunnelser>>()
+
+        val vedtaksperiode =
+            listOf(
+                lagVedtaksperiodeMedBegrunnelser(
+                    fom = LocalDate.of(2025, 10, 1),
+                    type = Vedtaksperiodetype.UTBETALING,
+                    begrunnelser = mutableSetOf(),
+                ),
+            )
+
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsak.id) } returns forrigeBehandling
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(forrigeBehandling.id) } returns forrigeAndeler
+        every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandling.id) } returns nåværendeAndeler
+        every { vedtaksperiodeService.hentPersisterteVedtaksperioder(any()) } returns vedtaksperiode
+        every { vedtakService.hentAktivForBehandlingThrows(behandling.id) } returns mockk()
+        every { vedtaksperiodeHentOgPersisterService.lagre(capture(oppdaterteVedtaksperioderSlot)) } answers { firstArg() }
+
+        // Act
+        autovedtakFinnmarkstilleggBegrunnelseService.begrunnAutovedtakForFinnmarkstillegg(behandling)
+
+        val oppdaterteVedtaksperioder = oppdaterteVedtaksperioderSlot.captured
+
+        assertThat(oppdaterteVedtaksperioder.size).isEqualTo(1)
+        assertThat(oppdaterteVedtaksperioder[0].begrunnelser.map { it.standardbegrunnelse })
+            .contains(
+                Standardbegrunnelse.REDUKSJON_FINNMARKSTILLEGG,
+                Standardbegrunnelse.INNVILGET_FINNMARKSTLLEGG,
+            )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggBegrunnelseUtilTest.kt
@@ -1,0 +1,355 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.datagenerator.lagVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.YearMonth
+
+internal class AutovedtakFinnmarkstilleggBegrunnelseUtilTest {
+    @Nested
+    inner class FinnInnvilgedeOgReduserteFinnmarkstilleggPerioderTest {
+        @Test
+        fun `Skal returnere alle perioder der det har kommet nye finnmarkstillegg andeler`() {
+            val barn = lagPerson(type = PersonType.BARN)
+            val behandling = lagBehandling()
+
+            val nåværendeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val innvilgedeOgReduserteFinnmarkstilleggPerioder =
+                finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+                    forrigeAndeler = emptyList(),
+                    nåværendeAndeler = nåværendeAndeler,
+                )
+
+            val innvilgedePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.first
+            val redusertePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.second
+
+            assertThat(redusertePerioder).isEmpty()
+            assertThat(innvilgedePerioder).hasSize(1)
+            assertThat(innvilgedePerioder.single()).isEqualTo(YearMonth.of(2025, 11))
+        }
+
+        @Test
+        fun `Skal differensiere mellom barn og returnere alle innvilgede perioder`() {
+            val barn = lagPerson(type = PersonType.BARN)
+            val barn2 = lagPerson(type = PersonType.BARN)
+            val behandling = lagBehandling()
+
+            val nåværendeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 10),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn2,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val innvilgedeOgReduserteFinnmarkstilleggPerioder =
+                finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+                    forrigeAndeler = emptyList(),
+                    nåværendeAndeler = nåværendeAndeler,
+                )
+
+            val innvilgedePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.first
+            val redusertePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.second
+
+            assertThat(redusertePerioder).isEmpty()
+            assertThat(innvilgedePerioder).hasSize(2)
+            assertThat(innvilgedePerioder).anySatisfy { assertThat(it).isEqualTo(YearMonth.of(2025, 10)) }
+            assertThat(innvilgedePerioder).anySatisfy { assertThat(it).isEqualTo(YearMonth.of(2025, 11)) }
+        }
+
+        @Test
+        fun `Ved flere barn som har lik innvilgeses tidspunkt returneres bare 1 periode`() {
+            val barn = lagPerson(type = PersonType.BARN)
+            val barn2 = lagPerson(type = PersonType.BARN)
+            val behandling = lagBehandling()
+
+            val nåværendeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn2,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val innvilgedeOgReduserteFinnmarkstilleggPerioder =
+                finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+                    forrigeAndeler = emptyList(),
+                    nåværendeAndeler = nåværendeAndeler,
+                )
+
+            val innvilgedePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.first
+            val redusertePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.second
+
+            assertThat(redusertePerioder).isEmpty()
+            assertThat(innvilgedePerioder).hasSize(1)
+            assertThat(innvilgedePerioder.single()).isEqualTo(YearMonth.of(2025, 11))
+        }
+
+        @Test
+        fun `Ved flere barn som både får og mister finnmarkstillegg for samme periode skal det dannes innvilget og reduksjonsperiode`() {
+            val barn = lagPerson(type = PersonType.BARN)
+            val barn2 = lagPerson(type = PersonType.BARN)
+            val behandling = lagBehandling()
+            val forrigeBehandling = lagBehandling()
+
+            val forrigeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn,
+                        behandling = forrigeBehandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val nåværendeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn2,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val innvilgedeOgReduserteFinnmarkstilleggPerioder =
+                finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+                    forrigeAndeler = forrigeAndeler,
+                    nåværendeAndeler = nåværendeAndeler,
+                )
+
+            val innvilgedePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.first
+            val redusertePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.second
+
+            assertThat(redusertePerioder).hasSize(1)
+            assertThat(redusertePerioder.single()).isEqualTo(YearMonth.of(2025, 11))
+            assertThat(innvilgedePerioder).hasSize(1)
+            assertThat(innvilgedePerioder.single()).isEqualTo(YearMonth.of(2025, 11))
+        }
+
+        @Test
+        fun `Ikke returner noe innvilgesesPerioder dersom andelene allerede fantes i forrige behandling`() {
+            val barn = lagPerson(type = PersonType.BARN)
+            val barn2 = lagPerson(type = PersonType.BARN)
+            val behandling = lagBehandling()
+            val behandling2 = lagBehandling()
+
+            val nåværendeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn2,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val forrigeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn,
+                        behandling = behandling2,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn2,
+                        behandling = behandling2,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val innvilgedeOgReduserteFinnmarkstilleggPerioder =
+                finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+                    forrigeAndeler = forrigeAndeler,
+                    nåværendeAndeler = nåværendeAndeler,
+                )
+
+            val innvilgedePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.first
+            val redusertePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.second
+
+            assertThat(redusertePerioder).isEmpty()
+            assertThat(innvilgedePerioder).isEmpty()
+        }
+
+        @Test
+        fun `Skal returnere alle perioder der man har mistet finnmarkstillegg andeler siden forrige behandling`() {
+            val barn = lagPerson(type = PersonType.BARN)
+            val behandling = lagBehandling()
+
+            val forrigeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 11),
+                        tom = YearMonth.of(2025, 12),
+                        person = barn,
+                        behandling = behandling,
+                        beløp = 500,
+                        sats = 500,
+                        ytelseType = YtelseType.FINNMARKSTILLEGG,
+                    ),
+                )
+
+            val innvilgedeOgReduserteFinnmarkstilleggPerioder =
+                finnInnvilgedeOgReduserteFinnmarkstilleggPerioder(
+                    forrigeAndeler = forrigeAndeler,
+                    nåværendeAndeler = emptyList(),
+                )
+
+            val innvilgedePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.first
+            val redusertePerioder = innvilgedeOgReduserteFinnmarkstilleggPerioder.second
+
+            assertThat(innvilgedePerioder).isEmpty()
+            assertThat(redusertePerioder).hasSize(1)
+            assertThat(redusertePerioder.single()).isEqualTo(YearMonth.of(2025, 11))
+        }
+    }
+
+    @Nested
+    inner class LeggTilBegrunnelseIVedtaksperiodeTest {
+        @Test
+        fun `Skal kaste feil dersom det ikke finnes noe vedtaksperioder som passer noe utbetalings perioden begrunnelsen skal legges i`() {
+            // Arrange
+            val vedtaksperioderIBehandling =
+                listOf(
+                    lagVedtaksperiodeMedBegrunnelser(
+                        fom = LocalDate.of(2025, 10, 1),
+                        tom = LocalDate.of(2025, 10, 1),
+                        type = Vedtaksperiodetype.UTBETALING,
+                    ),
+                    lagVedtaksperiodeMedBegrunnelser(
+                        fom = LocalDate.of(2025, 11, 1),
+                        tom = LocalDate.of(2025, 11, 1),
+                        type = Vedtaksperiodetype.OPPHØR,
+                    ),
+                    lagVedtaksperiodeMedBegrunnelser(
+                        fom = LocalDate.of(2025, 12, 1),
+                        tom = LocalDate.of(2025, 12, 1),
+                        type = Vedtaksperiodetype.UTBETALING,
+                    ),
+                )
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<Feil> {
+                    leggTilBegrunnelseIVedtaksperiode(
+                        vedtaksperiodeStartDato = YearMonth.of(2025, 11),
+                        standardbegrunnelse = Standardbegrunnelse.INNVILGET_FINNMARKSTLLEGG,
+                        vedtaksperioder = vedtaksperioderIBehandling,
+                    )
+                }.message
+
+            assertThat(feilmelding).isEqualTo("Finner ikke aktuell periode å begrunne ved autovedtak finnmarkstillegg. Se securelogger for detaljer.")
+        }
+
+        @Test
+        fun `Skal legge til begrunnelse i riktig vedtaksperiode`() {
+            // Arrange
+            val vedtaksperioderIBehandling =
+                listOf(
+                    lagVedtaksperiodeMedBegrunnelser(
+                        fom = LocalDate.of(2025, 10, 1),
+                        tom = LocalDate.of(2025, 10, 1),
+                        type = Vedtaksperiodetype.UTBETALING,
+                    ),
+                    lagVedtaksperiodeMedBegrunnelser(
+                        fom = LocalDate.of(2025, 11, 1),
+                        tom = LocalDate.of(2025, 11, 1),
+                        type = Vedtaksperiodetype.UTBETALING,
+                    ),
+                    lagVedtaksperiodeMedBegrunnelser(
+                        fom = LocalDate.of(2025, 12, 1),
+                        tom = LocalDate.of(2025, 12, 1),
+                        type = Vedtaksperiodetype.UTBETALING,
+                    ),
+                )
+
+            // Act
+            leggTilBegrunnelseIVedtaksperiode(
+                vedtaksperiodeStartDato = YearMonth.of(2025, 11),
+                standardbegrunnelse = Standardbegrunnelse.INNVILGET_FINNMARKSTLLEGG,
+                vedtaksperioder = vedtaksperioderIBehandling,
+            )
+
+            // Assert
+            val vedtaksperiode = vedtaksperioderIBehandling.single { it.fom == LocalDate.of(2025, 11, 1) }
+            assertThat(vedtaksperiode.begrunnelser.map { it.standardbegrunnelse }).contains(Standardbegrunnelse.INNVILGET_FINNMARKSTLLEGG)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggServiceTest.kt
@@ -42,6 +42,7 @@ class AutovedtakFinnmarkstilleggServiceTest {
     private val fagsakService = mockk<FagsakService>()
     private val pdlRestClient = mockk<SystemOnlyPdlRestClient>()
     private val simuleringService = mockk<SimuleringService>()
+    private val autovedtakFinnmarkstilleggBegrunnelseService = mockk<AutovedtakFinnmarkstilleggBegrunnelseService>()
 
     private val autovedtakFinnmarkstilleggService =
         AutovedtakFinnmarkstilleggService(
@@ -51,6 +52,7 @@ class AutovedtakFinnmarkstilleggServiceTest {
             fagsakService = fagsakService,
             pdlRestClient = pdlRestClient,
             simuleringService = simuleringService,
+            autovedtakFinnmarkstilleggBegrunnelseService = autovedtakFinnmarkstilleggBegrunnelseService,
             autovedtakService = mockk(),
             behandlingService = mockk(),
             taskService = mockk(),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -27,9 +27,12 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.Utbetalin
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.internal.TestVerktøyService
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
+import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggBegrunnelseService
+import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.AutovedtakSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.behandling.AutomatiskBeslutningService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.EksternBehandlingRelasjonService
 import no.nav.familie.ba.sak.kjerne.behandling.SnikeIKøenService
@@ -79,6 +82,7 @@ import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningBrevService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningService
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling.PreutfyllBosattIRiketService
@@ -578,6 +582,15 @@ class CucumberMock(
         )
 
     val månedligValutajusteringService = MånedligValutajusteringService(ecbService = ecbService, valutakursService = valutakursService)
+
+    val autovedtakFinnmarkstilleggBegrunnelseService =
+        AutovedtakFinnmarkstilleggBegrunnelseService(
+            vedtaksperiodeService = vedtaksperiodeService,
+            vedtakService = vedtakService,
+            beregningService = beregningService,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            vedtaksperiodeHentOgPersisterService = vedtaksperiodeHentOgPersisterService,
+        )
 
     val vilkårsvurderingSteg =
         VilkårsvurderingSteg(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockAutovedtakFinnmarkstilleggService.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockAutovedtakFinnmarkstilleggService.kt
@@ -34,5 +34,6 @@ fun mockAutovedtakFinnmarkstilleggService(
         beregningService = cucumberMock.beregningService,
         simuleringService = cucumberMock.simuleringService,
         pdlRestClient = cucumberMock.systemOnlyPdlRestClient,
+        autovedtakFinnmarkstilleggBegrunnelseService = cucumberMock.autovedtakFinnmarkstilleggBegrunnelseService,
     )
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543

Når vi kjører gjennom en finnmarkstillegg sak, og det skal iverksettes, ønsker vi å sende ut et vedtaksbrev til bruker.
Dette brevet må inneholde vedtaksperioder med begrunnelser om innvilgelse eller reduksjon, avhengig av hva slags finnmarkstillegg andel som er gitt eller fjernet.