### PR TITLE
Sett cut off på preutfylling av bosatt i riket-vilkåret for finnmarks- og svalbardtilleggbehandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
+private val PREUTFYLLING_BOSATT_I_RIKET_CUT_OFF_FOM_DATO_FINNMARKS_OG_SVALBARDTILLEGG = LocalDate.of(2025, 9, 1)
+
 @Service
 class VilkårsvurderingForNyBehandlingService(
     private val vilkårsvurderingService: VilkårsvurderingService,
@@ -165,7 +167,10 @@ class VilkårsvurderingForNyBehandlingService(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                 ).also {
                     if (inneværendeBehandling.erFinnmarksEllerSvalbardtillegg()) {
-                        preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(it)
+                        preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(
+                            vilkårsvurdering = it,
+                            cutOffFomDato = PREUTFYLLING_BOSATT_I_RIKET_CUT_OFF_FOM_DATO_FINNMARKS_OG_SVALBARDTILLEGG,
+                        )
                     }
                 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -218,7 +218,7 @@ class VilkårsvurderingForNyBehandlingService(
                     }
                 }
             try {
-                preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(
+                preutfyllVilkårService.preutfyllBosattIRiketForFødselshendelseBehandlinger(
                     vilkårsvurdering = initiellVilkårsvurdering,
                     identerVilkårSkalPreutfyllesFor = identerVilkårSkalPreutfyllesFor,
                 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class PreutfyllVilkårService(
@@ -30,8 +31,13 @@ class PreutfyllVilkårService(
     fun preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(
         vilkårsvurdering: Vilkårsvurdering,
         identerVilkårSkalPreutfyllesFor: List<String>? = null,
+        cutOffFomDato: LocalDate? = null,
     ) {
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, identerVilkårSkalPreutfyllesFor)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(
+            vilkårsvurdering = vilkårsvurdering,
+            identerVilkårSkalPreutfyllesFor = identerVilkårSkalPreutfyllesFor,
+            cutOffFomDato = cutOffFomDato,
+        )
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
@@ -30,13 +30,21 @@ class PreutfyllVilkårService(
 
     fun preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(
         vilkårsvurdering: Vilkårsvurdering,
-        identerVilkårSkalPreutfyllesFor: List<String>? = null,
-        cutOffFomDato: LocalDate? = null,
+        cutOffFomDato: LocalDate,
+    ) {
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(
+            vilkårsvurdering = vilkårsvurdering,
+            cutOffFomDato = cutOffFomDato,
+        )
+    }
+
+    fun preutfyllBosattIRiketForFødselshendelseBehandlinger(
+        vilkårsvurdering: Vilkårsvurdering,
+        identerVilkårSkalPreutfyllesFor: List<String>?,
     ) {
         preutfyllBosattIRiketService.preutfyllBosattIRiket(
             vilkårsvurdering = vilkårsvurdering,
             identerVilkårSkalPreutfyllesFor = identerVilkårSkalPreutfyllesFor,
-            cutOffFomDato = cutOffFomDato,
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggServiceTest.kt
@@ -71,10 +71,10 @@ class AutovedtakFinnmarkstilleggServiceTest {
 
     private val adresse = Vegadresse(null, null, null, null, null, null, null, null)
     private val bostedsadresseUtenforFinnmark =
-        Bostedsadresse(gyldigFraOgMed = LocalDate.now(), vegadresse = adresse.copy(kommunenummer = "0301"))
+        Bostedsadresse(gyldigFraOgMed = LocalDate.of(2025, 9, 15), vegadresse = adresse.copy(kommunenummer = "0301"))
 
     private val bostedsadresseIFinnmark =
-        Bostedsadresse(gyldigFraOgMed = LocalDate.now(), vegadresse = adresse.copy(kommunenummer = "5601"))
+        Bostedsadresse(gyldigFraOgMed = LocalDate.of(2025, 9, 15), vegadresse = adresse.copy(kommunenummer = "5601"))
 
     @BeforeEach
     fun setUp() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/svalbardtillegg/AutovedtakSvalbardtilleggServiceTest.kt
@@ -71,10 +71,10 @@ class AutovedtakSvalbardtilleggServiceTest {
 
     private val adresse = Vegadresse(null, null, null, null, null, null, null, null)
     private val oppholdsadresseUtenforSvalbard =
-        Oppholdsadresse(gyldigFraOgMed = LocalDate.now(), vegadresse = adresse.copy(kommunenummer = "0301"))
+        Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 9, 15), vegadresse = adresse.copy(kommunenummer = "0301"))
 
     private val oppholsadressePåSvalbard =
-        Oppholdsadresse(gyldigFraOgMed = LocalDate.now(), vegadresse = adresse.copy(kommunenummer = "2100"))
+        Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 9, 15), vegadresse = adresse.copy(kommunenummer = "2100"))
 
     @BeforeEach
     fun setUp() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
@@ -379,7 +379,7 @@ class VilkårsvurderingForNyBehandlingServiceTest {
 
                 every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
                 every { vilkårsvurderingService.hentAktivForBehandling(forrigeBehandling.id) } returns forrigeVilkårsvurdering
-                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any()) } just runs
+                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any(), any(), any()) } just runs
                 every { endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(behandling, forrigeBehandling) } just runs
                 every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(capture(vilkårsvurderingSlot)) } returnsArgument 0
 
@@ -504,7 +504,7 @@ class VilkårsvurderingForNyBehandlingServiceTest {
 
                 every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
                 every { vilkårsvurderingService.hentAktivForBehandling(forrigeBehandling.id) } returns forrigeVilkårsvurdering
-                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any()) } just runs
+                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any(), any(), any()) } just runs
                 every { endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(behandling, forrigeBehandling) } just runs
                 every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(capture(vilkårsvurderingSlot)) } returnsArgument 0
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingServiceTest.kt
@@ -379,7 +379,7 @@ class VilkårsvurderingForNyBehandlingServiceTest {
 
                 every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
                 every { vilkårsvurderingService.hentAktivForBehandling(forrigeBehandling.id) } returns forrigeVilkårsvurdering
-                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any(), any(), any()) } just runs
+                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any(), any()) } just runs
                 every { endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(behandling, forrigeBehandling) } just runs
                 every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(capture(vilkårsvurderingSlot)) } returnsArgument 0
 
@@ -504,7 +504,7 @@ class VilkårsvurderingForNyBehandlingServiceTest {
 
                 every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
                 every { vilkårsvurderingService.hentAktivForBehandling(forrigeBehandling.id) } returns forrigeVilkårsvurdering
-                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any(), any(), any()) } just runs
+                every { preutfyllVilkårService.preutfyllBosattIRiketForFinnmarksOgSvalbardtilleggBehandlinger(any(), any()) } just runs
                 every { endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(behandling, forrigeBehandling) } just runs
                 every { vilkårsvurderingService.lagreNyOgDeaktiverGammel(capture(vilkårsvurderingSlot)) } returnsArgument 0
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
@@ -439,6 +439,7 @@ class StegServiceIntegrationTest(
             stegService = stegService,
             vedtaksperiodeService = vedtaksperiodeService,
             brevmalService = brevmalService,
+            vilkårInnvilgetFom = LocalDate.now().minusMonths(4),
         )
 
         val nyMigreringsdato = LocalDate.now().minusMonths(6)
@@ -553,6 +554,7 @@ class StegServiceIntegrationTest(
             stegService = stegService,
             vedtaksperiodeService = vedtaksperiodeService,
             brevmalService = brevmalService,
+            vilkårInnvilgetFom = LocalDate.now().minusMonths(4),
         )
 
         val nyMigreringsdato = LocalDate.now().minusMonths(6)
@@ -667,6 +669,7 @@ class StegServiceIntegrationTest(
             stegService = stegService,
             vedtaksperiodeService = vedtaksperiodeService,
             brevmalService = brevmalService,
+            vilkårInnvilgetFom = LocalDate.now().minusMonths(4),
         )
 
         val nyMigreringsdato = LocalDate.now().minusMonths(6)
@@ -1134,6 +1137,7 @@ class StegServiceIntegrationTest(
             stegService = stegService,
             vedtaksperiodeService = vedtaksperiodeService,
             brevmalService = brevmalService,
+            vilkårInnvilgetFom = LocalDate.now().minusMonths(4),
         )
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søkerFnr)

--- a/src/test/resources/cucumber/finnmarkstillegg/finnmarkstillegg.feature
+++ b/src/test/resources/cucumber/finnmarkstillegg/finnmarkstillegg.feature
@@ -16,7 +16,6 @@ Egenskap: Finnmarkstillegg autovedtak
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1       | SØKER      | 01.01.2000  |
       | 1            | 2       | BARN       | 01.01.2025  |
-      | 1            | 3       | BARN       | 01.04.2025  |
 
   Scenario: Skal oppdatere vilkårresultater og generere andeler når autovedtak finnmarkstillegg kjøres
     Og dagens dato er 01.09.2025
@@ -45,14 +44,14 @@ Egenskap: Finnmarkstillegg autovedtak
 
     Så forvent følgende vilkårresultater for behandling 2
       | AktørId | Vilkår                        | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
-      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 1       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 1       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 1       | LOVLIG_OPPHOLD                | 01.01.2025 |            | OPPFYLT  |                              |
 
       | 2       | UNDER_18_ÅR                   | 01.01.2025 | 31.12.2042 | OPPFYLT  |                              |
       | 2       | GIFT_PARTNERSKAP              | 01.01.2025 |            | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 2       | BOR_MED_SØKER, LOVLIG_OPPHOLD | 01.01.2025 |            | OPPFYLT  |                              |
 
     Så forvent følgende andeler tilkjent ytelse for behandling 2
@@ -63,7 +62,7 @@ Egenskap: Finnmarkstillegg autovedtak
 
     Så forvent følgende vedtaksperioder for behandling 2
       | Fra dato   | Til dato   | Vedtaksperiodetype | Begrunnelser               |
-      | 01.05.2025 | 30.09.2025 | Utbetaling         |                            |
+      | 01.09.2025 | 30.09.2025 | Utbetaling         |                            |
       | 01.10.2025 | 31.12.2042 | Utbetaling         | INNVILGET_FINNMARKSTILLEGG |
       | 01.01.2043 |            | Opphør             |                            |
 
@@ -139,14 +138,14 @@ Egenskap: Finnmarkstillegg autovedtak
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1
       | AktørId | Vilkår                        | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
-      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 1       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 1       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 1       | LOVLIG_OPPHOLD                | 01.01.2025 |            | OPPFYLT  |                              |
 
       | 2       | UNDER_18_ÅR                   | 01.01.2025 | 31.12.2042 | OPPFYLT  |                              |
       | 2       | GIFT_PARTNERSKAP              | 01.01.2025 |            | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 2       | BOR_MED_SØKER, LOVLIG_OPPHOLD | 01.01.2025 |            | OPPFYLT  |                              |
 
     Og med andeler tilkjent ytelse
@@ -165,13 +164,14 @@ Egenskap: Finnmarkstillegg autovedtak
 
     Så forvent følgende vilkårresultater for behandling 2
       | AktørId | Vilkår                        | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
-      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 1       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 1       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 1       | LOVLIG_OPPHOLD                | 01.01.2025 |            | OPPFYLT  |                              |
 
       | 2       | UNDER_18_ÅR                   | 01.01.2025 | 31.12.2042 | OPPFYLT  |                              |
       | 2       | GIFT_PARTNERSKAP              | 01.01.2025 |            | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.01.2025 |            | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  |                              |
       | 2       | BOR_MED_SØKER, LOVLIG_OPPHOLD | 01.01.2025 |            | OPPFYLT  |                              |
 
     Så forvent følgende andeler tilkjent ytelse for behandling 2
@@ -181,7 +181,7 @@ Egenskap: Finnmarkstillegg autovedtak
 
     Så forvent følgende vedtaksperioder for behandling 2
       | Fra dato   | Til dato   | Vedtaksperiodetype                                      | Begrunnelser                                        |
-      | 01.05.2025 | 30.09.2025 | Utbetaling                                              |                                                     |
+      | 01.09.2025 | 30.09.2025 | Utbetaling                                              |                                                     |
       | 01.10.2025 | 31.12.2042 | UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING | REDUKSJON_FINNMARKSTILLEGG_BODDE_IKKE_I_TILLEGGSONE |
       | 01.01.2043 |            | Opphør                                                  |                                                     |
 
@@ -195,14 +195,14 @@ Egenskap: Finnmarkstillegg autovedtak
     Og lag personresultater for behandling 1
     Og legg til nye vilkårresultater for behandling 1
       | AktørId | Vilkår                        | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
-      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 1       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 1       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 1       | LOVLIG_OPPHOLD                | 01.01.2025 |            | OPPFYLT  |                              |
 
       | 2       | UNDER_18_ÅR                   | 01.01.2025 | 31.12.2042 | OPPFYLT  |                              |
       | 2       | GIFT_PARTNERSKAP              | 01.01.2025 |            | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 2       | BOR_MED_SØKER, LOVLIG_OPPHOLD | 01.01.2025 |            | OPPFYLT  |                              |
 
     Og med andeler tilkjent ytelse
@@ -221,13 +221,14 @@ Egenskap: Finnmarkstillegg autovedtak
 
     Så forvent følgende vilkårresultater for behandling 2
       | AktørId | Vilkår                        | Fra dato   | Til dato   | Resultat | Utdypende vilkår             |
-      | 1       | BOSATT_I_RIKET                | 01.01.2025 |            | OPPFYLT  |                              |
+      | 1       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 1       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  |                              |
       | 1       | LOVLIG_OPPHOLD                | 01.01.2025 |            | OPPFYLT  |                              |
 
       | 2       | UNDER_18_ÅR                   | 01.01.2025 | 31.12.2042 | OPPFYLT  |                              |
       | 2       | GIFT_PARTNERSKAP              | 01.01.2025 |            | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 30.04.2025 | OPPFYLT  |                              |
-      | 2       | BOSATT_I_RIKET                | 01.05.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
+      | 2       | BOSATT_I_RIKET                | 01.01.2025 | 31.08.2025 | OPPFYLT  |                              |
+      | 2       | BOSATT_I_RIKET                | 01.09.2025 |            | OPPFYLT  | BOSATT_I_FINNMARK_NORD_TROMS |
       | 2       | BOR_MED_SØKER, LOVLIG_OPPHOLD | 01.01.2025 |            | OPPFYLT  |                              |
 
     Så forvent følgende andeler tilkjent ytelse for behandling 2
@@ -237,7 +238,7 @@ Egenskap: Finnmarkstillegg autovedtak
 
     Så forvent følgende vedtaksperioder for behandling 2
       | Fra dato   | Til dato   | Vedtaksperiodetype                                      | Begrunnelser                                        |
-      | 01.05.2025 | 30.09.2025 | Utbetaling                                              |                                                     |
+      | 01.09.2025 | 30.09.2025 | Utbetaling                                              |                                                     |
       | 01.10.2025 | 31.12.2042 | UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING | REDUKSJON_FINNMARKSTILLEGG_BODDE_IKKE_I_TILLEGGSONE |
       | 01.01.2043 |            | Opphør                                                  |                                                     |
 

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/VilkårsvurderingGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/VilkårsvurderingGenerator.kt
@@ -155,7 +155,7 @@ fun vurderVilkårsvurderingTilInnvilget(
                 it.periodeTom = barn.fødselsdato.plusYears(18)
             } else {
                 it.resultat = OPPFYLT
-                it.periodeFom = innvilgetFom ?: LocalDate.now()
+                it.periodeFom = innvilgetFom ?: barn.fødselsdato
             }
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-26374

For å unngå at Finnmarks- og Svalbardtilleggbehandlinger gjør endringer på 'Bosatt i riket'-vilkåret langt bakover i tid, som er irrelevante for tilleggene, men som kan føre til endringer ordinære/utvidet andeler, setter vi en cut off på preutfyllingen fra og med september 2025.

Splitter også inngangen til `PreutfyllBosattIRiketService` for finnmarks- og svalbardtilleggbehandlinger og fødselshendelsebehandlinger i to funksjoner

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Cut off'en i preutfyllingen blir i praksis testet i de endrede Cucumber-testene

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
