### PR TITLE
Fix: Sørger for at vi alltid har en gyldig verdi i feltet utbetalingsoppdrag på TilkjentYtelse i tester

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.randomFnr
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.IdentInformasjon
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
@@ -106,7 +107,7 @@ internal class BisysServiceTest {
     fun `Skal returnere utvidet barnetrygdperiode fra basak`() {
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling).copy(utbetalingsoppdrag = "utbetalt")
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
 
         val andelTilkjentYtelse =
             lagAndelTilkjentYtelseUtvidet(
@@ -145,7 +146,7 @@ internal class BisysServiceTest {
     fun `Skal slå sammen resultat fra ba-sak og infotrygd`() {
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling).copy(utbetalingsoppdrag = "utbetalt")
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
 
         val kalkulertbeløp = 660
         val andelTilkjentYtelse =
@@ -201,7 +202,7 @@ internal class BisysServiceTest {
     fun `Skal slå sammen resultat fra ba-sak og infotrygd når periodene overlapper`() {
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling).copy(utbetalingsoppdrag = "utbetalt")
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
 
         val andelTilkjentYtelse =
             lagAndelTilkjentYtelseUtvidet(
@@ -256,7 +257,7 @@ internal class BisysServiceTest {
     fun `Skal slå sammen resultat fra ba-sak og infotrygd, typisk rett etter en migrering, hvor tomMåned i infotrygd er null`() {
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling).copy(utbetalingsoppdrag = "utbetalt")
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
 
         val andelTilkjentYtelse =
             lagAndelTilkjentYtelseUtvidet(
@@ -311,7 +312,11 @@ internal class BisysServiceTest {
     fun `Skal ikke slå sammen resultat fra ba-sak og infotrygd hvis periode er manuelt beregnet i infotrygd`() {
         val behandling = lagBehandling()
 
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling).copy(utbetalingsoppdrag = "utbetalt")
+        val tilkjentYtelse =
+            lagInitiellTilkjentYtelse(
+                behandling = behandling,
+                utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id),
+            )
 
         val andelTilkjentYtelse =
             lagAndelTilkjentYtelseUtvidet(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BeregnetUtbetalingsoppdragDataGenerator.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BeregnetUtbetalingsoppdragDataGenerator.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag
 
+import no.nav.familie.ba.sak.integrasjoner.økonomi.lagUtbetalingsperiode
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.Opphør
 import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag
 import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode
+import no.nav.familie.kontrakter.felles.objectMapper
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -17,6 +19,25 @@ fun lagBeregnetUtbetalingsoppdragLongId(
     BeregnetUtbetalingsoppdragLongId(
         lagUtbetalingsoppdrag(utbetalingsperioder),
         andeler = andeler,
+    )
+
+fun lagMinimalUtbetalingsoppdragString(
+    behandlingId: Long,
+    ytelseTypeBa: YtelsetypeBA? = YtelsetypeBA.ORDINÆR_BARNETRYGD,
+): String =
+    objectMapper.writeValueAsString(
+        Utbetalingsoppdrag(
+            kodeEndring = Utbetalingsoppdrag.KodeEndring.NY,
+            fagSystem = "BA",
+            saksnummer = "",
+            aktoer = UUID.randomUUID().toString(),
+            saksbehandlerId = "",
+            avstemmingTidspunkt = LocalDateTime.now(),
+            utbetalingsperiode =
+                listOf(
+                    lagUtbetalingsperiode(behandlingId = behandlingId, periodeId = 0, forrigePeriodeId = null, ytelseTypeBa = ytelseTypeBa ?: YtelsetypeBA.ORDINÆR_BARNETRYGD),
+                ),
+        ),
     )
 
 fun lagUtbetalingsoppdrag(utbetalingsperioder: List<Utbetalingsperiode>): Utbetalingsoppdrag =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/FinnIdenterMedLøpendeBarnetrygdForGittÅrTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/FinnIdenterMedLøpendeBarnetrygdForGittÅrTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
 import no.nav.familie.ba.sak.datagenerator.årMnd
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -53,7 +54,7 @@ class FinnIdenterMedLøpendeBarnetrygdForGittÅrTest : AbstractSpringIntegration
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søker.aktør.aktivFødselsnummer())
         with(behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))) {
             val behandling = this
-            with(lagInitiellTilkjentYtelse(behandling, "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(behandling, lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))) {
                 val andel =
                     lagAndelTilkjentYtelse(
                         årMnd("2019-04"),
@@ -85,7 +86,7 @@ class FinnIdenterMedLøpendeBarnetrygdForGittÅrTest : AbstractSpringIntegration
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søker.aktør.aktivFødselsnummer())
         with(behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))) {
             val behandling = this
-            with(lagInitiellTilkjentYtelse(behandling, "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(behandling, lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))) {
                 val andel =
                     lagAndelTilkjentYtelse(
                         årMnd("2019-04"),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonServiceIntegrationTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
 import no.nav.familie.ba.sak.datagenerator.årMnd
 import no.nav.familie.ba.sak.integrasjoner.infotrygd.InfotrygdBarnetrygdClient
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -164,7 +165,7 @@ class PensjonServiceIntegrationTest : AbstractSpringIntegrationTest() {
     ) {
         with(behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))) {
             val behandling = this
-            with(lagInitiellTilkjentYtelse(behandling, "utbetalingsoppdrag")) {
+            with(lagInitiellTilkjentYtelse(behandling, lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))) {
                 val andel =
                     lagAndelTilkjentYtelse(
                         fom,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBServiceIntegrationTest.kt
@@ -40,9 +40,9 @@ class ECBServiceIntegrationTest(
             )
         every {
             ecbClient.hentValutakurs(
-                any(),
-                any(),
-                any(),
+                Frequency.Daily,
+                listOf("NOK", "EUR"),
+                valutakursDato,
             )
         } returns ecbExchangeRatesData.toExchangeRates()
 
@@ -52,6 +52,7 @@ class ECBServiceIntegrationTest(
 
         // Assert
         assertEquals(valutakurs!!.kurs, BigDecimal.valueOf(9.4567))
+
         ecbService.hentValutakurs("EUR", valutakursDato)
         verify(exactly = 1) {
             ecbClient.hentValutakurs(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.datagenerator.nyOrdinærBehandling
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
@@ -176,7 +177,7 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
         behandling = behandling,
         opprettetDato = LocalDate.now(),
         endretDato = LocalDate.now(),
-        utbetalingsoppdrag = if (erIverksatt) "Skal ikke være null" else null,
+        utbetalingsoppdrag = if (erIverksatt) lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id) else null,
     )
 
     // Kun offset og kobling til behandling/tilkjent ytelse som er relevant når man skal plukke ut til konsistensavstemming

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingUtplukkingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingUtplukkingIntegrationTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.datagenerator.nyOrdinærBehandling
 import no.nav.familie.ba.sak.datagenerator.nyRevurdering
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
@@ -275,7 +276,12 @@ class KonsistensavstemmingUtplukkingIntegrationTest(
         behandling = behandling,
         opprettetDato = LocalDate.now(),
         endretDato = LocalDate.now(),
-        utbetalingsoppdrag = if (erIverksatt) "Skal ikke være null" else null,
+        utbetalingsoppdrag =
+            if (erIverksatt) {
+                lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id)
+            } else {
+                null
+            },
     )
 
     // Kun offset og kobling til behandling/tilkjent ytelse som er relevant når man skal plukke ut til konsistensavstemming

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/AutovedtakSatsendringServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
@@ -220,7 +221,7 @@ class AutovedtakSatsendringServiceTest(
                 behandlingSteg = StegType.BEHANDLING_AVSLUTTET,
             )
         behandling.behandlingStegTilstand.add(avsluttetSteg)
-        with(lagInitiellTilkjentYtelse(behandling, "utbetalingsoppdrag")) {
+        with(lagInitiellTilkjentYtelse(behandling, lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))) {
             val andel =
                 lagAndelTilkjentYtelse(
                     // Tidspunkt før siste satsendring

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceIntegrationTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.nyOrdinærBehandling
 import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
@@ -91,9 +92,10 @@ class BehandlingServiceIntegrationTest(
         val førstegangsbehandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))
 
         tilkjentYtelseRepository.save(
-            lagInitiellTilkjentYtelse(førstegangsbehandling).also {
-                it.utbetalingsoppdrag = "Utbetalingsoppdrag()"
-            },
+            lagInitiellTilkjentYtelse(
+                behandling = førstegangsbehandling,
+                utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = førstegangsbehandling.id),
+            ),
         )
         ferdigstillBehandling(førstegangsbehandling)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.config.MockPersonopplysningerService.Companion.legg
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagVedtak
 import no.nav.familie.ba.sak.datagenerator.randomSøkerFødselsdato
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
@@ -303,7 +304,7 @@ class SnikeIKøenServiceTest(
     }
 
     private fun lagUtbetalingsoppdragOgAvslutt(behandling: Behandling) {
-        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling, utbetalingsoppdrag = "utbetalingsoppdrag")
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
         tilkjentYtelseRepository.saveAndFlush(tilkjentYtelse)
         behandlingService.leggTilStegPåBehandlingOgSettTidligereStegSomUtført(behandling.id, StegType.BEHANDLING_AVSLUTTET)
         behandlingRepository.finnBehandling(behandling.id).let { behandlingFraDb ->

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.AVSLUTTET
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.IVERKSETTER_VEDTAK
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -113,7 +114,12 @@ class BehandlingRepositoryTest(
             val tilkjentYtelse =
                 lagInitiellTilkjentYtelse(
                     behandling = it,
-                    utbetalingsoppdrag = if (medUtbetalingsoppdrag) "~" else null,
+                    utbetalingsoppdrag =
+                        if (medUtbetalingsoppdrag) {
+                            lagMinimalUtbetalingsoppdragString(behandlingId = it.id)
+                        } else {
+                            null
+                        },
                 )
             tilkjentRepository.saveAndFlush(tilkjentYtelse)
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/TilkjentYtelseRepositoryTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
 import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagUtbetalingsoppdrag
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagUtbetalingsperiode
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
@@ -41,7 +42,7 @@ class TilkjentYtelseRepositoryTest(
             tilkjentYtelseRepository.save(
                 lagTilkjentYtelse(
                     behandling = behandling,
-                    utbetalingsoppdrag = "\"klassifisering\":\"BAUTV-OP\"",
+                    utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id, ytelseTypeBa = YtelsetypeBA.UTVIDET_BARNETRYGD),
                 ),
             )
 
@@ -63,7 +64,7 @@ class TilkjentYtelseRepositoryTest(
             tilkjentYtelseRepository.save(
                 lagTilkjentYtelse(
                     behandling = behandling,
-                    utbetalingsoppdrag = "\"klassifisering\":\"BATR\"",
+                    utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id),
                 ),
             )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
@@ -10,6 +10,8 @@ import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.YtelsetypeBA
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -100,11 +102,12 @@ class MinSideBarnetrygdControllerTest(
                         status = BehandlingStatus.AVSLUTTET,
                     ),
                 )
+
             val tilkjentYtelse =
                 tilkjentYtelseRepository.save(
                     lagInitiellTilkjentYtelse(
                         behandling = behandling,
-                        utbetalingsoppdrag = "\"klassifisering\":\"BAUTV-OP\"",
+                        utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id, ytelseTypeBa = YtelsetypeBA.UTVIDET_BARNETRYGD),
                     ),
                 )
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceIntegrasjonsTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagVedtak
 import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -49,7 +50,8 @@ class StønadsstatistikkServiceIntegrasjonsTest(
         )
         vedtakRepository.saveAndFlush(lagVedtak(behandling = behandling1, vedtaksdato = now()))
         val behandling = behandling1
-        tilkjentYtelseRepository.save(lagTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = "Ikke-tom streng"))
+
+        tilkjentYtelseRepository.save(lagTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id)))
 
         // Act
         val vedtakDVHV2 = stønadsstatistikkService.hentVedtakV2(behandlingId = behandling.id)
@@ -76,7 +78,7 @@ class StønadsstatistikkServiceIntegrasjonsTest(
         )
         vedtakRepository.saveAndFlush(lagVedtak(behandling = behandling, vedtaksdato = now()))
 
-        tilkjentYtelseRepository.save(lagTilkjentYtelse(behandling = behandlingAvsluttet, utbetalingsoppdrag = "Ikke-tom streng"))
+        tilkjentYtelseRepository.save(lagTilkjentYtelse(behandling = behandlingAvsluttet, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id)))
         tilkjentYtelseRepository.save(lagTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = null))
 
         // Act

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -16,3 +16,7 @@ unleash:
 
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS
 
+logging:
+  level:
+    root: WARN
+

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,5 +7,5 @@
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
 
-    <logger name="no" level="DEBUG"/>
+    <logger name="no" level="WARN"/>
 </configuration>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
En del tester oppretter og lagrer `TilkjentYtelse` med feltet `utbetalingsoppdrag` satt til en vilkårlig tekst. Nå når db ikke blir tømt mellom hver test vil tester som tester som aktivt bruker feltet `utbetalingsoppdrag` feile.

Sørger her for at vi alltid lagrer en gyldig verdi.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
