### PR TITLE
fjern aktørId-felt i StatusFraOppdragDTO.kt som ikke blir brukt til noe

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StatusFraOppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/StatusFraOppdrag.kt
@@ -78,7 +78,7 @@ class StatusFraOppdrag(
     private fun opprettFerdigstillBehandling(statusFraOppdragDTO: StatusFraOppdragDTO) {
         val ferdigstillBehandling =
             FerdigstillBehandlingTask.opprettTask(
-                søkerIdent = statusFraOppdragDTO.aktørId ?: statusFraOppdragDTO.personIdent,
+                søkerIdent = statusFraOppdragDTO.personIdent,
                 behandlingsId = statusFraOppdragDTO.behandlingsId,
             )
         taskRepository.save(ferdigstillBehandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdragTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/IverksettMotOppdragTask.kt
@@ -45,7 +45,6 @@ class IverksettMotOppdragTask(
             StatusFraOppdragTask.opprettTask(
                 StatusFraOppdragDTO(
                     personIdent = personIdent,
-                    aktørId = null,
                     fagsystem = FAGSYSTEM,
                     behandlingsId = iverksettingTask.behandlingsId,
                     vedtaksId = iverksettingTask.vedtaksId,

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/dto/StatusFraOppdragDTO.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/dto/StatusFraOppdragDTO.kt
@@ -6,7 +6,6 @@ data class StatusFraOppdragDTO(
     val fagsystem: String,
     // OppdragId trenger personIdent
     val personIdent: String,
-    val aktørId: String?,
     val behandlingsId: Long,
     val vedtaksId: Long,
 ) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/HentStatusTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/HentStatusTest.kt
@@ -156,7 +156,6 @@ class HentStatusTest {
             StatusFraOppdragDTO(
                 fagsystem = "BA",
                 personIdent = tilfeldigPerson.aktør.aktivFødselsnummer(),
-                aktørId = "Søker1",
                 behandlingsId = nyBehandling.id,
                 vedtaksId = 0L,
             ),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Utils.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/Utils.kt
@@ -187,7 +187,6 @@ fun håndterIverksettingAvBehandling(
                     StatusFraOppdragDTO(
                         fagsystem = FAGSYSTEM,
                         personIdent = søkerFnr,
-                        aktørId = behandlingEtterVurdering.fagsak.aktør.aktørId,
                         behandlingsId = behandlingEtterIverksetteVedtak.id,
                         vedtaksId = vedtak.id,
                     ),

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/kjørbehandling/KjørStegprosessForBehandlingGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/kjørbehandling/KjørStegprosessForBehandlingGenerator.kt
@@ -219,7 +219,6 @@ private fun håndterStatusFraOppdragSteg(
                 StatusFraOppdragDTO(
                     fagsystem = FAGSYSTEM,
                     personIdent = søkerFnr,
-                    aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktørId,
                     behandlingsId = behandlingEtterIverksetteVedtak.id,
                     vedtaksId = vedtak!!.id,
                 ),
@@ -459,7 +458,6 @@ fun kjørStegprosessForFGB(
                     StatusFraOppdragDTO(
                         fagsystem = FAGSYSTEM,
                         personIdent = søkerFnr,
-                        aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktivFødselsnummer(),
                         behandlingsId = behandlingEtterIverksetteVedtak.id,
                         vedtaksId = vedtak.id,
                     ),
@@ -597,7 +595,6 @@ fun kjørStegprosessForRevurderingÅrligKontroll(
                     StatusFraOppdragDTO(
                         fagsystem = FAGSYSTEM,
                         personIdent = søkerFnr,
-                        aktørId = behandlingEtterIverksetteVedtak.fagsak.aktør.aktørId,
                         behandlingsId = behandlingEtterIverksetteVedtak.id,
                         vedtaksId = vedtak.id,
                     ),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
AktørId-feltet i StatusFraOppdragDTO blir ikke brukt til noe og kan fjernes nå som det ikke er noen tasker som har feltet satt lenger. 

