### PR TITLE
Vi tillater henting av sammensatt kontrollsak uavhengig av tilgang el…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakController.kt
@@ -42,10 +42,6 @@ class SammensattKontrollsakController(
     fun hentSammensattKontrollsak(
         @PathVariable behandlingId: Long,
     ): ResponseEntity<Ressurs<SammensattKontrollsakDto?>> {
-        if (!featureToggleService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
-            throw FunksjonellFeil(melding = ikkeTilgangFeilmelding)
-        }
-
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "Hent SammensattKontrollsak",


### PR DESCRIPTION
### 📮 Favro: Nav-28889

### 💰 Hva skal gjøres, og hvorfor?

Hver gang en saksbehandler navigerer rundt i en behandling så gjøres det et kall mot backend for å hente sammensatt kontrollsak.
Men dette skjer uavhengig om en saksbehandler har tilgang for å endre eller oppdatere sammensatte kontrollsaker.
Når dette skjer skaper det mye støy hos oss, siden saksbehandler forsøker å hente en sammensatt kontroll sak uten tilgangen til å endre eller oppdatere.

<img width="1522" height="911" alt="STØY" src="https://github.com/user-attachments/assets/012157a8-4bd7-4f26-976f-ebe83229e95a" />

Har snakket med Anna om dette, og det skal uansett være mulig for en saksbehandler å hente disse sakene uavhengig av tilgang.