### PR TITLE
Legg til delt bosted i personopplysningsgrunnlag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestRegisterhistorikk.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RestRegisterhistorikk.kt
@@ -10,6 +10,7 @@ data class RestRegisterhistorikk(
     val oppholdstillatelse: List<RestRegisteropplysning>? = emptyList(),
     val statsborgerskap: List<RestRegisteropplysning>? = emptyList(),
     val bostedsadresse: List<RestRegisteropplysning>? = emptyList(),
+    val deltBosted: List<RestRegisteropplysning>? = emptyList(),
     val oppholdsadresse: List<RestRegisteropplysning>? = emptyList(),
     val dødsboadresse: List<RestRegisteropplysning>? = emptyList(),
 )
@@ -21,6 +22,7 @@ fun Person.tilRestRegisterhistorikk() =
         statsborgerskap = statsborgerskap.map { it.tilRestRegisteropplysning() },
         bostedsadresse = this.bostedsadresser.map { it.tilRestRegisteropplysning() }.fyllInnTomDatoer(),
         oppholdsadresse = this.oppholdsadresser.map { it.tilRestRegisteropplysning() }.fyllInnTomDatoer(),
+        deltBosted = this.deltBosted.map { it.tilRestRegisteropplysning() }.fyllInnTomDatoer(),
         sivilstand = this.sivilstander.map { it.tilRestRegisteropplysning() },
         dødsboadresse = if (this.dødsfall == null) emptyList() else listOf(this.dødsfall!!.tilRestRegisteropplysning()),
     )

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlRestClient.kt
@@ -116,6 +116,7 @@ class PdlRestClient(
                     adressebeskyttelseGradering = it.adressebeskyttelse.firstOrNull()?.gradering,
                     bostedsadresser = it.bostedsadresse,
                     oppholdsadresser = it.oppholdsadresse,
+                    deltBosted = it.deltBosted,
                     statsborgerskap = it.statsborgerskap,
                     opphold = it.opphold,
                     sivilstander = it.sivilstand,

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PdlHentPersonResponse.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.integrasjoner.pdl.logger
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.kontrakter.felles.personopplysning.Adressebeskyttelse
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
+import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
 import no.nav.familie.kontrakter.felles.personopplysning.ForelderBarnRelasjon
 import no.nav.familie.kontrakter.felles.personopplysning.Opphold
 import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
@@ -28,6 +29,7 @@ data class PdlPersonData(
     val sivilstand: List<Sivilstand> = emptyList(),
     val bostedsadresse: List<Bostedsadresse>,
     val oppholdsadresse: List<Oppholdsadresse> = emptyList(),
+    val deltBosted: List<DeltBosted> = emptyList(),
     val opphold: List<Opphold> = emptyList(),
     val statsborgerskap: List<Statsborgerskap> = emptyList(),
     val doedsfall: List<PdlDødsfallResponse> = emptyList(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PersonInfo.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/domene/PersonInfo.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
+import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.Opphold
 import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
@@ -37,6 +38,7 @@ data class PersonInfo(
     override val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,
     val bostedsadresser: List<Bostedsadresse> = emptyList(),
     val oppholdsadresser: List<Oppholdsadresse> = emptyList(),
+    val deltBosted: List<DeltBosted> = emptyList(),
     val sivilstander: List<Sivilstand> = emptyList(),
     val opphold: List<Opphold>? = emptyList(),
     val statsborgerskap: List<Statsborgerskap>? = emptyList(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/Person.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/Person.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ba.sak.common.sisteDagIMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.arbeidsforhold.GrArbeidsforhold
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.bostedsadresse.GrBostedsadresse
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted.GrDeltBosted
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.opphold.GrOpphold
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.oppholdsadresse.GrOppholdsadresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.sivilstand.GrSivilstand
@@ -76,6 +77,9 @@ data class Person(
     @Fetch(value = FetchMode.SUBSELECT)
     var oppholdsadresser: MutableList<GrOppholdsadresse> = mutableListOf(),
     @OneToMany(mappedBy = "person", cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
+    var deltBosted: MutableList<GrDeltBosted> = mutableListOf(),
+    @OneToMany(mappedBy = "person", cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
     // Workaround før Hibernatebug https://hibernate.atlassian.net/browse/HHH-1718
     @Fetch(value = FetchMode.SUBSELECT)
     var statsborgerskap: MutableList<GrStatsborgerskap> = mutableListOf(),
@@ -100,6 +104,7 @@ data class Person(
             personopplysningGrunnlag = nyttPersonopplysningGrunnlag,
             bostedsadresser = mutableListOf(),
             oppholdsadresser = mutableListOf(),
+            deltBosted = mutableListOf(),
             statsborgerskap = mutableListOf(),
             opphold = mutableListOf(),
             arbeidsforhold = mutableListOf(),
@@ -113,6 +118,11 @@ data class Person(
             it.oppholdsadresser.addAll(
                 oppholdsadresser.map { grBostedsadresse ->
                     grBostedsadresse.tilKopiForNyPerson(it)
+                },
+            )
+            it.deltBosted.addAll(
+                deltBosted.map { grDeltBosted ->
+                    grDeltBosted.tilKopiForNyPerson(it)
                 },
             )
             it.statsborgerskap.addAll(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.NORMAL
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType.SKJERMET_BARN
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.arbeidsforhold.ArbeidsforholdService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.bostedsadresse.GrBostedsadresse
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted.GrDeltBosted
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.opphold.GrOpphold
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.oppholdsadresse.GrOppholdsadresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.sivilstand.GrSivilstand
@@ -35,6 +36,7 @@ import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
+import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
 import org.slf4j.LoggerFactory
@@ -286,6 +288,8 @@ class PersongrunnlagService(
 
     private fun Bostedsadresse.poststed(): String? = kodeverkService.hentPoststed(vegadresse?.postnummer ?: matrikkeladresse?.postnummer)
 
+    private fun DeltBosted.poststed(): String? = kodeverkService.hentPoststed(vegadresse?.postnummer ?: matrikkeladresse?.postnummer)
+
     private fun Oppholdsadresse.poststed(): String? = kodeverkService.hentPoststed(vegadresse?.postnummer ?: matrikkeladresse?.postnummer)
 
     private fun hentPerson(
@@ -309,7 +313,7 @@ class PersongrunnlagService(
             fødselsdato = personinfo.fødselsdato,
             aktør = aktør,
             navn = personinfo.navn ?: "",
-            kjønn = personinfo.kjønn ?: Kjønn.UKJENT,
+            kjønn = personinfo.kjønn,
             målform = målform,
         ).also { person ->
             person.opphold =
@@ -329,6 +333,15 @@ class PersongrunnlagService(
                     .map {
                         GrOppholdsadresse.fraOppholdsadresse(
                             oppholdsadresse = it,
+                            person = person,
+                            poststed = it.poststed(),
+                        )
+                    }.toMutableList()
+            person.deltBosted =
+                personinfo.deltBosted
+                    .map {
+                        GrDeltBosted.fraDeltBosted(
+                            deltBosted = it,
                             person = person,
                             poststed = it.poststed(),
                         )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrDeltBosted.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrDeltBosted.kt
@@ -1,0 +1,90 @@
+package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import jakarta.persistence.DiscriminatorColumn
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import no.nav.familie.ba.sak.common.BaseEntitet
+import no.nav.familie.ba.sak.common.DatoIntervallEntitet
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.ekstern.restDomene.RestRegisteropplysning
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted.GrMatrikkeladresseDeltBosted.Companion.fraMatrikkeladresse
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted.GrUkjentBostedDeltBosted.Companion.fraUkjentBosted
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted.GrVegadresseDeltBosted.Companion.fraVegadresse
+import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
+import java.time.LocalDate
+
+@EntityListeners(RollestyringMotDatabase::class)
+@Entity(name = "GrDeltBosted")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+@Table(name = "PO_DELT_BOSTED")
+abstract class GrDeltBosted(
+    // Alle attributter må være open ellers kastes feil ved oppstart.
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "po_delt_bosted_seq_generator")
+    @SequenceGenerator(
+        name = "po_delt_bosted_seq_generator",
+        sequenceName = "po_delt_bosted_seq",
+        allocationSize = 50,
+    )
+    open val id: Long = 0,
+    @Embedded
+    open var periode: DatoIntervallEntitet? = null,
+    @JsonIgnore
+    @ManyToOne
+    @JoinColumn(name = "fk_po_person_id")
+    open var person: Person? = null,
+) : BaseEntitet() {
+    abstract fun toSecureString(): String
+
+    abstract fun tilFrontendString(): String
+
+    protected abstract fun tilKopiForNyPerson(): GrDeltBosted
+
+    fun tilKopiForNyPerson(nyPerson: Person): GrDeltBosted =
+        tilKopiForNyPerson().also {
+            it.periode = periode
+            it.person = nyPerson
+        }
+
+    fun tilRestRegisteropplysning() =
+        RestRegisteropplysning(
+            fom = this.periode?.fom.takeIf { it != fregManglendeFlytteDato },
+            tom = this.periode?.tom,
+            verdi = this.tilFrontendString(),
+        )
+
+    companion object {
+        // Når flyttedato er satt til 0001-01-01, så mangler den egentlig.
+        // Det er en feil i Freg, som har arvet mangelfulle data fra DSF.
+        val fregManglendeFlytteDato = LocalDate.of(1, 1, 1)
+
+        fun fraDeltBosted(
+            deltBosted: DeltBosted,
+            person: Person,
+            poststed: String? = null,
+        ): GrDeltBosted =
+            when {
+                deltBosted.vegadresse != null -> fraVegadresse(deltBosted.vegadresse!!, poststed)
+                deltBosted.matrikkeladresse != null -> fraMatrikkeladresse(deltBosted.matrikkeladresse!!, poststed)
+                deltBosted.ukjentBosted != null -> fraUkjentBosted(deltBosted.ukjentBosted!!)
+                else -> throw Feil("Vegadresse, matrikkeladresse og ukjent bosted har verdi null ved mapping fra bostedadresse")
+            }.also {
+                it.person = person
+                it.periode = DatoIntervallEntitet(deltBosted.startdatoForKontrakt, deltBosted.sluttdatoForKontrakt)
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrDeltBosted.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrDeltBosted.kt
@@ -81,7 +81,7 @@ abstract class GrDeltBosted(
                 deltBosted.vegadresse != null -> fraVegadresse(deltBosted.vegadresse!!, poststed)
                 deltBosted.matrikkeladresse != null -> fraMatrikkeladresse(deltBosted.matrikkeladresse!!, poststed)
                 deltBosted.ukjentBosted != null -> fraUkjentBosted(deltBosted.ukjentBosted!!)
-                else -> throw Feil("Vegadresse, matrikkeladresse og ukjent bosted har verdi null ved mapping fra bostedadresse")
+                else -> throw Feil("Vegadresse, matrikkeladresse og ukjent bosted har verdi null ved mapping fra delt bosted")
             }.also {
                 it.person = person
                 it.periode = DatoIntervallEntitet(deltBosted.startdatoForKontrakt, deltBosted.sluttdatoForKontrakt)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrMatrikkeladresseDeltBosted.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrMatrikkeladresseDeltBosted.kt
@@ -1,0 +1,83 @@
+package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
+import java.util.Objects
+
+@EntityListeners(RollestyringMotDatabase::class)
+@Entity(name = "GrMatrikkeladresseDeltBosted")
+@DiscriminatorValue("Matrikkeladresse")
+data class GrMatrikkeladresseDeltBosted(
+    @Column(name = "matrikkel_id")
+    val matrikkelId: Long?,
+    @Column(name = "bruksenhetsnummer")
+    val bruksenhetsnummer: String?,
+    @Column(name = "tilleggsnavn")
+    val tilleggsnavn: String?,
+    @Column(name = "postnummer")
+    val postnummer: String?,
+    @Column(name = "poststed")
+    val poststed: String?,
+    @Column(name = "kommunenummer")
+    val kommunenummer: String?,
+) : GrDeltBosted() {
+    override fun tilKopiForNyPerson(): GrDeltBosted =
+        GrMatrikkeladresseDeltBosted(
+            matrikkelId,
+            bruksenhetsnummer,
+            tilleggsnavn,
+            postnummer,
+            poststed,
+            kommunenummer,
+        )
+
+    override fun toSecureString(): String =
+        "GrMatrikkeladresseDeltBosted(" +
+            "matrikkelId=$matrikkelId, " +
+            "bruksenhetsnummer=$bruksenhetsnummer, " +
+            "tilleggsnavn=$tilleggsnavn, " +
+            "postnummer=$postnummer, " +
+            "poststed=$poststed, " +
+            "kommunenummer=$kommunenummer" +
+            ")"
+
+    override fun toString(): String = "GrMatrikkeladresseDeltBosted(detaljer skjult)"
+
+    override fun tilFrontendString(): String {
+        val postnummer = postnummer?.let { "Postnummer $postnummer" }
+        val poststed = poststed?.let { ", $poststed" } ?: ""
+        return postnummer?.let { "$postnummer$poststed" } ?: "Ukjent adresse"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || javaClass != other.javaClass) {
+            return false
+        }
+        val otherMatrikkeladresse = other as GrMatrikkeladresseDeltBosted
+        return this === other ||
+            matrikkelId != null &&
+            matrikkelId == otherMatrikkeladresse.matrikkelId &&
+            bruksenhetsnummer == otherMatrikkeladresse.bruksenhetsnummer
+    }
+
+    override fun hashCode(): Int = Objects.hash(matrikkelId)
+
+    companion object {
+        fun fraMatrikkeladresse(
+            matrikkeladresse: Matrikkeladresse,
+            poststed: String?,
+        ): GrMatrikkeladresseDeltBosted =
+            GrMatrikkeladresseDeltBosted(
+                matrikkelId = matrikkeladresse.matrikkelId,
+                bruksenhetsnummer = matrikkeladresse.bruksenhetsnummer.takeUnless { it.isNullOrBlank() },
+                tilleggsnavn = matrikkeladresse.tilleggsnavn.takeUnless { it.isNullOrBlank() },
+                postnummer = matrikkeladresse.postnummer.takeUnless { it.isNullOrBlank() },
+                poststed = poststed.takeUnless { it.isNullOrBlank() },
+                kommunenummer = matrikkeladresse.kommunenummer.takeUnless { it.isNullOrBlank() },
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrUkjentBostedDeltBosted.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrUkjentBostedDeltBosted.kt
@@ -1,0 +1,28 @@
+package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.kontrakter.felles.personopplysning.UkjentBosted
+
+@EntityListeners(RollestyringMotDatabase::class)
+@Entity(name = "GrUkjentBostedDeltBosted")
+@DiscriminatorValue("ukjentBosted")
+data class GrUkjentBostedDeltBosted(
+    @Column(name = "bostedskommune")
+    val bostedskommune: String,
+) : GrDeltBosted() {
+    override fun tilKopiForNyPerson(): GrDeltBosted = GrUkjentBostedDeltBosted(bostedskommune)
+
+    override fun toSecureString(): String = """GrUkjentBostedDeltBosted(bostedskommune=$bostedskommune)""".trimMargin()
+
+    override fun tilFrontendString() = """Ukjent adresse, kommune $bostedskommune""".trimMargin()
+
+    override fun toString(): String = "GrUkjentBostedDeltBosted(detaljer skjult)"
+
+    companion object {
+        fun fraUkjentBosted(ukjentBosted: UkjentBosted): GrUkjentBostedDeltBosted = GrUkjentBostedDeltBosted(bostedskommune = ukjentBosted.bostedskommune)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrVegadresseDeltBosted.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/GrVegadresseDeltBosted.kt
@@ -1,0 +1,116 @@
+package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import no.nav.familie.ba.sak.common.Utils.nullableTilString
+import no.nav.familie.ba.sak.common.Utils.storForbokstavIHvertOrd
+import no.nav.familie.ba.sak.sikkerhet.RollestyringMotDatabase
+import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
+import java.util.Objects
+
+@EntityListeners(RollestyringMotDatabase::class)
+@Entity(name = "GrVegadresseDeltBosted")
+@DiscriminatorValue("Vegadresse")
+data class GrVegadresseDeltBosted(
+    @Column(name = "matrikkel_id")
+    val matrikkelId: Long?,
+    @Column(name = "husnummer")
+    val husnummer: String?,
+    @Column(name = "husbokstav")
+    val husbokstav: String?,
+    @Column(name = "bruksenhetsnummer")
+    val bruksenhetsnummer: String?,
+    @Column(name = "adressenavn")
+    val adressenavn: String?,
+    @Column(name = "kommunenummer")
+    val kommunenummer: String?,
+    @Column(name = "tilleggsnavn")
+    val tilleggsnavn: String?,
+    @Column(name = "postnummer")
+    val postnummer: String?,
+    @Column(name = "poststed")
+    val poststed: String?,
+) : GrDeltBosted() {
+    override fun tilKopiForNyPerson(): GrDeltBosted =
+        GrVegadresseDeltBosted(
+            matrikkelId,
+            husnummer,
+            husbokstav,
+            bruksenhetsnummer,
+            adressenavn,
+            kommunenummer,
+            tilleggsnavn,
+            postnummer,
+            poststed,
+        )
+
+    override fun toSecureString(): String =
+        "GrVegadresseDeltBosted(" +
+            "husnummer=$husnummer, " +
+            "husbokstav=$husbokstav, " +
+            "matrikkelId=$matrikkelId, " +
+            "bruksenhetsnummer=$bruksenhetsnummer, " +
+            "adressenavn=$adressenavn, " +
+            "kommunenummer=$kommunenummer, " +
+            "tilleggsnavn=$tilleggsnavn, " +
+            "postnummer=$postnummer, " +
+            "poststed=$poststed" +
+            ")"
+
+    override fun toString(): String = "GrVegadresseDeltBosted(detaljer skjult)"
+
+    override fun tilFrontendString(): String {
+        val adressenavn = adressenavn?.storForbokstavIHvertOrd()
+        val husnummer = husnummer.nullableTilString()
+        val husbokstav = husbokstav.nullableTilString()
+        val postnummer = postnummer?.let { ", $it" } ?: ""
+        val poststed = poststed?.let { ", $it" } ?: ""
+        return when (adressenavn) {
+            null -> "Ukjent adresse"
+            else -> "$adressenavn $husnummer$husbokstav$postnummer$poststed"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || javaClass != other.javaClass) {
+            return false
+        }
+        val otherVegadresse = other as GrVegadresseDeltBosted
+
+        return this === other ||
+            (
+                (matrikkelId != null && matrikkelId == otherVegadresse.matrikkelId) ||
+                    (
+                        (matrikkelId == null && otherVegadresse.matrikkelId == null) &&
+                            postnummer != null &&
+                            !(adressenavn == null && husnummer == null && husbokstav == null) &&
+                            (adressenavn == otherVegadresse.adressenavn) &&
+                            (husnummer == otherVegadresse.husnummer) &&
+                            (husbokstav == otherVegadresse.husbokstav) &&
+                            (postnummer == otherVegadresse.postnummer)
+                    )
+            )
+    }
+
+    override fun hashCode(): Int = Objects.hash(matrikkelId)
+
+    companion object {
+        fun fraVegadresse(
+            vegadresse: Vegadresse,
+            poststed: String?,
+        ): GrVegadresseDeltBosted =
+            GrVegadresseDeltBosted(
+                matrikkelId = vegadresse.matrikkelId,
+                husnummer = vegadresse.husnummer,
+                husbokstav = vegadresse.husbokstav,
+                bruksenhetsnummer = vegadresse.bruksenhetsnummer,
+                adressenavn = vegadresse.adressenavn,
+                kommunenummer = vegadresse.kommunenummer,
+                tilleggsnavn = vegadresse.tilleggsnavn,
+                postnummer = vegadresse.postnummer,
+                poststed = poststed,
+            )
+    }
+}

--- a/src/main/resources/db/migration/V295__opprett_delt_bosted_tabell.sql
+++ b/src/main/resources/db/migration/V295__opprett_delt_bosted_tabell.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS PO_DELT_BOSTED
+(
+    id                BIGINT                                 NOT NULL PRIMARY KEY,
+    type              VARCHAR                                NOT NULL,
+    fom               DATE,
+    tom               DATE,
+    fk_po_person_id   BIGINT REFERENCES PO_PERSON (id) ON DELETE CASCADE,
+
+    matrikkel_id      BIGINT,
+    husnummer         VARCHAR,
+    husbokstav        VARCHAR,
+    bruksenhetsnummer VARCHAR,
+    adressenavn       VARCHAR,
+    kommunenummer     VARCHAR,
+    tilleggsnavn      VARCHAR,
+    postnummer        VARCHAR,
+    poststed          VARCHAR,
+    bostedskommune    VARCHAR,
+
+    opprettet_av      VARCHAR      DEFAULT 'VL'              NOT NULL,
+    opprettet_tid     TIMESTAMP(3) DEFAULT current_timestamp NOT NULL,
+    endret_av         VARCHAR,
+    endret_tid        TIMESTAMP(3),
+    versjon           BIGINT       DEFAULT 0                 NOT NULL
+);
+
+CREATE SEQUENCE po_delt_bosted_seq INCREMENT BY 50 START WITH 1000000 NO CYCLE;
+
+CREATE INDEX po_delt_bosted_person_id_idx ON PO_DELT_BOSTED (fk_po_person_id);

--- a/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
+++ b/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
@@ -54,6 +54,31 @@ query($ident: ID!) {person: hentPerson(ident: $ident) {
             bostedskommune
         }
     }
+
+    deltBosted(historikk: true) {
+        startdatoForKontrakt
+        sluttdatoForKontrakt
+        vegadresse {
+            matrikkelId
+            husnummer
+            husbokstav
+            bruksenhetsnummer
+            adressenavn
+            kommunenummer
+            tilleggsnavn
+            postnummer
+        }
+        matrikkeladresse {
+            matrikkelId
+            bruksenhetsnummer
+            tilleggsnavn
+            postnummer
+            kommunenummer
+        }
+        ukjentBosted {
+            bostedskommune
+        }
+    }
     oppholdsadresse(historikk: true) {
         gyldigFraOgMed
         gyldigTilOgMed

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/DeltBostedTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/DeltBostedTest.kt
@@ -105,7 +105,7 @@ class DeltBostedTest {
                 }
 
             // Assert
-            assertThat(feil.message).isEqualTo("Vegadresse, matrikkeladresse og ukjent bosted har verdi null ved mapping fra bostedadresse")
+            assertThat(feil.message).isEqualTo("Vegadresse, matrikkeladresse og ukjent bosted har verdi null ved mapping fra delt bosted")
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/DeltBostedTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/deltbosted/DeltBostedTest.kt
@@ -1,0 +1,466 @@
+package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted
+
+import io.mockk.mockk
+import no.nav.familie.ba.sak.common.DatoIntervallEntitet
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.deltbosted.GrDeltBosted.Companion.fraDeltBosted
+import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
+import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
+import no.nav.familie.kontrakter.felles.personopplysning.UkjentBosted
+import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class DeltBostedTest {
+    private val person1 = mockk<Person>()
+    private val person2 = mockk<Person>()
+    private val fom = LocalDate.of(2024, 1, 1)
+    private val tom = LocalDate.of(2024, 12, 31)
+    private val vegadresse =
+        Vegadresse(
+            matrikkelId = 12345L,
+            husnummer = "10",
+            husbokstav = "A",
+            bruksenhetsnummer = "H101",
+            adressenavn = "Testgata",
+            kommunenummer = "0301",
+            tilleggsnavn = "Bak butikken",
+            postnummer = "0123",
+        )
+
+    private val matrikkeladresse =
+        Matrikkeladresse(
+            matrikkelId = 67890L,
+            bruksenhetsnummer = "H202",
+            tilleggsnavn = "Ved skogen",
+            postnummer = "1234",
+            kommunenummer = "0219",
+        )
+
+    private val ukjentBosted =
+        UkjentBosted(bostedskommune = "0301")
+
+    private val deltBosted = DeltBosted(startdatoForKontrakt = fom, sluttdatoForKontrakt = tom)
+
+    @Nested
+    inner class FraOppholdsadresse {
+        @Test
+        fun `fraDeltBosted skal returnere GrVegadresse når delt bosted har vegadresse`() {
+            // Arrange
+            val deltBosted = deltBosted.copy(vegadresse = vegadresse)
+
+            // Act
+            val grDeltBosted = fraDeltBosted(deltBosted, person1)
+
+            // Assert
+            assertThat(grDeltBosted).isInstanceOf(GrVegadresseDeltBosted::class.java)
+
+            val grVegadresse = grDeltBosted as GrVegadresseDeltBosted
+            assertDeltBosted(grVegadresse)
+            assertVegadresse(grVegadresse)
+        }
+
+        @Test
+        fun `fraDeltBosted skal returnere GrMatrikkeladresse når delt bosted har matrikkeladresse`() {
+            // Arrange
+            val deltBosted = deltBosted.copy(matrikkeladresse = matrikkeladresse)
+
+            // Act
+            val grDeltBosted = fraDeltBosted(deltBosted, person1)
+
+            // Assert
+            assertThat(grDeltBosted).isInstanceOf(GrMatrikkeladresseDeltBosted::class.java)
+
+            val grMatrikkeladresse = grDeltBosted as GrMatrikkeladresseDeltBosted
+            assertDeltBosted(grMatrikkeladresse)
+            assertMatrikkeladresse(grMatrikkeladresse)
+        }
+
+        @Test
+        fun `fraDeltBosted skal returnere GrUkjentBosted når delt bosted har ukjentBosted`() {
+            // Arrange
+            val deltBosted = deltBosted.copy(ukjentBosted = ukjentBosted)
+
+            // Act
+            val grDeltBosted = fraDeltBosted(deltBosted, person1)
+
+            // Assert
+            assertThat(grDeltBosted).isInstanceOf(GrUkjentBostedDeltBosted::class.java)
+
+            val grUkjentBosted = grDeltBosted as GrUkjentBostedDeltBosted
+            assertDeltBosted(grUkjentBosted)
+            assertUkjentBosted(grUkjentBosted)
+        }
+
+        @Test
+        fun `fraDeltBosted skal kaste feil når delt bosted ikke har noen adressetyper`() {
+            // Act
+            val feil =
+                assertThrows<Feil> {
+                    fraDeltBosted(deltBosted, person1)
+                }
+
+            // Assert
+            assertThat(feil.message).isEqualTo("Vegadresse, matrikkeladresse og ukjent bosted har verdi null ved mapping fra bostedadresse")
+        }
+
+        @Test
+        fun `fraDeltBosted skal håndtere null verdier for startdatoForKontrakt og sluttdatoForKontrakt`() {
+            // Arrange
+            val deltBosted = deltBosted.copy(startdatoForKontrakt = null, sluttdatoForKontrakt = null, vegadresse = vegadresse)
+
+            // Act
+            val grDeltBosted = fraDeltBosted(deltBosted, person1)
+
+            // Assert
+            assertDeltBosted(grDeltBosted, forventetFom = null, forventetTom = null)
+        }
+
+        @Test
+        fun `fraDeltBosted skal prioritere vegadresse over matrikkeladresse over ukjent bosted`() {
+            // Arrange
+            val deltBostedMedUkjentBosted =
+                deltBosted.copy(ukjentBosted = ukjentBosted)
+
+            val deltBostedMedMatrikkelOgUkjentBosted =
+                deltBosted.copy(matrikkeladresse = matrikkeladresse, ukjentBosted = ukjentBosted)
+
+            val deltBostedMedVegMatrikkelOgUkjentBosted =
+                deltBosted.copy(vegadresse = vegadresse, matrikkeladresse = matrikkeladresse, ukjentBosted = ukjentBosted)
+
+            // Act
+            val grUkjentBosted = fraDeltBosted(deltBostedMedUkjentBosted, person1)
+            val grMatrikkeladresse = fraDeltBosted(deltBostedMedMatrikkelOgUkjentBosted, person1)
+            val grVegadresse = fraDeltBosted(deltBostedMedVegMatrikkelOgUkjentBosted, person1)
+
+            // Assert
+            assertThat(grUkjentBosted).isInstanceOf(GrUkjentBostedDeltBosted::class.java)
+            assertThat(grMatrikkeladresse).isInstanceOf(GrMatrikkeladresseDeltBosted::class.java)
+            assertThat(grVegadresse).isInstanceOf(GrVegadresseDeltBosted::class.java)
+        }
+    }
+
+    private val grVegadresse =
+        fraDeltBosted(
+            deltBosted = deltBosted.copy(vegadresse = vegadresse),
+            person = person1,
+        ) as GrVegadresseDeltBosted
+
+    private val grMatrikkeladresse =
+        fraDeltBosted(
+            deltBosted = deltBosted.copy(matrikkeladresse = matrikkeladresse),
+            person = person1,
+        ) as GrMatrikkeladresseDeltBosted
+
+    private val grUkjentBosted =
+        fraDeltBosted(
+            deltBosted = deltBosted.copy(ukjentBosted = ukjentBosted),
+            person = person1,
+        ) as GrUkjentBostedDeltBosted
+
+    @Nested
+    inner class ToString {
+        @Test
+        fun `GrVegadresse toString skal returnere riktig format`() {
+            // Arrange
+            val vegadresse = grVegadresse
+
+            // Act
+            val result = vegadresse.toString()
+
+            // Assert
+            assertThat(result).isEqualTo("GrVegadresseDeltBosted(detaljer skjult)")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse toString skal returnere riktig format`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse
+
+            // Act
+            val result = matrikkeladresse.toString()
+
+            // Assert
+            assertThat(result).isEqualTo("GrMatrikkeladresseDeltBosted(detaljer skjult)")
+        }
+
+        @Test
+        fun `GrUkjentBosted toString skal returnere riktig format`() {
+            // Arrange
+            val ukjentBosted = grUkjentBosted
+
+            // Act
+            val result = ukjentBosted.toString()
+            // Assert
+            assertThat(result).isEqualTo("GrUkjentBostedDeltBosted(detaljer skjult)")
+        }
+    }
+
+    @Nested
+    inner class ToSecureString {
+        @Test
+        fun `GrVegadresse toSecureString skal returnere riktig format`() {
+            // Arrange
+            val vegadresse = grVegadresse.copy(poststed = "Oslo")
+
+            // Act
+            val result = vegadresse.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo(
+                "GrVegadresseDeltBosted(husnummer=10, husbokstav=A, matrikkelId=12345, " +
+                    "bruksenhetsnummer=H101, adressenavn=Testgata, kommunenummer=0301, " +
+                    "tilleggsnavn=Bak butikken, postnummer=0123, poststed=Oslo)",
+            )
+        }
+
+        @Test
+        fun `GrMatrikkeladresse toSecureString skal returnere riktig format`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse.copy(poststed = "Oslo")
+
+            // Act
+            val result = matrikkeladresse.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo(
+                "GrMatrikkeladresseDeltBosted(matrikkelId=67890, bruksenhetsnummer=H202, " +
+                    "tilleggsnavn=Ved skogen, postnummer=1234, poststed=Oslo, " +
+                    "kommunenummer=0219)",
+            )
+        }
+
+        @Test
+        fun `GrUkjentBosted toSecureString skal returnere riktig format`() {
+            // Arrange
+            val ukjentBosted = grUkjentBosted.copy()
+
+            // Act
+            val result = ukjentBosted.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo(
+                "GrUkjentBostedDeltBosted(bostedskommune=0301)",
+            )
+        }
+    }
+
+    @Nested
+    inner class TilFrontendString {
+        @Test
+        fun `GrVegadresse tilFrontendString uten adressenavn`() {
+            // Arrange
+            val vegadresse = grVegadresse.copy(adressenavn = null)
+
+            // Act
+            val result = vegadresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse tilFrontendString med postnummer skal returnere formatert streng`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse
+
+            // Act
+            val result = matrikkeladresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Postnummer 1234")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse tilFrontendString uten postnummer skal returnere 'Ukjent adresse'`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse.copy(postnummer = null)
+
+            // Act
+            val result = matrikkeladresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse")
+        }
+
+        @Test
+        fun `GrUkjentBosted tilFrontendString med komplett adresse skal returnere formatert streng`() {
+            // Arrange
+            val ukjentBosted = grUkjentBosted
+
+            // Act
+            val result = ukjentBosted.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse, kommune 0301")
+        }
+    }
+
+    @Nested
+    inner class TilKopiForNyPerson {
+        @Test
+        fun `GrUkjentAdresse tilKopiForNyPerson skal returnere ny instans med samme data`() {
+            // Arrange
+            val originalAdresse =
+                grUkjentBosted.copy().apply {
+                    periode = DatoIntervallEntitet(fom, tom)
+                    person = person1
+                }
+
+            // Act
+            val kopiForNyPerson = originalAdresse.tilKopiForNyPerson(person2)
+
+            // Assert
+            assertThat(kopiForNyPerson).isInstanceOf(GrUkjentBostedDeltBosted::class.java)
+            assertThat(kopiForNyPerson).isNotSameAs(originalAdresse)
+            assertDeltBosted(kopiForNyPerson, forventetPerson = person2)
+        }
+
+        @Test
+        fun `GrVegadresse tilKopiForNyPerson skal returnere ny instans med samme data`() {
+            // Arrange
+            val originalAdresse =
+                grVegadresse.copy().apply {
+                    periode = DatoIntervallEntitet(fom, tom)
+                    person = person1
+                }
+
+            // Act
+            val kopiForNyPerson = originalAdresse.tilKopiForNyPerson(person2)
+
+            // Assert
+            assertThat(kopiForNyPerson).isInstanceOf(GrVegadresseDeltBosted::class.java)
+            assertThat(kopiForNyPerson).isNotSameAs(originalAdresse)
+
+            val kopierteVegadresse = kopiForNyPerson as GrVegadresseDeltBosted
+            assertVegadresse(kopierteVegadresse)
+            assertDeltBosted(kopierteVegadresse, forventetPerson = person2)
+        }
+
+        @Test
+        fun `GrMatrikkeladresse tilKopiForNyPerson skal returnere ny instans med samme data`() {
+            // Arrange
+            val originalAdresse =
+                grMatrikkeladresse.copy().apply {
+                    periode = DatoIntervallEntitet(fom, tom)
+                    person = person1
+                }
+
+            // Act
+            val kopiForNyPerson = originalAdresse.tilKopiForNyPerson(person2)
+
+            // Assert
+            assertThat(kopiForNyPerson).isInstanceOf(GrMatrikkeladresseDeltBosted::class.java)
+            assertThat(kopiForNyPerson).isNotSameAs(originalAdresse)
+
+            val kopierteMatrikkeladresse = kopiForNyPerson as GrMatrikkeladresseDeltBosted
+            assertMatrikkeladresse(kopierteMatrikkeladresse)
+            assertDeltBosted(kopierteMatrikkeladresse, forventetPerson = person2)
+        }
+
+        @Test
+        fun `GrUkjentBosted tilKopiForNyPerson skal returnere ny instans med samme data`() {
+            // Arrange
+            val originalAdresse =
+                grUkjentBosted.copy().apply {
+                    periode = DatoIntervallEntitet(fom, tom)
+                    person = person1
+                }
+
+            // Act
+            val kopiForNyPerson = originalAdresse.tilKopiForNyPerson(person2)
+
+            // Assert
+            assertThat(kopiForNyPerson).isInstanceOf(GrUkjentBostedDeltBosted::class.java)
+            assertThat(kopiForNyPerson).isNotSameAs(originalAdresse)
+
+            val kopiertUkjentBosted = kopiForNyPerson as GrUkjentBostedDeltBosted
+            assertUkjentBosted(kopiertUkjentBosted)
+            assertDeltBosted(kopiertUkjentBosted, forventetPerson = person2)
+        }
+
+        @Test
+        fun `tilKopiForNyPerson skal håndtere null verdier korrekt`() {
+            // Arrange
+            val originalAdresse =
+                GrVegadresseDeltBosted(
+                    matrikkelId = null,
+                    husnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    adressenavn = null,
+                    kommunenummer = null,
+                    tilleggsnavn = null,
+                    postnummer = null,
+                    poststed = null,
+                ).apply {
+                    periode = null
+                    person = person1
+                }
+
+            // Act
+            val kopiForNyPerson = originalAdresse.tilKopiForNyPerson(person2)
+
+            // Assert
+            assertDeltBosted(kopiForNyPerson, forventetPerson = person2, forventetFom = null, forventetTom = null)
+        }
+    }
+
+    fun assertDeltBosted(
+        grDeltBosted: GrDeltBosted,
+        forventetPerson: Person = person1,
+        forventetFom: LocalDate? = fom,
+        forventetTom: LocalDate? = tom,
+    ) {
+        assertThat(grDeltBosted.person).isEqualTo(forventetPerson)
+        assertThat(grDeltBosted.periode?.fom).isEqualTo(forventetFom)
+        assertThat(grDeltBosted.periode?.tom).isEqualTo(forventetTom)
+    }
+
+    fun assertVegadresse(
+        grVegadresse: GrVegadresseDeltBosted,
+        forventetMatrikkelId: Long? = vegadresse.matrikkelId,
+        forventetHusnummer: String? = vegadresse.husnummer,
+        forventetHusbokstav: String? = vegadresse.husbokstav,
+        forventetBruksenhetsnummer: String? = vegadresse.bruksenhetsnummer,
+        forventetAdressename: String? = vegadresse.adressenavn,
+        forventetKommunenummer: String? = vegadresse.kommunenummer,
+        forventetTilleggsnavn: String? = vegadresse.tilleggsnavn,
+        forventetPostnummer: String? = vegadresse.postnummer,
+    ) {
+        assertThat(grVegadresse.matrikkelId).isEqualTo(forventetMatrikkelId)
+        assertThat(grVegadresse.husnummer).isEqualTo(forventetHusnummer)
+        assertThat(grVegadresse.husbokstav).isEqualTo(forventetHusbokstav)
+        assertThat(grVegadresse.bruksenhetsnummer).isEqualTo(forventetBruksenhetsnummer)
+        assertThat(grVegadresse.adressenavn).isEqualTo(forventetAdressename)
+        assertThat(grVegadresse.kommunenummer).isEqualTo(forventetKommunenummer)
+        assertThat(grVegadresse.tilleggsnavn).isEqualTo(forventetTilleggsnavn)
+        assertThat(grVegadresse.postnummer).isEqualTo(forventetPostnummer)
+    }
+
+    fun assertMatrikkeladresse(
+        grMatrikkeladresse: GrMatrikkeladresseDeltBosted,
+        forventetMatrikkelId: Long? = matrikkeladresse.matrikkelId,
+        forventetBruksenhetsnummer: String? = matrikkeladresse.bruksenhetsnummer,
+        forventetTilleggsnavn: String? = matrikkeladresse.tilleggsnavn,
+        forventetPostnummer: String? = matrikkeladresse.postnummer,
+        forventetKommunenummer: String? = matrikkeladresse.kommunenummer,
+    ) {
+        assertThat(grMatrikkeladresse.matrikkelId).isEqualTo(forventetMatrikkelId)
+        assertThat(grMatrikkeladresse.bruksenhetsnummer).isEqualTo(forventetBruksenhetsnummer)
+        assertThat(grMatrikkeladresse.tilleggsnavn).isEqualTo(forventetTilleggsnavn)
+        assertThat(grMatrikkeladresse.postnummer).isEqualTo(forventetPostnummer)
+        assertThat(grMatrikkeladresse.kommunenummer).isEqualTo(forventetKommunenummer)
+    }
+
+    fun assertUkjentBosted(
+        grUkjentBosted: GrUkjentBostedDeltBosted,
+        forventetBostedskommune: String? = ukjentBosted.bostedskommune,
+    ) {
+        assertThat(grUkjentBosted.bostedskommune).isEqualTo(forventetBostedskommune)
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-26415

Henter delt bosted fra PDL og lagrer i personopplysningsgrunnlaget
