### PR TITLE
Nav 29028 - Preutfyll vilkår i revurdering med årsak søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -53,4 +53,7 @@ enum class FeatureToggle(
     // NAV-28902
     FAGSAKLÅSING_SCHEDULER("familie-ba-sak.fagsaklaasing-scheduler"),
     KAN_LÅSE_FAGSAK("familie-ba-sak.kan-laase-fagsak"),
+
+    // NAV-29028
+    PREUTFYLL_VILKÅR_REVURDERING_SØKNAD("familie-ba-sak.preutfyll-vilkar-revurdering-soknad"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.Adresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.Adresser
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.erSammeAdresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.tilPerson
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.BOR_MED_SØKER
@@ -27,12 +28,16 @@ import java.time.temporal.ChronoUnit
 class PreutfyllBorMedSøkerService(
     private val persongrunnlagService: PersongrunnlagService,
 ) {
-    fun preutfyllBorMedSøker(vilkårsvurdering: Vilkårsvurdering) {
+    fun preutfyllBorMedSøker(
+        vilkårsvurdering: Vilkårsvurdering,
+        aktørerVilkårSkalPreutfyllesFor: List<Aktør>,
+    ) {
         val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(vilkårsvurdering.behandling.id)
         val bostedsadresserSøker = Adresser.opprettFra(personopplysningGrunnlag.søker)
 
         vilkårsvurdering.personResultater
             .filterNot { it.erSøkersResultater() }
+            .filter { it.aktør in aktørerVilkårSkalPreutfyllesFor }
             .forEach { personResultat ->
                 val barn = personResultat.aktør.tilPerson(personopplysningGrunnlag)
                 val adresserForBarn = Adresser.opprettFra(barn)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.Adresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.iUkraina
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.lagErNordiskStatsborgerTidslinje
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.tilPerson
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.søknad.Søknad
 import no.nav.familie.ba.sak.kjerne.søknad.SøknadService
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
@@ -36,7 +37,7 @@ class PreutfyllBosattIRiketService(
 ) {
     fun preutfyllBosattIRiket(
         vilkårsvurdering: Vilkårsvurdering,
-        identerVilkårSkalPreutfyllesFor: List<String>? = null,
+        aktørerVilkårSkalPreutfyllesFor: List<Aktør>,
     ) {
         val behandling = vilkårsvurdering.behandling
 
@@ -44,14 +45,8 @@ class PreutfyllBosattIRiketService(
 
         val digitalSøknad = søknadService.finnDigitalSøknad(behandling.id)
 
-        val identer =
-            vilkårsvurdering
-                .personResultater
-                .map { it.aktør.aktivFødselsnummer() }
-                .filter { identerVilkårSkalPreutfyllesFor?.contains(it) ?: true }
-
         vilkårsvurdering.personResultater
-            .filter { it.aktør.aktivFødselsnummer() in identer }
+            .filter { it.aktør in aktørerVilkårSkalPreutfyllesFor }
             .forEach { personResultat ->
                 val person = personResultat.aktør.tilPerson(personopplysningGrunnlag)
                 if (person.statsborgerskap.iUkraina()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.iUkraina
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.statsborgerskap.lagErNordiskStatsborgerTidslinje
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.tilPerson
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.tidslinje.transformasjon.beskjærFraOgMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår.LOVLIG_OPPHOLD
@@ -37,12 +38,16 @@ import java.time.LocalDate
 class PreutfyllLovligOppholdService(
     private val persongrunnlagService: PersongrunnlagService,
 ) {
-    fun preutfyllLovligOpphold(vilkårsvurdering: Vilkårsvurdering) {
+    fun preutfyllLovligOpphold(
+        vilkårsvurdering: Vilkårsvurdering,
+        aktørerVilkårSkalPreutfyllesFor: List<Aktør>,
+    ) {
         val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(vilkårsvurdering.behandling.id)
 
         val søkerErEøsBorgerOgHarArbeidsforholdTidslinje = lagErEøsBorgerOgHarArbeidsforholdTidslinje(personopplysningGrunnlag.søker)
 
         vilkårsvurdering.personResultater
+            .filter { it.aktør in aktørerVilkårSkalPreutfyllesFor }
             .forEach { personResultat ->
                 val person = personResultat.aktør.tilPerson(personopplysningGrunnlag)
                 if (person.statsborgerskap.iUkraina()) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
@@ -1,9 +1,14 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType.FØRSTEGANGSBEHANDLING
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType.REVURDERING
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import org.springframework.stereotype.Service
 
@@ -14,21 +19,53 @@ class PreutfyllVilkårService(
     private val preutfyllBosattIRiketService: PreutfyllBosattIRiketService,
     private val preutfyllBosattIRiketForFødselshendelserService: PreutfyllBosattIRiketForFødselshendelserService,
     private val persongrunnlagService: PersongrunnlagService,
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
 ) {
     fun preutfyllVilkår(vilkårsvurdering: Vilkårsvurdering) {
         val behandling = vilkårsvurdering.behandling
 
         if (behandling.kategori == BehandlingKategori.EØS) return
-        if (behandling.type != FØRSTEGANGSBEHANDLING) return
         if (behandling.fagsak.type == FagsakType.SKJERMET_BARN) return
+
+        val aktørerSomViSkalPreutfylleFor =
+            when (behandling.type) {
+                FØRSTEGANGSBEHANDLING -> {
+                    hentSøkerOgBarnIBehandling(behandling)
+                }
+
+                REVURDERING -> {
+                    if (behandling.opprettetÅrsak != BehandlingÅrsak.SØKNAD) return
+
+                    finnNyeAktørerIBehandling(behandling)
+                }
+
+                else -> {
+                    return
+                }
+            }.ifEmpty { return }
 
         persongrunnlagService.oppdaterRegisteropplysninger(behandling.id)
 
-        preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering)
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
-
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering, aktørerSomViSkalPreutfylleFor)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, aktørerSomViSkalPreutfylleFor)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, aktørerSomViSkalPreutfylleFor)
     }
+
+    private fun finnNyeAktørerIBehandling(behandling: Behandling): List<Aktør> {
+        val aktørerIInneværendeBehandling = hentSøkerOgBarnIBehandling(behandling)
+
+        val aktørerIForrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+                ?.let { hentSøkerOgBarnIBehandling (it) }
+                ?: emptyList()
+
+        return aktørerIInneværendeBehandling - aktørerIForrigeBehandling.toSet()
+    }
+
+    private fun hentSøkerOgBarnIBehandling(behandling: Behandling): List<Aktør> =
+        persongrunnlagService
+            .hentAktivThrows(behandling.id)
+            .søkerOgBarn
+            .map { it.aktør }
 
     fun preutfyllBosattIRiketForFødselshendelseBehandlinger(
         vilkårsvurdering: Vilkårsvurdering,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
@@ -20,6 +22,7 @@ class PreutfyllVilkårService(
     private val preutfyllBosattIRiketForFødselshendelserService: PreutfyllBosattIRiketForFødselshendelserService,
     private val persongrunnlagService: PersongrunnlagService,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     fun preutfyllVilkår(vilkårsvurdering: Vilkårsvurdering) {
         val behandling = vilkårsvurdering.behandling
@@ -27,13 +30,14 @@ class PreutfyllVilkårService(
         if (behandling.kategori == BehandlingKategori.EØS) return
         if (behandling.fagsak.type == FagsakType.SKJERMET_BARN) return
 
-        val aktørerSomViSkalPreutfylleFor =
+        val aktørerVilkårSkalPreutfyllesFor =
             when (behandling.type) {
                 FØRSTEGANGSBEHANDLING -> {
                     hentSøkerOgBarnIBehandling(behandling)
                 }
 
                 REVURDERING -> {
+                    if (!featureToggleService.isEnabled(FeatureToggle.PREUTFYLL_VILKÅR_REVURDERING_SØKNAD)) return
                     if (behandling.opprettetÅrsak != BehandlingÅrsak.SØKNAD) return
 
                     finnNyeAktørerIBehandling(behandling)
@@ -46,9 +50,9 @@ class PreutfyllVilkårService(
 
         persongrunnlagService.oppdaterRegisteropplysninger(behandling.id)
 
-        preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering, aktørerSomViSkalPreutfylleFor)
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, aktørerSomViSkalPreutfylleFor)
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, aktørerSomViSkalPreutfylleFor)
+        preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor)
     }
 
     private fun finnNyeAktørerIBehandling(behandling: Behandling): List<Aktør> {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårService.kt
@@ -54,8 +54,10 @@ class PreutfyllVilkårService(
     private fun finnNyeAktørerIBehandling(behandling: Behandling): List<Aktør> {
         val aktørerIInneværendeBehandling = hentSøkerOgBarnIBehandling(behandling)
 
-        val aktørerIForrigeBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
-                ?.let { hentSøkerOgBarnIBehandling (it) }
+        val aktørerIForrigeBehandling =
+            behandlingHentOgPersisterService
+                .hentForrigeBehandlingSomErVedtatt(behandling)
+                ?.let { hentSøkerOgBarnIBehandling(it) }
                 ?: emptyList()
 
         return aktørerIInneværendeBehandling - aktørerIForrigeBehandling.toSet()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -602,6 +602,7 @@ class CucumberMock(
             preutfyllBorMedSøkerService = preutfyllBorMedSøkerService,
             preutfyllBosattIRiketForFødselshendelserService = preutfyllBosattIRiketForFødselshendelserService,
             persongrunnlagService = persongrunnlagService,
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
         )
 
     val vilkårsvurderingForNyBehandlingService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -603,6 +603,7 @@ class CucumberMock(
             preutfyllBosattIRiketForFødselshendelserService = preutfyllBosattIRiketForFødselshendelserService,
             persongrunnlagService = persongrunnlagService,
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            featureToggleService = featureToggleService,
         )
 
     val vilkårsvurderingForNyBehandlingService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerServiceTest.kt
@@ -967,7 +967,7 @@ class PreutfyllBorMedSøkerServiceTest {
     }
 
     @Test
-    fun `skal kun preutfylle bor fast hos søker for barn med aktør i aktørerVilkårSkalPreutfyllesFor`() {
+    fun `skal kun preutfylle bor fast hos søker for barn i aktørerVilkårSkalPreutfyllesFor`() {
         // Arrange
         val nåDato = LocalDate.now()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerServiceTest.kt
@@ -71,7 +71,7 @@ class PreutfyllBorMedSøkerServiceTest {
             )
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -136,7 +136,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagForskjelligAdresseForSøkerOgBarn
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -194,7 +194,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagBarnHarBoddKun2MånederPåSammeAdresseSomSøker
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -266,7 +266,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagSøkerOgBarnFLyttetMellomDiverseAdresser
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -327,7 +327,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagAlleHarSammeAdresse
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -385,7 +385,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagBarnHarBoddKortereEnnSøkerPåSammeAdresse
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -442,7 +442,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagBarnHarBoddLengerEnnSøkerPåSammeAdresse
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -523,7 +523,7 @@ class PreutfyllBorMedSøkerServiceTest {
                 overstyrendeVilkårResultater = emptyMap(),
             )
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val personResultat =
@@ -628,7 +628,7 @@ class PreutfyllBorMedSøkerServiceTest {
                 overstyrendeVilkårResultater = emptyMap(),
             )
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val personResultat =
@@ -706,7 +706,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagMedSammeAdresseFraFødsel
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -769,7 +769,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagMedSammeAdresseI3Måneder
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -853,7 +853,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagMedSammeDeltBostedAdresseFraFødsel
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -944,7 +944,7 @@ class PreutfyllBorMedSøkerServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagMedFlytting
 
         // Act
-        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering)
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val borFastHosSøkerVilkår =
@@ -964,5 +964,71 @@ class PreutfyllBorMedSøkerServiceTest {
         assertThat(periode2.periodeFom).isEqualTo(fødselsdatoBarn.plusMonths(2).plusDays(1))
         assertThat(periode2.periodeTom).isNull()
         assertThat(periode2.begrunnelse).contains("Har ikke samme fast eller delt bostedsadresse som søker")
+    }
+
+    @Test
+    fun `skal kun preutfylle bor fast hos søker for barn med aktør i aktørerVilkårSkalPreutfyllesFor`() {
+        // Arrange
+        val nåDato = LocalDate.now()
+
+        val aktørSøker = randomAktør()
+        val aktørBarn1 = randomAktør()
+        val aktørBarn2 = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val persongrunnlag =
+            lagTestPersonopplysningGrunnlag(
+                behandlingId = behandling.id,
+                søkerPersonIdent = aktørSøker.aktivFødselsnummer(),
+                barnasIdenter = listOf(aktørBarn1.aktivFødselsnummer(), aktørBarn2.aktivFødselsnummer()),
+                søkerAktør = aktørSøker,
+                barnAktør = listOf(aktørBarn1, aktørBarn2),
+            ).also { persongrunnlag ->
+                persongrunnlag.personer.forEach { person ->
+                    person.bostedsadresser =
+                        mutableListOf(
+                            lagGrVegadresse(matrikkelId = 12345L).also {
+                                it.periode =
+                                    DatoIntervallEntitet(
+                                        fom = nåDato.minusYears(10),
+                                        tom = null,
+                                    )
+                                it.person = person
+                            },
+                        )
+                }
+            }
+        every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlag
+
+        val vilkårsvurdering =
+            lagVilkårsvurderingMedOverstyrendeResultater(
+                behandling = behandling,
+                søker = persongrunnlag.søker,
+                barna = persongrunnlag.barna,
+                overstyrendeVilkårResultater = emptyMap(),
+            )
+
+        // Act
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(
+            vilkårsvurdering,
+            listOf(aktørBarn1),
+        )
+
+        // Assert
+        val barn1BorMedSøker =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == aktørBarn1 }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOR_MED_SØKER }
+        assertThat(barn1BorMedSøker).isNotEmpty
+        assertThat(barn1BorMedSøker).allMatch { it.erAutomatiskVurdert }
+
+        val barn2BorMedSøker =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == aktørBarn2 }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOR_MED_SØKER }
+        assertThat(barn2BorMedSøker).allMatch { !it.erAutomatiskVurdert }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
@@ -1644,7 +1644,7 @@ class PreutfyllBosattIRiketServiceTest {
     }
 
     @Test
-    fun `skal kun preutfylle bosatt i riket for personResultater med aktør i aktørerVilkårSkalPreutfyllesFor`() {
+    fun `skal kun preutfylle bosatt i riket for aktører i aktørerVilkårSkalPreutfyllesFor`() {
         // Arrange
         val behandling = lagBehandling()
         val søkerAktør = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
@@ -103,7 +103,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -163,7 +163,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         vilkårsvurdering.personResultater.forEach { personResultat ->
@@ -213,7 +213,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -261,7 +261,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { søknadService.finnDigitalSøknad(behandling.id) } returns lagSøknad(søkerPlanleggerÅBoINorge12Mnd = false)
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -308,7 +308,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { søknadService.finnDigitalSøknad(behandling.id) } returns lagSøknad(søkerPlanleggerÅBoINorge12Mnd = true)
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -369,7 +369,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { søknadService.finnDigitalSøknad(behandling.id) } returns lagSøknad(søkerPlanleggerÅBoINorge12Mnd = false, barneIdenterTilPlanleggerBoINorge12Mnd = mapOf(barnAktør.aktivFødselsnummer() to true))
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -430,7 +430,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { søknadService.finnDigitalSøknad(behandling.id) } returns null
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -497,7 +497,7 @@ class PreutfyllBosattIRiketServiceTest {
             }
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -566,7 +566,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { søknadService.finnDigitalSøknad(behandling.id) } returns lagSøknad()
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat = vilkårsvurdering.personResultater.find { it.erSøkersResultater() }?.vilkårResultater ?: emptyList()
@@ -636,7 +636,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { søknadService.finnDigitalSøknad(behandling.id) } returns lagSøknad()
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -682,7 +682,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -741,7 +741,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -815,7 +815,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val søkerBosattIRiketVilkårResultat =
@@ -862,7 +862,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -915,7 +915,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -970,7 +970,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1020,7 +1020,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1075,7 +1075,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1125,7 +1125,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1174,7 +1174,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1223,7 +1223,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1272,7 +1272,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1332,7 +1332,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1389,7 +1389,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1448,7 +1448,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1511,7 +1511,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1568,7 +1568,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val vilkårResultat =
@@ -1632,7 +1632,7 @@ class PreutfyllBosattIRiketServiceTest {
         every { persongrunnlagService.hentAktivThrows(vilkårsvurdering.behandling.id) } returns persongrunnlag
 
         // Act
-        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering = vilkårsvurdering)
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
         // Assert
         val bosattIRiketResultater =
@@ -1641,5 +1641,78 @@ class PreutfyllBosattIRiketServiceTest {
                 .vilkårResultater
 
         assertThat(bosattIRiketResultater).isEmpty()
+    }
+
+    @Test
+    fun `skal kun preutfylle bosatt i riket for personResultater med aktør i aktørerVilkårSkalPreutfyllesFor`() {
+        // Arrange
+        val behandling = lagBehandling()
+        val søkerAktør = randomAktør()
+        val barnAktør = randomAktør()
+        val persongrunnlag =
+            lagTestPersonopplysningGrunnlag(
+                behandlingId = behandling.id,
+                søkerPersonIdent = søkerAktør.aktivFødselsnummer(),
+                barnasIdenter = listOf(barnAktør.aktivFødselsnummer()),
+                søkerAktør = søkerAktør,
+                barnAktør = listOf(barnAktør),
+            ).also {
+                it.personer.forEach { person ->
+                    person.bostedsadresser =
+                        mutableListOf(
+                            lagGrVegadresseBostedsadresse(
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.now().minusYears(5),
+                                        tom = null,
+                                    ),
+                                matrikkelId = 12345L,
+                            ),
+                        )
+                }
+            }
+
+        val vilkårsvurdering =
+            lagVilkårsvurdering(behandling = behandling).also {
+                it.personResultater =
+                    setOf(
+                        lagPersonResultat(
+                            vilkårsvurdering = it,
+                            aktør = søkerAktør,
+                            lagVilkårResultater = { emptySet() },
+                            lagAnnenVurderinger = { emptySet() },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = it,
+                            aktør = barnAktør,
+                            lagVilkårResultater = { emptySet() },
+                            lagAnnenVurderinger = { emptySet() },
+                        ),
+                    )
+            }
+
+        every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlag
+
+        // Act
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(
+            vilkårsvurdering = vilkårsvurdering,
+            aktørerVilkårSkalPreutfyllesFor = listOf(barnAktør),
+        )
+
+        // Assert
+        val søkerBosattIRiket =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == søkerAktør }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
+        assertThat(søkerBosattIRiket).isEmpty()
+
+        val barnBosattIRiket =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == barnAktør }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
+        assertThat(barnBosattIRiket).isNotEmpty
+        assertThat(barnBosattIRiket).allMatch { it.erAutomatiskVurdert }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -61,7 +61,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdVilkår =
@@ -99,7 +99,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -139,7 +139,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -175,7 +175,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -209,7 +209,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -252,7 +252,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -304,7 +304,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -368,7 +368,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -401,7 +401,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -466,7 +466,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { persongrunnlagService.hentAktivThrows(vilkårsvurdering.behandling.id) } returns persongrunnlag
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdVilkårResultater =
@@ -506,7 +506,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -561,7 +561,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultat =
@@ -606,7 +606,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -640,7 +640,7 @@ class PreutfyllLovligOppholdServiceTest {
             every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -681,7 +681,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -751,7 +751,7 @@ class PreutfyllLovligOppholdServiceTest {
                 }
 
             // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering)
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
 
             // Assert
             val lovligOppholdResultater =
@@ -763,6 +763,78 @@ class PreutfyllLovligOppholdServiceTest {
             assertThat(lovligOppholdResultater).hasSize(1)
             assertThat(lovligOppholdResultater.single().resultat).isEqualTo(Resultat.OPPFYLT)
             assertThat(lovligOppholdResultater.single().periodeFom).isEqualTo(innvandringstidspunkt)
+        }
+
+        @Test
+        fun `skal kun preutfylle lovlig opphold for personResultater hvis aktør er i aktørerVilkårSkalPreutfyllesFor`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = behandling,
+                    lagPersonResultater = {
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = søkerAktør,
+                                lagVilkårResultater = { emptySet() },
+                                lagAnnenVurderinger = { emptySet() },
+                            ),
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = barn.aktør,
+                                lagVilkårResultater = { emptySet() },
+                                lagAnnenVurderinger = { emptySet() },
+                            ),
+                        )
+                    },
+                )
+
+            every { persongrunnlagService.hentAktivThrows(behandling.id) } returns
+                lagPersonopplysningGrunnlag(behandlingId = behandling.id) { grunnlag ->
+                    val norskStatsborgerskap: (Person) -> GrStatsborgerskap = { person ->
+                        GrStatsborgerskap(
+                            landkode = "NOR",
+                            gyldigPeriode = sisteTiÅr,
+                            medlemskap = Medlemskap.NORDEN,
+                            person = person,
+                        )
+                    }
+                    setOf(
+                        lagPerson(aktør = søkerAktør, personopplysningGrunnlag = grunnlag).apply {
+                            statsborgerskap = mutableListOf(norskStatsborgerskap(this))
+                        },
+                        lagPerson(
+                            aktør = barn.aktør,
+                            type = PersonType.BARN,
+                            fødselsdato = barn.fødselsdato,
+                            personopplysningGrunnlag = grunnlag,
+                        ).apply {
+                            statsborgerskap = mutableListOf(norskStatsborgerskap(this))
+                        },
+                    )
+                }
+
+            // Act
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(
+                vilkårsvurdering = vilkårsvurdering,
+                aktørerVilkårSkalPreutfyllesFor = listOf(barn.aktør),
+            )
+
+            // Assert
+            val søkerLovligOpphold =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == søkerAktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+            assertThat(søkerLovligOpphold).isEmpty()
+
+            val barnLovligOpphold =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == barn.aktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+            assertThat(barnLovligOpphold).isNotEmpty
+            assertThat(barnLovligOpphold).allMatch { it.erAutomatiskVurdert }
         }
 
         private fun lagPersonopplysningGrunnlagMedSøkerOgBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -766,7 +766,7 @@ class PreutfyllLovligOppholdServiceTest {
         }
 
         @Test
-        fun `skal kun preutfylle lovlig opphold for personResultater hvis aktør er i aktørerVilkårSkalPreutfyllesFor`() {
+        fun `skal kun preutfylle lovlig opphold for aktører i aktørerVilkårSkalPreutfyllesFor`() {
             // Arrange
             val vilkårsvurdering =
                 lagVilkårsvurdering(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårServiceTest.kt
@@ -1,20 +1,29 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.datagenerator.lagVilkårsvurdering
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakType
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import org.junit.jupiter.api.Test
 
 class PreutfyllVilkårServiceTest {
-    private val preutfyllLovligOppholdService: PreutfyllLovligOppholdService = mockk()
-    private val preutfyllBorMedSøkerService: PreutfyllBorMedSøkerService = mockk()
-    private val preutfyllBosattIRiketService: PreutfyllBosattIRiketService = mockk()
+    private val preutfyllLovligOppholdService: PreutfyllLovligOppholdService = mockk(relaxed = true)
+    private val preutfyllBorMedSøkerService: PreutfyllBorMedSøkerService = mockk(relaxed = true)
+    private val preutfyllBosattIRiketService: PreutfyllBosattIRiketService = mockk(relaxed = true)
     private val preutfyllBosattIRiketForFødselshendelserService: PreutfyllBosattIRiketForFødselshendelserService = mockk()
     private val persongrunnlagService: PersongrunnlagService = mockk()
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
 
     val preutfyllVilkårService =
         PreutfyllVilkårService(
@@ -23,6 +32,7 @@ class PreutfyllVilkårServiceTest {
             preutfyllBosattIRiketService,
             preutfyllBosattIRiketForFødselshendelserService,
             persongrunnlagService,
+            behandlingHentOgPersisterService,
         )
 
     @Test
@@ -39,8 +49,123 @@ class PreutfyllVilkårServiceTest {
         preutfyllVilkårService.preutfyllVilkår(vilkårsvurdering = vilkårsvurdering)
 
         // Assert
-        verify(exactly = 0) { preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering) }
-        verify(exactly = 0) { preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering) }
-        verify(exactly = 0) { preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering) }
+        verify(exactly = 0) { preutfyllLovligOppholdService.preutfyllLovligOpphold(any(), any()) }
+        verify(exactly = 0) { preutfyllBosattIRiketService.preutfyllBosattIRiket(any(), any()) }
+        verify(exactly = 0) { preutfyllBorMedSøkerService.preutfyllBorMedSøker(any(), any()) }
+    }
+
+    @Test
+    fun `Skal ikke kjøre preutfylling for EØS-behandling`() {
+        // Arrange
+        val behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS)
+        val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+
+        // Act
+        preutfyllVilkårService.preutfyllVilkår(vilkårsvurdering = vilkårsvurdering)
+
+        // Assert
+        verify(exactly = 0) { preutfyllLovligOppholdService.preutfyllLovligOpphold(any(), any()) }
+        verify(exactly = 0) { preutfyllBosattIRiketService.preutfyllBosattIRiket(any(), any()) }
+        verify(exactly = 0) { preutfyllBorMedSøkerService.preutfyllBorMedSøker(any(), any()) }
+    }
+
+    @Test
+    fun `Skal preutfylle alle vilkår med alle aktører for førstegangsbehandling`() {
+        // Arrange
+        val fagsak = lagFagsak()
+        val behandling = lagBehandling(fagsak = fagsak, behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING, årsak = BehandlingÅrsak.SØKNAD)
+        val søker = lagPerson(type = PersonType.SØKER)
+        val barn = lagPerson(type = PersonType.BARN)
+        every { persongrunnlagService.hentAktivThrows(behandling.id) } returns
+            lagTestPersonopplysningGrunnlag(behandling.id, søker, barn)
+        every { persongrunnlagService.oppdaterRegisteropplysninger(behandling.id) } returns mockk()
+
+        val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+        val alleAktører = listOf(søker.aktør, barn.aktør)
+
+        // Act
+        preutfyllVilkårService.preutfyllVilkår(vilkårsvurdering = vilkårsvurdering)
+
+        // Assert
+        verify(exactly = 1) { preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering, alleAktører) }
+        verify(exactly = 1) { preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, alleAktører) }
+        verify(exactly = 1) { preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, alleAktører) }
+    }
+
+    @Test
+    fun `Skal ikke kjøre preutfylling for revurdering med årsak som ikke er søknad`() {
+        // Arrange
+        val behandling =
+            lagBehandling(
+                behandlingType = BehandlingType.REVURDERING,
+                årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+            )
+        val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+
+        // Act
+        preutfyllVilkårService.preutfyllVilkår(vilkårsvurdering = vilkårsvurdering)
+
+        // Assert
+        verify(exactly = 0) { preutfyllLovligOppholdService.preutfyllLovligOpphold(any(), any()) }
+        verify(exactly = 0) { preutfyllBosattIRiketService.preutfyllBosattIRiket(any(), any()) }
+        verify(exactly = 0) { preutfyllBorMedSøkerService.preutfyllBorMedSøker(any(), any()) }
+    }
+
+    @Test
+    fun `Skal preutfylle bare for nye barn i revurdering med årsak søknad`() {
+        // Arrange
+        val fagsak = lagFagsak()
+        val behandling = lagBehandling(fagsak = fagsak, behandlingType = BehandlingType.REVURDERING, årsak = BehandlingÅrsak.SØKNAD)
+        val forrigeBehandling = lagBehandling(fagsak = fagsak, behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING, årsak = BehandlingÅrsak.SØKNAD)
+
+        val søker = lagPerson(type = PersonType.SØKER)
+        val eksisterendeBarn = lagPerson(type = PersonType.BARN)
+        val nyttBarn = lagPerson(type = PersonType.BARN)
+
+        every { persongrunnlagService.hentAktivThrows(behandling.id) } returns
+            lagTestPersonopplysningGrunnlag(behandling.id, søker, eksisterendeBarn, nyttBarn)
+        every { persongrunnlagService.hentAktivThrows(forrigeBehandling.id) } returns
+            lagTestPersonopplysningGrunnlag(forrigeBehandling.id, søker, eksisterendeBarn)
+        every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling) } returns forrigeBehandling
+        every { persongrunnlagService.oppdaterRegisteropplysninger(behandling.id) } returns mockk()
+
+        val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+        val nyttBarnAktør = nyttBarn.aktør
+
+        // Act
+        preutfyllVilkårService.preutfyllVilkår(vilkårsvurdering = vilkårsvurdering)
+
+        // Assert
+        verify(exactly = 1) { preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering, listOf(nyttBarnAktør)) }
+        verify(exactly = 1) { preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, listOf(nyttBarnAktør)) }
+        verify(exactly = 1) { preutfyllBosattIRiketService.preutfyllBosattIRiket(vilkårsvurdering, listOf(nyttBarnAktør)) }
+    }
+
+    @Test
+    fun `Skal ikke preutfylle for revurdering med årsak søknad hvis ingen nye barn`() {
+        // Arrange
+        val fagsak = lagFagsak()
+        val behandling = lagBehandling(fagsak = fagsak, behandlingType = BehandlingType.REVURDERING, årsak = BehandlingÅrsak.SØKNAD)
+        val forrigeBehandling = lagBehandling(fagsak = fagsak, behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING, årsak = BehandlingÅrsak.SØKNAD)
+
+        val søker = lagPerson(type = PersonType.SØKER)
+        val eksisterendeBarn = lagPerson(type = PersonType.BARN)
+
+        every { persongrunnlagService.hentAktivThrows(behandling.id) } returns
+            lagTestPersonopplysningGrunnlag(behandling.id, søker, eksisterendeBarn)
+        every { persongrunnlagService.hentAktivThrows(forrigeBehandling.id) } returns
+            lagTestPersonopplysningGrunnlag(forrigeBehandling.id, søker, eksisterendeBarn)
+        every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling) } returns forrigeBehandling
+
+        val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+
+        // Act
+        preutfyllVilkårService.preutfyllVilkår(vilkårsvurdering = vilkårsvurdering)
+
+        // Assert
+        verify(exactly = 0) { persongrunnlagService.oppdaterRegisteropplysninger(any()) }
+        verify(exactly = 0) { preutfyllLovligOppholdService.preutfyllLovligOpphold(any(), any()) }
+        verify(exactly = 0) { preutfyllBorMedSøkerService.preutfyllBorMedSøker(any(), any()) }
+        verify(exactly = 0) { preutfyllBosattIRiketService.preutfyllBosattIRiket(any(), any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllVilkårServiceTest.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagFagsak
 import no.nav.familie.ba.sak.datagenerator.lagPerson
@@ -24,6 +26,7 @@ class PreutfyllVilkårServiceTest {
     private val preutfyllBosattIRiketForFødselshendelserService: PreutfyllBosattIRiketForFødselshendelserService = mockk()
     private val persongrunnlagService: PersongrunnlagService = mockk()
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService = mockk()
+    private val featureToggleService: FeatureToggleService = mockk()
 
     val preutfyllVilkårService =
         PreutfyllVilkårService(
@@ -33,6 +36,7 @@ class PreutfyllVilkårServiceTest {
             preutfyllBosattIRiketForFødselshendelserService,
             persongrunnlagService,
             behandlingHentOgPersisterService,
+            featureToggleService = featureToggleService,
         )
 
     @Test
@@ -101,6 +105,7 @@ class PreutfyllVilkårServiceTest {
                 årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
             )
         val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+        every { featureToggleService.isEnabled(FeatureToggle.PREUTFYLL_VILKÅR_REVURDERING_SØKNAD) } returns true
 
         // Act
         preutfyllVilkårService.preutfyllVilkår(vilkårsvurdering = vilkårsvurdering)
@@ -112,7 +117,7 @@ class PreutfyllVilkårServiceTest {
     }
 
     @Test
-    fun `Skal preutfylle bare for nye barn i revurdering med årsak søknad`() {
+    fun `Skal preutfylle bare for nye barn i revurdering med årsak søknad når toggle er på`() {
         // Arrange
         val fagsak = lagFagsak()
         val behandling = lagBehandling(fagsak = fagsak, behandlingType = BehandlingType.REVURDERING, årsak = BehandlingÅrsak.SØKNAD)
@@ -122,6 +127,7 @@ class PreutfyllVilkårServiceTest {
         val eksisterendeBarn = lagPerson(type = PersonType.BARN)
         val nyttBarn = lagPerson(type = PersonType.BARN)
 
+        every { featureToggleService.isEnabled(FeatureToggle.PREUTFYLL_VILKÅR_REVURDERING_SØKNAD) } returns true
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns
             lagTestPersonopplysningGrunnlag(behandling.id, søker, eksisterendeBarn, nyttBarn)
         every { persongrunnlagService.hentAktivThrows(forrigeBehandling.id) } returns
@@ -151,6 +157,7 @@ class PreutfyllVilkårServiceTest {
         val søker = lagPerson(type = PersonType.SØKER)
         val eksisterendeBarn = lagPerson(type = PersonType.BARN)
 
+        every { featureToggleService.isEnabled(FeatureToggle.PREUTFYLL_VILKÅR_REVURDERING_SØKNAD) } returns true
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns
             lagTestPersonopplysningGrunnlag(behandling.id, søker, eksisterendeBarn)
         every { persongrunnlagService.hentAktivThrows(forrigeBehandling.id) } returns


### PR DESCRIPTION
### 📮 Favro: NAV-29028

### 💰 Hva skal gjøres, og hvorfor?
 
 Vi utvider PreutfyllVilkårService slik at revurderinger med årsak SØKNAD også preutfylles. Merk at dette kun gjelder for nye barn som ikke fantes i forrige vedtatte behandling. Førstegangsbehandlinger preutfyllers fortsatt for alle som før.

Vi gjør dette ved å sende inn en liste til preutfylle servicene som sier hvem det skal preutfylles for.
For revurdering søknader så sender vi inn bare nye barn, mens i alle andre førstegangsbehandlinger sender vi inn alle sammen.

Testet OK i preprod.

FørstegangsbehandlingSøknad:
https://barnetrygd.ansatt.dev.nav.no/fagsak/200149951/100295451/vedtak

RevurderingSøknad:
https://barnetrygd.ansatt.dev.nav.no/fagsak/200149951/100295501/vilkaarsvurdering