### PR TITLE
NAV-26201: Omdøper pakkenavn fra "svalbardstillegg" til "svalbardtillegg" (uten en ekstra "s")

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -22,8 +22,8 @@ import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.AutovedtakMånedligValutajusteringService
 import no.nav.familie.ba.sak.kjerne.autovedtak.månedligvalutajustering.MånedligValutajusteringScheduler
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.FinnPersonerSomBorPåSvalbardIFagsakerTask
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.FinnPersonerSomBorPåSvalbardIFagsakerTask
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggScheduler.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg
 
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggTaskOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggTaskOppretter.kt
@@ -1,10 +1,10 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg
 
 import jakarta.transaction.Transactional
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene.SvalbardtilleggKjøring
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene.SvalbardtilleggKjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene.SvalbardtilleggKjøring
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene.SvalbardtilleggKjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/FinnPersonerSomBorIFinnmarkNordTromsEllerPåSvalbardTask.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg
 
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/FinnPersonerSomBorPåSvalbardIFagsakerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/FinnPersonerSomBorPåSvalbardIFagsakerTask.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg
 
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.familie.ba.sak.common.Feil

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/domene/SvalbardtilleggKjøring.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/domene/SvalbardtilleggKjøring.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/domene/SvalbardtilleggKjøringRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/domene/SvalbardtilleggKjøringRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene
 
 import org.springframework.data.jpa.repository.JpaRepository
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggSchedulerTest.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg
 
 import io.mockk.every
 import io.mockk.just

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggTaskOppretterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggTaskOppretterTest.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg
 
 import io.mockk.every
 import io.mockk.just
@@ -14,8 +14,8 @@ import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.lagVegadresse
 import no.nav.familie.ba.sak.integrasjoner.pdl.SystemOnlyPdlRestClient
 import no.nav.familie.ba.sak.integrasjoner.pdl.domene.PdlBostedsadresseDeltBostedOppholdsadressePerson
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene.SvalbardtilleggKjøring
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene.SvalbardtilleggKjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene.SvalbardtilleggKjøring
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene.SvalbardtilleggKjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/domene/SvalbardtilleggKjøringRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/domene/SvalbardtilleggKjøringRepositoryTest.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene
+package no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene
 
 import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
 import no.nav.familie.ba.sak.datagenerator.lagAktør

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
@@ -8,8 +8,8 @@ import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.domene.FinnmarkstilleggKjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.domene.FinnmarkstilleggKjøringRepository
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene.SvalbardtilleggKjøring
-import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.domene.SvalbardtilleggKjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene.SvalbardtilleggKjøring
+import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.domene.SvalbardtilleggKjøringRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26201

Omdøper pakkenavn fra "svalbardstillegg" til "svalbardtillegg" (uten en ekstra "s")

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
