### PR TITLE
NAV-29215: Legg til /begrunnelser/ alias for /standardbegrunnelser/

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelserController.kt
@@ -44,7 +44,7 @@ class VedtaksperiodeMedBegrunnelserController(
     private val kodeverkService: KodeverkService,
     private val testVerktøyService: TestVerktøyService,
 ) {
-    @PutMapping("/standardbegrunnelser/{vedtaksperiodeId}")
+    @PutMapping(path = ["/standardbegrunnelser/{vedtaksperiodeId}", "/begrunnelser/{vedtaksperiodeId}"])
     fun oppdaterVedtaksperiodeStandardbegrunnelser(
         @PathVariable
         vedtaksperiodeId: Long,


### PR DESCRIPTION
### 📮 Favro: NAV-29215

### 💰 Hva skal gjøres, og hvorfor?
Renamer standardbegrunnelser til begrunnelser.