### PR TITLE
Slå sammen perioder innenfor samme måned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -176,22 +176,17 @@ class PreutfyllLovligOppholdService(
  * F.eks. 14.feb→16.feb + 19.feb→28.feb → 14.feb→28.feb
  */
 private fun List<Periode<Boolean>>.slåSammenPerioderInnenforSammeMåned(): List<Periode<Boolean>> =
-    sortedBy { it.fom }.fold(mutableListOf()) { acc, periode ->
-        val forrige = acc.lastOrNull()
+    sortedBy { it.fom }.fold(emptyList()) { acc, periode ->
+        val forrigePeriode = acc.lastOrNull()
+        val forrigePeriodeTom = forrigePeriode?.tom
+        val dennePeriodeFom = periode.fom
+        val kanSlåsSammen = forrigePeriode != null && (forrigePeriodeTom == null || dennePeriodeFom == null || dennePeriodeFom.toYearMonth() <= forrigePeriodeTom.toYearMonth())
 
-        if (forrige == null || !oppholdstillatelsePerioderKanSlåsSammen(forrige.tom, periode.fom)) {
-            acc.add(periode)
+        if (kanSlåsSammen) {
+            val nyTom = forrigePeriode.tom?.let { forrigePeriodeTom -> periode.tom?.let { dennePeriodeTom -> maxOf(forrigePeriodeTom, dennePeriodeTom) } }
+
+            acc.dropLast(1) + Periode(verdi = true, fom = forrigePeriode.fom, tom = nyTom)
         } else {
-            val forrigeTom = forrige.tom
-            val periodeTom = periode.tom
-
-            val nyTom = if (forrigeTom == null || periodeTom == null) null else maxOf(forrigeTom, periodeTom)
-            acc[acc.lastIndex] = Periode(verdi = true, fom = forrige.fom, tom = nyTom)
+            acc + periode
         }
-        acc
     }
-
-private fun oppholdstillatelsePerioderKanSlåsSammen(
-    forrigePeriodeTom: LocalDate?,
-    dennePeriodeFom: LocalDate?,
-): Boolean = forrigePeriodeTom == null || dennePeriodeFom == null || dennePeriodeFom.toYearMonth() <= forrigePeriodeTom.toYearMonth()

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -159,11 +160,38 @@ class PreutfyllLovligOppholdService(
     ): Tidslinje<Boolean> =
         oppholdstillatelse
             .filter { it.type in setOf(PERMANENT, MIDLERTIDIG) }
-            .map { oppholdstillatelse ->
+            .map {
                 Periode(
                     verdi = true,
-                    fom = oppholdstillatelse.gyldigPeriode?.fom,
-                    tom = oppholdstillatelse.gyldigPeriode?.tom?.takeIf { it.isSameOrBefore(LocalDate.now()) },
-                ).tilTidslinje()
-            }.kombiner { it.any() }
+                    fom = it.gyldigPeriode?.fom,
+                    tom = it.gyldigPeriode?.tom?.takeIf { it.isSameOrBefore(LocalDate.now()) },
+                )
+            }.slåSammenPerioderInnenforSammeMåned()
+            .map { it.tilTidslinje() }
+            .kombiner { it.any() }
 }
+
+/**
+ * Slår sammen perioder som overlapper eller har gap innenfor samme eller påfølgende måned.
+ * F.eks. 14.des→19.des + 21.des→4.feb → 14.des→4.feb
+ */
+private fun List<Periode<Boolean>>.slåSammenPerioderInnenforSammeMåned(): List<Periode<Boolean>> =
+    sortedBy { it.fom }.fold(mutableListOf()) { acc, periode ->
+        val forrige = acc.lastOrNull()
+
+        if (forrige == null || !kanSlåsSammen(forrige.tom, periode.fom)) {
+            acc.add(periode)
+        } else {
+            val forrigeTom = forrige.tom
+            val periodeTom = periode.tom
+
+            val nyTom = if (forrigeTom == null || periodeTom == null) null else maxOf(forrigeTom, periodeTom)
+            acc[acc.lastIndex] = Periode(verdi = true, fom = forrige.fom, tom = nyTom)
+        }
+        acc
+    }
+
+private fun kanSlåsSammen(
+    tom: LocalDate?,
+    fom: LocalDate?,
+): Boolean = tom == null || fom == null || fom.toYearMonth() <= tom.toYearMonth().plusMonths(1)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -164,7 +164,7 @@ class PreutfyllLovligOppholdService(
                 Periode(
                     verdi = true,
                     fom = it.gyldigPeriode?.fom,
-                    tom = it.gyldigPeriode?.tom?.takeIf { it.isSameOrBefore(LocalDate.now()) },
+                    tom = it.gyldigPeriode?.tom?.takeIf { tom -> tom.isSameOrBefore(LocalDate.now()) },
                 )
             }.slåSammenPerioderInnenforSammeMåned()
             .map { it.tilTidslinje() }
@@ -172,14 +172,14 @@ class PreutfyllLovligOppholdService(
 }
 
 /**
- * Slår sammen perioder som overlapper eller har gap innenfor samme eller påfølgende måned.
- * F.eks. 14.des→19.des + 21.des→4.feb → 14.des→4.feb
+ * Slår sammen perioder som overlapper eller har mellomrom innenfor samme måned.
+ * F.eks. 14.feb→16.feb + 19.feb→28.feb → 14.feb→28.feb
  */
 private fun List<Periode<Boolean>>.slåSammenPerioderInnenforSammeMåned(): List<Periode<Boolean>> =
     sortedBy { it.fom }.fold(mutableListOf()) { acc, periode ->
         val forrige = acc.lastOrNull()
 
-        if (forrige == null || !kanSlåsSammen(forrige.tom, periode.fom)) {
+        if (forrige == null || !oppholdstillatelsePerioderKanSlåsSammen(forrige.tom, periode.fom)) {
             acc.add(periode)
         } else {
             val forrigeTom = forrige.tom
@@ -191,7 +191,7 @@ private fun List<Periode<Boolean>>.slåSammenPerioderInnenforSammeMåned(): List
         acc
     }
 
-private fun kanSlåsSammen(
-    tom: LocalDate?,
-    fom: LocalDate?,
-): Boolean = tom == null || fom == null || fom.toYearMonth() <= tom.toYearMonth().plusMonths(1)
+private fun oppholdstillatelsePerioderKanSlåsSammen(
+    forrigePeriodeTom: LocalDate?,
+    dennePeriodeFom: LocalDate?,
+): Boolean = forrigePeriodeTom == null || dennePeriodeFom == null || dennePeriodeFom.toYearMonth() <= forrigePeriodeTom.toYearMonth()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -615,8 +615,9 @@ class PreutfyllLovligOppholdServiceTest {
                     .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
                     .sortedBy { it.periodeFom }
 
-            val sisteOppfylteVilkår = lovligOppholdResultater.last { it.resultat == Resultat.OPPFYLT }
-            assertThat(sisteOppfylteVilkår.periodeTom).isNull()
+            val oppfylteVilkår = lovligOppholdResultater.filter { it.resultat == Resultat.OPPFYLT }
+            assertThat(oppfylteVilkår).hasSize(1)
+            assertThat(oppfylteVilkår.single().periodeTom).isNull()
         }
 
         @Test
@@ -919,6 +920,203 @@ class PreutfyllLovligOppholdServiceTest {
                     .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
             assertThat(barnLovligOpphold).isNotEmpty
             assertThat(barnLovligOpphold).allMatch { it.erAutomatiskVurdert }
+        }
+
+        @Test
+        fun `skal slå sammen oppholdstillatelser med gap innenfor samme måned til én sammenhengende oppfylt periode`() {
+            // Arrange
+            val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+            val førsteOppholdstillatelseFom = LocalDate.of(2022, 12, 1)
+            val personopplysningsgrunnlag =
+                lagPersonopplysningGrunnlagMedSøkerOgBarn { søker ->
+                    søker.apply {
+                        opphold =
+                            mutableListOf(
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = førsteOppholdstillatelseFom, tom = LocalDate.of(2023, 12, 15)),
+                                    person = this,
+                                ),
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2023, 12, 20), tom = LocalDate.of(2024, 12, 15)),
+                                    person = this,
+                                ),
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2025, 1, 5), tom = LocalDate.now().plusYears(1)),
+                                    person = this,
+                                ),
+                            )
+                        statsborgerskap =
+                            mutableListOf(
+                                GrStatsborgerskap(
+                                    landkode = "AFG",
+                                    gyldigPeriode = DatoIntervallEntitet(fom = førsteOppholdstillatelseFom, tom = null),
+                                    person = this,
+                                ),
+                            )
+                    }
+                }
+
+            every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
+
+            // Act
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
+
+            // Assert
+            val lovligOppholdResultater =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == søkerAktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+
+            val oppfylteVilkår = lovligOppholdResultater.filter { it.resultat == Resultat.OPPFYLT }
+            assertThat(oppfylteVilkår).hasSize(1)
+            assertThat(oppfylteVilkår.single().periodeFom).isEqualTo(førsteOppholdstillatelseFom)
+            assertThat(oppfylteVilkår.single().periodeTom).isNull()
+        }
+
+        @Test
+        fun `skal ikke slå sammen oppholdstillatelser med gap på mer enn en måned`() {
+            // Arrange
+            val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+            val personopplysningsgrunnlag =
+                lagPersonopplysningGrunnlagMedSøkerOgBarn { søker ->
+                    søker.apply {
+                        opphold =
+                            mutableListOf(
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = LocalDate.now().minusYears(3)),
+                                    person = this,
+                                ),
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(3).plusMonths(2), tom = LocalDate.now().minusYears(1)),
+                                    person = this,
+                                ),
+                            )
+                        statsborgerskap =
+                            mutableListOf(
+                                GrStatsborgerskap(
+                                    landkode = "AFG",
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = null),
+                                    person = this,
+                                ),
+                            )
+                    }
+                }
+
+            every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
+
+            // Act
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
+
+            // Assert
+            val lovligOppholdResultater =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == søkerAktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+
+            val oppfylteVilkår = lovligOppholdResultater.filter { it.resultat == Resultat.OPPFYLT }
+            assertThat(oppfylteVilkår).hasSize(2)
+        }
+
+        @Test
+        fun `skal slå sammen oppholdstillatelser som går kant i kant over månedsskifte`() {
+            // Arrange
+            val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+            val personopplysningsgrunnlag =
+                lagPersonopplysningGrunnlagMedSøkerOgBarn { søker ->
+                    søker.apply {
+                        opphold =
+                            mutableListOf(
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = LocalDate.of(2024, 1, 31)),
+                                    person = this,
+                                ),
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 2, 1), tom = LocalDate.now().plusYears(1)),
+                                    person = this,
+                                ),
+                            )
+                        statsborgerskap =
+                            mutableListOf(
+                                GrStatsborgerskap(
+                                    landkode = "AFG",
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = null),
+                                    person = this,
+                                ),
+                            )
+                    }
+                }
+
+            every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
+
+            // Act
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
+
+            // Assert
+            val lovligOppholdResultater =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == søkerAktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+
+            val oppfylteVilkår = lovligOppholdResultater.filter { it.resultat == Resultat.OPPFYLT }
+            assertThat(oppfylteVilkår).hasSize(1)
+            assertThat(oppfylteVilkår.single().periodeTom).isNull()
+        }
+
+        @Test
+        fun `skal ikke slå sammen oppholdstillatelser med gap på en hel måned uten dekning`() {
+            // Arrange - tom i januar, fom i mars = februar har ingen dekning
+            val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
+            val personopplysningsgrunnlag =
+                lagPersonopplysningGrunnlagMedSøkerOgBarn { søker ->
+                    søker.apply {
+                        opphold =
+                            mutableListOf(
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = LocalDate.of(2024, 1, 31)),
+                                    person = this,
+                                ),
+                                GrOpphold(
+                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 3, 1), tom = LocalDate.now().minusMonths(1)),
+                                    person = this,
+                                ),
+                            )
+                        statsborgerskap =
+                            mutableListOf(
+                                GrStatsborgerskap(
+                                    landkode = "AFG",
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = null),
+                                    person = this,
+                                ),
+                            )
+                    }
+                }
+
+            every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
+
+            // Act
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
+
+            // Assert
+            val lovligOppholdResultater =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == søkerAktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+
+            val oppfylteVilkår = lovligOppholdResultater.filter { it.resultat == Resultat.OPPFYLT }
+            assertThat(oppfylteVilkår).hasSize(2)
         }
 
         private fun lagPersonopplysningGrunnlagMedSøkerOgBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -944,7 +944,7 @@ class PreutfyllLovligOppholdServiceTest {
                                 ),
                                 GrOpphold(
                                     type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
-                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2025, 1, 5), tom = LocalDate.now().plusYears(1)),
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 12, 20), tom = null),
                                     person = this,
                                 ),
                             )
@@ -1025,7 +1025,7 @@ class PreutfyllLovligOppholdServiceTest {
         }
 
         @Test
-        fun `skal slå sammen oppholdstillatelser som går kant i kant over månedsskifte`() {
+        fun `skal ikke slå sammen oppholdstillatelser som går kant i kant over månedsskifte`() {
             // Arrange
             val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
             val personopplysningsgrunnlag =
@@ -1035,60 +1035,12 @@ class PreutfyllLovligOppholdServiceTest {
                             mutableListOf(
                                 GrOpphold(
                                     type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
-                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = LocalDate.of(2024, 1, 31)),
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = LocalDate.of(2024, 1, 15)),
                                     person = this,
                                 ),
                                 GrOpphold(
                                     type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
-                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 2, 1), tom = LocalDate.now().plusYears(1)),
-                                    person = this,
-                                ),
-                            )
-                        statsborgerskap =
-                            mutableListOf(
-                                GrStatsborgerskap(
-                                    landkode = "AFG",
-                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = null),
-                                    person = this,
-                                ),
-                            )
-                    }
-                }
-
-            every { persongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningsgrunnlag
-
-            // Act
-            preutfyllLovligOppholdService.preutfyllLovligOpphold(vilkårsvurdering = vilkårsvurdering, aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør })
-
-            // Assert
-            val lovligOppholdResultater =
-                vilkårsvurdering.personResultater
-                    .first { it.aktør == søkerAktør }
-                    .vilkårResultater
-                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
-
-            val oppfylteVilkår = lovligOppholdResultater.filter { it.resultat == Resultat.OPPFYLT }
-            assertThat(oppfylteVilkår).hasSize(1)
-            assertThat(oppfylteVilkår.single().periodeTom).isNull()
-        }
-
-        @Test
-        fun `skal ikke slå sammen oppholdstillatelser med gap på en hel måned uten dekning`() {
-            // Arrange - tom i januar, fom i mars = februar har ingen dekning
-            val vilkårsvurdering = lagVilkårsvurdering(behandling = behandling)
-            val personopplysningsgrunnlag =
-                lagPersonopplysningGrunnlagMedSøkerOgBarn { søker ->
-                    søker.apply {
-                        opphold =
-                            mutableListOf(
-                                GrOpphold(
-                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
-                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.now().minusYears(5), tom = LocalDate.of(2024, 1, 31)),
-                                    person = this,
-                                ),
-                                GrOpphold(
-                                    type = OPPHOLDSTILLATELSE.MIDLERTIDIG,
-                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 3, 1), tom = LocalDate.now().minusMonths(1)),
+                                    gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 2, 5), tom = LocalDate.now().minusMonths(1)),
                                     person = this,
                                 ),
                             )


### PR DESCRIPTION
### 📮 Favro: NAV-29212

### 💰 Hva skal gjøres, og hvorfor?

Når personen har flere oppholdstillatelser som går kant i kant (innenfor samme måned), skal dette registreres som én sammenhengende oppfylt periode i vilkåret. 

F.eks: søker har bodd i Norge fra desember 2022, og har flere hatt oppholdstillatelser fra desember 22, som har gått kant i kant innenfor samme måned. Har også en oppholdstillatelse nå, som gjelder fram til desember 2026. Da skal  vilkåret lovlig opphold stå som oppfylt fra desember 2022, og uten til og med dato.


