### PR TITLE
Tillatt å begrunne mer enn 1 periode hvis det ikke er rent opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -340,6 +340,8 @@ enum class Behandlingsresultat(
     fun erAvslått(): Boolean = this in listOf(AVSLÅTT, AVSLÅTT_OG_OPPHØRT, AVSLÅTT_OG_ENDRET, AVSLÅTT_ENDRET_OG_OPPHØRT)
 
     fun erFortsattInnvilget(): Boolean = this in listOf(FORTSATT_INNVILGET, ENDRET_OG_FORTSATT_INNVILGET)
+
+    fun erEndretOgOpphørt(): Boolean = this in listOf(ENDRET_OG_FORTSATT_OPPHØRT, ENDRET_OG_OPPHØRT, INNVILGET_ENDRET_OG_OPPHØRT, DELVIS_INNVILGET_ENDRET_OG_OPPHØRT, AVSLÅTT_ENDRET_OG_OPPHØRT)
 }
 
 /**

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.sak.common.tilDagMånedÅr
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toLocalDate
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.KodeverkService
 import no.nav.familie.ba.sak.integrasjoner.organisasjon.OrganisasjonService
@@ -22,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.finnInnvilgedeOg
 import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardstillegg.finnInnvilgedeOgReduserteSvalbardtilleggPerioder
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatOpphørUtils.filtrerBortIrrelevanteAndeler
 import no.nav.familie.ba.sak.kjerne.beregning.AvregningService
@@ -104,14 +104,12 @@ class BrevService(
     private val testVerktøyService: TestVerktøyService,
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
-    private val kompetanseRepository: KompetanseRepository,
     private val valutakursRepository: ValutakursRepository,
     private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
     private val hjemmeltekstUtleder: HjemmeltekstUtleder,
     private val avregningService: AvregningService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val clockProvider: ClockProvider,
-    private val featureToggle: FeatureToggleService,
 ) {
     fun hentVedtaksbrevData(vedtak: Vedtak): Vedtaksbrev {
         val behandling = vedtak.behandling
@@ -122,7 +120,7 @@ class BrevService(
             )
 
         val vedtakFellesfelter = lagVedtaksbrevFellesfelter(vedtak)
-        validerBrevdata(brevmal, vedtakFellesfelter)
+        validerBrevdata(brevmal, vedtakFellesfelter, behandling.resultat)
 
         val skalMeldeFraOmEndringerEøsSelvstendigRett by lazy {
             vedtaksperiodeService.skalMeldeFraOmEndringerEøsSelvstendigRett(vedtak)
@@ -363,14 +361,11 @@ class BrevService(
     private fun validerBrevdata(
         brevmal: Brevmal,
         vedtakFellesfelter: VedtakFellesfelter,
+        behandlingsresultat: Behandlingsresultat,
     ) {
-        if (brevmal in
-            listOf(
-                Brevmal.VEDTAK_OPPHØRT,
-                Brevmal.VEDTAK_OPPHØRT_INSTITUSJON,
-            ) &&
-            vedtakFellesfelter.perioder.size > 1
-        ) {
+        val erOpphørtBrevmal = brevmal in listOf(Brevmal.VEDTAK_OPPHØRT, Brevmal.VEDTAK_OPPHØRT_INSTITUSJON)
+
+        if (erOpphørtBrevmal && !behandlingsresultat.erEndretOgOpphørt() && vedtakFellesfelter.perioder.size > 1) {
             throw FunksjonellFeil(
                 "Behandlingsstatusen er \"Opphørt\", men mer enn én periode er begrunnet. Du skal kun begrunne perioden uten utbetaling.",
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.brev
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.TestClockProvider
+import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.cucumber.mock.komponentMocks.mockFeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
@@ -11,9 +12,15 @@ import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.AvregningService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.BrevPeriodeType
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Hjemmeltekst
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.VedtakFellesfelter
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriode
 import no.nav.familie.ba.sak.kjerne.brev.hjemler.HjemmeltekstUtleder
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
@@ -49,7 +56,6 @@ class BrevServiceTest {
     val mockAvregningService = mockk<AvregningService>()
 
     val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(LocalDate.of(2025, 12, 1))
-    val mockedFeatureToggleServie = mockFeatureToggleService()
     val brevService =
         BrevService(
             totrinnskontrollService = mockTotrinnskontrollService,
@@ -67,13 +73,11 @@ class BrevServiceTest {
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
             utenlandskPeriodebeløpRepository = mockk(),
             valutakursRepository = mockk(),
-            kompetanseRepository = mockk(),
             endretUtbetalingAndelRepository = endretUtbetalingAndelRepository,
             hjemmeltekstUtleder = hjemmeltekstUtleder,
             avregningService = mockAvregningService,
             behandlingHentOgPersisterService = mockk(),
             clockProvider = clockProvider,
-            featureToggle = mockedFeatureToggleServie,
         )
 
     @BeforeEach


### PR DESCRIPTION
### 📮 Favro: NAV-28496

### 💰 Hva skal gjøres, og hvorfor?
Vi ønsker å kunne begrunne mer enn 1 periode i vedtaksperiode siden dersom det er slik at det er endring + opphør i samme behandling.