### PR TITLE
Sjekk simuleringsavvik for alle perioder, ikke bare før mars 2023

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.sak.kjerne.simulering
 import io.micrometer.core.instrument.Metrics
 import jakarta.transaction.Transactional
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.common.isSameOrBefore
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.UtbetalingsoppdragGenerator
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.tilUtbetalingsoppdragDto
@@ -178,19 +177,13 @@ class SimuleringService(
         behandling: Behandling,
         antallBarn: Int,
     ): Boolean {
-        val finnesEtterBetaling = hentTotalEtterbetalingFørMars2023(behandling.id) != BigDecimal.ZERO
+        val finnesEtterBetaling = hentEtterbetaling(behandling.id) != BigDecimal.ZERO
         if (!finnesEtterBetaling) return true
 
-        val simuleringsperioderFørMars2023 = hentSimuleringsperioderFørMars2023(behandling.id)
-        if (
-            simuleringsperioderFørMars2023.harKunPositiveResultater() &&
-            simuleringsperioderFørMars2023.harMaks1KroneIResultatPerBarn(antallBarn) &&
-            simuleringsperioderFørMars2023.harTotaltAvvikUnderBeløpsgrense()
-        ) {
-            return true
-        }
-
-        return false
+        val simuleringsperioder = hentAlleSimuleringsperioder(behandling.id)
+        return simuleringsperioder.harKunPositiveResultater() &&
+            simuleringsperioder.harMaks1KroneIResultatPerBarn(antallBarn) &&
+            simuleringsperioder.harTotaltAvvikUnderBeløpsgrense()
     }
 
     private fun sjekkOmBehandlingHarFeilutbetalingInnenforBeløpsgrenser(
@@ -200,29 +193,16 @@ class SimuleringService(
         val finnesFeilutbetaling = hentFeilutbetaling(behandling.id) != BigDecimal.ZERO
         if (!finnesFeilutbetaling) return true
 
-        val simuleringsperioderFørMars2023 = hentSimuleringsperioderFørMars2023(behandling.id)
-        if (
-            simuleringsperioderFørMars2023.harKunNegativeResultater() &&
-            simuleringsperioderFørMars2023.harMaks1KroneIResultatPerBarn(antallBarn) &&
-            simuleringsperioderFørMars2023.harTotaltAvvikUnderBeløpsgrense()
-        ) {
-            return true
-        }
-
-        return false
+        val simuleringsperioder = hentAlleSimuleringsperioder(behandling.id)
+        return simuleringsperioder.harKunNegativeResultater() &&
+            simuleringsperioder.harMaks1KroneIResultatPerBarn(antallBarn) &&
+            simuleringsperioder.harTotaltAvvikUnderBeløpsgrense()
     }
 
-    private fun hentSimuleringsperioderFørMars2023(behandlingId: Long): List<SimuleringsPeriode> {
-        val februar2023 = LocalDate.of(2023, 2, 1)
-
-        return vedtakSimuleringMottakereTilSimuleringPerioder(
+    private fun hentAlleSimuleringsperioder(behandlingId: Long): List<SimuleringsPeriode> =
+        vedtakSimuleringMottakereTilSimuleringPerioder(
             økonomiSimuleringMottakere = hentSimuleringPåBehandling(behandlingId),
-        ).filter {
-            it.fom.isSameOrBefore(februar2023)
-        }
-    }
-
-    private fun hentTotalEtterbetalingFørMars2023(behandlingId: Long) = hentTotalEtterbetaling(hentSimuleringsperioderFørMars2023(behandlingId), null)
+        )
 
     private fun List<SimuleringsPeriode>.harKunPositiveResultater() = all { it.resultat >= BigDecimal.ZERO }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalDate.now
 
 internal class SimuleringServiceEnhetTest {
     private val økonomiKlient: ØkonomiKlient = mockk()
@@ -61,8 +62,6 @@ internal class SimuleringServiceEnhetTest {
             tilkjentYtelseRepository = tilkjentYtelseRepository,
         )
 
-    val februar2023 = LocalDate.of(2023, 2, 1)
-
     @ParameterizedTest
     @EnumSource(value = BehandlingÅrsak::class, names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"])
     fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal returnere true dersom det finnes avvik i form av etterbetaling som er innenfor beløpsgrense`(
@@ -78,12 +77,12 @@ internal class SimuleringServiceEnhetTest {
         // etterbetaling 4 KR pga. avrundingsfeil. 1 KR per barn i hver periode.
         val posteringer =
             listOf(
-                mockVedtakSimuleringPostering(fom = februar2023, beløp = 2, betalingType = BetalingType.DEBIT),
-                mockVedtakSimuleringPostering(fom = februar2023, beløp = -2, betalingType = BetalingType.KREDIT),
-                mockVedtakSimuleringPostering(fom = februar2023, beløp = 2, betalingType = BetalingType.DEBIT),
-                mockVedtakSimuleringPostering(beløp = 2, betalingType = BetalingType.DEBIT),
-                mockVedtakSimuleringPostering(beløp = -2, betalingType = BetalingType.KREDIT),
-                mockVedtakSimuleringPostering(beløp = 2, betalingType = BetalingType.DEBIT),
+                mockVedtakSimuleringPostering(fom = now().minusMonths(4), tom = now().minusMonths(3), beløp = 2, betalingType = BetalingType.DEBIT),
+                mockVedtakSimuleringPostering(fom = now().minusMonths(4), tom = now().minusMonths(3), beløp = -2, betalingType = BetalingType.KREDIT),
+                mockVedtakSimuleringPostering(fom = now().minusMonths(4), tom = now().minusMonths(3), beløp = 2, betalingType = BetalingType.DEBIT),
+                mockVedtakSimuleringPostering(fom = now().minusMonths(2), tom = now().minusMonths(1), beløp = 2, betalingType = BetalingType.DEBIT),
+                mockVedtakSimuleringPostering(fom = now().minusMonths(2), tom = now().minusMonths(1), beløp = -2, betalingType = BetalingType.KREDIT),
+                mockVedtakSimuleringPostering(fom = now().minusMonths(2), tom = now().minusMonths(1), beløp = 2, betalingType = BetalingType.DEBIT),
             )
         val simuleringMottaker =
             listOf(mockØkonomiSimuleringMottaker(behandling = behandling, økonomiSimuleringPostering = posteringer))
@@ -209,7 +208,7 @@ internal class SimuleringServiceEnhetTest {
 
     @ParameterizedTest
     @EnumSource(value = BehandlingÅrsak::class, names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"])
-    fun `harMigreringsbehandlingManuellePosteringerFørMars2023 skal returnere true dersom det finnes manuelle posteringer i simuleringsresultat før mars 2023`(
+    fun `harMigreringsbehandlingManuellePosteringer skal returnere true dersom det finnes manuelle posteringer i simuleringsresultat`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
         val behandling: Behandling =
@@ -236,10 +235,10 @@ internal class SimuleringServiceEnhetTest {
 
         every { økonomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
 
-        val behandlingHarManuellePosteringerFørMars2023 =
+        val behandlingHarManuellePosteringer =
             simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
 
-        assertThat(behandlingHarManuellePosteringerFørMars2023).isTrue
+        assertThat(behandlingHarManuellePosteringer).isTrue
     }
 
     @ParameterizedTest
@@ -247,7 +246,7 @@ internal class SimuleringServiceEnhetTest {
         value = BehandlingÅrsak::class,
         names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"],
     )
-    fun `harMigreringsbehandlingManuellePosteringerFørMars2023 skal returnere false dersom det ikke finnes manuelle posteringer i simuleringsresultat før mars 2023`(
+    fun `harMigreringsbehandlingManuellePosteringer skal returnere false dersom det ikke finnes manuelle posteringer i simuleringsresultat`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
         val behandling: Behandling =
@@ -270,10 +269,10 @@ internal class SimuleringServiceEnhetTest {
 
         every { økonomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
 
-        val behandlingHarManuellePosteringerFørMars2023 =
+        val behandlingHarManuellePosteringer =
             simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
 
-        assertThat(behandlingHarManuellePosteringerFørMars2023).isFalse
+        assertThat(behandlingHarManuellePosteringer).isFalse
     }
 
     @ParameterizedTest
@@ -282,7 +281,7 @@ internal class SimuleringServiceEnhetTest {
         mode = EnumSource.Mode.EXCLUDE,
         names = ["HELMANUELL_MIGRERING", "ENDRE_MIGRERINGSDATO"],
     )
-    fun `harMigreringsbehandlingManuellePosteringerFørMars2023 skal kaste feil dersom behandlingen ikke er en manuell migrering`(
+    fun `harMigreringsbehandlingManuellePosteringer skal kaste feil dersom behandlingen ikke er en manuell migrering`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
         val behandling: Behandling =
@@ -303,7 +302,7 @@ internal class SimuleringServiceEnhetTest {
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
                         tidSimuleringHentet = null,
-                        forfallsdatoNestePeriode = LocalDate.now(),
+                        forfallsdatoNestePeriode = now(),
                     ),
                 )
             assertThat(erUtdatert).isTrue()
@@ -314,8 +313,8 @@ internal class SimuleringServiceEnhetTest {
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
-                        tidSimuleringHentet = LocalDate.now().minusDays(10),
-                        forfallsdatoNestePeriode = LocalDate.now().minusDays(5),
+                        tidSimuleringHentet = now().minusDays(10),
+                        forfallsdatoNestePeriode = now().minusDays(5),
                     ),
                 )
             assertThat(erUtdatert).isTrue()
@@ -326,7 +325,7 @@ internal class SimuleringServiceEnhetTest {
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
-                        tidSimuleringHentet = LocalDate.now(),
+                        tidSimuleringHentet = now(),
                         forfallsdatoNestePeriode = null,
                     ),
                 )
@@ -338,8 +337,8 @@ internal class SimuleringServiceEnhetTest {
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
-                        tidSimuleringHentet = LocalDate.now(),
-                        forfallsdatoNestePeriode = LocalDate.now(),
+                        tidSimuleringHentet = now(),
+                        forfallsdatoNestePeriode = now(),
                     ),
                 )
             assertThat(erUtdatert).isFalse()
@@ -350,8 +349,8 @@ internal class SimuleringServiceEnhetTest {
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
-                        tidSimuleringHentet = LocalDate.now().minusDays(10),
-                        forfallsdatoNestePeriode = LocalDate.now().plusDays(5),
+                        tidSimuleringHentet = now().minusDays(10),
+                        forfallsdatoNestePeriode = now().plusDays(5),
                     ),
                 )
             assertThat(erUtdatert).isFalse()
@@ -362,8 +361,8 @@ internal class SimuleringServiceEnhetTest {
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
-                        tidSimuleringHentet = LocalDate.now().minusDays(5),
-                        forfallsdatoNestePeriode = LocalDate.now().minusDays(5),
+                        tidSimuleringHentet = now().minusDays(5),
+                        forfallsdatoNestePeriode = now().minusDays(5),
                     ),
                 )
             assertThat(erUtdatert).isFalse()
@@ -374,8 +373,8 @@ internal class SimuleringServiceEnhetTest {
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
-                        tidSimuleringHentet = LocalDate.now().minusDays(1),
-                        forfallsdatoNestePeriode = LocalDate.now().minusDays(5),
+                        tidSimuleringHentet = now().minusDays(1),
+                        forfallsdatoNestePeriode = now().minusDays(5),
                     ),
                 )
             assertThat(erUtdatert).isFalse()
@@ -410,11 +409,11 @@ internal class SimuleringServiceEnhetTest {
         økonomiSimuleringMottaker: ØkonomiSimuleringMottaker = mockk(relaxed = true),
         beløp: Int = 0,
         fagOmrådeKode: FagOmrådeKode = FagOmrådeKode.BARNETRYGD,
-        fom: LocalDate = LocalDate.of(2023, 1, 1),
-        tom: LocalDate = LocalDate.of(2023, 1, 1),
+        fom: LocalDate = now().minusYears(1).minusMonths(1),
+        tom: LocalDate = now().minusYears(1),
         betalingType: BetalingType = BetalingType.DEBIT,
         posteringType: PosteringType = PosteringType.YTELSE,
-        forfallsdato: LocalDate = LocalDate.of(2023, 1, 1),
+        forfallsdato: LocalDate = now().minusYears(1),
         utenInntrekk: Boolean = false,
         fagsakId: Long = 0L,
     ) = ØkonomiSimuleringPostering(


### PR DESCRIPTION
### 📮 Favro: NAV-29337

### 💰 Hva skal gjøres, og hvorfor?

`SimuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser` sjekket
tidligere kun simuleringsperioder før mars 2023 når den vurderte om avvik var
innenfor beløpsgrensene. Dette medførte at etterbetaling eller feilutbetaling
i perioder etter februar 2023 ble ignorert.

Endringen gjør at begge sjekker (etterbetaling og feilutbetaling) nå vurderer
alle simuleringsperioder. Den datobegrensede hjelpefunksjonen
`hentSimuleringsperioderFørMars2023` og `hentTotalEtterbetalingFørMars2023`
er fjernet da de ikke lenger er i bruk.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.