### PR TITLE
Vi ønsker å tillatte visning av fagsak og behandling selv med skjermet barn uten SB rettigheter hvis barn ikke har løpende andeler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -52,4 +52,7 @@ enum class FeatureToggle(
     SKAL_KUNNE_BEHANDLE_BA_INSTITUSJONSFAGSAKER_I_KLAGE("familie-klage.skal-kunne-behandle-ba-institusjon-fagsaker"),
 
     KAN_OPPRETTE_SKJERMET_BARN_KLAGE("familie-ba-sak.kan-opprette-skjermet-barn-klage"),
+
+    // NAV-28471
+    TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER("familie-ba-sak.tillat-tilgang-skjermet-barn-uten-lopende-andeler"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -1,18 +1,20 @@
 package no.nav.familie.ba.sak.sikkerhet
 
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.RolleTilgangskontrollFeil
 import no.nav.familie.ba.sak.common.Utils.slåSammen
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.validerBehandlingKanRedigeres
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.config.RolleConfig
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
-import no.nav.familie.ba.sak.kjerne.steg.StegType
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import org.springframework.stereotype.Service
 
@@ -24,6 +26,8 @@ class TilgangService(
     private val rolleConfig: RolleConfig,
     private val familieIntegrasjonerTilgangskontrollService: FamilieIntegrasjonerTilgangskontrollService,
     private val auditLogger: AuditLogger,
+    private val featureToggleService: FeatureToggleService,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
 ) {
     /**
      * Sjekk om saksbehandler har tilgang til å gjøre en gitt handling.
@@ -90,16 +94,14 @@ class TilgangService(
         behandlingId: Long,
         event: AuditLoggerEvent,
     ) {
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        val personerPåBehandling = persongrunnlagService.hentSøkerOgBarnPåBehandling(behandlingId)
+        val søker = behandling.fagsak.skjermetBarnSøker?.aktør ?: behandling.fagsak.aktør
+
         val personIdenter =
-            persongrunnlagService
-                .hentSøkerOgBarnPåBehandling(behandlingId)
+            personerPåBehandling
                 ?.map { it.aktør.aktivFødselsnummer() }
-                ?: listOf(
-                    behandlingHentOgPersisterService
-                        .hent(behandlingId)
-                        .fagsak.aktør
-                        .aktivFødselsnummer(),
-                )
+                ?: listOf(behandling.fagsak.aktør.aktivFødselsnummer())
 
         if (!SikkerhetContext.erSystemKontekst()) {
             personIdenter.forEach {
@@ -114,7 +116,10 @@ class TilgangService(
         }
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenter)
-        if (!harTilgangTilAllePersoner(tilgangerTilPersoner)) {
+        val allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler =
+            allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeandeler(behandling.fagsak.id, tilgangerTilPersoner, søker)
+
+        if (!harTilgangTilAllePersoner(tilgangerTilPersoner) && !allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
             throw RolleTilgangskontrollFeil(
                 melding =
@@ -130,14 +135,16 @@ class TilgangService(
         event: AuditLoggerEvent,
     ) {
         val aktør = fagsakService.hentAktør(fagsakId)
+        val fagsak = fagsakService.hentPåFagsakId(fagsakId)
+        val søker = fagsak.skjermetBarnSøker?.aktør ?: fagsak.aktør
+
+        val personerPåFagsak = persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsakId)
         val personIdenterIFagsak =
             (
-                persongrunnlagService
-                    .hentSøkerOgBarnPåFagsak(fagsakId)
+                personerPåFagsak
                     ?.map { it.aktør.aktivFødselsnummer() }
                     ?: emptyList()
             ).ifEmpty {
-                val fagsak = fagsakService.hentPåFagsakId(fagsakId)
                 listOfNotNull(aktør.aktivFødselsnummer(), fagsak.skjermetBarnSøker?.aktør?.aktivFødselsnummer())
             }
 
@@ -152,7 +159,10 @@ class TilgangService(
         }
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenterIFagsak)
-        if (!harTilgangTilAllePersoner(tilgangerTilPersoner)) {
+        val allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler =
+            allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeandeler(fagsak.id, tilgangerTilPersoner, søker)
+
+        if (!harTilgangTilAllePersoner(tilgangerTilPersoner) && !allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
             throw RolleTilgangskontrollFeil(
                 melding =
@@ -185,11 +195,52 @@ class TilgangService(
         validerBehandlingKanRedigeres(behandlingHentOgPersisterService.hentStatus(behandlingId))
     }
 
-    fun validerErPåBeslutteVedtakSteg(behandlingId: Long) {
-        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
-        if (behandling.status != BehandlingStatus.FATTER_VEDTAK && behandling.steg == StegType.BESLUTTE_VEDTAK) {
-            throw Feil(message = "Er ikke i riktig steg eller status. Forventer status FATTER_VEDTAK og steg BESLUTTE_VEDTAK")
+    /**
+     * Sjekker om tilgang til en fagsak kan tillates selv om saksbehandler mangler
+     * strengt fortrolig-tilgang for en eller flere barn. Tilgang tillates dersom:
+     * - Det finnes en iverksatt behandling
+     * - Hvert barn som det mangles tilgang til har ikke lenger løpende andeler per sist iverksatt behandling
+     * - Saksbehandler har tilgang til søker fra før
+     */
+    private fun allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeandeler(
+        fagsakId: Long,
+        tilgangerTilPersoner: List<Tilgang>,
+        søker: Aktør,
+    ): Boolean {
+        if (!featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER)) {
+            return false
         }
+
+        if (tilgangerTilPersoner.none { it.harTilgang && it.personIdent == søker.aktivFødselsnummer() }) {
+            return false
+        }
+
+        val personerSaksbehandlerIkkeHarTilgangTilPågrunnAvManglendeStrengtFortroligTilgang =
+            tilgangerTilPersoner
+                .filter { !it.harTilgang }
+                .takeIf { it.isNotEmpty() && it.all { p -> p.begrunnelse?.contains("Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'") == true } }
+                ?.map { it.personIdent }
+                ?: return false
+
+        val sisteIverksatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId) ?: return false
+        val andelerPåBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id)
+
+        val alleSkjermedeBarnHarIngenLøpendeAndeler =
+            personerSaksbehandlerIkkeHarTilgangTilPågrunnAvManglendeStrengtFortroligTilgang.all { ident ->
+                andelerPåBehandling
+                    .filter { it.aktør.aktivFødselsnummer() == ident }
+                    .none { it.erLøpende() }
+            }
+
+        if (alleSkjermedeBarnHarIngenLøpendeAndeler) {
+            secureLogger.info(
+                "Tillater tilgang til fagsak=$fagsakId for saksbehandler=${SikkerhetContext.hentSaksbehandler()}. " +
+                    "Saksbehandler har ikke tilgang til personer med strengt fortrolig addresse, men barn som er skjermet har ikke lenger løpende andeler",
+            )
+            return true
+        }
+
+        return false
     }
 
     private fun harTilgangTilAllePersoner(tilganger: List<Tilgang>): Boolean = tilganger.all { it.harTilgang }

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -117,7 +117,7 @@ class TilgangService(
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenter)
         val allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler =
-            allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeandeler(behandling.fagsak.id, tilgangerTilPersoner, søker)
+            allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler(behandling.fagsak.id, tilgangerTilPersoner, søker)
 
         if (!harTilgangTilAllePersoner(tilgangerTilPersoner) && !allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
@@ -160,7 +160,7 @@ class TilgangService(
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenterIFagsak)
         val allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler =
-            allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeandeler(fagsak.id, tilgangerTilPersoner, søker)
+            allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler(fagsak.id, tilgangerTilPersoner, søker)
 
         if (!harTilgangTilAllePersoner(tilgangerTilPersoner) && !allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
@@ -202,7 +202,7 @@ class TilgangService(
      * - Hvert barn som det mangles tilgang til har ikke lenger løpende andeler per sist iverksatt behandling
      * - Saksbehandler har tilgang til søker fra før
      */
-    private fun allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeandeler(
+    private fun allePersonerSaksbehandlerIkkeHarTilgangTilErSkjermetBarnUtenLøpendeAndeler(
         fagsakId: Long,
         tilgangerTilPersoner: List<Tilgang>,
         søker: Aktør,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
@@ -6,14 +6,19 @@ import no.nav.familie.ba.sak.common.RolleTilgangskontrollFeil
 import no.nav.familie.ba.sak.common.clearAllCaches
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.RolleConfig
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.defaultFagsak
+import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.datagenerator.randomFnr
 import no.nav.familie.ba.sak.datagenerator.tilPersonEnkelSøkerOgBarn
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasjonerTilgangskontrollService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
@@ -29,17 +34,22 @@ import no.nav.familie.log.mdc.MDCConstants
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.slf4j.MDC
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.web.client.RestTemplate
 import java.time.LocalDate
+import java.time.YearMonth
 
 class TilgangServiceTest {
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
     private val fagsakService: FagsakService = mockk()
     private val persongrunnlagService: PersongrunnlagService = mockk()
+    private val featureToggleService: FeatureToggleService = mockk()
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository = mockk()
     private val cacheManager = ConcurrentMapCacheManager()
     private val kode6Gruppe = "kode6"
     private val kode7Gruppe = "kode7"
@@ -61,6 +71,8 @@ class TilgangServiceTest {
             fagsakService = fagsakService,
             rolleConfig = rolleConfig,
             auditLogger = auditLogger,
+            featureToggleService = featureToggleService,
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
         )
 
     private val fagsak = defaultFagsak()
@@ -79,9 +91,11 @@ class TilgangServiceTest {
         MDC.put(MDCConstants.MDC_CALL_ID, "00001111")
         mockBrukerContext()
         every { fagsakService.hentAktør(fagsak.id) } returns fagsak.aktør
+        every { fagsakService.hentPåFagsakId(fagsak.id) } returns fagsak
         every { behandlingHentOgPersisterService.hent(any()) } returns behandling
         every { persongrunnlagService.hentSøkerOgBarnPåBehandling(behandling.id) } returns
             personopplysningGrunnlag.tilPersonEnkelSøkerOgBarn()
+        every { featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER) } returns false
         cacheManager.clearAllCaches()
     }
 
@@ -266,7 +280,7 @@ class TilgangServiceTest {
                 Tilgang(
                     søkerAktør.aktivFødselsnummer(),
                     false,
-                    "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse",
+                    "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'",
                 ),
             ),
         )
@@ -281,8 +295,8 @@ class TilgangServiceTest {
                     AuditLoggerEvent.ACCESS,
                 )
             }
-        assertThat(rolletilgangskontrollFeil.message).isEqualTo("Saksbehandler A har ikke tilgang til fagsak=${fagsak.id}. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse.")
-        assertThat(rolletilgangskontrollFeil.frontendFeilmelding).isEqualTo("Fagsaken inneholder personer som krever ytterligere tilganger. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse.")
+        assertThat(rolletilgangskontrollFeil.message).isEqualTo("Saksbehandler A har ikke tilgang til fagsak=${fagsak.id}. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'.")
+        assertThat(rolletilgangskontrollFeil.frontendFeilmelding).isEqualTo("Fagsaken inneholder personer som krever ytterligere tilganger. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'.")
     }
 
     @Test
@@ -305,7 +319,7 @@ class TilgangServiceTest {
                 Tilgang(
                     søkerAktør.aktivFødselsnummer(),
                     false,
-                    "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse",
+                    "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'",
                 ),
             ),
         )
@@ -319,8 +333,8 @@ class TilgangServiceTest {
                     AuditLoggerEvent.ACCESS,
                 )
             }
-        assertThat(rolletilgangskontrollFeil.message).isEqualTo("Saksbehandler A har ikke tilgang til fagsak=${fagsak.id}. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse.")
-        assertThat(rolletilgangskontrollFeil.frontendFeilmelding).isEqualTo("Fagsaken inneholder personer som krever ytterligere tilganger. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse.")
+        assertThat(rolletilgangskontrollFeil.message).isEqualTo("Saksbehandler A har ikke tilgang til fagsak=${fagsak.id}. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'.")
+        assertThat(rolletilgangskontrollFeil.frontendFeilmelding).isEqualTo("Fagsaken inneholder personer som krever ytterligere tilganger. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'.")
         assertThat(fakeFamilieIntegrasjonerTilgangskontrollKlient.hentKallMotSjekkTilgangTilPersoner())
             .hasSize(1)
             .containsOnly(listOf(barnAktør.aktivFødselsnummer(), søkerAktør.aktivFødselsnummer()))
@@ -343,6 +357,202 @@ class TilgangServiceTest {
                 listOf(fnr, fnr2, fnr3),
                 AuditLoggerEvent.ACCESS,
             )
+        }
+    }
+
+    @Nested
+    inner class SkjermedePersonerUtenLøpendeAndelerTest {
+        private val barnAktør = randomAktør()
+        private val søkerAktør = randomAktør()
+        private val testFagsak =
+            lagFagsak(
+                aktør = søkerAktør,
+                type = FagsakType.NORMAL,
+            )
+        private val testBehandling = lagBehandling(testFagsak)
+
+        @BeforeEach
+        fun setUp() {
+            every { fagsakService.hentAktør(testFagsak.id) } returns søkerAktør
+            every { fagsakService.hentPåFagsakId(testFagsak.id) } returns testFagsak
+            every { persongrunnlagService.hentSøkerOgBarnPåFagsak(testFagsak.id) } returns
+                setOf(
+                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),
+                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),
+                )
+            every { featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER) } returns true
+            mockBrukerContext("A")
+        }
+
+        @AfterEach
+        fun tearDown() {
+            clearBrukerContext()
+        }
+
+        @Test
+        fun `validerTilgangTilFagsak - skal tillate tilgang til saksbehandler uten strengt fortrolig tilgang ved skjermet barn uten løpende andeler`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(testBehandling.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2024, 12),
+                        behandling = testBehandling,
+                        aktør = barnAktør,
+                    ),
+                )
+
+            fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
+                listOf(
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'"),
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                ),
+            )
+
+            // Act && Assert
+            assertDoesNotThrow {
+                tilgangService.validerTilgangTilFagsak(testFagsak.id, AuditLoggerEvent.ACCESS)
+            }
+        }
+
+        @Test
+        fun `validerTilgangTilFagsak - skal blokkere tilgang til saksbehandler uten strengt fortrolig tilgang ved skjermet barn med løpende andeler`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(testBehandling.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.now().plusYears(1),
+                        behandling = testBehandling,
+                        aktør = barnAktør,
+                    ),
+                )
+
+            fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
+                listOf(
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'"),
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                ),
+            )
+
+            // Act && Assert
+            assertThrows<RolleTilgangskontrollFeil> {
+                tilgangService.validerTilgangTilFagsak(testFagsak.id, AuditLoggerEvent.ACCESS)
+            }
+        }
+
+        @Test
+        fun `validerTilgangTilFagsak - skal blokkere tilgang uavhengig av årsak hvis toggle er deaktivert`() {
+            // Arrange
+            every { featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER) } returns false
+
+            fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
+                listOf(
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'"),
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                ),
+            )
+
+            // Act && Assert
+            assertThrows<RolleTilgangskontrollFeil> {
+                tilgangService.validerTilgangTilFagsak(testFagsak.id, AuditLoggerEvent.ACCESS)
+            }
+        }
+
+        @Test
+        fun `validerTilgangTilFagsak - skal blokkere tilgang uavhengig av årsak hvis ingen behandling er iverksatt på fagsaken`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns null
+
+            fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
+                listOf(
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'"),
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                ),
+            )
+
+            // Act && Assert
+            assertThrows<RolleTilgangskontrollFeil> {
+                tilgangService.validerTilgangTilFagsak(testFagsak.id, AuditLoggerEvent.ACCESS)
+            }
+        }
+
+        @Test
+        fun `validerTilgangTilFagsak - skal blokkere tilgang når både søker og barn er skjermet, selv om barn ikke har løpende andeler`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(testBehandling.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2024, 12),
+                        behandling = testBehandling,
+                        aktør = barnAktør,
+                    ),
+                )
+
+            fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
+                listOf(
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'"),
+                    Tilgang(søkerAktør.aktivFødselsnummer(), false, "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'"),
+                ),
+            )
+
+            // Act && Assert
+            assertThrows<RolleTilgangskontrollFeil> {
+                tilgangService.validerTilgangTilFagsak(testFagsak.id, AuditLoggerEvent.ACCESS)
+            }
+        }
+
+        @Test
+        fun `validerTilgangTilFagsak - skal blokkere tilgang når barn er stanses av annen årsak enn strengt fortrolig`() {
+            // Arrange
+            fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
+                listOf(
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, "NAV-ansatt"),
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                ),
+            )
+
+            // Act && Assert
+            assertThrows<RolleTilgangskontrollFeil> {
+                tilgangService.validerTilgangTilFagsak(testFagsak.id, AuditLoggerEvent.ACCESS)
+            }
+        }
+
+        @Test
+        fun `validerTilgangTilBehandling - skal tillate tilgang til behandling hvis skjermet barn ikke har løpende andeler`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hent(testBehandling.id) } returns testBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { persongrunnlagService.hentSøkerOgBarnPåBehandling(testBehandling.id) } returns
+                listOf(
+                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),
+                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),
+                )
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(testBehandling.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2024, 12),
+                        behandling = testBehandling,
+                        aktør = barnAktør,
+                    ),
+                )
+
+            fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
+                listOf(
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'"),
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                ),
+            )
+
+            // Act && Assert
+            assertDoesNotThrow {
+                tilgangService.validerTilgangTilBehandling(testBehandling.id, AuditLoggerEvent.ACCESS)
+            }
         }
     }
 }


### PR DESCRIPTION
### 📮 Favro: Nav-28471

### 💰 Hva skal gjøres, og hvorfor?

Per i dag kan bare fagsaker som inneholder barn/personer som er skjermet bli åpnet og behandlet av saksbehandlere med strengt fortrolig tilgang. Dersom en saksbehandler uten tilgangen åpner fagsaken vil denne feilmeldingen oppstå:

"Feil oppstod ved innlasting av fagsak: Fagsaken inneholder personer som krever ytterligere tilganger. Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse"

Vi må tillate at behandlinger og fagsak kan åpnes av Saksbehandlere uten tilgangen, dersom de personene i fagsak/behandling ikke lenger har løpende andeler, altså at barnetrygden er opphørt.

