### PR TITLE
Fiks navn på felt fra PDL

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlGeografiskTilknytningResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlGeografiskTilknytningResponse.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ba.sak.integrasjoner.pdl.domene
 private const val KOMMUNENUMMER_SVALBARD = "2100"
 
 data class PdlGeografiskTilknytningResponse(
-    val geografiskTilknytning: GeografiskTilknytning,
+    val geografiskTilknytning: GeografiskTilknytning?,
 )
 
 data class GeografiskTilknytning(

--- a/src/main/resources/pdl/geografisk-tilknytning.graphql
+++ b/src/main/resources/pdl/geografisk-tilknytning.graphql
@@ -1,5 +1,5 @@
 query($ident: ID!) {
-    data: hentGeografiskTilknytning(ident: $ident) {
+    geografiskTilknytning: hentGeografiskTilknytning(ident: $ident) {
         gtType
         gtKommune
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Variabelnavn i spørring mot PDL og i DTO er forskjellige.
Endrer så begge heter `geografiskTilknytning`.
Gjør også feltet nullable.