### PR TITLE
hentFagsakDeltagere skal ikke omgjøre funksjonell feil til feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.fagsak
 
 import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.ekstern.restDomene.FagsakDeltagerRolle
 import no.nav.familie.ba.sak.ekstern.restDomene.RestFagsakDeltager
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
@@ -211,8 +212,12 @@ class FagsakDeltagerService(
                     adressebeskyttelseGradering = it.adressebeskyttelseGradering,
                 )
             },
-            onFailure = {
-                throw Feil("Feil ved henting av person fra PDL", throwable = it)
+            onFailure = { exception ->
+                when (exception) {
+                    // Kaster funksjonell feil videre, ellers kaster vi Feil
+                    is FunksjonellFeil -> throw exception
+                    else -> throw Feil("Feil ved henting av person fra PDL", throwable = exception)
+                }
             },
         )
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26490

fagsakDeltagerService.hentFagsakDeltagere returnerte Feil selv om det ble kastet en funksjonell feil tidligere i kallet. Endret til at funksjonell feil blir kastet igjennom

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
