### PR TITLE
simulering overlappende perioder bug på flere mottakere

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/OverlappendeSimuleringsperioder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/OverlappendeSimuleringsperioder.kt
@@ -20,8 +20,6 @@ fun finnOverlappendePerioder(
     økonomiSimuleringMottakere: List<ØkonomiSimuleringMottaker>,
     fagsakId: Long,
 ): List<OverlappendePerioderMedAndreFagsaker> {
-    val tidSimuleringHentet = økonomiSimuleringMottakere.singleOrNull()?.opprettetTidspunkt?.toLocalDate() ?: return emptyList()
-
     val posteringerMedFagsakId = økonomiSimuleringMottakere.flatMap { it.økonomiSimuleringPostering }.filter { it.fagsakId != null }
     val posteringerPerFagsak = posteringerMedFagsakId.groupBy { it.fagsakId!! }
     val fagsakTilTidslinje =
@@ -30,7 +28,11 @@ fun finnOverlappendePerioder(
             val tidslinjeMedFeilOgEtterbetalingForFagsak =
                 perioderForFagsak
                     .map { (fomOgTom, posteringForFagsakIPeriode) ->
-                        posteringForFagsakIPeriode.lagPerioderMedFeilOgEtterbetalinger(tidSimuleringHentet, fagsakId, fomOgTom)
+                        posteringForFagsakIPeriode.lagPerioderMedFeilOgEtterbetalinger(
+                            tidSimuleringHentet = økonomiSimuleringMottakere.first().opprettetTidspunkt.toLocalDate(),
+                            fagsakId = fagsakId,
+                            fomOgTom = fomOgTom,
+                        )
                     }.tilTidslinje()
             tidslinjeMedFeilOgEtterbetalingForFagsak
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/FinnOverlappendePerioderTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/FinnOverlappendePerioderTest.kt
@@ -65,6 +65,81 @@ class FinnOverlappendePerioderTest {
     }
 
     @Test
+    fun `finnOverlappendePerioder finner overlappende perioder selv hvis det er forskjellige mottakere på samme behandling`() {
+        // Arrange
+        val økonomiSimuleringMottakere =
+            listOf(
+                lagØkonomiSimuleringMottaker(
+                    økonomiSimuleringPostering =
+                        listOf(
+                            lagØkonomiSimuleringPostering(
+                                fom = LocalDate.of(2025, 8, 1),
+                                tom = LocalDate.of(2025, 8, 31),
+                                posteringType = PosteringType.YTELSE,
+                                beløp = 984,
+                                fagsakId = 1,
+                            ),
+                            lagØkonomiSimuleringPostering(
+                                fom = LocalDate.of(2025, 8, 1),
+                                tom = LocalDate.of(2025, 8, 31),
+                                posteringType = PosteringType.JUSTERING,
+                                beløp = -984,
+                                fagsakId = 1,
+                            ),
+                        ),
+                ),
+                lagØkonomiSimuleringMottaker(
+                    økonomiSimuleringPostering =
+                        listOf(
+                            lagØkonomiSimuleringPostering(
+                                fom = LocalDate.of(2025, 8, 1),
+                                tom = LocalDate.of(2025, 8, 31),
+                                posteringType = PosteringType.YTELSE,
+                                beløp = 984,
+                                fagsakId = 2,
+                            ),
+                            lagØkonomiSimuleringPostering(
+                                fom = LocalDate.of(2025, 8, 1),
+                                tom = LocalDate.of(2025, 8, 31),
+                                posteringType = PosteringType.FEILUTBETALING,
+                                beløp = 984,
+                                fagsakId = 2,
+                            ),
+                            lagØkonomiSimuleringPostering(
+                                fom = LocalDate.of(2025, 8, 1),
+                                tom = LocalDate.of(2025, 8, 31),
+                                posteringType = PosteringType.JUSTERING,
+                                beløp = -984,
+                                fagsakId = 2,
+                            ),
+                            lagØkonomiSimuleringPostering(
+                                fom = LocalDate.of(2025, 8, 1),
+                                tom = LocalDate.of(2025, 8, 31),
+                                posteringType = PosteringType.MOTP,
+                                beløp = -984,
+                                fagsakId = 2,
+                            ),
+                            lagØkonomiSimuleringPostering(
+                                fom = LocalDate.of(2025, 8, 1),
+                                tom = LocalDate.of(2025, 8, 31),
+                                posteringType = PosteringType.YTELSE,
+                                beløp = -1968,
+                                fagsakId = 2,
+                            ),
+                        ),
+                ),
+            )
+
+        // Act
+        val overlappendePerioder = finnOverlappendePerioder(økonomiSimuleringMottakere = økonomiSimuleringMottakere, 1)
+
+        // Assert
+        assertThat(overlappendePerioder).hasSize(1)
+        val overlappendeFagsak = overlappendePerioder.singleOrNull()?.fagsakerMedFeilutbetaling?.singleOrNull()
+        assertThat(overlappendeFagsak).isEqualTo(2L)
+    }
+
+    @Test
     fun `finnOverlappendePerioder finner overlappende perioder i forskjellige fagsaker med både feilutbetaling og etterbetaling`() {
         // Arrange
         val økonomiSimuleringMottakere =


### PR DESCRIPTION
### 📮 Favro: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26373

### 💰 Hva skal gjøres, og hvorfor?
Fant ikke overlappende perioder. Dette skyldes at vi lagrer flere mottakere på én behandling og det tok ikke metoden som regnet ut overlapp høyde for. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
