### PR TITLE
Task for å hente antall personer som bor i Finnmark/Nord-Troms eller på Svalbard

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/SystemOnlyPdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/SystemOnlyPdlRestClient.kt
@@ -73,14 +73,14 @@ class SystemOnlyPdlRestClient(
         )
     }
 
-    fun hentBostedsadresseOgDeltBostedForPersoner(identer: List<String>): Map<String, PdlBostedsadresseOgDeltBostedPerson> {
+    fun hentBostedsadresseOgDeltBostedForPersoner(identer: List<String>): Map<String, PdlBostedsadresseDeltBostedOppholdsadressePerson> {
         val pdlPersonRequest =
             PdlPersonBolkRequest(
                 variables = PdlPersonBolkRequestVariables(identer),
                 query = hentGraphqlQuery("bostedsadresse-og-delt-bosted"),
             )
 
-        val pdlResponse: PdlBolkResponse<PdlBostedsadresseOgDeltBostedPerson> =
+        val pdlResponse: PdlBolkResponse<PdlBostedsadresseDeltBostedOppholdsadressePerson> =
             kallEksternTjeneste(
                 tjeneste = "pdl",
                 uri = pdlUri,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/SystemOnlyPdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/SystemOnlyPdlRestClient.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ba.sak.common.kallEksternTjeneste
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlAdressebeskyttelsePerson
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlAdressebeskyttelseResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBaseResponse
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonBolkRequest
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonBolkRequestVariables
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonRequest
@@ -85,6 +85,25 @@ class SystemOnlyPdlRestClient(
                 tjeneste = "pdl",
                 uri = pdlUri,
                 formål = "Hent bostedsadresse og delt bosted for personer",
+            ) {
+                postForEntity(pdlUri, pdlPersonRequest, httpHeaders())
+            }
+
+        return feilsjekkOgReturnerData(pdlResponse = pdlResponse)
+    }
+
+    fun hentBostedsadresseDeltBostedOgOppholdsadresseForPersoner(identer: List<String>): Map<String, PdlBostedsadresseDeltBostedOppholdsadressePerson> {
+        val pdlPersonRequest =
+            PdlPersonBolkRequest(
+                variables = PdlPersonBolkRequestVariables(identer),
+                query = hentGraphqlQuery("bostedsadresse-delt-bosted-oppholdsadresse"),
+            )
+
+        val pdlResponse: PdlBolkResponse<PdlBostedsadresseDeltBostedOppholdsadressePerson> =
+            kallEksternTjeneste(
+                tjeneste = "pdl",
+                uri = pdlUri,
+                formål = "Hent bostedsadresse, delt bosted og oppholdsadresse for personer",
             ) {
                 postForEntity(pdlUri, pdlPersonRequest, httpHeaders())
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlBostedsadresseDeltBostedOppholdsadressePerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlBostedsadresseDeltBostedOppholdsadressePerson.kt
@@ -6,8 +6,9 @@ import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
 
 data class PdlBostedsadresseDeltBostedOppholdsadressePerson(
-    val bostedsadresse: List<Bostedsadresse>,
-    val deltBosted: List<DeltBosted>,
+    val bostedsadresse: List<Bostedsadresse> = emptyList(),
+    val deltBosted: List<DeltBosted> = emptyList(),
+    val oppholdsadresse: List<Oppholdsadresse> = emptyList(),
 )
 
 fun PdlBostedsadresseDeltBostedOppholdsadressePerson?.tilAdresser(): BostedsadresserOgDelteBosteder =

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlBostedsadresseDeltBostedOppholdsadressePerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlBostedsadresseDeltBostedOppholdsadressePerson.kt
@@ -5,12 +5,12 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.bostedsadresse.t
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
 
-data class PdlBostedsadresseOgDeltBostedPerson(
+data class PdlBostedsadresseDeltBostedOppholdsadressePerson(
     val bostedsadresse: List<Bostedsadresse>,
     val deltBosted: List<DeltBosted>,
 )
 
-fun PdlBostedsadresseOgDeltBostedPerson?.tilAdresser(): BostedsadresserOgDelteBosteder =
+fun PdlBostedsadresseDeltBostedOppholdsadressePerson?.tilAdresser(): BostedsadresserOgDelteBosteder =
     BostedsadresserOgDelteBosteder(
         bostedsadresser = this?.let { bostedsadresse.map { it.tilAdresse() } } ?: emptyList(),
         delteBosteder = this?.let { deltBosted.map { it.tilAdresse() } } ?: emptyList(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlOppholdsadressePerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlOppholdsadressePerson.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.ba.sak.integrasjoner.pdl.domene
+
+import no.nav.familie.ba.sak.common.isSameOrAfter
+import no.nav.familie.ba.sak.common.isSameOrBefore
+import java.time.LocalDate
+
+data class PdlOppholdsadressePerson(
+    val oppholdsadresse: List<Oppholdsadresse>,
+)
+
+data class Oppholdsadresse(
+    val gyldigFraOgMed: LocalDate? = null,
+    val gyldigTilOgMed: LocalDate? = null,
+    val oppholdAnnetSted: String? = null,
+) {
+    internal fun erPåSvalbard(): Boolean = oppholdAnnetSted == "PAA_SVALBARD"
+}
+
+fun List<Oppholdsadresse>.oppholdsadresseErPåSvalbardPåDato(dato: LocalDate): Boolean = hentForDato(dato)?.erPåSvalbard() ?: false
+
+private fun List<Oppholdsadresse>.hentForDato(dato: LocalDate): Oppholdsadresse? =
+    filter { it.gyldigFraOgMed != null }
+        .sortedBy { it.gyldigFraOgMed }
+        .lastOrNull {
+            it.gyldigFraOgMed!!.isSameOrBefore(dato) &&
+                (it.gyldigTilOgMed == null || it.gyldigTilOgMed.isSameOrAfter(dato))
+        }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringScheduler
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -68,6 +69,7 @@ import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.UUID
 import kotlin.concurrent.thread
+import kotlin.time.measureTimedValue
 
 @RestController
 @RequestMapping("/api/forvalter")
@@ -634,6 +636,48 @@ class ForvalterController(
         DeaktiverMinsideTask.opprettTask(personIdent.aktør)
 
         return ResponseEntity.ok("Task for deaktivering av minside for ident opprettet")
+    }
+
+    @PostMapping("/opprett-tasker-som-finner-personer-som-bor-i-finnmark-nord-troms-eller-paa-svalbard")
+    @Operation(
+        summary = "Oppretter tasker som finner personer med bostedsadresse eller delt bosted i Finnmark/Nord-Troms eller oppholdsadresse på Svalbard",
+    )
+    fun opprettTaskerSomFinnerPersonerMedOppholdsadressePåSvalbard(
+        @RequestBody dryRun: Boolean = true,
+    ): ResponseEntity<String> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Opprett tasker som finner personer med bostedsadresse eller delt bosted i Finnmark/Nord-Troms eller oppholdsadresse på Svalbard",
+        )
+
+        val (antallTasker, tid) =
+            measureTimedValue {
+                val sisteIverksatteBehandlingerFraLøpendeFagsaker =
+                    behandlingHentOgPersisterService
+                        .hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
+
+                val chunksMedPersoner =
+                    sisteIverksatteBehandlingerFraLøpendeFagsaker
+                        .flatMap { behandlingId ->
+                            persongrunnlagService
+                                .hentAktiv(behandlingId)
+                                ?.personer
+                                ?.map { it.aktør.aktivFødselsnummer() }
+                                ?: emptyList()
+                        }.chunked(10000)
+
+                chunksMedPersoner
+                    .onEachIndexed { index, identer ->
+                        val task =
+                            FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask
+                                .opprettTask(identer)
+                                .medTriggerTid(LocalDateTime.now().plusSeconds(index * 5L))
+
+                        if (!dryRun) taskService.save(task)
+                    }.size
+            }
+
+        return ResponseEntity.ok("Brukte ${tid.inWholeSeconds} sekunder på å opprette $antallTasker tasker")
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardstillegg/FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardstillegg/FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask.kt
@@ -1,0 +1,99 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg
+
+import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.oppholdsadresseErPåSvalbardPåDato
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.tilAdresser
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import kotlin.time.measureTimedValue
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask.TASK_STEP_TYPE,
+    beskrivelse = "Finn personer med bostedsadresse eller delt bosted i Finnmark/Nord-Troms eller oppholdsadresse på Svalbard",
+    maxAntallFeil = 1,
+)
+class FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask(
+    private val systemOnlyPdlRestClient: SystemOnlyPdlRestClient,
+    private val fagsakService: FagsakService,
+    private val personidentService: PersonidentService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val identer = task.payload.split(",")
+
+        val (personerSomBorIFinnmarkNordTromsEllerPåSvalbard, tid) =
+            measureTimedValue {
+                identer
+                    .chunked(1000)
+                    .flatMap { identer ->
+                        systemOnlyPdlRestClient
+                            .hentBostedsadresseDeltBostedOgOppholdsadresseForPersoner(identer)
+                            .mapNotNull { (ident, adresser) ->
+                                val dato = LocalDate.now()
+
+                                val borIFinnmarkEllerNordTroms =
+                                    adresser
+                                        .tilAdresser()
+                                        .bostedsadresseEllerDeltBostedErIFinnmarkEllerNordTromsPåDato(dato)
+
+                                val borPåSvalbard =
+                                    adresser
+                                        .oppholdsadresse
+                                        .oppholdsadresseErPåSvalbardPåDato(dato)
+
+                                if (borIFinnmarkEllerNordTroms || borPåSvalbard) {
+                                    val aktør = personidentService.hentAktør(ident)
+                                    val fagsakIder =
+                                        fagsakService
+                                            .finnAlleFagsakerHvorAktørErSøkerEllerMottarLøpendeOrdinær(aktør)
+                                            .map { it.id }
+                                            .distinct()
+
+                                    ident to
+                                        BorIFinnmarkNordTromsEllerPåSvalbard(
+                                            borIFinnmarkNordTroms = borIFinnmarkEllerNordTroms,
+                                            borPåSvalbard = borPåSvalbard,
+                                            fagsakIder = fagsakIder,
+                                        )
+                                } else {
+                                    null
+                                }
+                            }
+                    }.toMap()
+            }
+
+        val personerSomBorIFinnmarkEllerNordTroms = personerSomBorIFinnmarkNordTromsEllerPåSvalbard.filterValues { it.borIFinnmarkNordTroms }
+        val personerSomBorPåSvalbard = personerSomBorIFinnmarkNordTromsEllerPåSvalbard.filterValues { it.borPåSvalbard }
+        val fagsakerMedPersonerSomBorIFinnmarkEllerNordTroms = personerSomBorIFinnmarkEllerNordTroms.values.flatMap { it.fagsakIder }.distinct()
+        val fagsakerMedPersonerSomBorPåSvalbard = personerSomBorPåSvalbard.values.flatMap { it.fagsakIder }.distinct()
+
+        task.metadata["Antall personer med bostedsadresse eller delt bosted i Finnmark"] = personerSomBorIFinnmarkEllerNordTroms.size
+        task.metadata["Antall personer med oppholdsadresse på Svalbard"] = personerSomBorPåSvalbard.size
+        task.metadata["Antall fagsaker der minst én person har bostedsadresse eller delt bosted i Finnmark"] = fagsakerMedPersonerSomBorIFinnmarkEllerNordTroms.size
+        task.metadata["Antall fagsaker der minst én person har oppholdsadresse på Svalbard"] = fagsakerMedPersonerSomBorPåSvalbard.size
+        task.metadata["Tid brukt på å kjøre task"] = "${tid.inWholeMilliseconds} ms"
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "finnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask"
+
+        fun opprettTask(
+            identer: List<String>,
+        ): Task =
+            Task(
+                type = TASK_STEP_TYPE,
+                payload = identer.joinToString(","),
+            )
+    }
+
+    private data class BorIFinnmarkNordTromsEllerPåSvalbard(
+        val borIFinnmarkNordTroms: Boolean,
+        val borPåSvalbard: Boolean,
+        val fagsakIder: List<Long>,
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/bostedsadresse/BostedsadresserOgDelteBosteder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/bostedsadresse/BostedsadresserOgDelteBosteder.kt
@@ -16,6 +16,10 @@ data class BostedsadresserOgDelteBosteder(
     val bostedsadresser: List<Adresse>,
     val delteBosteder: List<Adresse>,
 ) {
+    fun bostedsadresseEllerDeltBostedErIFinnmarkEllerNordTromsPåDato(dato: LocalDate): Boolean =
+        bostedsadresser.hentForDato(dato)?.erIFinnmarkEllerNordTroms() ?: false ||
+            delteBosteder.hentForDato(dato)?.erIFinnmarkEllerNordTroms() ?: false
+
     fun harBostedsadresseEllerDeltBostedSomErRelevantForFinnmarkstillegg(): Boolean =
         bostedsadresser.filtrerUtAdresserSomErRelevanteForFinnmarkstillegg().any { it.erIFinnmarkEllerNordTroms() } ||
             delteBosteder.filtrerUtAdresserSomErRelevanteForFinnmarkstillegg().any { it.erIFinnmarkEllerNordTroms() }
@@ -58,6 +62,14 @@ fun DeltBosted.tilAdresse(): Adresse =
         matrikkeladresse = matrikkeladresse,
         ukjentBosted = ukjentBosted,
     )
+
+fun List<Adresse>.hentForDato(dato: LocalDate): Adresse? =
+    filter { it.gyldigFraOgMed != null }
+        .sortedBy { it.gyldigFraOgMed }
+        .lastOrNull {
+            it.gyldigFraOgMed!!.isSameOrBefore(dato) &&
+                (it.gyldigTilOgMed == null || it.gyldigTilOgMed.isSameOrAfter(dato))
+        }
 
 fun Adresse?.erIFinnmarkEllerNordTroms(): Boolean =
     this?.vegadresse?.kommunenummer?.let { kommuneErIFinnmarkEllerNordTroms(it) }

--- a/src/main/resources/pdl/bostedsadresse-delt-bosted-oppholdsadresse.graphql
+++ b/src/main/resources/pdl/bostedsadresse-delt-bosted-oppholdsadresse.graphql
@@ -1,0 +1,39 @@
+query($identer: [ID!]!){
+    personBolk: hentPersonBolk(identer: $identer) {
+        code
+        ident
+        person {
+            bostedsadresse(historikk: false) {
+                gyldigFraOgMed
+                gyldigTilOgMed
+                vegadresse {
+                    kommunenummer
+                }
+                matrikkeladresse {
+                    kommunenummer
+                }
+                ukjentBosted {
+                    bostedskommune
+                }
+            }
+            deltBosted(historikk: false) {
+                startdatoForKontrakt
+                sluttdatoForKontrakt
+                vegadresse {
+                    kommunenummer
+                }
+                matrikkeladresse {
+                    kommunenummer
+                }
+                ukjentBosted {
+                    bostedskommune
+                }
+            }
+            oppholdsadresse(historikk: false) {
+                gyldigFraOgMed
+                gyldigTilOgMed
+                oppholdAnnetSted
+            }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockPdlRestClient.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/MockPdlRestClient.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ba.sak.config
 
 import no.nav.familie.ba.sak.datagenerator.lagMatrikkeladresse
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
@@ -27,9 +27,9 @@ class MockPdlRestClient(
         restTemplate = restOperations,
         personidentService = personidentService,
     ) {
-    override fun hentBostedsadresseOgDeltBostedForPersoner(identer: List<String>): Map<String, PdlBostedsadresseOgDeltBostedPerson> =
+    override fun hentBostedsadresseOgDeltBostedForPersoner(identer: List<String>): Map<String, PdlBostedsadresseDeltBostedOppholdsadressePerson> =
         identer.associateWith {
-            PdlBostedsadresseOgDeltBostedPerson(
+            PdlBostedsadresseDeltBostedOppholdsadressePerson(
                 bostedsadresse =
                     listOf(
                         Bostedsadresse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggSchedulerTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.domene.FinnmarkstilleggKjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.domene.FinnmarkstilleggKjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -64,7 +64,7 @@ class AutovedtakFinnmarkstilleggSchedulerTest {
         lagTestPersonopplysningGrunnlag(behandlingId = behandling2.id, søker2)
 
     private val bostedsadresseIFinnmark =
-        PdlBostedsadresseOgDeltBostedPerson(
+        PdlBostedsadresseDeltBostedOppholdsadressePerson(
             bostedsadresse =
                 listOf(
                     Bostedsadresse(
@@ -86,7 +86,7 @@ class AutovedtakFinnmarkstilleggSchedulerTest {
         )
 
     private val bostedsadresseIOslo =
-        PdlBostedsadresseOgDeltBostedPerson(
+        PdlBostedsadresseDeltBostedOppholdsadressePerson(
             bostedsadresse =
                 listOf(
                     Bostedsadresse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.FinnmarkstilleggData
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
@@ -156,8 +156,8 @@ class AutovedtakFinnmarkstilleggServiceTest {
             // Arrange
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(listOf(søkerIdent, barnIdent)) } returns
                 mapOf(
-                    søkerIdent to PdlBostedsadresseOgDeltBostedPerson(bostedsadresse = listOf(bostedsadresseUtenforFinnmark), deltBosted = emptyList()),
-                    barnIdent to PdlBostedsadresseOgDeltBostedPerson(bostedsadresse = listOf(bostedsadresseUtenforFinnmark), deltBosted = emptyList()),
+                    søkerIdent to PdlBostedsadresseDeltBostedOppholdsadressePerson(bostedsadresse = listOf(bostedsadresseUtenforFinnmark), deltBosted = emptyList()),
+                    barnIdent to PdlBostedsadresseDeltBostedOppholdsadressePerson(bostedsadresse = listOf(bostedsadresseUtenforFinnmark), deltBosted = emptyList()),
                 )
 
             // Act
@@ -172,8 +172,8 @@ class AutovedtakFinnmarkstilleggServiceTest {
             // Arrange
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(listOf(søkerIdent, barnIdent)) } returns
                 mapOf(
-                    søkerIdent to PdlBostedsadresseOgDeltBostedPerson(bostedsadresse = listOf(bostedsadresseIFinnmark), deltBosted = emptyList()),
-                    barnIdent to PdlBostedsadresseOgDeltBostedPerson(bostedsadresse = listOf(bostedsadresseUtenforFinnmark), deltBosted = emptyList()),
+                    søkerIdent to PdlBostedsadresseDeltBostedOppholdsadressePerson(bostedsadresse = listOf(bostedsadresseIFinnmark), deltBosted = emptyList()),
+                    barnIdent to PdlBostedsadresseDeltBostedOppholdsadressePerson(bostedsadresse = listOf(bostedsadresseUtenforFinnmark), deltBosted = emptyList()),
                 )
 
             // Act

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Ansettels
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsforhold
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Periode
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -56,7 +56,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(
@@ -114,7 +114,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(
@@ -169,7 +169,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(
@@ -228,7 +228,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(
@@ -282,7 +282,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(
@@ -336,7 +336,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(
@@ -395,7 +395,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(
@@ -453,7 +453,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { pdlRestClient.hentBostedsadresseOgDeltBostedForPersoner(any()) } answers {
                 val identer = firstArg<List<String>>()
                 identer.associateWith {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse =
                             listOf(
                                 Bostedsadresse(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/VedtaksperioderOgBegrunnelserStepDefinition.kt
@@ -28,7 +28,7 @@ import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockAutovedtakFinnmark
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockUnleashNextMedContextService
 import no.nav.familie.ba.sak.cucumber.mock.mockAutovedtakMånedligValutajusteringService
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.FinnmarkstilleggData
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -98,7 +98,7 @@ class VedtaksperioderOgBegrunnelserStepDefinition {
     var uregistrerteBarn = listOf<BarnMedOpplysninger>()
     var dagensDato: LocalDate = LocalDate.now()
     var toggles = mapOf<Long, Map<String, Boolean>>()
-    var adresser = mutableMapOf<String, PdlBostedsadresseOgDeltBostedPerson>()
+    var adresser = mutableMapOf<String, PdlBostedsadresseDeltBostedOppholdsadressePerson>()
 
     var utvidetVedtaksperiodeMedBegrunnelser = listOf<UtvidetVedtaksperiodeMedBegrunnelser>()
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/AdresseParser.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/domeneparser/AdresseParser.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.AKTØR_ID
 import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.parseAktørId
 import no.nav.familie.ba.sak.cucumber.domeneparser.VedtaksperiodeMedBegrunnelserParser.parseAktørIdListe
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
@@ -16,7 +16,7 @@ import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
 fun parseAdresser(
     dataTable: DataTable,
     persongrunnlag: Map<Long, PersonopplysningGrunnlag>,
-): Map<String, PdlBostedsadresseOgDeltBostedPerson> =
+): Map<String, PdlBostedsadresseDeltBostedOppholdsadressePerson> =
     dataTable
         .asMaps()
         .flatMap {
@@ -89,7 +89,7 @@ fun parseAdresser(
                     .aktivFødselsnummer()
 
             ident to
-                PdlBostedsadresseOgDeltBostedPerson(
+                PdlBostedsadresseDeltBostedOppholdsadressePerson(
                     bostedsadresse = bostedsadresser,
                     deltBosted = deltBosted,
                 )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSystemOnlyPdlRestClient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockSystemOnlyPdlRestClient.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinition
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
@@ -26,7 +26,7 @@ fun mockSystemOnlyPdlRestClient(
 
                 val eksisterendeAdresser = dataFraCucumber.adresser[ident]
                 if (eksisterendeAdresser == null || eksisterendeAdresser.bostedsadresse.isEmpty()) {
-                    PdlBostedsadresseOgDeltBostedPerson(
+                    PdlBostedsadresseDeltBostedOppholdsadressePerson(
                         bostedsadresse = listOf(Bostedsadresse(gyldigFraOgMed = fødselsdato, vegadresse = vegadresseIOslo)),
                         deltBosted = eksisterendeAdresser?.deltBosted ?: emptyList(),
                     )

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/scenario/StubsForVerdikjedetester.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/scenario/StubsForVerdikjedetester.kt
@@ -18,7 +18,7 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.domene.Folkeregisteridentifikator
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.FolkeregisteridentifikatorType
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBaseResponse
-import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseOgDeltBostedPerson
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlFolkeregisteridentifikator
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlFødselsDato
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentIdenterResponse
@@ -184,7 +184,7 @@ private fun stubHentBostedsadresserOgDeltBostedForPerson(restScenario: RestScena
                                     ident = person.ident,
                                     code = "ok",
                                     person =
-                                        PdlBostedsadresseOgDeltBostedPerson(
+                                        PdlBostedsadresseDeltBostedOppholdsadressePerson(
                                             bostedsadresse =
                                                 listOf(
                                                     Bostedsadresse(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Vi ønsker å finne omtrent hvor mange personer som har registrert oppholdsadresse på Svalbard.
Sjekker samtidig antall personer som har bostedsadresse eller delt bosted i Finnmark/Nord-Troms.
Inkluderer også omtrent hvor mange fagsaker det gjelder.