### PR TITLE
Bugfiks_validering_på_endret_utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidering.kt
@@ -239,19 +239,19 @@ object EndretUtbetalingAndelValidering {
     }
 
     fun validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(
-        endretUtbetalingAndelerMedÅrsakDeltBosted: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
+        endretUtbetalingAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
     ) {
-        val endredeUtvidetUtbetalingerAndeler =
-            endretUtbetalingAndelerMedÅrsakDeltBosted
+        val endredeUtvidetUtbetalingerAndelerMedÅrsakDeltBosted =
+            endretUtbetalingAndeler
                 .filter { endretUtbetaling ->
-                    endretUtbetaling.andelerTilkjentYtelse.any { it.erUtvidet() }
+                    endretUtbetaling.årsak == Årsak.DELT_BOSTED && endretUtbetaling.andelerTilkjentYtelse.any { it.erUtvidet() }
                 }
 
-        endredeUtvidetUtbetalingerAndeler.forEach { endretPåUtvidetUtbetalinger ->
+        endredeUtvidetUtbetalingerAndelerMedÅrsakDeltBosted.forEach { endretPåUtvidetUtbetalinger ->
             val endretUtbetalingAndelInneholderBarn = endretPåUtvidetUtbetalinger.personer.any { it.type == PersonType.BARN }
 
             val deltBostedEndringerISammePeriode =
-                endretUtbetalingAndelerMedÅrsakDeltBosted.filter {
+                endretUtbetalingAndeler.filter {
                     it.årsak == Årsak.DELT_BOSTED &&
                         it.fom!!.isSameOrBefore(endretPåUtvidetUtbetalinger.fom!!) &&
                         it.tom!!.isSameOrAfter(endretPåUtvidetUtbetalinger.tom!!) &&


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26375

Test kommer i senere PR, ønsker å få ut denne asap.

Tidligere ble parameter endretUtbetalingAndelerMedÅrsakDeltBosted sendt inn med bare endret utbetalinger med årsak delt bosted, men dette er gjort om til å sende alle endret utbetalinger i en tidligere PR, som førte til feil.

Vi endrer derfor parameter navn og filtrerer inne i metoden.