### PR TITLE
Fjern unødvendig begrunnelseTypeForPerson_felt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -505,10 +505,7 @@ private fun ISanityBegrunnelse.erEksplisittAvslagPåSøker(
             ?.dennePerioden
             ?.eksplisitteAvslagForPerson ?: emptyList()
 
-    return explisitteAvslagsvilkårForSøker.any {
-        this.begrunnelseTypeForPerson == VedtakBegrunnelseType.AVSLAG &&
-            it.vilkårType in this.vilkår
-    }
+    return explisitteAvslagsvilkårForSøker.any { it.vilkårType in this.vilkår }
 }
 
 private fun hentBarnMedOppfylteVilkår(begrunnelsesGrunnlagPerPerson: Map<Person, IBegrunnelseGrunnlagForPeriode>) =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ISanityBegrunnelse.kt
@@ -23,7 +23,6 @@ sealed interface ISanityBegrunnelse {
     val tema: Tema?
     val valgbarhet: Valgbarhet?
     val periodeType: BrevPeriodeType?
-    val begrunnelseTypeForPerson: VedtakBegrunnelseType? // TODO: Fjern når migrering av ny felter er ferdig
     val øvrigeTriggere: List<ØvrigTrigger>
     val ikkeIBruk: Boolean
     val støtterFritekst: Boolean
@@ -74,7 +73,6 @@ data class SanityBegrunnelse(
     override val tema: Tema? = null,
     override val valgbarhet: Valgbarhet? = null,
     override val periodeType: BrevPeriodeType? = null,
-    override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
     override val øvrigeTriggere: List<ØvrigTrigger> = emptyList(),
     override val ikkeIBruk: Boolean = false,
     override val støtterFritekst: Boolean = false,
@@ -108,7 +106,6 @@ data class SanityEØSBegrunnelse(
     override val fagsakType: FagsakType?,
     override val tema: Tema?,
     override val periodeType: BrevPeriodeType?,
-    override val begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
     override val valgbarhet: Valgbarhet?,
     override val øvrigeTriggere: List<ØvrigTrigger> = emptyList(),
     override val ikkeIBruk: Boolean = false,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelseDto.kt
@@ -41,7 +41,6 @@ data class SanityBegrunnelseDto(
     val fagsakType: String?,
     val regelverk: String?,
     val brevPeriodeType: String?,
-    val begrunnelseTypeForPerson: String?,
     val ikkeIBruk: Boolean?,
 ) {
     fun tilSanityBegrunnelse(): SanityBegrunnelse? {
@@ -102,7 +101,6 @@ data class SanityBegrunnelseDto(
             fagsakType = fagsakType.finnEnumverdiNullable<FagsakType>(),
             tema = (regelverk).finnEnumverdi<Tema>(apiNavn),
             periodeType = (brevPeriodeType).finnEnumverdi<BrevPeriodeType>(apiNavn),
-            begrunnelseTypeForPerson = begrunnelseTypeForPerson.finnEnumverdi<VedtakBegrunnelseType>(apiNavn),
             ikkeIBruk = ikkeIBruk ?: false,
         )
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/SanityEØSBegrunnelseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/eøs/SanityEØSBegrunnelseDto.kt
@@ -43,7 +43,6 @@ data class SanityEØSBegrunnelseDto(
     @Deprecated("Skal bruke periodeResultatForPerson i stedet")
     val periodeType: String?,
     val brevPeriodeType: String?,
-    val begrunnelseTypeForPerson: String?,
     val valgbarhet: String?,
     val ikkeIBruk: Boolean?,
     val endringsaarsaker: List<String>? = emptyList(),
@@ -90,7 +89,6 @@ data class SanityEØSBegrunnelseDto(
                 ovrigeTriggere?.mapNotNull {
                     it.finnEnumverdi<ØvrigTrigger>(apiNavn)
                 } ?: emptyList(),
-            begrunnelseTypeForPerson = begrunnelseTypeForPerson.finnEnumverdi<VedtakBegrunnelseType>(apiNavn),
             endringsaarsaker =
                 endringsaarsaker?.mapNotNull {
                     it.finnEnumverdi<Årsak>(apiNavn)

--- a/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/SanityBegrunnelseGenerator.kt
+++ b/src/test/testdata/kotlin/no/nav/familie/ba/sak/datagenerator/SanityBegrunnelseGenerator.kt
@@ -39,7 +39,6 @@ fun lagRestSanityBegrunnelse(
     fagsakType: String? = null,
     regelverk: String? = null,
     brevPeriodeType: String? = null,
-    begrunnelseTypeForPerson: String? = null,
     ikkeIBruk: Boolean? = false,
     stotterFritekst: Boolean? = false,
 ): SanityBegrunnelseDto =
@@ -62,7 +61,6 @@ fun lagRestSanityBegrunnelse(
         fagsakType = fagsakType,
         regelverk = regelverk,
         brevPeriodeType = brevPeriodeType,
-        begrunnelseTypeForPerson = begrunnelseTypeForPerson,
         ikkeIBruk = ikkeIBruk,
         stotterFritekst = stotterFritekst,
     )
@@ -85,7 +83,6 @@ fun lagSanityBegrunnelse(
     resultat: SanityPeriodeResultat? = null,
     fagsakType: FagsakType? = null,
     periodeType: BrevPeriodeType? = null,
-    begrunnelseTypeForPerson: VedtakBegrunnelseType? = null,
 ): SanityBegrunnelse =
     SanityBegrunnelse(
         apiNavn = apiNavn,
@@ -105,7 +102,6 @@ fun lagSanityBegrunnelse(
         periodeResultat = resultat,
         fagsakType = fagsakType,
         periodeType = periodeType,
-        begrunnelseTypeForPerson = begrunnelseTypeForPerson,
     )
 
 fun lagSanityEøsBegrunnelse(


### PR DESCRIPTION
### 📮 Favro: Nav-28403

### 💰 Hva skal gjøres, og hvorfor?
begrunnelseTypeForPerson feltet finnes i begrunnelser, noe som kan fjernes da den blir brukt til veldig lite. Dette forminsker kompleksiteten til et stort domene.

