### PR TITLE
Fiks flaky test i MinSideBarnetrygdControllerTest

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/WebSpringAuthTestRunner.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/WebSpringAuthTestRunner.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ba.sak.config.AbstractMockkSpringRunner
 import no.nav.familie.ba.sak.config.ApplicationConfig
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
-import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.TestInstance
@@ -14,8 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.web.client.RestTemplate
 
@@ -108,26 +105,6 @@ abstract class WebSpringAuthTestRunner : AbstractMockkSpringRunner() {
         )
 
     companion object {
-        val mockOAuth2Server by lazy {
-            MockOAuth2Server().also {
-                it.start()
-                Runtime.getRuntime().addShutdownHook(Thread { it.shutdown() })
-            }
-        }
-
-        @JvmStatic
-        @DynamicPropertySource
-        @Suppress("unused")
-        fun mockOAuth2ServerProperties(registry: DynamicPropertyRegistry) {
-            val port = mockOAuth2Server.config.httpServer.port()
-            registry.add("AZURE_OPENID_CONFIG_ISSUER") { "http://localhost:$port/$AZUREAD_ISSUER_ID" }
-            registry.add("AZURE_OPENID_CONFIG_JWKS_URI") { "http://localhost:$port/$AZUREAD_ISSUER_ID/jwks" }
-            registry.add("AZURE_APP_CLIENT_ID") { DEFAULT_AUDIENCE }
-            registry.add("TOKEN_X_ISSUER") { "http://localhost:$port/$TOKENX_ISSUER_ID" }
-            registry.add("TOKEN_X_JWKS_URI") { "http://localhost:$port/$TOKENX_ISSUER_ID/jwks" }
-            registry.add("TOKEN_X_CLIENT_ID") { DEFAULT_AUDIENCE }
-        }
-
         const val AZUREAD_ISSUER_ID = "azuread"
         const val TOKENX_ISSUER_ID = "tokenx"
         const val DEFAULT_SUBJECT = "subject"

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/AbstractMockkSpringRunner.kt
@@ -1,10 +1,13 @@
 package no.nav.familie.ba.sak.config
 
+import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.BeforeEach
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.CacheManager
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import java.util.UUID
 
 abstract class AbstractMockkSpringRunner {
@@ -37,6 +40,27 @@ abstract class AbstractMockkSpringRunner {
             it.cacheNames
                 .mapNotNull { cacheName -> it.getCache(cacheName) }
                 .forEach { cache -> cache.clear() }
+        }
+    }
+
+    companion object {
+        val mockOAuth2Server =
+            MockOAuth2Server().also {
+                it.start()
+                Runtime.getRuntime().addShutdownHook(Thread { it.shutdown() })
+            }
+
+        @JvmStatic
+        @DynamicPropertySource
+        @Suppress("unused")
+        fun registrerMockOAuth2ServerProperties(registry: DynamicPropertyRegistry) {
+            val port = mockOAuth2Server.config.httpServer.port()
+            registry.add("AZURE_OPENID_CONFIG_ISSUER") { "http://localhost:$port/azuread" }
+            registry.add("AZURE_OPENID_CONFIG_JWKS_URI") { "http://localhost:$port/azuread/jwks" }
+            registry.add("AZURE_APP_CLIENT_ID") { "some-audience" }
+            registry.add("TOKEN_X_ISSUER") { "http://localhost:$port/tokenx" }
+            registry.add("TOKEN_X_JWKS_URI") { "http://localhost:$port/tokenx/jwks" }
+            registry.add("TOKEN_X_CLIENT_ID") { "some-audience" }
         }
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29437

### 💰 Hva skal gjøres, og hvorfor?

Testen `skal returnere BAD_REQUEST når token inneholder ugyldig fødselsnummer` returnerte sporadisk 403 i stedet for 400.

`TokenContextHolder` blir overskrevet av `AbstractSpringIntegrationTest` sin Spring-kontekst (bruker `TOKEN_X_ISSUER: dummy`), noe som fikk `hasTokenFor("tokenx")` til å feile og controlleren til å svare 403.

Fix: Flyttet `mockOAuth2Server` og `@DynamicPropertySource` til `AbstractMockkSpringRunner` slik at alle Spring-kontekster alltid får riktig issuer-mapping.