### PR TITLE
Legg til endepunkt for å låse opp fagsak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <eksterne-kontrakter-bisys.version>2.0_20260323170751_4c02e3c</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.saksstatistikk>2.0_20260323170751_4c02e3c</familie.kontrakter.saksstatistikk>
         <familie.kontrakter.stønadsstatistikk>2.0_20260323170751_4c02e3c</familie.kontrakter.stønadsstatistikk>
-        <felles-kontrakter.version>4.0_20260505124916_025d466</felles-kontrakter.version>
+        <felles-kontrakter.version>4.0_20260514200726_bf1a1ee</felles-kontrakter.version>
         <utbetalingsgenerator.version>1.0_20251127080440_b935966</utbetalingsgenerator.version>
         <cucumber.version>7.34.3</cucumber.version>
         <mockk.version>1.14.9</mockk.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonKlient.kt
@@ -28,6 +28,7 @@ import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokdist.AdresseType
 import no.nav.familie.kontrakter.felles.dokdist.DistribuerJournalpostRequest
@@ -494,6 +495,18 @@ class IntegrasjonKlient(
             tjeneste = "dokarkiv",
             uri = uri,
             formål = "Avslutt sak ${request.fagsakId} i fagsaksystem ${request.fagsaksystem}",
+        ) {
+            patchForEntity<Ressurs<Any>>(uri, request)
+        }
+    }
+
+    fun gjenåpneSakIDokarkiv(request: GjenåpneSakRequest) {
+        val uri = URI.create("$integrasjonUri/arkiv/gjenaapneSak")
+
+        kallEksternTjenesteUtenRespons(
+            tjeneste = "dokarkiv",
+            uri = uri,
+            formål = "Gjenåpne sak ${request.fagsakId} i fagsaksystem ${request.fagsaksystem}",
         ) {
             patchForEntity<Ressurs<Any>>(uri, request)
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakController.kt
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -200,6 +201,22 @@ class FagsakController(
         return tilbakekrevingService.opprettTilbakekrevingsbehandlingManuelt(fagsakId)
     }
 
+    @PatchMapping(path = ["/{fagsakId}/laas-opp"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun låsOppFagsak(
+        @PathVariable fagsakId: Long,
+        @RequestBody request: LåsOppFagsakRequestDto,
+    ): ResponseEntity<Ressurs<MinimalFagsakDto>> {
+        logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} låser opp fagsak med id $fagsakId")
+        tilgangService.validerTilgangTilFagsak(fagsakId = fagsakId, event = AuditLoggerEvent.UPDATE)
+        tilgangService.verifiserHarTilgangTilHandling(BehandlerRolle.SAKSBEHANDLER, "låse opp fagsak")
+
+        fagsakService.låsOppFagsak(fagsakId, request.begrunnelse)
+
+        val fagsakDto = fagsakService.hentMinimalFagsakDto(fagsakId)
+
+        return ResponseEntity.ok().body(fagsakDto)
+    }
+
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(FagsakController::class.java)
     }
@@ -218,3 +235,7 @@ enum class Beslutning {
 
     fun erGodkjent() = this == GODKJENT
 }
+
+data class LåsOppFagsakRequestDto(
+    val begrunnelse: String,
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -56,7 +56,6 @@ class FagsakService(
     private val skjermetBarnSøkerRepository: SkjermetBarnSøkerRepository,
     private val featureToggleService: FeatureToggleService,
     private val strengtFortroligService: StrengtFortroligService,
-    private val fagsakLåsingRepository: FagsakLåsingRepository,
     private val fagsakLåsingService: FagsakLåsingService,
 ) {
     private val antallFagsakerOpprettetFraManuell =
@@ -272,7 +271,7 @@ class FagsakService(
                 finnesStrengtFortroligPersonIFagsak = strengtFortroligService.harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak),
                 låstTidspunkt =
                     if (fagsak.status == FagsakStatus.LÅST) {
-                        fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id)?.tidspunkt
+                        fagsakLåsingService.finnAktivLåsForFagsak(fagsak.id)?.tidspunkt
                     } else {
                         null
                     },

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakService.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingRepository
+import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonRepository
 import no.nav.familie.ba.sak.kjerne.institusjon.InstitusjonService
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
@@ -56,6 +57,7 @@ class FagsakService(
     private val featureToggleService: FeatureToggleService,
     private val strengtFortroligService: StrengtFortroligService,
     private val fagsakLåsingRepository: FagsakLåsingRepository,
+    private val fagsakLåsingService: FagsakLåsingService,
 ) {
     private val antallFagsakerOpprettetFraManuell =
         Metrics.counter("familie.ba.sak.fagsak.opprettet", "saksbehandling", "manuell")
@@ -356,6 +358,11 @@ class FagsakService(
     fun finnOrgnummerForLøpendeFagsaker(): List<String> = fagsakRepository.finnOrgnummerForLøpendeFagsaker()
 
     fun finnIdenterForLøpendeFagsaker(): List<String> = fagsakRepository.finnIdenterForLøpendeFagsaker()
+
+    fun låsOppFagsak(
+        fagsakId: Long,
+        begrunnelse: String,
+    ) = fagsakLåsingService.låsOppFagsak(fagsakId, begrunnelse)
 
     companion object {
         private val logger = LoggerFactory.getLogger(FagsakService::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -1,0 +1,77 @@
+package no.nav.familie.ba.sak.kjerne.fagsaklåsing
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.kontrakter.felles.BrukerIdType
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class FagsakLåsingService(
+    private val fagsakRepository: FagsakRepository,
+    private val fagsakLåsingRepository: FagsakLåsingRepository,
+    private val integrasjonKlient: IntegrasjonKlient,
+) {
+    @Transactional
+    fun låsOppFagsak(
+        fagsakId: Long,
+        begrunnelseForÅLåseOppFagsak: String,
+    ): Fagsak {
+        val fagsak = fagsakRepository.finnFagsak(fagsakId) ?: throw Feil("Finner ikke fagsak med id $fagsakId")
+
+        if (fagsak.status != FagsakStatus.LÅST) {
+            throw FunksjonellFeil("Fagsaken må ha status LÅST for å kunne låses opp. Nåværende status: ${fagsak.status}")
+        }
+
+        if (begrunnelseForÅLåseOppFagsak.isBlank()) {
+            throw FunksjonellFeil("Begrunnelse kan ikke være tom")
+        }
+
+        lagreOgDeaktiverGammel(
+            FagsakLåsing(
+                fagsak = fagsak,
+                tidspunkt = LocalDateTime.now(),
+                hendelse = FagsakLåsHendelse.LÅST_OPP,
+                begrunnelse = begrunnelseForÅLåseOppFagsak,
+                aktiv = true,
+            ),
+        )
+
+        fagsak.status = FagsakStatus.AVSLUTTET
+        fagsakRepository.save(fagsak)
+
+        integrasjonKlient.gjenåpneSakIDokarkiv(
+            GjenåpneSakRequest(
+                tema = Tema.BAR,
+                fagsakId = fagsakId.toString(),
+                fagsaksystem = Fagsystem.BA,
+                bruker =
+                    DokarkivBruker(
+                        idType = BrukerIdType.FNR,
+                        id = fagsak.aktør.aktivFødselsnummer(),
+                    ),
+            ),
+        )
+
+        return fagsak
+    }
+
+    fun lagreOgDeaktiverGammel(fagsakLåsing: FagsakLåsing): FagsakLåsing {
+        val aktivFagsakLåsing = fagsakLåsingRepository.finnAktivLåsForFagsak(fagsakLåsing.fagsak.id)
+
+        if (aktivFagsakLåsing != null && aktivFagsakLåsing.id != fagsakLåsing.id) {
+            fagsakLåsingRepository.saveAndFlush(aktivFagsakLåsing.also { it.aktiv = false })
+        }
+
+        return fagsakLåsingRepository.save(fagsakLåsing)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.sak.kjerne.fagsaklåsing
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
@@ -64,6 +65,8 @@ class FagsakLåsingService(
 
         return fagsak
     }
+
+    fun finnAktivLåsForFagsak(fagsakId: Long) = fagsakLåsingRepository.finnAktivLåsForFagsak(fagsakId = fagsakId)
 
     fun lagreOgDeaktiverGammel(fagsakLåsing: FagsakLåsing): FagsakLåsing {
         val aktivFagsakLåsing = fagsakLåsingRepository.finnAktivLåsForFagsak(fagsakLåsing.fagsak.id)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsHendelse
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsing
 import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingRepository
+import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonRepository
 import no.nav.familie.ba.sak.kjerne.institusjon.InstitusjonService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
@@ -60,6 +61,7 @@ class FagsakServiceTest {
     private val skjermetBarnSøkerRepository = mockk<SkjermetBarnSøkerRepository>()
     private val fagsakLåsingRepository = mockk<FagsakLåsingRepository>()
     private val strengtFortroligService = mockk<StrengtFortroligService>()
+    private val fagsakLåsingService = mockk<FagsakLåsingService>()
     private val fagsakService =
         FagsakService(
             fagsakRepository = fagsakRepository,
@@ -78,6 +80,7 @@ class FagsakServiceTest {
             featureToggleService = featureToggleService,
             strengtFortroligService = strengtFortroligService,
             fagsakLåsingRepository = fagsakLåsingRepository,
+            fagsakLåsingService = fagsakLåsingService,
         )
 
     @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -59,7 +59,6 @@ class FagsakServiceTest {
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
     private val featureToggleService = mockk<FeatureToggleService>()
     private val skjermetBarnSøkerRepository = mockk<SkjermetBarnSøkerRepository>()
-    private val fagsakLåsingRepository = mockk<FagsakLåsingRepository>()
     private val strengtFortroligService = mockk<StrengtFortroligService>()
     private val fagsakLåsingService = mockk<FagsakLåsingService>()
     private val fagsakService =
@@ -79,7 +78,6 @@ class FagsakServiceTest {
             skjermetBarnSøkerRepository = skjermetBarnSøkerRepository,
             featureToggleService = featureToggleService,
             strengtFortroligService = strengtFortroligService,
-            fagsakLåsingRepository = fagsakLåsingRepository,
             fagsakLåsingService = fagsakLåsingService,
         )
 
@@ -141,7 +139,7 @@ class FagsakServiceTest {
             every { strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak) } returns emptySet()
             every { strengtFortroligService.harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak) } returns false
             every { strengtFortroligService.anonymiserFagsakDto(any(), any()) } answers { firstArg() }
-            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns null
+            every { fagsakLåsingService.finnAktivLåsForFagsak(fagsak.id) } returns null
 
             // Act
             val restMinimalFagsak = fagsakService.lagMinimalFagsakDto(fagsak.id)
@@ -231,7 +229,7 @@ class FagsakServiceTest {
             every { vedtaksperiodeService.hentUtbetalingsperioder(sisteBehandlingSomErVedtatt) } returns emptyList()
             every { behandlingHentOgPersisterService.hentVisningsbehandlinger(fagsak.id) } returns listOf(visningsbehandling)
             every { behandlingService.hentMigreringsdatoPåFagsak(fagsak.id) } returns null
-            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns fagsakLåsing
+            every { fagsakLåsingService.finnAktivLåsForFagsak(fagsak.id) } returns fagsakLåsing
             every { strengtFortroligService.harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak) } returns false
             every { strengtFortroligService.anonymiserFagsakDto(any(), any()) } answers { firstArg() }
             every { strengtFortroligService.hentSkjermedeBarnUtenLøpendeAndelerSaksbehandlerIkkeHarTilgangTil(fagsak) } returns emptySet()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
@@ -1,0 +1,149 @@
+package no.nav.familie.ba.sak.kjerne.fagsaklåsing
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlient
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.kontrakter.felles.BrukerIdType
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class FagsakLåsingServiceTest {
+    private val fagsakRepository = mockk<FagsakRepository>()
+    private val fagsakLåsingRepository = mockk<FagsakLåsingRepository>()
+    private val integrasjonKlient = mockk<IntegrasjonKlient>()
+
+    private val fagsakLåsingService =
+        FagsakLåsingService(
+            fagsakRepository = fagsakRepository,
+            fagsakLåsingRepository = fagsakLåsingRepository,
+            integrasjonKlient = integrasjonKlient,
+        )
+
+    @Nested
+    inner class LåsOppFagsak {
+        @BeforeEach
+        fun setUp() {
+            every { fagsakLåsingRepository.finnAktivLåsForFagsak(any()) } returns null
+            every { fagsakLåsingRepository.save(any()) } answers { firstArg() }
+            every { fagsakRepository.save(any()) } answers { firstArg() }
+            every { integrasjonKlient.gjenåpneSakIDokarkiv(any()) } just runs
+        }
+
+        @Test
+        fun `skal låse opp fagsak, sette status til AVSLUTTET, og gjenåpne sak i Joark`() {
+            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+
+            val resultat = fagsakLåsingService.låsOppFagsak(fagsak.id, "Test begrunnelse")
+
+            assertThat(resultat.status).isEqualTo(FagsakStatus.AVSLUTTET)
+        }
+
+        @Test
+        fun `skal opprette FagsakLåsing med hendelse LÅST_OPP`() {
+            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+
+            val låsingSlot = slot<FagsakLåsing>()
+            every { fagsakLåsingRepository.save(capture(låsingSlot)) } answers { firstArg() }
+
+            fagsakLåsingService.låsOppFagsak(fagsak.id, "En god grunn")
+
+            assertThat(låsingSlot.captured.hendelse).isEqualTo(FagsakLåsHendelse.LÅST_OPP)
+            assertThat(låsingSlot.captured.begrunnelse).isEqualTo("En god grunn")
+            assertThat(låsingSlot.captured.fagsak.id).isEqualTo(fagsak.id)
+        }
+
+        @Test
+        fun `skal deaktivere gammel aktiv låsing før ny lagres`() {
+            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
+            val gammelLåsing =
+                FagsakLåsing(
+                    id = 99,
+                    fagsak = fagsak,
+                    tidspunkt = java.time.LocalDateTime.now(),
+                    hendelse = FagsakLåsHendelse.LÅST,
+                    begrunnelse = "Gammel",
+                    aktiv = true,
+                )
+
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns gammelLåsing
+            every { fagsakLåsingRepository.saveAndFlush(any()) } answers { firstArg() }
+
+            fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
+
+            verify { fagsakLåsingRepository.saveAndFlush(match { !it.aktiv && it.id == 99L }) }
+        }
+
+        @Test
+        fun `skal kalle gjenaapneSak på integrasjonsklienten med riktige verdier`() {
+            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+
+            val requestSlot = slot<GjenåpneSakRequest>()
+            every { integrasjonKlient.gjenåpneSakIDokarkiv(capture(requestSlot)) } just runs
+
+            fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
+
+            val request = requestSlot.captured
+            assertThat(request.tema).isEqualTo(Tema.BAR)
+            assertThat(request.fagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(request.fagsaksystem).isEqualTo(Fagsystem.BA)
+            assertThat(request.bruker.idType).isEqualTo(BrukerIdType.FNR)
+            assertThat(request.bruker.id).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+        }
+
+        @Test
+        fun `skal kaste FunksjonellFeil hvis fagsak ikke har status LÅST`() {
+            val fagsak = lagFagsak(status = FagsakStatus.LØPENDE)
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+
+            val feil =
+                assertThrows<FunksjonellFeil> {
+                    fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
+                }
+
+            assertThat(feil.message).contains("LÅST")
+            assertThat(feil.message).contains("LØPENDE")
+            verify(exactly = 0) { fagsakLåsingRepository.save(any()) }
+            verify(exactly = 0) { integrasjonKlient.gjenåpneSakIDokarkiv(any()) }
+        }
+
+        @Test
+        fun `skal kaste feil hvis begrunnelse er blank`() {
+            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+
+            assertThrows<FunksjonellFeil> {
+                fagsakLåsingService.låsOppFagsak(fagsak.id, "   ")
+            }
+
+            verify(exactly = 0) { fagsakLåsingRepository.save(any()) }
+            verify(exactly = 0) { integrasjonKlient.gjenåpneSakIDokarkiv(any()) }
+        }
+
+        @Test
+        fun `skal kaste Feil hvis fagsak ikke finnes`() {
+            every { fagsakRepository.finnFagsak(any()) } returns null
+
+            assertThrows<no.nav.familie.ba.sak.common.Feil> {
+                fagsakLåsingService.låsOppFagsak(999L, "Begrunnelse")
+            }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
@@ -44,62 +44,77 @@ class FagsakLåsingServiceTest {
         }
 
         @Test
-        fun `skal låse opp fagsak, sette status til AVSLUTTET, og gjenåpne sak i Joark`() {
-            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
-            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
-
-            val resultat = fagsakLåsingService.låsOppFagsak(fagsak.id, "Test begrunnelse")
-
-            assertThat(resultat.status).isEqualTo(FagsakStatus.AVSLUTTET)
-        }
-
-        @Test
         fun `skal opprette FagsakLåsing med hendelse LÅST_OPP`() {
+            // Arrange
             val fagsak = lagFagsak(status = FagsakStatus.LÅST)
             every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
 
             val låsingSlot = slot<FagsakLåsing>()
             every { fagsakLåsingRepository.save(capture(låsingSlot)) } answers { firstArg() }
 
+            // Act
             fagsakLåsingService.låsOppFagsak(fagsak.id, "En god grunn")
 
+            // Assert
             assertThat(låsingSlot.captured.hendelse).isEqualTo(FagsakLåsHendelse.LÅST_OPP)
             assertThat(låsingSlot.captured.begrunnelse).isEqualTo("En god grunn")
             assertThat(låsingSlot.captured.fagsak.id).isEqualTo(fagsak.id)
         }
 
         @Test
-        fun `skal deaktivere gammel aktiv låsing før ny lagres`() {
+        fun `skal sette fagsak status til AVSLUTTET`() {
+            // Arrange
             val fagsak = lagFagsak(status = FagsakStatus.LÅST)
-            val gammelLåsing =
-                FagsakLåsing(
-                    id = 99,
-                    fagsak = fagsak,
-                    tidspunkt = java.time.LocalDateTime.now(),
-                    hendelse = FagsakLåsHendelse.LÅST,
-                    begrunnelse = "Gammel",
-                    aktiv = true,
-                )
-
             every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
-            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns gammelLåsing
-            every { fagsakLåsingRepository.saveAndFlush(any()) } answers { firstArg() }
 
-            fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
+            // Act
+            val oppdatertFagsak = fagsakLåsingService.låsOppFagsak(fagsak.id, "En god grunn")
 
-            verify { fagsakLåsingRepository.saveAndFlush(match { !it.aktiv && it.id == 99L }) }
+            // Assert
+            assertThat(oppdatertFagsak.status).isEqualTo(FagsakStatus.AVSLUTTET)
+            verify { fagsakRepository.save(match { it.status == FagsakStatus.AVSLUTTET }) }
         }
 
         @Test
-        fun `skal kalle gjenaapneSak på integrasjonsklienten med riktige verdier`() {
+        fun `skal deaktivere eksisterende aktiv låsing før lagring av ny`() {
+            // Arrange
+            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
+
+            val eksisterendeLåsing =
+                FagsakLåsing(
+                    fagsak = fagsak,
+                    tidspunkt =
+                        java.time.LocalDateTime
+                            .now()
+                            .minusDays(1),
+                    hendelse = FagsakLåsHendelse.LÅST,
+                    begrunnelse = "Gammel låsing",
+                    aktiv = true,
+                )
+            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns eksisterendeLåsing
+            every { fagsakLåsingRepository.saveAndFlush(any()) } answers { firstArg() }
+
+            // Act
+            fagsakLåsingService.låsOppFagsak(fagsak.id, "Lås opp igjen")
+
+            // Assert
+            verify { fagsakLåsingRepository.saveAndFlush(match { !it.aktiv }) }
+        }
+
+        @Test
+        fun `skal kalle gjenåpneSak på integrasjonsklienten med riktige verdier`() {
+            // Arrange
             val fagsak = lagFagsak(status = FagsakStatus.LÅST)
             every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
 
             val requestSlot = slot<GjenåpneSakRequest>()
             every { integrasjonKlient.gjenåpneSakIDokarkiv(capture(requestSlot)) } just runs
 
+            // Act
             fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
 
+            // Assert
             val request = requestSlot.captured
             assertThat(request.tema).isEqualTo(Tema.BAR)
             assertThat(request.fagsakId).isEqualTo(fagsak.id.toString())
@@ -110,9 +125,11 @@ class FagsakLåsingServiceTest {
 
         @Test
         fun `skal kaste FunksjonellFeil hvis fagsak ikke har status LÅST`() {
+            // Arrange
             val fagsak = lagFagsak(status = FagsakStatus.LØPENDE)
             every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
 
+            // Act & Assert
             val feil =
                 assertThrows<FunksjonellFeil> {
                     fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
@@ -125,10 +142,12 @@ class FagsakLåsingServiceTest {
         }
 
         @Test
-        fun `skal kaste feil hvis begrunnelse er blank`() {
+        fun `skal kaste FunksjonellFeil hvis begrunnelse er blank`() {
+            // Arrange
             val fagsak = lagFagsak(status = FagsakStatus.LÅST)
             every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
 
+            // Act & Assert
             assertThrows<FunksjonellFeil> {
                 fagsakLåsingService.låsOppFagsak(fagsak.id, "   ")
             }
@@ -138,12 +157,18 @@ class FagsakLåsingServiceTest {
         }
 
         @Test
-        fun `skal kaste Feil hvis fagsak ikke finnes`() {
-            every { fagsakRepository.finnFagsak(any()) } returns null
+        fun `skal ikke kalle integrasjonsklienten hvis fagsak har feil status`() {
+            // Arrange
+            val fagsak = lagFagsak(status = FagsakStatus.OPPRETTET)
+            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
 
-            assertThrows<no.nav.familie.ba.sak.common.Feil> {
-                fagsakLåsingService.låsOppFagsak(999L, "Begrunnelse")
+            // Act & Assert
+            assertThrows<FunksjonellFeil> {
+                fagsakLåsingService.låsOppFagsak(fagsak.id, "Begrunnelse")
             }
+
+            verify(exactly = 0) { integrasjonKlient.gjenåpneSakIDokarkiv(any()) }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
@@ -76,33 +76,6 @@ class FagsakLåsingServiceTest {
         }
 
         @Test
-        fun `skal deaktivere eksisterende aktiv låsing før lagring av ny`() {
-            // Arrange
-            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
-            every { fagsakRepository.finnFagsak(fagsak.id) } returns fagsak
-
-            val eksisterendeLåsing =
-                FagsakLåsing(
-                    fagsak = fagsak,
-                    tidspunkt =
-                        java.time.LocalDateTime
-                            .now()
-                            .minusDays(1),
-                    hendelse = FagsakLåsHendelse.LÅST,
-                    begrunnelse = "Gammel låsing",
-                    aktiv = true,
-                )
-            every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns eksisterendeLåsing
-            every { fagsakLåsingRepository.saveAndFlush(any()) } answers { firstArg() }
-
-            // Act
-            fagsakLåsingService.låsOppFagsak(fagsak.id, "Lås opp igjen")
-
-            // Assert
-            verify { fagsakLåsingRepository.saveAndFlush(match { !it.aktiv }) }
-        }
-
-        @Test
         fun `skal kalle gjenåpneSak på integrasjonsklienten med riktige verdier`() {
             // Arrange
             val fagsak = lagFagsak(status = FagsakStatus.LÅST)


### PR DESCRIPTION
### 📮 Favro: Nav-29111
Frontend PR: https://github.com/navikt/familie-ba-sak-frontend/pull/4527

### 💰 Hva skal gjøres, og hvorfor?

Nå som vi oppretter funksjonalitet for å låse fagsak, så må vi også ha funksjonalitet for å låse dem opp.
Fagsak skal låses opp gjennom automatiske behandlinger (f.eks fødsel) og manuelt.
I denne pullrequesten legger jeg til manuell løype for å låse opp fagsak.

- Legger til et endepunkt `/{fagsakId}/laas-opp`
Denne setter fagsak status til AVSLUTTET fra LÅST, logger hendelsen i FagsakLåsing, og kaller videre på integrasjoner som låser opp saken i dokarkiv.



https://github.com/user-attachments/assets/3d6416b1-fe05-4009-98b9-534698833f32


