### PR TITLE
Hent ut id for alle løpende fagsaker i stedet for hele fagsaken

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -700,10 +700,12 @@ class ForvalterController(
             measureTimedValue {
                 val chunksMedFagsakIder =
                     fagsakService
-                        .hentLøpendeFagsaker()
-                        .map { it.id }
+                        .hentIdPåLøpendeFagsaker()
+                        .also { logger.info("Hentet ${it.size} fagsaker for løpende fagsaker") }
                         .take(antallFagsaker)
                         .chunked(chunkSize)
+
+                logger.info("Lagde ${chunksMedFagsakIder.size} chunks á $chunkSize fagsaker")
 
                 chunksMedFagsakIder
                     .onEachIndexed { index, fagsakIder ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -58,6 +58,10 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
 
     @Lock(LockModeType.NONE)
     @Query(value = "SELECT f.id from Fagsak f WHERE f.status = 'LØPENDE'  AND f.arkivert = false")
+    fun finnIdPåLøpendeFagsaker(): List<Long>
+
+    @Lock(LockModeType.NONE)
+    @Query(value = "SELECT f.id from Fagsak f WHERE f.status = 'LØPENDE'  AND f.arkivert = false")
     fun finnLøpendeFagsaker(page: Pageable): Slice<Long>
 
     @Query(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -301,6 +301,8 @@ class FagsakService(
 
     fun hentLøpendeFagsaker(): List<Fagsak> = fagsakRepository.finnLøpendeFagsaker()
 
+    fun hentIdPåLøpendeFagsaker(): List<Long> = fagsakRepository.finnIdPåLøpendeFagsaker()
+
     fun finnAlleFagsakerHvorAktørHarLøpendeYtelseAvType(
         aktør: Aktør,
         ytelseTyper: List<YtelseType>,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25970

Pod'en hadde ikke nok minne, så reduserer det ved å bare hente ut fagsak-id'en i stedet for hele fagsaken
Legger også på mer logging