### PR TITLE
Legg til manglende ETTER_ENDRET_UTBETALING-begrunnelser for Finnmarkstillegg og Svalbardtillegg

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/Standardbegrunnelse.kt
@@ -1706,6 +1706,14 @@ enum class Standardbegrunnelse : IVedtakBegrunnelse {
         override val sanityApiNavn = "etterEndretUtbetalingEndreMottaker"
         override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
     },
+    ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_MÅNEDER_FINNMARKSTILLEGG {
+        override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreMaanederFinnmarkstillegg"
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
+    },
+    ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_MÅNEDER_SVALBARDTILLEGG {
+        override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreMaanederSvalbardtillegg"
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.ETTER_ENDRET_UTBETALING
+    },
 
     // Begrunnelser for institusjon
     INNVILGET_BOR_FAST_I_INSTITUSJON {


### PR DESCRIPTION
### 📮 Favro: NAV-29103

### 💰 Hva skal gjøres, og hvorfor?

Legger til to begrunnelser som manglet fra da Finnmarks- og Svalbardtillegg ble innført, og som nå er etterspurt i produksjon:

- `ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_MÅNEDER_FINNMARKSTILLEGG`
- `ETTER_ENDRET_UTBETALING_SVALBARDTILLEGG`

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Endringen er kun tillegg av to nye enum-verdier uten logikk. Ingen eksisterende tester enumererer alle `Standardbegrunnelse`-verdier.