### PR TITLE
Vi forbedrer feilmelding ved ingen rett til utvidet barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdGenerator.kt
@@ -56,7 +56,7 @@ data class UtvidetBarnetrygdGenerator(
 
         if (utvidetAndeler.isEmpty()) {
             throw FunksjonellFeil(
-                "Du har lagt til utvidet barnetrygd for en periode der det ikke er rett til barnetrygd for " +
+                "Du har lagt til utvidet barnetrygd for en periode der det ikke er rett til utvidet barnetrygd for " +
                     "noen av barna. Hvis du trenger hjelp, meld sak i Porten.",
             )
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
@@ -81,7 +81,7 @@ class UtvidetBarnetrygdUtilTest {
                     testBeregnUtvidet.med(UtdypendeVilkårsvurdering.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER)
                 }.melding
 
-        val forventetFeilmelding = "Du har lagt til utvidet barnetrygd for en periode der det ikke er rett til barnetrygd"
+        val forventetFeilmelding = "Du har lagt til utvidet barnetrygd for en periode der det ikke er rett til utvidet barnetrygd"
 
         assertTrue(forventetFeilmelding in feilmeldinger.first && forventetFeilmelding in feilmeldinger.second)
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26088

Denne feilmeldingen kastes når man har satt rett til utvidet en periode, men ikke får noen utvidet andeler i perioden.
Etter diskusjon med Anna forbedrer vi på feilmeldingen som kastes slik at det er klart at det er utvidet barnetrygd det gjelder, da SB kan ha misforstått at man ikke har rett til noe barnetrygd i det hele tatt.