### PR TITLE
Oppgrader Kotlin fra 2.3.0 til 2.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
 
         <java.version>25</java.version>
-        <kotlin.version>2.3.0</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <kotlin.compiler.languageVersion>2.3</kotlin.compiler.languageVersion>
         <kotlin.compiler.apiVersion>2.3</kotlin.compiler.apiVersion>
         <revision>1</revision>

--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Tid.kt
@@ -193,13 +193,16 @@ fun VilkårResultat.toPeriode(): Periode =
         this.erEksplisittAvslagPåSøknad,
     )
 
-fun LocalDate.erInnenfor(periode: DatoIntervallEntitet): Boolean =
-    when {
-        periode.fom == null && periode.tom == null -> true
-        periode.fom == null -> isSameOrBefore(periode.tom!!)
-        periode.tom == null -> isSameOrAfter(periode.fom)
-        else -> isSameOrAfter(periode.fom) && isSameOrBefore(periode.tom)
+fun LocalDate.erInnenfor(periode: DatoIntervallEntitet): Boolean {
+    val fom = periode.fom
+    val tom = periode.tom
+    return when {
+        fom == null && tom == null -> true
+        fom == null -> isSameOrBefore(tom!!)
+        tom == null -> isSameOrAfter(fom)
+        else -> isSameOrAfter(fom) && isSameOrBefore(tom)
     }
+}
 
 class YearMonthIterator(
     startMåned: YearMonth,

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/UtenlandskPeriodebeløpDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/UtenlandskPeriodebeløpDto.kt
@@ -53,11 +53,13 @@ fun UtenlandskPeriodebeløpDto.tilKalkulertMånedligBeløp(): BigDecimal? {
 }
 
 fun UtenlandskPeriodebeløp.tilKalkulertMånedligBeløp(): BigDecimal? {
-    if (this.beløp == null || this.intervall == null) {
+    val beløp = this.beløp
+    val intervall = this.intervall
+    if (beløp == null || intervall == null) {
         return null
     }
 
-    return this.intervall.konverterBeløpTilMånedlig(this.beløp)
+    return intervall.konverterBeløpTilMånedlig(beløp)
 }
 
 fun UtenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto() =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/Regler.kt
@@ -284,20 +284,22 @@ private fun hentMaxAvstandAvDagerMellomPerioder(
 
     val perioderInnenAngittTidsrom =
         perioderMedTilkobletTom.filter {
-            it.tom == null ||
+            val itFom = it.fom
+            val itTom = it.tom
+            itTom == null ||
                 fom.isBetween(
                     Periode(
-                        fom = it.fom!!,
-                        tom = it.tom,
+                        fom = itFom!!,
+                        tom = itTom,
                     ),
                 ) ||
                 tom.isBetween(
                     Periode(
-                        fom = it.fom,
-                        tom = it.tom,
+                        fom = itFom,
+                        tom = itTom,
                     ),
                 ) ||
-                (it.fom >= fom && it.tom <= tom)
+                (itFom >= fom && itTom <= tom)
         }
 
     if (perioderInnenAngittTidsrom.isEmpty()) return Duration.between(fom.atStartOfDay(), tom.atStartOfDay()).toDays()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -162,10 +162,12 @@ data class AndelTilkjentYtelse(
 
     fun erAndelSomSkalSendesTilOppdrag(): Boolean = this.kalkulertUtbetalingsbeløp != 0
 
-    fun erAndelSomharNullutbetalingPgaDifferanseberegning() =
-        this.kalkulertUtbetalingsbeløp == 0 &&
-            this.differanseberegnetPeriodebeløp != null &&
-            this.differanseberegnetPeriodebeløp <= 0
+    fun erAndelSomharNullutbetalingPgaDifferanseberegning(): Boolean {
+        val differanseberegnetBeløp = this.differanseberegnetPeriodebeløp
+        return this.kalkulertUtbetalingsbeløp == 0 &&
+            differanseberegnetBeløp != null &&
+            differanseberegnetBeløp <= 0
+    }
 
     private fun finnRelevanteVilkårsresulaterForRegelverk(
         personResultater: Set<PersonResultat>,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -547,12 +547,14 @@ fun hentAntallBarnForBegrunnelse(
     }
 }
 
-fun VedtaksperiodeMedBegrunnelser.hentMånedOgÅrForBegrunnelse(): String? =
-    if (this.fom == null || fom == TIDENES_MORGEN) {
+fun VedtaksperiodeMedBegrunnelser.hentMånedOgÅrForBegrunnelse(): String? {
+    val fom = this.fom
+    return if (fom == null || fom == TIDENES_MORGEN) {
         null
     } else {
         fom.forrigeMåned().tilMånedÅr()
     }
+}
 
 private fun hentBeløp(
     gjelderSøker: Boolean,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
@@ -115,16 +115,19 @@ private fun VedtaksperiodeMedBegrunnelser.byggBrevPeriode(
 
 private fun VedtaksperiodeMedBegrunnelser.hentTomTekstForBrev(
     brevPeriodeType: BrevPeriodeType,
-) = if (this.tom == null) {
-    ""
-} else {
-    val tomDato = this.tom.tilMånedÅr()
-    when (brevPeriodeType) {
-        BrevPeriodeType.UTBETALING -> "til $tomDato"
-        BrevPeriodeType.INGEN_UTBETALING -> if (this.type == Vedtaksperiodetype.AVSLAG) "til og med $tomDato " else ""
-        BrevPeriodeType.INGEN_UTBETALING_UTEN_PERIODE -> ""
-        BrevPeriodeType.FORTSATT_INNVILGET -> ""
-        else -> throw Feil("$brevPeriodeType skal ikke brukes")
+): String {
+    val tom = this.tom
+    return if (tom == null) {
+        ""
+    } else {
+        val tomDato = tom.tilMånedÅr()
+        when (brevPeriodeType) {
+            BrevPeriodeType.UTBETALING -> "til $tomDato"
+            BrevPeriodeType.INGEN_UTBETALING -> if (this.type == Vedtaksperiodetype.AVSLAG) "til og med $tomDato " else ""
+            BrevPeriodeType.INGEN_UTBETALING_UTEN_PERIODE -> ""
+            BrevPeriodeType.FORTSATT_INNVILGET -> ""
+            else -> throw Feil("$brevPeriodeType skal ikke brukes")
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/domene/Valutaberegning.kt
@@ -27,17 +27,21 @@ operator fun Valutabeløp?.times(kronerPerValutaenhet: KronerPerValutaenhet?): B
 }
 
 fun UtenlandskPeriodebeløp?.tilMånedligValutabeløp(): Valutabeløp? {
-    if (this?.kalkulertMånedligBeløp == null || this.valutakode == null) {
+    val kalkulertMånedligBeløp = this?.kalkulertMånedligBeløp
+    val valutakode = this?.valutakode
+    if (kalkulertMånedligBeløp == null || valutakode == null) {
         return null
     }
 
-    return Valutabeløp(this.kalkulertMånedligBeløp, this.valutakode)
+    return Valutabeløp(kalkulertMånedligBeløp, valutakode)
 }
 
 fun Valutakurs?.tilKronerPerValutaenhet(): KronerPerValutaenhet? {
-    if (this?.kurs == null || this.valutakode == null) {
+    val kurs = this?.kurs
+    val valutakode = this?.valutakode
+    if (kurs == null || valutakode == null) {
         return null
     }
 
-    return KronerPerValutaenhet(this.kurs, this.valutakode)
+    return KronerPerValutaenhet(kurs, valutakode)
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseController.kt
@@ -73,10 +73,11 @@ class KompetanseController(
     }
 
     private fun validerOppdatering(oppdatertKompetanse: Kompetanse) {
-        if (oppdatertKompetanse.fom == null) {
+        val fom = oppdatertKompetanse.fom
+        if (fom == null) {
             throw FunksjonellFeil("Manglende fra-og-med", httpStatus = HttpStatus.BAD_REQUEST)
         }
-        if (oppdatertKompetanse.tom != null && oppdatertKompetanse.fom > oppdatertKompetanse.tom) {
+        if (oppdatertKompetanse.tom != null && fom > oppdatertKompetanse.tom) {
             throw FunksjonellFeil("Fra-og-med er etter til-og-med", httpStatus = HttpStatus.BAD_REQUEST)
         }
         if (oppdatertKompetanse.barnAktører.isEmpty()) {
@@ -88,7 +89,7 @@ class KompetanseController(
             (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == false && oppdatertKompetanse.søkersAktivitet?.gyldigForSøker == false)
         ) {
             throw FunksjonellFeil(
-                "Valgt verdi for søkers aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning) "når annen forelder er omfattet av norsk lovgivning" else ""}"
+                "Valgt verdi for søkers aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == true) "når annen forelder er omfattet av norsk lovgivning" else ""}"
                     .trim(),
             )
         }
@@ -97,7 +98,7 @@ class KompetanseController(
             (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == false && oppdatertKompetanse.annenForeldersAktivitet?.gyldigForAnnenForelder == false)
         ) {
             throw FunksjonellFeil(
-                "Valgt verdi for annen forelders aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning) "når annen forelder er omfattet av norsk lovgivning" else ""}"
+                "Valgt verdi for annen forelders aktivitet er ikke gyldig ${if (oppdatertKompetanse.erAnnenForelderOmfattetAvNorskLovgivning == true) "når annen forelder er omfattet av norsk lovgivning" else ""}"
                     .trim(),
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
@@ -58,7 +58,10 @@ data class GrMatrikkeladresseOppholdsadresse(
         return postnummer?.let { "$postnummer$poststed$oppholdAnnetSted" } ?: "Ukjent adresse$oppholdAnnetSted"
     }
 
-    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
+    override fun erPåSvalbard(): Boolean {
+        val kommunenummer = this.kommunenummer
+        return (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
+    }
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrVegadresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/adresser/oppholdsadresse/GrVegadresseOppholdsadresse.kt
@@ -78,7 +78,10 @@ data class GrVegadresseOppholdsadresse(
         }
     }
 
-    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
+    override fun erPåSvalbard(): Boolean {
+        val kommunenummer = this.kommunenummer
+        return (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
+    }
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/GrArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/GrArbeidsforhold.kt
@@ -75,8 +75,9 @@ data class GrArbeidsforhold(
         return result
     }
 
-    fun tilRegisteropplysningDto() =
-        RegisteropplysningDto(
+    fun tilRegisteropplysningDto(): RegisteropplysningDto {
+        val arbeidsgiverId = this.arbeidsgiverId
+        return RegisteropplysningDto(
             fom = this.periode?.fom,
             tom = this.periode?.tom,
             verdi =
@@ -86,6 +87,7 @@ data class GrArbeidsforhold(
                     else -> "Ukjent arbeidsgiver"
                 },
         )
+    }
 
     companion object {
         fun Arbeidsforhold.tilGrArbeidsforhold(
@@ -112,5 +114,6 @@ data class GrArbeidsforhold(
 
 fun List<GrArbeidsforhold>.harLøpendeArbeidsforhold(): Boolean =
     this.any {
-        it.periode?.tom == null || it.periode.tom >= LocalDate.now()
+        val tom = it.periode?.tom
+        tom == null || tom >= LocalDate.now()
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/opphold/GrOpphold.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/opphold/GrOpphold.kt
@@ -47,6 +47,7 @@ data class GrOpphold(
     fun tilKopiForNyPerson(nyPerson: Person): GrOpphold = copy(id = 0, person = nyPerson)
 
     fun gjeldendeNå(): Boolean {
+        val gyldigPeriode = this.gyldigPeriode
         if (gyldigPeriode == null) return true
         return LocalDate.now().erInnenfor(gyldigPeriode)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/GrStatsborgerskap.kt
@@ -55,6 +55,7 @@ data class GrStatsborgerskap(
     fun tilKopiForNyPerson(nyPerson: Person): GrStatsborgerskap = copy(id = 0, person = nyPerson)
 
     fun gjeldendeNå(): Boolean {
+        val gyldigPeriode = this.gyldigPeriode
         if (gyldigPeriode == null) return true
         return LocalDate.now().erInnenfor(gyldigPeriode)
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakService.kt
@@ -13,7 +13,10 @@ class VedtakService(
     private val vedtakRepository: VedtakRepository,
     private val dokumentGenereringService: DokumentGenereringService,
 ) {
-    fun hent(vedtakId: Long): Vedtak = vedtakRepository.getReferenceById(vedtakId)
+    fun hent(vedtakId: Long): Vedtak =
+        vedtakRepository.findById(vedtakId).orElseThrow {
+            Feil("Finner ikke vedtak med id=$vedtakId")
+        }
 
     fun hentAktivForBehandling(behandlingId: Long): Vedtak? = vedtakRepository.findByBehandlingAndAktivOptional(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -483,7 +483,10 @@ class VedtaksperiodeService(
     fun skalHaÅrligKontroll(vedtak: Vedtak): Boolean =
         kompetanseRepository
             .finnFraBehandlingId(vedtak.behandling.id)
-            .any { it.tom == null || it.tom.isAfter(YearMonth.now()) }
+            .any {
+                val tom = it.tom
+                tom == null || tom.isAfter(YearMonth.now())
+            }
 
     fun skalMeldeFraOmEndringerEøsSelvstendigRett(vedtak: Vedtak): Boolean {
         val vilkårsvurdering =

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/BegrunnelseGrunnlagForPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtakBegrunnelseProdusent/BegrunnelseGrunnlagForPeriode.kt
@@ -40,7 +40,8 @@ sealed interface IBegrunnelseGrunnlagForPeriode {
                 .filter { it.type == SatsType.FINNMARKSTILLEGG }
                 .minOfOrNull { it.gyldigFom } ?: LocalDate.MAX
 
-        if (vedtaksperiode.fom == null || vedtaksperiode.fom.isSameOrBefore(startdatoForFinnmarkstillegg)) {
+        val fom = vedtaksperiode.fom
+        if (fom == null || fom.isSameOrBefore(startdatoForFinnmarkstillegg)) {
             return false
         }
 
@@ -97,7 +98,8 @@ sealed interface IBegrunnelseGrunnlagForPeriode {
                 .filter { it.type == SatsType.SVALBARDTILLEGG }
                 .minOfOrNull { it.gyldigFom } ?: LocalDate.MAX
 
-        if (vedtaksperiode.fom == null || vedtaksperiode.fom.isSameOrBefore(startdatoForSvalbardtillegg)) {
+        val fom = vedtaksperiode.fom
+        if (fom == null || fom.isSameOrBefore(startdatoForSvalbardtillegg)) {
             return false
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
@@ -104,12 +104,14 @@ class StønadsstatistikkService(
         val kompetanser = kompetanseService.hentKompetanser(behandlingId)
 
         return kompetanser.filter { it.resultat != null }.map { kompetanse ->
+            val annenForeldersAktivitet = kompetanse.annenForeldersAktivitet
+            val søkersAktivitet = kompetanse.søkersAktivitet
             Kompetanse(
                 barnsIdenter = kompetanse.barnAktører.map { aktør -> aktør.aktivFødselsnummer() },
                 annenForeldersAktivitet =
-                    if (kompetanse.annenForeldersAktivitet != null) {
+                    if (annenForeldersAktivitet != null) {
                         KompetanseAktivitet.valueOf(
-                            kompetanse.annenForeldersAktivitet.name,
+                            annenForeldersAktivitet.name,
                         )
                     } else {
                         null
@@ -119,7 +121,7 @@ class StønadsstatistikkService(
                 fom = kompetanse.fom!!,
                 tom = kompetanse.tom,
                 resultat = KompetanseResultat.valueOf(kompetanse.resultat!!.name),
-                sokersaktivitet = if (kompetanse.søkersAktivitet != null) KompetanseAktivitet.valueOf(kompetanse.søkersAktivitet.name) else null,
+                sokersaktivitet = if (søkersAktivitet != null) KompetanseAktivitet.valueOf(søkersAktivitet.name) else null,
                 sokersAktivitetsland = kompetanse.søkersAktivitetsland,
             )
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockVedtakRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/komponentMocks/MockVedtakRepository.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.cucumber.VedtaksperioderOgBegrunnelserStepDefinitio
 import no.nav.familie.ba.sak.datagenerator.lagVedtakMedId
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
+import java.util.Optional
 
 fun mockVedtakRepository(dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefinition): VedtakRepository {
     val vedtakRepository = mockk<VedtakRepository>()
@@ -16,6 +17,11 @@ fun mockVedtakRepository(dataFraCucumber: VedtaksperioderOgBegrunnelserStepDefin
     every { vedtakRepository.getReferenceById(any()) } answers {
         val vedtakId = firstArg<Long>()
         dataFraCucumber.vedtaksliste.first { it.id == vedtakId }
+    }
+    every { vedtakRepository.findById(any()) } answers {
+        val vedtakId = firstArg<Long>()
+        val vedtak = dataFraCucumber.vedtaksliste.find { it.id == vedtakId }
+        if (vedtak != null) Optional.of(vedtak) else Optional.empty()
     }
     every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } answers {
         val behandlingId = firstArg<Long>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/ValutakursBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/util/ValutakursBuilder.kt
@@ -42,9 +42,10 @@ class ValutakursBuilder(
     }.apply {
         if (automatiskSettValutakursdato) {
             medTransformasjon { valutakurs ->
-                if (valutakurs.fom != null && valutakurs.valutakursdato == null) {
+                val fom = valutakurs.fom
+                if (fom != null && valutakurs.valutakursdato == null) {
                     valutakurs.copy(
-                        valutakursdato = valutakurs.fom.minusMonths(1).tilSisteVirkedag(),
+                        valutakursdato = fom.minusMonths(1).tilSisteVirkedag(),
                     )
                 } else {
                     valutakurs

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
@@ -136,9 +136,9 @@ class FagsakControllerTest(
         assertEquals(Ressurs.Status.SUKSESS, nyFagsakDto.body?.status)
         assertEquals(fnr, fagsakService.hentNormalFagsak(aktør)?.aktør?.aktivFødselsnummer())
 
-        personidentRepository.save(
-            personidentRepository.getReferenceById(fnr).also { it.aktiv = false },
-        )
+        val existingPersonident = personidentRepository.findById(fnr).orElseThrow()
+        existingPersonident.aktiv = false
+        personidentRepository.save(existingPersonident)
         personidentRepository.save(Personident(fødselsnummer = nyttFnr, aktør = aktør, aktiv = true))
 
         val eksisterendeFagsakDto =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bumper Kotlin fra 2.3.0 til 2.3.20.

Hvorfor kodeendringer?

Kotlin 2.x innførte strengere regler for smart cast av klasseegenskaper (val-er) som har åpne eller egendefinerte gettere. Tidligere aksepterte
kompilatoren at en egenskap ble smart-castet til ikke-nullbar etter en null-sjekk, selv om gettere teknisk sett kan returnere ulik verdi hver gang de
kalles. Dette var en feil i kompilatoren som nå er rettet.

Fra og med 2.3.20 avvises slike casts konsekvent, og koden må eksplisitt håndtere nullabilitet. Endringene følger ett av to mønstre:

- Oppgraderer Kotlin fra 2.3.0 til 2.3.20
- Fikser smart cast-feil i 16 filer ved å lagre nullable properties i lokale variabler
- Erstatter `getReferenceById` med `findById` for å unngå `LazyInitializationException`

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

Testet en iverksettelse i preprod med visning av vedtaksbrev