### PR TITLE
Forvalterendepunkt som henter alle institusjoner på løpende fagsaker og sjekker om de er i finnmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250804113739_6d49ef6</prosessering.version>
         <felles.version>3.20250804101327_a0f5fad</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250819081736_d4884f9</eksterne-kontrakter-bisys.version>
-        <felles-kontrakter.version>3.0_20250805142725_8942276</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250819182959_b55d05b</felles-kontrakter.version>
         <familie.kontrakter.saksstatistikk>2.0_20250819081736_d4884f9</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20250819081736_d4884f9</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250415144931_0dc88d8</utbetalingsgenerator.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -77,6 +77,16 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
     ): Page<Long>
 
     @Query(
+        value = """SELECT distinct f.institusjon.orgNummer
+            FROM   Fagsak f
+            WHERE  f.status = 'LØPENDE' 
+            AND f.institusjon is not null
+            AND f.arkivert = false""",
+        nativeQuery = false,
+    )
+    fun finnOrgnummerForLøpendeFagsaker(): List<String>
+
+    @Query(
         value = """
             SELECT f.id
             FROM   Fagsak f

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -574,6 +574,8 @@ class FagsakService(
         return fagsakDeltagere
     }
 
+    fun finnOrgnummerForLøpendeFagsaker(): List<String> = fagsakRepository.finnOrgnummerForLøpendeFagsaker()
+
     companion object {
         private val logger = LoggerFactory.getLogger(FagsakService::class.java)
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Forvalterendepunkt som henter alle institusjoner på løpende fagsaker og sjekker om de er i finnmark. Dette fordi man ønsker en oversikt over omfanget av institusjoner som kvalifiserer for Finnmarkstillegget

Tar i bruk utvidelsen av kontrakten i
 https://github.com/navikt/familie-integrasjoner/pull/1153
