### PR TITLE
Ikke marker det som en endring hvis søknadstidspunkt i endret utbetaling andel har blitt justert og det fantes fra før

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -15,11 +15,14 @@ object EndringIEndretUtbetalingAndelUtil {
 
         val endringerTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
-                (
-                    nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted ||
-                        nåværende?.årsak != forrige?.årsak ||
-                        nåværende?.søknadstidspunkt != forrige?.søknadstidspunkt
-                )
+                val endringIAvtaletidspunktDeltBosted = nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted
+                val endringIÅrsak = nåværende?.årsak != forrige?.årsak
+                val endringISøknadstidspunkt = nåværende?.søknadstidspunkt != forrige?.søknadstidspunkt
+                val haddeTidligereIkkeSøknadstidspunkt = forrige?.søknadstidspunkt == null
+
+                endringIAvtaletidspunktDeltBosted ||
+                    endringIÅrsak ||
+                    (endringISøknadstidspunkt && haddeTidligereIkkeSøknadstidspunkt)
             }
 
         return endringerTidslinje

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -988,7 +988,7 @@ class BehandlingsresultatEndringUtilsTest {
     }
 
     @Test
-    fun `Endring i endret utbetaling andel - skal returnere true hvis søknadstidspunkt er endret`() {
+    fun `Endring i endret utbetaling andel - skal returnere true hvis søknadstidspunkt er endret og det ikke var satt før`() {
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -997,7 +997,7 @@ class BehandlingsresultatEndringUtilsTest {
                 fom = jan22,
                 tom = aug22,
                 årsak = Årsak.DELT_BOSTED,
-                søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
+                søknadstidspunkt = null,
                 avtaletidspunktDeltBosted = jan22.førsteDagIInneværendeMåned(),
             )
 

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/EndretUtbetalingGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/EndretUtbetalingGenerator.kt
@@ -32,7 +32,7 @@ fun lagEndretUtbetalingAndel(
     tom: YearMonth? = YearMonth.now(),
     årsak: Årsak = Årsak.DELT_BOSTED,
     avtaletidspunktDeltBosted: LocalDate = LocalDate.now().minusMonths(1),
-    søknadstidspunkt: LocalDate = LocalDate.now().minusMonths(1),
+    søknadstidspunkt: LocalDate? = LocalDate.now().minusMonths(1),
 ) = EndretUtbetalingAndel(
     id = id,
     behandlingId = behandlingId,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26086

Nå som vi autogenerer endret utbetaling andeler og setter søknadstidspunkt, så vil man alltid få "ENDRET" i nye behandlinger, fordi søknadstidspunktet blir oppdatert.

Dette trigger en endring i behandlingsresultatet, noe som er feil.
Endrer på logikken slik at det bare trigger en endring, dersom det ikke var satt fra før i en periode.
Dette kan skje dersom fom/tom blir justert.