### PR TITLE
Lås opp fagsak automagisk ved automatiske behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingService.kt
@@ -26,6 +26,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.initStatus
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingService
 import no.nav.familie.ba.sak.kjerne.logg.BehandlingLoggRequest
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.steg.FØRSTE_STEG
@@ -65,6 +66,7 @@ class BehandlingService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val featureToggleService: FeatureToggleService,
     private val eksternBehandlingRelasjonService: EksternBehandlingRelasjonService,
+    private val fagsakLåsingService: FagsakLåsingService,
 ) {
     @Transactional
     fun opprettBehandling(nyBehandling: NyBehandling): Behandling {
@@ -75,10 +77,17 @@ class BehandlingService(
             )
 
         if (fagsak.status == FagsakStatus.LÅST) {
-            throw FunksjonellFeil(
-                melding = "Kan ikke opprette behandling på en låst fagsak ${fagsak.id}.",
-                frontendFeilmelding = "Fagsaken er låst og det er ikke mulig å opprette nye behandlinger.",
-            )
+            if (nyBehandling.skalBehandlesAutomatisk) {
+                fagsakLåsingService.låsOppFagsak(
+                    fagsakId = fagsak.id,
+                    begrunnelseForÅLåseOppFagsak = "Låst opp grunnet automatisk behandling ${nyBehandling.behandlingÅrsak}",
+                )
+            } else {
+                throw FunksjonellFeil(
+                    melding = "Kan ikke opprette behandling på en låst fagsak ${fagsak.id}.",
+                    frontendFeilmelding = "Fagsaken er låst og det er ikke mulig å opprette nye behandlinger.",
+                )
+            }
         }
 
         val aktivBehandling = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId = fagsak.id)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/OppdragSteg.kt
@@ -92,6 +92,7 @@ class OppdragSteg {
             vilkårsvurderingService = mockk(),
             featureToggleService = featureToggleService,
             eksternBehandlingRelasjonService = mockk(),
+            fagsakLåsingService = mockk(),
         )
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -300,6 +300,7 @@ class CucumberMock(
             vilkårsvurderingService = vilkårsvurderingService,
             featureToggleService = featureToggleService,
             eksternBehandlingRelasjonService = eksternBehandlingRelasjonService,
+            fagsakLåsingService = mockk(relaxed = true),
         )
 
     val tilbakestillBehandlingTilBehandlingsresultatService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -29,6 +29,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingService
 import no.nav.familie.ba.sak.kjerne.logg.BehandlingLoggRequest
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
@@ -60,6 +61,7 @@ class BehandlingServiceTest {
     private val vilkårsvurderingService: VilkårsvurderingService = mockk()
     private val featureToggleService: FeatureToggleService = mockk()
     private val eksternBehandlingRelasjonService = mockk<EksternBehandlingRelasjonService>()
+    private val fagsakLåsingService: FagsakLåsingService = mockk()
 
     private val behandlingService: BehandlingService =
         BehandlingService(
@@ -80,6 +82,7 @@ class BehandlingServiceTest {
             vilkårsvurderingService = vilkårsvurderingService,
             featureToggleService = featureToggleService,
             eksternBehandlingRelasjonService = eksternBehandlingRelasjonService,
+            fagsakLåsingService = fagsakLåsingService,
         )
 
     @Nested
@@ -262,6 +265,49 @@ class BehandlingServiceTest {
             assertThatThrownBy { behandlingService.opprettBehandling(nyBehandling) }
                 .isInstanceOf(FunksjonellFeil::class.java)
                 .hasMessageContaining("Kan ikke opprette behandling på en låst fagsak")
+        }
+
+        @Test
+        fun `skal låse opp fagsak og opprette behandling dersom fagsaken er LÅST og behandlingen skal behandles automatisk`() {
+            // Arrange
+            val fagsak = lagFagsak(status = FagsakStatus.LÅST)
+
+            val nyBehandling =
+                lagNyBehandling(
+                    fagsakId = fagsak.id,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    behandlingÅrsak = BehandlingÅrsak.FØDSELSHENDELSE,
+                    skalBehandlesAutomatisk = true,
+                )
+
+            val begrunnelseSlot = slot<String>()
+
+            every { fagsakRepository.finnFagsak(nyBehandling.fagsakId) } returns fagsak
+            every { fagsakLåsingService.låsOppFagsak(nyBehandling.fagsakId, capture(begrunnelseSlot)) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivForFagsak(nyBehandling.fagsakId) } returns null
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(nyBehandling.fagsakId) } returns null
+            every { behandlingstemaService.finnBehandlingKategori(nyBehandling.fagsakId) } returns BehandlingKategori.NASJONAL
+            every { behandlingstemaService.finnLøpendeUnderkategoriFraForrigeVedtatteBehandling(nyBehandling.fagsakId) } returns BehandlingUnderkategori.ORDINÆR
+            every { behandlingstemaService.finnUnderkategoriFraAktivBehandling(nyBehandling.fagsakId) } returns BehandlingUnderkategori.ORDINÆR
+            every { behandlingHentOgPersisterService.lagreEllerOppdater(any(), any()) } returnsArgument 0
+            every { arbeidsfordelingService.fastsettBehandlendeEnhet(any(), any()) } just runs
+            every { behandlingMetrikker.tellNøkkelTallVedOpprettelseAvBehandling(any()) } just runs
+            every { behandlingSøknadsinfoService.lagreSøknadsinfo(any(), any(), any()) } just runs
+            every { saksstatistikkEventPublisher.publiserBehandlingsstatistikk(any()) } just runs
+            every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns null
+            every { vedtaksperiodeService.kopierOverVedtaksperioder(any(), any()) } just runs
+            every { vedtakRepository.save(any()) } returnsArgument 0
+            every { loggService.opprettBehandlingLogg(any()) } just runs
+            every { taskRepository.save(any()) } returnsArgument 0
+            every { featureToggleService.isEnabled(FeatureToggle.SJEKK_AKTIV_INFOTRYGD_SAK_REPLIKA, true) } returns false
+
+            // Act
+            val opprettetBehandling = behandlingService.opprettBehandling(nyBehandling)
+
+            // Assert
+            assertThat(opprettetBehandling.id).isEqualTo(0L)
+            verify(exactly = 1) { fagsakLåsingService.låsOppFagsak(nyBehandling.fagsakId, any()) }
+            assertThat(begrunnelseSlot.captured).isEqualTo("Låst opp grunnet automatisk behandling FØDSELSHENDELSE")
         }
 
         @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
@@ -67,6 +67,7 @@ class LagreMigreringsdatoTest {
             vilkårsvurderingService = vilkårsvurderingService,
             featureToggleService = mockFeatureToggleService,
             eksternBehandlingRelasjonService = eksternBehandlingRelasjonService,
+            fagsakLåsingService = mockk(),
         )
 
     @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ba.sak.kjerne.fagsaklåsing.FagsakLåsingService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
@@ -90,6 +91,8 @@ class VedtakServiceTest(
     private val featureToggleService: FeatureToggleService,
     @Autowired
     private val eksternBehandlingRelasjonService: EksternBehandlingRelasjonService,
+    @Autowired
+    private val fagsakLåsingService: FagsakLåsingService,
 ) : AbstractSpringIntegrationTest() {
     lateinit var behandlingService: BehandlingService
     lateinit var vilkårResultat1: VilkårResultat
@@ -122,6 +125,7 @@ class VedtakServiceTest(
                 vilkårsvurderingService,
                 featureToggleService,
                 eksternBehandlingRelasjonService,
+                fagsakLåsingService,
             )
 
         val personAktørId = randomAktør()


### PR DESCRIPTION
### 📮 Favro: Nav-29385

### 💰 Hva skal gjøres, og hvorfor?
Når en fagsak er låst er det ikke mulig å opprette nye behandlinger.
Ved automatiske behandligner som f.eks fødselshendelse, automatisk journalføring av søknad, osv osv, så ønsker vi at fagsaken låses opp.