### PR TITLE
Utvider validering av avsender ident ved journalføring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtil.kt
@@ -6,4 +6,4 @@ fun String.saner(): String = Regex("[^$ALFANUMERISKE_TEGN]*").replace(this, "")
 
 fun String.erAlfanummerisk(): Boolean = Regex("[$ALFANUMERISKE_TEGN]*").matches(this)
 
-fun String.erAlfanummeriskPlussKolon(): Boolean = Regex("[$ALFANUMERISKE_TEGN:]*").matches(this)
+fun String.erAlfanummeriskPlussKolonMellomromOgUnderstrek(): Boolean = Regex("[$ALFANUMERISKE_TEGN:_ ]*").matches(this)

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestJournalføring.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.ekstern.restDomene
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.common.erAlfanummeriskPlussKolon
+import no.nav.familie.ba.sak.common.erAlfanummeriskPlussKolonMellomromOgUnderstrek
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Bruker
 import no.nav.familie.ba.sak.integrasjoner.journalføring.domene.Journalføringsbehandlingstype
@@ -105,7 +105,7 @@ data class NavnOgIdent(
 ) {
     // Bruker init til å validere personidenten
     init {
-        if (!id.erAlfanummeriskPlussKolon()) {
+        if (!id.erAlfanummeriskPlussKolonMellomromOgUnderstrek()) {
             secureLogger.info("Ugyldig ident: $id")
             throw FunksjonellFeil(
                 melding = "Ugyldig ident. Se securelog for mer informasjon.",

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
@@ -25,10 +25,12 @@ class TekstSaniteringUtilTest {
 
     @Test
     fun `erAlfanummeriskPlussKolon skal tillate tekst med kolon, mens erAlfanummerisk skal ikke tillate tekst med kolon`() {
-        assertThat("Tekst:MedKolon".erAlfanummeriskPlussKolon()).isTrue()
-        assertThat("TekstUtenKolon".erAlfanummeriskPlussKolon()).isTrue()
+        assertThat("Tekst:MedKolon".erAlfanummeriskPlussKolonMellomromOgUnderstrek()).isTrue()
+        assertThat("TekstUtenKolon".erAlfanummeriskPlussKolonMellomromOgUnderstrek()).isTrue()
+        assertThat("Tekst: MedMellomrom".erAlfanummeriskPlussKolonMellomromOgUnderstrek()).isTrue()
+        assertThat("Tekst:Med_Understrek".erAlfanummeriskPlussKolonMellomromOgUnderstrek()).isTrue()
         assertThat("TekstUtenKolon".erAlfanummerisk()).isTrue()
         assertThat("Tekst:MedKolon".erAlfanummerisk()).isFalse()
-        assertThat("".erAlfanummeriskPlussKolon()).isTrue()
+        assertThat("".erAlfanummeriskPlussKolonMellomromOgUnderstrek()).isTrue()
     }
 }


### PR DESCRIPTION
Favro: [NAV-26265](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26265)

### 💰 Hva skal gjøres, og hvorfor?
Mellomrom og understrek kan forekomme i avsender ident ved journalføring og dette var tidligere ikke støttet.

Legger her inn støtte for det.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer
- [x] Jeg har skrevet tester. 