### PR TITLE
Forbedrer opprettelse av finnmarkstilleggtasker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
+import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
@@ -96,6 +97,7 @@ class ForvalterController(
     private val utbetalingsTidslinjeService: UtbetalingsTidslinjeService,
     private val personidentRepository: PersonidentRepository,
     private val autovedtakFinnmarkstilleggTaskOppretter: AutovedtakFinnmarkstilleggTaskOppretter,
+    private val envService: EnvService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ForvalterController::class.java)
 
@@ -543,8 +545,8 @@ class ForvalterController(
             handling = "Opprett task for autovedtak av Finnmarkstillegg",
         )
 
-        if (!featureToggleService.isEnabled(FeatureToggle.KAN_KJØRE_AUTOVEDTAK_FINNMARKSTILLEGG)) {
-            throw Feil("Toggle for å opprette tasker for autovedtak av Finnmarkstillegg er skrudd av")
+        if (envService.erProd()) {
+            throw Feil("Dette endepunktet skal ikke brukes i prod")
         }
 
         opprettTaskService.opprettAutovedtakFinnmarkstilleggTasker(fagsakIder)
@@ -585,8 +587,8 @@ class ForvalterController(
             handling = "Opprett task for autovedtak av Svalbardtillegg",
         )
 
-        if (!featureToggleService.isEnabled(FeatureToggle.KAN_KJØRE_AUTOVEDTAK_SVALBARDTILLEGG)) {
-            throw Feil("Toggle for å opprette tasker for autovedtak av Svalbardtillegg er skrudd av")
+        if (envService.erProd()) {
+            throw Feil("Dette endepunktet skal ikke brukes i prod")
         }
 
         opprettTaskService.opprettAutovedtakSvalbardtilleggTasker(fagsakIder)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggTaskOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/finnmarkstillegg/AutovedtakFinnmarkstilleggTaskOppretter.kt
@@ -32,8 +32,6 @@ class AutovedtakFinnmarkstilleggTaskOppretter(
             val page = fagsakRepository.finnLøpendeFagsakerForFinnmarkstilleggKjøring(Pageable.ofSize(antallFagsaker))
             val fagsakIder = page.toSet()
 
-            finnmarkstilleggKjøringRepository.saveAll(fagsakIder.map { FinnmarkstilleggKjøring(fagsakId = it) })
-
             val iverksatteBehandlinger =
                 behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksattForFagsaker(fagsakIder).values
 
@@ -69,6 +67,9 @@ class AutovedtakFinnmarkstilleggTaskOppretter(
                 fagsakerMedPersonidenter
                     .filterValues { personerSomBorIFinnmarkEllerNordTroms.intersect(it).isNotEmpty() }
                     .keys
+
+            val fagsakIderSomIkkeSkalOpprettesTaskFor = fagsakIder - fagsakerDerMinstEnAktørBorIFinnmarkEllerNordTroms
+            finnmarkstilleggKjøringRepository.saveAll(fagsakIderSomIkkeSkalOpprettesTaskFor.map { FinnmarkstilleggKjøring(fagsakId = it) })
 
             opprettTaskService.opprettAutovedtakFinnmarkstilleggTasker(fagsakerDerMinstEnAktørBorIFinnmarkEllerNordTroms)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -4,6 +4,8 @@ import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.common.inneværendeMåned
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle.SKAL_BRUKE_ADRESSEHENDELSELØYPE_FINNMARKSTILLEGG
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggTask
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
@@ -34,6 +36,7 @@ class OpprettTaskService(
     private val taskRepository: TaskRepositoryWrapper,
     private val satskjøringRepository: SatskjøringRepository,
     private val envService: EnvService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     fun opprettOppgaveTask(
         behandlingId: Long,
@@ -180,7 +183,7 @@ class OpprettTaskService(
                                 this["fagsakId"] = fagsakId.toString()
                             },
                     ).apply {
-                        if (envService.erProd()) {
+                        if (envService.erProd() && featureToggleService.isEnabled(SKAL_BRUKE_ADRESSEHENDELSELØYPE_FINNMARKSTILLEGG)) {
                             medTriggerTid(LocalDateTime.now().plusHours(1))
                         }
                     },

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -7,6 +7,8 @@ import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle.SKAL_BRUKE_ADRESSEHENDELSELØYPE_FINNMARKSTILLEGG
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggTask
+import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.domene.FinnmarkstilleggKjøring
+import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.domene.FinnmarkstilleggKjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.AutovedtakSvalbardtilleggTask
@@ -37,6 +39,7 @@ class OpprettTaskService(
     private val satskjøringRepository: SatskjøringRepository,
     private val envService: EnvService,
     private val featureToggleService: FeatureToggleService,
+    private val finnmarkstilleggKjøringRepository: FinnmarkstilleggKjøringRepository,
 ) {
     fun opprettOppgaveTask(
         behandlingId: Long,
@@ -189,6 +192,8 @@ class OpprettTaskService(
                     },
                 )
             }
+
+            finnmarkstilleggKjøringRepository.save(FinnmarkstilleggKjøring(fagsakId = fagsakId))
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -657,6 +657,7 @@ class CucumberMock(
             taskRepository = taskRepository,
             satskjøringRepository = mockk(),
             envService = mockk(),
+            featureToggleService = featureToggleService,
         )
 
     val stegService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -45,7 +45,7 @@ internal class StartSatsendringTest {
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(any(), any()) } returns null
         val taskSlot = slot<Task>()
         every { taskRepository.save(capture(taskSlot)) } answers { taskSlot.captured }
-        val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository, mockk())
+        val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository, mockk(), featureToggleService)
 
         every { satsendringService.erFagsakOppdatertMedSisteSatser(any()) } returns true
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
@@ -26,7 +26,7 @@ class GrensesnittavstemMotOppdragTest {
     fun setUp() {
         val avstemmingServiceMock = mockk<AvstemmingService>()
         taskRepositoryMock = mockk()
-        grensesnittavstemMotOppdrag = GrensesnittavstemMotOppdrag(avstemmingServiceMock, OpprettTaskService(taskRepositoryMock, mockk(), mockk()))
+        grensesnittavstemMotOppdrag = GrensesnittavstemMotOppdrag(avstemmingServiceMock, OpprettTaskService(taskRepositoryMock, mockk(), mockk(), featureToggleService))
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-26388

Legger til forbedringer for å kunne kjøre finnmarkstilleggbehandlinger i prod

- Legger til nytt endepunkt som starter et gitt antall finnmarkstilleggbehandlinger via `AutovedtakFinnmarkstilleggTaskOppretter`
- Sperrer to endepunkter som ikke skal brukes i prod, bare for testing
- Fjerner triggertid på +1 time for batch-kjøring
- Flytter markering av fagsaker som er opprettet finnmarkstilleggtask for nærmere opprettelse av tasken. Dette resulterer i flere kall til databasen, men er tryggere fordi vi ikke risikerer å markere en fagsak som kjørt uten at tasken ble opprettet, hvis det skjer noe galt underveis