### PR TITLE
Nedgrader surefire fordi 3.5.3 har en bug som gjør at den ikke plukker opp Cucumber feil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.2</version>
                 <configuration>
                     <!-- exclude tags -->
                     <!--suppress UnresolvedMavenProperty -->


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Feil i cucumber plukkes ikke opp. Dette pga en bug i surefire i 3.5.3. 
Diskuteres her: https://github.com/cucumber/cucumber-jvm/issues/2984

Etter nedgradering
<img width="1003" height="129" alt="image" src="https://github.com/user-attachments/assets/fc7f443c-8172-44ff-84f4-14dc3b6a76aa" />

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇