### PR TITLE
NAV-26038: Ser på fagsak aktør sin behandlende enhet og tilpasser det i forhold til enhetene saksbehandler har tilgang til for oppretting av klage request

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -68,4 +68,7 @@ enum class FeatureToggle(
     AUTOMATISK_KJØRING_AV_AUTOVEDTAK_FINNMARKSTILLEGG("familie-ba-sak.kjoering-autovedtak-finnmarkstillegg"),
 
     KAN_KJØRE_AUTOVEDTAK_FINNMARKSTILLEGG("familie-ba-sak.kan-kjoere-autovedtak-finnmarkstillegg"),
+
+    // NAV-26038
+    BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING("familie-ba-sak.bruk-ny-logikk-for-aa-finne-enhet-for-oppretting-av-klagebehandling"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/domene/Arbeidsfordelingsenhet.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/domene/Arbeidsfordelingsenhet.kt
@@ -1,6 +1,16 @@
 package no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene
 
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
+
 data class Arbeidsfordelingsenhet(
     val enhetId: String,
     val enhetNavn: String,
-)
+) {
+    companion object {
+        fun opprettFra(enhet: BarnetrygdEnhet): Arbeidsfordelingsenhet =
+            Arbeidsfordelingsenhet(
+                enhetId = enhet.enhetsnummer,
+                enhetNavn = enhet.enhetsnavn,
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
@@ -71,18 +71,12 @@ class TilpassArbeidsfordelingService(
         val navIdentHarKunTilgangTilVikafossen = enheterNavIdentHarTilgangTil.map { it.enhetsnummer }.containsExactly(BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer)
         if (navIdentHarKunTilgangTilVikafossen) {
             // Skal kun være lovt til å sette Vikafossen når det er eneste valgmulighet
-            return Arbeidsfordelingsenhet(
-                BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-            )
+            return Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
         }
         val enheterNavIdentHarTilgangTilForutenVikafossen = enheterNavIdentHarTilgangTil.filter { it.enhetsnummer != BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer }
         // Velger bare det første enhetsnummeret i tilfeller hvor man har flere, avklart med fag
         val nyBehandlendeEnhet = enheterNavIdentHarTilgangTilForutenVikafossen.first()
-        return Arbeidsfordelingsenhet(
-            nyBehandlendeEnhet.enhetsnummer,
-            nyBehandlendeEnhet.enhetsnavn,
-        )
+        return Arbeidsfordelingsenhet.opprettFra(nyBehandlendeEnhet)
     }
 
     private fun håndterVikafossenEnhet2103(
@@ -92,10 +86,7 @@ class TilpassArbeidsfordelingService(
             logger.error("Kan ikke håndtere ${BarnetrygdEnhet.VIKAFOSSEN} om man mangler NAV-ident.")
             throw Feil("Kan ikke håndtere ${BarnetrygdEnhet.VIKAFOSSEN} om man mangler NAV-ident.")
         }
-        return Arbeidsfordelingsenhet(
-            BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-            BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-        )
+        return Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
     }
 
     private fun håndterAndreEnheter(
@@ -104,10 +95,7 @@ class TilpassArbeidsfordelingService(
     ): Arbeidsfordelingsenhet {
         if (navIdent == null || navIdent.erSystemIdent()) {
             // navIdent er null ved automatisk journalføring
-            return Arbeidsfordelingsenhet(
-                arbeidsfordelingsenhet.enhetId,
-                arbeidsfordelingsenhet.enhetNavn,
-            )
+            return arbeidsfordelingsenhet
         }
         val enheterNavIdentHarTilgangTil = integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent)
         if (enheterNavIdentHarTilgangTil.isEmpty()) {
@@ -118,25 +106,16 @@ class TilpassArbeidsfordelingService(
         val navIdentHarKunTilgangTilVikafossen = enheterNavIdentHarTilgangTil.map { it.enhetsnummer }.containsExactly(BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer)
         if (navIdentHarKunTilgangTilVikafossen) {
             // Skal kun være lovt til å sette Vikafossen når det er eneste valgmulighet
-            return Arbeidsfordelingsenhet(
-                BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-            )
+            return Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
         }
         val enheterNavIdentHarTilgangTilForutenVikafossen = enheterNavIdentHarTilgangTil.filter { it.enhetsnummer != BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer }
         val harTilgangTilBehandledeEnhet = enheterNavIdentHarTilgangTilForutenVikafossen.any { it.enhetsnummer == arbeidsfordelingsenhet.enhetId }
         if (!harTilgangTilBehandledeEnhet) {
             // Velger bare det første enhetsnummeret i tilfeller hvor man har flere, avklart med fag
             val nyBehandlendeEnhet = enheterNavIdentHarTilgangTilForutenVikafossen.first()
-            return Arbeidsfordelingsenhet(
-                nyBehandlendeEnhet.enhetsnummer,
-                nyBehandlendeEnhet.enhetsnavn,
-            )
+            return Arbeidsfordelingsenhet.opprettFra(nyBehandlendeEnhet)
         }
-        return Arbeidsfordelingsenhet(
-            arbeidsfordelingsenhet.enhetId,
-            arbeidsfordelingsenhet.enhetNavn,
-        )
+        return arbeidsfordelingsenhet
     }
 
     private fun NavIdent.erSystemIdent(): Boolean = this.ident == SYSTEM_FORKORTELSE

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingOppretter.kt
@@ -1,0 +1,97 @@
+package no.nav.familie.ba.sak.kjerne.klage
+
+import no.nav.familie.ba.sak.common.ClockProvider
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.TilpassArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.klage.dto.OpprettKlageDto
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.kontrakter.felles.NavIdent
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
+import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.util.UUID
+
+@Component
+class KlagebehandlingOppretter(
+    private val fagsakService: FagsakService,
+    private val klageClient: KlageClient,
+    private val integrasjonClient: IntegrasjonClient,
+    private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
+    private val clockProvider: ClockProvider,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
+) {
+    private val logger = LoggerFactory.getLogger(KlagebehandlingOppretter::class.java)
+
+    fun opprettKlage(
+        fagsakId: Long,
+        opprettKlageDto: OpprettKlageDto,
+    ): UUID {
+        val fagsak = fagsakService.hentPåFagsakId(fagsakId)
+        return opprettKlage(fagsak, opprettKlageDto.klageMottattDato)
+    }
+
+    fun opprettKlage(
+        fagsak: Fagsak,
+        klageMottattDato: LocalDate,
+    ): UUID {
+        if (klageMottattDato.isAfter(LocalDate.now(clockProvider.get()))) {
+            throw FunksjonellFeil("Kan ikke opprette klage med krav mottatt frem i tid.")
+        }
+
+        val fødselsnummer = fagsak.aktør.aktivFødselsnummer()
+        val navIdent = NavIdent(SikkerhetContext.hentSaksbehandler())
+
+        val behandlendeEnhet =
+            if (unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING)) {
+                val arbeidsfordelingsenheter = integrasjonClient.hentBehandlendeEnhet(fødselsnummer)
+
+                if (arbeidsfordelingsenheter.isEmpty()) {
+                    logger.error("Fant ingen arbeidsfordelingsenheter for aktør. Se SecureLogs for detaljer.")
+                    secureLogger.error("Fant ingen arbeidsfordelingsenheter for aktør $fødselsnummer.")
+                    throw Feil("Fant ingen arbeidsfordelingsenhet for aktør.")
+                }
+
+                if (arbeidsfordelingsenheter.size > 1) {
+                    logger.error("Fant flere arbeidsfordelingsenheter for aktør. Se SecureLogs for detaljer.")
+                    secureLogger.error("Fant flere arbeidsfordelingsenheter for aktør $fødselsnummer.")
+                    throw Feil("Fant flere arbeidsfordelingsenheter for aktør.")
+                }
+
+                val tilpassetArbeidsfordelingsenhet =
+                    tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(
+                        arbeidsfordelingsenheter.single(),
+                        navIdent,
+                    )
+
+                tilpassetArbeidsfordelingsenhet.enhetId
+            } else {
+                integrasjonClient
+                    .hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
+                    .first()
+                    .enhetsnummer
+            }
+
+        return klageClient.opprettKlage(
+            OpprettKlagebehandlingRequest(
+                ident = fødselsnummer,
+                stønadstype = Stønadstype.BARNETRYGD,
+                eksternFagsakId = fagsak.id.toString(),
+                fagsystem = Fagsystem.BA,
+                klageMottatt = klageMottattDato,
+                behandlendeEnhet = behandlendeEnhet,
+                behandlingsårsak = Klagebehandlingsårsak.ORDINÆR,
+            ),
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/domene/ArbeidsfordelingsenhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/domene/ArbeidsfordelingsenhetTest.kt
@@ -1,0 +1,23 @@
+package no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene
+
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class ArbeidsfordelingsenhetTest {
+    @Nested
+    inner class OpprettFra {
+        @ParameterizedTest
+        @EnumSource(BarnetrygdEnhet::class)
+        fun `skal opprette arbeidsfordelingsenhet fra barnetrygdenhet`(enhet: BarnetrygdEnhet) {
+            // Act
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(enhet)
+
+            // Assert
+            assertThat(arbeidsfordelingsenhet.enhetId).isEqualTo(enhet.enhetsnummer)
+            assertThat(arbeidsfordelingsenhet.enhetNavn).isEqualTo(enhet.enhetsnavn)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
@@ -25,11 +25,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal kaste feil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident er null`() {
             // Arrange
-            val arbeidsfordelingPåBehandling =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingPåBehandling = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.MIDLERTIDIG_ENHET)
 
             // Act & assert
             val exception =
@@ -45,11 +41,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal kaste midlertidigEnhetIAutomatiskBehandlingFeil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident er systembruker`() {
             // Arrange
-            val arbeidsfordelingPåBehandling =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingPåBehandling = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.MIDLERTIDIG_ENHET)
 
             // Act & assert
             val exception =
@@ -67,11 +59,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.MIDLERTIDIG_ENHET)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
@@ -93,11 +81,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.MIDLERTIDIG_ENHET)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
@@ -122,13 +106,8 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
 
             val enhetNavIdentHarTilgangTil1 = BarnetrygdEnhet.OSLO
-            val enhetNavIdentHarTilgangTil2 = BarnetrygdEnhet.DRAMMEN
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.MIDLERTIDIG_ENHET)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
@@ -155,11 +134,7 @@ class TilpassArbeidsfordelingServiceTest {
         fun `skal kaste feil hvis arbeidsfordeling returnerer Vikafossen 2103 og NAV-ident er null`() {
             // Arrange
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
 
             // Act & assert
             val exception =
@@ -177,14 +152,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val enhetNavIdentHarTilgangTil1 = BarnetrygdEnhet.STEINKJER
-            val enhetNavIdentHarTilgangTil2 = BarnetrygdEnhet.VADSØ
-
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
@@ -211,11 +179,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
@@ -318,11 +282,7 @@ class TilpassArbeidsfordelingServiceTest {
 
             val enhetNavIdentHarTilgangTil1 = BarnetrygdEnhet.OSLO
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.STEINKJER.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.STEINKJER.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.STEINKJER)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
@@ -352,11 +312,7 @@ class TilpassArbeidsfordelingServiceTest {
 
             val arbeidsfordelingEnhet = BarnetrygdEnhet.OSLO
 
-            val arbeidsfordelingPåBehandling =
-                Arbeidsfordelingsenhet(
-                    enhetId = arbeidsfordelingEnhet.enhetsnummer,
-                    enhetNavn = arbeidsfordelingEnhet.enhetsnavn,
-                )
+            val arbeidsfordelingPåBehandling = Arbeidsfordelingsenhet.opprettFra(arbeidsfordelingEnhet)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
@@ -406,11 +362,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere navIdent dersom navIdent har tilgang til arbeidsfordelingsenhet`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
@@ -427,11 +379,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere null dersom navIdent ikke har tilgang til arbeidsfordelingsenhet`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
@@ -448,11 +396,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere null dersom navIdent er null`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
             val navIdent = null
 
             // Act
@@ -466,11 +410,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere null dersom vi er i systemkontekst`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = BarnetrygdEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VIKAFOSSEN)
             val navIdent = NavIdent(SYSTEM_FORKORTELSE)
 
             // Act

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
@@ -1,0 +1,217 @@
+package no.nav.familie.ba.sak.kjerne.klage
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.ba.sak.TestClockProvider
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.config.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonClient
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.TilpassArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.klage.dto.OpprettKlageDto
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
+import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.util.UUID
+
+class KlagebehandlingOppretterTest {
+    private val dagensDato = LocalDate.of(2025, 8, 25)
+
+    private val fagsakService = mockk<FagsakService>()
+    private val klageClient = mockk<KlageClient>()
+    private val integrasjonClient = mockk<IntegrasjonClient>()
+    private val tilpassArbeidsfordelingService = mockk<TilpassArbeidsfordelingService>()
+    private val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensDato)
+    private val unleash = mockk<UnleashNextMedContextService>()
+
+    private val klagebehandlingOppretter =
+        KlagebehandlingOppretter(
+            fagsakService,
+            klageClient,
+            integrasjonClient,
+            tilpassArbeidsfordelingService,
+            clockProvider,
+            unleash,
+        )
+
+    @BeforeEach
+    fun setup() {
+        every { unleash.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING) } returns true
+    }
+
+    @Nested
+    inner class OpprettKlage {
+        @Test
+        fun `skal kaste exception hvis klagebehandlingen blir mottatt etter dagens dato`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato.plusDays(1)
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+                }
+            assertThat(exception.message).isEqualTo("Kan ikke opprette klage med krav mottatt frem i tid.")
+        }
+
+        @Test
+        fun `skal kaste exception om man ikke finner en behandlende enhet for aktør`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+
+            every { integrasjonClient.hentBehandlendeEnhet(fagsak.aktør.aktivFødselsnummer()) } returns emptyList()
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+                }
+            assertThat(exception.message).isEqualTo("Fant ingen arbeidsfordelingsenhet for aktør.")
+        }
+
+        @Test
+        fun `skal kaste exception om man ikke finner flere behandlende enheter for aktør`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+
+            every { integrasjonClient.hentBehandlendeEnhet(fagsak.aktør.aktivFødselsnummer()) } returns
+                listOf(
+                    Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.OSLO),
+                    Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VADSØ),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+                }
+            assertThat(exception.message).isEqualTo("Fant flere arbeidsfordelingsenheter for aktør.")
+        }
+
+        @Test
+        fun `skal opprette klage ved å sende inn kun fagsakId som parameter`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val opprettKlageDto = OpprettKlageDto(dagensDato)
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.OSLO)
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { fagsakService.hentPåFagsakId(fagsak.id) } returns fagsak
+            every { integrasjonClient.hentBehandlendeEnhet(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+            every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns arbeidsfordelingsenhet
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak.id, opprettKlageDto)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.BARNETRYGD)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.BA)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(arbeidsfordelingsenhet.enhetId)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+
+        @Test
+        fun `skal lage OpprettKlageRequest uten å tilpasse enhetsnummeret fra fagsak aktør`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.OSLO)
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { integrasjonClient.hentBehandlendeEnhet(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+            every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns arbeidsfordelingsenhet
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.BARNETRYGD)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.BA)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(arbeidsfordelingsenhet.enhetId)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+
+        @Test
+        fun `skal lage OpprettKlageRequest og tilpasse enhetsnummeret fra fagsak aktør basert på tilgangene til saksbehandler`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.OSLO)
+            val tilpassetArbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(BarnetrygdEnhet.VADSØ)
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { integrasjonClient.hentBehandlendeEnhet(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+            every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns tilpassetArbeidsfordelingsenhet
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.BARNETRYGD)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.BA)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(tilpassetArbeidsfordelingsenhet.enhetId)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+
+        @Test
+        fun `skal lage OpprettKlageRequest hvor behandlendeEnhet er satt til saksbehandlers enhet når toggle er av`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { unleash.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING) } returns false
+            every { integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(any()) } returns listOf(BarnetrygdEnhet.OSLO, BarnetrygdEnhet.VIKAFOSSEN)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.BARNETRYGD)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.BA)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(BarnetrygdEnhet.OSLO.enhetsnummer)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26038

Når vi velger enhet for opprett klage requesten må vi se på hvilken enhet som tilhører fagsak aktør før vi deretter tilpasser det i forhold til enhetene saksbehandler har tilgang til. 

Endringene er gjemt bak en toggle.

Relatert PR for KS: https://github.com/navikt/familie-ks-sak/pull/1397

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
