### PR TITLE
Batch som låser fagsaker etter arkivlovens kasseringsregler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -49,4 +49,8 @@ enum class FeatureToggle(
     TILLAT_TILGANG_SKJERMET_BARN_UTEN_LØPENDE_ANDELER("familie-ba-sak.tillat-tilgang-skjermet-barn-uten-lopende-andeler"),
 
     UTLED_AVREGNING_PÅ_TVERS_AV_BEHANDLINGER("familie-ba-sak.utled-avregning-paa-tvers-av-behandlinger"),
+
+    // NAV-28902
+    FAGSAKLÅSING_SCHEDULER("familie-ba-sak.fagsaklaasing-scheduler"),
+    KAN_LÅSE_FAGSAK("familie-ba-sak.kan-laase-fagsak"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/ForvalterController.kt
@@ -28,6 +28,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatusScheduler
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentRepository
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
@@ -95,6 +96,7 @@ class ForvalterController(
     private val taskService: TaskService,
     private val autovedtakMånedligValutajusteringService: AutovedtakMånedligValutajusteringService,
     private val månedligValutajusteringScheduler: MånedligValutajusteringScheduler,
+    private val fagsakStatusScheduler: FagsakStatusScheduler,
     private val fagsakService: FagsakService,
     private val featureToggleService: FeatureToggleService,
     private val taskRepository: TaskRepositoryWrapper,
@@ -755,5 +757,29 @@ class ForvalterController(
             behandlingHentOgPersisterService.lagreEllerOppdater(this, sendTilDvh = false)
             secureLogger.info("Patchet ${behandling.fagsak.id} ved å deaktivere behandling ${behandling.id} og setter siste vedtatte behandling ($id) til aktiv")
         }
+    }
+
+    @PostMapping("/fagsaklåsing/start-batch")
+    @Operation(summary = "Start batch for å låse fagsaker iht. arkivloven")
+    fun startFagsakLåsingBatch(): ResponseEntity<Ressurs<String>> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Start fagsaklåsing-batch",
+        )
+        fagsakStatusScheduler.startFagsakLåsing()
+        return ResponseEntity.ok(Ressurs.success("Fagsaklåsing-batch startet"))
+    }
+
+    @PostMapping("/fagsaklåsing/lås-fagsak/{fagsakId}")
+    @Operation(summary = "Lås én fagsak iht. arkivloven")
+    fun låsFagsak(
+        @PathVariable fagsakId: Long,
+    ): ResponseEntity<Ressurs<String>> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "Lås fagsak",
+        )
+        fagsakService.låsFagsak(fagsakId)
+        return ResponseEntity.ok(Ressurs.success("Fagsak $fagsakId er låst"))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -273,4 +273,42 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
         nativeQuery = true,
     )
     fun finnIdenterForLøpendeFagsaker(): List<String>
+
+    @Lock(LockModeType.NONE)
+    @Query(
+        value = """
+        WITH siste_vedtatte AS (
+            -- Siste vedtatte behandling per fagsak
+            SELECT DISTINCT ON (b.fk_fagsak_id) b.id, b.fk_fagsak_id
+            FROM behandling b
+            INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
+            WHERE f.status   = 'AVSLUTTET'
+              AND f.arkivert  = FALSE
+              AND b.status   = 'AVSLUTTET'
+              AND b.resultat NOT LIKE 'HENLAGT%'
+            ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC
+        ),
+        yngste_barn AS (
+            SELECT sv.fk_fagsak_id,
+                   MAX(p.foedselsdato) AS yngste_foedselsdato
+            FROM   siste_vedtatte sv
+            INNER JOIN gr_personopplysninger gr
+                   ON  gr.fk_behandling_id = sv.id AND gr.aktiv = TRUE
+            INNER JOIN po_person p
+                   ON  p.fk_gr_personopplysninger_id = gr.id AND p.type = 'BARN'
+            GROUP BY sv.fk_fagsak_id
+        )
+        -- Fagsaker der yngste barn har fylt 18 år for mer enn 1 år siden,
+        -- og som ikke allerede er aktivt låst
+        SELECT yb.fk_fagsak_id
+        FROM   yngste_barn yb
+        WHERE  yb.yngste_foedselsdato + INTERVAL '19 years' <= CURRENT_DATE
+          AND  NOT EXISTS (
+                   SELECT 1 FROM fagsak_laasing fl
+                   WHERE  fl.fk_fagsak_id = yb.fk_fagsak_id AND fl.aktiv = TRUE
+               )
+        """,
+        nativeQuery = true,
+    )
+    fun finnAvsluttedeFagsakerSomSkalLåses(): List<Long>
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -21,7 +21,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.UtvidetBehandlingService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingRepository
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonRepository
 import no.nav.familie.ba.sak.kjerne.institusjon.InstitusjonService
@@ -271,7 +270,7 @@ class FagsakService(
                 finnesStrengtFortroligPersonIFagsak = strengtFortroligService.harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak),
                 låstTidspunkt =
                     if (fagsak.status == FagsakStatus.LÅST) {
-                        fagsakLåsingService.finnAktivLåsForFagsak(fagsak.id)?.tidspunkt
+                        fagsakLåsingService.finnAktivLåsForFagsak(fagsak.id)?.opprettetTidspunkt
                     } else {
                         null
                     },
@@ -362,6 +361,9 @@ class FagsakService(
         fagsakId: Long,
         begrunnelse: String,
     ) = fagsakLåsingService.låsOppFagsak(fagsakId, begrunnelse)
+
+    @Transactional
+    fun låsFagsak(fagsakId: Long) = fagsakLåsingService.låsFagsak(fagsakId)
 
     companion object {
         private val logger = LoggerFactory.getLogger(FagsakService::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
-import no.nav.familie.ba.sak.task.`FinnFagsakerSomSkalLåsesTask`
+import no.nav.familie.ba.sak.task.FinnFagsakerSomSkalLåsesTask
 import no.nav.familie.ba.sak.task.OppdaterLøpendeFlagg
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -3,6 +3,9 @@ package no.nav.familie.ba.sak.kjerne.fagsak
 import no.nav.familie.ba.sak.common.EnvService
 import no.nav.familie.ba.sak.config.LeaderClientService
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ba.sak.task.`FinnFagsakerSomSkalLåsesTask`
 import no.nav.familie.ba.sak.task.OppdaterLøpendeFlagg
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
@@ -14,6 +17,7 @@ class FagsakStatusScheduler(
     private val taskRepository: TaskRepositoryWrapper,
     private val envService: EnvService,
     private val leaderClientService: LeaderClientService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     /*
      * Siden barnetrygd er en månedsytelse vil en fagsak alltid løpe ut en måned
@@ -32,6 +36,18 @@ class FagsakStatusScheduler(
             false -> {
                 logger.info("Ikke opprettet oppdaterLøpendeFlaggTask på denne poden")
             }
+        }
+    }
+
+    @Scheduled(cron = "\${CRON_FAGSAKSTATUS_SCHEDULER}")
+    fun startFagsakLåsing() {
+        if (!featureToggleService.isEnabled(FeatureToggle.FAGSAKLÅSING_SCHEDULER)) {
+            logger.info("Fagsaklåsing-scheduler-toggle er av, hopper over batch")
+            return
+        }
+        if (leaderClientService.isLeader() || envService.erDev()) {
+            taskRepository.save(Task(type = FinnFagsakerSomSkalLåsesTask.TASK_STEP_TYPE, payload = ""))
+            logger.info("Opprettet FinnFagsakerForLåsingTask")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakStatusScheduler.kt
@@ -39,7 +39,7 @@ class FagsakStatusScheduler(
         }
     }
 
-    @Scheduled(cron = "\${CRON_FAGSAKSTATUS_SCHEDULER}")
+    @Scheduled(cron = "\${CRON_LÅS_FAGSAK_SCHEDULER}")
     fun startFagsakLåsing() {
         if (!featureToggleService.isEnabled(FeatureToggle.FAGSAKLÅSING_SCHEDULER)) {
             logger.info("Fagsaklåsing-scheduler-toggle er av, hopper over batch")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -87,7 +87,7 @@ class FagsakLåsingService(
         lagreOgDeaktiverGammel(
             FagsakLåsing(
                 fagsak = fagsak,
-                tidspunkt = LocalDateTime.now(),
+                tidspunkt = låsedato,
                 hendelse = FagsakLåsHendelse.LÅST,
                 begrunnelse = "Automatisk låst iht. arkivloven fordi yngste barn fylte 18 år ${yngsteBarnsFødselsdato.plusYears(18)}",
                 aktiv = true,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -178,7 +178,7 @@ class FagsakLåsingService(
     }
 
     private fun lagre(fagsak: Fagsak): Fagsak {
-        logger.info("${hentSaksbehandlerNavn()} oppretter fagsak $fagsak")
+        logger.info("${hentSaksbehandlerNavn()} oppdaterer fagsak $fagsak")
         return fagsakRepository.save(fagsak).also { saksstatistikkEventPublisher.publiserSaksstatistikk(it.id) }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -2,16 +2,25 @@ package no.nav.familie.ba.sak.kjerne.fagsaklåsing
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.hentSaksbehandlerNavn
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
 import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -19,9 +28,90 @@ import java.time.LocalDateTime
 @Service
 class FagsakLåsingService(
     private val fagsakRepository: FagsakRepository,
-    private val fagsakLåsingRepository: FagsakLåsingRepository,
+    private val `fagsakLåsingRepository`: FagsakLåsingRepository,
     private val integrasjonKlient: IntegrasjonKlient,
+    private val persongrunnlagService: PersongrunnlagService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val featureToggleService: FeatureToggleService,
+    private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @Transactional
+    fun låsFagsak(fagsakId: Long) {
+        if (!featureToggleService.isEnabled(FeatureToggle.KAN_LÅSE_FAGSAK)) {
+            logger.info("Toggle for låsing av fagsak er av, hopper ut")
+            return
+        }
+
+        val fagsak =
+            fagsakRepository.finnFagsak(fagsakId)
+                ?: throw Feil("Fant ikke fagsak $fagsakId")
+
+        if (fagsak.status != FagsakStatus.AVSLUTTET) {
+            logger.info("Status for fagsak $fagsakId er ${fagsak.status}, hopper ut")
+            return
+        }
+
+        if (behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(fagsakId)) {
+            logger.info("Fagsak $fagsakId har åpen behandling, hopper ut")
+            return
+        }
+
+        val aktivLåsForFagsak = finnAktivLåsForFagsak(fagsak.id)
+        if (aktivLåsForFagsak?.hendelse == FagsakLåsHendelse.LÅST) {
+            throw Feil("Fagsak $fagsakId har allerede aktiv låsing")
+        }
+
+        val fagsakBleLåstOppForUnder30DagerSiden = aktivLåsForFagsak?.opprettetTidspunkt?.isAfter(LocalDateTime.now().minusDays(30)) == true
+        if (fagsakBleLåstOppForUnder30DagerSiden) {
+            logger.info("Fagsak $fagsakId ble låst opp for under 30 dager siden, hopper ut")
+            return
+        }
+
+        val barnPåFagsak =
+            persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsakId)?.filter { it.type == PersonType.BARN }
+                ?: throw Feil("Fant ingen barn på fagsak $fagsakId")
+
+        val yngsteBarnsFødselsdato =
+            barnPåFagsak.maxOfOrNull { it.fødselsdato }
+                ?: throw Feil("Fant ikke yngste barns fødselsdato på fagsak $fagsakId")
+
+        val låsedato = yngsteBarnsFødselsdato.plusYears(19).atStartOfDay()
+        if (LocalDateTime.now() < låsedato) {
+            logger.info("Fagsak skal ikke låses før $låsedato, hopper ut")
+            return
+        }
+
+        lagreOgDeaktiverGammel(
+            FagsakLåsing(
+                fagsak = fagsak,
+                tidspunkt = LocalDateTime.now(),
+                hendelse = FagsakLåsHendelse.LÅST,
+                begrunnelse = "Automatisk låst iht. arkivloven fordi yngste barn fylte 18 år ${yngsteBarnsFødselsdato.plusYears(18)}",
+                aktiv = true,
+            ),
+        )
+
+        oppdaterStatus(fagsak, FagsakStatus.LÅST)
+
+        val arbeidsfordeling = arbeidsfordelingService.hentArbeidsfordelingsenhetPåIdenter(fagsak, barnPåFagsak.map { it.aktør.aktivFødselsnummer() }, null)
+
+        integrasjonKlient.avsluttSak(
+            AvsluttSakRequest(
+                tema = Tema.BAR,
+                fagsakId = fagsakId.toString(),
+                fagsaksystem = Fagsystem.BA,
+                bruker = DokarkivBruker(BrukerIdType.FNR, fagsak.aktør.aktivFødselsnummer()),
+                opprettetDato = fagsak.opprettetTidspunkt,
+                avsluttetDato = låsedato,
+                administrativEnhet = arbeidsfordeling.enhetId,
+            ),
+        )
+        logger.info("Fagsak $fagsakId er låst og meldt til Joark")
+    }
+
     @Transactional
     fun låsOppFagsak(
         fagsakId: Long,
@@ -47,8 +137,7 @@ class FagsakLåsingService(
             ),
         )
 
-        fagsak.status = FagsakStatus.AVSLUTTET
-        fagsakRepository.save(fagsak)
+        oppdaterStatus(fagsak, FagsakStatus.AVSLUTTET)
 
         integrasjonKlient.gjenåpneSakIDokarkiv(
             GjenåpneSakRequest(
@@ -68,7 +157,7 @@ class FagsakLåsingService(
 
     fun finnAktivLåsForFagsak(fagsakId: Long) = fagsakLåsingRepository.finnAktivLåsForFagsak(fagsakId = fagsakId)
 
-    fun lagreOgDeaktiverGammel(fagsakLåsing: FagsakLåsing): FagsakLåsing {
+    private fun lagreOgDeaktiverGammel(fagsakLåsing: FagsakLåsing): FagsakLåsing {
         val aktivFagsakLåsing = fagsakLåsingRepository.finnAktivLåsForFagsak(fagsakLåsing.fagsak.id)
 
         if (aktivFagsakLåsing != null && aktivFagsakLåsing.id != fagsakLåsing.id) {
@@ -76,5 +165,20 @@ class FagsakLåsingService(
         }
 
         return fagsakLåsingRepository.save(fagsakLåsing)
+    }
+
+    private fun oppdaterStatus(
+        fagsak: Fagsak,
+        nyStatus: FagsakStatus,
+    ): Fagsak {
+        logger.info("${hentSaksbehandlerNavn()} endrer status på fagsak ${fagsak.id} fra ${fagsak.status} til $nyStatus")
+        fagsak.status = nyStatus
+
+        return lagre(fagsak)
+    }
+
+    private fun lagre(fagsak: Fagsak): Fagsak {
+        logger.info("${hentSaksbehandlerNavn()} oppretter fagsak $fagsak")
+        return fagsakRepository.save(fagsak).also { saksstatistikkEventPublisher.publiserSaksstatistikk(it.id) }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -28,7 +28,7 @@ import java.time.LocalDateTime
 @Service
 class FagsakLåsingService(
     private val fagsakRepository: FagsakRepository,
-    private val `fagsakLåsingRepository`: FagsakLåsingRepository,
+    private val fagsakLåsingRepository: FagsakLåsingRepository,
     private val integrasjonKlient: IntegrasjonKlient,
     private val persongrunnlagService: PersongrunnlagService,
     private val arbeidsfordelingService: ArbeidsfordelingService,

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/FinnFagsakerSomSkalLåsesTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/FinnFagsakerSomSkalLåsesTask.kt
@@ -1,0 +1,34 @@
+package no.nav.familie.ba.sak.task
+
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = FinnFagsakerSomSkalLåsesTask.TASK_STEP_TYPE,
+    beskrivelse = "Finn fagsaker som skal låses",
+    maxAntallFeil = 3,
+)
+class FinnFagsakerSomSkalLåsesTask(
+    private val taskRepository: TaskRepositoryWrapper,
+    private val fagsakRepository: FagsakRepository,
+) : AsyncTaskStep {
+    @WithSpan
+    override fun doTask(task: Task) {
+        fagsakRepository
+            .finnAvsluttedeFagsakerSomSkalLåses()
+            .also { logger.info("Fant ${it.size} fagsaker som skal låses") }
+            .forEach { taskRepository.save(LåsFagsakTask.opprettTask(it)) }
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "finnFagsakerSomSkalLåsesTask"
+        private val logger = LoggerFactory.getLogger(FinnFagsakerSomSkalLåsesTask::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/LåsFagsakTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/LåsFagsakTask.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ba.sak.task
+
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.task.OpprettTaskService.Companion.overstyrTaskMedNyCallId
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.log.IdUtils
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import tools.jackson.module.kotlin.readValue
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = LåsFagsakTask.TASK_STEP_TYPE,
+    beskrivelse = "Lås fagsak og send melding til statistikk og Joark",
+    maxAntallFeil = 3,
+    settTilManuellOppfølgning = true,
+)
+class LåsFagsakTask(
+    private val fagsakService: FagsakService,
+) : AsyncTaskStep {
+    @WithSpan
+    override fun doTask(task: Task) {
+        val fagsakId = jsonMapper.readValue<Long>(task.payload)
+        fagsakService.låsFagsak(fagsakId)
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "låsFagsakTask"
+
+        fun opprettTask(fagsakId: Long): Task =
+            overstyrTaskMedNyCallId(IdUtils.generateId()) {
+                Task(
+                    type = TASK_STEP_TYPE,
+                    payload = jsonMapper.writeValueAsString(fagsakId),
+                )
+            }
+    }
+}

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -162,5 +162,6 @@ FAMILIE_BA_INFOTRYGD_FEED_API_URL: https://familie-ba-infotrygd-feed.dev-fss-pub
 
 FAMILIE_OPPDRAG_API_URL: https://familie-oppdrag.dev-fss-pub.nais.io/api
 CRON_FAGSAKSTATUS_SCHEDULER: "0 0/30 * ? * *"
+CRON_LÅS_FAGSAK_SCHEDULER: "0 0/30 * ? * *"
 
 ENVIRONMENT_NAME: q2

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -156,6 +156,7 @@ SANITY_FAMILIE_API_URL: https://xsrv1mh6.apicdn.sanity.io/v2021-06-07/data/query
 ECB_API_URL: https://data-api.ecb.europa.eu/service/data/EXR/
 NORGES_BANK_API_URL: https://data.norges-bank.no/api/data/EXR/
 CRON_FAGSAKSTATUS_SCHEDULER: "0 0 6 1 * *"
+CRON_LÅS_FAGSAK_SCHEDULER: "0 0 5 1 * *"
 
 # Swagger
 AUTHORIZATION_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/authorize

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -26,7 +26,6 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsHendelse
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsing
-import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingRepository
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonRepository
 import no.nav.familie.ba.sak.kjerne.institusjon.InstitusjonService
@@ -238,7 +237,7 @@ class FagsakServiceTest {
             val restMinimalFagsak = fagsakService.lagMinimalFagsakDto(fagsak.id)
 
             // Assert
-            assertThat(restMinimalFagsak.låstTidspunkt).isEqualTo(låstTidspunkt)
+            assertThat(restMinimalFagsak.låstTidspunkt).isEqualTo(fagsakLåsing.opprettetTidspunkt)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
@@ -1,37 +1,273 @@
 package no.nav.familie.ba.sak.kjerne.fagsaklåsing
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.datagenerator.lagPersonEnkel
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
+import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 class FagsakLåsingServiceTest {
     private val fagsakRepository = mockk<FagsakRepository>()
     private val fagsakLåsingRepository = mockk<FagsakLåsingRepository>()
     private val integrasjonKlient = mockk<IntegrasjonKlient>()
+    private val persongrunnlagService = mockk<PersongrunnlagService>()
+    private val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val saksstatistikkEventPublisher = mockk<SaksstatistikkEventPublisher>()
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
 
     private val fagsakLåsingService =
         FagsakLåsingService(
             fagsakRepository = fagsakRepository,
             fagsakLåsingRepository = fagsakLåsingRepository,
             integrasjonKlient = integrasjonKlient,
+            persongrunnlagService = persongrunnlagService,
+            arbeidsfordelingService = arbeidsfordelingService,
+            featureToggleService = featureToggleService,
+            saksstatistikkEventPublisher = saksstatistikkEventPublisher,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
         )
+
+    @Nested
+    inner class LåsFagsak {
+        private val fagsak = lagFagsak(status = FagsakStatus.AVSLUTTET)
+        private val arbeidsfordelingsenhet = Arbeidsfordelingsenhet(enhetId = "1234", enhetNavn = "Enhet")
+        private val yngsteBarnFødselsdato = LocalDate.now().minusYears(20)
+        private val personer = setOf(lagPersonEnkel(personType = PersonType.BARN, fødselsdato = yngsteBarnFødselsdato))
+        private var listAppender = ListAppender<ILoggingEvent>().apply { start() }
+
+        @BeforeEach
+        fun setup() {
+            every { featureToggleService.isEnabled(FeatureToggle.KAN_LÅSE_FAGSAK) } returns true
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns null
+            every { persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsak.id) } returns personer
+            every { behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(fagsak.id) } returns false
+            every { fagsakLåsingRepository.save(any()) } answers { firstArg() }
+            every { fagsakRepository.save(fagsak) } returns fagsak
+            every { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) } just runs
+            every { arbeidsfordelingService.hentArbeidsfordelingsenhetPåIdenter(fagsak, personer.map { it.aktør.aktivFødselsnummer() }, any()) } returns arbeidsfordelingsenhet
+            every { integrasjonKlient.avsluttSak(any()) } just runs
+
+            listAppender = ListAppender<ILoggingEvent>().apply { start() }
+            (LoggerFactory.getLogger(FagsakLåsingService::class.java) as Logger).run {
+                level = Level.INFO
+                detachAndStopAllAppenders()
+                addAppender(listAppender)
+            }
+        }
+
+        @Test
+        fun `skal låse avsluttet fagsak og sende melding til Joark`() {
+            // Arrange
+            val lagretLåsSlot = slot<FagsakLåsing>()
+            val joarkRequestSlot = slot<AvsluttSakRequest>()
+
+            // Mocker for å kunne sette `opprettetTidspunkt` til mer enn 30 dager siden
+            val låstOppFagsakLåsing =
+                mockk<FagsakLåsing>(relaxed = true) {
+                    every { opprettetTidspunkt } returns LocalDateTime.now().minusDays(50)
+                }
+
+            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns låstOppFagsakLåsing
+            every { fagsakLåsingRepository.save(capture(lagretLåsSlot)) } answers { firstArg() }
+            every { integrasjonKlient.avsluttSak(capture(joarkRequestSlot)) } just runs
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(fagsak.status).isEqualTo(FagsakStatus.LÅST)
+            assertThat(lagretLåsSlot.captured.hendelse).isEqualTo(FagsakLåsHendelse.LÅST)
+            assertThat(lagretLåsSlot.captured.aktiv).isTrue()
+            assertThat(lagretLåsSlot.captured.begrunnelse).isEqualTo("Automatisk låst iht. arkivloven fordi yngste barn fylte 18 år ${yngsteBarnFødselsdato.plusYears(18)}")
+            assertThat(joarkRequestSlot.captured.fagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(joarkRequestSlot.captured.administrativEnhet).isEqualTo(arbeidsfordelingsenhet.enhetId)
+            verify { saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id) }
+        }
+
+        @Test
+        fun `skal hoppe over låsing når toggle er av`() {
+            // Arrange
+            every { featureToggleService.isEnabled(FeatureToggle.KAN_LÅSE_FAGSAK) } returns false
+
+            // Act
+            fagsakLåsingService.låsFagsak(1)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).isEqualTo("Toggle for låsing av fagsak er av, hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.finnFagsak(any()) }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak som ikke er AVSLUTTET`() {
+            // Arrange
+            val fagsak = lagFagsak(status = FagsakStatus.LØPENDE)
+
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).isEqualTo("Status for fagsak ${fagsak.id} er LØPENDE, hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { fagsakLåsingRepository.save(any()) }
+            verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak som har åpen behandling`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(fagsak.id) } returns true
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen behandling, hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal kaste Feil hvis fagsak har FagsakLåsing med hendelse LÅST`() {
+            // Arrange
+            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns
+                FagsakLåsing(
+                    fagsak = fagsak,
+                    tidspunkt = LocalDateTime.now().minusDays(1),
+                    hendelse = FagsakLåsHendelse.LÅST,
+                    begrunnelse = "Allerede låst",
+                    aktiv = true,
+                )
+
+            // Act
+            val feil = assertThrows<Feil> { fagsakLåsingService.låsFagsak(fagsak.id) }
+
+            // Assert
+            assertThat(feil.message).isEqualTo("Fagsak ${fagsak.id} har allerede aktiv låsing")
+        }
+
+        @Test
+        fun `skal hoppe over fagsak som ble låst opp for under 30 dager siden`() {
+            // Arrange
+            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns
+                FagsakLåsing(
+                    fagsak = fagsak,
+                    tidspunkt = LocalDateTime.now().minusDays(1),
+                    hendelse = FagsakLåsHendelse.LÅST_OPP,
+                    begrunnelse = "Låst opp",
+                    aktiv = true,
+                )
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} ble låst opp for under 30 dager siden, hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal kaste Feil hvis fagsak ikke finnes`() {
+            // Arrange
+            every { fagsakRepository.finnFagsak(999) } returns null
+
+            // Act & Assert
+            assertThrows<Feil> { fagsakLåsingService.låsFagsak(999) }
+        }
+
+        @Test
+        fun `skal kaste Feil hvis det ikke finnes barn på fagsak`() {
+            // Arrange
+            every { persongrunnlagService.hentSøkerOgBarnPåFagsak(any()) } returns null
+
+            // Act & Assert
+            assertThrows<Feil> { fagsakLåsingService.låsFagsak(fagsak.id) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak der yngste barn ikke er gammelt nok`() {
+            // Arrange
+            every { persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsak.id) } returns
+                setOf(
+                    lagPersonEnkel(
+                        personType = PersonType.BARN,
+                        fødselsdato = LocalDate.now().minusYears(17),
+                    ),
+                )
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert — ingen mutasjoner
+            verify(exactly = 0) { fagsakLåsingRepository.save(any()) }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal propagere exception fra Joark slik at transaksjonen ruller tilbake`() {
+            // Arrange
+            every { integrasjonKlient.avsluttSak(any()) } throws RuntimeException("Joark er nede")
+
+            // Act & Assert
+            assertThrows<RuntimeException> { fagsakLåsingService.låsFagsak(fagsak.id) }
+        }
+    }
 
     @Nested
     inner class LåsOppFagsak {
@@ -51,6 +287,7 @@ class FagsakLåsingServiceTest {
 
             val låsingSlot = slot<FagsakLåsing>()
             every { fagsakLåsingRepository.save(capture(låsingSlot)) } answers { firstArg() }
+            every { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) } just runs
 
             // Act
             fagsakLåsingService.låsOppFagsak(fagsak.id, "En god grunn")
@@ -59,6 +296,7 @@ class FagsakLåsingServiceTest {
             assertThat(låsingSlot.captured.hendelse).isEqualTo(FagsakLåsHendelse.LÅST_OPP)
             assertThat(låsingSlot.captured.begrunnelse).isEqualTo("En god grunn")
             assertThat(låsingSlot.captured.fagsak.id).isEqualTo(fagsak.id)
+            verify { saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id) }
         }
 
         @Test
@@ -66,6 +304,7 @@ class FagsakLåsingServiceTest {
             // Arrange
             val fagsak = lagFagsak(status = FagsakStatus.LÅST)
             every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+            every { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) } just runs
 
             // Act
             val oppdatertFagsak = fagsakLåsingService.låsOppFagsak(fagsak.id, "En god grunn")
@@ -73,6 +312,7 @@ class FagsakLåsingServiceTest {
             // Assert
             assertThat(oppdatertFagsak.status).isEqualTo(FagsakStatus.AVSLUTTET)
             verify { fagsakRepository.save(match { it.status == FagsakStatus.AVSLUTTET }) }
+            verify { saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id) }
         }
 
         @Test
@@ -83,6 +323,7 @@ class FagsakLåsingServiceTest {
 
             val requestSlot = slot<GjenåpneSakRequest>()
             every { integrasjonKlient.gjenåpneSakIDokarkiv(capture(requestSlot)) } just runs
+            every { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) } just runs
 
             // Act
             fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
@@ -94,6 +335,7 @@ class FagsakLåsingServiceTest {
             assertThat(request.fagsaksystem).isEqualTo(Fagsystem.BA)
             assertThat(request.bruker.idType).isEqualTo(BrukerIdType.FNR)
             assertThat(request.bruker.id).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            verify { saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id) }
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
@@ -114,6 +114,7 @@ class FagsakLåsingServiceTest {
             assertThat(lagretLåsSlot.captured.hendelse).isEqualTo(FagsakLåsHendelse.LÅST)
             assertThat(lagretLåsSlot.captured.aktiv).isTrue()
             assertThat(lagretLåsSlot.captured.begrunnelse).isEqualTo("Automatisk låst iht. arkivloven fordi yngste barn fylte 18 år ${yngsteBarnFødselsdato.plusYears(18)}")
+            assertThat(lagretLåsSlot.captured.tidspunkt).isEqualTo(yngsteBarnFødselsdato.plusYears(19).atStartOfDay())
             assertThat(joarkRequestSlot.captured.fagsakId).isEqualTo(fagsak.id.toString())
             assertThat(joarkRequestSlot.captured.administrativEnhet).isEqualTo(arbeidsfordelingsenhet.enhetId)
             verify { saksstatistikkEventPublisher.publiserSaksstatistikk(fagsak.id) }

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -177,6 +177,7 @@ KAFKA_BROKERS: http://localhost:9092
 retry.backoff.delay: 5
 NAIS_APP_NAME: familie-ba-sak
 CRON_FAGSAKSTATUS_SCHEDULER: "0 0/10 * ? * *"
+CRON_LÅS_FAGSAK_SCHEDULER: "0 0/10 * ? * *"
 
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
 


### PR DESCRIPTION
### 📮 Favro: NAV-28902

### 💰 Hva skal gjøres, og hvorfor?

Implementerer en automatisk batch-jobb som låser avsluttede fagsaker iht. arkivloven. En fagsak låses 1 år etter yngste barn har fylt 18 år, ved å sette status LÅST og sende `avsluttSak` til Joark.

Løsningen er et 2-task fan-out-mønster:
1. `FinnFagsakerSomSkalLåsesTask` henter alle kandidater og oppretter én `LåsFagsakTask` per fagsak
2. `LåsFagsakTask` låser fagsaken transaksjonelt — Joark-feil gir full rollback

Scheduleren kjører første i måneden kl. **06:00.** `låsFagsak()` validerer aldersgrensen på nytt (uavhengig av SQL-filteret), slik at forvalter-endepunktet ikke kan misbrukes til å låse fagsaker for tidlig.

To feature toggles:
- `familie-ba-sak.fagsaklaasing-scheduler` — styrer scheduleren
- `familie-ba-sak.kan-laase-fagsak` — styrer selve låsingen

Forvalter-endepunkter:
- `POST /forvalter/fagsaklåsing/start-batch`
- `POST /forvalter/fagsaklåsing/lås-fagsak/{fagsakId}`

Relatert til NAV-28903 (infrastruktur, PR #6249) og NAV-28978 (avsluttSak i familie-integrasjoner, PR #1251).

Tar også i bruk `oppdaterStatus` i `låsOppFagsak`, slik at sakstatistikk blir oppdatert

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

SQL-spørringen i `finnAvsluttedeFagsakerSomSkalLåses` — CTE med `DISTINCT ON` for å finne siste vedtatte behandling per fagsak, med filter på `resultat NOT LIKE 'HENLAGT%'`.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.