### PR TITLE
NAV-26393: Forvalter-endepunkt for å kunne sende behandlingsstatistikk til datavarehus manuelt 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -29,6 +29,7 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentRepository
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.ba.sak.statistikk.stønadsstatistikk.StønadsstatistikkService
 import no.nav.familie.ba.sak.task.DeaktiverMinsideTask
 import no.nav.familie.ba.sak.task.GrensesnittavstemMotOppdrag
@@ -100,6 +101,7 @@ class ForvalterController(
     private val autovedtakFinnmarkstilleggTaskOppretter: AutovedtakFinnmarkstilleggTaskOppretter,
     private val envService: EnvService,
     private val autovedtakSvalbardtilleggTaskOppretter: AutovedtakSvalbardtilleggTaskOppretter,
+    private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ForvalterController::class.java)
 
@@ -696,5 +698,17 @@ class ForvalterController(
                 }
 
         return ResponseEntity.ok(institusjonerSomSkalHaFinnmarkstillegg)
+    }
+
+    @PostMapping("/send-behandlingsstatistikk-til-dvh")
+    fun sendBehandlingsstatistikkTilDvh(
+        @RequestBody behandlingId: Long,
+    ): ResponseEntity<String> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Sende behandlingsstatistikk for behandling til Datavarehus",
+        )
+        saksstatistikkEventPublisher.publiserBehandlingsstatistikk(behandlingId)
+        return ResponseEntity.ok("Sendt behandlingsstatistikk for behandling $behandlingId til Datavarehus")
     }
 }


### PR DESCRIPTION
Favro: [NAV-26393](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26393)

### 💰 Hva skal gjøres, og hvorfor?
Et par behandlinger har feil status i datavarehus og vi trenger å sende oppdatert informasjon om behandlingen manuelt.

Legger til forvalter-endepunkt som lar oss trigge manuell sending av behandlingsstatistikk for bestemte behandlingsId'er
