### PR TITLE
Hent ut geografisk tilknytning for personer med D-nummer i task som henter personer i Finnmark/Nord-Troms/Svalbard

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -3,8 +3,10 @@ package no.nav.familie.ba.sak.integrasjoner.pdl
 import no.nav.familie.ba.sak.common.kallEksternTjeneste
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.DødsfallData
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.ForelderBarnRelasjon
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.GeografiskTilknytning
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBaseResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlDødsfallResponse
+import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlGeografiskTilknytningResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlHentPersonResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlOppholdResponse
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlPersonRequest
@@ -231,6 +233,27 @@ class PdlRestClient(
                 it.person!!.bostedsadresse
             }
         return bostedsadresser.firstOrNull { bostedsadresse -> bostedsadresse.utenlandskAdresse != null }?.utenlandskAdresse
+    }
+
+    fun hentGeografiskTilknytning(ident: String): GeografiskTilknytning? {
+        val pdlPersonRequest =
+            PdlPersonRequest(
+                variables = PdlPersonRequestVariables(ident),
+                query = hentGraphqlQuery("geografisk-tilknytning"),
+            )
+        val pdlResponse: PdlBaseResponse<PdlGeografiskTilknytningResponse> =
+            kallEksternTjeneste(
+                tjeneste = "pdl",
+                uri = pdlUri,
+                formål = "Hent geografisk tilknytning",
+            ) {
+                postForEntity(pdlUri, pdlPersonRequest, httpHeaders())
+            }
+
+        return feilsjekkOgReturnerData(
+            ident = ident,
+            pdlResponse = pdlResponse,
+        ) { it.geografiskTilknytning }
     }
 
     fun httpHeaders(): HttpHeaders =

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlGeografiskTilknytningResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlGeografiskTilknytningResponse.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.ba.sak.integrasjoner.pdl.domene
+
+data class PdlGeografiskTilknytningResponse(
+    val geografiskTilknytning: GeografiskTilknytning,
+)
+
+data class GeografiskTilknytning(
+    val gtType: String? = null,
+    val gtKommune: String? = null,
+)
+
+fun GeografiskTilknytning?.erSvalbard() = this != null && gtType == "KOMMUNE" && gtKommune == "2100"

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlGeografiskTilknytningResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlGeografiskTilknytningResponse.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.integrasjoner.pdl.domene
 
+private const val KOMMUNENUMMER_SVALBARD = "2100"
+
 data class PdlGeografiskTilknytningResponse(
     val geografiskTilknytning: GeografiskTilknytning,
 )
@@ -9,4 +11,4 @@ data class GeografiskTilknytning(
     val gtKommune: String? = null,
 )
 
-fun GeografiskTilknytning?.erSvalbard() = this != null && gtType == "KOMMUNE" && gtKommune == "2100"
+fun GeografiskTilknytning?.erSvalbard() = this != null && gtType == "KOMMUNE" && gtKommune == KOMMUNENUMMER_SVALBARD

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -643,7 +643,8 @@ class ForvalterController(
         summary = "Oppretter tasker som finner personer med bostedsadresse eller delt bosted i Finnmark/Nord-Troms eller oppholdsadresse på Svalbard",
     )
     fun opprettTaskerSomFinnerPersonerMedOppholdsadressePåSvalbard(
-        @RequestBody dryRun: Boolean = true,
+        @RequestParam dryRun: Boolean = true,
+        @RequestParam antallFagsaker: Int? = null,
     ): ResponseEntity<String> {
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
@@ -655,6 +656,7 @@ class ForvalterController(
                 val sisteIverksatteBehandlingerFraLøpendeFagsaker =
                     behandlingHentOgPersisterService
                         .hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
+                        .take(antallFagsaker ?: Int.MAX_VALUE)
 
                 val chunksMedPersoner =
                     sisteIverksatteBehandlingerFraLøpendeFagsaker
@@ -677,6 +679,8 @@ class ForvalterController(
                         if (!dryRun) taskService.save(task)
                     }.size
             }
+
+        logger.info("Brukte ${tid.inWholeSeconds} sekunder på å opprette $antallTasker tasker for å finne personer som bor i Finnmark, Nord-Troms eller på Svalbard")
 
         return ResponseEntity.ok("Brukte ${tid.inWholeSeconds} sekunder på å opprette $antallTasker tasker")
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardstillegg/FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardstillegg/FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask.kt
@@ -61,39 +61,38 @@ class FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask(
                                         .oppholdsadresse
                                         .oppholdsadresseErPåSvalbardPåDato(dato)
 
-                                val harDNummerOgGeografiskTilknytningTilSvalbard by lazy {
+                                val harDNummerOgGeografiskTilknytningTilSvalbard =
                                     Fødselsnummer(ident).erDNummer &&
                                         systemOnlyPdlRestClient
                                             .hentGeografiskTilknytning(ident)
                                             .erSvalbard()
-                                }
 
-                                if (harBostedsadresseIFinnmarkEllerNordTroms ||
-                                    harDeltBostedIFinnmarkEllerNordTroms ||
-                                    harOppholdsadressePåSvalbard ||
-                                    harDNummerOgGeografiskTilknytningTilSvalbard
+                                if (!harBostedsadresseIFinnmarkEllerNordTroms &&
+                                    !harDeltBostedIFinnmarkEllerNordTroms &&
+                                    !harOppholdsadressePåSvalbard &&
+                                    !harDNummerOgGeografiskTilknytningTilSvalbard
                                 ) {
-                                    val aktør = personidentService.hentAktør(ident)
-                                    val fagsakIder =
-                                        fagsakService
-                                            .finnAlleFagsakerHvorAktørErSøkerEllerMottarLøpendeOrdinær(aktør)
-                                            .map { it.id }
-
-                                    if (fagsakIder.isNotEmpty()) {
-                                        ident to
-                                            BorIFinnmarkNordTromsEllerPåSvalbard(
-                                                harBostedsadresseIFinnmarkNordTroms = harBostedsadresseIFinnmarkEllerNordTroms,
-                                                harDeltBostedIFinnmarkNordTroms = harDeltBostedIFinnmarkEllerNordTroms,
-                                                harOppholdsadressePåSvalbard = harOppholdsadressePåSvalbard,
-                                                harDNummerOgGeografiskTilknytningTilSvalbard = harDNummerOgGeografiskTilknytningTilSvalbard,
-                                                fagsakIder = fagsakIder,
-                                            )
-                                    } else {
-                                        null
-                                    }
-                                } else {
-                                    null
+                                    return@mapNotNull null
                                 }
+
+                                val aktør = personidentService.hentAktør(ident)
+                                val fagsakIder =
+                                    fagsakService
+                                        .finnAlleFagsakerHvorAktørErSøkerEllerMottarLøpendeOrdinær(aktør)
+                                        .map { it.id }
+
+                                if (fagsakIder.isEmpty()) {
+                                    return@mapNotNull null
+                                }
+
+                                ident to
+                                    BorIFinnmarkNordTromsEllerPåSvalbard(
+                                        harBostedsadresseIFinnmarkNordTroms = harBostedsadresseIFinnmarkEllerNordTroms,
+                                        harDeltBostedIFinnmarkNordTroms = harDeltBostedIFinnmarkEllerNordTroms,
+                                        harOppholdsadressePåSvalbard = harOppholdsadressePåSvalbard,
+                                        harDNummerOgGeografiskTilknytningTilSvalbard = harDNummerOgGeografiskTilknytningTilSvalbard,
+                                        fagsakIder = fagsakIder,
+                                    )
                             }
                     }.toMap()
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/bostedsadresse/BostedsadresserOgDelteBosteder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/bostedsadresse/BostedsadresserOgDelteBosteder.kt
@@ -16,10 +16,6 @@ data class BostedsadresserOgDelteBosteder(
     val bostedsadresser: List<Adresse>,
     val delteBosteder: List<Adresse>,
 ) {
-    fun bostedsadresseEllerDeltBostedErIFinnmarkEllerNordTromsPåDato(dato: LocalDate): Boolean =
-        bostedsadresser.hentForDato(dato)?.erIFinnmarkEllerNordTroms() ?: false ||
-            delteBosteder.hentForDato(dato)?.erIFinnmarkEllerNordTroms() ?: false
-
     fun harBostedsadresseEllerDeltBostedSomErRelevantForFinnmarkstillegg(): Boolean =
         bostedsadresser.filtrerUtAdresserSomErRelevanteForFinnmarkstillegg().any { it.erIFinnmarkEllerNordTroms() } ||
             delteBosteder.filtrerUtAdresserSomErRelevanteForFinnmarkstillegg().any { it.erIFinnmarkEllerNordTroms() }

--- a/src/main/resources/pdl/geografisk-tilknytning.graphql
+++ b/src/main/resources/pdl/geografisk-tilknytning.graphql
@@ -1,0 +1,6 @@
+query($ident: ID!) {
+    data: hentGeografiskTilknytning(ident: $ident) {
+        gtType
+        gtKommune
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25970

I tillegg til å hente personer med bostedsadresse/delt bosted i Finnmark/Nord-Troms eller oppholdsadresse på Svalbard, ønsker vi å sjekke hvor mange personer med D-nummer som har geografisk tilknytning til Svalbard
