### PR TITLE
Utled avregning på tvers av behandlinger bak feature toggle

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -55,4 +55,6 @@ enum class FeatureToggle(
 
     // NAV-28471
     TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER("familie-ba-sak.tillat-tilgang-skjermet-barn-uten-lopende-andeler"),
+
+    UTLED_AVREGNING_PÅ_TVERS_AV_BEHANDLINGER("familie-ba-sak.utled-avregning-paa-tvers-av-behandlinger"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningService.kt
@@ -3,7 +3,10 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import no.nav.familie.ba.sak.common.ClockProvider
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.sisteDagIForrigeMåned
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -14,6 +17,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgTyp
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.simulering.domene.AvregningPeriode
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærTilOgMed
+import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.utvidelser.kombiner
@@ -29,24 +33,59 @@ class AvregningService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
     private val clockProvider: ClockProvider,
+    private val tilbakekrevingService: TilbakekrevingService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     fun behandlingHarPerioderSomAvregnes(behandlingId: Long): Boolean = hentPerioderMedAvregning(behandlingId).isNotEmpty()
 
     fun hentPerioderMedAvregning(behandlingId: Long): List<AvregningPeriode> {
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
 
-        if (behandling.kategori == BehandlingKategori.EØS || behandling.type == BehandlingType.TEKNISK_ENDRING ||
-            behandling.opprettetÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO
-        ) {
+        if (skalIkkeUtledePerioderMedAvregning(behandling)) {
             return emptyList()
         }
 
+        val avregningsperioderInnenforBehandling = hentPerioderMedAvregningInnenforBehandling(behandling)
+        val avregningsperioderPåTvers = hentPerioderMedAvregningPåTversAvBehandlinger(behandling)
+
+        return (avregningsperioderInnenforBehandling + avregningsperioderPåTvers).distinctBy { it.fom to it.tom }
+    }
+
+    private fun hentPerioderMedAvregningInnenforBehandling(behandling: Behandling): List<AvregningPeriode> {
         val sisteVedtatteBehandling =
             behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
                 ?: return emptyList()
 
-        val andelerInneværendeBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
-        val andelerForrigeBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(sisteVedtatteBehandling.id)
+        return hentPerioderMedAvregningMellomToBehandlinger(behandling.id, sisteVedtatteBehandling.id)
+    }
+
+    private fun hentPerioderMedAvregningPåTversAvBehandlinger(behandling: Behandling): List<AvregningPeriode> {
+        if (!featureToggleService.isEnabled(FeatureToggle.UTLED_AVREGNING_PÅ_TVERS_AV_BEHANDLINGER)) {
+            return emptyList()
+        }
+
+        val behandlingMedÅpenTilbakekreving =
+            tilbakekrevingService.hentBehandlingKnyttetTilÅpenTilbakekreving(behandling.fagsak.id)
+                ?: return emptyList()
+
+        val forrigeBehandling =
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandlingMedÅpenTilbakekreving)
+                ?: return emptyList()
+
+        return hentPerioderMedAvregningMellomToBehandlinger(behandling.id, forrigeBehandling.id)
+    }
+
+    private fun skalIkkeUtledePerioderMedAvregning(behandling: Behandling): Boolean =
+        behandling.kategori == BehandlingKategori.EØS ||
+            behandling.type == BehandlingType.TEKNISK_ENDRING ||
+            behandling.opprettetÅrsak == BehandlingÅrsak.ENDRE_MIGRERINGSDATO
+
+    private fun hentPerioderMedAvregningMellomToBehandlinger(
+        behandlingId: Long,
+        forrigeBehandlingId: Long,
+    ): List<AvregningPeriode> {
+        val andelerInneværendeBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId)
+        val andelerForrigeBehandling = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandlingId)
 
         val sisteDagIForrigeMåned = LocalDate.now(clockProvider.get()).sisteDagIForrigeMåned()
 
@@ -55,12 +94,9 @@ class AvregningService(
 
         val tidslinjerMedDifferanser = lagTidslinjerMedDifferanser(andelerInneværendeBehandlingTidslinjer, andelerForrigeBehandlingTidslinjer)
 
-        val perioderMedEtterbetalingerOgFeilutbetalinger =
-            summerEtterbetalingerOgFeilutbetalinger(tidslinjerMedDifferanser)
-                .tilPerioderIkkeNull()
-                .tilAvregningPerioder()
-
-        return perioderMedEtterbetalingerOgFeilutbetalinger
+        return summerEtterbetalingerOgFeilutbetalinger(tidslinjerMedDifferanser)
+            .tilPerioderIkkeNull()
+            .tilAvregningPerioder()
     }
 
     private fun lagTidslinjerMedDifferanser(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringController.kt
@@ -30,7 +30,7 @@ class SimuleringController(
     ): ResponseEntity<Ressurs<SimuleringDto>> {
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         val vedtakSimuleringMottaker = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId)
-        val avregningsperioder = avregningService.hentPerioderMedAvregning(behandlingId)
+        val alleAvregningsperioder = avregningService.hentPerioderMedAvregning(behandlingId)
 
         val fagsakId = behandlingRepository.finnBehandling(behandlingId).fagsak.id
         val overlappendePerioderMedAndreFagsaker = finnOverlappendePerioder(vedtakSimuleringMottaker, fagsakId)
@@ -45,7 +45,7 @@ class SimuleringController(
             )
 
         val restSimulering =
-            simulering.tilSimuleringDto(avregningsperioder, overlappendePerioderMedAndreFagsaker)
+            simulering.tilSimuleringDto(alleAvregningsperioder, overlappendePerioderMedAndreFagsaker)
         return ResponseEntity.ok(Ressurs.success(restSimulering))
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsstatus
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingstype
 import no.nav.familie.kontrakter.felles.tilbakekreving.Brevmottaker
 import no.nav.familie.kontrakter.felles.tilbakekreving.FeilutbetaltePerioderDto
@@ -124,6 +125,18 @@ class TilbakekrevingService(
     }
 
     fun søkerHarÅpenTilbakekreving(fagsakId: Long): Boolean = tilbakekrevingKlient.harÅpenTilbakekrevingsbehandling(fagsakId)
+
+    fun hentBehandlingKnyttetTilÅpenTilbakekreving(fagsakId: Long): Behandling? {
+        val åpenTilbakekrevingsbehandling =
+            tilbakekrevingKlient
+                .hentTilbakekrevingsbehandlinger(fagsakId)
+                .find { it.status != Behandlingsstatus.AVSLUTTET }
+                ?: return null
+
+        return tilbakekrevingRepository
+            .findByTilbakekrevingsbehandlingId(åpenTilbakekrevingsbehandling.behandlingId.toString())
+            ?.behandling
+    }
 
     fun opprettTilbakekreving(behandling: Behandling): TilbakekrevingId = tilbakekrevingKlient.opprettTilbakekrevingBehandling(lagOpprettTilbakekrevingRequest(behandling))
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/domene/TilbakekrevingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/domene/TilbakekrevingRepository.kt
@@ -8,6 +8,8 @@ interface TilbakekrevingRepository : JpaRepository<Tilbakekreving, Long> {
     @Query(value = "SELECT t FROM Tilbakekreving t JOIN t.behandling b WHERE b.id = :behandlingId")
     fun findByBehandlingId(behandlingId: Long): Tilbakekreving?
 
+    fun findByTilbakekrevingsbehandlingId(tilbakekrevingsbehandlingId: String): Tilbakekreving?
+
     @Modifying
     @Query(value = "DELETE FROM Tilbakekreving t WHERE t.behandling.id = :behandlingId")
     fun deleteByBehandlingId(behandlingId: Long)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AvregningServiceTest.kt
@@ -3,12 +3,17 @@ package no.nav.familie.ba.sak.kjerne.beregning
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.TestClockProvider
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -18,10 +23,12 @@ import no.nav.familie.ba.sak.kjerne.tidslinje.util.feb
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jan
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.jul
 import no.nav.familie.ba.sak.kjerne.tidslinje.util.mar
+import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 class AvregningServiceTest {
     private val søker = lagPerson()
@@ -33,18 +40,25 @@ class AvregningServiceTest {
 
     private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val tilbakekrevingService = mockk<TilbakekrevingService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val avregningService =
         AvregningService(
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
             clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(mar(2025)),
+            tilbakekrevingService = tilbakekrevingService,
+            featureToggleService = featureToggleService,
         )
 
     @BeforeEach
     fun setup() {
         every { behandlingHentOgPersisterService.hent(any()) } returns inneværendeBehandling
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns sisteVedtatteBehandling
+        every { tilbakekrevingService.hentBehandlingKnyttetTilÅpenTilbakekreving(any()) } returns null
+        every { featureToggleService.isEnabled(any<FeatureToggle>()) } returns false
+        every { featureToggleService.isEnabled(any<FeatureToggle>(), any<Boolean>()) } returns false
     }
 
     @Nested
@@ -683,6 +697,285 @@ class AvregningServiceTest {
                 )
 
             assertThat(perioderMedEtterbetalingOgFeilutbetaling.single()).isEqualTo(forventet)
+        }
+    }
+
+    @Nested
+    inner class `avregning på tvers av behandlinger` {
+        private val fagsak = lagFagsak()
+
+        private val vedtattBehandling1 =
+            lagBehandling(
+                fagsak = fagsak,
+                status = BehandlingStatus.AVSLUTTET,
+                resultat = Behandlingsresultat.INNVILGET,
+                aktivertTid = LocalDateTime.of(2024, 1, 1, 0, 0),
+            )
+        private val vedtattBehandling2 =
+            lagBehandling(
+                fagsak = fagsak,
+                status = BehandlingStatus.AVSLUTTET,
+                resultat = Behandlingsresultat.INNVILGET,
+                aktivertTid = LocalDateTime.of(2024, 6, 1, 0, 0),
+            )
+        private val gjeldendBehandling =
+            lagBehandling(
+                fagsak = fagsak,
+            )
+
+        @BeforeEach
+        fun setup() {
+            every { featureToggleService.isEnabled(FeatureToggle.UTLED_AVREGNING_PÅ_TVERS_AV_BEHANDLINGER) } returns true
+        }
+
+        @Test
+        fun `skal returnere tom liste når det ikke finnes åpen tilbakekreving`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hent(gjeldendBehandling.id) } returns gjeldendBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns null
+            every { tilbakekrevingService.hentBehandlingKnyttetTilÅpenTilbakekreving(fagsak.id) } returns null
+
+            // Act
+            val perioder = avregningService.hentPerioderMedAvregning(gjeldendBehandling.id)
+
+            // Assert
+            assertThat(perioder).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere tom liste for EØS behandling selv med åpen tilbakekreving`() {
+            // Arrange
+            val eøsBehandling = lagBehandling(fagsak = fagsak, behandlingKategori = BehandlingKategori.EØS)
+
+            every { behandlingHentOgPersisterService.hent(eøsBehandling.id) } returns eøsBehandling
+
+            // Act
+            val perioder = avregningService.hentPerioderMedAvregning(eøsBehandling.id)
+
+            // Assert
+            assertThat(perioder).isEmpty()
+        }
+
+        @Test
+        fun `skal finne avregningsperioder på tvers av behandlinger`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hent(gjeldendBehandling.id) } returns gjeldendBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns null
+            every { tilbakekrevingService.hentBehandlingKnyttetTilÅpenTilbakekreving(fagsak.id) } returns vedtattBehandling2
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(vedtattBehandling2) } returns vedtattBehandling1
+
+            val andelerBehandling1 =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = vedtattBehandling1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn2,
+                        behandling = vedtattBehandling1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            val andelerGjeldende =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = gjeldendBehandling,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn2,
+                        behandling = gjeldendBehandling,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtattBehandling1.id) } returns andelerBehandling1
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(gjeldendBehandling.id) } returns andelerGjeldende
+
+            // Act
+            val perioder = avregningService.hentPerioderMedAvregning(gjeldendBehandling.id)
+
+            // Assert
+            val forventet =
+                AvregningPeriode(
+                    totalEtterbetaling = 2000.toBigDecimal(),
+                    totalFeilutbetaling = 2000.toBigDecimal(),
+                    fom = 1.jan(2025),
+                    tom = 28.feb(2025),
+                )
+            assertThat(perioder).hasSize(1)
+            assertThat(perioder.single()).isEqualTo(forventet)
+        }
+
+        @Test
+        fun `skal returnere tom liste når det ikke er avregning mellom behandlinger i kjeden`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hent(gjeldendBehandling.id) } returns gjeldendBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns null
+            every { tilbakekrevingService.hentBehandlingKnyttetTilÅpenTilbakekreving(fagsak.id) } returns vedtattBehandling2
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(vedtattBehandling2) } returns vedtattBehandling1
+
+            val andelerBehandling1 =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = vedtattBehandling1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            val andelerGjeldende =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = gjeldendBehandling,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtattBehandling1.id) } returns andelerBehandling1
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(gjeldendBehandling.id) } returns andelerGjeldende
+
+            // Act
+            val perioder = avregningService.hentPerioderMedAvregning(gjeldendBehandling.id)
+
+            // Assert
+            assertThat(perioder).isEmpty()
+        }
+
+        @Test
+        fun `behandlingHarPerioderSomAvregnes returnerer true ved avregning på tvers`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hent(gjeldendBehandling.id) } returns gjeldendBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns null
+            every { tilbakekrevingService.hentBehandlingKnyttetTilÅpenTilbakekreving(fagsak.id) } returns vedtattBehandling2
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(vedtattBehandling2) } returns vedtattBehandling1
+
+            val andelerBehandling1 =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = vedtattBehandling1,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn2,
+                        behandling = vedtattBehandling1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            val andelerGjeldende =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = gjeldendBehandling,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn2,
+                        behandling = gjeldendBehandling,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtattBehandling1.id) } returns andelerBehandling1
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(gjeldendBehandling.id) } returns andelerGjeldende
+
+            // Act
+            val harAvregning = avregningService.behandlingHarPerioderSomAvregnes(gjeldendBehandling.id)
+
+            // Assert
+            assertThat(harAvregning).isTrue()
+        }
+
+        @Test
+        fun `skal detektere avregning når nåværende behandling har etterbetaling i periode med åpen tilbakekreving`() {
+            // B1: barn1 = 2000/mnd for jan-feb 2025
+            // B2: barn1 = 1000/mnd for jan-feb 2025 (reduksjon → tilbakekreving opprettet, knyttet til B2)
+            // B3 (gjeldende): barn1 = 1000/mnd, barn2 = 1500/mnd for jan-feb 2025 (barn2 innvilget)
+            //
+            // Forventet: avregning fordi etterbetalingen for barn2 (B3→B2) vil bli avregnet mot
+            // feilutbetalingen for barn1 (B2→B1) i økonomi, siden tilbakekrevingen er åpen.
+
+            // Arrange
+            every { behandlingHentOgPersisterService.hent(gjeldendBehandling.id) } returns gjeldendBehandling
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns vedtattBehandling2
+            every { tilbakekrevingService.hentBehandlingKnyttetTilÅpenTilbakekreving(fagsak.id) } returns vedtattBehandling2
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(vedtattBehandling2) } returns vedtattBehandling1
+
+            val andelerBehandling1 =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = vedtattBehandling1,
+                        kalkulertUtbetalingsbeløp = 2000,
+                    ),
+                )
+
+            val andelerBehandling2 =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = vedtattBehandling2,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                )
+
+            val andelerGjeldende =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn1,
+                        behandling = gjeldendBehandling,
+                        kalkulertUtbetalingsbeløp = 1000,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = jan(2025),
+                        tom = feb(2025),
+                        person = barn2,
+                        behandling = gjeldendBehandling,
+                        kalkulertUtbetalingsbeløp = 1500,
+                    ),
+                )
+
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtattBehandling1.id) } returns andelerBehandling1
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(vedtattBehandling2.id) } returns andelerBehandling2
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(gjeldendBehandling.id) } returns andelerGjeldende
+
+            // Act
+            val perioder = avregningService.hentPerioderMedAvregning(gjeldendBehandling.id)
+
+            // Assert
+            assertThat(perioder).isNotEmpty()
         }
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-28632

### 💰 Hva skal gjøres, og hvorfor?

Legger til funksjonalitet for å detektere avregning på tvers av behandlinger i `AvregningService`, bak feature toggle `UTLED_AVREGNING_PÅ_TVERS_AV_BEHANDLINGER`.

Avregning skjer når økonomi motregner etterbetaling mot feilutbetaling i samme periode. Dette kan oppstå på tvers av behandlinger: f.eks. en bruker mister ytelse for barn1 (→ tilbakekreving), og i en ny behandling får ytelse for barn2 i samme periode. Da vil etterbetalingen for barn2 avregnes mot feilutbetalingen for barn1, så lenge tilbakekrevingen er åpen.

**Endringer:**

- **`AvregningService`**: Refaktorert til to separate sjekker: "innenfor behandling" (eksisterende logikk, ekstrahert til egen metode) og "på tvers av behandlinger" (ny logikk bak toggle). "På tvers"-logikken slår opp behandlingen knyttet til åpen tilbakekreving, finner forrige vedtatte behandling, og sammenligner gjeldende behandling mot denne.
- **`TilbakekrevingService`**: Ny metode `hentBehandlingKnyttetTilÅpenTilbakekreving` som finner ba-sak-behandlingen knyttet til en åpen tilbakekrevingsbehandling.
- **`TilbakekrevingRepository`**: Ny `findByTilbakekrevingsbehandlingId` for oppslag.
- **`FeatureToggle`**: Ny toggle `UTLED_AVREGNING_PÅ_TVERS_AV_BEHANDLINGER`.
- **`AvregningServiceTest`**: 20 tester totalt, inkludert 6 nye for "på tvers"-scenarioer.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.