### PR TITLE
Mer validering for å låse fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepository.kt
@@ -298,15 +298,10 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
                    ON  p.fk_gr_personopplysninger_id = gr.id AND p.type = 'BARN'
             GROUP BY sv.fk_fagsak_id
         )
-        -- Fagsaker der yngste barn har fylt 18 år for mer enn 1 år siden,
-        -- og som ikke allerede er aktivt låst
+        -- Fagsaker der yngste barn har fylt 18 år for mer enn 1 år siden
         SELECT yb.fk_fagsak_id
         FROM   yngste_barn yb
         WHERE  yb.yngste_foedselsdato + INTERVAL '19 years' <= CURRENT_DATE
-          AND  NOT EXISTS (
-                   SELECT 1 FROM fagsak_laasing fl
-                   WHERE  fl.fk_fagsak_id = yb.fk_fagsak_id AND fl.aktiv = TRUE
-               )
         """,
         nativeQuery = true,
     )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -12,6 +12,8 @@ import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.klage.KlagebehandlingHenter
+import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.hentSaksbehandlerNavn
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.BrukerIdType
@@ -20,10 +22,12 @@ import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
 import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsstatus
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus as KlageBehandlingStatus
 
 @Service
 class FagsakLåsingService(
@@ -35,6 +39,8 @@ class FagsakLåsingService(
     private val featureToggleService: FeatureToggleService,
     private val saksstatistikkEventPublisher: SaksstatistikkEventPublisher,
     private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val klagebehandlingHenter: KlagebehandlingHenter,
+    private val tilbakekrevingKlient: TilbakekrevingKlient,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -56,6 +62,33 @@ class FagsakLåsingService(
 
         if (behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(fagsakId)) {
             logger.info("Fagsak $fagsakId har åpen behandling, hopper ut")
+            return
+        }
+
+        val klagebehandlinger = klageService.hentKlagebehandlingerPåFagsak(fagsakId)
+        if (klagebehandlinger.any { it.status != KlageBehandlingStatus.FERDIGSTILT }) {
+            logger.info("Fagsak $fagsakId har åpen klagebehandling, hopper ut")
+            return
+        }
+
+        val tilbakekrevingsbehandlinger = tilbakekrevingService.hentTilbakekrevingbehandlingerPåFagsak(fagsakId)
+        if (tilbakekrevingsbehandlinger.any { it.status != Behandlingsstatus.AVSLUTTET }) {
+            logger.info("Fagsak $fagsakId har åpen tilbakekrevingsbehandling, hopper ut")
+            return
+        }
+
+        val sisteAvsluttetTidspunkt =
+            listOfNotNull(
+                behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId)?.endretTidspunkt,
+                klagebehandlinger.mapNotNull { it.vedtaksdato }.maxOrNull(),
+                tilbakekrevingsbehandlinger.mapNotNull { it.vedtaksdato }.maxOrNull(),
+            ).maxOrNull()
+
+        if (sisteAvsluttetTidspunkt != null && sisteAvsluttetTidspunkt.isAfter(LocalDateTime.now().minusYears(1))) {
+            logger.info(
+                "Fagsak $fagsakId hadde siste avsluttede behandling $sisteAvsluttetTidspunkt," +
+                    " som er for under 1 år siden. Hopper ut",
+            )
             return
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingService.kt
@@ -55,54 +55,6 @@ class FagsakLåsingService(
             fagsakRepository.finnFagsak(fagsakId)
                 ?: throw Feil("Fant ikke fagsak $fagsakId")
 
-        if (fagsak.status != FagsakStatus.AVSLUTTET) {
-            logger.info("Status for fagsak $fagsakId er ${fagsak.status}, hopper ut")
-            return
-        }
-
-        if (behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(fagsakId)) {
-            logger.info("Fagsak $fagsakId har åpen behandling, hopper ut")
-            return
-        }
-
-        val klagebehandlinger = klageService.hentKlagebehandlingerPåFagsak(fagsakId)
-        if (klagebehandlinger.any { it.status != KlageBehandlingStatus.FERDIGSTILT }) {
-            logger.info("Fagsak $fagsakId har åpen klagebehandling, hopper ut")
-            return
-        }
-
-        val tilbakekrevingsbehandlinger = tilbakekrevingService.hentTilbakekrevingbehandlingerPåFagsak(fagsakId)
-        if (tilbakekrevingsbehandlinger.any { it.status != Behandlingsstatus.AVSLUTTET }) {
-            logger.info("Fagsak $fagsakId har åpen tilbakekrevingsbehandling, hopper ut")
-            return
-        }
-
-        val sisteAvsluttetTidspunkt =
-            listOfNotNull(
-                behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId)?.endretTidspunkt,
-                klagebehandlinger.mapNotNull { it.vedtaksdato }.maxOrNull(),
-                tilbakekrevingsbehandlinger.mapNotNull { it.vedtaksdato }.maxOrNull(),
-            ).maxOrNull()
-
-        if (sisteAvsluttetTidspunkt != null && sisteAvsluttetTidspunkt.isAfter(LocalDateTime.now().minusYears(1))) {
-            logger.info(
-                "Fagsak $fagsakId hadde siste avsluttede behandling $sisteAvsluttetTidspunkt," +
-                    " som er for under 1 år siden. Hopper ut",
-            )
-            return
-        }
-
-        val aktivLåsForFagsak = finnAktivLåsForFagsak(fagsak.id)
-        if (aktivLåsForFagsak?.hendelse == FagsakLåsHendelse.LÅST) {
-            throw Feil("Fagsak $fagsakId har allerede aktiv låsing")
-        }
-
-        val fagsakBleLåstOppForUnder30DagerSiden = aktivLåsForFagsak?.opprettetTidspunkt?.isAfter(LocalDateTime.now().minusDays(30)) == true
-        if (fagsakBleLåstOppForUnder30DagerSiden) {
-            logger.info("Fagsak $fagsakId ble låst opp for under 30 dager siden, hopper ut")
-            return
-        }
-
         val barnPåFagsak =
             persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsakId)?.filter { it.type == PersonType.BARN }
                 ?: throw Feil("Fant ingen barn på fagsak $fagsakId")
@@ -112,10 +64,8 @@ class FagsakLåsingService(
                 ?: throw Feil("Fant ikke yngste barns fødselsdato på fagsak $fagsakId")
 
         val låsedato = yngsteBarnsFødselsdato.plusYears(19).atStartOfDay()
-        if (LocalDateTime.now() < låsedato) {
-            logger.info("Fagsak skal ikke låses før $låsedato, hopper ut")
-            return
-        }
+
+        if (fagsakSkalIkkeLåses(fagsak, låsedato)) return
 
         lagreOgDeaktiverGammel(
             FagsakLåsing(
@@ -143,6 +93,62 @@ class FagsakLåsingService(
             ),
         )
         logger.info("Fagsak $fagsakId er låst og meldt til Joark")
+    }
+
+    private fun fagsakSkalIkkeLåses(
+        fagsak: Fagsak,
+        låsedato: LocalDateTime,
+    ): Boolean {
+        if (fagsak.status != FagsakStatus.AVSLUTTET) {
+            logger.info("Status for fagsak ${fagsak.id} er ${fagsak.status}. Hopper ut av fagsaklåsing.")
+            return true
+        }
+
+        val aktivLåsForFagsak = finnAktivLåsForFagsak(fagsak.id)
+        if (aktivLåsForFagsak?.hendelse == FagsakLåsHendelse.LÅST) {
+            throw Feil("Fagsak ${fagsak.id} med status ${fagsak.status} har allerede en aktiv låsing.")
+        }
+
+        if (aktivLåsForFagsak?.opprettetTidspunkt?.isAfter(LocalDateTime.now().minusDays(30)) == true) {
+            logger.info("Fagsak ${fagsak.id} ble låst opp for under 30 dager siden. Hopper ut av fagsaklåsing.")
+            return true
+        }
+
+        if (behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(fagsak.id)) {
+            logger.info("Fagsak ${fagsak.id} har åpen behandling. Hopper ut av fagsaklåsing.")
+            return true
+        }
+
+        val klagebehandlinger = klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsak.id)
+        if (klagebehandlinger.any { it.status != KlageBehandlingStatus.FERDIGSTILT }) {
+            logger.info("Fagsak ${fagsak.id} har åpen klagebehandling. Hopper ut av fagsaklåsing.")
+            return true
+        }
+
+        val tilbakekrevingsbehandlinger = tilbakekrevingKlient.hentTilbakekrevingsbehandlinger(fagsak.id)
+        if (tilbakekrevingsbehandlinger.any { it.status != Behandlingsstatus.AVSLUTTET }) {
+            logger.info("Fagsak ${fagsak.id} har åpen tilbakekrevingsbehandling. Hopper ut av fagsaklåsing.")
+            return true
+        }
+
+        val sisteAvsluttetTidspunkt =
+            listOfNotNull(
+                behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id)?.endretTidspunkt,
+                klagebehandlinger.mapNotNull { it.vedtaksdato }.maxOrNull(),
+                tilbakekrevingsbehandlinger.mapNotNull { it.vedtaksdato }.maxOrNull(),
+            ).maxOrNull()
+
+        if (sisteAvsluttetTidspunkt != null && sisteAvsluttetTidspunkt.isAfter(LocalDateTime.now().minusYears(1))) {
+            logger.info("Fagsak ${fagsak.id} hadde siste avsluttede behandling $sisteAvsluttetTidspunkt, som er for under 1 år siden. Hopper ut av fagsaklåsing.")
+            return true
+        }
+
+        if (LocalDateTime.now() < låsedato) {
+            logger.info("Fagsak skal ikke låses før $låsedato. Hopper ut av fagsaklåsing.")
+            return true
+        }
+
+        return false
     }
 
     @Transactional

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
@@ -20,16 +20,20 @@ import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.IntegrasjonKlien
 import no.nav.familie.ba.sak.integrasjoner.familieintegrasjoner.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
+import no.nav.familie.ba.sak.kjerne.klage.KlagebehandlingHenter
+import no.nav.familie.ba.sak.kjerne.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ba.sak.statistikk.saksstatistikk.SaksstatistikkEventPublisher
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsstatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -38,6 +42,7 @@ import org.junit.jupiter.api.assertThrows
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus as KlageBehandlingStatus
 
 class FagsakLåsingServiceTest {
     private val fagsakRepository = mockk<FagsakRepository>()
@@ -48,6 +53,8 @@ class FagsakLåsingServiceTest {
     private val featureToggleService = mockk<FeatureToggleService>()
     private val saksstatistikkEventPublisher = mockk<SaksstatistikkEventPublisher>()
     private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val klagebehandlingHenter = mockk<KlagebehandlingHenter>()
+    private val tilbakekrevingKlient = mockk<TilbakekrevingKlient>()
 
     private val fagsakLåsingService =
         FagsakLåsingService(
@@ -59,6 +66,8 @@ class FagsakLåsingServiceTest {
             featureToggleService = featureToggleService,
             saksstatistikkEventPublisher = saksstatistikkEventPublisher,
             behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            klagebehandlingHenter = klagebehandlingHenter,
+            tilbakekrevingKlient = tilbakekrevingKlient,
         )
 
     @Nested
@@ -76,6 +85,9 @@ class FagsakLåsingServiceTest {
             every { fagsakLåsingRepository.finnAktivLåsForFagsak(fagsak.id) } returns null
             every { persongrunnlagService.hentSøkerOgBarnPåFagsak(fagsak.id) } returns personer
             every { behandlingHentOgPersisterService.erÅpenBehandlingPåFagsak(fagsak.id) } returns false
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns null
+            every { klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsak.id) } returns emptyList()
+            every { tilbakekrevingKlient.hentTilbakekrevingsbehandlinger(fagsak.id) } returns emptyList()
             every { fagsakLåsingRepository.save(any()) } answers { firstArg() }
             every { fagsakRepository.save(fagsak) } returns fagsak
             every { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) } just runs
@@ -157,6 +169,108 @@ class FagsakLåsingServiceTest {
             verify(exactly = 0) { fagsakRepository.save(any()) }
             verify(exactly = 0) { fagsakLåsingRepository.save(any()) }
             verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak som har åpen klagebehandling`() {
+            // Arrange
+            every { klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsak.id) } returns
+                listOf(mockk { every { status } returns KlageBehandlingStatus.UTREDES })
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen klagebehandling, hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak som har åpen tilbakekrevingsbehandling`() {
+            // Arrange
+            every { tilbakekrevingKlient.hentTilbakekrevingsbehandlinger(fagsak.id) } returns
+                listOf(mockk { every { status } returns Behandlingsstatus.UTREDES })
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen tilbakekrevingsbehandling, hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak der siste BA-sak behandling ble avsluttet for under 1 år siden`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns
+                mockk<Behandling> { every { endretTidspunkt } returns LocalDateTime.now().minusMonths(6) }
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).contains("som er for under 1 år siden. Hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak der siste klagebehandling ble avsluttet for under 1 år siden`() {
+            // Arrange
+            every { klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsak.id) } returns
+                listOf(
+                    mockk {
+                        every { status } returns KlageBehandlingStatus.FERDIGSTILT
+                        every { vedtaksdato } returns LocalDateTime.now().minusMonths(6)
+                    },
+                )
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).contains("som er for under 1 år siden. Hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
+            verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
+        }
+
+        @Test
+        fun `skal hoppe over fagsak der siste tilbakekrevingsbehandling ble avsluttet for under 1 år siden`() {
+            // Arrange
+            every { tilbakekrevingKlient.hentTilbakekrevingsbehandlinger(fagsak.id) } returns
+                listOf(
+                    mockk {
+                        every { status } returns Behandlingsstatus.AVSLUTTET
+                        every { vedtaksdato } returns LocalDateTime.now().minusMonths(6)
+                    },
+                )
+
+            // Act
+            fagsakLåsingService.låsFagsak(fagsak.id)
+
+            // Assert
+            assertThat(listAppender.list).anySatisfy {
+                assertThat(it.level.toString()).isEqualTo("INFO")
+                assertThat(it.formattedMessage).contains("som er for under 1 år siden. Hopper ut")
+            }
+            verify(exactly = 0) { fagsakRepository.save(any()) }
             verify(exactly = 0) { integrasjonKlient.avsluttSak(any()) }
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsaklåsing/FagsakLåsingServiceTest.kt
@@ -164,7 +164,7 @@ class FagsakLåsingServiceTest {
             // Assert
             assertThat(listAppender.list).anySatisfy {
                 assertThat(it.level.toString()).isEqualTo("INFO")
-                assertThat(it.formattedMessage).isEqualTo("Status for fagsak ${fagsak.id} er LØPENDE, hopper ut")
+                assertThat(it.formattedMessage).isEqualTo("Status for fagsak ${fagsak.id} er LØPENDE. Hopper ut av fagsaklåsing.")
             }
             verify(exactly = 0) { fagsakRepository.save(any()) }
             verify(exactly = 0) { fagsakLåsingRepository.save(any()) }
@@ -184,7 +184,7 @@ class FagsakLåsingServiceTest {
             // Assert
             assertThat(listAppender.list).anySatisfy {
                 assertThat(it.level.toString()).isEqualTo("INFO")
-                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen klagebehandling, hopper ut")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen klagebehandling. Hopper ut av fagsaklåsing.")
             }
             verify(exactly = 0) { fagsakRepository.save(any()) }
             verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
@@ -203,7 +203,7 @@ class FagsakLåsingServiceTest {
             // Assert
             assertThat(listAppender.list).anySatisfy {
                 assertThat(it.level.toString()).isEqualTo("INFO")
-                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen tilbakekrevingsbehandling, hopper ut")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen tilbakekrevingsbehandling. Hopper ut av fagsaklåsing.")
             }
             verify(exactly = 0) { fagsakRepository.save(any()) }
             verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
@@ -285,7 +285,7 @@ class FagsakLåsingServiceTest {
             // Assert
             assertThat(listAppender.list).anySatisfy {
                 assertThat(it.level.toString()).isEqualTo("INFO")
-                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen behandling, hopper ut")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} har åpen behandling. Hopper ut av fagsaklåsing.")
             }
             verify(exactly = 0) { fagsakRepository.save(any()) }
             verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }
@@ -308,7 +308,7 @@ class FagsakLåsingServiceTest {
             val feil = assertThrows<Feil> { fagsakLåsingService.låsFagsak(fagsak.id) }
 
             // Assert
-            assertThat(feil.message).isEqualTo("Fagsak ${fagsak.id} har allerede aktiv låsing")
+            assertThat(feil.message).isEqualTo("Fagsak ${fagsak.id} med status AVSLUTTET har allerede en aktiv låsing.")
         }
 
         @Test
@@ -329,7 +329,7 @@ class FagsakLåsingServiceTest {
             // Assert
             assertThat(listAppender.list).anySatisfy {
                 assertThat(it.level.toString()).isEqualTo("INFO")
-                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} ble låst opp for under 30 dager siden, hopper ut")
+                assertThat(it.formattedMessage).isEqualTo("Fagsak ${fagsak.id} ble låst opp for under 30 dager siden. Hopper ut av fagsaklåsing.")
             }
             verify(exactly = 0) { fagsakRepository.save(any()) }
             verify(exactly = 0) { saksstatistikkEventPublisher.publiserSaksstatistikk(any()) }


### PR DESCRIPTION
### 📮 Favro: NAV-29381

### 💰 Hva skal gjøres, og hvorfor?
Mer validering ved låsing av fagsak:
- Avbryt låsing hvis det er en åpen ba-sak-, klage- eller tilbakekrevingbehandling knyttet til fagsaken
- Avbryt låsing siste avsluttede ba-sak-, klage- eller tilbakekrevingbehandling knyttet til fagsaken ble avsluttet for under et år siden

Justerer spørringen for henting av fagsaker som skal lukkes litt, slik at fagsaker som har status `AVSLUTTET`, men som av en eller annen grunn har en aktiv låsing blir inkludert og så kastes det en feil når vi prøver å låse den. Sånn spørringen er nå ville disse aldri blitt låst.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.