### PR TITLE
Ikke trigg endring i behandlingsresultat hvis det bare har vært en endring mellom etterbetaling årsaker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ba.sak.kjerne.beregning.tilTidslinje
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 
@@ -16,7 +17,7 @@ object EndringIEndretUtbetalingAndelUtil {
         val endringerTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
                 val endringIAvtaletidspunktDeltBosted = nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted
-                val endringIÅrsak = nåværende?.årsak != forrige?.årsak
+                val endringIÅrsak = nåværende?.årsak != forrige?.årsak && !erKunEndringMellomEtterbetalingsårsaker(nåværende?.årsak, forrige?.årsak)
                 val endringISøknadstidspunkt = nåværende?.søknadstidspunkt != forrige?.søknadstidspunkt
                 val haddeTidligereIkkeSøknadstidspunkt = forrige?.søknadstidspunkt == null
 
@@ -27,4 +28,11 @@ object EndringIEndretUtbetalingAndelUtil {
 
         return endringerTidslinje
     }
+
+    private val etterbetalingsårsaker = setOf(Årsak.ETTERBETALING_3ÅR, Årsak.ETTERBETALING_3MND)
+
+    private fun erKunEndringMellomEtterbetalingsårsaker(
+        nåværendeÅrsak: Årsak?,
+        forrigeÅrsak: Årsak?,
+    ): Boolean = nåværendeÅrsak in etterbetalingsårsaker && forrigeÅrsak in etterbetalingsårsaker
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -725,14 +725,6 @@ class BehandlingsresultatEndringUtilsTest {
                 )
             }
 
-//        val erEndringIEndretAndeler =
-//            listOf(barn1, barn2).any {
-//                erEndringIEndretUtbetalingAndelerForPerson(
-//                    forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.personer.contains(it) },
-//                    nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT)).filter { endretAndel -> endretAndel.personer.contains(it) },
-//                )
-//            }
-
         assertTrue(erEndringIEndretAndeler)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
@@ -184,10 +184,10 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         val perioderMedEndring =
             listOf(barn1, barn2)
-                .map {
+                .map { person ->
                     EndringIEndretUtbetalingAndelUtil.lagEndringIEndretUbetalingAndelPerPersonTidslinje(
-                        forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.personer.contains(it) },
-                        nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ETTERBETALING_3MND)).filter { endretAndel -> endretAndel.personer.contains(it) },
+                        forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.personer.contains(person) },
+                        nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ETTERBETALING_3MND)).filter { endretAndel -> endretAndel.personer.contains(person) },
                     )
                 }.flatMap { it.tilPerioder() }
                 .filter { it.verdi == true }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
@@ -20,7 +20,33 @@ class EndringIEndretUtbetalingAndelUtilTest {
     val des22 = YearMonth.of(2022, 12)
 
     @Test
-    fun `Endring i endret utbetaling andel - skal ha endret periode hvis årsak er endret`() {
+    fun `Endring i endret utbetaling andel - skal ikke ha endret periode hvis årsak endres mellom etterbetaling 3 år og 3 mnd`() {
+        val barn = lagPerson(type = PersonType.BARN)
+        val forrigeEndretAndel =
+            lagEndretUtbetalingAndel(
+                personer = setOf(barn),
+                prosent = BigDecimal.ZERO,
+                fom = jan22,
+                tom = aug22,
+                årsak = Årsak.ETTERBETALING_3ÅR,
+                søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
+            )
+
+        val nåværendeEndretAndel = forrigeEndretAndel.copy(årsak = Årsak.ETTERBETALING_3MND)
+
+        val perioderMedEndring =
+            EndringIEndretUtbetalingAndelUtil
+                .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
+                    forrigeEndretAndelerForPerson = listOf(forrigeEndretAndel),
+                    nåværendeEndretAndelerForPerson = listOf(nåværendeEndretAndel),
+                ).tilPerioder()
+                .filter { it.verdi == true }
+
+        assertTrue(perioderMedEndring.isEmpty())
+    }
+
+    @Test
+    fun `Endring i endret utbetaling andel - skal ha endret periode hvis årsak endres til noe annet enn etterbetaling`() {
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -131,7 +157,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
     }
 
     @Test
-    fun `Endring i endret utbetaling andel - skal returnere endret periode hvis et av to barn har endring på årsak`() {
+    fun `Endring i endret utbetaling andel - skal ikke returnere endret periode hvis et av to barn kun har endring mellom etterbetalingsårsaker`() {
         val barn1 = lagPerson(type = PersonType.BARN)
         val barn2 = lagPerson(type = PersonType.BARN)
 
@@ -161,7 +187,46 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 .map {
                     EndringIEndretUtbetalingAndelUtil.lagEndringIEndretUbetalingAndelPerPersonTidslinje(
                         forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.personer.contains(it) },
-                        nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT)).filter { endretAndel -> endretAndel.personer.contains(it) },
+                        nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ETTERBETALING_3MND)).filter { endretAndel -> endretAndel.personer.contains(it) },
+                    )
+                }.flatMap { it.tilPerioder() }
+                .filter { it.verdi == true }
+
+        assertTrue(perioderMedEndring.isEmpty())
+    }
+
+    @Test
+    fun `Endring i endret utbetaling andel - skal returnere endret periode hvis et barn har reell endring selv om et annet barn kun har endring mellom etterbetalingsårsaker`() {
+        val barn1 = lagPerson(type = PersonType.BARN)
+        val barn2 = lagPerson(type = PersonType.BARN)
+
+        val forrigeEndretAndelBarn1 =
+            lagEndretUtbetalingAndel(
+                personer = setOf(barn1),
+                prosent = BigDecimal.ZERO,
+                fom = jan22,
+                tom = aug22,
+                årsak = Årsak.DELT_BOSTED,
+                søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
+                avtaletidspunktDeltBosted = jan22.førsteDagIInneværendeMåned(),
+            )
+
+        val forrigeEndretAndelBarn2 =
+            lagEndretUtbetalingAndel(
+                personer = setOf(barn2),
+                prosent = BigDecimal.ZERO,
+                fom = jan22,
+                tom = aug22,
+                årsak = Årsak.ETTERBETALING_3ÅR,
+                søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
+            )
+
+        val perioderMedEndring =
+            listOf(barn1, barn2)
+                .map {
+                    EndringIEndretUtbetalingAndelUtil.lagEndringIEndretUbetalingAndelPerPersonTidslinje(
+                        forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.personer.contains(it) },
+                        nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1.copy(årsak = Årsak.ALLEREDE_UTBETALT), forrigeEndretAndelBarn2.copy(årsak = Årsak.ETTERBETALING_3MND)).filter { endretAndel -> endretAndel.personer.contains(it) },
                     )
                 }.flatMap { it.tilPerioder() }
                 .filter { it.verdi == true }


### PR DESCRIPTION
### 📮 Favro: Nav-28942

### 💰 Hva skal gjøres, og hvorfor?
Vi ønsker ikke at det skal trigges "ENDRING" i behandlingsresultatet hvis forskjellen mellom denne og forrige behandling er at man har endret mellom etterbetalingsårsakene i endret utbetaling, da dette ikke har noe å si for selve barnetrygden med mindre andel tilkjent ytelse har endret på seg.