### PR TITLE
Vis barn i brevperiode og brevbegrunnelse ved delt bosted med 0 kr utvidet barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevBegrunnelseProdusent.kt
@@ -11,9 +11,9 @@ import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.ekstern.restDomene.BarnMedOpplysninger
 import no.nav.familie.ba.sak.integrasjoner.pdl.logger
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.erBetaltUtvidetIPeriode
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.erNullPgaDifferanseberegningEllerDeltBosted
-import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.finnBarnMedAlleredeUtbetalt
+import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.erRettPåUtvidetIPeriode
+import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.finnBarnMedAlleredeUtbetaltEllerDeltBostedIngenUtbetaling
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.finnUtvidetAndelerIDennePerioden
 import no.nav.familie.ba.sak.kjerne.brev.brevPeriodeProdusent.finnUtvidetAndelerIForrigePeriode
 import no.nav.familie.ba.sak.kjerne.brev.domene.EndretUtbetalingsperiodeDeltBostedTriggere
@@ -317,9 +317,9 @@ fun ISanityBegrunnelse.hentBarnasFødselsdatoerForBegrunnelse(
         begrunnelsesGrunnlagPerPerson
             .finnBarnMedUtbetaling()
             .ifEmpty {
-                val erBetaltUtvidetIPeriode = begrunnelsesGrunnlagPerPerson.erBetaltUtvidetIPeriode()
+                val erRettPåUtvidetIPeriode = begrunnelsesGrunnlagPerPerson.erRettPåUtvidetIPeriode()
                 when {
-                    erBetaltUtvidetIPeriode -> begrunnelsesGrunnlagPerPerson.finnBarnMedAlleredeUtbetalt()
+                    erRettPåUtvidetIPeriode -> begrunnelsesGrunnlagPerPerson.finnBarnMedAlleredeUtbetaltEllerDeltBostedIngenUtbetaling()
                     else -> emptySet()
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevPeriodeProdusent/BrevPeriodeProdusent.kt
@@ -83,9 +83,9 @@ private fun VedtaksperiodeMedBegrunnelser.byggBrevPeriode(
         begrunnelseGrunnlagPerPerson
             .finnBarnMedUtbetaling()
             .ifEmpty {
-                val erBetaltUtvidetIPeriode = begrunnelseGrunnlagPerPerson.erBetaltUtvidetIPeriode()
+                val erRettPåUtvidetIPeriode = begrunnelseGrunnlagPerPerson.erRettPåUtvidetIPeriode()
                 when {
-                    erBetaltUtvidetIPeriode -> begrunnelseGrunnlagPerPerson.finnBarnMedAlleredeUtbetalt()
+                    erRettPåUtvidetIPeriode -> begrunnelseGrunnlagPerPerson.finnBarnMedAlleredeUtbetaltEllerDeltBostedIngenUtbetaling()
                     else -> emptySet()
                 }
             }
@@ -149,10 +149,10 @@ fun erNullPgaDifferanseberegningEllerDeltBosted(grunnlag: IBegrunnelseGrunnlagFo
                 grunnlag.forrigePeriode?.endretUtbetalingAndel?.årsak != Årsak.DELT_BOSTED
         )
 
-fun Map<Person, IBegrunnelseGrunnlagForPeriode>.erBetaltUtvidetIPeriode(): Boolean =
+fun Map<Person, IBegrunnelseGrunnlagForPeriode>.erRettPåUtvidetIPeriode(): Boolean =
     this.any {
         it.value.dennePerioden.andeler.any { andel ->
-            andel.type == YtelseType.UTVIDET_BARNETRYGD && andel.kalkulertUtbetalingsbeløp > 0
+            andel.type == YtelseType.UTVIDET_BARNETRYGD
         }
     }
 
@@ -170,10 +170,10 @@ fun Map<Person, IBegrunnelseGrunnlagForPeriode>.finnUtvidetAndelerIDennePerioden
         }
     }
 
-fun Map<Person, IBegrunnelseGrunnlagForPeriode>.finnBarnMedAlleredeUtbetalt(): Set<Person> =
+fun Map<Person, IBegrunnelseGrunnlagForPeriode>.finnBarnMedAlleredeUtbetaltEllerDeltBostedIngenUtbetaling(): Set<Person> =
     this
         .filterKeys { it.type == PersonType.BARN }
-        .filterValues { it.dennePerioden.endretUtbetalingAndel?.årsak == Årsak.ALLEREDE_UTBETALT }
+        .filterValues { it.dennePerioden.endretUtbetalingAndel?.run { årsak == Årsak.ALLEREDE_UTBETALT || (årsak == Årsak.DELT_BOSTED && prosent == BigDecimal.ZERO) } ?: false }
         .keys
 
 fun Set<Person>.tilBarnasFødselsdatoer(): String {

--- a/src/test/resources/cucumber/brevBegrunnelser/allerede_utbetalt_og_delt_bosted.feature
+++ b/src/test/resources/cucumber/brevBegrunnelser/allerede_utbetalt_og_delt_bosted.feature
@@ -1,0 +1,82 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Brevperioder: Allerede utbetalt og delt bosted med utvidet barnetrygd
+
+  Scenario: Barn skal ikke vises i brevperiode for allerede utbetalt uten utvidet barnetrygd, men skal vises fra første delt bosted-periode og videre
+
+    Gitt følgende fagsaker
+      | FagsakId | Fagsaktype |
+      | 1        | NORMAL     |
+
+    Gitt følgende behandlinger
+      | BehandlingId | FagsakId | Behandlingsresultat | Behandlingsårsak | Skal behandles automatisk | Behandlingskategori |
+      | 1            | 1        | DELVIS_INNVILGET    | SØKNAD           | Nei                       | NASJONAL            |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 01.01.1990  |
+      | 1            | 2       | BARN       | 01.01.2020  |
+
+    Og dagens dato er 01.06.2026
+    Og lag personresultater for behandling 1
+
+    Og legg til nye vilkårresultater for behandling 1
+      | AktørId | Vilkår                        | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD,BOSATT_I_RIKET |                  | 01.12.2025 |            | OPPFYLT  | Nei                  | NASJONALE_REGLER |
+      | 1       | UTVIDET_BARNETRYGD            |                  | 01.04.2026 |            | OPPFYLT  | Nei                  |                  |
+
+      | 2       | UNDER_18_ÅR                   |                  | 01.01.2020 | 31.12.2037 | OPPFYLT  | Nei                  |                  |
+      | 2       | GIFT_PARTNERSKAP              |                  | 01.01.2020 |            | OPPFYLT  | Nei                  |                  |
+      | 2       | LOVLIG_OPPHOLD,BOSATT_I_RIKET |                  | 01.12.2025 |            | OPPFYLT  | Nei                  | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 |                  | 01.12.2025 | 28.02.2026 | OPPFYLT  | Nei                  | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                 | DELT_BOSTED      | 01.03.2026 |            | OPPFYLT  | Nei                  | NASJONALE_REGLER |
+
+    Og med andeler tilkjent ytelse
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Beløp | Ytelse type        | Prosent | Sats |
+      | 2       | 1            | 01.01.2026 | 28.02.2026 | 0     | ORDINÆR_BARNETRYGD | 0       | 1766 |
+      | 2       | 1            | 01.03.2026 | 31.05.2026 | 0     | ORDINÆR_BARNETRYGD | 0       | 1766 |
+      | 2       | 1            | 01.06.2026 | 31.12.2037 | 2068  | ORDINÆR_BARNETRYGD | 100     | 2068 |
+      | 1       | 1            | 01.04.2026 | 31.05.2026 | 0     | UTVIDET_BARNETRYGD | 0       | 2516 |
+      | 1       | 1            | 01.06.2026 | 31.12.2037 | 2516  | UTVIDET_BARNETRYGD | 100     | 2516 |
+
+    Og med endrede utbetalinger
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak             | Prosent | Søknadstidspunkt | Avtaletidspunkt delt bosted |
+      | 2       | 1            | 01.01.2026 | 28.02.2026 | ALLEREDE_UTBETALT | 0       | 01.01.2026       |                             |
+      | 2       | 1            | 01.03.2026 | 31.05.2026 | DELT_BOSTED       | 0       | 01.03.2026       | 01.01.2026                  |
+      | 1       | 1            | 01.04.2026 | 31.05.2026 | DELT_BOSTED       | 0       | 01.03.2026       | 01.01.2026                  |
+
+    Når vedtaksperiodene genereres for behandling 1
+
+    Så forvent at følgende begrunnelser er gyldige
+      | Fra dato   | Til dato   | VedtaksperiodeType | Gyldige begrunnelser                                      |
+      | 01.03.2026 | 31.03.2026 | UTBETALING         | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY |
+      | 01.04.2026 | 30.04.2026 | UTBETALING         | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY |
+      | 01.05.2026 | 31.05.2026 | UTBETALING         | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY |
+      | 01.06.2026 | 31.12.2037 | UTBETALING         | ETTER_ENDRET_UTBETALING_HAR_AVTALE_DELT_BOSTED            |
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato   | Standardbegrunnelser                                      |
+      | 01.03.2026 | 31.03.2026 | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY |
+      | 01.04.2026 | 30.04.2026 | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY |
+      | 01.05.2026 | 31.05.2026 | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY |
+      | 01.06.2026 | 31.12.2037 | ETTER_ENDRET_UTBETALING_HAR_AVTALE_DELT_BOSTED            |
+
+    Så forvent følgende brevperioder for behandling 1
+      | Brevperiodetype | Fra dato   | Til dato          | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
+      | UTBETALING      | mars 2026  | til mars 2026     | 0     | 1                          | 01.01.20            | du                     |
+      | UTBETALING      | april 2026 | til april 2026    | 0     | 1                          | 01.01.20            | du                     |
+      | UTBETALING      | mai 2026   | til mai 2026      | 0     | 1                          | 01.01.20            | du                     |
+      | UTBETALING      | juni 2026  | til desember 2037 | 4584  | 1                          | 01.01.20            | du                     |
+
+    Så forvent følgende brevbegrunnelser i rekkefølge for behandling 1 i periode 01.03.2026 til 31.03.2026
+      | Begrunnelse                                               | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt |
+      | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY | STANDARD | Nei           | 01.01.20             | 1           | februar 2026                         | 0     | 01.03.26         |
+
+    Så forvent følgende brevbegrunnelser i rekkefølge for behandling 1 i periode 01.04.2026 til 30.04.2026
+      | Begrunnelse                                               | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Søkers rett til utvidet     |
+      | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY | STANDARD | Nei           | 01.01.20             | 1           | mars 2026                            | 0     | 01.03.26         | SØKER_HAR_RETT_MEN_FÅR_IKKE |
+
+    Så forvent følgende brevbegrunnelser i rekkefølge for behandling 1 i periode 01.05.2026 til 31.05.2026
+      | Begrunnelse                                               | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Søkers rett til utvidet     |
+      | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY | STANDARD | Nei           | 01.01.20             | 1           | april 2026                           | 0     | 01.03.26         | SØKER_HAR_RETT_MEN_FÅR_IKKE |

--- a/src/test/resources/cucumber/vedtaksperioder/endret_utbetaling.feature
+++ b/src/test/resources/cucumber/vedtaksperioder/endret_utbetaling.feature
@@ -236,7 +236,7 @@ Egenskap: Vedtaksperioder med endret utbetaling der endringstidspunkt påvirker 
 
     Så forvent følgende brevbegrunnelser i rekkefølge for behandling 1 i periode 01.12.2024 til 31.03.2025
       | Begrunnelse                                                       | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Målform | Beløp | Søknadstidspunkt | Søkers rett til utvidet | Avtaletidspunkt delt bosted |
-      | ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_MÅNEDER_KUN_UTVIDET_DEL | STANDARD | Ja            |                      | 0           | november 2024                        |         | 1 258 | 26.03.25         | SØKER_FÅR_UTVIDET       |                             |
+      | ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_MÅNEDER_KUN_UTVIDET_DEL | STANDARD | Ja            | 17.08.07 og 26.07.09 | 2           | november 2024                        |         | 1 258 | 26.03.25         | SØKER_FÅR_UTVIDET       |                             |
       | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_ENDRET_UTBETALING           | STANDARD | Nei           | 17.08.07 og 26.07.09 | 2           | november 2024                        |         | 0     | 26.03.25         | SØKER_FÅR_UTVIDET       | 01.08.23                    |
       | ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_INGEN_UTBETALING_NY         | STANDARD | Nei           | 17.08.07 og 26.07.09 | 2           | november 2024                        |         | 0     | 26.03.25         | SØKER_FÅR_UTVIDET       |                             |
 


### PR DESCRIPTION
### 📮 Favro: NAV-29521

### 💰 Hva skal gjøres, og hvorfor?

To funksjoner er endret for å vise barn korrekt i brevperioder og brevbegrunnelser når utvidet barnetrygd er 0 kr pga. delt bosted:

**`BrevPeriodeProdusent::byggBrevPeriode`**
- Erstattet `erBetaltUtvidetIPeriode()` (krevde `kalkulertUtbetalingsbeløp > 0`) med `erRettPåUtvidetIPeriode()` (nok at UTVIDET_BARNETRYGD-andelen eksisterer)
- Erstattet `finnBarnMedAlleredeUtbetalt()` med `finnBarnMedAlleredeUtbetaltEllerDeltBostedIngenUtbetaling()`, som i tillegg til ALLEREDE_UTBETALT også inkluderer barn med DELT_BOSTED-andel på 0 %
- Effekt: barn vises nå korrekt i `antallBarn` og `barnasFodselsdager` i brevperioden selv om utvidet er 0 kr

**`BrevBegrunnelseProdusent::hentBarnasFødselsdatoerForBegrunnelse`**
- Samme endring som over, slik at barnas fødselsdatoer flettes riktig inn i brevbegrunnelsene

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

Den eksisterende testen `Ved ingen endringer på endring utbetaling i en periode så skal alle barn som har begrunnelsen som en gyldig valg flettes inn.` i `vedtaksperioder/endret_utbetaling.feature` ble endret i commit 24b8d5d til å forvente tomme barnasFodselsdatoer og 0 barn for `ETTER_ENDRET_UTBETALING_ETTERBETALING_TRE_MÅNEDER_KUN_UTVIDET_DEL`. Den er revertet tilbake til å forvente de faktiske barnas fødselsdatoer, da dette er korrekt ny atferd.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.