### PR TITLE
Ikke stopp preutfylling bare fordi det feiler for 1 person eller 1 vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.Adresse
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.adresser.Adresser
@@ -39,20 +40,27 @@ class PreutfyllBorMedSøkerService(
             .filterNot { it.erSøkersResultater() }
             .filter { it.aktør in aktørerVilkårSkalPreutfyllesFor }
             .forEach { personResultat ->
-                val barn = personResultat.aktør.tilPerson(personopplysningGrunnlag)
-                val adresserForBarn = Adresser.opprettFra(barn)
+                try {
+                    val barn = personResultat.aktør.tilPerson(personopplysningGrunnlag)
+                    val adresserForBarn = Adresser.opprettFra(barn)
 
-                val nyeBorMedSøkerVilkårResultat =
-                    genererBorMedSøkerVilkårResultat(
-                        personResultat = personResultat,
-                        bostedsadresserBarn = adresserForBarn,
-                        bostedsadresserSøker = bostedsadresserSøker,
-                        barnFødselsdato = barn.fødselsdato,
+                    val nyeBorMedSøkerVilkårResultat =
+                        genererBorMedSøkerVilkårResultat(
+                            personResultat = personResultat,
+                            bostedsadresserBarn = adresserForBarn,
+                            bostedsadresserSøker = bostedsadresserSøker,
+                            barnFødselsdato = barn.fødselsdato,
+                        )
+
+                    if (nyeBorMedSøkerVilkårResultat.isNotEmpty()) {
+                        personResultat.vilkårResultater.removeIf { it.vilkårType == BOR_MED_SØKER }
+                        personResultat.vilkårResultater.addAll(nyeBorMedSøkerVilkårResultat)
+                    }
+                } catch (exception: Exception) {
+                    secureLogger.warn(
+                        "Preutfylling av bor med søker feilet for aktør ${personResultat.aktør.aktørId} i behandling ${vilkårsvurdering.behandling.id}, fortsetter med neste person",
+                        exception,
                     )
-
-                if (nyeBorMedSøkerVilkårResultat.isNotEmpty()) {
-                    personResultat.vilkårResultater.removeIf { it.vilkårType == BOR_MED_SØKER }
-                    personResultat.vilkårResultater.addAll(nyeBorMedSøkerVilkårResultat)
                 }
             }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.vilkårsvurdering.utfall.VilkårIkkeOppfyltÅrsak
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.vilkårsvurdering.utfall.VilkårKanskjeOppfyltÅrsak
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -48,29 +49,33 @@ class PreutfyllBosattIRiketService(
         vilkårsvurdering.personResultater
             .filter { it.aktør in aktørerVilkårSkalPreutfyllesFor }
             .forEach { personResultat ->
-                val person = personResultat.aktør.tilPerson(personopplysningGrunnlag)
-                if (person.statsborgerskap.iUkraina()) {
-                    return@forEach
-                }
-
-                val datoForBeskjæringAvFom =
-                    if (person.type == PersonType.SØKER) {
-                        personopplysningGrunnlag.eldsteBarnSinFødselsdato ?: person.fødselsdato
-                    } else {
-                        person.fødselsdato
+                try {
+                    val person = personResultat.aktør.tilPerson(personopplysningGrunnlag)
+                    if (person.statsborgerskap.iUkraina()) {
+                        return@forEach
                     }
 
-                val nyeBosattIRiketVilkårResultater =
-                    genererBosattIRiketVilkårResultat(
-                        personResultat = personResultat,
-                        datoForBeskjæringAvFom = datoForBeskjæringAvFom,
-                        person = person,
-                        digitalSøknad = digitalSøknad,
-                    )
+                    val datoForBeskjæringAvFom =
+                        if (person.type == PersonType.SØKER) {
+                            personopplysningGrunnlag.eldsteBarnSinFødselsdato ?: person.fødselsdato
+                        } else {
+                            person.fødselsdato
+                        }
 
-                if (nyeBosattIRiketVilkårResultater.isNotEmpty()) {
-                    personResultat.vilkårResultater.removeIf { it.vilkårType == BOSATT_I_RIKET }
-                    personResultat.vilkårResultater.addAll(nyeBosattIRiketVilkårResultater)
+                    val nyeBosattIRiketVilkårResultater =
+                        genererBosattIRiketVilkårResultat(
+                            personResultat = personResultat,
+                            datoForBeskjæringAvFom = datoForBeskjæringAvFom,
+                            person = person,
+                            digitalSøknad = digitalSøknad,
+                        )
+
+                    if (nyeBosattIRiketVilkårResultater.isNotEmpty()) {
+                        personResultat.vilkårResultater.removeIf { it.vilkårType == BOSATT_I_RIKET }
+                        personResultat.vilkårResultater.addAll(nyeBosattIRiketVilkårResultater)
+                    }
+                } catch (exception: Exception) {
+                    secureLogger.warn("Preutfylling av bosatt i riket feilet for aktør ${personResultat.aktør.aktørId} i behandling ${behandling.id}", exception)
                 }
             }
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Medlemskap
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.Person
@@ -50,24 +51,28 @@ class PreutfyllLovligOppholdService(
         vilkårsvurdering.personResultater
             .filter { it.aktør in aktørerVilkårSkalPreutfyllesFor }
             .forEach { personResultat ->
-                val person = personResultat.aktør.tilPerson(personopplysningGrunnlag)
-                if (person.statsborgerskap.iUkraina()) {
-                    return@forEach
-                }
+                try {
+                    val person = personResultat.aktør.tilPerson(personopplysningGrunnlag)
+                    if (person.statsborgerskap.iUkraina()) {
+                        return@forEach
+                    }
 
-                val datoForBeskjæringAvFom = finnDatoForBeskjæringAvFom(person, personopplysningGrunnlag)
+                    val datoForBeskjæringAvFom = finnDatoForBeskjæringAvFom(person, personopplysningGrunnlag)
 
-                val nyeLovligOppholdVilkårResultat =
-                    genererLovligOppholdVilkårResultat(
-                        personResultat = personResultat,
-                        person = person,
-                        søkerErEøsBorgerOgHarArbeidsforholdTidslinje = søkerErEøsBorgerOgHarArbeidsforholdTidslinje,
-                        datoForBeskjæringAvFom = datoForBeskjæringAvFom,
-                    )
+                    val nyeLovligOppholdVilkårResultat =
+                        genererLovligOppholdVilkårResultat(
+                            personResultat = personResultat,
+                            person = person,
+                            søkerErEøsBorgerOgHarArbeidsforholdTidslinje = søkerErEøsBorgerOgHarArbeidsforholdTidslinje,
+                            datoForBeskjæringAvFom = datoForBeskjæringAvFom,
+                        )
 
-                if (nyeLovligOppholdVilkårResultat.isNotEmpty()) {
-                    personResultat.vilkårResultater.removeIf { it.vilkårType == LOVLIG_OPPHOLD }
-                    personResultat.vilkårResultater.addAll(nyeLovligOppholdVilkårResultat)
+                    if (nyeLovligOppholdVilkårResultat.isNotEmpty()) {
+                        personResultat.vilkårResultater.removeIf { it.vilkårType == LOVLIG_OPPHOLD }
+                        personResultat.vilkårResultater.addAll(nyeLovligOppholdVilkårResultat)
+                    }
+                } catch (exception: Exception) {
+                    secureLogger.warn("Preutfylling av lovlig opphold feilet for aktør ${personResultat.aktør.aktørId} i behandling ${vilkårsvurdering.behandling.id}, fortsetter med neste person", exception)
                 }
             }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBorMedSøkerServiceTest.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
@@ -18,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling.PreutfyllVilkårService.Companion.PREUTFYLT_VILKÅR_BEGRUNNELSE_OVERSKRIFT
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 class PreutfyllBorMedSøkerServiceTest {
@@ -1030,5 +1034,78 @@ class PreutfyllBorMedSøkerServiceTest {
                 .vilkårResultater
                 .filter { it.vilkårType == Vilkår.BOR_MED_SØKER }
         assertThat(barn2BorMedSøker).allMatch { !it.erAutomatiskVurdert }
+    }
+
+    @Test
+    fun `Ved preutfylling feil skal preutfyllingen bare hoppe over personen og fortsette med neste`() {
+        // Arrange
+        val secureLogger = LoggerFactory.getLogger("secureLogger") as Logger
+        val listAppender = ListAppender<ILoggingEvent>().apply { start() }
+        secureLogger.addAppender(listAppender)
+
+        val nåDato = LocalDate.now()
+
+        val aktørSøker = randomAktør()
+        val aktørBarnIGrunnlag = randomAktør()
+        val aktørBarnSomManglerIGrunnlag = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val persongrunnlagUtenDetEneBarnet =
+            lagTestPersonopplysningGrunnlag(
+                behandlingId = behandling.id,
+                søkerPersonIdent = aktørSøker.aktivFødselsnummer(),
+                barnasIdenter = listOf(aktørBarnIGrunnlag.aktivFødselsnummer()),
+                søkerAktør = aktørSøker,
+                barnAktør = listOf(aktørBarnIGrunnlag),
+            ).also { persongrunnlag ->
+                persongrunnlag.personer.forEach { person ->
+                    person.bostedsadresser =
+                        mutableListOf(
+                            lagGrVegadresse(matrikkelId = 12345L).also {
+                                it.periode =
+                                    DatoIntervallEntitet(
+                                        fom = nåDato.minusYears(10),
+                                        tom = null,
+                                    )
+                                it.person = person
+                            },
+                        )
+                }
+            }
+        every { persongrunnlagService.hentAktivThrows(behandlingId = behandling.id) } returns persongrunnlagUtenDetEneBarnet
+
+        val vilkårsvurdering =
+            lagVilkårsvurderingMedOverstyrendeResultater(
+                behandling = behandling,
+                søker = persongrunnlagUtenDetEneBarnet.søker,
+                barna = persongrunnlagUtenDetEneBarnet.barna + lagPerson(type = PersonType.BARN, aktør = aktørBarnSomManglerIGrunnlag),
+                overstyrendeVilkårResultater = emptyMap(),
+            )
+
+        // Act
+        preutfyllBorMedSøkerService.preutfyllBorMedSøker(vilkårsvurdering, vilkårsvurdering.personResultater.map { it.aktør })
+
+        // Assert
+        val barnIGrunnlagBorMedSøker =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == aktørBarnIGrunnlag }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOR_MED_SØKER }
+        assertThat(barnIGrunnlagBorMedSøker).isNotEmpty
+        assertThat(barnIGrunnlagBorMedSøker).allMatch { it.erAutomatiskVurdert }
+
+        val barnSomManglerBorMedSøker =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == aktørBarnSomManglerIGrunnlag }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOR_MED_SØKER }
+        assertThat(barnSomManglerBorMedSøker).isNotEmpty
+        assertThat(barnSomManglerBorMedSøker).allMatch { !it.erAutomatiskVurdert }
+
+        assertThat(listAppender.list).anySatisfy {
+            assertThat(it.level.toString()).isEqualTo("WARN")
+            assertThat(it.formattedMessage).contains("Preutfylling av bor med søker feilet for aktør ${aktørBarnSomManglerIGrunnlag.aktørId}")
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllBosattIRiketServiceTest.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
@@ -36,6 +39,7 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling.PreutfyllVilk
 import no.nav.familie.kontrakter.felles.personopplysning.OPPHOLDSTILLATELSE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 class PreutfyllBosattIRiketServiceTest {
@@ -1714,5 +1718,101 @@ class PreutfyllBosattIRiketServiceTest {
                 .filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
         assertThat(barnBosattIRiket).isNotEmpty
         assertThat(barnBosattIRiket).allMatch { it.erAutomatiskVurdert }
+    }
+
+    @Test
+    fun `Ved preutfylling feil skal preutfyllingen bare hoppe over personen og fortsette med neste`() {
+        // Arrange
+        val secureLogger = LoggerFactory.getLogger("secureLogger") as Logger
+        val listAppender = ListAppender<ILoggingEvent>().apply { start() }
+        secureLogger.addAppender(listAppender)
+
+        val behandling = lagBehandling()
+        val søkerAktør = randomAktør()
+        val barnIGrunnlagAktør = randomAktør()
+        val barnSomManglerIGrunnlagAktør = randomAktør()
+
+        val persongrunnlagUtenDetEneBarnet =
+            lagTestPersonopplysningGrunnlag(
+                behandlingId = behandling.id,
+                søkerPersonIdent = søkerAktør.aktivFødselsnummer(),
+                barnasIdenter = listOf(barnIGrunnlagAktør.aktivFødselsnummer()),
+                søkerAktør = søkerAktør,
+                barnAktør = listOf(barnIGrunnlagAktør),
+            ).also {
+                it.personer.forEach { person ->
+                    person.bostedsadresser =
+                        mutableListOf(
+                            lagGrVegadresseBostedsadresse(
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.now().minusYears(5),
+                                        tom = null,
+                                    ),
+                                matrikkelId = 12345L,
+                            ),
+                        )
+                }
+            }
+
+        val vilkårsvurdering =
+            lagVilkårsvurdering(behandling = behandling).also {
+                it.personResultater =
+                    setOf(
+                        lagPersonResultat(
+                            vilkårsvurdering = it,
+                            aktør = søkerAktør,
+                            lagVilkårResultater = { emptySet() },
+                            lagAnnenVurderinger = { emptySet() },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = it,
+                            aktør = barnSomManglerIGrunnlagAktør,
+                            lagVilkårResultater = { emptySet() },
+                            lagAnnenVurderinger = { emptySet() },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = it,
+                            aktør = barnIGrunnlagAktør,
+                            lagVilkårResultater = { emptySet() },
+                            lagAnnenVurderinger = { emptySet() },
+                        ),
+                    )
+            }
+
+        every { persongrunnlagService.hentAktivThrows(behandling.id) } returns persongrunnlagUtenDetEneBarnet
+
+        // Act
+        preutfyllBosattIRiketService.preutfyllBosattIRiket(
+            vilkårsvurdering = vilkårsvurdering,
+            aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør },
+        )
+
+        // Assert
+        val søkerBosattIRiket =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == søkerAktør }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
+        assertThat(søkerBosattIRiket).isNotEmpty
+
+        val barnSomManglerBosattIRiket =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == barnSomManglerIGrunnlagAktør }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
+        assertThat(barnSomManglerBosattIRiket).isEmpty()
+
+        val barnIGrunnlagBosattIRiket =
+            vilkårsvurdering.personResultater
+                .first { it.aktør == barnIGrunnlagAktør }
+                .vilkårResultater
+                .filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
+        assertThat(barnIGrunnlagBosattIRiket).isNotEmpty
+
+        assertThat(listAppender.list).anySatisfy {
+            assertThat(it.level.toString()).isEqualTo("WARN")
+            assertThat(it.formattedMessage).contains("Preutfylling av bosatt i riket feilet for aktør ${barnSomManglerIGrunnlagAktør.aktørId}")
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/preutfylling/PreutfyllLovligOppholdServiceTest.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.preutfylling
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ba.sak.common.DatoIntervallEntitet
@@ -26,6 +29,7 @@ import no.nav.familie.kontrakter.felles.personopplysning.OPPHOLDSTILLATELSE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 class PreutfyllLovligOppholdServiceTest {
@@ -920,6 +924,101 @@ class PreutfyllLovligOppholdServiceTest {
                     .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
             assertThat(barnLovligOpphold).isNotEmpty
             assertThat(barnLovligOpphold).allMatch { it.erAutomatiskVurdert }
+        }
+
+        @Test
+        fun `Ved preutfylling feil skal preutfyllingen bare hoppe over personen og fortsette med neste`() {
+            // Arrange
+            val secureLogger = LoggerFactory.getLogger("secureLogger") as Logger
+            val listAppender = ListAppender<ILoggingEvent>().apply { start() }
+            secureLogger.addAppender(listAppender)
+
+            val barnSomMangler = lagPerson(aktør = randomAktør(), type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(5))
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = behandling,
+                    lagPersonResultater = {
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = søkerAktør,
+                                lagVilkårResultater = { emptySet() },
+                                lagAnnenVurderinger = { emptySet() },
+                            ),
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = barnSomMangler.aktør,
+                                lagVilkårResultater = { emptySet() },
+                                lagAnnenVurderinger = { emptySet() },
+                            ),
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = barn.aktør,
+                                lagVilkårResultater = { emptySet() },
+                                lagAnnenVurderinger = { emptySet() },
+                            ),
+                        )
+                    },
+                )
+
+            every { persongrunnlagService.hentAktivThrows(behandling.id) } returns
+                lagPersonopplysningGrunnlag(behandlingId = behandling.id) { grunnlag ->
+                    val norskStatsborgerskap: (Person) -> GrStatsborgerskap = { person ->
+                        GrStatsborgerskap(
+                            landkode = "NOR",
+                            gyldigPeriode = sisteTiÅr,
+                            medlemskap = Medlemskap.NORDEN,
+                            person = person,
+                        )
+                    }
+                    setOf(
+                        lagPerson(aktør = søkerAktør, personopplysningGrunnlag = grunnlag).apply {
+                            statsborgerskap = mutableListOf(norskStatsborgerskap(this))
+                        },
+                        lagPerson(
+                            aktør = barn.aktør,
+                            type = PersonType.BARN,
+                            fødselsdato = barn.fødselsdato,
+                            personopplysningGrunnlag = grunnlag,
+                        ).apply {
+                            statsborgerskap = mutableListOf(norskStatsborgerskap(this))
+                        },
+                    )
+                }
+
+            // Act
+            preutfyllLovligOppholdService.preutfyllLovligOpphold(
+                vilkårsvurdering = vilkårsvurdering,
+                aktørerVilkårSkalPreutfyllesFor = vilkårsvurdering.personResultater.map { it.aktør },
+            )
+
+            // Assert
+            val søkerLovligOpphold =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == søkerAktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+            assertThat(søkerLovligOpphold).isNotEmpty
+
+            val barnSomManglerLovligOpphold =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == barnSomMangler.aktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+            assertThat(barnSomManglerLovligOpphold).isEmpty()
+
+            val barnLovligOpphold =
+                vilkårsvurdering.personResultater
+                    .first { it.aktør == barn.aktør }
+                    .vilkårResultater
+                    .filter { it.vilkårType == Vilkår.LOVLIG_OPPHOLD }
+            assertThat(barnLovligOpphold).isNotEmpty
+
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("WARN")
+                assertThat(it.formattedMessage).contains("Preutfylling av lovlig opphold feilet for aktør ${barnSomMangler.aktør.aktørId}")
+            }
         }
 
         @Test


### PR DESCRIPTION
### 📮 Favro: Nav-29307

### 💰 Hva skal gjøres, og hvorfor?

Per i dag er det slik at vi har en try catch rundt preutfylling av vilkår.

Dersom noe feiler så kansellerer vi hele preutfyllingen, og vi ingen personer eller vilkår blir preutfylt.
Vi burde endre på logikken slik at hvis det feiler for 1 vilkår/person, så hopper man bare til neste.
På denne måten kan vi f.eks få preutfylt 7 av 8 personer, noe som gir mye verdi for saksbehandler.

Avklart med funksjonelle at dette er ønsket oppførsel.