### PR TITLE
NAV-26210: Legger til metoder for å hente ut iverksatte behandliger per fagsak og personopplysning grunnlag per behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterService.kt
@@ -6,8 +6,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Visningsbehandling
-import no.nav.familie.ba.sak.kjerne.steg.BehandlingStegStatus
-import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import org.springframework.stereotype.Service
@@ -47,6 +45,8 @@ class BehandlingHentOgPersisterService(
      * Henter siste iverksatte behandling på fagsak
      */
     fun hentSisteBehandlingSomErIverksatt(fagsakId: Long): Behandling? = behandlingRepository.finnSisteIverksatteBehandling(fagsakId = fagsakId)
+
+    fun hentSisteBehandlingSomErIverksattForFagsaker(fagsakIder: Collection<Long>): Map<Long, Behandling> = behandlingRepository.finnSisteIverksatteBehandlingForFagsaker(fagsakIder = fagsakIder).associate { it.fagsak.id to it }
 
     fun hentIdForSisteBehandlingSomErIverksatt(fagsakId: Long): Long? = behandlingRepository.finnIdForSisteIverksatteBehandling(fagsakId = fagsakId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -105,6 +105,20 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnSisteIverksatteBehandling(fagsakId: Long): Behandling?
 
     @Query(
+        """SELECT DISTINCT ON(b.fk_fagsak_id) b.*
+            FROM behandling b
+                     INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
+                     INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
+            WHERE f.id in :fagsakIder
+              AND ty.utbetalingsoppdrag IS NOT NULL
+              AND f.arkivert = false
+              AND b.status = 'AVSLUTTET'
+            ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC""",
+        nativeQuery = true,
+    )
+    fun finnSisteIverksatteBehandlingForFagsaker(fagsakIder: Collection<Long>): List<Behandling>
+
+    @Query(
         """SELECT DISTINCT ON(b.fk_fagsak_id) b.id
             FROM behandling b
                      INNER JOIN fagsak f ON f.id = b.fk_fagsak_id

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -110,6 +110,8 @@ class PersongrunnlagService(
 
     fun hentAktiv(behandlingId: Long): PersonopplysningGrunnlag? = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = behandlingId)
 
+    fun hentAktivForBehandlinger(behandlingIder: Collection<Long>): Map<Long, PersonopplysningGrunnlag> = personopplysningGrunnlagRepository.hentAktivForBehandlinger(behandlingIder).associate { it.behandlingId to it }
+
     fun hentAktivThrows(behandlingId: Long): PersonopplysningGrunnlag =
         hentAktiv(behandlingId = behandlingId)
             ?: throw Feil("Finner ikke personopplysningsgrunnlag på behandling $behandlingId")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagRepository.kt
@@ -7,6 +7,9 @@ interface PersonopplysningGrunnlagRepository : JpaRepository<PersonopplysningGru
     @Query("SELECT gr FROM PersonopplysningGrunnlag gr WHERE gr.behandlingId = :behandlingId AND gr.aktiv = true")
     fun findByBehandlingAndAktiv(behandlingId: Long): PersonopplysningGrunnlag?
 
+    @Query("SELECT gr FROM PersonopplysningGrunnlag gr WHERE gr.behandlingId in :behandlingIder AND gr.aktiv = true")
+    fun hentAktivForBehandlinger(behandlingIder: Collection<Long>): List<PersonopplysningGrunnlag>
+
     @Query(
         """
         SELECT new no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel(p.type, a, p.fødselsdato, d.dødsfallDato, p.målform)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceTest.kt
@@ -28,6 +28,45 @@ class BehandlingHentOgPersisterServiceTest {
         )
 
     @Nested
+    inner class HentSisteBehandlingSomErIverksattForFagsaker {
+        @Test
+        fun `skal hente siste behandling som er iverksatt per fagsak`() {
+            // Arrange
+            val fagsak1 = lagFagsak(id = 1)
+            val fagsak2 = lagFagsak(id = 2)
+            val fagsaker = setOf(fagsak1.id, fagsak2.id)
+
+            val behandling1 = lagBehandling(fagsak = fagsak1)
+            val behandling2 = lagBehandling(fagsak = fagsak2)
+
+            every { behandlingRepository.finnSisteIverksatteBehandlingForFagsaker(fagsaker) } returns listOf(behandling1, behandling2)
+
+            // Act
+            val iverksattBehandlingPerFagsak = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksattForFagsaker(fagsaker)
+
+            // Assert
+            assertThat(iverksattBehandlingPerFagsak).hasSize(2)
+            assertThat(iverksattBehandlingPerFagsak).containsKeys(fagsak1.id, fagsak2.id)
+            assertThat(iverksattBehandlingPerFagsak[fagsak1.id]).isEqualTo(behandling1)
+            assertThat(iverksattBehandlingPerFagsak[fagsak2.id]).isEqualTo(behandling2)
+        }
+
+        @Test
+        fun `skal returnere et tomt map hvis en tom collection av fagsakIder blir sendt inn`() {
+            // Arrange
+            val fagsaker = emptySet<Long>()
+
+            every { behandlingRepository.finnSisteIverksatteBehandlingForFagsaker(fagsaker) } returns emptyList()
+
+            // Act
+            val iverksattBehandlingPerFagsak = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksattForFagsaker(fagsaker)
+
+            // Assert
+            assertThat(iverksattBehandlingPerFagsak).isEmpty()
+        }
+    }
+
+    @Nested
     inner class HentVisningsbehandlinger {
         @Test
         fun `skal hente visningsbehandlinger`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.datagenerator.defaultFagsak
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.datagenerator.lagPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.lagSøknadDTO
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.integrasjoner.pdl.PersonopplysningerService
@@ -24,12 +25,12 @@ import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.kontrakter.felles.PersonIdent
 import org.assertj.core.api.Assertions
-import org.hamcrest.MatcherAssert.assertThat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.YearMonth
-import org.hamcrest.CoreMatchers.`is` as Is
 
 class PersongrunnlagServiceTest {
     val personidentService = mockk<PersonidentService>()
@@ -183,7 +184,7 @@ class PersongrunnlagServiceTest {
                 )
             }
 
-        assertThat(funksjonellFeil.melding, Is("Du kan ikke sette dødsfall dato til en dato som er før SØKER sin fødselsdato"))
+        assertThat(funksjonellFeil.melding).isEqualTo("Du kan ikke sette dødsfall dato til en dato som er før SØKER sin fødselsdato")
     }
 
     @Test
@@ -216,7 +217,7 @@ class PersongrunnlagServiceTest {
                 )
             }
 
-        assertThat(funksjonellFeil.melding, Is("Dødsfall dato er allerede registrert på person med navn ${person.navn}"))
+        assertThat(funksjonellFeil.melding).isEqualTo("Dødsfall dato er allerede registrert på person med navn ${person.navn}")
     }
 
     @Test
@@ -249,5 +250,44 @@ class PersongrunnlagServiceTest {
         verify(exactly = 1) { personidentService.hentAktør(personFnr) }
         verify(exactly = 1) { loggService.loggManueltRegistrertDødsfallDato(any(), any(), "test") }
         verify(exactly = 1) { vilkårsvurderingService.oppdaterVilkårVedDødsfall(any(), any(), any()) }
+    }
+
+    @Nested
+    inner class HentAktivForBehandlinger {
+        @Test
+        fun `skal hente aktive grunnlag for behandlinger`() {
+            // Arrange
+            val behandlingId1 = 1L
+            val behandlingId2 = 2L
+            val behandlingIder = setOf(behandlingId1, behandlingId2)
+
+            val grunnlag1 = lagPersonopplysningGrunnlag(behandlingId = behandlingId1)
+            val grunnlag2 = lagPersonopplysningGrunnlag(behandlingId = behandlingId2)
+
+            every { personopplysningGrunnlagRepository.hentAktivForBehandlinger(behandlingIder) } returns listOf(grunnlag1, grunnlag2)
+
+            // Act
+            val aktive = persongrunnlagService.hentAktivForBehandlinger(behandlingIder)
+
+            // Assert
+            assertThat(aktive).hasSize(2)
+            assertThat(aktive).containsKeys(behandlingId1, behandlingId2)
+            assertThat(aktive[behandlingId1]).isEqualTo(grunnlag1)
+            assertThat(aktive[behandlingId2]).isEqualTo(grunnlag2)
+        }
+
+        @Test
+        fun `skal returner et tomt map hvis en tom collection av behandlingIder blir sendt inn`() {
+            // Arrange
+            val behandlingIder = emptyList<Long>()
+
+            every { personopplysningGrunnlagRepository.hentAktivForBehandlinger(behandlingIder) } returns emptyList()
+
+            // Act
+            val aktive = persongrunnlagService.hentAktivForBehandlinger(behandlingIder)
+
+            // Assert
+            assertThat(aktive).isEmpty()
+        }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -2,14 +2,20 @@ package no.nav.familie.ba.sak.kjerne.behandling.domene
 
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
+import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.AVSLUTTET
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.IVERKSETTER_VEDTAK
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.UTREDES
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -19,6 +25,8 @@ import java.time.LocalDateTime
 
 class BehandlingRepositoryTest(
     @Autowired private val fagsakService: FagsakService,
+    @Autowired private val aktørIdRepository: AktørIdRepository,
+    @Autowired private val fagsakRepository: FagsakRepository,
     @Autowired private val behandlingRepository: BehandlingRepository,
     @Autowired private val tilkjentRepository: TilkjentYtelseRepository,
 ) : AbstractSpringIntegrationTest() {
@@ -65,6 +73,98 @@ class BehandlingRepositoryTest(
             opprettBehandling(fagsak, IVERKSETTER_VEDTAK).medTilkjentYtelse()
 
             assertThat(behandlingRepository.finnSisteIverksatteBehandling(fagsak.id)!!).isEqualTo(behandling3)
+        }
+    }
+
+    @Nested
+    inner class FinnSisteIverksatteBehandlingForFagsaker {
+        @Test
+        fun `skal finne siste iverksatte behandlingener`() {
+            // Arrange
+            val dagensDato = LocalDateTime.of(2025, 10, 16, 12, 0, 0)
+            val aktør = aktørIdRepository.save(randomAktør())
+
+            val fagsak1 = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, type = FagsakType.NORMAL))
+            val behandling1 = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak1, status = AVSLUTTET, aktivertTid = dagensDato.minusSeconds(1), aktiv = true))
+            tilkjentRepository.save(lagInitiellTilkjentYtelse(behandling = behandling1, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling1.id)))
+            val behandling2 = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak1, status = AVSLUTTET, aktivertTid = dagensDato.minusSeconds(2), aktiv = false))
+            tilkjentRepository.save(lagInitiellTilkjentYtelse(behandling = behandling2, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling2.id)))
+
+            val fagsak2 = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, type = FagsakType.BARN_ENSLIG_MINDREÅRIG))
+            val behandling3 = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak2, status = AVSLUTTET, aktivertTid = dagensDato.minusSeconds(1), aktiv = true))
+            tilkjentRepository.save(lagInitiellTilkjentYtelse(behandling = behandling3, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling3.id)))
+            val behandling4 = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak2, status = AVSLUTTET, aktivertTid = dagensDato.minusSeconds(2), aktiv = false))
+            tilkjentRepository.save(lagInitiellTilkjentYtelse(behandling = behandling4, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling4.id)))
+
+            val fagsaker = setOf(fagsak1.id, fagsak2.id)
+
+            // Act
+            val behandlinger = behandlingRepository.finnSisteIverksatteBehandlingForFagsaker(fagsaker)
+
+            // Assert
+            assertThat(behandlinger).anySatisfy { assertThat(it.id).isEqualTo(behandling1.id) }
+            assertThat(behandlinger).anySatisfy { assertThat(it.id).isEqualTo(behandling3.id) }
+            assertThat(behandlinger).noneSatisfy { assertThat(it.id).isEqualTo(behandling2.id) }
+            assertThat(behandlinger).noneSatisfy { assertThat(it.id).isEqualTo(behandling4.id) }
+        }
+
+        @Test
+        fun `skal filtrer bort behandling som ikke er avsluttet`() {
+            // Arrange
+            val dagensDato = LocalDateTime.of(2025, 10, 16, 12, 0, 0)
+            val aktør = aktørIdRepository.save(randomAktør())
+
+            val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, type = FagsakType.NORMAL))
+            val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak, status = UTREDES, aktivertTid = dagensDato, aktiv = true))
+            tilkjentRepository.save(lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id)))
+
+            val fagsaker = setOf(fagsak.id)
+
+            // Act
+            val behandlinger = behandlingRepository.finnSisteIverksatteBehandlingForFagsaker(fagsaker)
+
+            // Assert
+            assertThat(behandlinger).noneSatisfy { assertThat(it.id).isEqualTo(behandling.id) }
+            assertThat(behandlinger).noneSatisfy { assertThat(it.fagsak.id).isEqualTo(fagsak.id) }
+        }
+
+        @Test
+        fun `skal filtrer bort behandlinger på fagsaker som er arkivert`() {
+            // Arrange
+            val dagensDato = LocalDateTime.of(2025, 10, 16, 12, 0, 0)
+            val aktør = aktørIdRepository.save(randomAktør())
+
+            val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, type = FagsakType.NORMAL, arkivert = true))
+            val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak, status = AVSLUTTET, aktivertTid = dagensDato, aktiv = true))
+            tilkjentRepository.save(lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id)))
+
+            val fagsaker = setOf(fagsak.id)
+
+            // Act
+            val behandlinger = behandlingRepository.finnSisteIverksatteBehandlingForFagsaker(fagsaker)
+
+            // Assert
+            assertThat(behandlinger).noneSatisfy { assertThat(it.id).isEqualTo(behandling.id) }
+            assertThat(behandlinger).noneSatisfy { assertThat(it.fagsak.id).isEqualTo(fagsak.id) }
+        }
+
+        @Test
+        fun `skal filtrer bort behandlinger som ikke har utbetalingsoppdrag`() {
+            // Arrange
+            val dagensDato = LocalDateTime.of(2025, 10, 16, 12, 0, 0)
+            val aktør = aktørIdRepository.save(randomAktør())
+
+            val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, type = FagsakType.NORMAL, arkivert = false))
+            val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak, status = AVSLUTTET, aktivertTid = dagensDato, aktiv = true))
+
+            val fagsaker = setOf(fagsak.id)
+
+            // Act
+            val behandlinger = behandlingRepository.finnSisteIverksatteBehandlingForFagsaker(fagsaker)
+
+            // Assert
+            assertThat(behandlinger).noneSatisfy { assertThat(it.id).isEqualTo(behandling.id) }
+            assertThat(behandlinger).noneSatisfy { assertThat(it.fagsak.id).isEqualTo(fagsak.id) }
         }
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagRepositoryTest.kt
@@ -1,0 +1,52 @@
+package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger
+
+import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
+import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
+import no.nav.familie.ba.sak.datagenerator.lagPersonopplysningGrunnlagUtenId
+import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class PersonopplysningGrunnlagRepositoryTest(
+    @Autowired private val aktørIdRepository: AktørIdRepository,
+    @Autowired private val fagsakRepository: FagsakRepository,
+    @Autowired private val behandlingRepository: BehandlingRepository,
+    @Autowired private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+) : AbstractSpringIntegrationTest() {
+    @Nested
+    inner class HentAktivForBehandlinger {
+        @Test
+        fun `skal hente aktive grunnlag per behandling`() {
+            // Arrange
+            val aktør1 = aktørIdRepository.save(randomAktør())
+            val aktør2 = aktørIdRepository.save(randomAktør())
+
+            val fagsak1 = fagsakRepository.save(lagFagsakUtenId(aktør = aktør1))
+            val fagsak2 = fagsakRepository.save(lagFagsakUtenId(aktør = aktør2))
+
+            val behandling1 = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak1))
+            val behandling2 = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak2))
+            val behandlinger = setOf(behandling1.id, behandling2.id)
+
+            val grunnlag1 = personopplysningGrunnlagRepository.save(lagPersonopplysningGrunnlagUtenId(behandlingId = behandling1.id, aktiv = true))
+            val grunnlag2 = personopplysningGrunnlagRepository.save(lagPersonopplysningGrunnlagUtenId(behandlingId = behandling1.id, aktiv = false))
+            val grunnlag3 = personopplysningGrunnlagRepository.save(lagPersonopplysningGrunnlagUtenId(behandlingId = behandling2.id, aktiv = true))
+            val grunnlag4 = personopplysningGrunnlagRepository.save(lagPersonopplysningGrunnlagUtenId(behandlingId = behandling2.id, aktiv = false))
+
+            // Act
+            val aktive = personopplysningGrunnlagRepository.hentAktivForBehandlinger(behandlinger)
+
+            // Assert
+            assertThat(aktive).anySatisfy { assertThat(it.id).isEqualTo(grunnlag1.id) }
+            assertThat(aktive).anySatisfy { assertThat(it.id).isEqualTo(grunnlag3.id) }
+            assertThat(aktive).noneSatisfy { assertThat(it.id).isEqualTo(grunnlag2.id) }
+            assertThat(aktive).noneSatisfy { assertThat(it.id).isEqualTo(grunnlag4.id) }
+        }
+    }
+}

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/PersonopplysningGrunnlagGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/PersonopplysningGrunnlagGenerator.kt
@@ -13,6 +13,26 @@ import no.nav.familie.ba.sak.kjerne.personident.Personident
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTANDTYPE
 import java.time.LocalDate
 
+fun lagPersonopplysningGrunnlag(
+    id: Long = 0L,
+    behandlingId: Long = 0L,
+    aktiv: Boolean = true,
+    lagPersoner: (grunnlag: PersonopplysningGrunnlag) -> Set<Person> = { emptySet() },
+): PersonopplysningGrunnlag {
+    val personopplysningGrunnlag = PersonopplysningGrunnlag(id = id, behandlingId = behandlingId, aktiv = aktiv)
+    val personer = lagPersoner(personopplysningGrunnlag)
+    personopplysningGrunnlag.personer.addAll(personer)
+    return personopplysningGrunnlag
+}
+
+/**
+ * Bruk for integrasjonstest. Bruk lagPersonopplysningGrunnlag for enhetstest
+ */
+fun lagPersonopplysningGrunnlagUtenId(
+    behandlingId: Long,
+    aktiv: Boolean = true,
+): PersonopplysningGrunnlag = lagPersonopplysningGrunnlag(id = 0L, behandlingId = behandlingId, aktiv = aktiv)
+
 fun lagTestPersonopplysningGrunnlag(
     behandlingId: Long,
     vararg personer: Person,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26210

- Legger til metoder for å hente ut iversakke behandlinger for en collection av fagsaker.
- Legger til metoder for å hente ut personopplysning grunnlag for en collection av behandlinger.

Disse metodene skal brukes når vi kjører Svalbardtillegg / Finnmarkstillegg scheduleren. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
