### PR TITLE
 Legg til task for å patche erOpprinneligPreutfyltIBehandling på vilkårresultater

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -41,6 +41,7 @@ import no.nav.familie.ba.sak.task.LogJournalpostIdForFagsakTask
 import no.nav.familie.ba.sak.task.MaskineltUnderkjennVedtakTask
 import no.nav.familie.ba.sak.task.OppdaterLøpendeFlagg
 import no.nav.familie.ba.sak.task.OpprettTaskService
+import no.nav.familie.ba.sak.task.PatchErOpprinneligPreutfyltIBehandlingTask
 import no.nav.familie.ba.sak.task.PatchFomPåVilkårTilFødselsdato
 import no.nav.familie.ba.sak.task.PatchMergetAktørDto
 import no.nav.familie.ba.sak.task.PatchMergetIdentDto
@@ -683,5 +684,23 @@ class ForvalterController(
         logger.info("Opprettet ferdigstill behandling task for behandling ${dto.behandlingsId} gjennom forvalter-endepunktet")
 
         return ResponseEntity.ok("Task opprettet ${task.id}")
+    }
+
+    @PostMapping("/patch-er-opprinnelig-preutfylt-i-behandling")
+    @Operation(
+        summary = "Patcher erOpprinneligPreutfyltIBehandling på vilkårresultater der feltet mangler",
+        description = "Henter vilkårresultater der erOpprinneligPreutfylt=true og erOpprinneligPreutfyltIBehandling=null, og setter feltet til sistEndretIBehandlingId. Kjøres som dry run som default.",
+    )
+    fun patchErOpprinneligPreutfyltIBehandling(
+        @RequestParam antall: Int,
+        @RequestParam(defaultValue = "true") dryRun: Boolean,
+    ): ResponseEntity<String> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Patch erOpprinneligPreutfyltIBehandling på vilkårresultater",
+        )
+
+        val task = taskService.save(PatchErOpprinneligPreutfyltIBehandlingTask.opprettTask(antall = antall, dryRun = dryRun))
+        return ResponseEntity.ok("Opprettet task ${task.id} (dryRun=$dryRun) for å patche $antall vilkårresultater som mangler erOpprinneligPreutfyltIBehandling")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatRepository.kt
@@ -1,0 +1,22 @@
+package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
+
+interface VilkårResultatRepository : JpaRepository<VilkårResultat, Long> {
+    @Query(
+        "SELECT id FROM vilkar_resultat WHERE er_opprinnelig_preutfylt IS TRUE AND er_opprinnelig_preutfylt_i_behandling IS NULL LIMIT :antall",
+        nativeQuery = true,
+    )
+    fun finnPreutfylteVilkårResultaterUtenBehandlingId(antall: Int): List<Long>
+
+    @Modifying
+    @Transactional
+    @Query(
+        "UPDATE vilkar_resultat SET er_opprinnelig_preutfylt_i_behandling = sist_endret_i_behandling_id WHERE id = :id",
+        nativeQuery = true,
+    )
+    fun oppdaterErOpprinneligPreutfyltIBehandling(id: Long)
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/PatchErOpprinneligPreutfyltIBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/PatchErOpprinneligPreutfyltIBehandlingTask.kt
@@ -1,0 +1,67 @@
+package no.nav.familie.ba.sak.task
+
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultatRepository
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import kotlin.time.measureTime
+import kotlin.time.measureTimedValue
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = PatchErOpprinneligPreutfyltIBehandlingTask.TASK_STEP_TYPE,
+    beskrivelse = "Setter erOpprinneligPreutfyltIBehandling til sistEndretIBehandlingId for vilkårresultater der feltet mangler.",
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = true,
+)
+class PatchErOpprinneligPreutfyltIBehandlingTask(
+    private val vilkårResultatRepository: VilkårResultatRepository,
+) : AsyncTaskStep {
+    private val logger = LoggerFactory.getLogger(PatchErOpprinneligPreutfyltIBehandlingTask::class.java)
+
+    @WithSpan
+    override fun doTask(task: Task) {
+        val dto = jsonMapper.readValue(task.payload, PatchErOpprinneligPreutfyltIBehandlingDto::class.java)
+
+        val (vilkårResultatIder, durationHenting) =
+            measureTimedValue {
+                vilkårResultatRepository
+                    .finnPreutfylteVilkårResultaterUtenBehandlingId(dto.antall)
+            }
+
+        logger.info("Fant ${vilkårResultatIder.size} vilkårresultater på ${durationHenting.inWholeSeconds} sekunder")
+
+        if (dto.dryRun) return
+
+        val durationOppdatering =
+            measureTime {
+                vilkårResultatIder.forEach { id ->
+                    vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(id = id)
+                }
+            }
+
+        logger.info("Oppdaterte ${vilkårResultatIder.size} vilkårresultater på ${durationOppdatering.inWholeSeconds} sekunder")
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "PatchErOpprinneligPreutfyltIBehandling"
+
+        fun opprettTask(
+            antall: Int,
+            dryRun: Boolean,
+        ): Task =
+            Task(
+                type = TASK_STEP_TYPE,
+                payload = jsonMapper.writeValueAsString(PatchErOpprinneligPreutfyltIBehandlingDto(antall, dryRun)),
+            )
+    }
+}
+
+data class PatchErOpprinneligPreutfyltIBehandlingDto(
+    val antall: Int,
+    val dryRun: Boolean,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/PatchErOpprinneligPreutfyltIBehandlingTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/PatchErOpprinneligPreutfyltIBehandlingTaskTest.kt
@@ -1,0 +1,66 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.VilkårResultatRepository
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.prosessering.domene.Task
+import org.junit.jupiter.api.Test
+
+class PatchErOpprinneligPreutfyltIBehandlingTaskTest {
+    private val vilkårResultatRepository = mockk<VilkårResultatRepository>(relaxed = true)
+
+    private val task =
+        PatchErOpprinneligPreutfyltIBehandlingTask(
+            vilkårResultatRepository = vilkårResultatRepository,
+        )
+
+    private fun lagTask(
+        antall: Int,
+        dryRun: Boolean,
+    ) = Task(
+        type = PatchErOpprinneligPreutfyltIBehandlingTask.TASK_STEP_TYPE,
+        payload = jsonMapper.writeValueAsString(PatchErOpprinneligPreutfyltIBehandlingDto(antall, dryRun)),
+    )
+
+    @Test
+    fun `skal oppdatere vilkårresultater som mangler erOpprinneligPreutfyltIBehandling`() {
+        every { vilkårResultatRepository.finnPreutfylteVilkårResultaterUtenBehandlingId(10) } returns listOf(1L, 2L, 3L)
+
+        task.doTask(lagTask(antall = 10, dryRun = false))
+
+        verify(exactly = 1) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(1L) }
+        verify(exactly = 1) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(2L) }
+        verify(exactly = 1) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(3L) }
+    }
+
+    @Test
+    fun `skal ikke oppdatere noe ved dry run`() {
+        every { vilkårResultatRepository.finnPreutfylteVilkårResultaterUtenBehandlingId(10) } returns listOf(1L, 2L, 3L)
+
+        task.doTask(lagTask(antall = 10, dryRun = true))
+
+        verify(exactly = 0) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(any()) }
+    }
+
+    @Test
+    fun `skal ikke oppdatere noe dersom ingen vilkårresultater mangler erOpprinneligPreutfyltIBehandling`() {
+        every { vilkårResultatRepository.finnPreutfylteVilkårResultaterUtenBehandlingId(10) } returns emptyList()
+
+        task.doTask(lagTask(antall = 10, dryRun = false))
+
+        verify(exactly = 0) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(any()) }
+    }
+
+    @Test
+    fun `skal begrense antall oppdateringer til antall i payload`() {
+        every { vilkårResultatRepository.finnPreutfylteVilkårResultaterUtenBehandlingId(2) } returns listOf(1L, 2L)
+
+        task.doTask(lagTask(antall = 2, dryRun = false))
+
+        verify(exactly = 1) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(1L) }
+        verify(exactly = 1) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(2L) }
+        verify(exactly = 2) { vilkårResultatRepository.oppdaterErOpprinneligPreutfyltIBehandling(any()) }
+    }
+}


### PR DESCRIPTION
  ### 📮 Favro: NAV-28054

   ### 💰 Hva skal gjøres, og hvorfor?

   Vilkårresultater der `erOpprinneligPreutfylt = true` kan mangle `erOpprinneligPreutfyltIBehandling` dersom de ble opprettet før kolonnen ble lagt til (V308). Denne PR'en legger til en task som patcher
  disse radene ved å sette `erOpprinneligPreutfyltIBehandling = sistEndretIBehandlingId`.

   **Endringer:**
   - `VilkårResultatRepository` – ny repository med spørring (med DB-side LIMIT) og native `@Modifying`-query for å oppdatere feltet (nødvendig siden kolonnen er `updatable = false` i JPA)
   - `PatchErOpprinneligPreutfyltIBehandlingTask` – task med JSON-payload `{ antall, dryRun }`. Dry run logger antall rader som ville blitt oppdatert uten å skrive til DB.
   - Forvalterendepunkt `POST /api/forvalter/patch-er-opprinnelig-preutfylt-i-behandling?antall=N&dryRun=true` for å opprette tasken. `dryRun=true` er default.
   - 
   ### 🔎️ Er det noe spesielt du ønsker tilbakemelding om

   ### ✅ Checklist
   _Har du husket alle punktene i listen?_
   - [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵
   - [ ] Jeg har config- eller sql-endringer.
   - [x] Jeg har skrevet tester.