### PR TITLE
Sett ukjent navn ved 404 ved uthenting av organisasjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/ArbeidsforholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/ArbeidsforholdService.kt
@@ -10,10 +10,14 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.arbeidsforhold.G
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.GrStatsborgerskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.finnSterkesteMedlemskap
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
+import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
+import no.nav.familie.restklient.client.RessursException
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -22,6 +26,8 @@ class ArbeidsforholdService(
     private val systemOnlyIntegrasjonKlient: SystemOnlyIntegrasjonKlient,
     private val integrasjonKlient: IntegrasjonKlient,
 ) {
+    private val logger = LoggerFactory.getLogger(ArbeidsforholdService::class.java)
+
     fun hentArbeidsforhold(person: Person): List<GrArbeidsforhold> {
         val arbeidsforholdForSisteFemÅr = systemOnlyIntegrasjonKlient.hentArbeidsforholdMedSystembruker(person.aktør.aktivFødselsnummer(), LocalDate.now().minusYears(5))
 
@@ -83,10 +89,22 @@ class ArbeidsforholdService(
                         ansettelsesperiodeFom = medlemskapPeriode.fom ?: cutOffFomDato,
                         ansettelsesperiodeTom = medlemskapPeriode.tom,
                     ).associateWith { arbeidsforhold ->
-                        arbeidsforhold.arbeidsgiver?.organisasjonsnummer?.let { integrasjonKlient.hentOrganisasjon(it) }
+                        arbeidsforhold.arbeidsgiver?.organisasjonsnummer?.let { hentOrganisasjonMedFallback(it) }
                     }.map { (arbeidsforhold, organisasjon) ->
                         arbeidsforhold.tilGrArbeidsforhold(person, organisasjon)
                     }
             }
     }
+
+    private fun hentOrganisasjonMedFallback(organisasjonsnummer: String): Organisasjon =
+        try {
+            integrasjonKlient.hentOrganisasjon(organisasjonsnummer)
+        } catch (ressursException: RessursException) {
+            if (ressursException.httpStatus == HttpStatus.NOT_FOUND) {
+                logger.warn("Fant ikke organisasjon $organisasjonsnummer i EREG, bruker 'Ukjent navn' som fallback.")
+                Organisasjon(organisasjonsnummer = organisasjonsnummer, navn = "Ukjent navn")
+            } else {
+                throw ressursException
+            }
+        }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/ArbeidsforholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/ArbeidsforholdServiceTest.kt
@@ -13,9 +13,12 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsgi
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Periode
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
+import no.nav.familie.restklient.client.RessursException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import java.time.LocalDate
 
 class ArbeidsforholdServiceTest {
@@ -274,5 +277,76 @@ class ArbeidsforholdServiceTest {
         val ansettelsesperiode = privatArbeidsforhold.ansettelsesperiode?.periode!!
         assertThat(arbeidsforhold.single().periode?.fom).isEqualTo(ansettelsesperiode.fom)
         assertThat(arbeidsforhold.single().periode?.tom).isEqualTo(ansettelsesperiode.tom)
+    }
+
+    @Test
+    fun `setter organisasjonNavn til Ukjent navn når organisasjonen ikke finnes i EREG`() {
+        // Arrange
+        val ukjentOrgArbeidsforhold =
+            Arbeidsforhold(
+                arbeidsgiver = Arbeidsgiver(organisasjonsnummer = "302268428", type = ArbeidsgiverType.Organisasjon),
+                ansettelsesperiode = Ansettelsesperiode(Periode(LocalDate.now().minusYears(2))),
+            )
+        every {
+            systemOnlyIntegrasjonKlient.hentArbeidsforholdMedSystembruker(person.aktør.aktivFødselsnummer(), any(), any())
+        } returns listOf(nåværendeArbeidsforhold, ukjentOrgArbeidsforhold)
+        every { integrasjonKlient.hentOrganisasjon(ukjentOrgArbeidsforhold.arbeidsgiver!!.organisasjonsnummer!!) } throws
+            RessursException(ressurs = mockk(relaxed = true), httpStatus = HttpStatus.NOT_FOUND, cause = mockk(relaxed = true))
+
+        val statsborgerskap =
+            listOf(
+                lagGrStatsborgerskap(
+                    gyldigFraOgMed = LocalDate.now().minusYears(1),
+                    gyldigTilOgMed = null,
+                    landkode = "POL",
+                    medlemskap = Medlemskap.EØS,
+                    person = person,
+                ),
+            )
+
+        // Act
+        val arbeidsforhold =
+            arbeidsforholdService.hentArbeidsforholdPerioderMedSterkesteMedlemskapIEØS(
+                statsborgerskap,
+                person,
+                LocalDate.now().minusYears(20),
+            )
+
+        // Assert
+        assertThat(arbeidsforhold).hasSize(2)
+        val ukjent = arbeidsforhold.single { it.arbeidsgiverId == "302268428" }
+        assertThat(ukjent.organisasjonNavn).isEqualTo("Ukjent navn")
+        val kjent = arbeidsforhold.single { it.arbeidsgiverId == nåværendeArbeidsforhold.arbeidsgiver?.organisasjonsnummer }
+        assertThat(kjent.organisasjonNavn).isEqualTo("Nåværende AS")
+    }
+
+    @Test
+    fun `kaster feil når hentOrganisasjon feiler med annen feil enn 404 NOT_FOUND`() {
+        // Arrange
+        every {
+            systemOnlyIntegrasjonKlient.hentArbeidsforholdMedSystembruker(person.aktør.aktivFødselsnummer(), any(), any())
+        } returns listOf(nåværendeArbeidsforhold)
+        every { integrasjonKlient.hentOrganisasjon(nåværendeArbeidsforhold.arbeidsgiver!!.organisasjonsnummer!!) } throws
+            RessursException(ressurs = mockk(relaxed = true), httpStatus = HttpStatus.INTERNAL_SERVER_ERROR, cause = mockk(relaxed = true))
+
+        val statsborgerskap =
+            listOf(
+                lagGrStatsborgerskap(
+                    gyldigFraOgMed = LocalDate.now().minusYears(1),
+                    gyldigTilOgMed = null,
+                    landkode = "POL",
+                    medlemskap = Medlemskap.EØS,
+                    person = person,
+                ),
+            )
+
+        // Act & Assert
+        assertThatThrownBy {
+            arbeidsforholdService.hentArbeidsforholdPerioderMedSterkesteMedlemskapIEØS(
+                statsborgerskap,
+                person,
+                LocalDate.now().minusYears(20),
+            )
+        }.isInstanceOf(RessursException::class.java)
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-28693

### 💰 Hva skal gjøres, og hvorfor?
Avklart med funksjonelle at dersom vi får inn en org nummer som vi ikke får treff mot når vi slår opp i EREG, så setter vi bare navn til "Ukjent navn".