### PR TITLE
Ikke default prøv å sende kafkameldinger for min side i DevLauncherPostgresPreprod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringKafkaProducer.kt
@@ -78,7 +78,7 @@ class DefaultMinsideAktiveringKafkaProducer(
 
 @Service
 class MockMinsideAktiveringKafkaProducer : MinsideAktiveringKafkaProducer {
-    private val logger = LoggerFactory.getLogger(DefaultMinsideAktiveringKafkaProducer::class.java)
+    private val logger = LoggerFactory.getLogger(MockMinsideAktiveringKafkaProducer::class.java)
 
     override fun aktiver(aktør: Aktør) {
         logger.info("Sender aktiver til minside for aktør ${aktør.aktørId}")

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/producer/KafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/producer/KafkaProducer.kt
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Primary
-import org.springframework.context.annotation.Profile
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
@@ -53,7 +52,6 @@ interface KafkaProducer {
     matchIfMissing = false,
 )
 @Primary
-@Profile("!preprod-gcp & !prod-gcp")
 class DefaultKafkaProducer(
     val saksstatistikkMellomlagringRepository: SaksstatistikkMellomlagringRepository,
 ) : KafkaProducer {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringKafkaProducerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringKafkaProducerTest.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture
 
 class MinsideAktiveringKafkaProducerTest {
     private val kafkaTemplate: KafkaTemplate<String, String> = mockk()
-    private val minsideAktiveringKafkaProducer = MinsideAktiveringKafkaProducer(kafkaTemplate)
+    private val minsideAktiveringKafkaProducer = DefaultMinsideAktiveringKafkaProducer(kafkaTemplate)
 
     @Nested
     inner class Aktiver {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinsideAktiveringServiceTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class MinsideAktiveringServiceTest {
     private val minsideAktiveringRepository: MinsideAktiveringRepository = mockk()
-    private val minsideAktiveringKafkaProducer: MinsideAktiveringKafkaProducer = mockk()
+    private val minsideAktiveringKafkaProducer: DefaultMinsideAktiveringKafkaProducer = mockk()
     private val minsideAktiveringService =
         MinsideAktiveringService(
             minsideAktiveringRepository = minsideAktiveringRepository,

--- a/src/test/resources/application-dev-postgres-preprod.yaml
+++ b/src/test/resources/application-dev-postgres-preprod.yaml
@@ -130,7 +130,7 @@ credential:
   password: "not-a-real-password"
 
 logging:
-  config: "classpath:logback-test.xml"
+  config: "classpath:logback-devlauncher.xml"
 sentry.environment: local
 sentry.logging.enabled: false
 

--- a/src/test/resources/logback-devlauncher.xml
+++ b/src/test/resources/logback-devlauncher.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- override spring base logging pattern -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d [%-5level] [%thread] %logger{5} %replace(- [%X{consumerId}, %X{callId}, %X{userId}] ){'- \[, , \] ',''}- %m%n"/>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+
+    <logger name="no" level="INFO"/>
+</configuration>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
- **Lagt til bryter på sending av kafkameldinger på minside, slik at den ikke forsøker å sende i utviklingsmiljø**
I DevLauncherPostgresPreprod er kafka skrudd av for at loggene ikke skal spammes ned med feil i sending av kafka eller at man må starte opp kafka lokalt. Siden dette er det kommet en ny kafkaproducer, om ikke har denne bryteren. Denne commiten legger til tilsvarende funksjonalitet som KafkaProducer. MinsideAktiveringKafkaProducer er trukket ut som interface. Hvis property funksjonsbrytere.kafka.producer.enabled=true så brukes Kafka, mens hvis false så logges kun meldingen

- **Skrur på infologging på DevLauncherPostgresPreprod**
Etter at test-loggene ble satt til WARN, så ble de også skrudd av for lokal utvikling. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
