### PR TITLE
NAV-26201: Legger til metodene erSvalbardtillegg og erFinnmarksTilleggEllerSvalbardtillegg på behandling, tar dem i bruk, og skriver tester

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <felles.version>3.20250915092837_153983f</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250826113118_c8aa66d</eksterne-kontrakter-bisys.version>
         <felles-kontrakter.version>3.0_20250915121657_48d7e53</felles-kontrakter.version>
-        <familie.kontrakter.saksstatistikk>2.0_20250826113118_c8aa66d</familie.kontrakter.saksstatistikk>
-        <familie.kontrakter.stønadsstatistikk>2.0_20250901073230_e199a51</familie.kontrakter.stønadsstatistikk>
+        <familie.kontrakter.saksstatistikk>2.0_20250915155846_3e7ecd7</familie.kontrakter.saksstatistikk>
+        <familie.kontrakter.stønadsstatistikk>2.0_20250915155846_3e7ecd7</familie.kontrakter.stønadsstatistikk>
         <utbetalingsgenerator.version>1.0_20250804104526_5648100</utbetalingsgenerator.version>
         <cucumber.version>7.23.0</cucumber.version>
         <mockk.version>1.14.5</mockk.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-class FinnmarkstilleggIngenEndringFeil(
+class IngenEndringIBosattIRiketVilkårFeil(
     message: String,
 ) : RuntimeException(message)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg
 
 import io.opentelemetry.instrumentation.annotations.WithSpan
-import no.nav.familie.ba.sak.common.FinnmarkstilleggIngenEndringFeil
+import no.nav.familie.ba.sak.common.IngenEndringIBosattIRiketVilkårFeil
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -33,7 +33,7 @@ class AutovedtakFinnmarkstilleggTask(
                     fagsakId = fagsakId,
                     førstegangKjørt = task.opprettetTid,
                 )
-            } catch (e: FinnmarkstilleggIngenEndringFeil) {
+            } catch (e: IngenEndringIBosattIRiketVilkårFeil) {
                 "Finnmarkstillegg: ${e.message}"
             }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -122,7 +122,7 @@ data class Behandling(
             erManuellMigrering() -> false
             erMigrering() -> false
             erIverksetteKAVedtak() -> false
-            erFinnmarkstillegg() && resultat in setOf(FORTSATT_INNVILGET, FORTSATT_OPPHØRT) -> false
+            erFinnmarksTilleggEllerSvalbardtillegg() && resultat in setOf(FORTSATT_INNVILGET, FORTSATT_OPPHØRT) -> false
             else -> true
         }
 
@@ -166,7 +166,7 @@ data class Behandling(
             skalBehandlesAutomatisk && erSatsendring() && erEndringFraForrigeBehandlingSendtTilØkonomi -> true
             skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID && this.resultat == FORTSATT_INNVILGET -> true
             skalBehandlesAutomatisk && erMånedligValutajustering() -> true
-            skalBehandlesAutomatisk && erFinnmarkstillegg() -> true
+            skalBehandlesAutomatisk && erFinnmarksTilleggEllerSvalbardtillegg() -> true
             else -> false
         }
 
@@ -227,11 +227,15 @@ data class Behandling(
 
     fun erFinnmarkstillegg() = this.opprettetÅrsak == BehandlingÅrsak.FINNMARKSTILLEGG
 
+    fun erSvalbardtillegg() = this.opprettetÅrsak == BehandlingÅrsak.SVALBARDTILLEGG
+
+    fun erFinnmarksTilleggEllerSvalbardtillegg() = erFinnmarkstillegg() || erSvalbardtillegg()
+
     fun erSatsendringEllerMånedligValutajustering() = erSatsendring() || erMånedligValutajustering()
 
     fun erOppdaterUtvidetKlassekode() = this.opprettetÅrsak == BehandlingÅrsak.OPPDATER_UTVIDET_KLASSEKODE
 
-    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsendringEllerMånedligValutajustering() || erSmåbarnstillegg() || erOmregning() || erFinnmarkstillegg()
+    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsendringEllerMånedligValutajustering() || erSmåbarnstillegg() || erOmregning() || erFinnmarksTilleggEllerSvalbardtillegg()
 
     fun erManuellMigreringForEndreMigreringsdato() =
         erMigrering() &&
@@ -353,6 +357,7 @@ enum class BehandlingÅrsak(
     OPPDATER_UTVIDET_KLASSEKODE("Ny klassekode for utvidet barnetrygd"),
     IVERKSETTE_KA_VEDTAK("Iverksette KA-vedtak"),
     FINNMARKSTILLEGG("Finnmarkstillegg"),
+    SVALBARDTILLEGG("Svalbardtillegg"),
     ;
 
     fun erOmregningsårsak(): Boolean = this == OMREGNING_18ÅR || this == OMREGNING_SMÅBARNSTILLEGG

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -100,7 +100,7 @@ object BehandlingsresultatEndringUtils {
                     }
 
                 val erEndringIVilkårsvurderingForPerson =
-                    !behandling.erFinnmarkstillegg() &&
+                    !behandling.erFinnmarksTilleggEllerSvalbardtillegg() &&
                         erEndringIVilkårsvurderingForPerson(
                             tidligsteRelevanteFomDatoForPersonIVilkårsvurdering = tidligsteRelevanteFomDatoForPersonIVilkårsvurdering,
                             nåværendePersonResultaterForPerson = nåværendePersonResultatForPerson,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -57,7 +57,6 @@ import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.YearMonth
 
 @Service
@@ -84,7 +83,9 @@ class BehandlingsresultatSteg(
         behandling: Behandling,
         stegService: StegService?,
     ) {
-        if ((!behandling.erSatsendringEllerMånedligValutajustering() || !behandling.erFinnmarkstillegg()) && behandling.skalBehandlesAutomatisk) return
+        if ((!behandling.erSatsendringEllerMånedligValutajustering() || !behandling.erFinnmarksTilleggEllerSvalbardtillegg()) && behandling.skalBehandlesAutomatisk) {
+            return
+        }
 
         val søkerOgBarn = persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(behandling.id)
         if (behandling.type != BehandlingType.TEKNISK_ENDRING && behandling.type != BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT) {
@@ -109,7 +110,7 @@ class BehandlingsresultatSteg(
             søkerOgBarn = søkerOgBarn,
         )
 
-        if (!behandling.erSatsendringEllerMånedligValutajustering() || !behandling.erFinnmarkstillegg()) {
+        if (!behandling.erSatsendringEllerMånedligValutajustering() || !behandling.erFinnmarksTilleggEllerSvalbardtillegg()) {
             val endreteUtbetalingerMedAndeler =
                 andelerTilkjentYtelseOgEndreteUtbetalingerService
                     .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -29,7 +29,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val endreteUtbetalingerMedAndeler = lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
 
-        return if (!behandling.erSatsendringEllerMånedligValutajustering() || !behandling.erFinnmarkstillegg()) {
+        return if (!behandling.erSatsendringEllerMånedligValutajustering() || !behandling.erFinnmarksTilleggEllerSvalbardtillegg()) {
             // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
             // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
             // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadService.kt
@@ -34,7 +34,7 @@ class OvergangsstønadService(
         søkerAktør: Aktør,
         behandling: Behandling,
     ) {
-        if (behandling.erSatsendringEllerMånedligValutajustering() || behandling.erFinnmarkstillegg()) {
+        if (behandling.erSatsendringEllerMånedligValutajustering() || behandling.erFinnmarksTilleggEllerSvalbardtillegg()) {
             kopierPerioderMedOvergangsstønadFraForrigeBehandling(
                 behandling,
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
@@ -23,7 +23,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
         søkerIdent: String,
         barnasIdenter: List<String>,
     ) {
-        if (behandling.erSatsendringEllerMånedligValutajustering() || behandling.erFinnmarkstillegg() || behandling.opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING) {
+        if (behandling.erSatsendringEllerMånedligValutajustering() || behandling.erFinnmarksTilleggEllerSvalbardtillegg() || behandling.opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING) {
             if (forrigeBehandlingSomErVedtatt == null) {
                 throw Feil("Vi kan ikke kjøre behandling med årsak ${behandling.opprettetÅrsak} dersom det ikke finnes en tidligere behandling. Behandling: ${behandling.id}")
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
@@ -2,11 +2,12 @@ package no.nav.familie.ba.sak.kjerne.behandling
 
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -53,57 +54,6 @@ class BehandlingTest {
     }
 
     @Test
-    fun `erBehandlingMedVedtaksbrevutsending kan sende vedtaksbrev for ordinær førstegangsbehandling`() {
-        val behandling = lagBehandling()
-        assertTrue { behandling.erBehandlingMedVedtaksbrevutsending() }
-    }
-
-    @Test
-    fun `erBehandlingMedVedtaksbrevutsending kan sende vedtaksbrev for ordinær revurdering`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.REVURDERING,
-                årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
-            )
-        assertTrue { behandling.erBehandlingMedVedtaksbrevutsending() }
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = BehandlingÅrsak::class, names = ["ENDRE_MIGRERINGSDATO", "HELMANUELL_MIGRERING", "MIGRERING"])
-    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for behandlingstype MIGRERING_FRA_INFOTRYGD`(
-        årsak: BehandlingÅrsak,
-    ) {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
-                årsak = årsak,
-            )
-        assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
-    }
-
-    @Test
-    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for teknisk endring`() {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.TEKNISK_ENDRING,
-            )
-        assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
-    fun `erBehandlingMedVedtaksbrevutsending kan ikke sende vedtaksbrev for revurdering med årsak satsendring eller månedlig valutajustering`(
-        årsak: BehandlingÅrsak,
-    ) {
-        val behandling =
-            lagBehandling(
-                behandlingType = BehandlingType.REVURDERING,
-                årsak = årsak,
-            )
-        assertFalse { behandling.erBehandlingMedVedtaksbrevutsending() }
-    }
-
-    @Test
     fun `Skal svare med overstyrt dokumenttittel på alle behandlinger som er definert som omgjøringsårsaker`() {
         BehandlingÅrsak.entries.forEach {
             if (it.erOmregningsårsak()) {
@@ -111,6 +61,253 @@ class BehandlingTest {
             } else {
                 assertNull(it.hentOverstyrtDokumenttittelForOmregningsbehandling())
             }
+        }
+    }
+
+    @Nested
+    inner class ErFinnmarkstillegg {
+        @Test
+        fun `skal returnere true om behandlingsårsak er finnmarkstillegg`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.FINNMARKSTILLEGG)
+
+            // Act
+            val erFinnmarkstillegg = behandling.erFinnmarkstillegg()
+
+            // Assert
+            assertThat(erFinnmarkstillegg).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om behandlingsårsak ikke er finnmarkstillegg`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SVALBARDTILLEGG)
+
+            // Act
+            val erFinnmarkstillegg = behandling.erFinnmarkstillegg()
+
+            // Assert
+            assertThat(erFinnmarkstillegg).isFalse()
+        }
+    }
+
+    @Nested
+    inner class ErSvalbardtillegg {
+        @Test
+        fun `skal returnere true om behandlingsårsak er svalbardtillegg`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SVALBARDTILLEGG)
+
+            // Act
+            val erSvalbardtillegg = behandling.erSvalbardtillegg()
+
+            // Assert
+            assertThat(erSvalbardtillegg).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om behandlingsårsak ikke er svalbardtillegg`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.FINNMARKSTILLEGG)
+
+            // Act
+            val erSvalbardtillegg = behandling.erSvalbardtillegg()
+
+            // Assert
+            assertThat(erSvalbardtillegg).isFalse()
+        }
+    }
+
+    @Nested
+    inner class ErFinnmarksTilleggEllerSvalbardtillegg {
+        @Test
+        fun `skal returnere true om behandlingsårsak er finnmarkstillegg`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.FINNMARKSTILLEGG)
+
+            // Act
+            val erFinnmarksTilleggEllerSvalbardtillegg = behandling.erFinnmarksTilleggEllerSvalbardtillegg()
+
+            // Assert
+            assertThat(erFinnmarksTilleggEllerSvalbardtillegg).isTrue()
+        }
+
+        @Test
+        fun `skal returnere true om behandlingsårsak er svalbardtillegg`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SVALBARDTILLEGG)
+
+            // Act
+            val erFinnmarksTilleggEllerSvalbardtillegg = behandling.erFinnmarksTilleggEllerSvalbardtillegg()
+
+            // Assert
+            assertThat(erFinnmarksTilleggEllerSvalbardtillegg).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om behandlingsårsak ikke er finnmarkstillegg eller svalbardtillegg`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+
+            // Act
+            val erFinnmarksTilleggEllerSvalbardtillegg = behandling.erFinnmarksTilleggEllerSvalbardtillegg()
+
+            // Assert
+            assertThat(erFinnmarksTilleggEllerSvalbardtillegg).isFalse()
+        }
+    }
+
+    @Nested
+    inner class ErBehandlingMedVedtaksbrevutsending {
+        @Test
+        fun `kan sende vedtaksbrev for ordinær førstegangsbehandling`() {
+            // ARrange
+            val behandling = lagBehandling()
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isTrue()
+        }
+
+        @Test
+        fun `kan sende vedtaksbrev for ordinær revurdering`() {
+            // Arrange
+            val behandling = lagBehandling(behandlingType = BehandlingType.REVURDERING, årsak = BehandlingÅrsak.NYE_OPPLYSNINGER)
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isTrue()
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = BehandlingÅrsak::class, names = ["ENDRE_MIGRERINGSDATO", "HELMANUELL_MIGRERING", "MIGRERING"])
+        fun `kan ikke sende vedtaksbrev for behandlingstype MIGRERING_FRA_INFOTRYGD`(
+            årsak: BehandlingÅrsak,
+        ) {
+            // Arrange
+            val behandling = lagBehandling(behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD, årsak = årsak)
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isFalse()
+        }
+
+        @Test
+        fun `kan ikke sende vedtaksbrev for teknisk endring`() {
+            // Arrange
+            val behandling = lagBehandling(behandlingType = BehandlingType.TEKNISK_ENDRING)
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isFalse()
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
+        fun `kan ikke sende vedtaksbrev for revurdering med årsak satsendring eller månedlig valutajustering`(
+            årsak: BehandlingÅrsak,
+        ) {
+            // Arrange
+            val behandling = lagBehandling(behandlingType = BehandlingType.REVURDERING, årsak = årsak)
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isFalse()
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Behandlingsresultat::class, names = ["FORTSATT_INNVILGET", "FORTSATT_OPPHØRT"])
+        fun `skal returnere false om behandlingsårsak er svalbardtillegg og behandlingsresultatet er FORTSATT_INNVILGET eller FORTSATT_OPPHØRT`(
+            behandlingsresultat: Behandlingsresultat,
+        ) {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SVALBARDTILLEGG, resultat = behandlingsresultat)
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isFalse()
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Behandlingsresultat::class, names = ["FORTSATT_INNVILGET", "FORTSATT_OPPHØRT"])
+        fun `skal returnere false om behandlingsårsak er finnmarkstillegg og behandlingsresultatet er FORTSATT_INNVILGET eller FORTSATT_OPPHØRT`(
+            behandlingsresultat: Behandlingsresultat,
+        ) {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.FINNMARKSTILLEGG, resultat = behandlingsresultat)
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isFalse()
+        }
+    }
+
+    @Nested
+    inner class SkalRettFraBehandlingsresultatTilIverksetting {
+        @ParameterizedTest
+        @EnumSource(value = BehandlingÅrsak::class, names = ["FINNMARKSTILLEGG", "SVALBARDTILLEGG"])
+        fun `skal returnere true om behandlingen skal behandles automatisk og behandlingsårsak er finnmarkstillegg eller svalbardstillegg`(
+            behandlingÅrsak: BehandlingÅrsak,
+        ) {
+            // Arrange
+            val behandling = lagBehandling(skalBehandlesAutomatisk = true, årsak = behandlingÅrsak)
+
+            // Act
+            val skalRettFraBehandlingsresultatTilIverksetting = behandling.skalRettFraBehandlingsresultatTilIverksetting(false)
+
+            // Assert
+            assertThat(skalRettFraBehandlingsresultatTilIverksetting).isTrue()
+        }
+    }
+
+    @Nested
+    inner class ErAutomatiskOgSkalHaTidligereBehandling {
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingÅrsak::class,
+            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        fun `skal returnere true for gitte behandlingsårsaker`(behandlingÅrsak: BehandlingÅrsak) {
+            // Arrange
+            val behandling = lagBehandling(årsak = behandlingÅrsak)
+
+            // Act
+            val erAutomatiskOgSkalHaTidligereBehandling = behandling.erAutomatiskOgSkalHaTidligereBehandling()
+
+            // Assert
+            assertThat(erAutomatiskOgSkalHaTidligereBehandling).isTrue()
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingÅrsak::class,
+            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal returnere false for gitte behandlingsårsaker`(behandlingÅrsak: BehandlingÅrsak) {
+            // Arrange
+            val behandling = lagBehandling(årsak = behandlingÅrsak)
+
+            // Act
+            val erAutomatiskOgSkalHaTidligereBehandling = behandling.erAutomatiskOgSkalHaTidligereBehandling()
+
+            // Assert
+            assertThat(erAutomatiskOgSkalHaTidligereBehandling).isFalse()
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -31,391 +31,26 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import org.hamcrest.MatcherAssert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
-import org.hamcrest.CoreMatchers.`is` as Is
 
 class BehandlingsresultatEndringUtilsTest {
-    val søker = tilfeldigPerson()
+    private val søker = tilfeldigPerson()
 
     private val barn1Aktør = randomAktør()
 
-    val jan22 = YearMonth.of(2022, 1)
-    val feb22 = YearMonth.of(2022, 2)
-    val mai22 = YearMonth.of(2022, 5)
-    val aug22 = YearMonth.of(2022, 8)
-    val des22 = YearMonth.of(2022, 12)
-
-    @Test
-    fun `utledEndringsresultat skal returnere INGEN_ENDRING dersom det ikke finnes noe endringer i behandling`() {
-        val endringsresultat =
-            utledEndringsresultat(
-                behandling = lagBehandling(),
-                nåværendeAndeler = emptyList(),
-                forrigeAndeler = emptyList(),
-                personerFremstiltKravFor = emptyList(),
-                nåværendeKompetanser = emptyList(),
-                forrigeKompetanser = emptyList(),
-                nåværendePersonResultat = emptySet(),
-                forrigePersonResultat = emptySet(),
-                nåværendeEndretAndeler = emptyList(),
-                forrigeEndretAndeler = emptyList(),
-                personerIBehandling = emptySet(),
-                personerIForrigeBehandling = emptySet(),
-                nåMåned = YearMonth.now(),
-                nåværendeUtenlandskPeriodebeløp = emptyList(),
-                forrigeUtenlandskPeriodebeløp = emptyList(),
-                featureToggleService = mockFeatureToggleService(),
-            )
-
-        assertThat(endringsresultat, Is(Endringsresultat.INGEN_ENDRING))
-    }
-
-    @Test
-    fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i beløp`() {
-        val person = lagPerson()
-
-        val forrigeAndel =
-            lagAndelTilkjentYtelse(
-                fom = jan22,
-                tom = aug22,
-                beløp = 1054,
-                aktør = person.aktør,
-            )
-
-        val endringsresultat =
-            utledEndringsresultat(
-                behandling = lagBehandling(),
-                nåværendeAndeler = listOf(forrigeAndel.copy(kalkulertUtbetalingsbeløp = 40)),
-                forrigeAndeler = listOf(forrigeAndel),
-                personerFremstiltKravFor = emptyList(),
-                nåværendeKompetanser = emptyList(),
-                forrigeKompetanser = emptyList(),
-                nåværendePersonResultat = emptySet(),
-                forrigePersonResultat = emptySet(),
-                nåværendeEndretAndeler = emptyList(),
-                forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(person),
-                personerIForrigeBehandling = setOf(person),
-                nåMåned = YearMonth.now(),
-                nåværendeUtenlandskPeriodebeløp = emptyList(),
-                forrigeUtenlandskPeriodebeløp = emptyList(),
-                featureToggleService = mockFeatureToggleService(),
-            )
-
-        assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
-    }
-
-    @Test
-    fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i vilkårsvurderingen`() {
-        val fødselsdato = LocalDate.of(2015, 1, 1)
-        val barn = lagPerson(aktør = barn1Aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
-        val forrigeAndeler =
-            listOf(
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2015, 2),
-                    tom = YearMonth.of(2020, 1),
-                ),
-            )
-
-        val nåværendeAndeler =
-            listOf(
-                lagAndelTilkjentYtelse(
-                    fom = YearMonth.of(2015, 2),
-                    tom = YearMonth.of(2020, 1),
-                ),
-            )
-
-        val forrigeVilkårResultater =
-            listOf(
-                VilkårResultat(
-                    personResultat = null,
-                    vilkårType = Vilkår.BOSATT_I_RIKET,
-                    resultat = Resultat.OPPFYLT,
-                    periodeFom = fødselsdato,
-                    periodeTom = LocalDate.of(2020, 1, 1),
-                    begrunnelse = "begrunnelse",
-                    sistEndretIBehandlingId = 0,
-                    utdypendeVilkårsvurderinger =
-                        listOf(
-                            UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
-                            UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP,
-                        ),
-                    vurderesEtter = Regelverk.NASJONALE_REGLER,
-                ),
-            )
-
-        val nåværendeVilkårResultater =
-            listOf(
-                VilkårResultat(
-                    personResultat = null,
-                    vilkårType = Vilkår.BOSATT_I_RIKET,
-                    resultat = Resultat.OPPFYLT,
-                    periodeFom = fødselsdato,
-                    periodeTom = LocalDate.of(2020, 1, 1),
-                    begrunnelse = "begrunnelse",
-                    sistEndretIBehandlingId = 0,
-                    utdypendeVilkårsvurderinger =
-                        listOf(
-                            UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
-                            UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP,
-                        ),
-                    vurderesEtter = Regelverk.EØS_FORORDNINGEN,
-                ),
-            )
-
-        val forrigePersonResultat =
-            PersonResultat(
-                id = 0,
-                vilkårsvurdering = mockk(),
-                aktør = barn1Aktør,
-                vilkårResultater = forrigeVilkårResultater.toMutableSet(),
-            )
-
-        val nåværendePersonResultat =
-            PersonResultat(
-                id = 0,
-                vilkårsvurdering = mockk(),
-                aktør = barn1Aktør,
-                vilkårResultater = nåværendeVilkårResultater.toMutableSet(),
-            )
-
-        val endringsresultat =
-            utledEndringsresultat(
-                behandling = lagBehandling(),
-                nåværendeAndeler = nåværendeAndeler,
-                forrigeAndeler = forrigeAndeler,
-                personerFremstiltKravFor = emptyList(),
-                nåværendeKompetanser = emptyList(),
-                forrigeKompetanser = emptyList(),
-                nåværendePersonResultat = setOf(nåværendePersonResultat),
-                forrigePersonResultat = setOf(forrigePersonResultat),
-                nåværendeEndretAndeler = emptyList(),
-                forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(barn),
-                personerIForrigeBehandling = setOf(barn),
-                nåMåned = YearMonth.now(),
-                nåværendeUtenlandskPeriodebeløp = emptyList(),
-                forrigeUtenlandskPeriodebeløp = emptyList(),
-                featureToggleService = mockFeatureToggleService(),
-            )
-
-        assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
-    }
-
-    @Test
-    fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i kompetanse`() {
-        val forrigeBehandling = lagBehandling()
-        val nåværendeBehandling = lagBehandling()
-
-        val barnPerson = lagPerson(aktør = barn1Aktør)
-
-        val forrigeKompetanse =
-            lagKompetanse(
-                behandlingId = forrigeBehandling.id,
-                barnAktører = setOf(barn1Aktør),
-                barnetsBostedsland = "NO",
-                søkersAktivitet = KompetanseAktivitet.ARBEIDER,
-                søkersAktivitetsland = "NO",
-                annenForeldersAktivitet = KompetanseAktivitet.INAKTIV,
-                annenForeldersAktivitetsland = "PO",
-                kompetanseResultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
-                fom = YearMonth.now().minusMonths(6),
-                tom = null,
-            )
-
-        val endringsresultat =
-            utledEndringsresultat(
-                behandling = lagBehandling(),
-                nåværendeAndeler = emptyList(),
-                forrigeAndeler = emptyList(),
-                personerFremstiltKravFor = emptyList(),
-                nåværendeKompetanser =
-                    listOf(
-                        forrigeKompetanse
-                            .copy(søkersAktivitet = KompetanseAktivitet.ARBEIDER_PÅ_NORSK_SOKKEL)
-                            .apply { behandlingId = nåværendeBehandling.id },
-                    ),
-                forrigeKompetanser = listOf(forrigeKompetanse),
-                nåværendePersonResultat = emptySet(),
-                forrigePersonResultat = emptySet(),
-                nåværendeEndretAndeler = emptyList(),
-                forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(barnPerson),
-                personerIForrigeBehandling = setOf(barnPerson),
-                nåMåned = YearMonth.now(),
-                nåværendeUtenlandskPeriodebeløp = emptyList(),
-                forrigeUtenlandskPeriodebeløp = emptyList(),
-                featureToggleService = mockFeatureToggleService(),
-            )
-
-        assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
-    }
-
-    @Test
-    fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i endret utbetaling andeler`() {
-        val barn = lagPerson(type = PersonType.BARN)
-        val forrigeEndretAndel =
-            lagEndretUtbetalingAndel(
-                personer = setOf(barn),
-                prosent = BigDecimal.ZERO,
-                fom = jan22,
-                tom = aug22,
-                årsak = Årsak.ETTERBETALING_3ÅR,
-                søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
-            )
-
-        val endringsresultat =
-            utledEndringsresultat(
-                behandling = lagBehandling(),
-                nåværendeAndeler = emptyList(),
-                forrigeAndeler = emptyList(),
-                personerFremstiltKravFor = emptyList(),
-                nåværendeKompetanser = emptyList(),
-                forrigeKompetanser = emptyList(),
-                nåværendePersonResultat = emptySet(),
-                forrigePersonResultat = emptySet(),
-                nåværendeEndretAndeler = listOf(forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)),
-                forrigeEndretAndeler = listOf(forrigeEndretAndel),
-                personerIBehandling = setOf(barn),
-                personerIForrigeBehandling = setOf(barn),
-                nåMåned = YearMonth.now(),
-                nåværendeUtenlandskPeriodebeløp = emptyList(),
-                forrigeUtenlandskPeriodebeløp = emptyList(),
-                featureToggleService = mockFeatureToggleService(),
-            )
-
-        assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
-    }
-
-    @Test
-    fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i utenlandsk periodebeløp`() {
-        val barnPerson = lagPerson(aktør = barn1Aktør)
-        val forrigeBehandling = lagBehandling()
-        val nåværendeBehandling = lagBehandling()
-
-        val forrigeUtenlandskPeriodebeløp =
-            lagUtenlandskPeriodebeløp(
-                behandlingId = forrigeBehandling.id,
-                barnAktører = setOf(barn1Aktør),
-                valutakode = "NOK",
-                beløp = BigDecimal(500),
-                intervall = Intervall.MÅNEDLIG,
-                utbetalingsland = "NORGE",
-                fom = jan22,
-                tom = mai22,
-            )
-
-        val endringsresultat =
-            utledEndringsresultat(
-                behandling = lagBehandling(),
-                nåværendeAndeler = emptyList(),
-                forrigeAndeler = emptyList(),
-                personerFremstiltKravFor = emptyList(),
-                nåværendeKompetanser = emptyList(),
-                forrigeKompetanser = emptyList(),
-                nåværendePersonResultat = emptySet(),
-                forrigePersonResultat = emptySet(),
-                nåværendeEndretAndeler = emptyList(),
-                forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(barnPerson),
-                personerIForrigeBehandling = setOf(barnPerson),
-                nåMåned = YearMonth.now(),
-                nåværendeUtenlandskPeriodebeløp = listOf(forrigeUtenlandskPeriodebeløp.copy(valutakode = "SEK").apply { behandlingId = nåværendeBehandling.id }),
-                forrigeUtenlandskPeriodebeløp = listOf(forrigeUtenlandskPeriodebeløp),
-                featureToggleService = mockFeatureToggleService(),
-            )
-
-        assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
-    }
-
-    @Test
-    fun `utledEndringsresultat skal returnere INGEN_ENDRING hvis behandlingsårsak er FINNMARKSTILLEGG og eneste endring er i vilkårsvurdering`() {
-        val fødselsdato = LocalDate.of(2015, 1, 1)
-
-        val forrigePersonResultat =
-            PersonResultat(
-                id = 0,
-                vilkårsvurdering = mockk(),
-                aktør = barn1Aktør,
-                vilkårResultater =
-                    mutableSetOf(
-                        VilkårResultat(
-                            personResultat = null,
-                            vilkårType = Vilkår.BOSATT_I_RIKET,
-                            resultat = Resultat.OPPFYLT,
-                            periodeFom = fødselsdato,
-                            periodeTom = null,
-                            begrunnelse = "begrunnelse",
-                            sistEndretIBehandlingId = 0,
-                            utdypendeVilkårsvurderinger = listOf(),
-                            vurderesEtter = Regelverk.NASJONALE_REGLER,
-                        ),
-                    ),
-            )
-
-        val nåværendePersonResultat =
-            PersonResultat(
-                id = 0,
-                vilkårsvurdering = mockk(),
-                aktør = barn1Aktør,
-                vilkårResultater =
-                    mutableSetOf(
-                        VilkårResultat(
-                            personResultat = null,
-                            vilkårType = Vilkår.BOSATT_I_RIKET,
-                            resultat = Resultat.OPPFYLT,
-                            periodeFom = fødselsdato,
-                            periodeTom = LocalDate.of(2024, 12, 31),
-                            begrunnelse = "begrunnelse",
-                            sistEndretIBehandlingId = 0,
-                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS),
-                            vurderesEtter = Regelverk.NASJONALE_REGLER,
-                        ),
-                        VilkårResultat(
-                            personResultat = null,
-                            vilkårType = Vilkår.BOSATT_I_RIKET,
-                            resultat = Resultat.OPPFYLT,
-                            periodeFom = LocalDate.of(2025, 1, 1),
-                            periodeTom = null,
-                            begrunnelse = "begrunnelse",
-                            sistEndretIBehandlingId = 0,
-                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS),
-                            vurderesEtter = Regelverk.NASJONALE_REGLER,
-                        ),
-                    ),
-            )
-
-        val barn = lagPerson(aktør = barn1Aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
-
-        val endringsresultat =
-            utledEndringsresultat(
-                behandling = lagBehandling(årsak = BehandlingÅrsak.FINNMARKSTILLEGG),
-                nåværendeAndeler = emptyList(),
-                forrigeAndeler = emptyList(),
-                personerFremstiltKravFor = emptyList(),
-                nåværendeKompetanser = emptyList(),
-                forrigeKompetanser = emptyList(),
-                nåværendePersonResultat = setOf(nåværendePersonResultat),
-                forrigePersonResultat = setOf(forrigePersonResultat),
-                nåværendeEndretAndeler = emptyList(),
-                forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(barn),
-                personerIForrigeBehandling = setOf(barn),
-                nåMåned = YearMonth.now(),
-                nåværendeUtenlandskPeriodebeløp = emptyList(),
-                forrigeUtenlandskPeriodebeløp = emptyList(),
-                featureToggleService = mockFeatureToggleService(),
-            )
-
-        assertThat(endringsresultat, Is(Endringsresultat.INGEN_ENDRING))
-    }
+    private val jan22 = YearMonth.of(2022, 1)
+    private val feb22 = YearMonth.of(2022, 2)
+    private val mai22 = YearMonth.of(2022, 5)
+    private val aug22 = YearMonth.of(2022, 8)
+    private val des22 = YearMonth.of(2022, 12)
 
     @Test
     fun `Endring i beløp - Skal returnere false dersom eneste endring er opphør`() {
@@ -1455,7 +1090,7 @@ class BehandlingsresultatEndringUtilsTest {
                 featureToggleService = mockFeatureToggleService(),
             )
 
-        assertThat(erEndringIVilkårvurderingForPerson, Is(false))
+        assertThat(erEndringIVilkårvurderingForPerson).isFalse()
     }
 
     @Test
@@ -1512,7 +1147,7 @@ class BehandlingsresultatEndringUtilsTest {
                 featureToggleService = mockFeatureToggleService(),
             )
 
-        assertThat(erEndringIVilkårvurderingForPerson, Is(true))
+        assertThat(erEndringIVilkårvurderingForPerson).isTrue()
     }
 
     @Test
@@ -1568,7 +1203,7 @@ class BehandlingsresultatEndringUtilsTest {
                 featureToggleService = mockFeatureToggleService(),
             )
 
-        assertThat(erEndringIVilkårvurderingForPerson, Is(true))
+        assertThat(erEndringIVilkårvurderingForPerson).isTrue()
     }
 
     @Test
@@ -1628,7 +1263,7 @@ class BehandlingsresultatEndringUtilsTest {
                 featureToggleService = mockFeatureToggleService(),
             )
 
-        assertThat(erEndringIVilkårvurderingForPerson, Is(true))
+        assertThat(erEndringIVilkårvurderingForPerson).isTrue()
     }
 
     @Test
@@ -1685,7 +1320,488 @@ class BehandlingsresultatEndringUtilsTest {
                 featureToggleService = mockFeatureToggleService(),
             )
 
-        assertThat(erEndringIVilkårvurderingForPerson, Is(false))
+        assertThat(erEndringIVilkårvurderingForPerson).isFalse()
+    }
+
+    @Nested
+    inner class UtledEndringsresultat {
+        @Test
+        fun `skal returnere INGEN_ENDRING dersom det ikke finnes noe endringer i behandling`() {
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = lagBehandling(),
+                    nåværendeAndeler = emptyList(),
+                    forrigeAndeler = emptyList(),
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser = emptyList(),
+                    forrigeKompetanser = emptyList(),
+                    nåværendePersonResultat = emptySet(),
+                    forrigePersonResultat = emptySet(),
+                    nåværendeEndretAndeler = emptyList(),
+                    forrigeEndretAndeler = emptyList(),
+                    personerIBehandling = emptySet(),
+                    personerIForrigeBehandling = emptySet(),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = emptyList(),
+                    forrigeUtenlandskPeriodebeløp = emptyList(),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.INGEN_ENDRING)
+        }
+
+        @Test
+        fun `skal returnere ENDRING dersom det finnes endringer i beløp`() {
+            // Arrange
+            val person = lagPerson()
+
+            val forrigeAndel =
+                lagAndelTilkjentYtelse(
+                    fom = jan22,
+                    tom = aug22,
+                    beløp = 1054,
+                    aktør = person.aktør,
+                )
+
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = lagBehandling(),
+                    nåværendeAndeler = listOf(forrigeAndel.copy(kalkulertUtbetalingsbeløp = 40)),
+                    forrigeAndeler = listOf(forrigeAndel),
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser = emptyList(),
+                    forrigeKompetanser = emptyList(),
+                    nåværendePersonResultat = emptySet(),
+                    forrigePersonResultat = emptySet(),
+                    nåværendeEndretAndeler = emptyList(),
+                    forrigeEndretAndeler = emptyList(),
+                    personerIBehandling = setOf(person),
+                    personerIForrigeBehandling = setOf(person),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = emptyList(),
+                    forrigeUtenlandskPeriodebeløp = emptyList(),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.ENDRING)
+        }
+
+        @Test
+        fun `skal returnere ENDRING dersom det finnes endringer i vilkårsvurderingen`() {
+            // Arrange
+            val fødselsdato = LocalDate.of(2015, 1, 1)
+
+            val barn = lagPerson(aktør = barn1Aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
+
+            val forrigeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2015, 2),
+                        tom = YearMonth.of(2020, 1),
+                    ),
+                )
+
+            val nåværendeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2015, 2),
+                        tom = YearMonth.of(2020, 1),
+                    ),
+                )
+
+            val forrigeVilkårResultater =
+                listOf(
+                    VilkårResultat(
+                        personResultat = null,
+                        vilkårType = Vilkår.BOSATT_I_RIKET,
+                        resultat = Resultat.OPPFYLT,
+                        periodeFom = fødselsdato,
+                        periodeTom = LocalDate.of(2020, 1, 1),
+                        begrunnelse = "begrunnelse",
+                        sistEndretIBehandlingId = 0,
+                        utdypendeVilkårsvurderinger =
+                            listOf(
+                                UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
+                                UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP,
+                            ),
+                        vurderesEtter = Regelverk.NASJONALE_REGLER,
+                    ),
+                )
+
+            val nåværendeVilkårResultater =
+                listOf(
+                    VilkårResultat(
+                        personResultat = null,
+                        vilkårType = Vilkår.BOSATT_I_RIKET,
+                        resultat = Resultat.OPPFYLT,
+                        periodeFom = fødselsdato,
+                        periodeTom = LocalDate.of(2020, 1, 1),
+                        begrunnelse = "begrunnelse",
+                        sistEndretIBehandlingId = 0,
+                        utdypendeVilkårsvurderinger =
+                            listOf(
+                                UtdypendeVilkårsvurdering.BARN_BOR_I_NORGE,
+                                UtdypendeVilkårsvurdering.VURDERT_MEDLEMSKAP,
+                            ),
+                        vurderesEtter = Regelverk.EØS_FORORDNINGEN,
+                    ),
+                )
+
+            val forrigePersonResultat =
+                PersonResultat(
+                    id = 0,
+                    vilkårsvurdering = mockk(),
+                    aktør = barn1Aktør,
+                    vilkårResultater = forrigeVilkårResultater.toMutableSet(),
+                )
+
+            val nåværendePersonResultat =
+                PersonResultat(
+                    id = 0,
+                    vilkårsvurdering = mockk(),
+                    aktør = barn1Aktør,
+                    vilkårResultater = nåværendeVilkårResultater.toMutableSet(),
+                )
+
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = lagBehandling(),
+                    nåværendeAndeler = nåværendeAndeler,
+                    forrigeAndeler = forrigeAndeler,
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser = emptyList(),
+                    forrigeKompetanser = emptyList(),
+                    nåværendePersonResultat = setOf(nåværendePersonResultat),
+                    forrigePersonResultat = setOf(forrigePersonResultat),
+                    nåværendeEndretAndeler = emptyList(),
+                    forrigeEndretAndeler = emptyList(),
+                    personerIBehandling = setOf(barn),
+                    personerIForrigeBehandling = setOf(barn),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = emptyList(),
+                    forrigeUtenlandskPeriodebeløp = emptyList(),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.ENDRING)
+        }
+
+        @Test
+        fun `skal returnere ENDRING dersom det finnes endringer i kompetanse`() {
+            // Arrange
+            val forrigeBehandling = lagBehandling()
+            val nåværendeBehandling = lagBehandling()
+
+            val barnPerson = lagPerson(aktør = barn1Aktør)
+
+            val forrigeKompetanse =
+                lagKompetanse(
+                    behandlingId = forrigeBehandling.id,
+                    barnAktører = setOf(barn1Aktør),
+                    barnetsBostedsland = "NO",
+                    søkersAktivitet = KompetanseAktivitet.ARBEIDER,
+                    søkersAktivitetsland = "NO",
+                    annenForeldersAktivitet = KompetanseAktivitet.INAKTIV,
+                    annenForeldersAktivitetsland = "PO",
+                    kompetanseResultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
+                    fom = YearMonth.now().minusMonths(6),
+                    tom = null,
+                )
+
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = lagBehandling(),
+                    nåværendeAndeler = emptyList(),
+                    forrigeAndeler = emptyList(),
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser =
+                        listOf(
+                            forrigeKompetanse
+                                .copy(søkersAktivitet = KompetanseAktivitet.ARBEIDER_PÅ_NORSK_SOKKEL)
+                                .apply { behandlingId = nåværendeBehandling.id },
+                        ),
+                    forrigeKompetanser = listOf(forrigeKompetanse),
+                    nåværendePersonResultat = emptySet(),
+                    forrigePersonResultat = emptySet(),
+                    nåværendeEndretAndeler = emptyList(),
+                    forrigeEndretAndeler = emptyList(),
+                    personerIBehandling = setOf(barnPerson),
+                    personerIForrigeBehandling = setOf(barnPerson),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = emptyList(),
+                    forrigeUtenlandskPeriodebeløp = emptyList(),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.ENDRING)
+        }
+
+        @Test
+        fun `skal returnere ENDRING dersom det finnes endringer i endret utbetaling andeler`() {
+            // Arrange
+            val barn = lagPerson(type = PersonType.BARN)
+
+            val forrigeEndretAndel =
+                lagEndretUtbetalingAndel(
+                    personer = setOf(barn),
+                    prosent = BigDecimal.ZERO,
+                    fom = jan22,
+                    tom = aug22,
+                    årsak = Årsak.ETTERBETALING_3ÅR,
+                    søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
+                )
+
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = lagBehandling(),
+                    nåværendeAndeler = emptyList(),
+                    forrigeAndeler = emptyList(),
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser = emptyList(),
+                    forrigeKompetanser = emptyList(),
+                    nåværendePersonResultat = emptySet(),
+                    forrigePersonResultat = emptySet(),
+                    nåværendeEndretAndeler = listOf(forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)),
+                    forrigeEndretAndeler = listOf(forrigeEndretAndel),
+                    personerIBehandling = setOf(barn),
+                    personerIForrigeBehandling = setOf(barn),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = emptyList(),
+                    forrigeUtenlandskPeriodebeløp = emptyList(),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.ENDRING)
+        }
+
+        @Test
+        fun `skal returnere ENDRING dersom det finnes endringer i utenlandsk periodebeløp`() {
+            // Arrange
+            val barnPerson = lagPerson(aktør = barn1Aktør)
+
+            val forrigeBehandling = lagBehandling()
+            val nåværendeBehandling = lagBehandling()
+
+            val forrigeUtenlandskPeriodebeløp =
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = forrigeBehandling.id,
+                    barnAktører = setOf(barn1Aktør),
+                    valutakode = "NOK",
+                    beløp = BigDecimal(500),
+                    intervall = Intervall.MÅNEDLIG,
+                    utbetalingsland = "NORGE",
+                    fom = jan22,
+                    tom = mai22,
+                )
+
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = lagBehandling(),
+                    nåværendeAndeler = emptyList(),
+                    forrigeAndeler = emptyList(),
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser = emptyList(),
+                    forrigeKompetanser = emptyList(),
+                    nåværendePersonResultat = emptySet(),
+                    forrigePersonResultat = emptySet(),
+                    nåværendeEndretAndeler = emptyList(),
+                    forrigeEndretAndeler = emptyList(),
+                    personerIBehandling = setOf(barnPerson),
+                    personerIForrigeBehandling = setOf(barnPerson),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = listOf(forrigeUtenlandskPeriodebeløp.copy(valutakode = "SEK").apply { behandlingId = nåværendeBehandling.id }),
+                    forrigeUtenlandskPeriodebeløp = listOf(forrigeUtenlandskPeriodebeløp),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.ENDRING)
+        }
+
+        @Test
+        fun `skal returnere INGEN_ENDRING hvis behandlingsårsak er FINNMARKSTILLEGG og eneste endring er i vilkårsvurdering`() {
+            // Arrange
+            val fødselsdato = LocalDate.of(2015, 1, 1)
+
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.FINNMARKSTILLEGG)
+
+            val forrigePersonResultat =
+                PersonResultat(
+                    id = 0,
+                    vilkårsvurdering = mockk(),
+                    aktør = barn1Aktør,
+                    vilkårResultater =
+                        mutableSetOf(
+                            VilkårResultat(
+                                personResultat = null,
+                                vilkårType = Vilkår.BOSATT_I_RIKET,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = fødselsdato,
+                                periodeTom = null,
+                                begrunnelse = "begrunnelse",
+                                sistEndretIBehandlingId = 0,
+                                utdypendeVilkårsvurderinger = listOf(),
+                                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                            ),
+                        ),
+                )
+
+            val nåværendePersonResultat =
+                PersonResultat(
+                    id = 0,
+                    vilkårsvurdering = mockk(),
+                    aktør = barn1Aktør,
+                    vilkårResultater =
+                        mutableSetOf(
+                            VilkårResultat(
+                                personResultat = null,
+                                vilkårType = Vilkår.BOSATT_I_RIKET,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = fødselsdato,
+                                periodeTom = LocalDate.of(2024, 12, 31),
+                                begrunnelse = "begrunnelse",
+                                sistEndretIBehandlingId = 0,
+                                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS),
+                                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                            ),
+                            VilkårResultat(
+                                personResultat = null,
+                                vilkårType = Vilkår.BOSATT_I_RIKET,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = LocalDate.of(2025, 1, 1),
+                                periodeTom = null,
+                                begrunnelse = "begrunnelse",
+                                sistEndretIBehandlingId = 0,
+                                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS),
+                                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                            ),
+                        ),
+                )
+
+            val barn = lagPerson(aktør = barn1Aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
+
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = behandling,
+                    nåværendeAndeler = emptyList(),
+                    forrigeAndeler = emptyList(),
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser = emptyList(),
+                    forrigeKompetanser = emptyList(),
+                    nåværendePersonResultat = setOf(nåværendePersonResultat),
+                    forrigePersonResultat = setOf(forrigePersonResultat),
+                    nåværendeEndretAndeler = emptyList(),
+                    forrigeEndretAndeler = emptyList(),
+                    personerIBehandling = setOf(barn),
+                    personerIForrigeBehandling = setOf(barn),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = emptyList(),
+                    forrigeUtenlandskPeriodebeløp = emptyList(),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.INGEN_ENDRING)
+        }
+
+        @Test
+        fun `skal returnere INGEN_ENDRING hvis behandlingsårsak er SVALBARDTILLEGG og eneste endring er i vilkårsvurdering`() {
+            // Arrange
+            val fødselsdato = LocalDate.of(2015, 1, 1)
+
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SVALBARDTILLEGG)
+
+            val forrigePersonResultat =
+                PersonResultat(
+                    id = 0,
+                    vilkårsvurdering = mockk(),
+                    aktør = barn1Aktør,
+                    vilkårResultater =
+                        mutableSetOf(
+                            VilkårResultat(
+                                personResultat = null,
+                                vilkårType = Vilkår.BOSATT_I_RIKET,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = fødselsdato,
+                                periodeTom = null,
+                                begrunnelse = "begrunnelse",
+                                sistEndretIBehandlingId = 0,
+                                utdypendeVilkårsvurderinger = listOf(),
+                                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                            ),
+                        ),
+                )
+
+            val nåværendePersonResultat =
+                PersonResultat(
+                    id = 0,
+                    vilkårsvurdering = mockk(),
+                    aktør = barn1Aktør,
+                    vilkårResultater =
+                        mutableSetOf(
+                            VilkårResultat(
+                                personResultat = null,
+                                vilkårType = Vilkår.BOSATT_I_RIKET,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = fødselsdato,
+                                periodeTom = LocalDate.of(2024, 12, 31),
+                                begrunnelse = "begrunnelse",
+                                sistEndretIBehandlingId = 0,
+                                utdypendeVilkårsvurderinger = emptyList(),
+                                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                            ),
+                            VilkårResultat(
+                                personResultat = null,
+                                vilkårType = Vilkår.BOSATT_I_RIKET,
+                                resultat = Resultat.OPPFYLT,
+                                periodeFom = LocalDate.of(2025, 1, 1),
+                                periodeTom = null,
+                                begrunnelse = "begrunnelse",
+                                sistEndretIBehandlingId = 0,
+                                utdypendeVilkårsvurderinger = emptyList(),
+                                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                            ),
+                        ),
+                )
+
+            val barn = lagPerson(aktør = barn1Aktør, fødselsdato = fødselsdato, type = PersonType.BARN)
+
+            // Act
+            val endringsresultat =
+                utledEndringsresultat(
+                    behandling = behandling,
+                    nåværendeAndeler = emptyList(),
+                    forrigeAndeler = emptyList(),
+                    personerFremstiltKravFor = emptyList(),
+                    nåværendeKompetanser = emptyList(),
+                    forrigeKompetanser = emptyList(),
+                    nåværendePersonResultat = setOf(nåværendePersonResultat),
+                    forrigePersonResultat = setOf(forrigePersonResultat),
+                    nåværendeEndretAndeler = emptyList(),
+                    forrigeEndretAndeler = emptyList(),
+                    personerIBehandling = setOf(barn),
+                    personerIForrigeBehandling = setOf(barn),
+                    nåMåned = YearMonth.now(),
+                    nåværendeUtenlandskPeriodebeløp = emptyList(),
+                    forrigeUtenlandskPeriodebeløp = emptyList(),
+                    featureToggleService = mockFeatureToggleService(),
+                )
+
+            // Assert
+            assertThat(endringsresultat).isEqualTo(Endringsresultat.INGEN_ENDRING)
+        }
     }
 
     private fun lagPersonResultatFraVilkårResultater(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegTest.kt
@@ -77,6 +77,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
@@ -349,6 +351,18 @@ class BehandlingsresultatStegTest {
 
     @Nested
     inner class PreValiderStegTest {
+        @ParameterizedTest
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"])
+        fun `skal ikke valideres om behandlingen ikke har riktig årsak for behandling som skal automatisk behandles`(
+            behandlingÅrsak: BehandlingÅrsak,
+        ) {
+            // Arrange
+            val behandling = lagBehandling(skalBehandlesAutomatisk = true, årsak = behandlingÅrsak)
+
+            // Act & assert
+            assertDoesNotThrow { behandlingsresultatSteg.preValiderSteg(behandling) }
+        }
+
         @Test
         fun `Skal kaste feil dersom det finnes kompetanser der Norge er sekundærland men aktivitetsland og bosted er satt til Norge`() {
             // Arrange


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26201

Alle plasser (bortsett fra i behandlingsklassen) som brukte `erFinnmarkstillegg` er byttet ut med `erFinnmarksTilleggEllerSvalbardtillegg`.

- Legger til metoden `erSvalbardtillegg`
- Legger til metoden `erFinnmarksTilleggEllerSvalbardtillegg`
- Omdøper `FinnmarkstilleggIngenEndringFeil` til `IngenEndringIBosattIRiketVilkårFeil`
- Litt lett rekfatorering for å forbedre lesbarheten
- Skriver tester
- Oppdaterer til nyeste familie-ekstern-kontraker

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
