### PR TITLE
Ekskluder endringer i vilkårsvurdering når endringsresultat utledes for finnmarkstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.common.nesteMåned
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatOpphørUtils.utledOpphørsdatoForNåværendeBehandlingMedFallback
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
@@ -33,6 +34,7 @@ internal enum class Endringsresultat {
 
 object BehandlingsresultatEndringUtils {
     internal fun utledEndringsresultat(
+        behandling: Behandling,
         nåværendeAndeler: List<AndelTilkjentYtelse>,
         forrigeAndeler: List<AndelTilkjentYtelse>,
         personerFremstiltKravFor: List<Aktør>,
@@ -96,13 +98,14 @@ object BehandlingsresultatEndringUtils {
                     }
 
                 val erEndringIVilkårsvurderingForPerson =
-                    erEndringIVilkårsvurderingForPerson(
-                        tidligsteRelevanteFomDatoForPersonIVilkårsvurdering = tidligsteRelevanteFomDatoForPersonIVilkårsvurdering,
-                        nåværendePersonResultaterForPerson = nåværendePersonResultatForPerson,
-                        forrigePersonResultaterForPerson = forrigePersonResultatForPerson,
-                        personIBehandling = personIBehandling,
-                        personIForrigeBehandling = personIForrigeBehandling,
-                    )
+                    !behandling.erFinnmarkstillegg() &&
+                        erEndringIVilkårsvurderingForPerson(
+                            tidligsteRelevanteFomDatoForPersonIVilkårsvurdering = tidligsteRelevanteFomDatoForPersonIVilkårsvurdering,
+                            nåværendePersonResultaterForPerson = nåværendePersonResultatForPerson,
+                            forrigePersonResultaterForPerson = forrigePersonResultatForPerson,
+                            personIBehandling = personIBehandling,
+                            personIForrigeBehandling = personIForrigeBehandling,
+                        )
 
                 val erEndringIKompetanseForPerson =
                     erEndringIKompetanseForPerson(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatService.kt
@@ -79,6 +79,7 @@ class BehandlingsresultatService(
                 val forrigeUtenlandskPeriodebeløp = utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(BehandlingId(forrigeBehandling.id))
 
                 BehandlingsresultatEndringUtils.utledEndringsresultat(
+                    behandling = behandling,
                     nåværendeAndeler = andelerTilkjentYtelse,
                     forrigeAndeler = forrigeAndelerTilkjentYtelse,
                     nåværendeEndretAndeler = endretUtbetalingAndeler,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Når vi utleder endringsresultat for finnmarkstillegg må vi ekskludere endringer i vilkårsvurderingen, slik at endringsresultat blir `INGEN_ENDRING`