### PR TITLE
NAV-28606: Bare lagre ett logginnslag ved endring av preutfylt vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -94,13 +94,18 @@ class VilkårService(
                     )
                 }
 
-                endringIPreutfyltVilkårLoggRepository.save(
-                    opprettLoggForEndringIPreutfyltVilkår(
-                        behandling = vilkårsvurdering.behandling,
-                        forrigeVilkår = eksisterendeVilkårResultat,
-                        nyttVilkår = vilkårResultatDto,
-                    ),
-                )
+                val eksisterendeLogg =
+                    endringIPreutfyltVilkårLoggRepository.findByVilkårResultatId(eksisterendeVilkårResultat.id)
+
+                val logg =
+                    eksisterendeLogg?.oppdaterEndringIPreutfyltVilkårLogg(vilkårResultatDto)
+                        ?: opprettLoggForEndringIPreutfyltVilkår(
+                            behandling = vilkårsvurdering.behandling,
+                            forrigeVilkår = eksisterendeVilkårResultat,
+                            nyttVilkår = vilkårResultatDto,
+                        )
+
+                endringIPreutfyltVilkårLoggRepository.save(logg)
             }
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLogg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLogg.kt
@@ -68,6 +68,16 @@ data class EndringIPreutfyltVilkårLogg(
     @Column(name = "ny_utdypende_vilkarsvurdering")
     val nyUtdypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>?,
 ) {
+    fun oppdaterEndringIPreutfyltVilkårLogg(nyttVilkår: VilkårResultatDto): EndringIPreutfyltVilkårLogg =
+        copy(
+            begrunnelse = nyttVilkår.begrunnelse,
+            nyFom = nyttVilkår.periodeFom,
+            nyTom = nyttVilkår.periodeTom,
+            nyResultat = nyttVilkår.resultat,
+            nyVurderesEtter = nyttVilkår.vurderesEtter,
+            nyUtdypendeVilkårsvurdering = nyttVilkår.utdypendeVilkårsvurderinger,
+        )
+
     companion object {
         fun opprettLoggForEndringIPreutfyltVilkår(
             behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLoggRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLoggRepository.kt
@@ -2,4 +2,6 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface EndringIPreutfyltVilkårLoggRepository : JpaRepository<EndringIPreutfyltVilkårLogg, Long>
+interface EndringIPreutfyltVilkårLoggRepository : JpaRepository<EndringIPreutfyltVilkårLogg, Long> {
+    fun findByVilkårResultatId(vilkårResultatId: Long): EndringIPreutfyltVilkårLogg?
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLoggTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLoggTest.kt
@@ -10,6 +10,92 @@ import java.time.LocalDateTime
 
 class EndringIPreutfyltVilkårLoggTest {
     @Test
+    fun `oppdaterEndringIPreutfyltVilkårLogg beholder forrige-verdier og oppdaterer ny-verdier`() {
+        val behandling = lagBehandling(id = 1234)
+        val forrigeVilkår =
+            VilkårResultat(
+                personResultat = null,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.IKKE_OPPFYLT,
+                resultatBegrunnelse = null,
+                periodeFom = LocalDate.of(2020, 1, 1),
+                periodeTom = LocalDate.of(2020, 12, 31),
+                begrunnelse = "forrige begrunnelse",
+                sistEndretIBehandlingId = behandling.id,
+                erOpprinneligPreutfyltIBehandling = behandling.id,
+                vurderesEtter = Regelverk.EØS_FORORDNINGEN,
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.DELT_BOSTED),
+            )
+
+        val førsteEditDto =
+            VilkårResultatDto(
+                id = forrigeVilkår.id,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = LocalDate.of(2021, 1, 1),
+                periodeTom = LocalDate.of(2021, 12, 31),
+                begrunnelse = "første edit",
+                endretAv = "saksbehandler",
+                endretTidspunkt = LocalDateTime.now(),
+                behandlingId = behandling.id,
+                erVurdert = true,
+                erAutomatiskVurdert = false,
+                erEksplisittAvslagPåSøknad = false,
+                avslagBegrunnelser = emptyList(),
+                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS),
+                resultatBegrunnelse = null,
+                begrunnelseForManuellKontroll = null,
+            )
+
+        val andreEditDto =
+            VilkårResultatDto(
+                id = forrigeVilkår.id,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.IKKE_OPPFYLT,
+                periodeFom = LocalDate.of(2022, 6, 1),
+                periodeTom = LocalDate.of(2022, 12, 31),
+                begrunnelse = "andre edit",
+                endretAv = "saksbehandler",
+                endretTidspunkt = LocalDateTime.now(),
+                behandlingId = behandling.id,
+                erVurdert = true,
+                erAutomatiskVurdert = false,
+                erEksplisittAvslagPåSøknad = false,
+                avslagBegrunnelser = emptyList(),
+                vurderesEtter = Regelverk.EØS_FORORDNINGEN,
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD),
+                resultatBegrunnelse = null,
+                begrunnelseForManuellKontroll = null,
+            )
+
+        val opprinneligLogg =
+            EndringIPreutfyltVilkårLogg.opprettLoggForEndringIPreutfyltVilkår(
+                behandling = behandling,
+                forrigeVilkår = forrigeVilkår,
+                nyttVilkår = førsteEditDto,
+            )
+
+        val oppdatertLogg = opprinneligLogg.oppdaterEndringIPreutfyltVilkårLogg(andreEditDto)
+
+        // forrige*-felt er uendret (original preutfylt-tilstand)
+        assertThat(oppdatertLogg.forrigeResultat).isEqualTo(Resultat.IKKE_OPPFYLT)
+        assertThat(oppdatertLogg.forrigeFom).isEqualTo(LocalDate.of(2020, 1, 1))
+        assertThat(oppdatertLogg.forrigeTom).isEqualTo(LocalDate.of(2020, 12, 31))
+        assertThat(oppdatertLogg.forrigeVurderesEtter).isEqualTo(Regelverk.EØS_FORORDNINGEN)
+        assertThat(oppdatertLogg.forrigeUtdypendeVilkårsvurdering).containsExactly(UtdypendeVilkårsvurdering.DELT_BOSTED)
+        // ny*-felt er oppdatert til siste edit
+        assertThat(oppdatertLogg.nyResultat).isEqualTo(Resultat.IKKE_OPPFYLT)
+        assertThat(oppdatertLogg.nyFom).isEqualTo(LocalDate.of(2022, 6, 1))
+        assertThat(oppdatertLogg.nyTom).isEqualTo(LocalDate.of(2022, 12, 31))
+        assertThat(oppdatertLogg.nyVurderesEtter).isEqualTo(Regelverk.EØS_FORORDNINGEN)
+        assertThat(oppdatertLogg.nyUtdypendeVilkårsvurdering).containsExactly(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD)
+        assertThat(oppdatertLogg.begrunnelse).isEqualTo("andre edit")
+        // id er bevart slik at JPA gjør UPDATE i stedet for INSERT
+        assertThat(oppdatertLogg.id).isEqualTo(opprinneligLogg.id)
+    }
+
+    @Test
     fun `opprettLoggForEndringIPreutfyltVilkår mapper forrige og nye verdier`() {
         val behandling = lagBehandling(id = 1234)
         val forrigeVilkår =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -472,6 +472,87 @@ class VilkårServiceTest(
                 assertThat(begrunnelse).isEqualTo("Ny begrunnelse")
             }
         }
+
+        @Test
+        fun `skal oppdatere eksisterende logg i stedet for å opprette ny ved gjentatt endring av preutfylt vilkår`() {
+            // Arrange
+            val vilkårsvurdering =
+                vilkårsvurderingService.lagreNyOgDeaktiverGammel(
+                    lagVilkårsvurdering(behandling = behandling) { vilkårsvurdering ->
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = vilkårsvurdering,
+                                aktør = søkerAktør,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            personResultat = it,
+                                            behandlingId = behandling.id,
+                                            vilkårType = Vilkår.BOSATT_I_RIKET,
+                                            resultat = Resultat.IKKE_OPPFYLT,
+                                            vurderesEtter = Regelverk.NASJONALE_REGLER,
+                                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS),
+                                            erPreutfylt = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            val personResultatDto = vilkårsvurdering.personResultater.single().tilPersonResultatDto()
+            val vilkårResultatDto = personResultatDto.vilkårResultater.single()
+
+            val førsteEndring =
+                personResultatDto.copy(
+                    vilkårResultater =
+                        listOf(
+                            vilkårResultatDto.copy(
+                                periodeFom = LocalDate.of(2024, 1, 1),
+                                begrunnelse = "Første begrunnelse",
+                                resultat = Resultat.OPPFYLT,
+                                vurderesEtter = Regelverk.EØS_FORORDNINGEN,
+                                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD),
+                            ),
+                        ),
+                )
+
+            val andreEndring =
+                personResultatDto.copy(
+                    vilkårResultater =
+                        listOf(
+                            vilkårResultatDto.copy(
+                                periodeFom = LocalDate.of(2025, 3, 1),
+                                begrunnelse = "Andre begrunnelse",
+                                resultat = Resultat.IKKE_OPPFYLT,
+                                vurderesEtter = Regelverk.NASJONALE_REGLER,
+                                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.DELT_BOSTED),
+                            ),
+                        ),
+                )
+
+            // Act
+            vilkårService.endreVilkår(behandlingId = behandling.id, vilkårId = vilkårResultatDto.id, personResultatDto = førsteEndring)
+            vilkårService.endreVilkår(behandlingId = behandling.id, vilkårId = vilkårResultatDto.id, personResultatDto = andreEndring)
+
+            // Assert — kun ett logginnslag, forrige*-felt er uendret fra original, ny*-felt er fra siste endring
+            val endringIPreutfyltVilkårLogger = endringIPreutfyltVilkårLoggRepository.findAll().filter { it.behandling.id == behandling.id }
+
+            assertThat(endringIPreutfyltVilkårLogger).hasSize(1)
+            with(endringIPreutfyltVilkårLogger.single()) {
+                assertThat(vilkårResultatId).isEqualTo(vilkårResultatDto.id)
+                // forrige*-felt viser original preutfylt-tilstand
+                assertThat(forrigeResultat).isEqualTo(Resultat.IKKE_OPPFYLT)
+                assertThat(forrigeVurderesEtter).isEqualTo(Regelverk.NASJONALE_REGLER)
+                assertThat(forrigeUtdypendeVilkårsvurdering).containsExactly(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS)
+                // ny*-felt viser siste endring
+                assertThat(nyResultat).isEqualTo(Resultat.IKKE_OPPFYLT)
+                assertThat(nyVurderesEtter).isEqualTo(Regelverk.NASJONALE_REGLER)
+                assertThat(nyUtdypendeVilkårsvurdering).containsExactly(UtdypendeVilkårsvurdering.DELT_BOSTED)
+                assertThat(begrunnelse).isEqualTo("Andre begrunnelse")
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
### 📮 Favro: [NAV-28606](https://favro.com/organization/98c34fb974ce9c4b151bbb94/card/NAV-28606)

### 💰 Hva skal gjøres, og hvorfor?

Per nå lagres det et logginnslag **hver gang** en saksbehandler gjør endringer i et preutfylt vilkår. Vi trenger bare **ett** logginnslag som viser forskjellen mellom det preutfylte vilkåret og de endelige endringene — ikke alle endringer som gjøres underveis.

**Problemet:** I `VilkårService.endreVilkår()` ble `opprettLoggForEndringIPreutfyltVilkår()` alltid kalt med `id = 0`, som medfører at JPA alltid gjør INSERT og aldri UPDATE. Resultatet er at `endring_i_preutfylt_vilkar_logg` får én rad per lagring — og `forrige*`-feltene peker på feil tilstand etter første endring.

**Løsningen:** Upsert-logikk basert på `vilkårResultatId`:
- **Første endring:** oppretter et logginnslag der `forrige*`-feltene fanger den opprinnelige preutfylte tilstanden
- **Påfølgende endringer:** oppdaterer `ny*`-feltene i det eksisterende logginnslagget — `forrige*`-feltene forblir uendret

| Fil | Endring |
|-----|---------|
| `EndringIPreutfyltVilkårLoggRepository.kt` | Ny metode: `findByVilkårResultatId()` |
| `EndringIPreutfyltVilkårLogg.kt` | Ny metode: `oppdaterEndringIPreutfyltVilkårLogg()` som bevarer `forrige*`-felt |
| `VilkårService.kt` | Erstatter ubetinget save med upsert-logikk |
| `EndringIPreutfyltVilkårLoggTest.kt` | Ny enhetstest for `oppdaterEndringIPreutfyltVilkårLogg()` |
| `VilkårServiceTest.kt` | Ny integrasjonstest: dobbel endring → ett logginnslag |

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

Ingen API-endringer, ingen Flyway-migrasjoner i denne PRen. Som oppfølging bør vi vurdere unik indeks på `vilkar_resultat_id` (etter å ha verifisert ingen duplikater i prod), og tilsvarende fix i `familie-ks-sak`.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.