### PR TITLE
NAV-26278: Cognitive complexity `BeslutteVedtak`-steg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerService.kt
@@ -17,8 +17,6 @@ import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROL
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpStatusCodeException
-import java.time.LocalDate
-import java.time.Period
 
 @Service
 class FagsakDeltagerService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BeslutteVedtakTest.kt
@@ -304,7 +304,6 @@ class BeslutteVedtakTest {
             val behandling = lagBehandling(årsak = BehandlingÅrsak.KORREKSJON_VEDTAKSBREV)
             behandling.status = BehandlingStatus.FATTER_VEDTAK
             behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))
-            val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
 
             every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
             mockkObject(FerdigstillOppgaver.Companion)
@@ -314,7 +313,7 @@ class BeslutteVedtakTest {
                     payload = "",
                 )
 
-            assertThrows<FunksjonellFeil> { beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak) }
+            assertThrows<FunksjonellFeil> { beslutteVedtak.preValiderSteg(behandling) }
         }
 
         @Test
@@ -324,7 +323,6 @@ class BeslutteVedtakTest {
             val behandling = lagBehandling(årsak = BehandlingÅrsak.TEKNISK_ENDRING)
             behandling.status = BehandlingStatus.FATTER_VEDTAK
             behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))
-            val restBeslutningPåVedtak = RestBeslutningPåVedtak(Beslutning.GODKJENT)
 
             every { vedtakService.hentAktivForBehandling(any()) } returns lagVedtak(behandling)
             mockkObject(FerdigstillOppgaver.Companion)
@@ -334,7 +332,7 @@ class BeslutteVedtakTest {
                     payload = "",
                 )
 
-            assertThrows<FunksjonellFeil> { beslutteVedtak.utførStegOgAngiNeste(behandling, restBeslutningPåVedtak) }
+            assertThrows<FunksjonellFeil> { beslutteVedtak.preValiderSteg(behandling) }
         }
 
         @Test


### PR DESCRIPTION
Favro: [NAV-26278](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26278)

### 💰 Hva skal gjøres, og hvorfor?
Sonar-issue: "Refactor this method to reduce its Cognitive Complexity from 30 to the 15 allowed" for funksjonen `utførStegOgAngiNeste` i `BeslutteVedtak`-steg.

Omstrukturerer koden for å redusere kompleksitet: 
* Trekker logikk ut i hjelpe-funksjoner
* Fjerner bruk av `lazy`
* Flytter validering til `preValiderSteg`
* Justert tester som følge av flytting av validering til `preValiderSteg`

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. 
- [ ] Jeg har skrevet tester. 

Jeg har ikke skrevet tester fordi: Ingen ny logikk, kun omstrukturert kode.
