### PR TITLE
Legg til metode i integrasjonklient for å gjenåpne sak i dokarkiv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <eksterne-kontrakter-bisys.version>2.0_20260323170751_4c02e3c</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.saksstatistikk>2.0_20260323170751_4c02e3c</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20260323170751_4c02e3c</familie.kontrakter.stønadsstatistikk>
-        <felles-kontrakter.version>4.0_20260505124916_025d466</felles-kontrakter.version>
+        <felles-kontrakter.version>4.0_20260514200726_bf1a1ee</felles-kontrakter.version>
         <utbetalingsgenerator.version>1.0_20251127080440_b935966</utbetalingsgenerator.version>
         <cucumber.version>7.34.3</cucumber.version>
         <mockk.version>1.14.9</mockk.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonKlient.kt
@@ -28,6 +28,7 @@ import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokdist.AdresseType
 import no.nav.familie.kontrakter.felles.dokdist.DistribuerJournalpostRequest
@@ -494,6 +495,18 @@ class IntegrasjonKlient(
             tjeneste = "dokarkiv",
             uri = uri,
             formål = "Avslutt sak ${request.fagsakId} i fagsaksystem ${request.fagsaksystem}",
+        ) {
+            patchForEntity<Ressurs<Any>>(uri, request)
+        }
+    }
+
+    fun gjenaapneSak(request: GjenåpneSakRequest) {
+        val uri = URI.create("$integrasjonUri/arkiv/gjenaapneSak")
+
+        kallEksternTjenesteUtenRespons(
+            tjeneste = "dokarkiv",
+            uri = uri,
+            formål = "Gjenåpne sak ${request.fagsakId} i fagsaksystem ${request.fagsaksystem}",
         ) {
             patchForEntity<Ressurs<Any>>(uri, request)
         }


### PR DESCRIPTION
Favro: Nav-29110

Vi har tidligere lagt inn metode i integrasjonklient for å låse sak i dokarkiv. 
Nå legger jeg til en metode til som er tiltenkt bruk når vi skal gjenåpne saken.

Dokumentasjon for endepunktet vi kaller videre på:
https://dokarkiv.intern.dev.nav.no/swagger-ui/index.html#/journalpostapi%20-%20sak/gjenaapneSak