### PR TITLE
Opprett RedirectController med ubeskyttede redirect-endepunkter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/SecurityConfiguration.kt
@@ -42,7 +42,7 @@ class SecurityConfiguration(
     fun publicSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http {
             csrf { disable() }
-            securityMatcher("/internal/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+            securityMatcher("/internal/**", "/redirect/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
             authorizeHttpRequests {
                 authorize(anyRequest, permitAll)
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveService.kt
@@ -454,6 +454,8 @@ class OppgaveService(
             }
     }
 
+    fun hentBehandlingForOppgave(gsakId: String): Behandling? = oppgaveRepository.findByGsakId(gsakId)?.behandling
+
     companion object {
         private val logger = LoggerFactory.getLogger(OppgaveService::class.java)
         private val oppgavetyperSomBehandlesAvBaSak =

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/RedirectController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/RedirectController.kt
@@ -1,0 +1,79 @@
+package no.nav.familie.ba.sak.internal
+
+import no.nav.familie.ba.sak.common.EnvService
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@RestController
+@RequestMapping(value = ["/redirect"])
+class RedirectController(
+    private val envService: EnvService,
+    private val behandlingRepository: BehandlingRepository,
+    private val fagsakRepository: FagsakRepository,
+    private val oppgaveService: OppgaveService,
+) {
+    @GetMapping("/behandling/{behandlingId}")
+    fun redirectTilBehandling(
+        @PathVariable behandlingId: Long,
+    ): ResponseEntity<Any> {
+        val hostname = hentHostname()
+        val behandling = behandlingRepository.finnBehandlingNullable(behandlingId)
+        return if (behandling == null) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body("Fant ikke behandling med id $behandlingId")
+        } else {
+            ResponseEntity
+                .status(302)
+                .location(URI.create("$hostname/fagsak/${behandling.fagsak.id}/$behandlingId/"))
+                .build()
+        }
+    }
+
+    @GetMapping("/fagsak/{fagsakId}")
+    fun redirectTilFagsak(
+        @PathVariable fagsakId: Long,
+    ): ResponseEntity<Any> {
+        val hostname = hentHostname()
+        val fagsak = fagsakRepository.finnFagsak(fagsakId)
+        return if (fagsak == null) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body("Fant ikke fagsak med id $fagsakId")
+        } else {
+            ResponseEntity
+                .status(HttpStatus.FOUND)
+                .location(URI.create("$hostname/fagsak/$fagsakId/"))
+                .build()
+        }
+    }
+
+    @GetMapping("/oppgave/{gsakId}")
+    fun redirectTilBehandlingFraOppgaveId(
+        @PathVariable gsakId: String,
+    ): ResponseEntity<Any> {
+        val hostname = hentHostname()
+        val behandling = oppgaveService.hentBehandlingForOppgave(gsakId)
+        return if (behandling == null) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body("Fant ikke behandling knyttet til oppgave med id $gsakId")
+        } else {
+            ResponseEntity
+                .status(HttpStatus.FOUND)
+                .location(URI.create("$hostname/fagsak/${behandling.fagsak.id}/${behandling.id}"))
+                .build()
+        }
+    }
+
+    private fun hentHostname(): String =
+        when {
+            envService.erDev() -> "http://localhost:8000"
+            envService.erPreprod() -> "https://barnetrygd.intern.dev.nav.no"
+            envService.erProd() -> "https://barnetrygd.intern.nav.no"
+            else -> throw Feil("Klarer ikke å utlede miljø for redirect til fagsak")
+        }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/TestVerktøyController.kt
@@ -1,14 +1,12 @@
 package no.nav.familie.ba.sak.internal
 
 import no.nav.familie.ba.sak.common.EnvService
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutobrevScheduler
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.StartSatsendring
 import no.nav.familie.ba.sak.kjerne.behandling.NyBehandlingHendelse
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ba.sak.kjerne.simulering.SimuleringService
 import no.nav.familie.ba.sak.kjerne.simulering.domene.ØkonomiSimuleringMottaker
@@ -27,7 +25,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.net.URI
 
 @RestController
 @RequestMapping(value = ["/internal"])
@@ -40,7 +37,6 @@ class TestVerktøyController(
     private val tilgangService: TilgangService,
     private val simuleringService: SimuleringService,
     private val opprettTaskService: OpprettTaskService,
-    private val behandlingRepository: BehandlingRepository,
 ) {
     @GetMapping(path = ["/autobrev"])
     fun kjørSchedulerForAutobrev(): ResponseEntity<Ressurs<String>> =
@@ -108,31 +104,6 @@ class TestVerktøyController(
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
 
         return simuleringService.hentSimuleringPåBehandling(behandlingId)
-    }
-
-    @GetMapping("/redirect/behandling/{behandlingId}")
-    fun redirectTilBarnetrygd(
-        @PathVariable behandlingId: Long,
-    ): ResponseEntity<Any> {
-        val hostname =
-            if (envService.erDev()) {
-                "http://localhost:8000"
-            } else if (envService.erPreprod()) {
-                "https://barnetrygd.intern.dev.nav.no"
-            } else if (envService.erProd()) {
-                "https://barnetrygd.intern.nav.no"
-            } else {
-                throw Feil("Klarer ikke å utlede miljø for redirect til fagsak")
-            }
-        val behandling = behandlingRepository.finnBehandlingNullable(behandlingId)
-        return if (behandling == null) {
-            ResponseEntity.status(200).body("Fant ikke behandling med id $behandlingId")
-        } else {
-            ResponseEntity
-                .status(302)
-                .location(URI.create("$hostname/fagsak/${behandling.fagsak.id}/$behandlingId/"))
-                .build()
-        }
     }
 
     companion object {


### PR DESCRIPTION
### 📮 Favro: NAV-29518

### 💰 Hva skal gjøres, og hvorfor?

Oppretter en ny `RedirectController` med base path `/redirect`, lagt til som
ubeskyttet i `SecurityConfiguration` (matcher `/redirect/**`).

Redirect for behandling er flyttet fra `TestVerktøyController`. Redirect for
oppgave og fagsak er nye endepunkter. Returnerer `404 NOT_FOUND` hvis
behandling eller fagsak ikke finnes.