### PR TITLE
Rekjøring av gamle tasker for Autobrev og Valutajustering ender ikke med en task i manuell oppfølging

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
@@ -20,7 +20,7 @@ import java.time.YearMonth
 @TaskStepBeskrivelse(
     taskStepType = MånedligValutajusteringTask.TASK_STEP_TYPE,
     beskrivelse = "månedlig valutajustering",
-    maxAntallFeil = 5,
+    maxAntallFeil = 6,
     settTilManuellOppfølgning = true,
 )
 class MånedligValutajusteringTask(
@@ -32,7 +32,7 @@ class MånedligValutajusteringTask(
     override fun doTask(task: Task) {
         val taskdto = objectMapper.readValue(task.payload, MånedligValutajusteringTaskDto::class.java)
 
-        if (!LocalDate.now().toYearMonth().equals(taskdto.måned)) {
+        if (!YearMonth.now().equals(taskdto.måned)) {
             logger.info("Task for månedlig valutajustering må kjøres innenfor måneden det skal sjekkes mot.")
         } else {
             autovedtakMånedligValutajusteringService.utførMånedligValutajustering(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
@@ -20,7 +20,7 @@ import java.time.YearMonth
 @TaskStepBeskrivelse(
     taskStepType = MånedligValutajusteringTask.TASK_STEP_TYPE,
     beskrivelse = "månedlig valutajustering",
-    maxAntallFeil = 3,
+    maxAntallFeil = 5,
     settTilManuellOppfølgning = true,
 )
 class MånedligValutajusteringTask(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTask.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.task
 
 import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
 import no.nav.familie.ba.sak.task.OpprettTaskService.Companion.overstyrTaskMedNyCallId
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -9,8 +10,10 @@ import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.time.YearMonth
 
 @Service
@@ -23,13 +26,20 @@ import java.time.YearMonth
 class MånedligValutajusteringTask(
     val autovedtakMånedligValutajusteringService: AutovedtakMånedligValutajusteringService,
 ) : AsyncTaskStep {
+    private val logger = LoggerFactory.getLogger(MånedligValutajusteringTask::class.java)
+
     @WithSpan
     override fun doTask(task: Task) {
         val taskdto = objectMapper.readValue(task.payload, MånedligValutajusteringTaskDto::class.java)
-        autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
-            fagsakId = taskdto.fagsakId,
-            måned = taskdto.måned,
-        )
+
+        if (!LocalDate.now().toYearMonth().equals(taskdto.måned)) {
+            logger.info("Task for månedlig valutajustering må kjøres innenfor måneden det skal sjekkes mot.")
+        } else {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+                fagsakId = taskdto.fagsakId,
+                måned = taskdto.måned,
+            )
+        }
     }
 
     data class MånedligValutajusteringTaskDto(

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTask.kt
@@ -12,6 +12,7 @@ import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.time.YearMonth
 
 @Service
 @TaskStepBeskrivelse(
@@ -30,7 +31,7 @@ class SendAutobrevPgaAlderTask(
     override fun doTask(task: Task) {
         val autobrevDTO = objectMapper.readValue(task.payload, AutobrevPgaAlderDTO::class.java)
 
-        if (!LocalDate.now().toYearMonth().equals(autobrevDTO.årMåned)) {
+        if (!YearMonth.now().equals(autobrevDTO.årMåned)) {
             logger.info("Task for autobrev må kjøres innenfor måneden det skal sjekkes mot.")
             task.metadata["resultat"] = "Ignorerer task, da den ikke kjøres i riktig måned"
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTask.kt
@@ -9,6 +9,7 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -23,16 +24,19 @@ import java.time.LocalDate
 class SendAutobrevPgaAlderTask(
     private val autobrevOmregningPgaAlderService: AutobrevOmregningPgaAlderService,
 ) : AsyncTaskStep {
+    private val logger = LoggerFactory.getLogger(SendAutobrevPgaAlderTask::class.java)
+
     @WithSpan
     override fun doTask(task: Task) {
         val autobrevDTO = objectMapper.readValue(task.payload, AutobrevPgaAlderDTO::class.java)
 
         if (!LocalDate.now().toYearMonth().equals(autobrevDTO.årMåned)) {
-            throw Feil("Task for autobrev må kjøres innenfor måneden det skal sjekkes mot.")
+            logger.info("Task for autobrev må kjøres innenfor måneden det skal sjekkes mot.")
+            task.metadata["resultat"] = "Ignorerer task, da den ikke kjøres i riktig måned"
+        } else {
+            task.metadata["resultat"] =
+                autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevDTO, task.opprettetTid).name
         }
-
-        task.metadata["resultat"] =
-            autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevDTO, task.opprettetTid).name
     }
 
     companion object {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTaskTest.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.domene.Task
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class MånedligValutajusteringTaskTest {
+    private val autovedtakMånedligValutajusteringService = mockk<AutovedtakMånedligValutajusteringService>(relaxed = true)
+    private val task = MånedligValutajusteringTask(autovedtakMånedligValutajusteringService)
+
+    @Test
+    fun `doTask utfører valutajustering når nåværende måned samsvarer med oppgavens måned`() {
+        val currentMonth = YearMonth.now()
+        val taskDto =
+            MånedligValutajusteringTask.MånedligValutajusteringTaskDto(
+                fagsakId = 123L,
+                måned = currentMonth,
+            )
+        val taskPayload = objectMapper.writeValueAsString(taskDto)
+        val taskInstance = Task(type = MånedligValutajusteringTask.TASK_STEP_TYPE, payload = taskPayload)
+
+        assertDoesNotThrow {
+            task.doTask(taskInstance)
+        }
+
+        verify {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
+                fagsakId = 123L,
+                måned = currentMonth,
+            )
+        }
+    }
+
+    @Test
+    fun `doTask logger info og utfører ikke valutajustering når nåværende måned ikke samsvarer med oppgavens måned`() {
+        val taskDto =
+            MånedligValutajusteringTask.MånedligValutajusteringTaskDto(
+                fagsakId = 123L,
+                måned = YearMonth.now().minusMonths(1),
+            )
+        val taskPayload = objectMapper.writeValueAsString(taskDto)
+        val taskInstance = Task(type = MånedligValutajusteringTask.TASK_STEP_TYPE, payload = taskPayload)
+
+        assertDoesNotThrow {
+            task.doTask(taskInstance)
+        }
+
+        verify(exactly = 0) {
+            autovedtakMånedligValutajusteringService.utførMånedligValutajustering(any(), any())
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTaskTest.kt
@@ -14,7 +14,7 @@ class MånedligValutajusteringTaskTest {
     private val task = MånedligValutajusteringTask(autovedtakMånedligValutajusteringService)
 
     @Test
-    fun `doTask utfører valutajustering når nåværende måned samsvarer med oppgavens måned`() {
+    fun `doTask utfører valutajustering når nåværende måned samsvarer med måned i paýload`() {
         val currentMonth = YearMonth.now()
         val taskDto =
             MånedligValutajusteringTask.MånedligValutajusteringTaskDto(
@@ -37,7 +37,7 @@ class MånedligValutajusteringTaskTest {
     }
 
     @Test
-    fun `doTask logger info og utfører ikke valutajustering når nåværende måned ikke samsvarer med oppgavens måned`() {
+    fun `doTask logger info og utfører ikke valutajustering når nåværende måned ikke samsvarer med måned i paýload`() {
         val taskDto =
             MånedligValutajusteringTask.MånedligValutajusteringTaskDto(
                 fagsakId = 123L,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTaskTest.kt
@@ -1,0 +1,55 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutobrevOmregningPgaAlderService
+import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutobrevOmregningSvar
+import no.nav.familie.ba.sak.task.dto.AutobrevPgaAlderDTO
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.domene.Task
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class SendAutobrevPgaAlderTaskTest {
+    private val autobrevOmregningPgaAlderService = mockk<AutobrevOmregningPgaAlderService>(relaxed = true)
+    private val sendAutobrevPgaAlderTask = SendAutobrevPgaAlderTask(autobrevOmregningPgaAlderService)
+
+    @Test
+    fun `ignorere gammel task når nåværende måned ikke samsvarer med måned i payload`() {
+        val autobrevDTO = AutobrevPgaAlderDTO(fagsakId = 1, alder = 18, årMåned = YearMonth.now().minusMonths(1))
+        val taskPayload = objectMapper.writeValueAsString(autobrevDTO)
+        val taskInstance = Task(type = SendAutobrevPgaAlderTask.TASK_STEP_TYPE, payload = taskPayload)
+
+        assertDoesNotThrow {
+            sendAutobrevPgaAlderTask.doTask(taskInstance)
+        }
+
+        verify(exactly = 0) {
+            autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(any(), any())
+        }
+        assert(taskInstance.metadata["resultat"] == "Ignorerer task, da den ikke kjøres i riktig måned")
+    }
+
+    @Test
+    fun `Kall opprettOmregningsoppgaveForBarnIBrytingsalder hvis dato i tasken er nåværendeMåned måned`() {
+        val nåværendeMåned = YearMonth.now()
+        val autobrevDTO = AutobrevPgaAlderDTO(fagsakId = 1, alder = 18, årMåned = nåværendeMåned)
+        val taskPayload = objectMapper.writeValueAsString(autobrevDTO)
+        val taskInstance = Task(type = SendAutobrevPgaAlderTask.TASK_STEP_TYPE, payload = taskPayload)
+
+        every {
+            autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(any(), any())
+        } returns AutobrevOmregningSvar.OK
+
+        assertDoesNotThrow {
+            sendAutobrevPgaAlderTask.doTask(taskInstance)
+        }
+
+        verify {
+            autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(any(), any())
+        }
+        assert(taskInstance.metadata["resultat"] == "OK")
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-25979
- **Ignorerer autobrev-task som er for gammel og som likevel bare må avvikhåndteres**
- **Ignorerer månedlig valutajustering som er gammel og som likevel bare må avvikhåndteres**
- **Øker maks antall feil på valutajustering, slik at det tar lengre tid før task kommer i manuell feilhåndtering. F.eks ved totrinnskontroll**

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
