### PR TITLE
Toggle for preutfyll bosatt i riket for Finnmarks- og Svalbardstillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -165,7 +165,7 @@ class VilkårsvurderingForNyBehandlingService(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                 ).also {
                     if (inneværendeBehandling.erFinnmarksTilleggEllerSvalbardtillegg()) {
-                        preutfyllVilkårService.preutfyllBosattIRiket(it)
+                        preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(it)
                     }
                 }
 
@@ -213,7 +213,7 @@ class VilkårsvurderingForNyBehandlingService(
                     }
                 }
             try {
-                preutfyllVilkårService.preutfyllBosattIRiket(
+                preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(
                     vilkårsvurdering = initiellVilkårsvurdering,
                     identerVilkårSkalPreutfyllesFor = identerVilkårSkalPreutfyllesFor,
                 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
@@ -27,13 +27,11 @@ class PreutfyllVilkårService(
         }
     }
 
-    fun preutfyllBosattIRiket(
+    fun preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(
         vilkårsvurdering: Vilkårsvurdering,
         identerVilkårSkalPreutfyllesFor: List<String>? = null,
     ) {
-        if (featureToggleService.isEnabled(FeatureToggle.PREUTFYLLING_VILKÅR)) {
-            preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, identerVilkårSkalPreutfyllesFor)
-        }
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, identerVilkårSkalPreutfyllesFor)
     }
 
     companion object {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
@@ -379,7 +379,7 @@ class VilkårsvurderingForNyBehandlingServiceTest {
 
                 every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
                 every { vilkårsvurderingService.hentAktivForBehandling(forrigeBehandling.id) } returns forrigeVilkårsvurdering
-                every { preutfyllVilkårService.preutfyllBosattIRiket(any()) } just runs
+                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any()) } just runs
                 every { endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(behandling, forrigeBehandling) } just runs
                 every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(capture(vilkårsvurderingSlot)) } returnsArgument 0
 
@@ -504,7 +504,7 @@ class VilkårsvurderingForNyBehandlingServiceTest {
 
                 every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
                 every { vilkårsvurderingService.hentAktivForBehandling(forrigeBehandling.id) } returns forrigeVilkårsvurdering
-                every { preutfyllVilkårService.preutfyllBosattIRiket(any()) } just runs
+                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any()) } just runs
                 every { endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(behandling, forrigeBehandling) } just runs
                 every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(capture(vilkårsvurderingSlot)) } returnsArgument 0
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Navneendring, og fjern sjekk av togglen `PREUTFYLLING_VILKÅR` for preutfyll bosatt i riket for Finnmark og Svalbardstillegg behandlinger. Det er en egen sjekk `erFinnmarksTilleggEllerSvalbardtillegg()` i `VilkårsvurderingForNyBehandlingService` for behandlingen. Og det finnes en egen sjekk for toggle `SKAL_PREUTFYLLE_BOSATT_I_RIKET_I_FØDSELSHENDELSER`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke nødvendig? 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
