### PR TITLE
Rull Finnmarkstillegg-behandling tilbake hvis 'Bosatt i riket'-vilkår ikke er endret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -10,6 +10,10 @@ import java.time.LocalDateTime
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
+class FinnmarkstilleggIngenEndringFeil(
+    message: String,
+) : RuntimeException(message)
+
 open class Feil(
     message: String,
     open val frontendFeilmelding: String? = null,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.Standardbegrunnelse
 import no.nav.familie.ba.sak.task.dto.ManuellOppgaveType
 import no.nav.familie.prosessering.error.RekjørSenereException
 import no.nav.familie.util.VirkedagerProvider
+import no.nav.familie.util.VirkedagerProvider.nesteVirkedag
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -131,6 +132,7 @@ class AutovedtakStegService(
             førstegangKjørt = førstegangKjørt,
         )
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun kjørBehandlingFinnmarkstillegg(
         mottakersAktør: Aktør,
         fagsakId: Long,
@@ -241,6 +243,11 @@ class AutovedtakStegService(
                         årsak = autovedtaktype.tilMaskinellVentÅrsak(),
                     )
                     return false
+                } else if (autovedtaktype == Autovedtaktype.FINNMARKSTILLEGG) {
+                    throw RekjørSenereException(
+                        årsak = "Åpen behandling med status ${åpenBehandling.status} ble endret for under fire timer siden. Prøver igjen klokken 06.00 neste virkedag",
+                        triggerTid = nesteVirkedag(LocalDate.now()).atTime(6, 0),
+                    )
                 }
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggTask.kt
@@ -1,11 +1,14 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg
 
 import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.ba.sak.common.FinnmarkstilleggIngenEndringFeil
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -23,14 +26,22 @@ class AutovedtakFinnmarkstilleggTask(
     override fun doTask(task: Task) {
         val fagsakId = task.payload.toLong()
         val aktør = fagsakService.hentAktør(fagsakId)
-        autovedtakStegService.kjørBehandlingFinnmarkstillegg(
-            mottakersAktør = aktør,
-            fagsakId = fagsakId,
-            førstegangKjørt = task.opprettetTid,
-        )
+        val resultat =
+            try {
+                autovedtakStegService.kjørBehandlingFinnmarkstillegg(
+                    mottakersAktør = aktør,
+                    fagsakId = fagsakId,
+                    førstegangKjørt = task.opprettetTid,
+                )
+            } catch (e: FinnmarkstilleggIngenEndringFeil) {
+                "Finnmarkstillegg: ${e.message}"
+            }
+
+        logger.info(resultat)
     }
 
     companion object {
         const val TASK_STEP_TYPE = "autovedtakFinnmarkstilleggTask"
+        private val logger: Logger = LoggerFactory.getLogger(AutovedtakFinnmarkstilleggTask::class.java)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -574,6 +574,7 @@ class CucumberMock(
             vilkårsvurderingForNyBehandlingService = vilkårsvurderingForNyBehandlingService,
             personopplysningGrunnlagForNyBehandlingService = personopplysningGrunnlagForNyBehandlingService,
             eøsSkjemaerForNyBehandlingService = eøsSkjemaerForNyBehandlingService,
+            vilkårService = vilkårService,
         )
 
     val månedligValutajusteringService = MånedligValutajusteringService(ecbService = ecbService, valutakursService = valutakursService)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-26129

Autovedtak Finnmarkstillegg opprettes ved adresseendringer i PDL. Dersom behandlingen ikke har noen endringer i vilkårsvurderingen, vet vi at forrige behandling var oppdatert med siste adresser for alle personer, og ønsker ikke å fullføre behandlingen.

- Legger til ny exception-klasse `FinnmarkstilleggIngenEndringFeil`
- Legger til validering på at `Bosatt i riket`-vilkåret er endret i postvalideringen i `Registrere persongrunnlag`-steget, som kaster `FinnmarkstilleggIngenEndringFeil`
- Legger til `@Transactional(propagation = Propagation.REQUIRES_NEW)` på `AutovedtakStegService::kjørBehandlingFinnmarkstillegg`, slik at "snike i køen"-logikken også rulles tilbake hvis det kastes en feil.
- Kjører autovedtak Finnmarkstillegg inni en `try/catch`, som bare catcher `FinnmarkstilleggIngenEndringFeil`, slik at tasken ferdigstilles. Hvis andre feil kastes vil tasken feile.

