### PR TITLE
Vi må eksponere erOpprinneligPreutfyltIBehandling slik at frontend kan bruke denne for å se hvilke advarsler som skal vises

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/PersonResultatDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/PersonResultatDto.kt
@@ -44,6 +44,7 @@ data class VilkårResultatDto(
     val utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = emptyList(),
     val resultatBegrunnelse: ResultatBegrunnelse? = null,
     val begrunnelseForManuellKontroll: String? = null,
+    val erOpprinneligPreutfyltIBehandling: Long? = null,
 ) {
     fun erAvslagUtenPeriode() = this.erEksplisittAvslagPåSøknad == true && this.periodeFom == null && this.periodeTom == null
 
@@ -73,6 +74,7 @@ fun PersonResultat.tilPersonResultatDto() =
                     vurderesEtter = vilkårResultat.vurderesEtter,
                     utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger,
                     begrunnelseForManuellKontroll = vilkårResultat.begrunnelseForManuellKontroll?.begrunnelse(vilkårResultat.vilkårType),
+                    erOpprinneligPreutfyltIBehandling = vilkårResultat.erOpprinneligPreutfyltIBehandling,
                 )
             },
         andreVurderinger =


### PR DESCRIPTION
### 📮 Favro: NAV-29202

### 💰 Hva skal gjøres, og hvorfor?
Vi må eksponere erOpprinneligPreutfyltIBehandling slik at frontend kan bruke denne for å se hvilke advarsler som skal vises