### PR TITLE
NAV-26278: Fjerner forvalter funksjonalitet for å kunne korrigere andeler med feil offset

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -24,7 +24,6 @@ enum class FeatureToggle(
 
     // NAV-24387
     BRUK_UTBETALINGSTIDSLINJER_VED_GENERERING_AV_PERIODER_TIL_AVSTEMMING("familie-ba-sak.bruk-utbetalingstidslinjer-ved-generering-av-perioder-til-avstemming"),
-    SKAL_FINNE_OG_PATCHE_ANDELER_I_FAGAKER_MED_AVVIK("familie-ba-sak.skal-finne-og-patche-andeler-i-fagsaker-med-avvik"),
 
     // satsendring
     // Oppretter satsendring-tasker for de som ikke har fått ny task

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
@@ -518,33 +517,6 @@ class ForvalterController(
         )
 
         return ResponseEntity.ok(utbetalingsTidslinjeService.genererUtbetalingstidslinjerForFagsak(fagsakId).map { it.tilUtbetalingsperioder() })
-    }
-
-    @PostMapping("/finn-og-patch-andeler-tilkjent-ytelse-i-fagsaker-med-avvik")
-    @Operation(
-        summary = "Finner og patcher andeler tilkjent ytelse i fagsaker med avvik i konsistensavstemming",
-        description =
-            "Bruker Utbetalingtidslinjer til å sammenligne andelerTilkjentYtelse med faktiske utbetalingsperioder oversendt til Oppdrag." +
-                "Finner vi forskjeller mellom en andel og en utbetalingsperiode slettes den originale andelen og erstattes av en korrigert andel.",
-    )
-    fun finnOgPatchAndelerTilkjentYtelseIFagsakerMedAvvik(
-        @RequestBody finnOgPatchAndelerRequestDto: FinnOgPatchAndelerRequestDto,
-    ): ResponseEntity<List<Pair<Long, List<AndelTilkjentYtelseKorreksjonDto>?>>> {
-        tilgangService.verifiserHarTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
-            handling = "Finne og patche andeler tilkjent ytelse i fagsaker med avvik i konsistensavstemming",
-        )
-        if (!featureToggleService.isEnabled(FeatureToggle.SKAL_FINNE_OG_PATCHE_ANDELER_I_FAGAKER_MED_AVVIK, false)) {
-            throw FunksjonellFeil("Kan ikke finne og patche andeler. Toggelen ${FeatureToggle.SKAL_FINNE_OG_PATCHE_ANDELER_I_FAGAKER_MED_AVVIK} er skrudd av")
-        }
-
-        return ResponseEntity.ok(
-            forvalterService.finnOgPatchAndelerTilkjentYtelseIFagsakerMedAvvik(
-                fagsaker = finnOgPatchAndelerRequestDto.fagsaker,
-                korrigerAndelerFraOgMedDato = finnOgPatchAndelerRequestDto.korrigerAndelerFraOgMedDato,
-                dryRun = finnOgPatchAndelerRequestDto.dryRun,
-            ),
-        )
     }
 
     @GetMapping("/start-portefoljejustering-task")

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -780,9 +780,3 @@ class ForvalterController(
         return ResponseEntity.ok("Opprettet task for å finne personer som bor på Svalbard i ${fagsakIder.size} fagsaker")
     }
 }
-
-data class FinnOgPatchAndelerRequestDto(
-    val fagsaker: Set<Long>,
-    val korrigerAndelerFraOgMedDato: LocalDate = LocalDate.of(2025, 2, 1),
-    val dryRun: Boolean = true,
-)

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -10,50 +10,28 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.UtbetalingsikkerhetFeil
-import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.secureLogger
-import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsTidslinjeService
-import no.nav.familie.ba.sak.integrasjoner.økonomi.Utbetalingstidslinje
-import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.OppdaterTilkjentYtelseService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
-import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
-import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.UNDER_18_ÅR
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
-import no.nav.familie.ba.sak.task.AktiverMinsideTask
 import no.nav.familie.log.mdc.MDCConstants
-import no.nav.familie.prosessering.internal.TaskService
-import no.nav.familie.tidslinje.Periode
-import no.nav.familie.tidslinje.Tidslinje
-import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.tidslinje.utvidelser.filtrerIkkeNull
-import no.nav.familie.tidslinje.utvidelser.kombinerMed
-import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
-import no.nav.familie.tidslinje.verdier
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.YearMonth
 
 @Service
 class ForvalterService(
@@ -62,14 +40,10 @@ class ForvalterService(
     private val beregningService: BeregningService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val fagsakRepository: FagsakRepository,
-    private val behandlingRepository: BehandlingRepository,
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val persongrunnlagService: PersongrunnlagService,
-    private val utbetalingsTidslinjeService: UtbetalingsTidslinjeService,
-    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
-    private val oppdaterTilkjentYtelseService: OppdaterTilkjentYtelseService,
 ) {
     private val logger = LoggerFactory.getLogger(ForvalterService::class.java)
 
@@ -234,114 +208,4 @@ class ForvalterService(
             throw Feil("Det finnes flere vilkårresultater som begynner før fødselsdato til person: $this")
         }
     }
-
-    @Transactional
-    fun finnOgPatchAndelerTilkjentYtelseIFagsakerMedAvvik(
-        fagsaker: Set<Long>,
-        korrigerAndelerFraOgMedDato: LocalDate,
-        dryRun: Boolean = true,
-    ): List<Pair<Long, List<AndelTilkjentYtelseKorreksjonDto>?>> {
-        return fagsaker.map { fagsakId ->
-            val sisteIverksatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId = fagsakId)
-            if (sisteIverksatteBehandling != null) {
-                val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandlingId = sisteIverksatteBehandling.id)
-                val andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.groupBy { Pair(it.aktør, it.type) }
-                val utbetalingstidslinjer = utbetalingsTidslinjeService.genererUtbetalingstidslinjerForFagsak(fagsakId = fagsakId)
-                val andelTilkjentYtelseKorreksjoner: List<AndelTilkjentYtelseKorreksjon> =
-                    utbetalingstidslinjer.flatMap { utbetalingstidslinje ->
-                        val andeltidslinjeForUtbetalingstidslinje = finnAndelerTilkjentYtelseForUtbetalingstidslinje(utbetalingstidslinje = utbetalingstidslinje, andelerTilkjentYtelsePerAktørOgType = andelerTilkjentYtelse)
-                        utbetalingstidslinje.tidslinje
-                            // Ser kun på andeler som løper fra og med korrigerAndelerFraOgMedDato. Tanken er at vi ikke ønsker å korrigere bakover i tid.
-                            .beskjærFraOgMed(korrigerAndelerFraOgMedDato)
-                            .kombinerMed(andeltidslinjeForUtbetalingstidslinje) { utbetalingsperiode, andelTilkjentYtelse ->
-                                // Dersom verken utbetalingsperiode eller andelTilkjentYtelse er null betyr det at de overlapper.
-                                // Dersom de har ulike verdier for enten periodeId, forrigePeriodeId eller kildeBehandlingId oppretter vi en AndelTilkjentYtelseKorreksjon
-                                // Korreksjonen inneholder andelen med feil samt en korrigert versjon av andelen.
-                                if (utbetalingsperiode != null && andelTilkjentYtelse != null) {
-                                    if (utbetalingsperiode.periodeId != andelTilkjentYtelse.periodeOffset || utbetalingsperiode.forrigePeriodeId != andelTilkjentYtelse.forrigePeriodeOffset || utbetalingsperiode.behandlingId != andelTilkjentYtelse.kildeBehandlingId) {
-                                        return@kombinerMed AndelTilkjentYtelseKorreksjon(andelTilkjentYtelse, andelTilkjentYtelse.copy(id = 0, periodeOffset = utbetalingsperiode.periodeId, forrigePeriodeOffset = utbetalingsperiode.forrigePeriodeId, kildeBehandlingId = utbetalingsperiode.behandlingId))
-                                    }
-                                }
-                                return@kombinerMed null
-                            }.filtrerIkkeNull()
-                            .tilPerioderIkkeNull()
-                            .verdier()
-                    }
-
-                if (!dryRun) {
-                    // Sletter andeler med feil og oppretter korrigerte andeler.
-                    // Slettede andeler lagres i ny tabell PatchetAndelTilkjentYtelse slik at vi har mulighet til å finne ut hvordan de så ut før endringen.
-                    oppdaterTilkjentYtelseService.oppdaterTilkjentYtelseMedKorrigerteAndeler(
-                        tilkjentYtelse = tilkjentYtelse,
-                        andelTilkjentYtelseKorreksjoner = andelTilkjentYtelseKorreksjoner,
-                    )
-                }
-                return@map Pair(fagsakId, andelTilkjentYtelseKorreksjoner.tilAndelerTilkjentYtelseKorreksjonerDto())
-            }
-            return@map Pair(fagsakId, null)
-        }
-    }
-
-    private fun finnAndelerTilkjentYtelseForUtbetalingstidslinje(
-        utbetalingstidslinje: Utbetalingstidslinje,
-        andelerTilkjentYtelsePerAktørOgType: Map<Pair<Aktør, YtelseType>, List<AndelTilkjentYtelse>>,
-    ): Tidslinje<AndelTilkjentYtelse> =
-        andelerTilkjentYtelsePerAktørOgType.entries
-            .single { (_, andeler) ->
-
-                val førsteOffset =
-                    andeler
-                        .firstOrNull { it.erAndelSomSkalSendesTilOppdrag() && it.periodeOffset != null }
-                        ?.periodeOffset
-                if (førsteOffset != null) {
-                    return@single utbetalingstidslinje.erTidslinjeForPeriodeId(førsteOffset)
-                }
-                return@single false
-            }.value
-            .map { Periode(verdi = it, fom = it.stønadFom.førsteDagIInneværendeMåned(), tom = it.stønadTom.sisteDagIInneværendeMåned()) }
-            .tilTidslinje()
 }
-
-interface FagsakMedFlereMigreringer {
-    val fagsakId: Long
-    val fødselsnummer: String
-}
-
-data class AndelTilkjentYtelseKorreksjon(
-    val andelMedFeil: AndelTilkjentYtelse,
-    val korrigertAndel: AndelTilkjentYtelse,
-)
-
-fun List<AndelTilkjentYtelseKorreksjon>.tilAndelerTilkjentYtelseKorreksjonerDto() =
-    this.map {
-        AndelTilkjentYtelseKorreksjonDto(
-            andelMedFeil = it.andelMedFeil.tilAndelTilkjentYtelseDto(),
-            korrigertAndel = it.korrigertAndel.tilAndelTilkjentYtelseDto(),
-        )
-    }
-
-fun AndelTilkjentYtelse.tilAndelTilkjentYtelseDto() =
-    AndelTilkjentYtelseDto(
-        id = this.id,
-        stønadFom = this.stønadFom,
-        stønadTom = this.stønadTom,
-        beløp = this.kalkulertUtbetalingsbeløp,
-        periodeId = this.periodeOffset,
-        forrigePeriodeId = this.forrigePeriodeOffset,
-        kildeBehandlingId = this.kildeBehandlingId,
-    )
-
-data class AndelTilkjentYtelseKorreksjonDto(
-    val andelMedFeil: AndelTilkjentYtelseDto,
-    val korrigertAndel: AndelTilkjentYtelseDto,
-)
-
-data class AndelTilkjentYtelseDto(
-    val id: Long,
-    val stønadFom: YearMonth,
-    val stønadTom: YearMonth,
-    val beløp: Int,
-    val periodeId: Long?,
-    val forrigePeriodeId: Long?,
-    val kildeBehandlingId: Long?,
-)

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterService.kt
@@ -209,3 +209,8 @@ class ForvalterService(
         }
     }
 }
+
+interface FagsakMedFlereMigreringer {
+    val fagsakId: Long
+    val fødselsnummer: String
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -42,7 +42,6 @@ import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseGenerator
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
-import no.nav.familie.ba.sak.kjerne.beregning.domene.PatchetAndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerService
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterTilkjentYtelseService
@@ -146,7 +145,6 @@ class CucumberMock(
     val vurderingsstrategiForValutakurserRepository = mockVurderingsstrategiForValutakurserRepository()
     val brevmottakerService = mockk<BrevmottakerService>()
     val behandlingMigreringsinfoRepository = mockBehandlingMigreringsinfoRepository()
-    val patchetAndelTilkjentYtelseRepository = mockk<PatchetAndelTilkjentYtelseRepository>()
     val eksternBehandlingRelasjonService = mockk<EksternBehandlingRelasjonService>()
     val behandlingSøknadsinfoRepository = mockBehandlingSøknadsinfoRepository()
     val systemOnlyPdlRestClient = mockSystemOnlyPdlRestClient(dataFraCucumber)
@@ -471,7 +469,6 @@ class CucumberMock(
         OppdaterTilkjentYtelseService(
             endretUtbetalingAndelHentOgPersisterService,
             tilkjentYtelseRepository,
-            patchetAndelTilkjentYtelseRepository,
             clockProvider,
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterServiceTest.kt
@@ -1,37 +1,21 @@
 package no.nav.familie.ba.sak.internal
 
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrAfter
-import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
-import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
-import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagPerson
-import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagVilkårsvurdering
-import no.nav.familie.ba.sak.integrasjoner.økonomi.UtbetalingsTidslinjeService
-import no.nav.familie.ba.sak.integrasjoner.økonomi.Utbetalingstidslinje
-import no.nav.familie.ba.sak.integrasjoner.økonomi.lagUtbetalingsperiode
-import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.OppdaterTilkjentYtelseService
 import no.nav.familie.ba.sak.integrasjoner.økonomi.ØkonomiService
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValideringService
-import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
-import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -44,20 +28,12 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
-import no.nav.familie.prosessering.internal.TaskService
-import no.nav.familie.tidslinje.Periode
-import no.nav.familie.tidslinje.tilTidslinje
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.data.domain.Slice
-import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.YearMonth
 import kotlin.random.Random
-import no.nav.familie.ba.sak.common.Periode as CommonPeriode
 
 class ForvalterServiceTest {
     private val persongrunnlagService = mockk<PersongrunnlagService>()
@@ -67,12 +43,8 @@ class ForvalterServiceTest {
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
     private val vilkårsvurderingService = mockk<VilkårsvurderingService>()
     private val fagsakRepository = mockk<FagsakRepository>()
-    private val behandlingRepository = mockk<BehandlingRepository>()
     private val tilkjentYtelseValideringService = mockk<TilkjentYtelseValideringService>()
     private val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
-    private val utbetalingsTidslinjeService = mockk<UtbetalingsTidslinjeService>()
-    private val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
-    private val oppdaterTilkjentYtelseService = mockk<OppdaterTilkjentYtelseService>()
 
     private val forvalterService =
         ForvalterService(
@@ -81,14 +53,10 @@ class ForvalterServiceTest {
             beregningService = beregningService,
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             fagsakRepository = fagsakRepository,
-            behandlingRepository = behandlingRepository,
             tilkjentYtelseValideringService = tilkjentYtelseValideringService,
             arbeidsfordelingService = arbeidsfordelingService,
             vilkårsvurderingService = vilkårsvurderingService,
             persongrunnlagService = persongrunnlagService,
-            utbetalingsTidslinjeService = utbetalingsTidslinjeService,
-            tilkjentYtelseRepository = tilkjentYtelseRepository,
-            oppdaterTilkjentYtelseService = oppdaterTilkjentYtelseService,
         )
 
     @Test
@@ -325,304 +293,6 @@ class ForvalterServiceTest {
                     assertTrue(vilkårResultat.periodeFom?.isSameOrAfter(barn.fødselsdato) ?: false)
                 }
             }
-    }
-
-    @Nested
-    inner class FinnOgPatchAndelerTilkjentYtelseIFagsakerMedAvvik {
-        @Test
-        fun `skal finne og korrigere avvik i periodeId, forrigePeriodeId og kildeBehandlingId dersom dryRun er satt til false`() {
-            // Arrange
-            val fagsak = lagFagsak()
-            val behandling = lagBehandling(fagsak = fagsak)
-            val sisteIverksatteBehandling = lagBehandling(fagsak = fagsak)
-            val barn = lagPerson(type = PersonType.BARN)
-
-            // Perioder med utbetalinger i fagsak
-            val periode1 =
-                CommonPeriode(fom = YearMonth.of(2022, 7).førsteDagIInneværendeMåned(), tom = YearMonth.of(2024, 6).sisteDagIInneværendeMåned())
-            val periode2 =
-                CommonPeriode(fom = YearMonth.of(2024, 7).førsteDagIInneværendeMåned(), tom = YearMonth.of(2026, 2).sisteDagIInneværendeMåned())
-            val periode3 =
-                CommonPeriode(fom = YearMonth.of(2026, 3).førsteDagIInneværendeMåned(), tom = YearMonth.of(2035, 2).sisteDagIInneværendeMåned())
-
-            // Andeler i sisteIversatteBehandling med feil periodeId, forrigePeriodeId og kildeBehandlingsId for de 2 siste andelene
-            val andelTilkjentYtelse1 = lagAndelTilkjentYtelse(id = 1, fom = periode1.fom.toYearMonth(), tom = periode1.tom.toYearMonth(), aktør = barn.aktør, periodeIdOffset = 0, forrigeperiodeIdOffset = null, kildeBehandlingId = behandling.id)
-            val andelTilkjentYtelse2 = lagAndelTilkjentYtelse(id = 2, fom = periode2.fom.toYearMonth(), tom = periode2.tom.toYearMonth(), aktør = barn.aktør, periodeIdOffset = 1, forrigeperiodeIdOffset = 0, kildeBehandlingId = behandling.id)
-            val andelTilkjentYtelse3 = lagAndelTilkjentYtelse(id = 3, fom = periode3.fom.toYearMonth(), tom = periode3.tom.toYearMonth(), aktør = barn.aktør, periodeIdOffset = 2, forrigeperiodeIdOffset = 1, kildeBehandlingId = behandling.id)
-
-            // Tilkjent ytelse i sisteIverksatteBehandling
-            val tilkjentYtelse =
-                lagTilkjentYtelse(behandling = sisteIverksatteBehandling, lagAndelerTilkjentYtelse = {
-                    setOf(
-                        andelTilkjentYtelse1,
-                        andelTilkjentYtelse2,
-                        andelTilkjentYtelse3,
-                    )
-                })
-
-            // Alle utbetalingsperioder sendt til Oppdrag
-            val utbetalingsperiode1 =
-                lagUtbetalingsperiode(
-                    fom = periode1.fom,
-                    tom = periode1.tom,
-                    periodeId = 0,
-                    forrigePeriodeId = null,
-                    behandlingId = behandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            val utbetalingsperiode2 =
-                lagUtbetalingsperiode(
-                    fom = periode2.fom,
-                    tom = periode2.tom,
-                    periodeId = 1,
-                    forrigePeriodeId = 0,
-                    behandlingId = behandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            val utbetalingsperiode3 =
-                lagUtbetalingsperiode(
-                    fom = periode3.fom,
-                    tom = periode3.tom,
-                    periodeId = 2,
-                    forrigePeriodeId = 1,
-                    behandlingId = behandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            // Perioder oppdatert i sisteIverksatteBehandling
-            val utbetalingsperiode4 =
-                lagUtbetalingsperiode(
-                    fom = periode2.fom,
-                    tom = periode2.tom,
-                    periodeId = 3,
-                    forrigePeriodeId = 2,
-                    behandlingId = sisteIverksatteBehandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            val utbetalingsperiode5 =
-                lagUtbetalingsperiode(
-                    fom = periode3.fom,
-                    tom = periode3.tom,
-                    periodeId = 4,
-                    forrigePeriodeId = 3,
-                    behandlingId = sisteIverksatteBehandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            // Utbetalingstidslinjer i fagsak
-            val utbetalingstidslinjer: List<Utbetalingstidslinje> =
-                listOf(
-                    Utbetalingstidslinje(
-                        utbetalingsperioder = setOf(utbetalingsperiode1, utbetalingsperiode2, utbetalingsperiode3, utbetalingsperiode4, utbetalingsperiode5),
-                        tidslinje =
-                            listOf(
-                                Periode(
-                                    verdi = utbetalingsperiode1,
-                                    fom = periode1.fom,
-                                    tom = periode1.tom,
-                                ),
-                                Periode(
-                                    verdi = utbetalingsperiode4,
-                                    fom = periode2.fom,
-                                    tom = periode2.tom,
-                                ),
-                                Periode(
-                                    verdi = utbetalingsperiode5,
-                                    fom = periode3.fom,
-                                    tom = periode3.tom,
-                                ),
-                            ).tilTidslinje(),
-                    ),
-                )
-
-            val fagsaker = setOf(fagsak.id)
-            val korrigerAndelerFraOgMedDato = LocalDate.of(2025, 2, 1)
-
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId = fagsak.id) } returns sisteIverksatteBehandling
-            every { tilkjentYtelseRepository.findByBehandling(behandlingId = sisteIverksatteBehandling.id) } returns tilkjentYtelse
-            every { utbetalingsTidslinjeService.genererUtbetalingstidslinjerForFagsak(fagsakId = fagsak.id) } returns utbetalingstidslinjer
-            every { oppdaterTilkjentYtelseService.oppdaterTilkjentYtelseMedKorrigerteAndeler(any(), any()) } just Runs
-
-            // Act
-            val fagsakerMedTilhørendeAndelTilkjentYtelseKorreksjon =
-                forvalterService.finnOgPatchAndelerTilkjentYtelseIFagsakerMedAvvik(
-                    fagsaker = fagsaker,
-                    korrigerAndelerFraOgMedDato = korrigerAndelerFraOgMedDato,
-                    dryRun = false,
-                )
-
-            // Assert
-            assertThat(fagsakerMedTilhørendeAndelTilkjentYtelseKorreksjon).hasSize(1)
-            verify(exactly = 1) { oppdaterTilkjentYtelseService.oppdaterTilkjentYtelseMedKorrigerteAndeler(any(), any()) }
-
-            val andelTilkjentYtelseKorreksjonerForFagsak = fagsakerMedTilhørendeAndelTilkjentYtelseKorreksjon.first()
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.first).isEqualTo(fagsak.id)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second).hasSize(2)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.korrigertAndel.periodeId }).containsExactlyInAnyOrder(3, 4)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.korrigertAndel.forrigePeriodeId }).containsExactlyInAnyOrder(2, 3)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.korrigertAndel.kildeBehandlingId }?.toSet()).containsExactlyInAnyOrder(sisteIverksatteBehandling.id)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.andelMedFeil.id }).containsExactlyInAnyOrder(andelTilkjentYtelse2.id, andelTilkjentYtelse3.id)
-        }
-
-        @Test
-        fun `skal finne avvik i periodeId, forrigePeriodeId og kildeBehandlingId dersom dryRun er satt til true`() {
-            // Arrange
-            val fagsak = lagFagsak()
-            val behandling = lagBehandling(fagsak = fagsak)
-            val sisteIverksatteBehandling = lagBehandling(fagsak = fagsak)
-            val barn = lagPerson(type = PersonType.BARN)
-
-            // Perioder med utbetalinger i fagsak
-            val periode1 =
-                CommonPeriode(fom = YearMonth.of(2022, 7).førsteDagIInneværendeMåned(), tom = YearMonth.of(2024, 6).sisteDagIInneværendeMåned())
-            val periode2 =
-                CommonPeriode(fom = YearMonth.of(2024, 7).førsteDagIInneværendeMåned(), tom = YearMonth.of(2026, 2).sisteDagIInneværendeMåned())
-            val periode3 =
-                CommonPeriode(fom = YearMonth.of(2026, 3).førsteDagIInneværendeMåned(), tom = YearMonth.of(2035, 2).sisteDagIInneværendeMåned())
-
-            // Andeler i sisteIversatteBehandling med feil periodeId, forrigePeriodeId og kildeBehandlingsId for de 2 siste andelene
-            val andelTilkjentYtelse1 = lagAndelTilkjentYtelse(id = 1, fom = periode1.fom.toYearMonth(), tom = periode1.tom.toYearMonth(), aktør = barn.aktør, periodeIdOffset = 0, forrigeperiodeIdOffset = null, kildeBehandlingId = behandling.id)
-            val andelTilkjentYtelse2 = lagAndelTilkjentYtelse(id = 2, fom = periode2.fom.toYearMonth(), tom = periode2.tom.toYearMonth(), aktør = barn.aktør, periodeIdOffset = 1, forrigeperiodeIdOffset = 0, kildeBehandlingId = behandling.id)
-            val andelTilkjentYtelse3 = lagAndelTilkjentYtelse(id = 3, fom = periode3.fom.toYearMonth(), tom = periode3.tom.toYearMonth(), aktør = barn.aktør, periodeIdOffset = 2, forrigeperiodeIdOffset = 1, kildeBehandlingId = behandling.id)
-
-            // Tilkjent ytelse i sisteIverksatteBehandling
-            val tilkjentYtelse =
-                lagTilkjentYtelse(behandling = sisteIverksatteBehandling, lagAndelerTilkjentYtelse = {
-                    setOf(
-                        andelTilkjentYtelse1,
-                        andelTilkjentYtelse2,
-                        andelTilkjentYtelse3,
-                    )
-                })
-
-            // Alle utbetalingsperioder sendt til Oppdrag
-            val utbetalingsperiode1 =
-                lagUtbetalingsperiode(
-                    fom = periode1.fom,
-                    tom = periode1.tom,
-                    periodeId = 0,
-                    forrigePeriodeId = null,
-                    behandlingId = behandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            val utbetalingsperiode2 =
-                lagUtbetalingsperiode(
-                    fom = periode2.fom,
-                    tom = periode2.tom,
-                    periodeId = 1,
-                    forrigePeriodeId = 0,
-                    behandlingId = behandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            val utbetalingsperiode3 =
-                lagUtbetalingsperiode(
-                    fom = periode3.fom,
-                    tom = periode3.tom,
-                    periodeId = 2,
-                    forrigePeriodeId = 1,
-                    behandlingId = behandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            // Perioder oppdatert i sisteIverksatteBehandling
-            val utbetalingsperiode4 =
-                lagUtbetalingsperiode(
-                    fom = periode2.fom,
-                    tom = periode2.tom,
-                    periodeId = 3,
-                    forrigePeriodeId = 2,
-                    behandlingId = sisteIverksatteBehandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            val utbetalingsperiode5 =
-                lagUtbetalingsperiode(
-                    fom = periode3.fom,
-                    tom = periode3.tom,
-                    periodeId = 4,
-                    forrigePeriodeId = 3,
-                    behandlingId = sisteIverksatteBehandling.id,
-                    klassifisering = YtelseType.ORDINÆR_BARNETRYGD.klassifisering,
-                    beløp = BigDecimal(1766),
-                    opphør = null,
-                )
-
-            // Utbetalingstidslinjer i fagsak
-            val utbetalingstidslinjer: List<Utbetalingstidslinje> =
-                listOf(
-                    Utbetalingstidslinje(
-                        utbetalingsperioder = setOf(utbetalingsperiode1, utbetalingsperiode2, utbetalingsperiode3, utbetalingsperiode4, utbetalingsperiode5),
-                        tidslinje =
-                            listOf(
-                                Periode(
-                                    verdi = utbetalingsperiode1,
-                                    fom = periode1.fom,
-                                    tom = periode1.tom,
-                                ),
-                                Periode(
-                                    verdi = utbetalingsperiode4,
-                                    fom = periode2.fom,
-                                    tom = periode2.tom,
-                                ),
-                                Periode(
-                                    verdi = utbetalingsperiode5,
-                                    fom = periode3.fom,
-                                    tom = periode3.tom,
-                                ),
-                            ).tilTidslinje(),
-                    ),
-                )
-
-            val fagsaker = setOf(fagsak.id)
-            val korrigerAndelerFraOgMedDato = LocalDate.of(2025, 2, 1)
-
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId = fagsak.id) } returns sisteIverksatteBehandling
-            every { tilkjentYtelseRepository.findByBehandling(behandlingId = sisteIverksatteBehandling.id) } returns tilkjentYtelse
-            every { utbetalingsTidslinjeService.genererUtbetalingstidslinjerForFagsak(fagsakId = fagsak.id) } returns utbetalingstidslinjer
-
-            // Act
-            val fagsakerMedTilhørendeAndelTilkjentYtelseKorreksjon =
-                forvalterService.finnOgPatchAndelerTilkjentYtelseIFagsakerMedAvvik(
-                    fagsaker = fagsaker,
-                    korrigerAndelerFraOgMedDato = korrigerAndelerFraOgMedDato,
-                    dryRun = true,
-                )
-
-            // Assert
-            assertThat(fagsakerMedTilhørendeAndelTilkjentYtelseKorreksjon).hasSize(1)
-            verify(exactly = 0) { oppdaterTilkjentYtelseService.oppdaterTilkjentYtelseMedKorrigerteAndeler(any(), any()) }
-
-            val andelTilkjentYtelseKorreksjonerForFagsak = fagsakerMedTilhørendeAndelTilkjentYtelseKorreksjon.first()
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.first).isEqualTo(fagsak.id)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second).hasSize(2)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.korrigertAndel.periodeId }).containsExactlyInAnyOrder(3, 4)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.korrigertAndel.forrigePeriodeId }).containsExactlyInAnyOrder(2, 3)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.korrigertAndel.kildeBehandlingId }?.toSet()).containsExactlyInAnyOrder(sisteIverksatteBehandling.id)
-            assertThat(andelTilkjentYtelseKorreksjonerForFagsak.second?.map { it.andelMedFeil.id }).containsExactlyInAnyOrder(andelTilkjentYtelse2.id, andelTilkjentYtelse3.id)
-        }
     }
 
     private fun personTilPersonEnkel(barn: Person) =


### PR DESCRIPTION
Favro: [NAV-26278](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26278)

### 💰 Hva skal gjøres, og hvorfor?
Sonar varsler om "Cognitive Complexity" for metoden `finnOgPatchAndelerTilkjentYtelseIFagsakerMedAvvik`. Denne ble brukt i forbindelse med avvik i konsistensavstemming i februar-mars 2025. Den har ikke vært i bruk siden da.

Sletter metoden og tilhørende kode fremfor å forbedre den da den ikke er i bruk. Kan legges inn igjen senere dersom vi ser behov for det.
