### PR TITLE
Flytt Sonar-logikk ut av template

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -67,11 +67,37 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
     name: Sonar
     needs: [ enhetstest, integrasjonstest ]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/sonar.yaml@main # ratchet:exclude
-    with:
-      unit-test-artifact-name: 'enhetstest'
-      unit-test-artifact-path: 'coverage/enhetstest'
-      integration-test-artifact-name: 'integrasjonstest'
-      integration-test-artifact-path: 'coverage/integrasjonstest'
-    secrets: inherit
-
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup Java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # ratchet:actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Last ned enhetstest report artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # ratchet:actions/download-artifact@v7
+        with:
+          name: 'enhetstest'
+          path: 'coverage/enhetstest'
+      - name: Last ned integrasjonstest report artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # ratchet:actions/download-artifact@v7
+        with:
+          name: 'integrasjonstest'
+          path: 'coverage/integrasjonstest'
+      - name: Cache Sonar packages
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # ratchet:actions/cache@v5
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Sonar
+        env:
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths="coverage/enhetstest/enhetstest.xml,coverage/integrasjonstest/integrasjonstest.xml"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -10,14 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ktlint:
-    name: Ktlint
-    permissions:
-      contents: read
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/ktlint.yaml@main # ratchet:exclude
-    secrets: inherit
-
-  unit-test:
+  enhetstest:
     name: Unit test
     permissions:
       contents: read
@@ -30,7 +23,7 @@ jobs:
       java-version: '25'
     secrets: inherit
 
-  integration-test:
+  integrasjonstest:
     name: Integration test
     permissions:
       contents: read
@@ -45,13 +38,38 @@ jobs:
 
   sonar:
     name: Sonar
-    needs: [ unit-test, integration-test ]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/sonar.yaml@main # ratchet:exclude
-    with:
-      unit-test-artifact-name: 'enhetstest'
-      unit-test-artifact-path: 'coverage/enhetstest'
-      integration-test-artifact-name: 'integrasjonstest'
-      integration-test-artifact-path: 'coverage/integrasjonstest'
-      java-version: '25'
-    secrets: inherit
-
+    needs: [ enhetstest, integrasjonstest ]
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup Java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # ratchet:actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Last ned enhetstest report artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # ratchet:actions/download-artifact@v7
+        with:
+          name: 'enhetstest'
+          path: 'coverage/enhetstest'
+      - name: Last ned integrasjonstest report artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # ratchet:actions/download-artifact@v7
+        with:
+          name: 'integrasjonstest'
+          path: 'coverage/integrasjonstest'
+      - name: Cache Sonar packages
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # ratchet:actions/cache@v5
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Sonar
+        env:
+          MAVEN_OPTS: "-Xmx4g -Dmaven.artifact.threads=10"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths="coverage/enhetstest/enhetstest.xml,coverage/integrasjonstest/integrasjonstest.xml"


### PR DESCRIPTION
### 📮 Favro: N/A

### 💰 Hva skal gjøres, og hvorfor?
Template ble kun brukt i dette repo, og ble ikke strukturert på en heldig måte. Avvikler derfor bruken av template og flytter logikken tilbake hit igjen. Kode hentet fra [tidligere implementasjon](https://github.com/navikt/familie-ba-sak/pull/5471) og modifisert med ny java-versjon og nye navn.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Workflows