### PR TITLE
Reduksjon finnmarkstillegg søker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevEøsBegrunnelseProdusent.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.EØSBegrunnelseDataMedKompetan
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.EØSBegrunnelseDataUtenKompetanse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.IBegrunnelseGrunnlagForPeriode
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.begrunnelseGjelderOpphørFraForrigeBehandling
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.begrunnelseSkalTriggesForOpphørFraForrigeBehandling
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.hentGyldigeBegrunnelserPerPerson
 
 fun EØSStandardbegrunnelse.lagBrevBegrunnelse(
@@ -33,7 +33,7 @@ fun EØSStandardbegrunnelse.lagBrevBegrunnelse(
         begrunnelsesGrunnlagPerPerson.filter { (person, _) -> person in personerGjeldendeForBegrunnelse }
 
     val gjelderSøker = personerGjeldendeForBegrunnelse.any { it.type == PersonType.SØKER }
-    val begrunnelseGjelderSøkerOgOpphørFraForrigeBehandling = (sanityBegrunnelse.begrunnelseGjelderOpphørFraForrigeBehandling()) && gjelderSøker
+    val begrunnelseGjelderSøkerOgOpphørFraForrigeBehandling = (sanityBegrunnelse.begrunnelseSkalTriggesForOpphørFraForrigeBehandling()) && gjelderSøker
     val kompetanser =
         when (sanityBegrunnelse.periodeResultat) {
             SanityPeriodeResultat.INNVILGET_ELLER_ØKNING,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/ErGjeldendeForReduksjonFraForrigeBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/ErGjeldendeForReduksjonFraForrigeBehandling.kt
@@ -1,0 +1,65 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent
+
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.UtvidetBarnetrygdTrigger
+import no.nav.familie.ba.sak.kjerne.brev.domene.VilkårTrigger
+import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
+
+fun ISanityBegrunnelse.erGjeldendeForReduksjonFraForrigeBehandling(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode): Boolean {
+    if (begrunnelseGrunnlag !is BegrunnelseGrunnlagForPeriodeMedReduksjonPåTversAvBehandlinger) {
+        return false
+    }
+
+    val oppfylteVilkårDenneBehandlingen =
+        begrunnelseGrunnlag.dennePerioden.vilkårResultater
+            .filter { it.resultat == Resultat.OPPFYLT }
+            .map { it.vilkårType }
+            .toSet()
+    val oppfylteVilkårForrigeBehandling =
+        begrunnelseGrunnlag.sammePeriodeForrigeBehandling
+            ?.vilkårResultater
+            ?.filter { it.resultat == Resultat.OPPFYLT }
+            ?.map { it.vilkårType }
+            ?.toSet() ?: emptySet()
+
+    val vilkårMistetSidenForrigeBehandling = oppfylteVilkårForrigeBehandling - oppfylteVilkårDenneBehandlingen
+
+    val begrunnelseGjelderMistedeVilkår = this.vilkår.all { it in vilkårMistetSidenForrigeBehandling }
+
+    val begrunnelseGjelderTaptSmåbarnstillegg = sjekkOmBegrunnelseGjelderTaptSmåbarnstillegg(begrunnelseGrunnlag)
+    val begrunnelseGjelderTaptFinnmarkstillegg = sjekkOmBegrunnelseGjelderTaptFinnmarkstillegg(begrunnelseGrunnlag)
+    val begrunnelseGjelderTaptSvalbardtillegg = sjekkOmBegrunnelseGjelderTaptSvalbardtillegg(begrunnelseGrunnlag)
+
+    return begrunnelseSkalTriggesForReduksjonFraForrigeBehandling() &&
+        (
+            begrunnelseGjelderMistedeVilkår ||
+                begrunnelseGjelderTaptSmåbarnstillegg ||
+                begrunnelseGjelderTaptFinnmarkstillegg ||
+                begrunnelseGjelderTaptSvalbardtillegg
+        )
+}
+
+private fun ISanityBegrunnelse.sjekkOmBegrunnelseGjelderTaptSmåbarnstillegg(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode): Boolean {
+    val haddeSmåbarnstilleggForrigeBehandling = begrunnelseGrunnlag.erSmåbarnstilleggIForrigeBehandlingPeriode()
+    val harSmåbarnstilleggDennePerioden = begrunnelseGrunnlag.dennePerioden.andeler.any { it.type == YtelseType.SMÅBARNSTILLEGG }
+    val begrunnelseGjelderTaptSmåbarnstillegg = UtvidetBarnetrygdTrigger.SMÅBARNSTILLEGG in utvidetBarnetrygdTriggere && haddeSmåbarnstilleggForrigeBehandling && !harSmåbarnstilleggDennePerioden
+    return begrunnelseGjelderTaptSmåbarnstillegg
+}
+
+private fun ISanityBegrunnelse.sjekkOmBegrunnelseGjelderTaptFinnmarkstillegg(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode): Boolean {
+    val haddeKravPåFinnmarkstilleggForrigeBehandling = begrunnelseGrunnlag.sjekkOmharKravPåFinnmarkstilleggIForrigeBehandlingPeriode()
+    val harKravPåFinnmarkstilleggDennePerioden = begrunnelseGrunnlag.sjekkOmHarKravPåFinnmarkstilleggDennePeriode()
+    val begrunnelseGjelderTaptFinnmarkstillegg = VilkårTrigger.BOSATT_I_FINNMARK_NORD_TROMS in bosattIRiketTriggere && haddeKravPåFinnmarkstilleggForrigeBehandling && !harKravPåFinnmarkstilleggDennePerioden
+    return begrunnelseGjelderTaptFinnmarkstillegg
+}
+
+private fun ISanityBegrunnelse.sjekkOmBegrunnelseGjelderTaptSvalbardtillegg(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode): Boolean {
+    val haddeKravPåSvalbardtilleggForrigeBehandling = begrunnelseGrunnlag.sjekkOmharKravPåSvalbardtilleggIForrigeBehandlingPeriode()
+    val harKravPåSvalbardtilleggDennePerioden = begrunnelseGrunnlag.sjekkOmHarKravPåSvalbardtilleggDennePeriode()
+    val begrunnelseGjelderTaptSvalbardtillegg = VilkårTrigger.BOSATT_PÅ_SVALBARD in bosattIRiketTriggere && haddeKravPåSvalbardtilleggForrigeBehandling && !harKravPåSvalbardtilleggDennePerioden
+    return begrunnelseGjelderTaptSvalbardtillegg
+}
+
+internal fun ISanityBegrunnelse.begrunnelseSkalTriggesForReduksjonFraForrigeBehandling() = ØvrigTrigger.REDUKSJON_FRA_FORRIGE_BEHANDLING in this.øvrigeTriggere

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/FinnBegrunnelseGrunnlagPerPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/FinnBegrunnelseGrunnlagPerPerson.kt
@@ -1,0 +1,121 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent
+
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.nesteMåned
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
+import no.nav.familie.ba.sak.common.sisteDagIMåned
+import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.brev.brevBegrunnelseProdusent.GrunnlagForBegrunnelse
+import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
+import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.tomTidslinje
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
+import java.time.YearMonth
+
+data class ForrigeOgDennePerioden(
+    val forrige: BegrunnelseGrunnlagForPersonIPeriode?,
+    val denne: BegrunnelseGrunnlagForPersonIPeriode?,
+)
+
+fun VedtaksperiodeMedBegrunnelser.finnBegrunnelseGrunnlagPerPerson(
+    grunnlag: GrunnlagForBegrunnelse,
+): Map<Person, IBegrunnelseGrunnlagForPeriode> {
+    val tidslinjeMedVedtaksperioden = this.tilTidslinjeForAktuellPeriode()
+
+    val begrunnelsegrunnlagTidslinjerPerPerson =
+        grunnlag.behandlingsGrunnlagForVedtaksperioder.lagBegrunnelseGrunnlagTidslinjer()
+
+    val grunnlagTidslinjePerPersonForrigeBehandling =
+        grunnlag.behandlingsGrunnlagForVedtaksperioderForrigeBehandling?.lagBegrunnelseGrunnlagTidslinjer()
+
+    return begrunnelsegrunnlagTidslinjerPerPerson.mapValues { (person, grunnlagTidslinje) ->
+        val grunnlagMedForrigePeriodeOgBehandlingTidslinje =
+            tidslinjeMedVedtaksperioden.lagTidslinjeGrunnlagDennePeriodenForrigePeriodeOgPeriodeForrigeBehandling(
+                grunnlagTidslinje,
+                grunnlagTidslinjePerPersonForrigeBehandling,
+                person,
+            )
+
+        val begrunnelseperioderIVedtaksperiode =
+            grunnlagMedForrigePeriodeOgBehandlingTidslinje.tilPerioder().mapNotNull { it.verdi }
+
+        when (this.type) {
+            Vedtaksperiodetype.OPPHØR -> begrunnelseperioderIVedtaksperiode.first()
+            Vedtaksperiodetype.FORTSATT_INNVILGET ->
+                if (this.fom == null && this.tom == null) {
+                    val perioder = grunnlagMedForrigePeriodeOgBehandlingTidslinje.tilPerioder()
+                    perioder.single { grunnlag.nåDato.toYearMonth() in (it.fom?.toYearMonth() ?: MIN_MÅNED)..(it.tom?.toYearMonth() ?: MAX_MÅNED) }.verdi!!
+                } else {
+                    begrunnelseperioderIVedtaksperiode.first()
+                }
+
+            else -> begrunnelseperioderIVedtaksperiode.first()
+        }
+    }
+}
+
+private fun Tidslinje<VedtaksperiodeMedBegrunnelser>.lagTidslinjeGrunnlagDennePeriodenForrigePeriodeOgPeriodeForrigeBehandling(
+    grunnlagTidslinje: Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>,
+    grunnlagTidslinjePerPersonForrigeBehandling: Map<Person, Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>>?,
+    person: Person,
+): Tidslinje<IBegrunnelseGrunnlagForPeriode> {
+    val grunnlagMedForrigePeriodeTidslinje = grunnlagTidslinje.tilForrigeOgNåværendePeriodeTidslinje(this)
+
+    val grunnlagForrigeBehandlingTidslinje = grunnlagTidslinjePerPersonForrigeBehandling?.get(person) ?: tomTidslinje()
+
+    return this.kombinerMed(
+        grunnlagMedForrigePeriodeTidslinje,
+        grunnlagForrigeBehandlingTidslinje,
+    ) { vedtaksPerioden, forrigeOgDennePerioden, forrigeBehandling ->
+        val dennePerioden = forrigeOgDennePerioden?.denne
+
+        if (vedtaksPerioden == null) {
+            null
+        } else {
+            IBegrunnelseGrunnlagForPeriode.opprett(
+                dennePerioden = dennePerioden ?: BegrunnelseGrunnlagForPersonIPeriode.tomPeriode(person),
+                forrigePeriode = forrigeOgDennePerioden?.forrige,
+                sammePeriodeForrigeBehandling = forrigeBehandling,
+                periodetype = vedtaksPerioden.type,
+            )
+        }
+    }
+}
+
+private fun VedtaksperiodeMedBegrunnelser.tilTidslinjeForAktuellPeriode(): Tidslinje<VedtaksperiodeMedBegrunnelser> =
+    listOf(
+        Periode(
+            verdi = this,
+            fom = this.fom?.førsteDagIInneværendeMåned(),
+            tom = this.tom?.sisteDagIMåned(),
+        ),
+    ).tilTidslinje()
+
+private fun Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>.tilForrigeOgNåværendePeriodeTidslinje(
+    vedtaksperiodeTidslinje: Tidslinje<VedtaksperiodeMedBegrunnelser>,
+): Tidslinje<ForrigeOgDennePerioden> {
+    val grunnlagPerioderSplittetPåVedtaksperiode =
+        kombinerMed(vedtaksperiodeTidslinje) { grunnlag, periode ->
+            Pair(grunnlag, periode)
+        }.tilPerioder().map { Periode(it.verdi?.first, it.fom, it.tom) }
+
+    return (
+        listOf(
+            Periode(
+                verdi = null,
+                fom = YearMonth.now().førsteDagIInneværendeMåned(),
+                tom = YearMonth.now().sisteDagIInneværendeMåned(),
+            ),
+        ) + grunnlagPerioderSplittetPåVedtaksperiode
+    ).zipWithNext { forrige, denne ->
+        val innholdForrigePeriode = if (forrige.tom?.nesteMåned() == denne.fom?.toYearMonth()) forrige.verdi else null
+        Periode(ForrigeOgDennePerioden(innholdForrigePeriode, denne.verdi), denne.fom, denne.tom)
+    }.tilTidslinje()
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/HentResultaterForPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/HentResultaterForPeriode.kt
@@ -1,0 +1,156 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VilkårResultatForVedtaksperiode
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+
+internal fun hentResultaterForPeriode(
+    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
+    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
+    erUtbetalingPåSøkerIPeriode: Boolean,
+    erReduksjonIFinnmarkstillegg: Boolean,
+): List<SanityPeriodeResultat> {
+    val erAndelerPåPersonHvisBarn =
+        begrunnelseGrunnlagForPeriode.person.type != PersonType.BARN ||
+            begrunnelseGrunnlagForPeriode.andeler
+                .toList()
+                .isNotEmpty()
+
+    val erInnvilgetEtterVilkårOgEndretUtbetaling =
+        begrunnelseGrunnlagForPeriode.erOrdinæreVilkårInnvilget() && begrunnelseGrunnlagForPeriode.erInnvilgetEtterEndretUtbetaling()
+
+    val erReduksjonIFinnmarkPgaPerson =
+        hentErReduksjonIFinnmarkPgaPerson(
+            begrunnelseGrunnlagForPeriode.vilkårResultater,
+            begrunnelseGrunnlagForrigePeriode?.vilkårResultater,
+            erReduksjonIFinnmarkstillegg,
+        )
+
+    val erReduksjonIAndel =
+        erReduksjonIAndelMellomPerioder(
+            begrunnelseGrunnlagForPeriode,
+            begrunnelseGrunnlagForrigePeriode,
+        ) || erReduksjonIFinnmarkPgaPerson
+
+    val erEøs = begrunnelseGrunnlagForPeriode.kompetanse != null
+
+    return if (erInnvilgetEtterVilkårOgEndretUtbetaling && erAndelerPåPersonHvisBarn) {
+        val erØkingIAndel =
+            erØkningIAndelMellomPerioder(
+                begrunnelseGrunnlagForPeriode,
+                begrunnelseGrunnlagForrigePeriode,
+            )
+        val erSatsøkning =
+            erSatsøkningMellomPerioder(
+                begrunnelseGrunnlagForPeriode,
+                begrunnelseGrunnlagForrigePeriode,
+            )
+
+        val erSøker = begrunnelseGrunnlagForPeriode.person.type == PersonType.SØKER
+        val erOrdinæreVilkårOppfyltIForrigePeriode =
+            begrunnelseGrunnlagForrigePeriode?.erOrdinæreVilkårInnvilget() == true
+
+        val erIngenEndring = !erØkingIAndel && !erReduksjonIAndel && erOrdinæreVilkårOppfyltIForrigePeriode
+        val erKunReduksjonAvSats =
+            erKunReduksjonAvSats(begrunnelseGrunnlagForPeriode, begrunnelseGrunnlagForrigePeriode)
+
+        listOfNotNull(
+            if (erØkingIAndel || erSatsøkning || erSøker || erIngenEndring || erEøs || erKunReduksjonAvSats) SanityPeriodeResultat.INNVILGET_ELLER_ØKNING else null,
+            if (erReduksjonIAndel) SanityPeriodeResultat.REDUKSJON else null,
+            if (erIngenEndring || erKunReduksjonAvSats) SanityPeriodeResultat.INGEN_ENDRING else null,
+        )
+    } else {
+        listOfNotNull(
+            if (erUtbetalingPåSøkerIPeriode && erEøs) SanityPeriodeResultat.INNVILGET_ELLER_ØKNING else null,
+            if (erReduksjonIAndel) SanityPeriodeResultat.REDUKSJON else null,
+            SanityPeriodeResultat.IKKE_INNVILGET,
+        )
+    }
+}
+
+private fun hentErReduksjonIFinnmarkPgaPerson(
+    vilkårResultaterDennePerioden: Iterable<VilkårResultatForVedtaksperiode>,
+    vilkårResultaterForrigePeriode: Iterable<VilkårResultatForVedtaksperiode>?,
+    erReduksjonIFinnmarkstillegg: Boolean,
+): Boolean {
+    val erBosattIFinnmarkForrigePeriode =
+        vilkårResultaterForrigePeriode
+            ?.flatMap { it.utdypendeVilkårsvurderinger }
+            ?.any { it == UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS } ?: false
+    val erBosattIFinnmarkDennePeriode =
+        vilkårResultaterDennePerioden
+            .flatMap { it.utdypendeVilkårsvurderinger }
+            .any { it == UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS }
+
+    return erBosattIFinnmarkForrigePeriode && !erBosattIFinnmarkDennePeriode && erReduksjonIFinnmarkstillegg
+}
+
+private fun erKunReduksjonAvSats(
+    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
+    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
+): Boolean {
+    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
+    val andelerDennePerioden = begrunnelseGrunnlagForPeriode.andeler
+
+    return andelerForrigePeriode.any { andelIForrigePeriode ->
+        val sammeAndelDennePerioden = andelerDennePerioden.singleOrNull { andelIForrigePeriode.type == it.type }
+
+        val harAndelSammeProsent =
+            sammeAndelDennePerioden != null && andelIForrigePeriode.prosent == sammeAndelDennePerioden.prosent
+        val satsErRedusert = andelIForrigePeriode.sats > (sammeAndelDennePerioden?.sats ?: 0)
+
+        harAndelSammeProsent && satsErRedusert
+    }
+}
+
+private fun erReduksjonIAndelMellomPerioder(
+    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode?,
+    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
+): Boolean {
+    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
+    val andelerDennePerioden = begrunnelseGrunnlagForPeriode?.andeler ?: emptyList()
+
+    return andelerForrigePeriode.any { andelIForrigePeriode ->
+        val sammeAndelDennePerioden = andelerDennePerioden.singleOrNull { andelIForrigePeriode.type == it.type }
+
+        val erAndelenMistet =
+            sammeAndelDennePerioden == null && begrunnelseGrunnlagForrigePeriode?.erInnvilgetEtterEndretUtbetaling() == true
+        val harAndelenGåttNedIProsent =
+            sammeAndelDennePerioden != null && andelIForrigePeriode.prosent > sammeAndelDennePerioden.prosent
+        val erSatsenRedusert = andelIForrigePeriode.sats > (sammeAndelDennePerioden?.sats ?: 0)
+
+        erAndelenMistet || harAndelenGåttNedIProsent || erSatsenRedusert
+    }
+}
+
+private fun erØkningIAndelMellomPerioder(
+    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
+    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
+): Boolean {
+    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
+    val andelerDennePerioden = begrunnelseGrunnlagForPeriode.andeler
+
+    return andelerDennePerioden.any { andelIPeriode ->
+        val sammeAndelForrigePeriode = andelerForrigePeriode.singleOrNull { andelIPeriode.type == it.type }
+
+        val erAndelenTjent =
+            sammeAndelForrigePeriode == null && begrunnelseGrunnlagForPeriode.erInnvilgetEtterEndretUtbetaling()
+        val harAndelenGåttOppIProsent =
+            sammeAndelForrigePeriode != null && andelIPeriode.prosent > sammeAndelForrigePeriode.prosent
+
+        erAndelenTjent || harAndelenGåttOppIProsent
+    }
+}
+
+private fun erSatsøkningMellomPerioder(
+    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
+    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
+): Boolean {
+    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
+    val andelerDennePerioden = begrunnelseGrunnlagForPeriode.andeler
+    return andelerDennePerioden.any { andelIPeriode ->
+        val sammeAndelForrigePeriode = andelerForrigePeriode.singleOrNull { andelIPeriode.type == it.type }
+        sammeAndelForrigePeriode != null && andelIPeriode.sats > sammeAndelForrigePeriode.sats
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/SkalFiltreresPåHendelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/SkalFiltreresPåHendelser.kt
@@ -1,0 +1,80 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent
+
+import no.nav.familie.ba.sak.common.TIDENES_ENDE
+import no.nav.familie.ba.sak.common.TIDENES_MORGEN
+import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.beregning.SatsService
+import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksbegrunnelse
+import java.time.LocalDate
+
+fun ISanityBegrunnelse.skalFiltreresPåHendelser(
+    begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode,
+    fomVedtaksperiode: LocalDate?,
+    tomVedtaksperiode: LocalDate?,
+): Boolean =
+    if (!begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget()) {
+        val person = begrunnelseGrunnlag.dennePerioden.person
+
+        this.erBarnDød(person, fomVedtaksperiode)
+    } else {
+        val person = begrunnelseGrunnlag.dennePerioden.person
+
+        this.erBarn6År(person, fomVedtaksperiode) ||
+            this.erSatsendring(
+                person,
+                begrunnelseGrunnlag.dennePerioden.andeler,
+                fomVedtaksperiode,
+                tomVedtaksperiode,
+            )
+    }
+
+fun ISanityBegrunnelse.erBarn6År(
+    person: Person,
+    fomVedtaksperiode: LocalDate?,
+): Boolean {
+    val blirPerson6DennePerioden = person.hentSeksårsdag().toYearMonth() == fomVedtaksperiode?.toYearMonth()
+
+    return blirPerson6DennePerioden && this.øvrigeTriggere.contains(ØvrigTrigger.BARN_MED_6_ÅRS_DAG)
+}
+
+fun ISanityBegrunnelse.erBarnDød(
+    person: Person,
+    fomVedtaksperiode: LocalDate?,
+): Boolean {
+    val dødsfall = person.dødsfall
+    val personDødeForrigeMåned =
+        dødsfall != null && dødsfall.dødsfallDato.toYearMonth().plusMonths(1) == fomVedtaksperiode?.toYearMonth()
+
+    return personDødeForrigeMåned &&
+        person.type == PersonType.BARN &&
+        this.øvrigeTriggere.contains(ØvrigTrigger.BARN_DØD)
+}
+
+fun ISanityBegrunnelse.erSatsendring(
+    person: Person,
+    andeler: Iterable<AndelForVedtaksbegrunnelse>,
+    fomVedtaksperiode: LocalDate?,
+    tomVedtaksperiode: LocalDate?,
+): Boolean {
+    // Bruker fomVedtaksperiode siden satsendring alltid er i starten av perioden
+    val satstyperPåAndelene =
+        andeler
+            .flatMap {
+                it.type.tilSatsType(
+                    person = person,
+                    fom = (fomVedtaksperiode ?: TIDENES_MORGEN).toYearMonth(),
+                    tom = (tomVedtaksperiode ?: TIDENES_ENDE).toYearMonth(),
+                )
+            }.toSet()
+
+    val erSatsendringIPeriodenForPerson =
+        satstyperPåAndelene.any { satstype ->
+            SatsService.finnAlleSatserFor(satstype).any { it.gyldigFom == fomVedtaksperiode }
+        }
+
+    return erSatsendringIPeriodenForPerson && this.øvrigeTriggere.contains(ØvrigTrigger.SATSENDRING)
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/TemaerForBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/TemaerForBegrunnelser.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.ISanityBegrunnelse
+import no.nav.familie.ba.sak.kjerne.brev.domene.SanityPeriodeResultat
+import no.nav.familie.ba.sak.kjerne.brev.domene.Tema
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
+import kotlin.collections.contains
+
+data class TemaerForBegrunnelser(
+    val temaerForOpphør: Set<Tema>,
+    val temaForUtbetaling: Tema,
+)
+
+fun hentTemaSomPeriodeErVurdertEtter(
+    begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode,
+): TemaerForBegrunnelser {
+    val regelverkSomBlirBorteFraForrigePeriode =
+        finnRegelverkSomBlirBorte(
+            dennePerioden = begrunnelseGrunnlag.dennePerioden,
+            forrigePeriode = begrunnelseGrunnlag.forrigePeriode,
+        )
+    val regelverkSomBlirBorteFraForrigeBehandling =
+        finnRegelverkSomBlirBorte(
+            dennePerioden = begrunnelseGrunnlag.dennePerioden,
+            forrigePeriode = begrunnelseGrunnlag.sammePeriodeForrigeBehandling,
+        )
+    val vurdertEtterEøsDennePerioden =
+        begrunnelseGrunnlag.dennePerioden.vilkårResultater.any { it.vurderesEtter == Regelverk.EØS_FORORDNINGEN }
+
+    val regelverkSomBlirBorte =
+        listOfNotNull(regelverkSomBlirBorteFraForrigePeriode, regelverkSomBlirBorteFraForrigeBehandling).toSet()
+
+    return TemaerForBegrunnelser(
+        temaerForOpphør = regelverkSomBlirBorte.ifEmpty { setOf(Tema.NASJONAL) },
+        temaForUtbetaling = if (vurdertEtterEøsDennePerioden) Tema.EØS else Tema.NASJONAL,
+    )
+}
+
+fun ISanityBegrunnelse.erSammeTemaSomPeriode(
+    temaerForBegrunnelser: TemaerForBegrunnelser,
+): Boolean =
+    if (this.periodeResultat == SanityPeriodeResultat.IKKE_INNVILGET) {
+        temaerForBegrunnelser.temaerForOpphør.contains(tema) || tema == Tema.FELLES
+    } else {
+        temaerForBegrunnelser.temaForUtbetaling == tema || tema == Tema.FELLES
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/VedtakBegrunnelseProdusent.kt
@@ -1,14 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent
 
-import no.nav.familie.ba.sak.common.TIDENES_ENDE
-import no.nav.familie.ba.sak.common.TIDENES_MORGEN
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.nesteMåned
-import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
-import no.nav.familie.ba.sak.kjerne.beregning.SatsService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.brev.brevBegrunnelseProdusent.GrunnlagForBegrunnelse
@@ -23,8 +16,6 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.brev.domene.tilPersonType
 import no.nav.familie.ba.sak.kjerne.brev.domene.ØvrigTrigger
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
-import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MAX_MÅNED
-import no.nav.familie.ba.sak.kjerne.eøs.felles.util.MIN_MÅNED
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
@@ -32,26 +23,13 @@ import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.domene.hentBrevPeriodeType
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.hentBegrunnelser.hentAvslagsbegrunnelserPerPerson
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.hentBegrunnelser.hentEØSStandardBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.hentBegrunnelser.hentStandardBegrunnelser
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.AndelForVedtaksbegrunnelse
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.BehandlingsGrunnlagForVedtaksperioder
-import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.VilkårResultatForVedtaksperiode
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvedeVilkårTidslinjer
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Regelverk
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
-import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import no.nav.familie.tidslinje.Periode
-import no.nav.familie.tidslinje.Tidslinje
-import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.tidslinje.tomTidslinje
-import no.nav.familie.tidslinje.utvidelser.kombinerMed
-import no.nav.familie.tidslinje.utvidelser.tilPerioder
-import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.YearMonth
 
 fun VedtaksperiodeMedBegrunnelser.hentGyldigeBegrunnelserForPeriode(
     grunnlagForBegrunnelser: GrunnlagForBegrunnelse,
@@ -189,45 +167,6 @@ fun erUtbetalingEllerDeltBostedIPeriode(begrunnelseGrunnlagPerPerson: Map<Person
             dennePerioden.andeler.any { it.prosent != BigDecimal.ZERO }
     }
 
-fun ISanityBegrunnelse.erSammeTemaSomPeriode(
-    temaerForBegrunnelser: TemaerForBegrunnelser,
-): Boolean =
-    if (this.periodeResultat == SanityPeriodeResultat.IKKE_INNVILGET) {
-        temaerForBegrunnelser.temaerForOpphør.contains(tema) || tema == Tema.FELLES
-    } else {
-        temaerForBegrunnelser.temaForUtbetaling == tema || tema == Tema.FELLES
-    }
-
-data class TemaerForBegrunnelser(
-    val temaerForOpphør: Set<Tema>,
-    val temaForUtbetaling: Tema,
-)
-
-fun hentTemaSomPeriodeErVurdertEtter(
-    begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode,
-): TemaerForBegrunnelser {
-    val regelverkSomBlirBorteFraForrigePeriode =
-        finnRegelverkSomBlirBorte(
-            dennePerioden = begrunnelseGrunnlag.dennePerioden,
-            forrigePeriode = begrunnelseGrunnlag.forrigePeriode,
-        )
-    val regelverkSomBlirBorteFraForrigeBehandling =
-        finnRegelverkSomBlirBorte(
-            dennePerioden = begrunnelseGrunnlag.dennePerioden,
-            forrigePeriode = begrunnelseGrunnlag.sammePeriodeForrigeBehandling,
-        )
-    val vurdertEtterEøsDennePerioden =
-        begrunnelseGrunnlag.dennePerioden.vilkårResultater.any { it.vurderesEtter == Regelverk.EØS_FORORDNINGEN }
-
-    val regelverkSomBlirBorte =
-        listOfNotNull(regelverkSomBlirBorteFraForrigePeriode, regelverkSomBlirBorteFraForrigeBehandling).toSet()
-
-    return TemaerForBegrunnelser(
-        temaerForOpphør = regelverkSomBlirBorte.ifEmpty { setOf(Tema.NASJONAL) },
-        temaForUtbetaling = if (vurdertEtterEøsDennePerioden) Tema.EØS else Tema.NASJONAL,
-    )
-}
-
 fun finnRegelverkSomBlirBorte(
     dennePerioden: BegrunnelseGrunnlagForPersonIPeriode,
     forrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
@@ -254,38 +193,6 @@ fun finnRegelverkSomBlirBorte(
         null
     }
 }
-
-private fun VedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerson(
-    behandlingsGrunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
-): Map<Person, Set<IVedtakBegrunnelse>> =
-    behandlingsGrunnlagForVedtaksperioder.persongrunnlag.personer.associateWith { person ->
-        val vilkårResultaterForPerson =
-            behandlingsGrunnlagForVedtaksperioder
-                .personResultater
-                .firstOrNull { it.aktør == person.aktør }
-                ?.vilkårResultater ?: emptyList()
-
-        val (generelleAvslag, vilkårResultaterUtenGenerelleAvslag) = vilkårResultaterForPerson.partition { it.erEksplisittAvslagUtenPeriode() }
-
-        val generelleAvslagsbegrunnelser = generelleAvslag.flatMap { it.standardbegrunnelser }
-
-        val avslagsbegrunnelserMedPeriodeTidslinjer =
-            vilkårResultaterUtenGenerelleAvslag
-                .tilForskjøvedeVilkårTidslinjer(person.fødselsdato)
-                .filtrerKunEksplisittAvslagsPerioder()
-
-        val avslagsbegrunnelserMedPeriode = avslagsbegrunnelserMedPeriodeTidslinjer.flatMap { it.tilPerioder() }.filter { it.fom?.toYearMonth() == this.fom?.toYearMonth() }.flatMap { it.verdi?.standardbegrunnelser ?: emptyList() }
-
-        (generelleAvslagsbegrunnelser + avslagsbegrunnelserMedPeriode).toSet()
-    }
-
-private fun List<Tidslinje<VilkårResultat>>.filtrerKunEksplisittAvslagsPerioder(): List<Tidslinje<VilkårResultat>> =
-    this.map { tidslinjeForVilkår ->
-        tidslinjeForVilkår
-            .tilPerioderIkkeNull()
-            .filter { it.verdi.erEksplisittAvslagPåSøknad == true }
-            .tilTidslinje()
-    }
 
 internal fun ISanityBegrunnelse.skalVisesSelvOmIkkeEndring(
     begrunnelseGrunnlagForPersonIPeriode: BegrunnelseGrunnlagForPersonIPeriode,
@@ -322,9 +229,7 @@ fun ISanityBegrunnelse.erGjeldendeForFagsakType(
     true
 }
 
-internal fun ISanityBegrunnelse.begrunnelseGjelderReduksjonFraForrigeBehandling() = ØvrigTrigger.REDUKSJON_FRA_FORRIGE_BEHANDLING in this.øvrigeTriggere
-
-internal fun ISanityBegrunnelse.begrunnelseGjelderOpphørFraForrigeBehandling() = ØvrigTrigger.OPPHØR_FRA_FORRIGE_BEHANDLING in this.øvrigeTriggere
+internal fun ISanityBegrunnelse.begrunnelseSkalTriggesForOpphørFraForrigeBehandling() = ØvrigTrigger.OPPHØR_FRA_FORRIGE_BEHANDLING in this.øvrigeTriggere
 
 fun SanityBegrunnelse.erGjeldendeForRolle(
     person: Person,
@@ -363,74 +268,6 @@ fun SanityEØSBegrunnelse.erLikKompetanseIPeriode(
         this.kompetanseResultat.contains(kompetanse.resultat)
 }
 
-fun ISanityBegrunnelse.skalFiltreresPåHendelser(
-    begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode,
-    fomVedtaksperiode: LocalDate?,
-    tomVedtaksperiode: LocalDate?,
-): Boolean =
-    if (!begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget()) {
-        val person = begrunnelseGrunnlag.dennePerioden.person
-
-        this.erBarnDød(person, fomVedtaksperiode)
-    } else {
-        val person = begrunnelseGrunnlag.dennePerioden.person
-
-        this.erBarn6År(person, fomVedtaksperiode) ||
-            this.erSatsendring(
-                person,
-                begrunnelseGrunnlag.dennePerioden.andeler,
-                fomVedtaksperiode,
-                tomVedtaksperiode,
-            )
-    }
-
-fun ISanityBegrunnelse.erBarn6År(
-    person: Person,
-    fomVedtaksperiode: LocalDate?,
-): Boolean {
-    val blirPerson6DennePerioden = person.hentSeksårsdag().toYearMonth() == fomVedtaksperiode?.toYearMonth()
-
-    return blirPerson6DennePerioden && this.øvrigeTriggere.contains(ØvrigTrigger.BARN_MED_6_ÅRS_DAG)
-}
-
-fun ISanityBegrunnelse.erBarnDød(
-    person: Person,
-    fomVedtaksperiode: LocalDate?,
-): Boolean {
-    val dødsfall = person.dødsfall
-    val personDødeForrigeMåned =
-        dødsfall != null && dødsfall.dødsfallDato.toYearMonth().plusMonths(1) == fomVedtaksperiode?.toYearMonth()
-
-    return personDødeForrigeMåned &&
-        person.type == PersonType.BARN &&
-        this.øvrigeTriggere.contains(ØvrigTrigger.BARN_DØD)
-}
-
-fun ISanityBegrunnelse.erSatsendring(
-    person: Person,
-    andeler: Iterable<AndelForVedtaksbegrunnelse>,
-    fomVedtaksperiode: LocalDate?,
-    tomVedtaksperiode: LocalDate?,
-): Boolean {
-    // Bruker fomVedtaksperiode siden satsendring alltid er i starten av perioden
-    val satstyperPåAndelene =
-        andeler
-            .flatMap {
-                it.type.tilSatsType(
-                    person = person,
-                    fom = (fomVedtaksperiode ?: TIDENES_MORGEN).toYearMonth(),
-                    tom = (tomVedtaksperiode ?: TIDENES_ENDE).toYearMonth(),
-                )
-            }.toSet()
-
-    val erSatsendringIPeriodenForPerson =
-        satstyperPåAndelene.any { satstype ->
-            SatsService.finnAlleSatserFor(satstype).any { it.gyldigFom == fomVedtaksperiode }
-        }
-
-    return erSatsendringIPeriodenForPerson && this.øvrigeTriggere.contains(ØvrigTrigger.SATSENDRING)
-}
-
 internal fun hentResultaterForForrigePeriode(
     begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
 ) = if (begrunnelseGrunnlagForrigePeriode?.erOrdinæreVilkårInnvilget() == true && begrunnelseGrunnlagForrigePeriode.erInnvilgetEtterEndretUtbetaling()) {
@@ -445,258 +282,7 @@ internal fun hentResultaterForForrigePeriode(
     )
 }
 
-private fun hentResultaterForPeriode(
-    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
-    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
-    erUtbetalingPåSøkerIPeriode: Boolean,
-    erReduksjonIFinnmarkstillegg: Boolean,
-): List<SanityPeriodeResultat> {
-    val erAndelerPåPersonHvisBarn =
-        begrunnelseGrunnlagForPeriode.person.type != PersonType.BARN ||
-            begrunnelseGrunnlagForPeriode.andeler
-                .toList()
-                .isNotEmpty()
-
-    val erInnvilgetEtterVilkårOgEndretUtbetaling =
-        begrunnelseGrunnlagForPeriode.erOrdinæreVilkårInnvilget() && begrunnelseGrunnlagForPeriode.erInnvilgetEtterEndretUtbetaling()
-
-    val erReduksjonIFinnmarkPgaPerson =
-        hentErReduksjonIFinnmarkPgaPerson(
-            begrunnelseGrunnlagForPeriode.vilkårResultater,
-            begrunnelseGrunnlagForrigePeriode?.vilkårResultater,
-            erReduksjonIFinnmarkstillegg,
-        )
-
-    val erReduksjonIAndel =
-        erReduksjonIAndelMellomPerioder(
-            begrunnelseGrunnlagForPeriode,
-            begrunnelseGrunnlagForrigePeriode,
-        ) || erReduksjonIFinnmarkPgaPerson
-
-    val erEøs = begrunnelseGrunnlagForPeriode.kompetanse != null
-
-    return if (erInnvilgetEtterVilkårOgEndretUtbetaling && erAndelerPåPersonHvisBarn) {
-        val erØkingIAndel =
-            erØkningIAndelMellomPerioder(
-                begrunnelseGrunnlagForPeriode,
-                begrunnelseGrunnlagForrigePeriode,
-            )
-        val erSatsøkning =
-            erSatsøkningMellomPerioder(
-                begrunnelseGrunnlagForPeriode,
-                begrunnelseGrunnlagForrigePeriode,
-            )
-
-        val erSøker = begrunnelseGrunnlagForPeriode.person.type == PersonType.SØKER
-        val erOrdinæreVilkårOppfyltIForrigePeriode =
-            begrunnelseGrunnlagForrigePeriode?.erOrdinæreVilkårInnvilget() == true
-
-        val erIngenEndring = !erØkingIAndel && !erReduksjonIAndel && erOrdinæreVilkårOppfyltIForrigePeriode
-        val erKunReduksjonAvSats =
-            erKunReduksjonAvSats(begrunnelseGrunnlagForPeriode, begrunnelseGrunnlagForrigePeriode)
-
-        listOfNotNull(
-            if (erØkingIAndel || erSatsøkning || erSøker || erIngenEndring || erEøs || erKunReduksjonAvSats) SanityPeriodeResultat.INNVILGET_ELLER_ØKNING else null,
-            if (erReduksjonIAndel) SanityPeriodeResultat.REDUKSJON else null,
-            if (erIngenEndring || erKunReduksjonAvSats) SanityPeriodeResultat.INGEN_ENDRING else null,
-        )
-    } else {
-        listOfNotNull(
-            if (erUtbetalingPåSøkerIPeriode && erEøs) SanityPeriodeResultat.INNVILGET_ELLER_ØKNING else null,
-            if (erReduksjonIAndel) SanityPeriodeResultat.REDUKSJON else null,
-            SanityPeriodeResultat.IKKE_INNVILGET,
-        )
-    }
-}
-
-private fun hentErReduksjonIFinnmarkPgaPerson(
-    vilkårResultaterDennePerioden: Iterable<VilkårResultatForVedtaksperiode>,
-    vilkårResultaterForrigePeriode: Iterable<VilkårResultatForVedtaksperiode>?,
-    erReduksjonIFinnmarkstillegg: Boolean,
-): Boolean {
-    val erBosattIFinnmarkForrigePeriode =
-        vilkårResultaterForrigePeriode
-            ?.flatMap { it.utdypendeVilkårsvurderinger }
-            ?.any { it == UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS } ?: false
-    val erBosattIFinnmarkDennePeriode =
-        vilkårResultaterDennePerioden
-            .flatMap { it.utdypendeVilkårsvurderinger }
-            .any { it == UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS }
-
-    return erBosattIFinnmarkForrigePeriode && !erBosattIFinnmarkDennePeriode && erReduksjonIFinnmarkstillegg
-}
-
-private fun erKunReduksjonAvSats(
-    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
-    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
-): Boolean {
-    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
-    val andelerDennePerioden = begrunnelseGrunnlagForPeriode.andeler
-
-    return andelerForrigePeriode.any { andelIForrigePeriode ->
-        val sammeAndelDennePerioden = andelerDennePerioden.singleOrNull { andelIForrigePeriode.type == it.type }
-
-        val harAndelSammeProsent =
-            sammeAndelDennePerioden != null && andelIForrigePeriode.prosent == sammeAndelDennePerioden.prosent
-        val satsErRedusert = andelIForrigePeriode.sats > (sammeAndelDennePerioden?.sats ?: 0)
-
-        harAndelSammeProsent && satsErRedusert
-    }
-}
-
-private fun erReduksjonIAndelMellomPerioder(
-    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode?,
-    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
-): Boolean {
-    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
-    val andelerDennePerioden = begrunnelseGrunnlagForPeriode?.andeler ?: emptyList()
-
-    return andelerForrigePeriode.any { andelIForrigePeriode ->
-        val sammeAndelDennePerioden = andelerDennePerioden.singleOrNull { andelIForrigePeriode.type == it.type }
-
-        val erAndelenMistet =
-            sammeAndelDennePerioden == null && begrunnelseGrunnlagForrigePeriode?.erInnvilgetEtterEndretUtbetaling() == true
-        val harAndelenGåttNedIProsent =
-            sammeAndelDennePerioden != null && andelIForrigePeriode.prosent > sammeAndelDennePerioden.prosent
-        val erSatsenRedusert = andelIForrigePeriode.sats > (sammeAndelDennePerioden?.sats ?: 0)
-
-        erAndelenMistet || harAndelenGåttNedIProsent || erSatsenRedusert
-    }
-}
-
-private fun erØkningIAndelMellomPerioder(
-    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
-    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
-): Boolean {
-    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
-    val andelerDennePerioden = begrunnelseGrunnlagForPeriode.andeler
-
-    return andelerDennePerioden.any { andelIPeriode ->
-        val sammeAndelForrigePeriode = andelerForrigePeriode.singleOrNull { andelIPeriode.type == it.type }
-
-        val erAndelenTjent =
-            sammeAndelForrigePeriode == null && begrunnelseGrunnlagForPeriode.erInnvilgetEtterEndretUtbetaling()
-        val harAndelenGåttOppIProsent =
-            sammeAndelForrigePeriode != null && andelIPeriode.prosent > sammeAndelForrigePeriode.prosent
-
-        erAndelenTjent || harAndelenGåttOppIProsent
-    }
-}
-
-private fun erSatsøkningMellomPerioder(
-    begrunnelseGrunnlagForPeriode: BegrunnelseGrunnlagForPersonIPeriode,
-    begrunnelseGrunnlagForrigePeriode: BegrunnelseGrunnlagForPersonIPeriode?,
-): Boolean {
-    val andelerForrigePeriode = begrunnelseGrunnlagForrigePeriode?.andeler ?: emptyList()
-    val andelerDennePerioden = begrunnelseGrunnlagForPeriode.andeler
-    return andelerDennePerioden.any { andelIPeriode ->
-        val sammeAndelForrigePeriode = andelerForrigePeriode.singleOrNull { andelIPeriode.type == it.type }
-        sammeAndelForrigePeriode != null && andelIPeriode.sats > sammeAndelForrigePeriode.sats
-    }
-}
-
 internal fun hentEndretUtbetalingDennePerioden(begrunnelseGrunnlag: IBegrunnelseGrunnlagForPeriode) = begrunnelseGrunnlag.dennePerioden.endretUtbetalingAndel.takeIf { begrunnelseGrunnlag.dennePerioden.erOrdinæreVilkårInnvilget() }
-
-fun VedtaksperiodeMedBegrunnelser.finnBegrunnelseGrunnlagPerPerson(
-    grunnlag: GrunnlagForBegrunnelse,
-): Map<Person, IBegrunnelseGrunnlagForPeriode> {
-    val tidslinjeMedVedtaksperioden = this.tilTidslinjeForAktuellPeriode()
-
-    val begrunnelsegrunnlagTidslinjerPerPerson =
-        grunnlag.behandlingsGrunnlagForVedtaksperioder.lagBegrunnelseGrunnlagTidslinjer()
-
-    val grunnlagTidslinjePerPersonForrigeBehandling =
-        grunnlag.behandlingsGrunnlagForVedtaksperioderForrigeBehandling?.lagBegrunnelseGrunnlagTidslinjer()
-
-    return begrunnelsegrunnlagTidslinjerPerPerson.mapValues { (person, grunnlagTidslinje) ->
-        val grunnlagMedForrigePeriodeOgBehandlingTidslinje =
-            tidslinjeMedVedtaksperioden.lagTidslinjeGrunnlagDennePeriodenForrigePeriodeOgPeriodeForrigeBehandling(
-                grunnlagTidslinje,
-                grunnlagTidslinjePerPersonForrigeBehandling,
-                person,
-            )
-
-        val begrunnelseperioderIVedtaksperiode =
-            grunnlagMedForrigePeriodeOgBehandlingTidslinje.tilPerioder().mapNotNull { it.verdi }
-
-        when (this.type) {
-            Vedtaksperiodetype.OPPHØR -> begrunnelseperioderIVedtaksperiode.first()
-            Vedtaksperiodetype.FORTSATT_INNVILGET ->
-                if (this.fom == null && this.tom == null) {
-                    val perioder = grunnlagMedForrigePeriodeOgBehandlingTidslinje.tilPerioder()
-                    perioder.single { grunnlag.nåDato.toYearMonth() in (it.fom?.toYearMonth() ?: MIN_MÅNED)..(it.tom?.toYearMonth() ?: MAX_MÅNED) }.verdi!!
-                } else {
-                    begrunnelseperioderIVedtaksperiode.first()
-                }
-
-            else -> begrunnelseperioderIVedtaksperiode.first()
-        }
-    }
-}
-
-private fun Tidslinje<VedtaksperiodeMedBegrunnelser>.lagTidslinjeGrunnlagDennePeriodenForrigePeriodeOgPeriodeForrigeBehandling(
-    grunnlagTidslinje: Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>,
-    grunnlagTidslinjePerPersonForrigeBehandling: Map<Person, Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>>?,
-    person: Person,
-): Tidslinje<IBegrunnelseGrunnlagForPeriode> {
-    val grunnlagMedForrigePeriodeTidslinje = grunnlagTidslinje.tilForrigeOgNåværendePeriodeTidslinje(this)
-
-    val grunnlagForrigeBehandlingTidslinje = grunnlagTidslinjePerPersonForrigeBehandling?.get(person) ?: tomTidslinje()
-
-    return this.kombinerMed(
-        grunnlagMedForrigePeriodeTidslinje,
-        grunnlagForrigeBehandlingTidslinje,
-    ) { vedtaksPerioden, forrigeOgDennePerioden, forrigeBehandling ->
-        val dennePerioden = forrigeOgDennePerioden?.denne
-
-        if (vedtaksPerioden == null) {
-            null
-        } else {
-            IBegrunnelseGrunnlagForPeriode.opprett(
-                dennePerioden = dennePerioden ?: BegrunnelseGrunnlagForPersonIPeriode.tomPeriode(person),
-                forrigePeriode = forrigeOgDennePerioden?.forrige,
-                sammePeriodeForrigeBehandling = forrigeBehandling,
-                periodetype = vedtaksPerioden.type,
-            )
-        }
-    }
-}
-
-private fun VedtaksperiodeMedBegrunnelser.tilTidslinjeForAktuellPeriode(): Tidslinje<VedtaksperiodeMedBegrunnelser> =
-    listOf(
-        Periode(
-            verdi = this,
-            fom = this.fom?.førsteDagIInneværendeMåned(),
-            tom = this.tom?.sisteDagIMåned(),
-        ),
-    ).tilTidslinje()
-
-data class ForrigeOgDennePerioden(
-    val forrige: BegrunnelseGrunnlagForPersonIPeriode?,
-    val denne: BegrunnelseGrunnlagForPersonIPeriode?,
-)
-
-private fun Tidslinje<BegrunnelseGrunnlagForPersonIPeriode>.tilForrigeOgNåværendePeriodeTidslinje(
-    vedtaksperiodeTidslinje: Tidslinje<VedtaksperiodeMedBegrunnelser>,
-): Tidslinje<ForrigeOgDennePerioden> {
-    val grunnlagPerioderSplittetPåVedtaksperiode =
-        kombinerMed(vedtaksperiodeTidslinje) { grunnlag, periode ->
-            Pair(grunnlag, periode)
-        }.tilPerioder().map { Periode(it.verdi?.first, it.fom, it.tom) }
-
-    return (
-        listOf(
-            Periode(
-                verdi = null,
-                fom = YearMonth.now().førsteDagIInneværendeMåned(),
-                tom = YearMonth.now().sisteDagIInneværendeMåned(),
-            ),
-        ) + grunnlagPerioderSplittetPåVedtaksperiode
-    ).zipWithNext { forrige, denne ->
-        val innholdForrigePeriode = if (forrige.tom?.nesteMåned() == denne.fom?.toYearMonth()) forrige.verdi else null
-        Periode(ForrigeOgDennePerioden(innholdForrigePeriode, denne.verdi), denne.fom, denne.tom)
-    }.tilTidslinje()
-}
 
 fun ISanityBegrunnelse.erGjeldendeForBrevPeriodeType(
     vedtaksperiode: VedtaksperiodeMedBegrunnelser,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentAvslagsBegrunnelserPerPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentAvslagsBegrunnelserPerPerson.kt
@@ -1,0 +1,45 @@
+package no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.hentBegrunnelser
+
+import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.IVedtakBegrunnelse
+import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtaksperiodeProdusent.BehandlingsGrunnlagForVedtaksperioder
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingForskyvningUtils.tilForskjøvedeVilkårTidslinjer
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+
+internal fun VedtaksperiodeMedBegrunnelser.hentAvslagsbegrunnelserPerPerson(
+    behandlingsGrunnlagForVedtaksperioder: BehandlingsGrunnlagForVedtaksperioder,
+): Map<Person, Set<IVedtakBegrunnelse>> =
+    behandlingsGrunnlagForVedtaksperioder.persongrunnlag.personer.associateWith { person ->
+        val vilkårResultaterForPerson =
+            behandlingsGrunnlagForVedtaksperioder
+                .personResultater
+                .firstOrNull { it.aktør == person.aktør }
+                ?.vilkårResultater ?: emptyList()
+
+        val (generelleAvslag, vilkårResultaterUtenGenerelleAvslag) = vilkårResultaterForPerson.partition { it.erEksplisittAvslagUtenPeriode() }
+
+        val generelleAvslagsbegrunnelser = generelleAvslag.flatMap { it.standardbegrunnelser }
+
+        val avslagsbegrunnelserMedPeriodeTidslinjer =
+            vilkårResultaterUtenGenerelleAvslag
+                .tilForskjøvedeVilkårTidslinjer(person.fødselsdato)
+                .filtrerKunEksplisittAvslagsPerioder()
+
+        val avslagsbegrunnelserMedPeriode = avslagsbegrunnelserMedPeriodeTidslinjer.flatMap { it.tilPerioder() }.filter { it.fom?.toYearMonth() == this.fom?.toYearMonth() }.flatMap { it.verdi?.standardbegrunnelser ?: emptyList() }
+
+        (generelleAvslagsbegrunnelser + avslagsbegrunnelserMedPeriode).toSet()
+    }
+
+private fun List<Tidslinje<VilkårResultat>>.filtrerKunEksplisittAvslagsPerioder(): List<Tidslinje<VilkårResultat>> =
+    this.map { tidslinjeForVilkår ->
+        tidslinjeForVilkår
+            .tilPerioderIkkeNull()
+            .filter { it.verdi.erEksplisittAvslagPåSøknad == true }
+            .tilTidslinje()
+    }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentEØSStandardBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/hentBegrunnelser/HentEØSStandardBegrunnelser.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.IBegrunnelseGrunnlagForPeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.TemaerForBegrunnelser
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.erGjeldendeForBrevPeriodeType
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.erGjeldendeForReduksjonFraForrigeBehandling
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.erGjeldendeForUtgjørendeVilkår
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.erLikKompetanseIPeriode
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.vedtakBegrunnelseProdusent.erLikVilkårOgUtdypendeVilkårIPeriode

--- a/src/test/resources/cucumber/finnmarkstillegg/reduksjon-finnmarkstillegg.feature
+++ b/src/test/resources/cucumber/finnmarkstillegg/reduksjon-finnmarkstillegg.feature
@@ -1,0 +1,73 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Reduksjon på finnmarkstillegg
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype | Status  |
+      | 1        | NORMAL     | LØPENDE |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | DELVIS_INNVILGET    | SØKNAD           | Nei                       | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | ENDRET_UTBETALING   | NYE_OPPLYSNINGER | Nei                       | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato | Dødsfalldato |
+      | 1            | 1       | SØKER      | 26.12.1992  |              |
+      | 1            | 2       | BARN       | 14.06.2011  |              |
+      | 2            | 1       | SØKER      | 26.12.1992  |              |
+      | 2            | 2       | BARN       | 14.06.2011  |              |
+
+  Scenario: Skal få opp reduksjonsbegrunnelse for Finnmark når søker flytter ut av Finnmark
+    Og dagens dato er 17.09.2025
+
+    Og lag personresultater for behandling 1
+    Og lag personresultater for behandling 2
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår             | Fra dato   | Til dato   | Resultat |
+      | 1       | LOVLIG_OPPHOLD               |                              | 26.12.1992 |            | OPPFYLT  |
+      | 1       | BOSATT_I_RIKET               | BOSATT_I_FINNMARK_NORD_TROMS | 14.06.2011 |            | OPPFYLT  |
+
+      | 2       | BOR_MED_SØKER,LOVLIG_OPPHOLD |                              | 14.06.2011 |            | OPPFYLT  |
+      | 2       | GIFT_PARTNERSKAP             |                              | 14.06.2011 |            | OPPFYLT  |
+      | 2       | BOSATT_I_RIKET               | BOSATT_I_FINNMARK_NORD_TROMS | 14.06.2011 |            | OPPFYLT  |
+      | 2       | UNDER_18_ÅR                  |                              | 14.06.2011 | 13.06.2029 | OPPFYLT  |
+
+    Og legg til nye vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår             | Fra dato   | Til dato   | Resultat |
+      | 1       | LOVLIG_OPPHOLD               |                              | 26.12.1992 |            | OPPFYLT  |
+      | 1       | BOSATT_I_RIKET               | BOSATT_I_FINNMARK_NORD_TROMS | 14.06.2011 | 08.08.2025 | OPPFYLT  |
+      | 1       | BOSATT_I_RIKET               |                              | 09.08.2025 |            | OPPFYLT  |
+
+      | 2       | GIFT_PARTNERSKAP             |                              | 14.06.2011 |            | OPPFYLT  |
+      | 2       | UNDER_18_ÅR                  |                              | 14.06.2011 | 13.06.2029 | OPPFYLT  |
+      | 2       | BOR_MED_SØKER,LOVLIG_OPPHOLD |                              | 14.06.2011 |            | OPPFYLT  |
+      | 2       | BOSATT_I_RIKET               | BOSATT_I_FINNMARK_NORD_TROMS | 14.06.2011 |            | OPPFYLT  |
+
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.05.2025 | 31.05.2029 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 2       | 1            | 01.08.2025 | 31.05.2029 | 500   | FINNMARKSTILLEGG   | 100     | 500  |
+
+      | 2       | 2            | 01.05.2025 | 31.05.2029 | 1968  | ORDINÆR_BARNETRYGD | 100     | 1968 |
+      | 2       | 2            | 01.08.2025 | 31.08.2025 | 500   | FINNMARKSTILLEGG   | 100     | 500  |
+
+    Når vedtaksperiodene genereres for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser       | Ugyldige begrunnelser |
+      | 01.09.2025 | 31.05.2029 | UTBETALING         |                                | REDUKSJON_FINNMARKSTILLEGG |                       |
+      | 01.06.2029 |            | OPPHØR             |                                |                            |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser       | Eøsbegrunnelser | Fritekster |
+      | 01.09.2025 | 31.05.2029 | REDUKSJON_FINNMARKSTILLEGG |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2025 til 31.05.2029
+      | Begrunnelse                | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet | Avtaletidspunkt delt bosted |
+      | REDUKSJON_FINNMARKSTILLEGG | STANDARD | Ja            |                      | 0           | august 2025                          |         | 1 968 |                  | SØKER_HAR_IKKE_RETT     |                             |
+


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26271)

### 💰 Hva skal gjøres, og hvorfor?
Når det blir reduksjon i finnmarkstillegg fordi søker flyttet ut fra landet får vi ikke opp riktig begrunnelse.
Dette skyldes at det ikke er noen andeler på søker og vi ser på andelene for personen for å utlede om det er reduksjon.
Sender med en variabel som ser om det er reduksjon på finnmarkstillegg som sendes med når vi utleder reduksjon.

OBS! Har også refaktorisert VedtakBegrunnelseProdusent og trukket ut noen av de større metodene i egne filer i et forsøk på å gjøre filen litt kortere og mer lesbar. 
ANBEFALER DERFOR Å LESE COMMIT FOR COMMIT! 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Tar gjerne input på om noe av refaktoriseringen burde sett annerledes ut eller lignende. Eventuelt forslag til mappestrukturer. Scopet ned refaktoriseringen ved å kun ta de "åpenbare" casene, her kan det egentlig ryddes MYE mer. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇