### PR TITLE
Vi må tilbakestille endret utbetaling andeler ved endring i personopplysninggrunnlaget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -145,6 +145,29 @@ class EndretUtbetalingAndelService(
     }
 
     @Transactional
+    fun slettEndretUtbetalingAndelerForPersonerIkkeIPersonopplysningGrunnlag(behandling: Behandling) {
+        val personopplysningGrunnlag =
+            personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = behandling.id)
+                ?: return
+
+        val aktørerIBehandling = personopplysningGrunnlag.søkerOgBarn.map { it.aktør }.toSet()
+
+        endretUtbetalingAndelRepository.findByBehandlingId(behandling.id).forEach { endretUtbetalingAndel ->
+            val personerFortsattIBehandlingOgAndelen = endretUtbetalingAndel.personer.filter { it.aktør in aktørerIBehandling }.toMutableSet()
+            when {
+                personerFortsattIBehandlingOgAndelen.isEmpty() -> {
+                    endretUtbetalingAndelRepository.delete(endretUtbetalingAndel)
+                }
+
+                personerFortsattIBehandlingOgAndelen.size < endretUtbetalingAndel.personer.size -> {
+                    endretUtbetalingAndel.personer = personerFortsattIBehandlingOgAndelen
+                    endretUtbetalingAndelRepository.save(endretUtbetalingAndel)
+                }
+            }
+        }
+    }
+
+    @Transactional
     fun opprettTomEndretUtbetalingAndel(behandling: Behandling) =
         endretUtbetalingAndelRepository.save(
             EndretUtbetalingAndel(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrereSøknad.kt
@@ -56,7 +56,6 @@ class RegistrereSøknad(
             søknadDTO = søknadDTO,
         )
 
-        // TODO: Fjern EndretUtbetalingAndel for personer som ikke lenger er relevant for behandlingen
         tilbakestillBehandlingService.initierOgSettBehandlingTilVilkårsvurdering(
             behandling = behandling,
             bekreftEndringerViaFrontend = data.bekreftEndringerViaFrontend,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/TilbakestillBehandlingService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.beregning.AvregningService
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
@@ -27,6 +28,7 @@ class TilbakestillBehandlingService(
     private val vilkårsvurderingForNyBehandlingService: VilkårsvurderingForNyBehandlingService,
     private val avregningService: AvregningService,
     private val tilbakekrevingsvedtakMotregningService: TilbakekrevingsvedtakMotregningService,
+    private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
 ) {
     @Transactional
     fun initierOgSettBehandlingTilVilkårsvurdering(
@@ -44,14 +46,15 @@ class TilbakestillBehandlingService(
 
         val vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingId = behandling.id)
 
-        beregningService.slettTilkjentYtelseForBehandling(behandlingId = behandling.id)
         vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(vedtak = vedtak)
+        beregningService.slettTilkjentYtelseForBehandling(behandlingId = behandling.id)
+        endretUtbetalingAndelService.slettEndretUtbetalingAndelerForPersonerIkkeIPersonopplysningGrunnlag(behandling)
+        tilbakekrevingService.slettTilbakekrevingPåBehandling(behandling.id)
 
         behandlingService.leggTilStegPåBehandlingOgSettTidligereStegSomUtført(
             behandlingId = behandling.id,
             steg = StegType.VILKÅRSVURDERING,
         )
-        tilbakekrevingService.slettTilbakekrevingPåBehandling(behandling.id)
 
         vedtakRepository.saveAndFlush(vedtak)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -364,6 +364,73 @@ class EndretUtbetalingAndelServiceTest {
     }
 
     @Nested
+    inner class FjernEndretUtbetalingAndelerForPersonerIkkePåBehandling {
+        @Test
+        fun `Skal slette endret utbetalings andel når alle personer i andelen har blitt fjernet fra person opplysningsgrunnlaget`() {
+            // Arrange
+            val behandling = lagBehandling()
+            val barn = lagPerson(type = PersonType.BARN)
+            val barnSomErFjernet = lagPerson(type = PersonType.BARN)
+            val endretUtbetalingAndel = lagEndretUtbetalingAndel(behandlingId = behandling.id, personer = setOf(barnSomErFjernet))
+            val slettetEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
+
+            every { mockEndretUtbetalingAndelRepository.findByBehandlingId(behandling.id) } returns listOf(endretUtbetalingAndel)
+            every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) } returns
+                lagTestPersonopplysningGrunnlag(behandling.id, barn)
+            every { mockEndretUtbetalingAndelRepository.delete(capture(slettetEndretUtbetalingAndelSlot)) } returns mockk()
+
+            // Act
+            endretUtbetalingAndelService.slettEndretUtbetalingAndelerForPersonerIkkeIPersonopplysningGrunnlag(behandling)
+
+            // Assert
+            assertThat(slettetEndretUtbetalingAndelSlot.captured).isEqualTo(endretUtbetalingAndel)
+            verify(exactly = 1) { mockEndretUtbetalingAndelRepository.delete(endretUtbetalingAndel) }
+            verify(exactly = 0) { mockEndretUtbetalingAndelRepository.save(any()) }
+        }
+
+        @Test
+        fun `Skal oppdatere endret utbetaling andel når kun noen personer er fjernet fra person opplysningsgrunnlaget`() {
+            // Arrange
+            val behandling = lagBehandling()
+            val barn = lagPerson(type = PersonType.BARN)
+            val fjernetBarn = lagPerson(type = PersonType.BARN)
+
+            val endretUtbetalingAndel = lagEndretUtbetalingAndel(behandlingId = behandling.id, personer = setOf(barn, fjernetBarn))
+            val lagretEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
+
+            every { mockEndretUtbetalingAndelRepository.findByBehandlingId(behandling.id) } returns listOf(endretUtbetalingAndel)
+            every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) } returns lagTestPersonopplysningGrunnlag(behandling.id, barn)
+            every { mockEndretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) } returnsArgument 0
+
+            // Act
+            endretUtbetalingAndelService.slettEndretUtbetalingAndelerForPersonerIkkeIPersonopplysningGrunnlag(behandling)
+
+            // Assert
+            assertThat(lagretEndretUtbetalingAndelSlot.captured.personer).containsExactly(barn)
+            verify(exactly = 0) { mockEndretUtbetalingAndelRepository.delete(any()) }
+        }
+
+        @Test
+        fun `Skal ikke gjøre noe når alle personer fremdeles er i person opplysningsgrunnlaget`() {
+            // Arrange
+            val behandling = lagBehandling()
+            val barn = lagPerson(type = PersonType.BARN)
+            val endretUtbetalingAndel = lagEndretUtbetalingAndel(behandlingId = behandling.id, personer = setOf(barn))
+
+            every { mockEndretUtbetalingAndelRepository.findByBehandlingId(behandling.id) } returns listOf(endretUtbetalingAndel)
+            every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) } returns
+                lagTestPersonopplysningGrunnlag(behandling.id, barn)
+
+            // Act
+            endretUtbetalingAndelService.slettEndretUtbetalingAndelerForPersonerIkkeIPersonopplysningGrunnlag(behandling)
+
+            // Assert
+            verify(exactly = 0) { mockEndretUtbetalingAndelRepository.delete(any()) }
+            verify(exactly = 0) { mockEndretUtbetalingAndelRepository.save(any()) }
+        }
+    }
+
+    @Nested
     inner class FjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen {
         @Test
         fun `Skal slette eksisterende endretUtbetalingAndeler hvis den er ugyldig`() {


### PR DESCRIPTION
### 📮 Favro: Nav-28404

### 💰 Hva skal gjøres, og hvorfor?
Når vi per i dag setter opp endret utbetalings andeler for en person i søknadssteget, men senere fjerner personen, så blir ikke andelen resatt. Dette fører til en rar state som ikke lar saksbehandler komme seg videre før man fjerner hele andelen manuelt. I tillegg referer andelen til et fnr på et barn som ikke lenger er i grunnlaget.

<img width="1160" height="608" alt="preprod" src="https://github.com/user-attachments/assets/6c542a22-4b5c-42a4-9e62-1e2552e761a9" />

Vi løser dette ved å tilbakestille endret utbetaling andelene på samme måte som vi sletter tilkjent ytelse og tilbakekreving.

TESTET OK I PREPROD MANUELT.