### PR TITLE
Legg til hardkodet register for EØS-satser per land

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import java.math.BigDecimal
+import java.time.YearMonth
+
+/**
+ * Representerer en EØS-sats fra et bestemt land i landets valuta og utbetalingsintervall.
+ *
+ * Beløpet angir det utenlandske periodebeløpet som utbetales fra [land],
+ * i valutaen [valuta] og med hyppigheten [intervall].
+ *
+ * [fom] er første måned satsen gjelder.
+ * [tom] er siste måned satsen gjelder. Null betyr løpende (ingen kjent sluttdato).
+ */
+data class EøsSats(
+    val land: String,
+    val valuta: String,
+    val beløp: BigDecimal,
+    val fom: YearMonth,
+    val tom: YearMonth? = null,
+    val intervall: Intervall = Intervall.MÅNEDLIG,
+) {
+    fun erGyldigForMåned(måned: YearMonth): Boolean = måned >= fom && (tom == null || måned <= tom)
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsService.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.satser
+import java.time.YearMonth
+
+/**
+ * Hardkodet register over EØS-satser per land, analogt med [no.nav.familie.ba.sak.kjerne.beregning.SatsService].
+ *
+ * Nye land legges til i [satser] som egne [EøsSatser]-objekter.
+ * Satser innen hvert land vedlikeholdes i den tilhørende filen (f.eks. [EøsSatserPolen]).
+ */
+object EøsSatsService {
+    /**
+     * Register over alle land med EØS-satser.
+     * Nye land registreres her når de legges til i systemet.
+     */
+    internal val satser: List<EøsSatser> =
+        listOf(
+            EøsSatserPolen,
+        )
+
+    /**
+     * @return gjeldende sats for et land i en gitt måned eller null dersom ingen sats er registrert for landet i den aktuelle måneden.
+     */
+    fun finnGjeldendeSatsForLand(
+        land: String,
+        måned: YearMonth = YearMonth.now(),
+    ): EøsSats? =
+        satser
+            .find { it.land == land }
+            ?.satser
+            ?.find { it.erGyldigForMåned(måned) }
+
+    /**
+     * @return den nyeste satsen for et land.
+     * @throws [Feil] dersom ingen sats er registrert for landet.
+     */
+    fun hentSisteSatsForLand(land: String): EøsSats =
+        satser.find { it.land == land }?.satser?.maxByOrNull { it.fom }
+            ?: throw Feil("Ingen EØS-sats registrert for land: $land")
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatser.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+/**
+ * Abstrakt klasse som representerer alle registrerte EØS-satser for ett bestemt land.
+ *
+ * Hvert land som har EØS-satser i systemet oppretter et eget `object` som arver fra denne klassen,
+ * og legger inn sine satser i [satser]-listen.
+ *
+ * Eksempel på bruk:
+ * ```kotlin
+ * object EøsSatserPolen : EøsSatser() {
+ *     override val land = "PL"
+ *     override val satser = listOf(
+ *         EøsSats(land = "PL", valuta = "PLN", intervall = Intervall.MÅNEDLIG,
+ *                 beløp = BigDecimal("800"), fom = YearMonth.of(2025, 1)),
+ *     )
+ * }
+ * ```
+ *
+ * Nye land registreres i [EøsSatsService.satser].
+ */
+abstract class EøsSatser {
+    abstract val land: String
+    abstract val satser: List<EøsSats>
+
+    operator fun component1(): String = land
+
+    operator fun component2(): List<EøsSats> = satser
+}
+
+/**
+ * EØS-satser for Polen (PL) i polske zloty (PLN).
+ */
+object EøsSatserPolen : EøsSatser() {
+    override val land = "PL"
+    override val satser: List<EøsSats> = listOf()
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsServiceTest.kt
@@ -1,0 +1,211 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkObject
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.common.tilKortString
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.finnGjeldendeSatsForLand
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.hentSisteSatsForLand
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.YearMonth
+
+class EøsSatsServiceTest {
+    private val polskSats2024 =
+        EøsSats(
+            land = "PL",
+            valuta = "PLN",
+            intervall = Intervall.MÅNEDLIG,
+            beløp = BigDecimal("800"),
+            fom = YearMonth.of(2024, 1),
+            tom = YearMonth.of(2024, 12),
+        )
+
+    private val polskSats2025 =
+        EøsSats(
+            land = "PL",
+            valuta = "PLN",
+            intervall = Intervall.MÅNEDLIG,
+            beløp = BigDecimal("900"),
+            fom = YearMonth.of(2025, 1),
+            tom = null, // løpende
+        )
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(EøsSatserPolen)
+        every { EøsSatserPolen.satser } returns listOf(polskSats2024, polskSats2025)
+
+        mockkObject(EøsSatsService)
+        every { EøsSatsService.satser } returns listOf(EøsSatserPolen)
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Nested
+    inner class EøsSatsErGyldigForMåned {
+        @Test
+        fun `Sats med fom og tom - gyldig for måned inni perioden`() {
+            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2024, 6))).isTrue()
+        }
+
+        @Test
+        fun `Sats med fom og tom - gyldig for første måned`() {
+            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2024, 1))).isTrue()
+        }
+
+        @Test
+        fun `Sats med fom og tom - gyldig for siste måned`() {
+            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2024, 12))).isTrue()
+        }
+
+        @Test
+        fun `Sats med fom og tom - ikke gyldig for måned etter tom`() {
+            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2025, 1))).isFalse()
+        }
+
+        @Test
+        fun `Sats med fom og tom - ikke gyldig for måned før fom`() {
+            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2023, 12))).isFalse()
+        }
+
+        @Test
+        fun `Løpende sats (tom = null) - gyldig for måned etter fom`() {
+            assertThat(polskSats2025.erGyldigForMåned(YearMonth.of(2026, 6))).isTrue()
+        }
+
+        @Test
+        fun `Løpende sats (tom = null) - ikke gyldig for måned før fom`() {
+            assertThat(polskSats2025.erGyldigForMåned(YearMonth.of(2024, 12))).isFalse()
+        }
+    }
+
+    @Nested
+    inner class FinnGjeldendeSatsForLand {
+        @Test
+        fun `Returnerer korrekt sats for måned inni gyldig periode`() {
+            assertThat(finnGjeldendeSatsForLand("PL", YearMonth.of(2024, 6))).isEqualTo(polskSats2024)
+        }
+
+        @Test
+        fun `Returnerer løpende sats for måned etter siste fom`() {
+            // Act
+            val resultat = finnGjeldendeSatsForLand("PL", YearMonth.of(2025, 6))
+
+            // Assert
+            assertThat(resultat).isEqualTo(polskSats2025)
+            assertThat(resultat?.tom).isNull()
+        }
+
+        @Test
+        fun `Returnerer null for måned før noen satser`() {
+            assertThat(finnGjeldendeSatsForLand("PL", YearMonth.of(2023, 12))).isNull()
+        }
+
+        @Test
+        fun `Returnerer null når registeret er tomt`() {
+            // Arrange
+            every { EøsSatserPolen.satser } returns emptyList()
+
+            // Act & Assert
+            assertThat(finnGjeldendeSatsForLand("PL")).isNull()
+        }
+    }
+
+    @Nested
+    inner class HentSisteSatsForLand {
+        @Test
+        fun `Returnerer satsen med høyest fom for landet`() {
+            // Act
+            val resultat = hentSisteSatsForLand("PL")
+
+            // Assert
+            assertThat(resultat.beløp).isEqualTo(BigDecimal("900"))
+            assertThat(resultat.fom).isEqualTo(YearMonth.of(2025, 1))
+        }
+
+        @Test
+        fun `Returnerer eneste sats dersom kun én er registrert for landet`() {
+            // Arrange
+            every { EøsSatserPolen.satser } returns listOf(polskSats2024)
+
+            // Act & Assert
+            assertThat(hentSisteSatsForLand("PL")).isEqualTo(polskSats2024)
+        }
+
+        @Test
+        fun `Kaster Feil dersom ingen sats er registrert for landet`() {
+            // Arrange
+            every { EøsSatserPolen.satser } returns emptyList()
+
+            // Act & Assert
+            assertThatThrownBy { hentSisteSatsForLand("PL") }.isInstanceOf(Feil::class.java)
+        }
+    }
+
+    @Nested
+    inner class ProduksjonsSatserErKonsistente {
+        @BeforeEach
+        fun setup() {
+            unmockkObject(EøsSatsService)
+            unmockkObject(EøsSatserPolen)
+        }
+
+        @Test
+        fun `Ingen land har overlappende gyldighetsperioder`() {
+            EøsSatsService.satser.forEach { (land, satser) ->
+                satser.sortedBy { it.fom }.zipWithNext { nåværende, neste ->
+                    assertThat(nåværende.tom != null && nåværende.tom < neste.fom)
+                        .withFailMessage(
+                            "Satser for land $land overlapper: ${nåværende.fom.tilKortString()} – ${nåværende.tom?.tilKortString()}" +
+                                " og ${neste.fom.tilKortString()} – ${neste.tom?.tilKortString()}",
+                        ).isTrue()
+                }
+            }
+        }
+
+        @Test
+        fun `Alle satser har positivt beløp`() {
+            EøsSatsService.satser.forEach { (land, satser) ->
+                satser.forEach { sats ->
+                    assertThat(sats.beløp)
+                        .withFailMessage("Sats for $land har ikke-positivt beløp: ${sats.beløp}")
+                        .isGreaterThan(BigDecimal.ZERO)
+                }
+            }
+        }
+
+        @Test
+        fun `Alle satser har tom etter eller lik fom`() {
+            EøsSatsService.satser.forEach { (land, satser) ->
+                satser.forEach { sats ->
+                    assertThat(sats.tom == null || sats.tom >= sats.fom)
+                        .withFailMessage("Sats for $land har tom ${sats.tom?.tilKortString()} før fom ${sats.fom.tilKortString()}")
+                        .isTrue()
+                }
+            }
+        }
+
+        @Test
+        fun `EøsSats-land matcher land-objektets land-felt`() {
+            EøsSatsService.satser.forEach { (land, satser) ->
+                satser.forEach { sats ->
+                    assertThat(sats.land)
+                        .withFailMessage("Sats med land '${sats.land}' ligger i listen med satser for '$land'")
+                        .isEqualTo(land)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 📮 Favro: NAV-29738

### 💰 Hva skal gjøres, og hvorfor?

Del 1 av implementasjonen for EØS-satsendring-løypen. Introduserer en hardkodet datamodell for utenlandske periodebeløp per land, analogt med den eksisterende `SatsService` for norske satser.

Nye filer:
- `EøsSats` — data class med feltene `land`, `valuta`, `intervall`, `beløp`, `fom` og `tom`
- `EøsSatser` — abstrakt klasse per land med destruktureringsoperatorer; `EøsSatserPolen` som strukturell mal
- `EøsSatsService` — oppslag via `finnGjeldendeSatsForLand` og `hentSisteSatsForLand`

Satser for Polen er ment som eksempel og er foreløpig tomme.

### ✅ Checklist
- [x] Jeg har skrevet tester.