### PR TITLE
Fix: SendMeldingTilBisysTask feiler i alle tilfeller hvor det ikke finnes en tidligere behandling.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SendMeldingTilBisysTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SendMeldingTilBisysTask.kt
@@ -78,8 +78,7 @@ class SendMeldingTilBisysTask(
 
     fun finnBarnEndretOpplysning(behandling: Behandling): Map<String, List<BarnEndretOpplysning>> {
         val forrigeIverksatteBehandling =
-            behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling = behandling)
-                ?: throw Feil("Finnes ikke forrige behandling for behandling ${behandling.id}")
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling = behandling) ?: return emptyMap()
 
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandling.id)
         val forrigeTilkjentYtelse = tilkjentYtelseRepository.findByBehandling(forrigeIverksatteBehandling.id)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Etter at vi utvidet listen over behandlingsresultater i tasken `SendMeldingTilBisysTask`, vurderer vi nå sending av Kafka-meldinger for flere behandlinger enn tidligere. Nå vil vi også vurdere utsending av Kafka-melding for behandlinger som ikke har noen forrige behandling, og dette fører til at tasken feiler.

Skriver derfor om logikken slik at vi ikke feiler dersom det ikke finnes noen tidligere behandling.


