### PR TITLE
Lag spørring for å hente identer i løpende fagsaker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -302,6 +302,7 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
             INNER JOIN po_person p ON po.id = p.fk_gr_personopplysninger_id
             INNER JOIN personident ON personident.fk_aktoer_id = p.fk_aktoer_id
         WHERE personident.aktiv = true
+        ORDER BY b.id
         """,
         nativeQuery = true,
     )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -283,4 +283,27 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
         nativeQuery = true,
     )
     fun finnFagsakerMedFlereMigreringsbehandlinger(month: LocalDateTime): List<FagsakMedFlereMigreringer>
+
+    @Query(
+        """
+        WITH siste_iverksatte_behandling_for_løpende_fagsaker AS (
+            SELECT DISTINCT ON (b.fk_fagsak_id) b.id
+            FROM behandling b
+                INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
+                INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
+            WHERE f.status = 'LØPENDE'
+            AND ty.utbetalingsoppdrag IS NOT NULL
+            AND f.arkivert = false
+            ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC
+        )
+        SELECT DISTINCT personident.foedselsnummer
+        FROM siste_iverksatte_behandling_for_løpende_fagsaker b
+            INNER JOIN gr_personopplysninger po ON b.id = po.fk_behandling_id
+            INNER JOIN po_person p ON po.id = p.fk_gr_personopplysninger_id
+            INNER JOIN personident ON personident.fk_aktoer_id = p.fk_aktoer_id
+        WHERE personident.aktiv = true
+        """,
+        nativeQuery = true,
+    )
+    fun finnIdenterForLøpendeFagsaker(): List<String>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -576,6 +576,8 @@ class FagsakService(
 
     fun finnOrgnummerForLøpendeFagsaker(): List<String> = fagsakRepository.finnOrgnummerForLøpendeFagsaker()
 
+    fun finnIdenterForLøpendeFagsaker(): List<String> = fagsakRepository.finnIdenterForLøpendeFagsaker()
+
     companion object {
         private val logger = LoggerFactory.getLogger(FagsakService::class.java)
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25970

Uthenting av personer per behandling brukte altfor mye minne, så poden klarte ikke å håndtere det.
Flytter derfor joining av behandlinger med persongrunnlag inn i en egen spørring, som returnerer personidenter.
Forhåpentligvis bruker dette lite nok minne til at systemet kan håndtere det.
Spørringen bruker ~1 min 40 sek.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Ta gjerne en ekstra titt på at spørringen gir mening