### PR TITLE
Vi oppdaterer endretTidspunkt på personopplysninggrunnlaget når data hentes på nytt fra PDL og det er helt likt nåværende grunnlag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RegisterhistorikkDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/RegisterhistorikkDto.kt
@@ -20,7 +20,7 @@ data class RegisterhistorikkDto(
 
 fun Person.tilRegisterhistorikkDto(eldsteBarnsFødselsdato: LocalDate?) =
     RegisterhistorikkDto(
-        hentetTidspunkt = this.personopplysningGrunnlag.opprettetTidspunkt,
+        hentetTidspunkt = this.personopplysningGrunnlag.endretTidspunkt,
         oppholdstillatelse = opphold.map { it.tilRegisteropplysningDto() },
         statsborgerskap = statsborgerskap.map { it.tilRegisteropplysningDto() },
         bostedsadresse = this.bostedsadresser.map { it.tilRegisteropplysningDto() }.fyllInnTomDatoer(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 class PersongrunnlagService(
@@ -345,7 +346,11 @@ class PersongrunnlagService(
                 saksstatistikkEventPublisher.publiserSaksstatistikk(behandling.fagsak.id)
             }
         } else {
-            aktivtPersonopplysningGrunnlag
+            // Siden vi ikke har gjort noen endringer i det aktive personopplysningsgrunnlaget, trenger vi ikke å lagre det på nytt.
+            // Vi oppdaterer likevel endretTidspunkt for å reflektere at det er sjekket for oppdateringer i registeret.
+            aktivtPersonopplysningGrunnlag.apply {
+                endretTidspunkt = LocalDateTime.now()
+            }
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/PersonDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/PersonDtoTest.kt
@@ -13,6 +13,39 @@ import java.time.LocalDateTime
 
 class PersonDtoTest {
     @Test
+    fun `tilRegisterhistorikkDto skal bruke endretTidspunkt som hentetTidspunkt`() {
+        // Arrange
+        val endret = LocalDateTime.of(2025, 6, 15, 10, 30, 0)
+
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(
+                id = 1L,
+                behandlingId = 1L,
+                lagPersoner = { grunnlag ->
+                    setOf(
+                        Person(
+                            aktør = Aktør(aktørId = "1234567891011"),
+                            type = PersonType.SØKER,
+                            fødselsdato = LocalDate.of(1980, 1, 1),
+                            navn = "Test Testesen",
+                            kjønn = Kjønn.KVINNE,
+                            personopplysningGrunnlag = grunnlag,
+                        ),
+                    )
+                },
+            )
+
+        personopplysningGrunnlag.endretTidspunkt = endret
+
+        // Act
+        val dto = personopplysningGrunnlag.søker.tilRegisterhistorikkDto(eldsteBarnsFødselsdato = null)
+
+        // Assert
+        assertThat(dto.hentetTidspunkt).isEqualTo(endret)
+        assertThat(dto.hentetTidspunkt).isNotEqualTo(personopplysningGrunnlag.opprettetTidspunkt)
+    }
+
+    @Test
     fun `historiskeIdenter skal kun inkludere inaktive identer med gjelderTil lik eller etter eldste barn sin fødselsdato`() {
         // Arrange
         val aktør = Aktør(aktørId = "1234567891011")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagServiceTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 class PersongrunnlagServiceTest {
@@ -425,6 +426,45 @@ class PersongrunnlagServiceTest {
             val sorterteAdresser = bostedadresseSøker.sortedBy { it.periode?.fom }
             assertThat(sorterteAdresser.first().periode?.tom).isAfter(eldsteBarn.fødselsdato)
             assertThat(sorterteAdresser.last().periode?.fom).isAfter(eldsteBarn.fødselsdato)
+        }
+
+        @Test
+        fun `skal oppdatere endretTidspunkt på aktivt grunnlag når det ikke er relevante endringer`() {
+            // Arrange
+            val søker = lagPerson(type = PersonType.SØKER)
+            val barn = lagPerson(type = PersonType.BARN)
+            val behandling = lagBehandling(behandlingType = BehandlingType.REVURDERING)
+
+            val opprinneligEndretTidspunkt = LocalDateTime.of(2020, 1, 1, 12, 0, 0)
+            val aktivtGrunnlag =
+                lagTestPersonopplysningGrunnlag(
+                    behandlingId = behandling.id,
+                    personer = arrayOf(søker, barn),
+                ).apply {
+                    endretTidspunkt = opprinneligEndretTidspunkt
+                }
+
+            every { persongrunnlagService.hentAktiv(behandling.id) } returns aktivtGrunnlag
+
+            every { personopplysningerService.hentPersoninfoEnkel(barn.aktør) } returns PersonInfo(barn.fødselsdato)
+            every { personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(søker.aktør) } returns
+                PersonInfo(søker.fødselsdato, søker.navn, søker.kjønn)
+            every { personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(barn.aktør) } returns
+                PersonInfo(barn.fødselsdato, barn.navn, barn.kjønn)
+
+            // Act
+            val oppdatertPersonopplysningGrunnlag =
+                persongrunnlagService.hentOgLagreSøkerOgBarnINyttGrunnlag(
+                    aktør = søker.aktør,
+                    barnFraInneværendeBehandling = listOf(barn.aktør),
+                    behandling = behandling,
+                    målform = Målform.NB,
+                )
+
+            // Assert
+            assertThat(oppdatertPersonopplysningGrunnlag).isSameAs(aktivtGrunnlag)
+            assertThat(oppdatertPersonopplysningGrunnlag.endretTidspunkt).isAfter(opprinneligEndretTidspunkt)
+            verify(exactly = 0) { persongrunnlagService.lagreOgDeaktiverGammel(any()) }
         }
 
         @Nested


### PR DESCRIPTION
### 📮 Favro: Nav-28967

### 💰 Hva skal gjøres, og hvorfor?

I frontend viser vi fram når personopplysninggrunnlag er hentet ned fra PDL.
Dette har vi tidligere brukt opprettet_tidspunktet på grunnlaget til å gjøre.

I denne [pullrequesten](https://github.com/navikt/familie-ba-sak/pull/6113) gikk vi bort fra å lagre ned ny personopplysinggrunnlag når den er helt identisk med den vi allerede har. Dette for å kutte ned unødvendig lagring.

Sideeffekten av dette er at opprettet_tidspunktet da ikke forandrer på seg når saksbehandler trykker "oppdater registeropplysninger" knappen hvis det ikke har vært endring i pdl, siden vi ikke oppretter nytt objekt som fører.
Dette fører til at saksbehandler tror at knappen ikke fungerer.

Diskutert dette med @MagnusTonnessen og vi tenker at at vi bruker endret_tidspunktet på objektet, samtidig som vi oppdaterer det når knappen trykkes og det ikke er noe endringer.