### PR TITLE
Oppgrader til kotlin 2.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
 
         <java.version>25</java.version>
-        <kotlin.version>2.3.0</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <kotlin.compiler.languageVersion>2.3</kotlin.compiler.languageVersion>
         <kotlin.compiler.apiVersion>2.3</kotlin.compiler.apiVersion>
         <revision>1</revision>

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
@@ -193,13 +193,16 @@ fun VilkårResultat.toPeriode(): Periode =
         this.erEksplisittAvslagPåSøknad,
     )
 
-fun LocalDate.erInnenfor(periode: DatoIntervallEntitet): Boolean =
-    when {
-        periode.fom == null && periode.tom == null -> true
-        periode.fom == null -> isSameOrBefore(periode.tom!!)
-        periode.tom == null -> isSameOrAfter(periode.fom)
-        else -> isSameOrAfter(periode.fom) && isSameOrBefore(periode.tom)
+fun LocalDate.erInnenfor(periode: DatoIntervallEntitet): Boolean {
+    val fom = periode.fom
+    val tom = periode.tom
+    return when {
+        fom == null && tom == null -> true
+        fom == null -> isSameOrBefore(tom!!)
+        tom == null -> isSameOrAfter(fom)
+        else -> isSameOrAfter(fom) && isSameOrBefore(tom)
     }
+}
 
 class YearMonthIterator(
     startMåned: YearMonth,

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/UtenlandskPeriodebeløpDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/UtenlandskPeriodebeløpDto.kt
@@ -53,11 +53,9 @@ fun UtenlandskPeriodebeløpDto.tilKalkulertMånedligBeløp(): BigDecimal? {
 }
 
 fun UtenlandskPeriodebeløp.tilKalkulertMånedligBeløp(): BigDecimal? {
-    if (this.beløp == null || this.intervall == null) {
-        return null
-    }
-
-    return this.intervall.konverterBeløpTilMånedlig(this.beløp)
+    val beløp = this.beløp ?: return null
+    val intervall = this.intervall ?: return null
+    return intervall.konverterBeløpTilMånedlig(beløp)
 }
 
 fun UtenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -283,21 +283,23 @@ private fun hentMaxAvstandAvDagerMellomPerioder(
             }.toList()
 
     val perioderInnenAngittTidsrom =
-        perioderMedTilkobletTom.filter {
-            it.tom == null ||
+        perioderMedTilkobletTom.filter { datoIntervall ->
+            val itFom = datoIntervall.fom
+            val itTom = datoIntervall.tom
+            itTom == null ||
                 fom.isBetween(
                     Periode(
-                        fom = it.fom!!,
-                        tom = it.tom,
+                        fom = itFom!!,
+                        tom = itTom,
                     ),
                 ) ||
                 tom.isBetween(
                     Periode(
-                        fom = it.fom,
-                        tom = it.tom,
+                        fom = itFom,
+                        tom = itTom,
                     ),
                 ) ||
-                (it.fom >= fom && it.tom <= tom)
+                (itFom >= fom && itTom <= tom)
         }
 
     if (perioderInnenAngittTidsrom.isEmpty()) return Duration.between(fom.atStartOfDay(), tom.atStartOfDay()).toDays()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -165,7 +165,7 @@ data class AndelTilkjentYtelse(
     fun erAndelSomharNullutbetalingPgaDifferanseberegning() =
         this.kalkulertUtbetalingsbeløp == 0 &&
             this.differanseberegnetPeriodebeløp != null &&
-            this.differanseberegnetPeriodebeløp <= 0
+            this.differanseberegnetPeriodebeløp!! <= 0
 
     private fun finnRelevanteVilkårsresulaterForRegelverk(
         personResultater: Set<PersonResultat>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -551,7 +551,7 @@ fun VedtaksperiodeMedBegrunnelser.hentMånedOgÅrForBegrunnelse(): String? =
     if (this.fom == null || fom == TIDENES_MORGEN) {
         null
     } else {
-        fom.forrigeMåned().tilMånedÅr()
+        fom!!.forrigeMåned().tilMånedÅr()
     }
 
 private fun hentBeløp(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
@@ -118,7 +118,7 @@ private fun VedtaksperiodeMedBegrunnelser.hentTomTekstForBrev(
 ) = if (this.tom == null) {
     ""
 } else {
-    val tomDato = this.tom.tilMånedÅr()
+    val tomDato = this.tom!!.tilMånedÅr()
     when (brevPeriodeType) {
         BrevPeriodeType.UTBETALING -> "til $tomDato"
         BrevPeriodeType.INGEN_UTBETALING -> if (this.type == Vedtaksperiodetype.AVSLAG) "til og med $tomDato " else ""

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
@@ -27,17 +27,13 @@ operator fun Valutabeløp?.times(kronerPerValutaenhet: KronerPerValutaenhet?): B
 }
 
 fun UtenlandskPeriodebeløp?.tilMånedligValutabeløp(): Valutabeløp? {
-    if (this?.kalkulertMånedligBeløp == null || this.valutakode == null) {
-        return null
-    }
-
-    return Valutabeløp(this.kalkulertMånedligBeløp, this.valutakode)
+    val beløp = this?.kalkulertMånedligBeløp ?: return null
+    val valutakode = this.valutakode ?: return null
+    return Valutabeløp(beløp, valutakode)
 }
 
 fun Valutakurs?.tilKronerPerValutaenhet(): KronerPerValutaenhet? {
-    if (this?.kurs == null || this.valutakode == null) {
-        return null
-    }
-
-    return KronerPerValutaenhet(this.kurs, this.valutakode)
+    val kurs = this?.kurs ?: return null
+    val valutakode = this.valutakode ?: return null
+    return KronerPerValutaenhet(kurs, valutakode)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
@@ -76,7 +76,7 @@ class KompetanseController(
         if (oppdatertKompetanse.fom == null) {
             throw FunksjonellFeil("Manglende fra-og-med", httpStatus = HttpStatus.BAD_REQUEST)
         }
-        if (oppdatertKompetanse.tom != null && oppdatertKompetanse.fom > oppdatertKompetanse.tom) {
+        if (oppdatertKompetanse.tom != null && oppdatertKompetanse.fom!! > oppdatertKompetanse.tom) {
             throw FunksjonellFeil("Fra-og-med er etter til-og-med", httpStatus = HttpStatus.BAD_REQUEST)
         }
         if (oppdatertKompetanse.barnAktører.isEmpty()) {
@@ -88,7 +88,7 @@ class KompetanseController(
             (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == false && oppdatertKompetanse.søkersAktivitet?.gyldigForSøker == false)
         ) {
             throw FunksjonellFeil(
-                "Valgt verdi for søkers aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning) "når annen forelder er omfattet av norsk lovgivning" else ""}"
+                "Valgt verdi for søkers aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == true) "når annen forelder er omfattet av norsk lovgivning" else ""}"
                     .trim(),
             )
         }
@@ -97,7 +97,7 @@ class KompetanseController(
             (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == false && oppdatertKompetanse.annenForeldersAktivitet?.gyldigForAnnenForelder == false)
         ) {
             throw FunksjonellFeil(
-                "Valgt verdi for annen forelders aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning) "når annen forelder er omfattet av norsk lovgivning" else ""}"
+                "Valgt verdi for annen forelders aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == true) "når annen forelder er omfattet av norsk lovgivning" else ""}"
                     .trim(),
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
@@ -58,7 +58,7 @@ data class GrMatrikkeladresseOppholdsadresse(
         return postnummer?.let { "$postnummer$poststed$oppholdAnnetSted" } ?: "Ukjent adresse$oppholdAnnetSted"
     }
 
-    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
+    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer!!)) || oppholdAnnetSted == PAA_SVALBARD
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrVegadresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrVegadresseOppholdsadresse.kt
@@ -78,7 +78,7 @@ data class GrVegadresseOppholdsadresse(
         }
     }
 
-    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
+    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer!!)) || oppholdAnnetSted == PAA_SVALBARD
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/GrArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/GrArbeidsforhold.kt
@@ -81,7 +81,7 @@ data class GrArbeidsforhold(
             tom = this.periode?.tom,
             verdi =
                 when (arbeidsgiverType) {
-                    Organisasjon.name if arbeidsgiverId != null -> "${organisasjonNavn?.let { "$it\n" }.orEmpty()}${formaterOrganisasjonsnummer(arbeidsgiverId)}"
+                    Organisasjon.name if arbeidsgiverId != null -> "${organisasjonNavn?.let { "$it\n" }.orEmpty()}${formaterOrganisasjonsnummer(arbeidsgiverId!!)}"
                     Person.name -> "Privat ansettelse"
                     else -> "Ukjent arbeidsgiver"
                 },
@@ -112,5 +112,5 @@ data class GrArbeidsforhold(
 
 fun List<GrArbeidsforhold>.harLøpendeArbeidsforhold(): Boolean =
     this.any {
-        it.periode?.tom == null || it.periode.tom >= LocalDate.now()
+        it.periode?.tom == null || it.periode!!.tom!! >= LocalDate.now()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/opphold/GrOpphold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/opphold/GrOpphold.kt
@@ -48,7 +48,7 @@ data class GrOpphold(
 
     fun gjeldendeNå(): Boolean {
         if (gyldigPeriode == null) return true
-        return LocalDate.now().erInnenfor(gyldigPeriode)
+        return LocalDate.now().erInnenfor(gyldigPeriode!!)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
@@ -56,7 +56,7 @@ data class GrStatsborgerskap(
 
     fun gjeldendeNå(): Boolean {
         if (gyldigPeriode == null) return true
-        return LocalDate.now().erInnenfor(gyldigPeriode)
+        return LocalDate.now().erInnenfor(gyldigPeriode!!)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -483,7 +483,7 @@ class VedtaksperiodeService(
     fun skalHaÅrligKontroll(vedtak: Vedtak): Boolean =
         kompetanseRepository
             .finnFraBehandlingId(vedtak.behandling.id)
-            .any { it.tom == null || it.tom.isAfter(YearMonth.now()) }
+            .any { it.tom == null || it.tom!!.isAfter(YearMonth.now()) }
 
     fun skalMeldeFraOmEndringerEøsSelvstendigRett(vedtak: Vedtak): Boolean {
         val vilkårsvurdering =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/BegrunnelseGrunnlagForPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/BegrunnelseGrunnlagForPeriode.kt
@@ -40,7 +40,7 @@ sealed interface IBegrunnelseGrunnlagForPeriode {
                 .filter { it.type == SatsType.FINNMARKSTILLEGG }
                 .minOfOrNull { it.gyldigFom } ?: LocalDate.MAX
 
-        if (vedtaksperiode.fom == null || vedtaksperiode.fom.isSameOrBefore(startdatoForFinnmarkstillegg)) {
+        if (vedtaksperiode.fom == null || vedtaksperiode.fom!!.isSameOrBefore(startdatoForFinnmarkstillegg)) {
             return false
         }
 
@@ -97,7 +97,7 @@ sealed interface IBegrunnelseGrunnlagForPeriode {
                 .filter { it.type == SatsType.SVALBARDTILLEGG }
                 .minOfOrNull { it.gyldigFom } ?: LocalDate.MAX
 
-        if (vedtaksperiode.fom == null || vedtaksperiode.fom.isSameOrBefore(startdatoForSvalbardtillegg)) {
+        if (vedtaksperiode.fom == null || vedtaksperiode.fom!!.isSameOrBefore(startdatoForSvalbardtillegg)) {
             return false
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
@@ -109,7 +109,7 @@ class StønadsstatistikkService(
                 annenForeldersAktivitet =
                     if (kompetanse.annenForeldersAktivitet != null) {
                         KompetanseAktivitet.valueOf(
-                            kompetanse.annenForeldersAktivitet.name,
+                            kompetanse.annenForeldersAktivitet!!.name,
                         )
                     } else {
                         null
@@ -119,7 +119,7 @@ class StønadsstatistikkService(
                 fom = kompetanse.fom!!,
                 tom = kompetanse.tom,
                 resultat = KompetanseResultat.valueOf(kompetanse.resultat!!.name),
-                sokersaktivitet = if (kompetanse.søkersAktivitet != null) KompetanseAktivitet.valueOf(kompetanse.søkersAktivitet.name) else null,
+                sokersaktivitet = if (kompetanse.søkersAktivitet != null) KompetanseAktivitet.valueOf(kompetanse.søkersAktivitet!!.name) else null,
                 sokersAktivitetsland = kompetanse.søkersAktivitetsland,
             )
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/ValutakursBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/ValutakursBuilder.kt
@@ -44,7 +44,7 @@ class ValutakursBuilder(
             medTransformasjon { valutakurs ->
                 if (valutakurs.fom != null && valutakurs.valutakursdato == null) {
                     valutakurs.copy(
-                        valutakursdato = valutakurs.fom.minusMonths(1).tilSisteVirkedag(),
+                        valutakursdato = valutakurs.fom!!.minusMonths(1).tilSisteVirkedag(),
                     )
                 } else {
                     valutakurs


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bumper Kotlin fra 2.3.0 til 2.3.20.

Hvorfor kodeendringer?

Kotlin 2.x innførte strengere regler for smart cast av klasseegenskaper (val-er) som har åpne eller egendefinerte gettere. Tidligere aksepterte
kompilatoren at en egenskap ble smart-castet til ikke-nullbar etter en null-sjekk, selv om gettere teknisk sett kan returnere ulik verdi hver gang de
kalles. Dette var en feil i kompilatoren som nå er rettet.

Fra og med 2.3.20 avvises slike casts konsekvent, og koden må eksplisitt håndtere nullabilitet. Endringene følger ett av to mønstre:

 1. Lokal-variabel-fangst – brukt der samme egenskap leses flere ganger i en blokk, f.eks. i filter-lambdaer og when-uttrykk: val fom = periode.fom
  val tom = periode.tom
 2. !!-operator – brukt på steder der konteksten garanterer ikke-null (f.eks. rett etter en if (x == null) return-guard): fom!!.forrigeMåned()

I tillegg fikses ett tilfelle der Boolean? ble brukt direkte som betingelse i if, noe som ikke lenger tillates — erstattet med eksplisitt == true.



### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
