### PR TITLE
NAV-25971: Bruker siste vedtatte fremfor siste iverksatte behandling ved sjekk om utbetaling overstiger 100% for aktør i fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -152,7 +152,7 @@ class ForvalterService(
     fun sjekkChunkMedFagsakerOmDeHarUtbetalingerOver100Prosent(fagsaker: List<Long>) {
         fagsaker.forEach { fagsakId ->
             val sisteIverksatteBehandling =
-                behandlingRepository.finnSisteIverksatteBehandling(fagsakId = fagsakId)
+                behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId = fagsakId)
             if (sisteIverksatteBehandling != null) {
                 try {
                     tilkjentYtelseValideringService.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode(


### PR DESCRIPTION
Favro: [NAV-25971](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25971)

### 💰 Hva skal gjøres, og hvorfor?
Når vi sjekker alle fagsaker etter personer som mottar mer enn 100% barnetrygd, har vi frem til nå hentet ut siste iverksatte behandling i fagsak og sammenlignet denne med siste vedtatte behandling i andre fagsaker til personene i fagsaken. Dette har i noen tilfeller ført til at vi ser på utdaterte andeler ved sammenligningen. Ved å se på siste vedtatte behandling fremfor siste iverksatte sikrer vi at vi sammenligner de gjeldende andelene til enhver tid.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
