### PR TITLE
Vi skal ikke generere endret utbetaling andeler når det allerede finnes eksisterende andeler i samme periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -161,6 +161,7 @@ class EndretUtbetalingAndelService(
         val forrigeAndeler = beregningService.hentAndelerFraForrigeIverksattebehandling(behandling)
         val personIdenter = (nåværendeAndeler + forrigeAndeler).map { it.aktør.aktivFødselsnummer() }.distinct()
         val personerPåBehandling = persongrunnlagService.hentPersonerPåBehandling(personIdenter, behandling)
+        val nåværendeEndretUtbetalingAndeler = endretUtbetalingAndelRepository.findByBehandlingId(behandling.id)
 
         val endretUtbetalingAndeler =
             genererEndretUtbetalingAndelerMedÅrsakEtterbetaling3ÅrEller3Mnd(
@@ -169,6 +170,7 @@ class EndretUtbetalingAndelService(
                 nåværendeAndeler = nåværendeAndeler,
                 forrigeAndeler = forrigeAndeler,
                 personerPåBehandling = personerPåBehandling,
+                nåværendeEndretUtbetalingAndeler = nåværendeEndretUtbetalingAndeler,
             )
 
         endretUtbetalingAndelRepository.saveAllAndFlush(endretUtbetalingAndeler)


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26101

Vi har en bug i automatisk generering av endret utbetaling som låser opp hele behandlingen.

Dette skjer når man har en endret utbetaling andel med delt bosted som ikke skal utbetales, men deretter skiftes over til at den skal utbetales ved å endre utdypende vilkårsvurdering. Det vil da bli generert endret utbetaling andeler for perioden, men siden det allerede eksisterer en endret utbetaling andel for samme periode vil det oppstå overlapp.

Fikser det slik at vi bare automatisk genererer endret utbetaling andel for personer som ikke allerede har en eksisterende endret andel i samme periode.



