### PR TITLE
NAV-26466: Filtrer bort urelevante manglende perioder for svalbard/finnmark merking

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/ManglendeFinnmarkSvalbardMerkingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/ManglendeFinnmarkSvalbardMerkingDto.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.ekstern.restDomene
 import no.nav.familie.ba.sak.common.Utils.tilEtterfølgendePar
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.oppholdsadresse.GrOppholdsadresse
+import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -18,6 +19,8 @@ import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.time.LocalDate
+
+private val cutOffDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 9, 1)
 
 data class ManglendeFinnmarkSvalbardMerkingDto(
     val ident: String,
@@ -73,7 +76,8 @@ private fun <T> finnPerioderMedManglendeMerking(
     return bosattIRiketVilkårTidslinje
         .kombinerMed(beskjærtFinnmarkEllerSvalbardTidslinje) { bosattIRiketVilkår, finnmarkEllerSvalbard ->
             finnmarkEllerSvalbard != null && bosattIRiketVilkår != null && !bosattIRiketVilkår.utdypendeVilkårsvurderinger.contains(utdypendeVilkårsvurdering)
-        }.tilPerioderIkkeNull()
+        }.beskjærFraOgMed(cutOffDatoForVisningAvManglendeMerkinger)
+        .tilPerioderIkkeNull()
         .filter { it.verdi }
         .map { ManglendeFinnmarkSvalbardMerkingPeriodeDto(fom = it.fom, tom = it.tom) }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26466

Ønsker å vise kun perioder som har en fom dato som er fra og med 01.09.2025. Beskjærer dermed tidslinjen.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
