### PR TITLE
Sett highavailability og pointintimerecovery til false

### DIFF
--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -42,7 +42,8 @@ spec:
         name: familie-ba-sak
         autoBackupHour: 2
         diskAutoresize: true
-        highAvailability: true
+        highAvailability: false
+        pointInTimeRecovery: false
         databases:
           - name: familie-ba-sak
             envVarPrefix: DB


### PR DESCRIPTION
### 📮 Favro: NAV-29309

### 💰 Hva skal gjøres, og hvorfor?
Vi slår av highavailability og point in time recovery i prod.

Tanken er at dette merges torsdag kveld slik at vi kan starte setup  på fredag ettermiddag.