### PR TITLE
Endret begrunnelse for vilkår som blir automatisk utfylt fra søker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/genererbarnasvilkår/AutomatiskVilkårUtfyllingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/genererbarnasvilkår/AutomatiskVilkårUtfyllingService.kt
@@ -71,7 +71,7 @@ class AutomatiskVilkårUtfyllingService(
                                 resultat = vilkårResultatPeriode.verdi.resultat,
                                 periodeFom = vilkårResultatPeriode.fom,
                                 periodeTom = vilkårResultatPeriode.tom,
-                                begrunnelse = "Automatisk utfylt basert på søkers 'Bosatt i riket'-vilkår",
+                                begrunnelse = "Kopiert fra søkers 'Bosatt i riket'-vilkår",
                                 sistEndretIBehandlingId = behandlingId,
                             )
                         }


### PR DESCRIPTION
### 📮 Favro: NAV-29193

### 💰 Hva skal gjøres, og hvorfor?
Endrer begrunnelse i barnas vilkår som blir automatisk utfylt basert på søkers 'Bosatt i riket'-vilkår