### PR TITLE
Nav 28728 kode 6 19 valider ingen endring i utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringService.kt
@@ -6,8 +6,11 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.TIDENES_ENDE
 import no.nav.familie.ba.sak.common.Utils.storForbokstav
+import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.isSameOrAfter
 import no.nav.familie.ba.sak.common.isSameOrBefore
+import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -18,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValid
 import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValideringUtils.rekjørNesteMånedHvisYtelseTypeErInnvilgetToMånederFramITid
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.TilkjentYtelseValidering.validerAtSatsendringKunOppdatererSatsPåEksisterendePerioder
+import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -35,9 +39,16 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
+import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
 import no.nav.familie.ba.sak.kjerne.steg.BehandlingsresultatSteg
+import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNull
+import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.outerJoin
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import org.springframework.stereotype.Service
@@ -53,6 +64,7 @@ class BehandlingsresultatStegValideringService(
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
     private val valutakursRepository: ValutakursRepository,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
+    private val strengtFortroligService: StrengtFortroligService,
     private val clockProvider: ClockProvider,
 ) {
     fun validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling: Behandling) {
@@ -268,6 +280,66 @@ class BehandlingsresultatStegValideringService(
             }
     }
 
+    fun validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(behandling: Behandling) {
+        val skjermedeBarnSaksbehandlerIkkeHarTilgangTIl = strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(behandling.fagsak)
+        if (skjermedeBarnSaksbehandlerIkkeHarTilgangTIl.isEmpty()) return
+
+        val forrigeVedtatteBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling) ?: return
+        val forrigeAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeVedtatteBehandling.id)
+        val nåværendeAndeler = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
+
+        val forrigeAndelerForAndrePersoner = forrigeAndeler.filterNot { it.aktør.aktivFødselsnummer() in skjermedeBarnSaksbehandlerIkkeHarTilgangTIl }
+        val nåværendeAndelerForAndrePersoner = nåværendeAndeler.filterNot { it.aktør.aktivFødselsnummer() in skjermedeBarnSaksbehandlerIkkeHarTilgangTIl }
+
+        val endringIUtbetalingForAndrePersonerTidslinje =
+            EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje(
+                nåværendeAndeler = nåværendeAndelerForAndrePersoner,
+                forrigeAndeler = forrigeAndelerForAndrePersoner,
+            )
+
+        val skjermedeBarnAndelerIForrigeBehandling = forrigeAndeler.filter { it.aktør.aktivFødselsnummer() in skjermedeBarnSaksbehandlerIkkeHarTilgangTIl }.groupBy { it.aktør }
+        val skjermedeBarnAndelerINåværendeBehandling = nåværendeAndeler.filter { it.aktør.aktivFødselsnummer() in skjermedeBarnSaksbehandlerIkkeHarTilgangTIl }.groupBy { it.aktør }
+
+        val skjermedeBarn = skjermedeBarnAndelerIForrigeBehandling.keys + skjermedeBarnAndelerINåværendeBehandling.keys
+
+        skjermedeBarn.forEach { skjermetBarn ->
+            val skjermetBarnsAndelerForrige = skjermedeBarnAndelerIForrigeBehandling[skjermetBarn].orEmpty()
+            val skjermetBarnsAndelerNåværende = skjermedeBarnAndelerINåværendeBehandling[skjermetBarn].orEmpty()
+
+            val endringIUtbetalingForSkjermetBarnTidslinje =
+                EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje(
+                    nåværendeAndeler = skjermetBarnsAndelerNåværende,
+                    forrigeAndeler = skjermetBarnsAndelerForrige,
+                )
+
+            val andelTilkjentYtelseTidslinjeForSkjermetBarn = lagAndelTilkjentYtelseTidslinjeForSkjermetBarn(skjermetBarnsAndelerForrige)
+
+            val endringIUtbetalingForAndrePersonerSamtidigSomUtbetalingForSkjermetBarnTidslinje =
+                endringIUtbetalingForAndrePersonerTidslinje.kombinerUtenNullMed(andelTilkjentYtelseTidslinjeForSkjermetBarn) { erEndring, _ ->
+                    if (erEndring) true else null
+                }
+
+            val finnesEndringIUtbetalingForAndrePersonerSamtidigSomUtbetalingForSkjermetBarn = endringIUtbetalingForAndrePersonerSamtidigSomUtbetalingForSkjermetBarnTidslinje.tilPerioder().any { it.verdi == true }
+            val finnesEndringISkjermetBarnsAndeler = endringIUtbetalingForSkjermetBarnTidslinje.tilPerioder().any { it.verdi == true }
+
+            if (finnesEndringIUtbetalingForAndrePersonerSamtidigSomUtbetalingForSkjermetBarn || finnesEndringISkjermetBarnsAndeler) {
+                secureLogger.warn(
+                    "Endring i utbetaling oppdaget i periode hvor skjermet barn=${skjermetBarn.aktørId} har hatt andeler. " +
+                        "Behandling=${behandling.id}, fagsak=${behandling.fagsak.id}, saksbehandler=${SikkerhetContext.hentSaksbehandler()}.",
+                )
+                throw FunksjonellFeil(
+                    melding =
+                        "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} har endret utbetaling for andre personer " +
+                            "i en periode hvor et skjermet barn har hatt andeler på behandling=${behandling.id}. " +
+                            "Behandlingen må overføres til enhet 2103 (Vikafossen) og behandles der.",
+                    frontendFeilmelding =
+                        "Det er gjort endringer i utbetalingen i en periode hvor et skjermet barn har hatt andeler. " +
+                            "Behandlingen må overføres til enhet 2103 (Vikafossen) og behandles der.",
+                )
+            }
+        }
+    }
+
     fun validerFalskIdentitetBehandling(tilkjentYtelse: TilkjentYtelse) {
         val andelerDenneBehandlingen = tilkjentYtelse.andelerTilkjentYtelse.tilTidslinjerPerAktørOgType()
         val andelerForrigeBehandling = beregningService.hentAndelerFraForrigeVedtatteBehandling(tilkjentYtelse.behandling).tilTidslinjerPerAktørOgType()
@@ -279,4 +351,18 @@ class BehandlingsresultatStegValideringService(
             }
         }
     }
+
+    private fun lagAndelTilkjentYtelseTidslinjeForSkjermetBarn(andelerForBarn: List<AndelTilkjentYtelse>): Tidslinje<Boolean> =
+        andelerForBarn
+            .groupBy { it.type }
+            .map { (_, andelerForType) ->
+                andelerForType
+                    .map {
+                        Periode(
+                            verdi = true,
+                            fom = it.stønadFom.førsteDagIInneværendeMåned(),
+                            tom = it.stønadTom.sisteDagIInneværendeMåned(),
+                        )
+                    }.tilTidslinje()
+            }.kombinerUtenNull { _ -> true }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
@@ -65,6 +65,7 @@ class BehandlingsresultatSteg(
             behandlingsresultatstegValideringService.validerEndredeUtbetalingsandeler(tilkjentYtelse)
             behandlingsresultatstegValideringService.validerKompetanse(behandling.id)
             behandlingsresultatstegValideringService.validerSekundærlandKompetanse(behandling.id)
+            behandlingsresultatstegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(behandling)
         }
 
         if (behandling.erMånedligValutajustering()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/strengtfortrolig/StrengtFortroligService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.strengtfortrolig
 
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.PersonDto
@@ -186,7 +187,16 @@ class StrengtFortroligService(
 
         val skjermedeBarnUtenLøpendeAndeler = hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak)
 
-        return personerSaksbehandlerIkkeHarTilgangTil.all { it in skjermedeBarnUtenLøpendeAndeler }
+        val manglerBareTilgangTilSkjermedeBarnUtenAndeler = personerSaksbehandlerIkkeHarTilgangTil.all { it in skjermedeBarnUtenLøpendeAndeler }
+
+        if (manglerBareTilgangTilSkjermedeBarnUtenAndeler) {
+            secureLogger.info(
+                "Tillater tilgang til fagsak=${fagsak.id} for saksbehandler=${SikkerhetContext.hentSaksbehandler()}. " +
+                    "Saksbehandler har ikke tilgang til personer med strengt fortrolig adresse, men barn som er skjermet har ikke lenger løpende andeler",
+            )
+        }
+
+        return manglerBareTilgangTilSkjermedeBarnUtenAndeler
     }
 
     fun harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak: Fagsak): Boolean {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -438,6 +438,7 @@ class CucumberMock(
             valutakursRepository = valutakursRepository,
             clockProvider = clockProvider,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            strengtFortroligService = mockk(relaxed = true),
         )
 
     val behandlingsresultatSteg =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
@@ -11,10 +11,9 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.førsteDagINesteMåned
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagKompetanse
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
@@ -63,8 +62,8 @@ class BehandlingsresultatStegValideringServiceTest {
     private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository = mockk()
     private val valutakursRepository: ValutakursRepository = mockk()
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService = mockk()
+    private val strengtFortroligService = mockk<no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService>(relaxed = true)
     private val clockProvider = lagClockProviderMedFastTidspunkt(LocalDate.of(2025, 10, 10))
-    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val behandlingsresultatStegValideringService =
         BehandlingsresultatStegValideringService(
@@ -76,6 +75,7 @@ class BehandlingsresultatStegValideringServiceTest {
             utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepository,
             valutakursRepository = valutakursRepository,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            strengtFortroligService = strengtFortroligService,
             clockProvider = clockProvider,
         )
 
@@ -1453,6 +1453,199 @@ class BehandlingsresultatStegValideringServiceTest {
 
             // Act
             assertDoesNotThrow { behandlingsresultatStegValideringService.validerFalskIdentitetBehandling(tilkjentYtelse) }
+        }
+    }
+
+    @Nested
+    inner class ValiderIngenEndringIUtbetalingIPerioderMedSkjermedeBarnTest {
+        private val skjermetBarnAktør = randomAktør()
+        private val annetBarnAktør = randomAktør()
+        private val søkerAktør = randomAktør()
+        private val fagsak = lagFagsak(aktør = søkerAktør)
+        private val nåværendeBehandling = lagBehandling(fagsak = fagsak)
+        private val forrigeBehandling = lagBehandling(fagsak = fagsak)
+        private val skjermetPeriodeFom = YearMonth.of(2023, 1)
+        private val skjermetPeriodeTom = YearMonth.of(2024, 6)
+
+        private val skjermetBarnsHistoriskeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = skjermetPeriodeFom,
+                    tom = skjermetPeriodeTom,
+                    behandling = forrigeBehandling,
+                    aktør = skjermetBarnAktør,
+                ),
+            )
+
+        private val skjermetBarnsAndelerINåværendeBehandling =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = skjermetPeriodeFom,
+                    tom = skjermetPeriodeTom,
+                    behandling = nåværendeBehandling,
+                    aktør = skjermetBarnAktør,
+                ),
+            )
+
+        @Test
+        fun `skal ikke kaste feil når det ikke finnes skjermede barn uten løpende andeler`() {
+            // Arrange
+            every { strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak) } returns emptySet()
+
+            // Act + Assert
+            assertDoesNotThrow {
+                behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil når det ikke finnes en forrige vedtatt behandling`() {
+            // Arrange
+            every { strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak) } returns setOf(skjermetBarnAktør.aktivFødselsnummer())
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(nåværendeBehandling) } returns null
+
+            // Act + Assert
+            assertDoesNotThrow {
+                behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil når andre barns andeler er uendret i skjermet periode`() {
+            // Arrange
+            mockSkjermetBarnFinnesOgForrigeBehandlingErVedtatt()
+            val annetBarnsAndel =
+                lagAndelTilkjentYtelse(
+                    fom = skjermetPeriodeFom,
+                    tom = skjermetPeriodeTom,
+                    behandling = forrigeBehandling,
+                    aktør = annetBarnAktør,
+                )
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns skjermetBarnsHistoriskeAndeler + annetBarnsAndel
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns
+                skjermetBarnsAndelerINåværendeBehandling + annetBarnsAndel.copy(id = 0, behandlingId = nåværendeBehandling.id)
+
+            // Act + Assert
+            assertDoesNotThrow {
+                behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil når endring for andre barn er utenfor skjermet periode`() {
+            // Arrange
+            mockSkjermetBarnFinnesOgForrigeBehandlingErVedtatt()
+            val annetBarnsAndelFørSkjermetPeriode =
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2022, 1),
+                    tom = YearMonth.of(2022, 12),
+                    behandling = forrigeBehandling,
+                    aktør = annetBarnAktør,
+                    beløp = 1000,
+                )
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns skjermetBarnsHistoriskeAndeler + annetBarnsAndelFørSkjermetPeriode
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns
+                skjermetBarnsAndelerINåværendeBehandling +
+                annetBarnsAndelFørSkjermetPeriode.copy(id = 0, behandlingId = nåværendeBehandling.id, kalkulertUtbetalingsbeløp = 2000)
+
+            // Act + Assert
+            assertDoesNotThrow {
+                behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal kaste Funksjonell feil når endring for annet barn er innenfor skjermet periode`() {
+            // Arrange
+            mockSkjermetBarnFinnesOgForrigeBehandlingErVedtatt()
+            val annetBarnsAndelForrige =
+                lagAndelTilkjentYtelse(
+                    fom = skjermetPeriodeFom,
+                    tom = skjermetPeriodeTom,
+                    behandling = forrigeBehandling,
+                    aktør = annetBarnAktør,
+                    beløp = 1000,
+                )
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns skjermetBarnsHistoriskeAndeler + annetBarnsAndelForrige
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns
+                skjermetBarnsAndelerINåværendeBehandling +
+                annetBarnsAndelForrige.copy(id = 0, behandlingId = nåværendeBehandling.id, kalkulertUtbetalingsbeløp = 2000)
+
+            // Act + Assert
+            val feil =
+                assertThrows<FunksjonellFeil> {
+                    behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+                }
+
+            assertThat(feil.message).contains("Behandlingen må overføres til enhet 2103")
+        }
+
+        @Test
+        fun `skal kaste funksjonell feil ved endring i søkers utbetaling i skjermet periode`() {
+            // Arrange
+            mockSkjermetBarnFinnesOgForrigeBehandlingErVedtatt()
+            val søkerAndelForrige =
+                lagAndelTilkjentYtelse(
+                    fom = skjermetPeriodeFom,
+                    tom = skjermetPeriodeTom,
+                    behandling = forrigeBehandling,
+                    aktør = søkerAktør,
+                    ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                    beløp = 1000,
+                )
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns
+                skjermetBarnsHistoriskeAndeler + søkerAndelForrige
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns
+                skjermetBarnsAndelerINåværendeBehandling +
+                søkerAndelForrige.copy(id = 0, behandlingId = nåværendeBehandling.id, kalkulertUtbetalingsbeløp = 1500)
+
+            // Act + Assert
+            val feil =
+                assertThrows<FunksjonellFeil> {
+                    behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+                }
+
+            assertThat(feil.message).contains("Behandlingen må overføres til enhet 2103")
+        }
+
+        @Test
+        fun `skal kaste feil ved endring i det skjermede barnets egne andeler`() {
+            // Arrange
+            mockSkjermetBarnFinnesOgForrigeBehandlingErVedtatt()
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = skjermetPeriodeFom,
+                        tom = skjermetPeriodeTom,
+                        behandling = nåværendeBehandling,
+                        aktør = skjermetBarnAktør,
+                        beløp = 9999,
+                    ),
+                )
+
+            // Act + Assert
+            assertThrows<FunksjonellFeil> {
+                behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal kaste feil dersom skjermet barns andeler fjernes i ny behandling`() {
+            // Arrange
+            mockSkjermetBarnFinnesOgForrigeBehandlingErVedtatt()
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns emptyList()
+
+            // Act + Assert
+            assertThrows<FunksjonellFeil> {
+                behandlingsresultatStegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(nåværendeBehandling)
+            }
+        }
+
+        private fun mockSkjermetBarnFinnesOgForrigeBehandlingErVedtatt() {
+            every { strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak) } returns setOf(skjermetBarnAktør.aktivFødselsnummer())
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(nåværendeBehandling) } returns forrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns skjermetBarnsHistoriskeAndeler
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns skjermetBarnsAndelerINåværendeBehandling
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatStegTest.kt
@@ -111,6 +111,7 @@ class BehandlingsresultatStegTest {
             justRun { behandlingsresultatstegValideringService.validerIngenEndringTilbakeITid(any()) }
             justRun { behandlingsresultatstegValideringService.validerSatsErUendret(any()) }
             justRun { behandlingsresultatstegValideringService.validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(any()) }
+            justRun { behandlingsresultatstegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(any()) }
         }
 
         @ParameterizedTest


### PR DESCRIPTION
### 📮 Favro: NAV-28728

### 💰 Hva skal gjøres, og hvorfor?

Når man behandler fagsak som har eksisterende skjermet barn uten løpende utbetaling, må vi validere for at saksbehandler ikke gjør endringer som fører til endring i utbetaling samme periode som skjermet barn har hatt utbetaling.