### PR TITLE
Sett erOpprinneligPreutfyltIBehandling ved preutfylling av bosatt i riket-vilkårresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/Delvilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/Delvilkår.kt
@@ -86,5 +86,6 @@ fun List<Periode<Delvilkår>>.tilVilkårResultater(personResultat: PersonResulta
                 utdypendeVilkårsvurderinger = erBosattINorgePeriode.verdi.utdypendeVilkårsvurderinger,
                 erOpprinneligPreutfylt = true,
                 evalueringÅrsaker = erBosattINorgePeriode.verdi.evalueringÅrsaker.map { it.hentNavn() },
+                erOpprinneligPreutfyltIBehandling = personResultat.vilkårsvurdering.behandling.id,
             )
         }.toSet()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
@@ -119,6 +119,7 @@ class PreutfyllBosattIRiketServiceTest {
         assertThat(vilkårResultat.find { it.resultat == Resultat.IKKE_OPPFYLT }).isNotNull
         assertThat(vilkårResultat).allSatisfy {
             assertThat(it.begrunnelseForManuellKontroll).isNull()
+            assertThat(it.erOpprinneligPreutfyltIBehandling).isEqualTo(behandling.id)
         }
     }
 


### PR DESCRIPTION
### 📮 Favro: NAV-28054

### 💰 Hva skal gjøres, og hvorfor?
Setter feltet `erOpprinneligPreutfyltIBehandling` til inneværende behandling ved preutfylling av bosatt i riket-vilkåret

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.