### PR TITLE
siste periode på oppholdstillatelse skal settes til null

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -163,11 +163,12 @@ class PreutfyllLovligOppholdService(
 
         return oppholdstillatelse
             .filter { it.type == OPPHOLDSTILLATELSE.PERMANENT || it.type == OPPHOLDSTILLATELSE.MIDLERTIDIG }
-            .map {
+            .mapIndexed { index, it ->
+                val erSiste = index == oppholdstillatelse.lastIndex
                 Periode(
                     verdi = true,
                     fom = it.oppholdFra,
-                    tom = it.oppholdTil,
+                    tom = if (erSiste) null else it.oppholdTil,
                 )
             }.tilTidslinje()
     }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25552) 

### 💰 Hva skal gjøres, og hvorfor?
Oppholdstillatelse kan ha tom dato, men om det er siste periode ønsker vi at den skal være løpende, så i de tilfellene settes tom til null

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
