### PR TITLE
NAV-28767 Filtrer bort ugyldige statsborgerskap fra PDL

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -436,7 +436,7 @@ class PersongrunnlagService(
             person.statsborgerskap =
                 personInfo.statsborgerskap
                     ?.filtrerBortStatsborgerskapFørEldsteBarn(eldsteBarnsFødselsdato, filtrerRegisteropplysninger)
-                    ?.filtrerBortUgyldigeStatsborgerskap()
+                    ?.filtrerBortUgyldigeStatsborgerskap(aktør)
                     ?.flatMap {
                         statsborgerskapService.hentStatsborgerskapMedMedlemskap(
                             statsborgerskap = it,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Personopplysning
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningsgrunnlagFiltreringUtils.filtrerBortOppholdFørEldsteBarn
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningsgrunnlagFiltreringUtils.filtrerBortOppholdsadresserFørEldsteBarn
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningsgrunnlagFiltreringUtils.filtrerBortStatsborgerskapFørEldsteBarn
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningsgrunnlagFiltreringUtils.filtrerBortUgyldigeStatsborgerskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.deltbosted.GrDeltBosted
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.oppholdsadresse.GrOppholdsadresse
@@ -435,6 +436,7 @@ class PersongrunnlagService(
             person.statsborgerskap =
                 personInfo.statsborgerskap
                     ?.filtrerBortStatsborgerskapFørEldsteBarn(eldsteBarnsFødselsdato, filtrerRegisteropplysninger)
+                    ?.filtrerBortUgyldigeStatsborgerskap()
                     ?.flatMap {
                         statsborgerskapService.hentStatsborgerskapMedMedlemskap(
                             statsborgerskap = it,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningsgrunnlagFiltreringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningsgrunnlagFiltreringUtils.kt
@@ -59,7 +59,7 @@ object PersonopplysningsgrunnlagFiltreringUtils {
 
         if (ugyldigeStatsborgerskap.isNotEmpty()) {
             secureLogger.warn(
-                "Filtrerer bort ${ugyldigeStatsborgerskap.size} statsborgerskap fra PDL med gyldigFraOgMed etter gyldigTilOgMed: $ugyldigeStatsborgerskap",
+                "Filtrerer bort ${ugyldigeStatsborgerskap.size} statsborgerskap fra PDL med fom etter gyldigTilOgMed: $ugyldigeStatsborgerskap",
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningsgrunnlagFiltreringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningsgrunnlagFiltreringUtils.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.erFomEtterTom
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
 import no.nav.familie.kontrakter.felles.personopplysning.Opphold
@@ -54,12 +55,12 @@ object PersonopplysningsgrunnlagFiltreringUtils {
         return this.filter { it.gyldigTilOgMed?.isSameOrAfter(eldsteBarnsFødselsdato) ?: true }
     }
 
-    fun List<Statsborgerskap>.filtrerBortUgyldigeStatsborgerskap(): List<Statsborgerskap> {
+    fun List<Statsborgerskap>.filtrerBortUgyldigeStatsborgerskap(aktør: Aktør): List<Statsborgerskap> {
         val (ugyldigeStatsborgerskap, gyldigeStatsborgerskap) = this.partition { it.erFomEtterTom() }
 
         if (ugyldigeStatsborgerskap.isNotEmpty()) {
             secureLogger.warn(
-                "Filtrerer bort ${ugyldigeStatsborgerskap.size} statsborgerskap fra PDL med fom etter gyldigTilOgMed: $ugyldigeStatsborgerskap",
+                "Filtrerer bort ${ugyldigeStatsborgerskap.size} statsborgerskap fra PDL med fom etter gyldigTilOgMed: $ugyldigeStatsborgerskap - aktør ${aktør.aktørId}",
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningsgrunnlagFiltreringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningsgrunnlagFiltreringUtils.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger
 
 import no.nav.familie.ba.sak.common.isSameOrAfter
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingUnderkategori
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.erFomEtterTom
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.DeltBosted
 import no.nav.familie.kontrakter.felles.personopplysning.Opphold
@@ -50,6 +52,18 @@ object PersonopplysningsgrunnlagFiltreringUtils {
         if (!filtrerStatsborgerskap) return this
 
         return this.filter { it.gyldigTilOgMed?.isSameOrAfter(eldsteBarnsFødselsdato) ?: true }
+    }
+
+    fun List<Statsborgerskap>.filtrerBortUgyldigeStatsborgerskap(): List<Statsborgerskap> {
+        val (ugyldigeStatsborgerskap, gyldigeStatsborgerskap) = this.partition { it.erFomEtterTom() }
+
+        if (ugyldigeStatsborgerskap.isNotEmpty()) {
+            secureLogger.warn(
+                "Filtrerer bort ${ugyldigeStatsborgerskap.size} statsborgerskap fra PDL med gyldigFraOgMed etter gyldigTilOgMed: $ugyldigeStatsborgerskap",
+            )
+        }
+
+        return gyldigeStatsborgerskap
     }
 
     fun List<Opphold>.filtrerBortOppholdFørEldsteBarn(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/StatsborgerskapService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/statsborgerskap/StatsborgerskapService.kt
@@ -290,6 +290,12 @@ class StatsborgerskapService(
 
 fun Statsborgerskap.hentFom() = this.gyldigFraOgMed ?: this.bekreftelsesdato
 
+fun Statsborgerskap.erFomEtterTom(): Boolean {
+    val fom = this.hentFom()
+    val tom = this.gyldigTilOgMed
+    return fom != null && tom != null && fom.isAfter(tom)
+}
+
 fun Statsborgerskap.iNordiskLand() = Norden.entries.map { it.name }.contains(this.land)
 
 fun Statsborgerskap.iTredjeland() = this.land != StatsborgerskapService.LANDKODE_UKJENT

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/StatsborgerskapServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/StatsborgerskapServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.datagenerator.lagKodeverkLand
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.KodeverkService
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningsgrunnlagFiltreringUtils.filtrerBortUgyldigeStatsborgerskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.GrStatsborgerskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.StatsborgerskapService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.finnNåværendeMedlemskap
@@ -420,6 +421,70 @@ internal class StatsborgerskapServiceTest {
             assertEquals(Medlemskap.NORDEN, medlemskapNorden.finnSterkesteMedlemskap())
             assertEquals(Medlemskap.UKJENT, medlemskapUkjent.finnSterkesteMedlemskap())
             assertEquals(null, medlemskapIngen.finnSterkesteMedlemskap())
+        }
+    }
+
+    @Nested
+    inner class FiltrereUgyldigeStatsborgerskapTest {
+        @Test
+        fun `skal filtrere bort statsborgerskap der gyldigFraOgMed er etter gyldigTilOgMed`() {
+            // Arrange
+            val ugyldig =
+                Statsborgerskap(
+                    "POL",
+                    gyldigFraOgMed = LocalDate.of(2024, 2, 6),
+                    gyldigTilOgMed = LocalDate.of(2024, 2, 5),
+                    bekreftelsesdato = null,
+                )
+            val gyldig =
+                Statsborgerskap(
+                    "POL",
+                    gyldigFraOgMed = LocalDate.of(2024, 2, 6),
+                    gyldigTilOgMed = null,
+                    bekreftelsesdato = null,
+                )
+
+            // Act
+            val resultat = listOf(ugyldig, gyldig).filtrerBortUgyldigeStatsborgerskap()
+
+            // Assert
+            assertEquals(listOf(gyldig), resultat)
+        }
+
+        @Test
+        fun `skal beholde statsborgerskap med null fom og tom`() {
+            // Arrange
+            val statsborgerskap =
+                Statsborgerskap(
+                    "DEU",
+                    gyldigFraOgMed = null,
+                    gyldigTilOgMed = null,
+                    bekreftelsesdato = null,
+                )
+
+            // Act
+            val resultat = listOf(statsborgerskap).filtrerBortUgyldigeStatsborgerskap()
+
+            // Assert
+            assertEquals(listOf(statsborgerskap), resultat)
+        }
+
+        @Test
+        fun `skal beholde statsborgerskap med samme fom og tom`() {
+            // Arrange
+            val statsborgerskap =
+                Statsborgerskap(
+                    "POL",
+                    gyldigFraOgMed = LocalDate.of(2024, 2, 6),
+                    gyldigTilOgMed = LocalDate.of(2024, 2, 6),
+                    bekreftelsesdato = null,
+                )
+
+            // Act
+            val resultat = listOf(statsborgerskap).filtrerBortUgyldigeStatsborgerskap()
+
+            // Assert
+            assertEquals(listOf(statsborgerskap), resultat)
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/StatsborgerskapServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/StatsborgerskapServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.POL_EØS_FOM
 import no.nav.familie.ba.sak.datagenerator.lagKodeverkLand
 import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.KodeverkService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonopplysningsgrunnlagFiltreringUtils.filtrerBortUgyldigeStatsborgerskap
@@ -429,6 +430,8 @@ internal class StatsborgerskapServiceTest {
         @Test
         fun `skal filtrere bort statsborgerskap der gyldigFraOgMed er etter gyldigTilOgMed`() {
             // Arrange
+            val aktør = randomAktør()
+
             val ugyldig =
                 Statsborgerskap(
                     "POL",
@@ -445,7 +448,7 @@ internal class StatsborgerskapServiceTest {
                 )
 
             // Act
-            val resultat = listOf(ugyldig, gyldig).filtrerBortUgyldigeStatsborgerskap()
+            val resultat = listOf(ugyldig, gyldig).filtrerBortUgyldigeStatsborgerskap(aktør)
 
             // Assert
             assertEquals(listOf(gyldig), resultat)
@@ -454,6 +457,8 @@ internal class StatsborgerskapServiceTest {
         @Test
         fun `skal beholde statsborgerskap med null fom og tom`() {
             // Arrange
+            val aktør = randomAktør()
+
             val statsborgerskap =
                 Statsborgerskap(
                     "DEU",
@@ -463,7 +468,7 @@ internal class StatsborgerskapServiceTest {
                 )
 
             // Act
-            val resultat = listOf(statsborgerskap).filtrerBortUgyldigeStatsborgerskap()
+            val resultat = listOf(statsborgerskap).filtrerBortUgyldigeStatsborgerskap(aktør)
 
             // Assert
             assertEquals(listOf(statsborgerskap), resultat)
@@ -472,6 +477,8 @@ internal class StatsborgerskapServiceTest {
         @Test
         fun `skal beholde statsborgerskap med samme fom og tom`() {
             // Arrange
+            val aktør = randomAktør()
+
             val statsborgerskap =
                 Statsborgerskap(
                     "POL",
@@ -481,7 +488,7 @@ internal class StatsborgerskapServiceTest {
                 )
 
             // Act
-            val resultat = listOf(statsborgerskap).filtrerBortUgyldigeStatsborgerskap()
+            val resultat = listOf(statsborgerskap).filtrerBortUgyldigeStatsborgerskap(aktør)
 
             // Assert
             assertEquals(listOf(statsborgerskap), resultat)


### PR DESCRIPTION
### 📮 Favro: NAV-28767

### 💰 Hva skal gjøres, og hvorfor?

Opprettelse av behandling kræsjet når PDL leverte et statsborgerskap der gyldigFraOgMed var etter gyldigTilOgMed, fordi tidslinjebiblioteket kaster IllegalArgumentException for perioder med negativ lengde.

Filtrerer slike ugyldige perioder bort i PersongrunnlagService før de sendes inn i StatsborgerskapService, etter samme mønster som vi har for adresser.