### PR TITLE
Resetter ikke lenger cache mellom hver integrasjonstest

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
@@ -1,70 +1,29 @@
 package no.nav.familie.ba.sak.config
 
 import io.mockk.unmockkAll
-import no.nav.familie.ba.sak.fake.FakeEfSakRestClient
-import no.nav.familie.ba.sak.fake.FakePdlIdentRestClient
-import no.nav.familie.ba.sak.integrasjoner.ef.EfSakRestClient
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollClient
-import no.nav.familie.ba.sak.integrasjoner.pdl.PdlIdentRestClient
 import no.nav.familie.ba.sak.mock.FamilieIntegrasjonerTilgangskontrollMock
 import org.junit.jupiter.api.BeforeEach
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.cache.CacheManager
 import java.util.UUID
 
 abstract class AbstractMockkSpringRunner {
     @Autowired
-    private lateinit var pdlIdentRestClient: PdlIdentRestClient
-
-    @Autowired
-    private lateinit var efSakRestClient: EfSakRestClient
-
-    @Autowired
     private lateinit var mockFamilieIntegrasjonerTilgangskontrollClient: FamilieIntegrasjonerTilgangskontrollClient
-
-    /**
-     * Cachemanagere
-     */
-    @Autowired
-    private lateinit var defaultCacheManager: CacheManager
-
-    @Autowired
-    @Qualifier("dailyCache")
-    private lateinit var dailyCacheManager: CacheManager
-
-    @Autowired
-    @Qualifier("shortCache")
-    private lateinit var shortCacheManager: CacheManager
 
     @BeforeEach
     fun reset() {
-        clearCaches()
         clearMocks()
     }
 
     private fun clearMocks() {
         unmockkAll()
 
-        val fakePdlIdentRestClient = pdlIdentRestClient as? FakePdlIdentRestClient
-        fakePdlIdentRestClient?.reset()
-
-        val fakeEfSakRestClient = efSakRestClient as? FakeEfSakRestClient
-        fakeEfSakRestClient?.reset()
-
         FamilieIntegrasjonerTilgangskontrollMock.clearMockFamilieIntegrasjonerTilgangskontrollClient(
             mockFamilieIntegrasjonerTilgangskontrollClient,
         )
 
         MDC.put("callId", "${this::class.java.simpleName}-${UUID.randomUUID()}")
-    }
-
-    private fun clearCaches() {
-        listOf(defaultCacheManager, shortCacheManager, dailyCacheManager).forEach {
-            it.cacheNames
-                .mapNotNull { cacheName -> it.getCache(cacheName) }
-                .forEach { cache -> cache.clear() }
-        }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/fake/FakeEfSakRestClient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/fake/FakeEfSakRestClient.kt
@@ -39,8 +39,4 @@ class FakeEfSakRestClient(
     ) {
         eksternePerioderResponeMap[personIdent] = eksternePerioderResponse
     }
-
-    fun reset() {
-        eksternePerioderResponeMap.clear()
-    }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/fake/FakePdlIdentRestClient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/fake/FakePdlIdentRestClient.kt
@@ -48,8 +48,4 @@ class FakePdlIdentRestClient(
     ) {
         identMap[personIdent] = identInformasjon
     }
-
-    fun reset() {
-        identMap.clear()
-    }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandleSmåbarnstilleggTest.kt
@@ -325,7 +325,6 @@ class BehandleSmåbarnstilleggTest(
     @Test
     @Order(3)
     fun `Skal stoppe automatisk behandling som må fortsette manuelt pga tilbakekreving`() {
-        efSakRestClient.reset()
         val søkersAktør = personidentService.hentAktør(scenario.søker.aktørId)
 
         val periodeOvergangsstønadTom = LocalDate.now().minusMonths(3)
@@ -387,8 +386,6 @@ class BehandleSmåbarnstilleggTest(
     @Test
     @Order(4)
     fun `Skal automatisk endre småbarnstilleggperioder`() {
-        efSakRestClient.reset()
-
         val søkersIdent = scenario.søker.ident
         val søkersAktør = personidentService.hentAktør(søkersIdent)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner resetting av cache mellom hver integrasjonstest da vi ikke lenger har behov for det. Fjerner også `reset()`-funksjoner fra `FakeEfSakRestClient` og `FakePdlIdentRestClient`, da det heller ikke skal være behov for disse når testene er uavhengige av hverandre.
