### PR TITLE
Sørger for at vi får stacktrace når vi kaster FunksjonellFeil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
@@ -99,7 +99,7 @@ object RessursUtils {
         val className =
             if (funksjonellFeil.throwable != null) "[${funksjonellFeil.throwable!!::class.java.name}] " else ""
 
-        logger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message} ")
+        logger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message}. Se securelogs for detaljer.")
         secureLogger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message} ", funksjonellFeil)
 
         return ResponseEntity.status(funksjonellFeil.httpStatus).body(

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
@@ -99,7 +99,8 @@ object RessursUtils {
         val className =
             if (funksjonellFeil.throwable != null) "[${funksjonellFeil.throwable!!::class.java.name}] " else ""
 
-        logger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message} ", funksjonellFeil)
+        logger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message} ")
+        secureLogger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message} ", funksjonellFeil)
 
         return ResponseEntity.status(funksjonellFeil.httpStatus).body(
             Ressurs.funksjonellFeil(

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/RessursUtils.kt
@@ -99,7 +99,7 @@ object RessursUtils {
         val className =
             if (funksjonellFeil.throwable != null) "[${funksjonellFeil.throwable!!::class.java.name}] " else ""
 
-        logger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message} ")
+        logger.info("$className En funksjonell feil har oppstått(${funksjonellFeil.httpStatus}): ${funksjonellFeil.message} ", funksjonellFeil)
 
         return ResponseEntity.status(funksjonellFeil.httpStatus).body(
             Ressurs.funksjonellFeil(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Idag logges kun feilemeldingen til `FunksjonellFeil` når den kastes, men i noen tilfeller er det nyttig å kunne se selve stacktracen for å kunne debugge rare feil.

Sørger her for at stacktrace også logges når `FunksjonellFeil` kastes.
