### PR TITLE
chore: update cplt sandbox config

### DIFF
--- a/.cplt.toml
+++ b/.cplt.toml
@@ -1,0 +1,9 @@
+[propose]
+allow_docker = true
+allow_jvm_attach = true
+allow_localhost_any = true
+
+[propose.allow]
+ports = [5432]
+
+


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
cplt config for å tillate å kjøre mvn tester med testcontainers.