### PR TITLE
Bare logg endringer hvis endring av preutfylt vilkår gjøres i samme behandling vilkåret ble preutfylt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårService.kt
@@ -74,7 +74,7 @@ class VilkårService(
             personResultat.vilkårResultater.singleOrNull { it.id == vilkårId }
                 ?: throw Feil("Finner ikke vilkår med vilkårId $vilkårId på personResultat ${personResultat.id}")
 
-        if (eksisterendeVilkårResultat.erOpprinneligPreutfyltIBehandling != null) {
+        if (eksisterendeVilkårResultat.erOpprinneligPreutfyltIBehandling == behandlingId) {
             val erEndringIBegrunnelse = eksisterendeVilkårResultat.begrunnelse != vilkårResultatDto.begrunnelse
             val erEndringIAnnetFeltEnnBegrunnelse = erEndringIVilkår(eksisterendeVilkårResultat, vilkårResultatDto)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårServiceTest.kt
@@ -474,6 +474,62 @@ class VilkårServiceTest(
         }
 
         @Test
+        fun `skal ikke lagre logg når et preutfylt vilkår endres i en annen behandling enn den ble preutfylt i`() {
+            // Arrange
+            val tidligereBehandlingId = behandling.id + 1
+            val vilkårsvurdering =
+                vilkårsvurderingService.lagreNyOgDeaktiverGammel(
+                    lagVilkårsvurdering(behandling = behandling) { vilkårsvurdering ->
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = vilkårsvurdering,
+                                aktør = søkerAktør,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            personResultat = it,
+                                            behandlingId = behandling.id,
+                                            vilkårType = Vilkår.BOSATT_I_RIKET,
+                                            resultat = Resultat.IKKE_OPPFYLT,
+                                            vurderesEtter = Regelverk.NASJONALE_REGLER,
+                                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_I_FINNMARK_NORD_TROMS),
+                                        ).copy(erOpprinneligPreutfyltIBehandling = tidligereBehandlingId),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            val personResultatDto = vilkårsvurdering.personResultater.single().tilPersonResultatDto()
+            val vilkårResultatDto = personResultatDto.vilkårResultater.single()
+
+            val personResultatDtoMedEndring =
+                personResultatDto.copy(
+                    vilkårResultater =
+                        listOf(
+                            vilkårResultatDto.copy(
+                                periodeFom = LocalDate.of(2024, 1, 1),
+                                begrunnelse = "Ny begrunnelse",
+                                resultat = Resultat.OPPFYLT,
+                                vurderesEtter = Regelverk.EØS_FORORDNINGEN,
+                                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD),
+                            ),
+                        ),
+                )
+
+            // Act
+            vilkårService.endreVilkår(
+                behandlingId = behandling.id,
+                vilkårId = vilkårResultatDto.id,
+                personResultatDto = personResultatDtoMedEndring,
+            )
+
+            // Assert
+            assertThat(endringIPreutfyltVilkårLoggRepository.findAll().filter { it.behandling.id == behandling.id }).isEmpty()
+        }
+
+        @Test
         fun `skal oppdatere eksisterende logg i stedet for å opprette ny ved gjentatt endring av preutfylt vilkår`() {
             // Arrange
             val vilkårsvurdering =


### PR DESCRIPTION
### 📮 Favro: Nav-29375

### 💰 Hva skal gjøres, og hvorfor?
For statistikkens skyld ønsker vi at man bare skal logge endringer hvis endring av preutfylt vilkår gjøres i samme behandling vilkåret ble preutfylt.

Per nå logges det endring av preutfylt vilkår i revurdering etter behandlingen, noe som skaper litt feil statistikk.


