### PR TITLE
Fikser graphql spørring når vi henter oppholdsaddresse (relevant for svalbardtillegg)

### DIFF
--- a/src/main/resources/pdl/bostedsadresse-delt-bosted-oppholdsadresse.graphql
+++ b/src/main/resources/pdl/bostedsadresse-delt-bosted-oppholdsadresse.graphql
@@ -3,7 +3,7 @@ query($identer: [ID!]!){
         code
         ident
         person {
-            bostedsadresse(historikk: false) {
+            bostedsadresse(historikk: true) {
                 gyldigFraOgMed
                 gyldigTilOgMed
                 vegadresse {
@@ -16,7 +16,7 @@ query($identer: [ID!]!){
                     bostedskommune
                 }
             }
-            deltBosted(historikk: false) {
+            deltBosted(historikk: true) {
                 startdatoForKontrakt
                 sluttdatoForKontrakt
                 vegadresse {
@@ -29,10 +29,16 @@ query($identer: [ID!]!){
                     bostedskommune
                 }
             }
-            oppholdsadresse(historikk: false) {
+            oppholdsadresse(historikk: true) {
                 gyldigFraOgMed
                 gyldigTilOgMed
                 oppholdAnnetSted
+                vegadresse {
+                    kommunenummer
+                }
+                matrikkeladresse {
+                    kommunenummer
+                }
             }
         }
     }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26396

Når vi preutfyller bosatt i riket og ønsker å sette svalbardtillegget så sjekker vi oppholdsaddrese.
Hvis oppholdAnnetSted er satt til svalbard så setter vi flagget.
Hvis ikke oppholdAnnetSted er satt, så sjekker vi kommunenummer.

Problemet er at vi ikke henter inn kommunenummer per i dag.