### PR TITLE
Kopier persongrunnlag dersom saksbehandler ikke har tilgang til barn grunnet diskresjonskode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -237,12 +237,12 @@ class ArbeidsfordelingService(
                 )?.let { arbeidsfordelingPerson -> put(søkerIdent, arbeidsfordelingPerson) }
 
                 val skjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak =
-                    strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(behandling.fagsak)
+                    strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(behandling.fagsak)
 
                 personopplysningGrunnlagRepository
                     .finnSøkerOgBarnAktørerTilAktiv(behandling.id)
                     .barn()
-                    .filterNot { it.aktør in skjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak }
+                    .filterNot { it.aktør.aktivFødselsnummer() in skjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak }
                     .forEach { person ->
                         utledArbeidsfordelingPerson(
                             aktør = person.aktør,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ba.sak.common.secureLogger
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
@@ -45,7 +44,6 @@ class ArbeidsfordelingService(
     private val personopplysningerService: PersonopplysningerService,
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
-    private val featureToggleService: FeatureToggleService,
     private val strengtFortroligService: StrengtFortroligService,
 ) {
     @Transactional
@@ -230,8 +228,6 @@ class ArbeidsfordelingService(
         behandling: Behandling,
     ): Arbeidsfordelingsenhet {
         val søkerIdent = behandling.fagsak.aktør.aktivFødselsnummer()
-        val ekskluderteAktører =
-            strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(behandling.fagsak)
 
         val arbeidsfordelingPersoner =
             buildMap {
@@ -240,10 +236,13 @@ class ArbeidsfordelingService(
                     personType = PersonType.SØKER,
                 )?.let { arbeidsfordelingPerson -> put(søkerIdent, arbeidsfordelingPerson) }
 
+                val skjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak =
+                    strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(behandling.fagsak)
+
                 personopplysningGrunnlagRepository
                     .finnSøkerOgBarnAktørerTilAktiv(behandling.id)
                     .barn()
-                    .filterNot { it.aktør in ekskluderteAktører }
+                    .filterNot { it.aktør in skjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak }
                     .forEach { person ->
                         utledArbeidsfordelingPerson(
                             aktør = person.aktør,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.barn
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.NavIdent
@@ -45,6 +46,7 @@ class ArbeidsfordelingService(
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
     private val featureToggleService: FeatureToggleService,
+    private val strengtFortroligService: StrengtFortroligService,
 ) {
     @Transactional
     fun manueltOppdaterBehandlendeEnhet(
@@ -224,8 +226,12 @@ class ArbeidsfordelingService(
         arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandlingId)
             ?: throw Feil("Finner ikke tilknyttet arbeidsfordeling på behandling med id $behandlingId")
 
-    fun hentArbeidsfordelingsenhet(behandling: Behandling): Arbeidsfordelingsenhet {
+    fun hentArbeidsfordelingsenhet(
+        behandling: Behandling,
+    ): Arbeidsfordelingsenhet {
         val søkerIdent = behandling.fagsak.aktør.aktivFødselsnummer()
+        val ekskluderteAktører =
+            strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(behandling.fagsak)
 
         val arbeidsfordelingPersoner =
             buildMap {
@@ -237,6 +243,7 @@ class ArbeidsfordelingService(
                 personopplysningGrunnlagRepository
                     .finnSøkerOgBarnAktørerTilAktiv(behandling.id)
                     .barn()
+                    .filterNot { it.aktør in ekskluderteAktører }
                     .forEach { person ->
                         utledArbeidsfordelingPerson(
                             aktør = person.aktør,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/UtvidetBehandlingService.kt
@@ -197,6 +197,6 @@ class UtvidetBehandlingService(
                 manglendeFinnmarkmerking = samhandlerInfo?.tilManglendeFinnmarkmerkingPerioder(personResultater),
             )
 
-        return strengtFortroligService.anonymiserStrengtFortroligBarn(utvidetBehandlingDto, behandlingId)
+        return strengtFortroligService.anonymiserStrengtFortroligBarn(utvidetBehandlingDto, behandling.fagsak)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -254,18 +254,18 @@ class PersongrunnlagService(
         val alleBarna = barnFraInneværendeBehandling.union(barnFraForrigeBehandling).toList()
         val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
 
-        val forrigePersongrunnlag =
-            behandlingHentOgPersisterService
-                .hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
-                ?.let { hentAktivThrows(it.id) }
+        val sisteBehandlingSomErVedtatt = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
 
         val skjermedeBarnSaksbehandlerManglerTilgangTil =
-            forrigePersongrunnlag?.let {
-                strengtFortroligService
-                    .finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(behandling.fagsak)
-                    .filter { barn -> barn in alleBarna }
+            if (sisteBehandlingSomErVedtatt != null) {
+                val skjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(behandling.fagsak)
+                alleBarna.filter { barn -> barn.aktivFødselsnummer() in skjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil }
+            } else {
+                emptyList()
             }
-                ?: emptyList()
+
+        val forrigePersongrunnlag =
+            if (skjermedeBarnSaksbehandlerManglerTilgangTil.isNotEmpty()) hentAktivThrows(sisteBehandlingSomErVedtatt!!.id) else null
 
         val barnSomSkalKopieresFraForrigeGrunnlag =
             skjermedeBarnSaksbehandlerManglerTilgangTil.mapNotNull { barn ->

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -251,28 +251,38 @@ class PersongrunnlagService(
         barnFraForrigeBehandling: List<Aktør> = emptyList(),
     ): PersonopplysningGrunnlag {
         val nyttPersonopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
-
         val alleBarna = barnFraInneværendeBehandling.union(barnFraForrigeBehandling).toList()
+        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
 
-        // Skjermede barn (kode 6/19) uten løpende andeler som saksbehandler mangler tilgang til
-        // kopieres fra forrige vedtatte persongrunnlag i stedet for å hentes fra PDL (som vil feile).
-        val sisteBehandlingSomErVedtatt = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
-        val aktørerSomSkalKopieres: Set<Aktør> =
-            if (sisteBehandlingSomErVedtatt != null) {
+        val forrigePersongrunnlag =
+            behandlingHentOgPersisterService
+                .hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+                ?.let { hentAktivThrows(it.id) }
+
+        val skjermedeBarnSaksbehandlerManglerTilgangTil =
+            forrigePersongrunnlag?.let {
                 strengtFortroligService
                     .finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(behandling.fagsak)
-                    .filter { it in alleBarna }
-                    .toSet()
-            } else {
-                emptySet()
+                    .filter { barn -> barn in alleBarna }
             }
-        val forrigePersongrunnlag: PersonopplysningGrunnlag? =
-            if (aktørerSomSkalKopieres.isNotEmpty()) hentAktivThrows(sisteBehandlingSomErVedtatt!!.id) else null
+                ?: emptyList()
 
-        val barnSomSkalHentesFraPdl = alleBarna.filterNot { it in aktørerSomSkalKopieres }
-        val eldsteBarnsFødselsdato = finnEldstebarnsFødselsdato(alleBarna - aktørerSomSkalKopieres)
+        val barnSomSkalKopieresFraForrigeGrunnlag =
+            skjermedeBarnSaksbehandlerManglerTilgangTil.mapNotNull { barn ->
+                forrigePersongrunnlag?.personer?.firstOrNull { person -> person.aktør == barn }
+            }
 
-        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
+        barnSomSkalKopieresFraForrigeGrunnlag.forEach { person ->
+            person.tilKopiForNyttPersonopplysningGrunnlag(nyttPersonopplysningGrunnlag)
+        }
+
+        val barnSomSkalHentesFraPdl = alleBarna.filterNot { barn -> barn in skjermedeBarnSaksbehandlerManglerTilgangTil }
+
+        val eldsteBarnsFødselsdato =
+            listOfNotNull(
+                finnEldstebarnsFødselsdato(barnSomSkalHentesFraPdl),
+                barnSomSkalKopieresFraForrigeGrunnlag.maxOfOrNull { person -> person.fødselsdato },
+            ).max()
 
         val søker =
             hentPerson(
@@ -290,6 +300,7 @@ class PersongrunnlagService(
                 hentArbeidsforhold = behandling.skalBehandlesAutomatisk,
                 eldsteBarnsFødselsdato = eldsteBarnsFødselsdato,
             )
+
         nyttPersonopplysningGrunnlag.personer.add(søker)
 
         barnSomSkalHentesFraPdl.forEach { barnsAktør ->
@@ -304,14 +315,6 @@ class PersongrunnlagService(
                     skalHenteEnkelPersonInfo = skalHenteEnkelPersonInfo,
                     eldsteBarnsFødselsdato = eldsteBarnsFødselsdato,
                 ),
-            )
-        }
-
-        aktørerSomSkalKopieres.forEach { skjermetAktør ->
-            val personFraForrige = forrigePersongrunnlag!!.personer.firstOrNull { it.aktør == skjermetAktør }
-                ?: throw Feil("Fant ikke skjermet barn ${skjermetAktør.aktørId} i forrige persongrunnlag ${forrigePersongrunnlag.id}")
-            nyttPersonopplysningGrunnlag.personer.add(
-                personFraForrige.tilKopiForNyttPersonopplysningGrunnlag(nyttPersonopplysningGrunnlag),
             )
         }
 
@@ -334,12 +337,13 @@ class PersongrunnlagService(
         }
 
         val aktivtPersonopplysningGrunnlag = hentAktiv(behandling.id)
+
         return if (aktivtPersonopplysningGrunnlag == null || nyttPersonopplysningGrunnlag.harRelevantEndring(aktivtPersonopplysningGrunnlag)) {
             lagreOgDeaktiverGammel(nyttPersonopplysningGrunnlag).also {
-                    /*
-                     * For sikkerhetsskyld fastsetter vi alltid behandlende enhet når nytt personopplysningsgrunnlag opprettes.
-                     * Dette gjør vi fordi det kan ha blitt introdusert personer med fortrolig adresse.
-                     */
+                /*
+                 * For sikkerhetsskyld fastsetter vi alltid behandlende enhet når nytt personopplysningsgrunnlag opprettes.
+                 * Dette gjør vi fordi det kan ha blitt introdusert personer med fortrolig adresse.
+                 */
                 arbeidsfordelingService.fastsettBehandlendeEnhet(
                     behandling = behandling,
                 )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -42,6 +42,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
@@ -72,6 +73,7 @@ class PersongrunnlagService(
     private val kodeverkService: KodeverkService,
     private val featureToggleService: FeatureToggleService,
     private val falskIdentitetService: FalskIdentitetService,
+    private val strengtFortroligService: StrengtFortroligService,
 ) {
     fun mapTilPersonDtoMedStatsborgerskapLand(
         person: Person,
@@ -251,7 +253,24 @@ class PersongrunnlagService(
         val nyttPersonopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
 
         val alleBarna = barnFraInneværendeBehandling.union(barnFraForrigeBehandling).toList()
-        val eldsteBarnsFødselsdato = finnEldstebarnsFødselsdato(alleBarna)
+
+        // Skjermede barn (kode 6/19) uten løpende andeler som saksbehandler mangler tilgang til
+        // kopieres fra forrige vedtatte persongrunnlag i stedet for å hentes fra PDL (som vil feile).
+        val sisteBehandlingSomErVedtatt = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+        val aktørerSomSkalKopieres: Set<Aktør> =
+            if (sisteBehandlingSomErVedtatt != null) {
+                strengtFortroligService
+                    .finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(behandling.fagsak)
+                    .filter { it in alleBarna }
+                    .toSet()
+            } else {
+                emptySet()
+            }
+        val forrigePersongrunnlag: PersonopplysningGrunnlag? =
+            if (aktørerSomSkalKopieres.isNotEmpty()) hentAktivThrows(sisteBehandlingSomErVedtatt!!.id) else null
+
+        val barnSomSkalHentesFraPdl = alleBarna.filterNot { it in aktørerSomSkalKopieres }
+        val eldsteBarnsFødselsdato = finnEldstebarnsFødselsdato(alleBarna - aktørerSomSkalKopieres)
 
         val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
 
@@ -273,7 +292,7 @@ class PersongrunnlagService(
             )
         nyttPersonopplysningGrunnlag.personer.add(søker)
 
-        alleBarna.forEach { barnsAktør ->
+        barnSomSkalHentesFraPdl.forEach { barnsAktør ->
             nyttPersonopplysningGrunnlag.personer.add(
                 hentPerson(
                     aktør = barnsAktør,
@@ -285,6 +304,14 @@ class PersongrunnlagService(
                     skalHenteEnkelPersonInfo = skalHenteEnkelPersonInfo,
                     eldsteBarnsFødselsdato = eldsteBarnsFødselsdato,
                 ),
+            )
+        }
+
+        aktørerSomSkalKopieres.forEach { skjermetAktør ->
+            val personFraForrige = forrigePersongrunnlag!!.personer.firstOrNull { it.aktør == skjermetAktør }
+                ?: throw Feil("Fant ikke skjermet barn ${skjermetAktør.aktørId} i forrige persongrunnlag ${forrigePersongrunnlag.id}")
+            nyttPersonopplysningGrunnlag.personer.add(
+                personFraForrige.tilKopiForNyttPersonopplysningGrunnlag(nyttPersonopplysningGrunnlag),
             )
         }
 
@@ -313,7 +340,9 @@ class PersongrunnlagService(
                      * For sikkerhetsskyld fastsetter vi alltid behandlende enhet når nytt personopplysningsgrunnlag opprettes.
                      * Dette gjør vi fordi det kan ha blitt introdusert personer med fortrolig adresse.
                      */
-                arbeidsfordelingService.fastsettBehandlendeEnhet(behandling)
+                arbeidsfordelingService.fastsettBehandlendeEnhet(
+                    behandling = behandling,
+                )
                 saksstatistikkEventPublisher.publiserSaksstatistikk(behandling.fagsak.id)
             }
         } else {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggController.kt
@@ -31,7 +31,7 @@ class LoggController(
         return Result
             .runCatching {
                 val logger = loggService.hentLoggForBehandling(behandlingId)
-                strengtFortroligService.filtrerLoggForStrengtFortroligeBarn(logger, behandlingId)
+                strengtFortroligService.anonymiserLoggForStrengtFortroligeBarn(logger, behandlingId)
             }.fold(
                 onSuccess = { ResponseEntity.ok(Ressurs.success(it)) },
                 onFailure = {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
@@ -155,7 +155,7 @@ class StrengtFortroligService(
     }
 
     /**
-     * Anonymiserer vekk vedtaksperioder som inneholder utbetalingsdetaljer for skjermede barn
+     * Anonymiserer vekk vedtaksperioder som inneholder utbetalingsdetaljer for skjermede barn uten løpende andeler
      * som saksbehandler ikke har tilgang til.
      */
     fun anonymiserSkjermetBarnIVedtaksperioder(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ba.sak.kjerne.strengtfortrolig
 
-import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.PersonDto
@@ -9,10 +8,9 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasj
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.barn
 import no.nav.familie.ba.sak.kjerne.logg.Logg
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.Identkonverterer
 import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelserDto
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -34,9 +32,10 @@ class StrengtFortroligService(
      */
     fun anonymiserStrengtFortroligBarn(
         utvidetBehandlingDto: UtvidetBehandlingDto,
-        behandlingId: Long,
+        fagsak: Fagsak,
     ): UtvidetBehandlingDto {
-        val barnMedStrengtFortroligKodeSomSkalAnonymiseres = hentBarnMedStrengtFortroligKodeSomSkalAnonymiseres(behandlingId).takeIf { it.isNotEmpty() } ?: return utvidetBehandlingDto
+        val barnMedStrengtFortroligKodeSomSkalAnonymiseres =
+            hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak).takeIf { it.isNotEmpty() } ?: return utvidetBehandlingDto
 
         val anonymiserteNavnForIdent =
             barnMedStrengtFortroligKodeSomSkalAnonymiseres
@@ -126,14 +125,16 @@ class StrengtFortroligService(
     }
 
     /**
-     * Filtrerer bort logginnslag som inneholder personident eller navn til strengt fortrolige barn
+     * Anonymiserer logginnslag som inneholder personident eller navn til strengt fortrolige barn
      * som saksbehandler ikke har tilgang til.
      */
-    fun filtrerLoggForStrengtFortroligeBarn(
+    fun anonymiserLoggForStrengtFortroligeBarn(
         logger: List<Logg>,
         behandlingId: Long,
     ): List<Logg> {
-        val barnMedStrengtFortroligKodeSomSkalAnonymiseres = hentBarnMedStrengtFortroligKodeSomSkalAnonymiseres(behandlingId)
+        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
+        val barnMedStrengtFortroligKodeSomSkalAnonymiseres = hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(behandling.fagsak)
+
         if (barnMedStrengtFortroligKodeSomSkalAnonymiseres.isEmpty()) return logger
 
         val forbudteLogg =
@@ -154,14 +155,14 @@ class StrengtFortroligService(
     }
 
     /**
-     * Filtrerer vekk vedtaksperioder som inneholder utbetalingsdetaljer for skjermede barn
+     * Anonymiserer vekk vedtaksperioder som inneholder utbetalingsdetaljer for skjermede barn
      * som saksbehandler ikke har tilgang til.
      */
-    fun filtrerVekkVedtaksperioderMedSkjermetBarn(
+    fun anonymiserSkjermetBarnIVedtaksperioder(
         vedtaksperioder: List<UtvidetVedtaksperiodeMedBegrunnelserDto>,
-        behandlingId: Long,
+        fagsak: Fagsak,
     ): List<UtvidetVedtaksperiodeMedBegrunnelserDto> {
-        val skjermedeIdenter = hentBarnMedStrengtFortroligKodeSomSkalAnonymiseres(behandlingId)
+        val skjermedeIdenter = hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
         if (skjermedeIdenter.isEmpty()) return vedtaksperioder
 
         return vedtaksperioder.filterNot { periode ->
@@ -170,39 +171,22 @@ class StrengtFortroligService(
     }
 
     /**
-     * Sjekker om saksbehandler har tilgang til alle personer, eller om de eneste personene
-     * saksbehandler mangler tilgang til er skjermede barn uten løpende andeler.
+     * Sjekker om de eneste personene saksbehandler mangler tilgang til er skjermede barn uten
+     * løpende andeler. Når dette er tilfelle, kan saksbehandler likevel slippe gjennom
+     * tilgangskontrollen siden disse barna anonymiseres.
      */
-    fun harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
-        fagsakId: Long,
-        personIdenter: List<String>,
-        søker: Aktør,
+    fun saksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndeler(
+        fagsak: Fagsak,
+        tilgangerTilPersoner: List<Tilgang>,
     ): Boolean {
-        val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenter)
-        if (tilgangerTilPersoner.all { it.harTilgang }) return true
+        val personerSaksbehandlerIkkeHarTilgangTil =
+            tilgangerTilPersoner.filterNot { it.harTilgang }.map { it.personIdent }.toSet()
 
-        val personerSaksbehandlerIkkeHarTilgangTil = tilgangerTilPersoner.filterNot { it.harTilgang }.map { it.personIdent }.toSet()
-        val skjermedeBarnUtenAndeler = hentSkjermedeBarnUtenLøpendeAndeler(fagsakId, tilgangerTilPersoner, søker)
+        if (personerSaksbehandlerIkkeHarTilgangTil.isEmpty()) return false
 
-        return personerSaksbehandlerIkkeHarTilgangTil == skjermedeBarnUtenAndeler
-    }
+        val skjermedeBarnUtenLøpendeAndeler = hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
 
-    fun finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak: Fagsak): Set<Aktør> {
-        if (SikkerhetContext.erSystemKontekst()) return emptySet()
-
-        val søkerOgBarn = personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id).takeIf { it.isNotEmpty() } ?: return emptySet()
-        val søker =
-            søkerOgBarn.firstOrNull { it.type == PersonType.SØKER }?.aktør
-                ?: fagsak.skjermetBarnSøker?.aktør
-                ?: fagsak.aktør
-
-        val tilgangerTilPersoner = sjekkTilgangTilPersoner(søkerOgBarn.map { it.aktør.aktivFødselsnummer() })
-        val skjermedeIdenter = hentSkjermedeBarnUtenLøpendeAndeler(fagsak.id, tilgangerTilPersoner, søker)
-
-        return søkerOgBarn
-            .filter { it.aktør.aktivFødselsnummer() in skjermedeIdenter }
-            .map { it.aktør }
-            .toSet()
+        return personerSaksbehandlerIkkeHarTilgangTil.all { it in skjermedeBarnUtenLøpendeAndeler }
     }
 
     fun harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak: Fagsak): Boolean {
@@ -218,65 +202,47 @@ class StrengtFortroligService(
             .isNotEmpty()
     }
 
-    private fun hentBarnMedStrengtFortroligKodeSomSkalAnonymiseres(behandlingId: Long): Set<String> {
-        val behandling = behandlingHentOgPersisterService.hent(behandlingId)
-        val personerPåBehandling = personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilAktiv(behandlingId).takeIf { it.isNotEmpty() }
-        val søker = behandling.fagsak.skjermetBarnSøker?.aktør ?: behandling.fagsak.aktør
+    fun hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(
+        fagsak: Fagsak,
+    ): Set<String> {
+        if (SikkerhetContext.erSystemKontekst()) return emptySet()
 
-        val personIdenter =
-            personerPåBehandling
-                ?.map { it.aktør.aktivFødselsnummer() }
-                ?: listOf(behandling.fagsak.aktør.aktivFødselsnummer())
+        if (!featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER)) {
+            return emptySet()
+        }
 
-        val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenter)
+        val barnIdenter =
+            personopplysningGrunnlagRepository
+                .finnSøkerOgBarnAktørerTilFagsak(fagsak.id)
+                .barn()
+                .map { it.aktør.aktivFødselsnummer() }
+                .ifEmpty { return emptySet() }
 
-        return hentSkjermedeBarnUtenLøpendeAndeler(behandling.fagsak.id, tilgangerTilPersoner, søker)
+        val tilgangerTilBarn = sjekkTilgangTilPersoner(barnIdenter)
+
+        val barnSaksbehandlerIkkeHarTilgangTilGrunnetStrengtFortrolig =
+            tilgangerTilBarn
+                .filterNot { it.harTilgang }
+                .takeIf { it.isNotEmpty() && it.all { p -> p.begrunnelse?.contains(BEGRUNNELSE_STRENGT_FORTROLIG) == true } }
+                ?.map { it.personIdent }
+                ?: return emptySet()
+
+        val sisteVedtatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) ?: return emptySet()
+        val andelerPåBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteVedtatteBehandling.id)
+
+        val skjermedeBarnSomHarAndelerMenIngenLøpende =
+            barnSaksbehandlerIkkeHarTilgangTilGrunnetStrengtFortrolig.filter { ident ->
+                val barnetsAndeler = andelerPåBehandling.filter { it.aktør.aktivFødselsnummer() == ident }
+                barnetsAndeler.isNotEmpty() && barnetsAndeler.none { it.erLøpende() }
+            }
+
+        return skjermedeBarnSomHarAndelerMenIngenLøpende.toSet()
     }
 
     private fun sjekkTilgangTilPersoner(personIdenter: List<String>): List<Tilgang> =
         familieIntegrasjonerTilgangskontrollService
             .sjekkTilgangTilPersoner(personIdenter)
             .map { it.value }
-
-    private fun hentSkjermedeBarnUtenLøpendeAndeler(
-        fagsakId: Long,
-        tilgangerTilPersoner: List<Tilgang>,
-        søker: Aktør,
-    ): Set<String> {
-        if (!featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER)) {
-            return emptySet()
-        }
-
-        if (tilgangerTilPersoner.none { it.harTilgang && it.personIdent == søker.aktivFødselsnummer() }) {
-            return emptySet()
-        }
-
-        val barnUtenStrengtFortroligTilgang =
-            tilgangerTilPersoner
-                .filterNot { it.harTilgang }
-                .takeIf { it.isNotEmpty() && it.all { p -> p.begrunnelse?.contains(BEGRUNNELSE_STRENGT_FORTROLIG) == true } }
-                ?.map { it.personIdent }
-                ?: return emptySet()
-
-        val sisteVedtatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId) ?: return emptySet()
-        val andelerPåBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteVedtatteBehandling.id)
-
-        val alleSkjermedeBarnHarAndelerMenIngenLøpende =
-            barnUtenStrengtFortroligTilgang.all { ident ->
-                val barnetsAndeler = andelerPåBehandling.filter { it.aktør.aktivFødselsnummer() == ident }
-                barnetsAndeler.none { it.erLøpende() }
-            }
-
-        if (alleSkjermedeBarnHarAndelerMenIngenLøpende) {
-            secureLogger.info(
-                "Tillater tilgang til fagsak=$fagsakId for saksbehandler=${SikkerhetContext.hentSaksbehandler()}. " +
-                    "Saksbehandler har ikke tilgang til personer med strengt fortrolig adresse, men barn som er skjermet har ikke lenger løpende andeler",
-            )
-            return barnUtenStrengtFortroligTilgang.toSet()
-        }
-
-        return emptySet()
-    }
 
     private fun PersonDto.anonymiser(anonymisertNavn: String) =
         copy(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
@@ -264,7 +264,7 @@ class StrengtFortroligService(
         val alleSkjermedeBarnHarAndelerMenIngenLøpende =
             barnUtenStrengtFortroligTilgang.all { ident ->
                 val barnetsAndeler = andelerPåBehandling.filter { it.aktør.aktivFødselsnummer() == ident }
-                 barnetsAndeler.none { it.erLøpende() }
+                barnetsAndeler.none { it.erLøpende() }
             }
 
         if (alleSkjermedeBarnHarAndelerMenIngenLøpende) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
@@ -9,10 +9,12 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.FamilieIntegrasj
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.logg.Logg
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.personident.Identkonverterer
+import no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelserDto
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import org.springframework.stereotype.Service
@@ -21,7 +23,7 @@ import java.time.LocalDate
 @Service
 class StrengtFortroligService(
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
-    private val persongrunnlagService: PersongrunnlagService,
+    private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val familieIntegrasjonerTilgangskontrollService: FamilieIntegrasjonerTilgangskontrollService,
     private val featureToggleService: FeatureToggleService,
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
@@ -152,14 +154,31 @@ class StrengtFortroligService(
     }
 
     /**
+     * Filtrerer vekk vedtaksperioder som inneholder utbetalingsdetaljer for skjermede barn
+     * som saksbehandler ikke har tilgang til.
+     */
+    fun filtrerVekkVedtaksperioderMedSkjermetBarn(
+        vedtaksperioder: List<UtvidetVedtaksperiodeMedBegrunnelserDto>,
+        behandlingId: Long,
+    ): List<UtvidetVedtaksperiodeMedBegrunnelserDto> {
+        val skjermedeIdenter = hentBarnMedStrengtFortroligKodeSomSkalAnonymiseres(behandlingId)
+        if (skjermedeIdenter.isEmpty()) return vedtaksperioder
+
+        return vedtaksperioder.filterNot { periode ->
+            periode.utbetalingsperiodeDetaljer.any { it.person.personIdent in skjermedeIdenter }
+        }
+    }
+
+    /**
      * Sjekker om saksbehandler har tilgang til alle personer, eller om de eneste personene
      * saksbehandler mangler tilgang til er skjermede barn uten løpende andeler.
      */
     fun harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
         fagsakId: Long,
-        tilgangerTilPersoner: List<Tilgang>,
+        personIdenter: List<String>,
         søker: Aktør,
     ): Boolean {
+        val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenter)
         if (tilgangerTilPersoner.all { it.harTilgang }) return true
 
         val personerSaksbehandlerIkkeHarTilgangTil = tilgangerTilPersoner.filterNot { it.harTilgang }.map { it.personIdent }.toSet()
@@ -168,10 +187,29 @@ class StrengtFortroligService(
         return personerSaksbehandlerIkkeHarTilgangTil == skjermedeBarnUtenAndeler
     }
 
+    fun finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak: Fagsak): Set<Aktør> {
+        if (SikkerhetContext.erSystemKontekst()) return emptySet()
+
+        val søkerOgBarn = personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id).takeIf { it.isNotEmpty() } ?: return emptySet()
+        val søker =
+            søkerOgBarn.firstOrNull { it.type == PersonType.SØKER }?.aktør
+                ?: fagsak.skjermetBarnSøker?.aktør
+                ?: fagsak.aktør
+
+        val tilgangerTilPersoner = sjekkTilgangTilPersoner(søkerOgBarn.map { it.aktør.aktivFødselsnummer() })
+        val skjermedeIdenter = hentSkjermedeBarnUtenLøpendeAndeler(fagsak.id, tilgangerTilPersoner, søker)
+
+        return søkerOgBarn
+            .filter { it.aktør.aktivFødselsnummer() in skjermedeIdenter }
+            .map { it.aktør }
+            .toSet()
+    }
+
     fun harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak: Fagsak): Boolean {
         val identer =
-            persongrunnlagService
-                .hentSøkerOgBarnPåFagsak(fagsak.id)
+            personopplysningGrunnlagRepository
+                .finnSøkerOgBarnAktørerTilFagsak(fagsak.id)
+                .takeIf { it.isNotEmpty() }
                 ?.map { it.aktør.aktivFødselsnummer() }
                 ?: listOf(fagsak.skjermetBarnSøker?.aktør?.aktivFødselsnummer() ?: fagsak.aktør.aktivFødselsnummer())
 
@@ -182,7 +220,7 @@ class StrengtFortroligService(
 
     private fun hentBarnMedStrengtFortroligKodeSomSkalAnonymiseres(behandlingId: Long): Set<String> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
-        val personerPåBehandling = persongrunnlagService.hentSøkerOgBarnPåBehandling(behandlingId)
+        val personerPåBehandling = personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilAktiv(behandlingId).takeIf { it.isNotEmpty() }
         val søker = behandling.fagsak.skjermetBarnSøker?.aktør ?: behandling.fagsak.aktør
 
         val personIdenter =
@@ -220,13 +258,13 @@ class StrengtFortroligService(
                 ?.map { it.personIdent }
                 ?: return emptySet()
 
-        val sisteIverksatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsakId) ?: return emptySet()
-        val andelerPåBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id)
+        val sisteVedtatteBehandling = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId) ?: return emptySet()
+        val andelerPåBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteVedtatteBehandling.id)
 
         val alleSkjermedeBarnHarAndelerMenIngenLøpende =
             barnUtenStrengtFortroligTilgang.all { ident ->
                 val barnetsAndeler = andelerPåBehandling.filter { it.aktør.aktivFødselsnummer() == ident }
-                barnetsAndeler.isNotEmpty() && barnetsAndeler.none { it.erLøpende() }
+                 barnetsAndeler.none { it.erLøpende() }
             }
 
         if (alleSkjermedeBarnHarAndelerMenIngenLøpende) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -358,7 +358,7 @@ class VedtaksperiodeService(
 
         val skalMinimeres = behandling.status != BehandlingStatus.UTREDES
 
-        val filtrerteVedtaksperioder = strengtFortroligService.filtrerVekkVedtaksperioderMedSkjermetBarn(vedtaksperioder, behandlingId)
+        val filtrerteVedtaksperioder = strengtFortroligService.anonymiserSkjermetBarnIVedtaksperioder(vedtaksperioder, behandling.fagsak)
 
         return if (skalMinimeres) {
             filtrerteVedtaksperioder

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform.NN
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
+import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
 import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.kjerne.vedtak.begrunnelser.EØSStandardbegrunnelse
@@ -82,6 +83,7 @@ class VedtaksperiodeService(
     private val valutakursRepository: ValutakursRepository,
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
     private val featureToggleService: FeatureToggleService,
+    private val strengtFortroligService: StrengtFortroligService,
 ) {
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,
@@ -356,12 +358,14 @@ class VedtaksperiodeService(
 
         val skalMinimeres = behandling.status != BehandlingStatus.UTREDES
 
+        val filtrerteVedtaksperioder = strengtFortroligService.filtrerVekkVedtaksperioderMedSkjermetBarn(vedtaksperioder, behandlingId)
+
         return if (skalMinimeres) {
-            vedtaksperioder
+            filtrerteVedtaksperioder
                 .filter { it.begrunnelser.isNotEmpty() }
                 .map { it.copy(gyldigeBegrunnelser = emptyList()) }
         } else {
-            vedtaksperioder
+            filtrerteVedtaksperioder
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -94,7 +94,6 @@ class TilgangService(
     ) {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val personerPåBehandling = persongrunnlagService.hentSøkerOgBarnPåBehandling(behandlingId)
-        val søker = behandling.fagsak.skjermetBarnSøker?.aktør ?: behandling.fagsak.aktør
 
         val personIdenter =
             personerPåBehandling
@@ -115,7 +114,7 @@ class TilgangService(
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenter)
 
-        if (!strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(behandling.fagsak.id, personIdenter, søker)) {
+        if (tilgangerTilPersoner.any { !it.harTilgang } && !strengtFortroligService.saksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndeler(behandling.fagsak, tilgangerTilPersoner)) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
             throw RolleTilgangskontrollFeil(
                 melding =
@@ -132,7 +131,6 @@ class TilgangService(
     ) {
         val aktør = fagsakService.hentAktør(fagsakId)
         val fagsak = fagsakService.hentPåFagsakId(fagsakId)
-        val søker = fagsak.skjermetBarnSøker?.aktør ?: fagsak.aktør
 
         val personerPåFagsak = persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsakId)
         val personIdenterIFagsak =
@@ -156,7 +154,9 @@ class TilgangService(
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenterIFagsak)
 
-        if (!strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak.id, personIdenterIFagsak, søker)) {
+        if (tilgangerTilPersoner.any { !it.harTilgang } &&
+            !strengtFortroligService.saksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak, tilgangerTilPersoner)
+        ) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
             throw RolleTilgangskontrollFeil(
                 melding =

--- a/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangService.kt
@@ -115,7 +115,7 @@ class TilgangService(
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenter)
 
-        if (!strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(behandling.fagsak.id, tilgangerTilPersoner, søker)) {
+        if (!strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(behandling.fagsak.id, personIdenter, søker)) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
             throw RolleTilgangskontrollFeil(
                 melding =
@@ -156,7 +156,7 @@ class TilgangService(
 
         val tilgangerTilPersoner = sjekkTilgangTilPersoner(personIdenterIFagsak)
 
-        if (!strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak.id, tilgangerTilPersoner, søker)) {
+        if (!strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak.id, personIdenterIFagsak, søker)) {
             val adressebeskyttelsegraderingEllerNavAnsatt = tilgangerTilPersoner.tilBegrunnelserForManglendeTilgang()
             throw RolleTilgangskontrollFeil(
                 melding =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -80,6 +80,7 @@ import no.nav.familie.ba.sak.kjerne.steg.VilkårsvurderingSteg
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.EøsSkjemaerForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.PersonopplysningGrunnlagForNyBehandlingService
 import no.nav.familie.ba.sak.kjerne.steg.grunnlagForNyBehandling.VilkårsvurderingForNyBehandlingService
+import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
 import no.nav.familie.ba.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakService
 import no.nav.familie.ba.sak.kjerne.vedtak.tilbakekrevingsvedtakmotregning.TilbakekrevingsvedtakMotregningBrevService
@@ -271,6 +272,9 @@ class CucumberMock(
             valutakursRepository = valutakursRepository,
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             featureToggleService = featureToggleService,
+            strengtFortroligService = mockk<StrengtFortroligService>().also {
+                every { it.filtrerVekkVedtaksperioderMedSkjermetBarn(any(), any()) } answers { firstArg() }
+            },
         )
 
     val behandlingService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -274,7 +274,7 @@ class CucumberMock(
             featureToggleService = featureToggleService,
             strengtFortroligService =
                 mockk<StrengtFortroligService>().also {
-                    every { it.filtrerVekkVedtaksperioderMedSkjermetBarn(any(), any()) } answers { firstArg() }
+                    every { it.anonymiserSkjermetBarnIVedtaksperioder(any(), any()) } answers { firstArg() }
                 },
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -272,9 +272,10 @@ class CucumberMock(
             valutakursRepository = valutakursRepository,
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             featureToggleService = featureToggleService,
-            strengtFortroligService = mockk<StrengtFortroligService>().also {
-                every { it.filtrerVekkVedtaksperioderMedSkjermetBarn(any(), any()) } answers { firstArg() }
-            },
+            strengtFortroligService =
+                mockk<StrengtFortroligService>().also {
+                    every { it.filtrerVekkVedtaksperioderMedSkjermetBarn(any(), any()) } answers { firstArg() }
+                },
         )
 
     val behandlingService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -369,8 +369,8 @@ class ArbeidsfordelingServiceTest {
                 Arbeidsfordelingsenhet(enhetId = OSLO.enhetsnummer, enhetNavn = OSLO.enhetsnavn)
 
             every {
-                strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
-            } returns setOf(skjermetBarn.aktør)
+                strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
+            } returns setOf(skjermetBarn.aktør.aktivFødselsnummer())
 
             val arbeidsfordelingPåBehandlingSlot = slot<ArbeidsfordelingPåBehandling>()
             every { arbeidsfordelingPåBehandlingRepository.save(capture(arbeidsfordelingPåBehandlingSlot)) } answers { firstArg() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.NavIdent
@@ -56,6 +57,7 @@ class ArbeidsfordelingServiceTest {
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher = mockk()
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService = mockk()
     private val featureToggleService: FeatureToggleService = mockk()
+    private val strengtFortroligService: StrengtFortroligService = mockk(relaxed = true)
 
     private val arbeidsfordelingService: ArbeidsfordelingService =
         ArbeidsfordelingService(
@@ -69,6 +71,7 @@ class ArbeidsfordelingServiceTest {
             saksstatistikkEventPublisher = saksstatistikkEventPublisher,
             tilpassArbeidsfordelingService = tilpassArbeidsfordelingService,
             featureToggleService = featureToggleService,
+            strengtFortroligService = strengtFortroligService,
         )
 
     @Nested
@@ -342,6 +345,48 @@ class ArbeidsfordelingServiceTest {
             val arbeidsfordelingPåBehandling = arbeidsfordelingPåBehandlingSlot.captured
             assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetId).isEqualTo(BarnetrygdEnhet.DRAMMEN.enhetsnummer)
             assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetNavn).isEqualTo(BarnetrygdEnhet.DRAMMEN.enhetsnavn)
+        }
+        @Test
+        fun `fastsettBehandlendeEnhet skal ekskludere skjermede barn uten løpende andeler slik at enheten ikke blir Vikafossen`() {
+            // Arrange
+            val søker = lagPerson()
+            val skjermetBarn = lagPerson(type = PersonType.BARN)
+            val fagsak = lagFagsak(aktør = søker.aktør)
+            val forrigeBehandling = lagBehandling(fagsak = fagsak)
+            val behandling = lagBehandling(fagsak = fagsak, behandlingType = BehandlingType.REVURDERING)
+
+            every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(any()) } returns null
+
+            every {
+                personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilAktiv(behandling.id)
+            } returns listOf(lagPersonEnkel(PersonType.SØKER, søker.aktør), lagPersonEnkel(PersonType.BARN, skjermetBarn.aktør))
+
+            every { personopplysningerService.hentPdlPersonInfoEnkel(søker.aktør) } returns PdlPersonInfo.Person(lagPersonInfo())
+
+            every { integrasjonKlient.hentBehandlendeEnhet(søker.aktør.aktivFødselsnummer(), any()) } returns
+                listOf(Arbeidsfordelingsenhet(enhetId = OSLO.enhetsnummer, enhetNavn = OSLO.enhetsnavn))
+
+            every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(any(), any()) } returns
+                Arbeidsfordelingsenhet(enhetId = OSLO.enhetsnummer, enhetNavn = OSLO.enhetsnavn)
+
+            every {
+                strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+            } returns setOf(skjermetBarn.aktør)
+
+            val arbeidsfordelingPåBehandlingSlot = slot<ArbeidsfordelingPåBehandling>()
+            every { arbeidsfordelingPåBehandlingRepository.save(capture(arbeidsfordelingPåBehandlingSlot)) } answers { firstArg() }
+
+            // Act
+            arbeidsfordelingService.fastsettBehandlendeEnhet(
+                behandling = behandling,
+                sisteBehandlingSomErIverksatt = forrigeBehandling,
+            )
+
+            // Assert
+            verify(exactly = 0) { personopplysningerService.hentPdlPersonInfoEnkel(skjermetBarn.aktør) }
+            verify(exactly = 0) { integrasjonKlient.hentBehandlendeEnhet(skjermetBarn.aktør.aktivFødselsnummer(), any()) }
+            assertThat(arbeidsfordelingPåBehandlingSlot.captured.behandlendeEnhetId).isEqualTo(OSLO.enhetsnummer)
+            assertThat(arbeidsfordelingPåBehandlingSlot.captured.behandlendeEnhetId).isNotEqualTo(BarnetrygdEnhet.VIKAFOSSEN.enhetsnummer)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -56,7 +56,6 @@ class ArbeidsfordelingServiceTest {
     private val personopplysningerService: PersonopplysningerService = mockk()
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher = mockk()
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService = mockk()
-    private val featureToggleService: FeatureToggleService = mockk()
     private val strengtFortroligService: StrengtFortroligService = mockk(relaxed = true)
 
     private val arbeidsfordelingService: ArbeidsfordelingService =
@@ -70,7 +69,6 @@ class ArbeidsfordelingServiceTest {
             personopplysningerService = personopplysningerService,
             saksstatistikkEventPublisher = saksstatistikkEventPublisher,
             tilpassArbeidsfordelingService = tilpassArbeidsfordelingService,
-            featureToggleService = featureToggleService,
             strengtFortroligService = strengtFortroligService,
         )
 
@@ -346,6 +344,7 @@ class ArbeidsfordelingServiceTest {
             assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetId).isEqualTo(BarnetrygdEnhet.DRAMMEN.enhetsnummer)
             assertThat(arbeidsfordelingPåBehandling.behandlendeEnhetNavn).isEqualTo(BarnetrygdEnhet.DRAMMEN.enhetsnavn)
         }
+
         @Test
         fun `fastsettBehandlendeEnhet skal ekskludere skjermede barn uten løpende andeler slik at enheten ikke blir Vikafossen`() {
             // Arrange

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagServiceTest.kt
@@ -69,12 +69,14 @@ class PersongrunnlagServiceTest {
                 kodeverkService = kodeverkService,
                 featureToggleService = featureToggleService,
                 falskIdentitetService = falskIdentitetService,
+                strengtFortroligService = mockk(relaxed = true),
             ),
         )
 
     @BeforeEach
     fun setup() {
         every { featureToggleService.isEnabled(FeatureToggle.FILTRERE_REGISTEROPPLYSNINGER) } returns true
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns null
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
@@ -83,11 +83,11 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest {
 
             every {
                 persongrunnlagService.hentOgLagreSøkerOgBarnINyttGrunnlag(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
+                    aktør = any(),
+                    barnFraInneværendeBehandling = any(),
+                    behandling = any(),
+                    målform = any(),
+                    barnFraForrigeBehandling = any(),
                 )
             } returns PersonopplysningGrunnlag(behandlingId = behandling.id)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligServiceTest.kt
@@ -32,13 +32,14 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.logg.Logg
 import no.nav.familie.ba.sak.kjerne.logg.LoggType
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService.Companion.BEGRUNNELSE_STRENGT_FORTROLIG
 import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService.Companion.SKJERMET_BARN
 import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService.Companion.SKJERMET_BARN_FØDSELSDATO
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.util.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.ba.sak.util.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
@@ -53,7 +54,7 @@ import java.time.YearMonth
 
 class StrengtFortroligServiceTest {
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
-    private val persongrunnlagService: PersongrunnlagService = mockk()
+    private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository = mockk()
     private val familieIntegrasjonerTilgangskontrollService: FamilieIntegrasjonerTilgangskontrollService = mockk()
     private val featureToggleService: FeatureToggleService = mockk()
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository = mockk()
@@ -61,7 +62,7 @@ class StrengtFortroligServiceTest {
     private val strengtFortroligService =
         StrengtFortroligService(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
-            persongrunnlagService = persongrunnlagService,
+            personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
             familieIntegrasjonerTilgangskontrollService = familieIntegrasjonerTilgangskontrollService,
             featureToggleService = featureToggleService,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
@@ -78,19 +79,12 @@ class StrengtFortroligServiceTest {
         mockBrukerContext("testbruker")
         every { featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER) } returns true
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
-        every { persongrunnlagService.hentSøkerOgBarnPåBehandling(behandling.id) } returns
+        every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilAktiv(behandling.id) } returns
             listOf(
                 PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
                 PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
             )
-        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(fagsak.id) } returns sisteIverksatteBehandling
-        every { persongrunnlagService.hentBarna(behandling.id) } returns
-            listOf(
-                mockk<Person> {
-                    every { aktør } returns barnAktør
-                    every { navn } returns "Barn med diskresjonskode"
-                },
-            )
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns sisteIverksatteBehandling
     }
 
     @AfterEach
@@ -226,22 +220,19 @@ class StrengtFortroligServiceTest {
 
     @Nested
     inner class HarTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndelerTest {
+        private val personIdenter = listOf(søkerAktør.aktivFødselsnummer(), barnAktør.aktivFødselsnummer())
+
         @Test
         fun `skal returnere false når skjermet barn aldri har hatt andeler`() {
             // Arrange
+            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
             mockBarnUtenAndeler()
-
-            val tilganger =
-                listOf(
-                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
-                    Tilgang(barnAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
-                )
 
             // Act
             val resultat =
                 strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
                     fagsak.id,
-                    tilganger,
+                    personIdenter,
                     søkerAktør,
                 )
 
@@ -252,19 +243,14 @@ class StrengtFortroligServiceTest {
         @Test
         fun `skal returnere true når skjermet barn har hatt andeler som ikke lenger er løpende`() {
             // Arrange
+            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
             mockBarnUtenLøpendeAndeler()
-
-            val tilganger =
-                listOf(
-                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
-                    Tilgang(barnAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
-                )
 
             // Act
             val resultat =
                 strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
                     fagsak.id,
-                    tilganger,
+                    personIdenter,
                     søkerAktør,
                 )
 
@@ -275,17 +261,13 @@ class StrengtFortroligServiceTest {
         @Test
         fun `skal returnere true når saksbehandler har tilgang til alle personer`() {
             // Arrange
-            val tilganger =
-                listOf(
-                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
-                    Tilgang(barnAktør.aktivFødselsnummer(), true),
-                )
+            mockSaksbehandlerHarTilgangTilAllePersoner()
 
             // Act
             val resultat =
                 strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
                     fagsak.id,
-                    tilganger,
+                    personIdenter,
                     søkerAktør,
                 )
 
@@ -296,6 +278,7 @@ class StrengtFortroligServiceTest {
         @Test
         fun `skal returnere false når skjermet barn har løpende andeler og saksbehandler ikke har tilgang til barn`() {
             // Arrange
+            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns
                 listOf(
                     lagAndelTilkjentYtelse(
@@ -306,17 +289,11 @@ class StrengtFortroligServiceTest {
                     ),
                 )
 
-            val tilganger =
-                listOf(
-                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
-                    Tilgang(barnAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
-                )
-
             // Act
             val resultat =
                 strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
                     fagsak.id,
-                    tilganger,
+                    personIdenter,
                     søkerAktør,
                 )
 
@@ -324,6 +301,171 @@ class StrengtFortroligServiceTest {
             assertThat(resultat).isFalse()
         }
     }
+
+    @Nested
+    inner class FinnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsakTest {
+        @Test
+        fun `skal returnere tomt sett når saksbehandler har tilgang til alle personer`() {
+            // Arrange
+            mockSaksbehandlerHarTilgangTilAllePersoner()
+            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns
+                setOf(
+                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
+                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
+                )
+
+            // Act
+            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+
+            // Assert
+            assertThat(resultat).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere aktør for skjermet barn uten løpende andeler`() {
+            // Arrange
+            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
+            mockBarnUtenLøpendeAndeler()
+            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns
+                setOf(
+                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
+                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
+                )
+
+            // Act
+            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+
+            // Assert
+            assertThat(resultat).containsExactly(barnAktør)
+        }
+
+        @Test
+        fun `skal returnere tomt sett når skjermet barn fortsatt har løpende andeler`() {
+            // Arrange
+            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
+            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns
+                setOf(
+                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
+                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
+                )
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2023, 1),
+                        tom = YearMonth.of(2099, 12),
+                        behandling = sisteIverksatteBehandling,
+                        aktør = barnAktør,
+                    ),
+                )
+
+            // Act
+            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+
+            // Assert
+            assertThat(resultat).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere tomt sett når fagsaken ikke har noe persongrunnlag`() {
+            // Arrange
+            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns emptySet()
+
+            // Act
+            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+
+            // Assert
+            assertThat(resultat).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere tomt sett når kallet er systemkjøring`() {
+            // Arrange
+            clearBrukerContext()
+            mockBrukerContext(SikkerhetContext.SYSTEM_FORKORTELSE)
+
+            // Act
+            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+
+            // Assert
+            assertThat(resultat).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class FiltrerVekkVedtaksperioderMedSkjermetBarnTest {
+        @Test
+        fun `skal filtrere vekk perioder som inneholder skjermet barn`() {
+            // Arrange
+            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
+            mockBarnUtenLøpendeAndeler()
+
+            val periodeMedSkjermetBarn =
+                lagUtvidetVedtaksperiodeDto(
+                    id = 1L,
+                    identer = listOf(søkerAktør.aktivFødselsnummer(), barnAktør.aktivFødselsnummer()),
+                )
+            val periodeUtenSkjermetBarn =
+                lagUtvidetVedtaksperiodeDto(
+                    id = 2L,
+                    identer = listOf(søkerAktør.aktivFødselsnummer()),
+                )
+
+            // Act
+            val resultat =
+                strengtFortroligService.filtrerVekkVedtaksperioderMedSkjermetBarn(
+                    vedtaksperioder = listOf(periodeMedSkjermetBarn, periodeUtenSkjermetBarn),
+                    behandlingId = behandling.id,
+                )
+
+            // Assert
+            assertThat(resultat).containsExactly(periodeUtenSkjermetBarn)
+        }
+
+        @Test
+        fun `skal ikke filtrere noe når saksbehandler har tilgang til alle personer`() {
+            // Arrange
+            mockSaksbehandlerHarTilgangTilAllePersoner()
+
+            val perioder =
+                listOf(
+                    lagUtvidetVedtaksperiodeDto(id = 1L, identer = listOf(søkerAktør.aktivFødselsnummer(), barnAktør.aktivFødselsnummer())),
+                    lagUtvidetVedtaksperiodeDto(id = 2L, identer = listOf(søkerAktør.aktivFødselsnummer())),
+                )
+
+            // Act
+            val resultat =
+                strengtFortroligService.filtrerVekkVedtaksperioderMedSkjermetBarn(
+                    vedtaksperioder = perioder,
+                    behandlingId = behandling.id,
+                )
+
+            // Assert
+            assertThat(resultat).isEqualTo(perioder)
+        }
+    }
+
+    private fun lagUtvidetVedtaksperiodeDto(
+        id: Long,
+        identer: List<String>,
+    ) = no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelserDto(
+        id = id,
+        fom = LocalDate.of(2023, 1, 1),
+        tom = LocalDate.of(2023, 12, 31),
+        type = no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.Vedtaksperiodetype.UTBETALING,
+        begrunnelser = emptyList(),
+        gyldigeBegrunnelser = emptyList(),
+        utbetalingsperiodeDetaljer =
+            identer.map {
+                no.nav.familie.ba.sak.kjerne.vedtak.vedtaksperiode.UtbetalingsperiodeDetalj(
+                    person = lagPersonDto(it),
+                    ytelseType = no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType.ORDINÆR_BARNETRYGD,
+                    utbetaltPerMnd = 1000,
+                    erPåvirketAvEndring = false,
+                    endringsårsak = null,
+                    prosent = java.math.BigDecimal.valueOf(100),
+                )
+            },
+    )
 
     private fun lagPersonDto(
         personIdent: String,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligServiceTest.kt
@@ -29,7 +29,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Kjønn
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
-import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
@@ -79,8 +78,8 @@ class StrengtFortroligServiceTest {
         mockBrukerContext("testbruker")
         every { featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER) } returns true
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
-        every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilAktiv(behandling.id) } returns
-            listOf(
+        every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns
+            setOf(
                 PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
                 PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
             )
@@ -104,7 +103,7 @@ class StrengtFortroligServiceTest {
                 )
 
             // Act
-            val resultat = strengtFortroligService.anonymiserStrengtFortroligBarn(utvidetBehandlingDto, behandling.id)
+            val resultat = strengtFortroligService.anonymiserStrengtFortroligBarn(utvidetBehandlingDto, fagsak)
 
             // Assert
             assertThat(resultat).isEqualTo(utvidetBehandlingDto)
@@ -146,7 +145,7 @@ class StrengtFortroligServiceTest {
                 )
 
             // Act
-            val resultat = strengtFortroligService.anonymiserStrengtFortroligBarn(utvidetBehandlingDto, behandling.id)
+            val resultat = strengtFortroligService.anonymiserStrengtFortroligBarn(utvidetBehandlingDto, fagsak)
 
             // Assert
             val skjermetBarn = resultat.personer.find { it.type == PersonType.BARN }!!
@@ -190,7 +189,7 @@ class StrengtFortroligServiceTest {
                 )
 
             // Act
-            val resultat = strengtFortroligService.filtrerLoggForStrengtFortroligeBarn(logger, behandling.id)
+            val resultat = strengtFortroligService.anonymiserLoggForStrengtFortroligeBarn(logger, behandling.id)
 
             // Assert
             assertThat(resultat).hasSize(2)
@@ -210,7 +209,7 @@ class StrengtFortroligServiceTest {
                 )
 
             // Act
-            val resultat = strengtFortroligService.filtrerLoggForStrengtFortroligeBarn(logger, behandling.id)
+            val resultat = strengtFortroligService.anonymiserLoggForStrengtFortroligeBarn(logger, behandling.id)
 
             // Assert
             assertThat(resultat).hasSize(2)
@@ -219,64 +218,45 @@ class StrengtFortroligServiceTest {
     }
 
     @Nested
-    inner class HarTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndelerTest {
-        private val personIdenter = listOf(søkerAktør.aktivFødselsnummer(), barnAktør.aktivFødselsnummer())
-
+    inner class SaksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndelerTest {
         @Test
-        fun `skal returnere false når skjermet barn aldri har hatt andeler`() {
+        fun `skal returnere true når saksbehandler kun mangler tilgang til skjermet barn uten løpende andeler`() {
             // Arrange
             mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
-            mockBarnUtenAndeler()
+            mockBarnUtenLøpendeAndeler()
+            val tilganger =
+                listOf(
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
+                )
 
             // Act
             val resultat =
-                strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
-                    fagsak.id,
-                    personIdenter,
-                    søkerAktør,
+                strengtFortroligService.saksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak, tilganger)
+
+            // Assert
+            assertThat(resultat).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false når saksbehandler har tilgang til alle personer`() {
+            // Arrange
+            val tilganger =
+                listOf(
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                    Tilgang(barnAktør.aktivFødselsnummer(), true),
                 )
+
+            // Act
+            val resultat =
+                strengtFortroligService.saksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak, tilganger)
 
             // Assert
             assertThat(resultat).isFalse()
         }
 
         @Test
-        fun `skal returnere true når skjermet barn har hatt andeler som ikke lenger er løpende`() {
-            // Arrange
-            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
-            mockBarnUtenLøpendeAndeler()
-
-            // Act
-            val resultat =
-                strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
-                    fagsak.id,
-                    personIdenter,
-                    søkerAktør,
-                )
-
-            // Assert
-            assertThat(resultat).isTrue()
-        }
-
-        @Test
-        fun `skal returnere true når saksbehandler har tilgang til alle personer`() {
-            // Arrange
-            mockSaksbehandlerHarTilgangTilAllePersoner()
-
-            // Act
-            val resultat =
-                strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
-                    fagsak.id,
-                    personIdenter,
-                    søkerAktør,
-                )
-
-            // Assert
-            assertThat(resultat).isTrue()
-        }
-
-        @Test
-        fun `skal returnere false når skjermet barn har løpende andeler og saksbehandler ikke har tilgang til barn`() {
+        fun `skal returnere false når saksbehandler mangler tilgang til skjermet barn med løpende andeler`() {
             // Arrange
             mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns
@@ -288,14 +268,37 @@ class StrengtFortroligServiceTest {
                         aktør = barnAktør,
                     ),
                 )
+            val tilganger =
+                listOf(
+                    Tilgang(søkerAktør.aktivFødselsnummer(), true),
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
+                )
 
             // Act
             val resultat =
-                strengtFortroligService.harTilgangTilAllePersonerEllerKunManglendeTilgangTilSkjermedeBarnUtenLøpendeAndeler(
-                    fagsak.id,
-                    personIdenter,
-                    søkerAktør,
+                strengtFortroligService.saksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak, tilganger)
+
+            // Assert
+            assertThat(resultat).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false når saksbehandler mangler tilgang til søker`() {
+            // Arrange
+            mockBarnUtenLøpendeAndeler()
+            every { familieIntegrasjonerTilgangskontrollService.sjekkTilgangTilPersoner(any()) } returns
+                mapOf(
+                    barnAktør.aktivFødselsnummer() to Tilgang(barnAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
                 )
+            val tilganger =
+                listOf(
+                    Tilgang(søkerAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
+                    Tilgang(barnAktør.aktivFødselsnummer(), false, BEGRUNNELSE_STRENGT_FORTROLIG),
+                )
+
+            // Act
+            val resultat =
+                strengtFortroligService.saksbehandlerManglerKunTilgangTilSkjermedeBarnUtenLøpendeAndeler(fagsak, tilganger)
 
             // Assert
             assertThat(resultat).isFalse()
@@ -303,51 +306,36 @@ class StrengtFortroligServiceTest {
     }
 
     @Nested
-    inner class FinnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsakTest {
+    inner class HentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTilTest {
         @Test
-        fun `skal returnere tomt sett når saksbehandler har tilgang til alle personer`() {
+        fun `skal returnere tomt sett når saksbehandler har tilgang til alle barn`() {
             // Arrange
             mockSaksbehandlerHarTilgangTilAllePersoner()
-            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns
-                setOf(
-                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
-                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
-                )
 
             // Act
-            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
 
             // Assert
             assertThat(resultat).isEmpty()
         }
 
         @Test
-        fun `skal returnere aktør for skjermet barn uten løpende andeler`() {
+        fun `skal returnere ident for skjermet barn uten løpende andeler`() {
             // Arrange
             mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
             mockBarnUtenLøpendeAndeler()
-            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns
-                setOf(
-                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
-                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
-                )
 
             // Act
-            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
 
             // Assert
-            assertThat(resultat).containsExactly(barnAktør)
+            assertThat(resultat).containsExactly(barnAktør.aktivFødselsnummer())
         }
 
         @Test
         fun `skal returnere tomt sett når skjermet barn fortsatt har løpende andeler`() {
             // Arrange
             mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
-            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns
-                setOf(
-                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.of(1990, 1, 1), dødsfallDato = null, målform = Målform.NB),
-                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 6, 15), dødsfallDato = null, målform = Målform.NB),
-                )
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteIverksatteBehandling.id) } returns
                 listOf(
                     lagAndelTilkjentYtelse(
@@ -359,7 +347,20 @@ class StrengtFortroligServiceTest {
                 )
 
             // Act
-            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
+
+            // Assert
+            assertThat(resultat).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere tomt sett når skjermet barn aldri har hatt andeler`() {
+            // Arrange
+            mockSaksbehandlerHarTilgangTilSøkerMenIkkeBarn()
+            mockBarnUtenAndeler()
+
+            // Act
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
 
             // Assert
             assertThat(resultat).isEmpty()
@@ -371,7 +372,7 @@ class StrengtFortroligServiceTest {
             every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id) } returns emptySet()
 
             // Act
-            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
 
             // Assert
             assertThat(resultat).isEmpty()
@@ -384,7 +385,35 @@ class StrengtFortroligServiceTest {
             mockBrukerContext(SikkerhetContext.SYSTEM_FORKORTELSE)
 
             // Act
-            val resultat = strengtFortroligService.finnSkjermedeBarnSaksbehandlerManglerTilgangTilUtenLøpendeAndelerPåFagsak(fagsak)
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
+
+            // Assert
+            assertThat(resultat).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere tomt sett når feature toggle er deaktivert`() {
+            // Arrange
+            every { featureToggleService.isEnabled(FeatureToggle.TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER) } returns false
+
+            // Act
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
+
+            // Assert
+            assertThat(resultat).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere tomt sett når barn mangler tilgang av annen årsak enn strengt fortrolig`() {
+            // Arrange
+            every { familieIntegrasjonerTilgangskontrollService.sjekkTilgangTilPersoner(any()) } returns
+                mapOf(
+                    barnAktør.aktivFødselsnummer() to Tilgang(barnAktør.aktivFødselsnummer(), false, "Annen årsak"),
+                )
+            mockBarnUtenLøpendeAndeler()
+
+            // Act
+            val resultat = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
 
             // Assert
             assertThat(resultat).isEmpty()
@@ -412,9 +441,9 @@ class StrengtFortroligServiceTest {
 
             // Act
             val resultat =
-                strengtFortroligService.filtrerVekkVedtaksperioderMedSkjermetBarn(
+                strengtFortroligService.anonymiserSkjermetBarnIVedtaksperioder(
                     vedtaksperioder = listOf(periodeMedSkjermetBarn, periodeUtenSkjermetBarn),
-                    behandlingId = behandling.id,
+                    fagsak = fagsak,
                 )
 
             // Assert
@@ -434,9 +463,9 @@ class StrengtFortroligServiceTest {
 
             // Act
             val resultat =
-                strengtFortroligService.filtrerVekkVedtaksperioderMedSkjermetBarn(
+                strengtFortroligService.anonymiserSkjermetBarnIVedtaksperioder(
                     vedtaksperioder = perioder,
-                    behandlingId = behandling.id,
+                    fagsak = fagsak,
                 )
 
             // Assert

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -66,6 +66,7 @@ class VedtaksperiodeServiceTest {
                 valutakursRepository = mockk(),
                 utenlandskPeriodebeløpRepository = mockk(),
                 featureToggleService = mockk(),
+                strengtFortroligService = mockk(relaxed = true),
             ),
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
@@ -67,7 +67,7 @@ class TilgangServiceTest {
     private val strengtFortroligService =
         StrengtFortroligService(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
-            persongrunnlagService = persongrunnlagService,
+            personopplysningGrunnlagRepository = mockk(relaxed = true),
             familieIntegrasjonerTilgangskontrollService = familieIntegrasjonerTilgangskontrollService,
             featureToggleService = featureToggleService,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
@@ -400,7 +400,7 @@ class TilgangServiceTest {
         @Test
         fun `validerTilgangTilFagsak - skal tillate tilgang til saksbehandler uten strengt fortrolig tilgang ved skjermet barn uten løpende andeler`() {
             // Arrange
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(testFagsak.id) } returns testBehandling
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(testBehandling.id) } returns
                 listOf(
                     lagAndelTilkjentYtelse(
@@ -427,7 +427,7 @@ class TilgangServiceTest {
         @Test
         fun `validerTilgangTilFagsak - skal blokkere tilgang til saksbehandler uten strengt fortrolig tilgang ved skjermet barn med løpende andeler`() {
             // Arrange
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(testFagsak.id) } returns testBehandling
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(testBehandling.id) } returns
                 listOf(
                     lagAndelTilkjentYtelse(
@@ -472,7 +472,7 @@ class TilgangServiceTest {
         @Test
         fun `validerTilgangTilFagsak - skal blokkere tilgang uavhengig av årsak hvis ingen behandling er iverksatt på fagsaken`() {
             // Arrange
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns null
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(testFagsak.id) } returns null
 
             fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
                 listOf(
@@ -490,7 +490,7 @@ class TilgangServiceTest {
         @Test
         fun `validerTilgangTilFagsak - skal blokkere tilgang når både søker og barn er skjermet, selv om barn ikke har løpende andeler`() {
             // Arrange
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(testFagsak.id) } returns testBehandling
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(testBehandling.id) } returns
                 listOf(
                     lagAndelTilkjentYtelse(
@@ -534,7 +534,7 @@ class TilgangServiceTest {
         fun `validerTilgangTilBehandling - skal tillate tilgang til behandling hvis skjermet barn ikke har løpende andeler`() {
             // Arrange
             every { behandlingHentOgPersisterService.hent(testBehandling.id) } returns testBehandling
-            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(testFagsak.id) } returns testBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(testFagsak.id) } returns testBehandling
             every { persongrunnlagService.hentSøkerOgBarnPåBehandling(testBehandling.id) } returns
                 listOf(
                     PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangServiceTest.kt
@@ -25,6 +25,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Målform
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonEnkel
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.kjerne.skjermetbarnsøker.SkjermetBarnSøker
 import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
 import no.nav.familie.ba.sak.mock.FakeFamilieIntegrasjonerTilgangskontrollKlient
@@ -64,10 +65,11 @@ class TilgangServiceTest {
             cacheManager,
             mockk(),
         )
+    private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository = mockk(relaxed = true)
     private val strengtFortroligService =
         StrengtFortroligService(
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
-            personopplysningGrunnlagRepository = mockk(relaxed = true),
+            personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
             familieIntegrasjonerTilgangskontrollService = familieIntegrasjonerTilgangskontrollService,
             featureToggleService = featureToggleService,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
@@ -384,6 +386,11 @@ class TilgangServiceTest {
             every { fagsakService.hentAktør(testFagsak.id) } returns søkerAktør
             every { fagsakService.hentPåFagsakId(testFagsak.id) } returns testFagsak
             every { persongrunnlagService.hentSøkerOgBarnPåFagsak(testFagsak.id) } returns
+                setOf(
+                    PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),
+                    PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),
+                )
+            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(testFagsak.id) } returns
                 setOf(
                     PersonEnkel(aktør = søkerAktør, type = PersonType.SØKER, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),
                     PersonEnkel(aktør = barnAktør, type = PersonType.BARN, fødselsdato = LocalDate.now(), dødsfallDato = null, målform = Målform.NB),


### PR DESCRIPTION
### 📮 Favro: NAV-28613

### 💰 Hva skal gjøres, og hvorfor?

Når en saksbehandler forsøker å lage en behandling i en fagsak med skjermet barn uten løpende andeler, og vedkommende ikke har vikafossen tilgang, så vil opprettelse av behandlingen feile.

Dette er fordi at når vi lager personopplysningrunnlaget for nye behandlinger, vil vi forsøke å hente personen fra PDL. Dette kommer til å feile hvis vedkommende ikke har vikafossen tilgang, og prøver å hente et barn med diskresjonskode.

Jeg løser dette ved av å:

- Kopier persongrunnlag fra forrige behandling istedenfor for de barna
- Fjern utbetalingsdetaljer på vedtaksperiode siden for barn som er skjermet (og saksbehandler ikke har tilgang)
- Når vi fastsetter enhet for ny behandling og oppgaver, ekskluder skjermet barn uten løpende andeler