### PR TITLE
Koble SATSENDRING_EØS inn i behandlingsinfrastrukturen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <felles.version>4.20260529121328_2754f7c</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20260608094517_8c7d220</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.saksstatistikk>2.0_20260608094517_8c7d220</familie.kontrakter.saksstatistikk>
-        <familie.kontrakter.stønadsstatistikk>2.0_20260608094517_8c7d220</familie.kontrakter.stønadsstatistikk>
+        <familie.kontrakter.stønadsstatistikk>2.0_20260623154817_f726581</familie.kontrakter.stønadsstatistikk>
         <felles-kontrakter.version>4.0_20260608075026_1c29629</felles-kontrakter.version>
         <utbetalingsgenerator.version>1.0_20260527092003_ed16208</utbetalingsgenerator.version>
         <cucumber.version>7.34.3</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/utbetalingsoppdrag/BehandlingsinformasjonUtleder.kt
@@ -27,7 +27,7 @@ class BehandlingsinformasjonUtleder(
     ): Behandlingsinformasjon {
         val behandling = vedtak.behandling
         val fagsak = behandling.fagsak
-        val endretMigreringsdato = endretMigreringsdatoUtleder.utled(fagsak = fagsak, forrigeTilkjentYtelse = forrigeTilkjentYtelse, erSatsendring = behandling.erSatsendring())
+        val endretMigreringsdato = endretMigreringsdatoUtleder.utled(fagsak = fagsak, forrigeTilkjentYtelse = forrigeTilkjentYtelse, erSatsendring = behandling.erSatsendringNasjonal())
         return Behandlingsinformasjon(
             saksbehandlerId = saksbehandlerId,
             behandlingId = behandling.id.toString(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -118,11 +118,11 @@ data class Behandling(
         when {
             type == BehandlingType.TEKNISK_ENDRING -> false
             opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID -> false
-            erSatsendringEllerMånedligValutajustering() -> false
+            erSatsendringNasjonalEllerMånedligValutajustering() -> false
             erManuellMigrering() -> false
             erMigrering() -> false
             erIverksetteKAVedtak() -> false
-            erFinnmarksEllerSvalbardtillegg() && resultat in setOf(FORTSATT_INNVILGET, FORTSATT_OPPHØRT) -> false
+            erRegionstillegg() && resultat in setOf(FORTSATT_INNVILGET, FORTSATT_OPPHØRT) -> false
             erFalskIdentitet() -> false
             else -> true
         }
@@ -164,10 +164,10 @@ data class Behandling(
             skalBehandlesAutomatisk && erOmregning() && resultat in listOf(FORTSATT_INNVILGET, FORTSATT_OPPHØRT) -> true
             skalBehandlesAutomatisk && erMigrering() && !erManuellMigreringForEndreMigreringsdato() && resultat == Behandlingsresultat.INNVILGET -> true
             skalBehandlesAutomatisk && erFødselshendelse() -> true
-            skalBehandlesAutomatisk && erSatsendring() && erEndringFraForrigeBehandlingSendtTilØkonomi -> true
+            skalBehandlesAutomatisk && erSatsendringNasjonal() && erEndringFraForrigeBehandlingSendtTilØkonomi -> true
             skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID && this.resultat == FORTSATT_INNVILGET -> true
             skalBehandlesAutomatisk && erMånedligValutajustering() -> true
-            skalBehandlesAutomatisk && erFinnmarksEllerSvalbardtillegg() -> true
+            skalBehandlesAutomatisk && erRegionstillegg() -> true
             skalBehandlesAutomatisk && erSatsendringEøs() -> true
             else -> false
         }
@@ -227,7 +227,7 @@ data class Behandling(
 
     fun erMigrering() = type == BehandlingType.MIGRERING_FRA_INFOTRYGD || type == BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT
 
-    fun erSatsendring() = this.opprettetÅrsak == BehandlingÅrsak.SATSENDRING
+    fun erSatsendringNasjonal() = this.opprettetÅrsak == BehandlingÅrsak.SATSENDRING
 
     fun erMånedligValutajustering() = this.opprettetÅrsak == BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING
 
@@ -235,17 +235,17 @@ data class Behandling(
 
     fun erSvalbardtillegg() = this.opprettetÅrsak == BehandlingÅrsak.SVALBARDTILLEGG
 
-    fun erFinnmarksEllerSvalbardtillegg() = erFinnmarkstillegg() || erSvalbardtillegg()
+    fun erRegionstillegg() = erFinnmarkstillegg() || erSvalbardtillegg()
 
     fun erSatsendringEøs() = this.opprettetÅrsak == BehandlingÅrsak.SATSENDRING_EØS
 
-    fun erSatsendringEllerMånedligValutajustering() = erSatsendring() || erMånedligValutajustering()
+    fun erSatsendringNasjonalEllerMånedligValutajustering() = erSatsendringNasjonal() || erMånedligValutajustering()
 
-    fun erSatsEllerTilleggEndring() = erFinnmarksEllerSvalbardtillegg() || erSatsendringEllerMånedligValutajustering() || erSatsendringEøs()
+    fun erSatsendringMånedligValutajusteringEllerRegionstillegg() = erRegionstillegg() || erSatsendringNasjonalEllerMånedligValutajustering() || erSatsendringEøs()
 
     fun erOppdaterUtvidetKlassekode() = this.opprettetÅrsak == BehandlingÅrsak.OPPDATER_UTVIDET_KLASSEKODE
 
-    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsEllerTilleggEndring() || erSmåbarnstillegg() || erOmregning()
+    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsendringMånedligValutajusteringEllerRegionstillegg() || erSmåbarnstillegg() || erOmregning()
 
     fun erManuellMigreringForEndreMigreringsdato() =
         erMigrering() &&

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/Behandling.kt
@@ -168,6 +168,7 @@ data class Behandling(
             skalBehandlesAutomatisk && this.opprettetÅrsak == BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID && this.resultat == FORTSATT_INNVILGET -> true
             skalBehandlesAutomatisk && erMånedligValutajustering() -> true
             skalBehandlesAutomatisk && erFinnmarksEllerSvalbardtillegg() -> true
+            skalBehandlesAutomatisk && erSatsendringEøs() -> true
             else -> false
         }
 
@@ -236,13 +237,15 @@ data class Behandling(
 
     fun erFinnmarksEllerSvalbardtillegg() = erFinnmarkstillegg() || erSvalbardtillegg()
 
+    fun erSatsendringEøs() = this.opprettetÅrsak == BehandlingÅrsak.SATSENDRING_EØS
+
     fun erSatsendringEllerMånedligValutajustering() = erSatsendring() || erMånedligValutajustering()
 
-    fun erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg() = erFinnmarksEllerSvalbardtillegg() || erSatsendringEllerMånedligValutajustering()
+    fun erSatsEllerTilleggEndring() = erFinnmarksEllerSvalbardtillegg() || erSatsendringEllerMånedligValutajustering() || erSatsendringEøs()
 
     fun erOppdaterUtvidetKlassekode() = this.opprettetÅrsak == BehandlingÅrsak.OPPDATER_UTVIDET_KLASSEKODE
 
-    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg() || erSmåbarnstillegg() || erOmregning()
+    fun erAutomatiskOgSkalHaTidligereBehandling() = erSatsEllerTilleggEndring() || erSmåbarnstillegg() || erOmregning()
 
     fun erManuellMigreringForEndreMigreringsdato() =
         erMigrering() &&
@@ -373,6 +376,7 @@ enum class BehandlingÅrsak(
     FINNMARKSTILLEGG("Finnmarkstillegg"),
     SVALBARDTILLEGG("Svalbardtillegg"),
     FALSK_IDENTITET("Falsk identitet"),
+    SATSENDRING_EØS("Satsendring EØS"),
     ;
 
     fun erOmregningsårsak(): Boolean = this == OMREGNING_18ÅR || this == OMREGNING_SMÅBARNSTILLEGG

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -74,7 +74,7 @@ object BehandlingsresultatEndringUtils {
                     )
 
                 val erEndringIVilkårsvurderingForPerson =
-                    !behandling.erFinnmarksEllerSvalbardtillegg() &&
+                    !behandling.erRegionstillegg() &&
                         erEndringIVilkårsvurderingForPerson(
                             aktør = aktør,
                             nåværendePersonResultat = nåværendePersonResultat,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -26,7 +26,7 @@ class TilkjentYtelseValideringService(
     private val strengtFortroligService: StrengtFortroligService,
 ) {
     fun validerAtIngenUtbetalingerOverstiger100Prosent(behandling: Behandling) {
-        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring() || behandling.erMånedligValutajustering()) return
+        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring() || behandling.erMånedligValutajustering() || behandling.erSatsendringEøs()) return
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(behandling.id)
 
         if (totrinnskontroll?.godkjent == true) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -26,7 +26,7 @@ class TilkjentYtelseValideringService(
     private val strengtFortroligService: StrengtFortroligService,
 ) {
     fun validerAtIngenUtbetalingerOverstiger100Prosent(behandling: Behandling) {
-        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendring() || behandling.erMånedligValutajustering() || behandling.erSatsendringEøs()) return
+        if (behandling.erMigrering() || behandling.erTekniskEndring() || behandling.erSatsendringNasjonal() || behandling.erMånedligValutajustering() || behandling.erSatsendringEøs()) return
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(behandling.id)
 
         if (totrinnskontroll?.godkjent == true) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -29,7 +29,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val endreteUtbetalingerMedAndeler = lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
 
-        return if (!behandling.erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg()) {
+        return if (!behandling.erSatsEllerTilleggEndring()) {
             // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
             // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
             // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -29,7 +29,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         val behandling = behandlingHentOgPersisterService.hent(behandlingId)
         val endreteUtbetalingerMedAndeler = lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler()
 
-        return if (!behandling.erSatsEllerTilleggEndring()) {
+        return if (!behandling.erSatsendringMånedligValutajusteringEllerRegionstillegg()) {
             // Hvis noen valideringer feiler, så signalerer vi det til frontend ved å fjerne tilknyttede andeler
             // SB vil få en feilmelding og løsningen blir å slette eller oppdatere endringen
             // Da vil forhåpentligvis valideringen være ok, koblingene til andelene være beholdt

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadService.kt
@@ -34,7 +34,7 @@ class OvergangsstønadService(
         søkerAktør: Aktør,
         behandling: Behandling,
     ) {
-        if (behandling.erSatsEllerTilleggEndring()) {
+        if (behandling.erSatsendringMånedligValutajusteringEllerRegionstillegg()) {
             kopierPerioderMedOvergangsstønadFraForrigeBehandling(behandling)
         } else {
             hentOgLagrePerioderMedFullOvergangsstønadFraEf(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadService.kt
@@ -34,7 +34,7 @@ class OvergangsstønadService(
         søkerAktør: Aktør,
         behandling: Behandling,
     ) {
-        if (behandling.erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg()) {
+        if (behandling.erSatsEllerTilleggEndring()) {
             kopierPerioderMedOvergangsstønadFraForrigeBehandling(behandling)
         } else {
             hentOgLagrePerioderMedFullOvergangsstønadFraEf(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -251,7 +251,7 @@ class PersongrunnlagService(
     ): PersonopplysningGrunnlag {
         val nyttPersonopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
         val alleBarna = barnFraInneværendeBehandling.union(barnFraForrigeBehandling).toList()
-        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering()
+        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering() || behandling.erSatsendringEøs()
 
         val sisteBehandlingSomErVedtatt = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagService.kt
@@ -251,7 +251,7 @@ class PersongrunnlagService(
     ): PersonopplysningGrunnlag {
         val nyttPersonopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id)
         val alleBarna = barnFraInneværendeBehandling.union(barnFraForrigeBehandling).toList()
-        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringEllerMånedligValutajustering() || behandling.erSatsendringEøs()
+        val skalHenteEnkelPersonInfo = behandling.erMigrering() || behandling.erSatsendringNasjonalEllerMånedligValutajustering() || behandling.erSatsendringEøs()
 
         val sisteBehandlingSomErVedtatt = behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingSteg.kt
@@ -543,6 +543,21 @@ fun hentNesteSteg(
             }
         }
 
+        BehandlingÅrsak.SATSENDRING_EØS -> {
+            when (utførendeStegType) {
+                REGISTRERE_PERSONGRUNNLAG -> VILKÅRSVURDERING
+                VILKÅRSVURDERING -> BEHANDLINGSRESULTAT
+                BEHANDLINGSRESULTAT -> hentNesteStegTypeBasertPåOmDetErEndringIUtbetaling(endringerIUtbetaling)
+                IVERKSETT_MOT_OPPDRAG -> VENTE_PÅ_STATUS_FRA_ØKONOMI
+                VENTE_PÅ_STATUS_FRA_ØKONOMI -> JOURNALFØR_VEDTAKSBREV
+                JOURNALFØR_VEDTAKSBREV -> DISTRIBUER_VEDTAKSBREV
+                DISTRIBUER_VEDTAKSBREV -> FERDIGSTILLE_BEHANDLING
+                FERDIGSTILLE_BEHANDLING -> BEHANDLING_AVSLUTTET
+                BEHANDLING_AVSLUTTET -> BEHANDLING_AVSLUTTET
+                else -> throw Feil("Stegtype ${utførendeStegType.displayName()} er ikke implementert for behandling med årsak $behandlingÅrsak og type $behandlingType.")
+            }
+        }
+
         else -> {
             when (utførendeStegType) {
                 REGISTRERE_PERSONGRUNNLAG -> hentNesteStegBasertPåOmDetErInstitusjonEllerIkke(behandling)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
@@ -35,7 +35,7 @@ class BehandlingsresultatSteg(
         behandling: Behandling,
         stegService: StegService?,
     ) {
-        if (!behandling.erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg() && behandling.skalBehandlesAutomatisk) {
+        if (!behandling.erSatsEllerTilleggEndring() && behandling.skalBehandlesAutomatisk) {
             return
         }
 
@@ -61,7 +61,7 @@ class BehandlingsresultatSteg(
             behandlingsresultatstegValideringService.validerSvalbardtilleggBehandling(tilkjentYtelse)
         }
 
-        if (!behandling.erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg()) {
+        if (!behandling.erSatsEllerTilleggEndring()) {
             behandlingsresultatstegValideringService.validerEndredeUtbetalingsandeler(tilkjentYtelse)
             behandlingsresultatstegValideringService.validerKompetanse(behandling.id)
             behandlingsresultatstegValideringService.validerSekundærlandKompetanse(behandling.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
@@ -35,7 +35,7 @@ class BehandlingsresultatSteg(
         behandling: Behandling,
         stegService: StegService?,
     ) {
-        if (!behandling.erSatsEllerTilleggEndring() && behandling.skalBehandlesAutomatisk) {
+        if (!behandling.erSatsendringMånedligValutajusteringEllerRegionstillegg() && behandling.skalBehandlesAutomatisk) {
             return
         }
 
@@ -49,7 +49,7 @@ class BehandlingsresultatSteg(
 
         behandlingsresultatstegValideringService.validerAtUtenlandskPeriodebeløpOgValutakursErUtfylt(behandling = behandling)
 
-        if (behandling.erSatsendring()) {
+        if (behandling.erSatsendringNasjonal()) {
             behandlingsresultatstegValideringService.validerSatsendring(tilkjentYtelse)
         }
 
@@ -61,7 +61,7 @@ class BehandlingsresultatSteg(
             behandlingsresultatstegValideringService.validerSvalbardtilleggBehandling(tilkjentYtelse)
         }
 
-        if (!behandling.erSatsEllerTilleggEndring()) {
+        if (!behandling.erSatsendringMånedligValutajusteringEllerRegionstillegg()) {
             behandlingsresultatstegValideringService.validerEndredeUtbetalingsandeler(tilkjentYtelse)
             behandlingsresultatstegValideringService.validerKompetanse(behandling.id)
             behandlingsresultatstegValideringService.validerSekundærlandKompetanse(behandling.id)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -82,7 +82,7 @@ class VilkårsvurderingSteg(
                 vilkårsvurdering = this,
             )
 
-            if (behandling.erFinnmarksEllerSvalbardtillegg()) {
+            if (behandling.erRegionstillegg()) {
                 validerFinnmarkOgSvalbardBehandling(behandling = behandling, vilkårsvurdering = this)
             }
         }
@@ -123,7 +123,7 @@ class VilkårsvurderingSteg(
             utenlandskPeriodebeløpService.oppdaterBulgarskUtenlandskPeriodebeløpVedBehov(BehandlingId(behandling.id))
         }
 
-        if (!behandling.erSatsendring()) {
+        if (!behandling.erSatsendringNasjonal()) {
             tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id))
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
@@ -25,7 +25,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
         søkerIdent: String,
         barnasIdenter: List<String>,
     ) {
-        if (behandling.erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg() || behandling.erTekniskEndring() || behandling.erFalskIdentitet()) {
+        if (behandling.erSatsEllerTilleggEndring() || behandling.erTekniskEndring() || behandling.erFalskIdentitet()) {
             if (forrigeBehandlingSomErVedtatt == null) {
                 if (behandling.erTekniskEndring()) {
                     opprettPersonopplysningGrunnlag(behandling, null, søkerIdent, barnasIdenter)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingService.kt
@@ -25,7 +25,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
         søkerIdent: String,
         barnasIdenter: List<String>,
     ) {
-        if (behandling.erSatsEllerTilleggEndring() || behandling.erTekniskEndring() || behandling.erFalskIdentitet()) {
+        if (behandling.erSatsendringMånedligValutajusteringEllerRegionstillegg() || behandling.erTekniskEndring() || behandling.erFalskIdentitet()) {
             if (forrigeBehandlingSomErVedtatt == null) {
                 if (behandling.erTekniskEndring()) {
                     opprettPersonopplysningGrunnlag(behandling, null, søkerIdent, barnasIdenter)
@@ -37,7 +37,7 @@ class PersonopplysningGrunnlagForNyBehandlingService(
                 )
             }
 
-            if (behandling.erFinnmarksEllerSvalbardtillegg()) {
+            if (behandling.erRegionstillegg()) {
                 opprettKopiAvPersonopplysningGrunnlagMedNyAdresse(behandling, forrigeBehandlingSomErVedtatt, søkerIdent)
             } else if (behandling.erFalskIdentitet()) {
                 opprettKopiAvPersonopplysningGrunnlagMedFalskIdentitet(behandling, forrigeBehandlingSomErVedtatt, søkerIdent)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.FØDSELSH
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.HELMANUELL_MIGRERING
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SATSENDRING
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SATSENDRING_EØS
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SVALBARDTILLEGG
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SØKNAD
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -77,6 +78,7 @@ class VilkårsvurderingForNyBehandlingService(
             MÅNEDLIG_VALUTAJUSTERING,
             FINNMARKSTILLEGG,
             SVALBARDTILLEGG,
+            SATSENDRING_EØS,
             -> {
                 if (forrigeBehandlingSomErVedtatt == null) {
                     throw Feil("Kan ikke opprette behandling med årsak ${behandling.opprettetÅrsak} hvis det ikke finnes en tidligere behandling")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -165,7 +165,7 @@ class VilkårsvurderingForNyBehandlingService(
                     nyBehandling = inneværendeBehandling,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                 ).also {
-                    if (inneværendeBehandling.erFinnmarksEllerSvalbardtillegg()) {
+                    if (inneværendeBehandling.erRegionstillegg()) {
                         oppdaterUtdypendeVilkårForBosattIRiketMedFinnmarkOgSvalbardService.oppdaterUtdypendeVilkårForBosattIRiketMedFinnmarkOgSvalbard(vilkårsvurdering = it)
                     }
                 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -81,7 +81,7 @@ fun validerIkkeBlandetRegelverk(
     if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
         val feilmelding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna."
 
-        if (behandling.erSatsEllerTilleggEndring()) {
+        if (behandling.erSatsendringMånedligValutajusteringEllerRegionstillegg()) {
             logger.warn("$feilmelding Gjelder $behandling")
         } else {
             throw FunksjonellFeil(melding = feilmelding)
@@ -97,7 +97,7 @@ fun valider18ÅrsVilkårEksistererFraFødselsdato(
     vilkårsvurdering.personResultater.forEach { personResultat ->
         val person = søkerOgBarn.find { it.aktør == personResultat.aktør }
         if (person?.type == PersonType.BARN && !personResultat.vilkårResultater.finnesUnder18VilkårFraFødselsdato(person.fødselsdato)) {
-            if (behandling.erSatsEllerTilleggEndring() || behandling.opprettetÅrsak.erOmregningsårsak()) {
+            if (behandling.erSatsendringMånedligValutajusteringEllerRegionstillegg() || behandling.opprettetÅrsak.erOmregningsårsak()) {
                 secureLogger.warn(
                     "Fødselsdato ${person.fødselsdato} ulik fom ${
                         personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValidering.kt
@@ -81,7 +81,7 @@ fun validerIkkeBlandetRegelverk(
     if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
         val feilmelding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna."
 
-        if (behandling.erSatsendringEllerMånedligValutajustering() || behandling.erFinnmarksEllerSvalbardtillegg()) {
+        if (behandling.erSatsEllerTilleggEndring()) {
             logger.warn("$feilmelding Gjelder $behandling")
         } else {
             throw FunksjonellFeil(melding = feilmelding)
@@ -97,7 +97,7 @@ fun valider18ÅrsVilkårEksistererFraFødselsdato(
     vilkårsvurdering.personResultater.forEach { personResultat ->
         val person = søkerOgBarn.find { it.aktør == personResultat.aktør }
         if (person?.type == PersonType.BARN && !personResultat.vilkårResultater.finnesUnder18VilkårFraFødselsdato(person.fødselsdato)) {
-            if (behandling.erSatsendringMånedligValutajusteringFinnmarkstilleggEllerSvalbardtillegg() || behandling.opprettetÅrsak.erOmregningsårsak()) {
+            if (behandling.erSatsEllerTilleggEndring() || behandling.opprettetÅrsak.erOmregningsårsak()) {
                 secureLogger.warn(
                     "Fødselsdato ${person.fødselsdato} ulik fom ${
                         personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.UNDER_18_ÅR }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -118,7 +118,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal kaste Feil hvis forrige behandling er null for automatiske behandlinger som skal ha tidligere behandlinger`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val behandling = lagBehandling(årsak = behandlingÅrsak)
@@ -132,7 +132,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal sette 4863 til behandlende enhet dersom ingen av de tidligere behandlingene har hatt en annen behandlende enhet enn 4863`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()
@@ -166,7 +166,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal sette behandlende enhet til en gyldig enhet dersom en av de tidligere behandlingene har hatt en annen behandlende enhet enn 4863`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()
@@ -192,7 +192,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal ikke gjøre noe dersom aktiv behandlende enhet finnes`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()
@@ -399,7 +399,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal bruke ny enhet fra NORG hvis forrige enhet var 4817`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()
@@ -435,7 +435,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal bruke ny enhet fra NORG hvis forrige enhet var 4863`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()
@@ -471,7 +471,7 @@ class ArbeidsfordelingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"], mode = EnumSource.Mode.INCLUDE)
+        @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"], mode = EnumSource.Mode.INCLUDE)
         fun `fastsettBehandlendeEnhet skal bruke ny enhet hvis ny enhet fra NORG er 4863`(behandlingÅrsak: BehandlingÅrsak) {
             // Arrange
             val forrigeBehandling = lagBehandling()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
@@ -126,7 +126,7 @@ class BehandlingTest {
             val behandling = lagBehandling(årsak = BehandlingÅrsak.FINNMARKSTILLEGG)
 
             // Act
-            val erFinnmarksEllerSvalbardtillegg = behandling.erFinnmarksEllerSvalbardtillegg()
+            val erFinnmarksEllerSvalbardtillegg = behandling.erRegionstillegg()
 
             // Assert
             assertThat(erFinnmarksEllerSvalbardtillegg).isTrue()
@@ -138,7 +138,7 @@ class BehandlingTest {
             val behandling = lagBehandling(årsak = BehandlingÅrsak.SVALBARDTILLEGG)
 
             // Act
-            val erFinnmarksEllerSvalbardtillegg = behandling.erFinnmarksEllerSvalbardtillegg()
+            val erFinnmarksEllerSvalbardtillegg = behandling.erRegionstillegg()
 
             // Assert
             assertThat(erFinnmarksEllerSvalbardtillegg).isTrue()
@@ -150,7 +150,7 @@ class BehandlingTest {
             val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
 
             // Act
-            val erFinnmarksEllerSvalbardtillegg = behandling.erFinnmarksEllerSvalbardtillegg()
+            val erFinnmarksEllerSvalbardtillegg = behandling.erRegionstillegg()
 
             // Assert
             assertThat(erFinnmarksEllerSvalbardtillegg).isFalse()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingTest.kt
@@ -237,6 +237,18 @@ class BehandlingTest {
             assertThat(erBehandlingMedVedtaksbrevutsending).isFalse()
         }
 
+        @Test
+        fun `kan sende vedtaksbrev for revurdering med årsak satsendring EØS`() {
+            // Arrange
+            val behandling = lagBehandling(behandlingType = BehandlingType.REVURDERING, årsak = BehandlingÅrsak.SATSENDRING_EØS)
+
+            // Act
+            val erBehandlingMedVedtaksbrevutsending = behandling.erBehandlingMedVedtaksbrevutsending()
+
+            // Assert
+            assertThat(erBehandlingMedVedtaksbrevutsending).isTrue()
+        }
+
         @ParameterizedTest
         @EnumSource(value = Behandlingsresultat::class, names = ["FORTSATT_INNVILGET", "FORTSATT_OPPHØRT"])
         fun `skal returnere false om behandlingsårsak er svalbardtillegg og behandlingsresultatet er FORTSATT_INNVILGET eller FORTSATT_OPPHØRT`(
@@ -271,8 +283,8 @@ class BehandlingTest {
     @Nested
     inner class SkalRettFraBehandlingsresultatTilIverksetting {
         @ParameterizedTest
-        @EnumSource(value = BehandlingÅrsak::class, names = ["FINNMARKSTILLEGG", "SVALBARDTILLEGG"])
-        fun `skal returnere true om behandlingen skal behandles automatisk og behandlingsårsak er finnmarkstillegg eller svalbardstillegg`(
+        @EnumSource(value = BehandlingÅrsak::class, names = ["FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"])
+        fun `skal returnere true om behandlingen skal behandles automatisk og behandlingsårsak er finnmarkstillegg, svalbardtillegg eller satsendring EØS`(
             behandlingÅrsak: BehandlingÅrsak,
         ) {
             // Arrange
@@ -291,7 +303,7 @@ class BehandlingTest {
         @ParameterizedTest
         @EnumSource(
             value = BehandlingÅrsak::class,
-            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"],
+            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"],
             mode = EnumSource.Mode.INCLUDE,
         )
         fun `skal returnere true for gitte behandlingsårsaker`(behandlingÅrsak: BehandlingÅrsak) {
@@ -308,7 +320,7 @@ class BehandlingTest {
         @ParameterizedTest
         @EnumSource(
             value = BehandlingÅrsak::class,
-            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"],
+            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SMÅBARNSTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"],
             mode = EnumSource.Mode.EXCLUDE,
         )
         fun `skal returnere false for gitte behandlingsårsaker`(behandlingÅrsak: BehandlingÅrsak) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -45,8 +45,8 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
     @Nested
     inner class FinnEndreteUtbetalingerMedAndelerTilkjentYtelse {
         @ParameterizedTest
-        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"])
-        fun `For behandling med årsak satsendring, månedlig valutajustering finnmarkstillegg og svalbardtillegg blir ikke endrete utbetalinger filtrert bort`(
+        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"])
+        fun `For behandling med årsak satsendring, månedlig valutajustering, finnmarkstillegg, svalbardtillegg og satsendring EØS blir ikke endrete utbetalinger filtrert bort`(
             årsak: BehandlingÅrsak,
         ) {
             val behandling =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadServiceTest.kt
@@ -55,7 +55,7 @@ class OvergangsstønadServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
+    @EnumSource(BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SATSENDRING_EØS"])
     fun `Ved satsendring og månedlig valutajustering skal gamle perioder kopieres`(
         årsak: BehandlingÅrsak,
     ) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingStegTest.kt
@@ -1779,6 +1779,105 @@ class BehandlingStegTest {
         }
 
         @Nested
+        inner class SatsendringEøs {
+            @ParameterizedTest(name = "Henter neste steg for {0}")
+            @CsvSource(
+                "REGISTRERE_PERSONGRUNNLAG, VILKÅRSVURDERING",
+                "VILKÅRSVURDERING, BEHANDLINGSRESULTAT",
+                "BEHANDLINGSRESULTAT, IVERKSETT_MOT_OPPDRAG",
+                "IVERKSETT_MOT_OPPDRAG, VENTE_PÅ_STATUS_FRA_ØKONOMI",
+                "VENTE_PÅ_STATUS_FRA_ØKONOMI, JOURNALFØR_VEDTAKSBREV",
+                "JOURNALFØR_VEDTAKSBREV, DISTRIBUER_VEDTAKSBREV",
+                "DISTRIBUER_VEDTAKSBREV, FERDIGSTILLE_BEHANDLING",
+                "FERDIGSTILLE_BEHANDLING, BEHANDLING_AVSLUTTET",
+                "BEHANDLING_AVSLUTTET, BEHANDLING_AVSLUTTET",
+            )
+            fun `skal hente neste steg med endringer i utbetaling`(
+                nåværendeSteg: StegType,
+                forventetResultat: StegType,
+            ) {
+                // Arrange
+                val behandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING_EØS)
+
+                // Act
+                val nesteSteg =
+                    hentNesteSteg(
+                        behandling = behandling,
+                        utførendeStegType = nåværendeSteg,
+                        endringerIUtbetaling = EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING,
+                    )
+
+                // Assert
+                assertThat(nesteSteg).isEqualTo(forventetResultat)
+            }
+
+            @ParameterizedTest(name = "Henter neste steg for {0}")
+            @CsvSource(
+                "REGISTRERE_PERSONGRUNNLAG, VILKÅRSVURDERING",
+                "VILKÅRSVURDERING, BEHANDLINGSRESULTAT",
+                "BEHANDLINGSRESULTAT, JOURNALFØR_VEDTAKSBREV",
+                "JOURNALFØR_VEDTAKSBREV, DISTRIBUER_VEDTAKSBREV",
+                "DISTRIBUER_VEDTAKSBREV, FERDIGSTILLE_BEHANDLING",
+                "FERDIGSTILLE_BEHANDLING, BEHANDLING_AVSLUTTET",
+                "BEHANDLING_AVSLUTTET, BEHANDLING_AVSLUTTET",
+            )
+            fun `skal hente neste steg uten endringer i utbetaling`(
+                nåværendeSteg: StegType,
+                forventetResultat: StegType,
+            ) {
+                // Arrange
+                val behandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING_EØS)
+
+                // Act
+                val nesteSteg =
+                    hentNesteSteg(
+                        behandling = behandling,
+                        utførendeStegType = nåværendeSteg,
+                        endringerIUtbetaling = EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING,
+                    )
+
+                // Assert
+                assertThat(nesteSteg).isEqualTo(forventetResultat)
+            }
+
+            @Test
+            fun `skal kaste exception ved BEHANDLINGSRESULTAT når endringer i utbetaling ikke er utledet`() {
+                // Arrange
+                val behandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING_EØS)
+
+                // Act & assert
+                val exception =
+                    assertThrows<Feil> {
+                        hentNesteSteg(
+                            behandling = behandling,
+                            utførendeStegType = StegType.BEHANDLINGSRESULTAT,
+                            endringerIUtbetaling = EndringerIUtbetalingForBehandlingSteg.IKKE_RELEVANT,
+                        )
+                    }
+                assertThat(exception.message).isEqualTo("Endringer i utbetaling må utledes før man kan gå videre til neste steg.")
+            }
+
+            @Test
+            fun `skal kaste exception om stegtype ikke er støttet`() {
+                // Arrange
+                val behandling = lagBehandling(årsak = BehandlingÅrsak.SATSENDRING_EØS)
+
+                // Act & assert
+                val exception =
+                    assertThrows<Feil> {
+                        hentNesteSteg(
+                            behandling = behandling,
+                            utførendeStegType = StegType.REGISTRERE_INSTITUSJON,
+                            endringerIUtbetaling = EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING,
+                        )
+                    }
+                assertThat(exception.message).isEqualTo(
+                    "Stegtype ${StegType.REGISTRERE_INSTITUSJON.displayName()} er ikke implementert for behandling med årsak ${behandling.opprettetÅrsak} og type ${behandling.type}.",
+                )
+            }
+        }
+
+        @Nested
         inner class ÅrligKontroll {
             @ParameterizedTest(name = "Henter neste steg for {0}")
             @CsvSource(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatStegTest.kt
@@ -117,7 +117,7 @@ class BehandlingsresultatStegTest {
         @ParameterizedTest
         @EnumSource(
             value = BehandlingÅrsak::class,
-            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"],
+            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"],
             mode = EXCLUDE,
         )
         fun `skal ikke valideres om behandlingen ikke har riktig årsak for behandling som skal automatisk behandles`(
@@ -189,7 +189,7 @@ class BehandlingsresultatStegTest {
         @ParameterizedTest
         @EnumSource(
             value = BehandlingÅrsak::class,
-            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"],
+            names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"],
             mode = EXCLUDE,
         )
         fun `skal validere endrede utbetalinger og kompetanse`(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
@@ -109,8 +109,8 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING"])
-        fun `skal kopiere persongrunnlaget fra forrige behandling ved satsendring og månedlig valutajustering`(
+        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "SATSENDRING_EØS"])
+        fun `skal kopiere persongrunnlaget fra forrige behandling ved satsendring, månedlig valutajustering og satsendring EØS`(
             årsak: BehandlingÅrsak,
         ) {
             val forrigeBehandling = lagBehandling()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingValideringTest.kt
@@ -71,7 +71,7 @@ class VilkårsvurderingValideringTest {
         }
 
         @ParameterizedTest(name = "skal ikke kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS om det er av årsak {0}")
-        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG"])
+        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "SATSENDRING_EØS"])
         fun `skal ikke kaste feil hvis søker vurderes etter nasjonal og minst ett barn etter EØS om årsak er en av typene`(
             behandlingÅrsak: BehandlingÅrsak,
         ) {
@@ -243,7 +243,7 @@ class VilkårsvurderingValideringTest {
         }
 
         @ParameterizedTest
-        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG"])
+        @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING", "MÅNEDLIG_VALUTAJUSTERING", "FINNMARKSTILLEGG", "SVALBARDTILLEGG", "OMREGNING_18ÅR", "OMREGNING_SMÅBARNSTILLEGG", "SATSENDRING_EØS"])
         fun `skal ikke kaste feil for gitte behandlingsårsaker selv om barn ikke har 18-års vilkår vurdert fra fødselsdato`(
             årsak: BehandlingÅrsak,
         ) {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
@@ -375,7 +375,7 @@ class RestartAvSmåbarnstilleggTest(
     ) {
         unmockkObject(SatsTidspunkt)
         autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(fagsakId, satsendringsTidspunkt))
-        val satsendring = behandlingHentOgPersisterService.hentBehandlinger(fagsakId).first { it.erSatsendring() }
+        val satsendring = behandlingHentOgPersisterService.hentBehandlinger(fagsakId).first { it.erSatsendringNasjonal() }
 
         val iverksattBehandling =
             håndterIverksettingAvBehandling(


### PR DESCRIPTION
### 📮 Favro: NAV-29741

### 💰 Hva skal gjøres, og hvorfor?

Del 2 av EØS-satsendring-løypen. Kobler `BehandlingÅrsak.SATSENDRING_EØS` inn i behandlingsinfrastrukturen slik at en automatisk revurdering med denne årsaken rutes korrekt gjennom stegene — uten at noe oppretter slike behandlinger ennå. Oppdatering av UtenlandskPeriodebeløp, resultatvalidering og orkestrering (task/endepunkt) kommer i senere PR-er.

`SATSENDRING_EØS` har sin egen dedikerte steg-gren og sender alltid brev, uavhengig av om det er endring i utbetaling:

**Med endring i utbetaling:** REGISTRERE_PERSONGRUNNLAG → VILKÅRSVURDERING → BEHANDLINGSRESULTAT → IVERKSETT_MOT_OPPDRAG → VENTE_PÅ_STATUS_FRA_ØKONOMI → JOURNALFØR_VEDTAKSBREV → DISTRIBUER_VEDTAKSBREV → FERDIGSTILLE_BEHANDLING

**Uten endring i utbetaling:** BEHANDLINGSRESULTAT → JOURNALFØR_VEDTAKSBREV → DISTRIBUER_VEDTAKSBREV → FERDIGSTILLE_BEHANDLING

Endringer:
- `Behandling.kt`: ny `erSatsendringEøs()`, `SATSENDRING_EØS` inn i den brede grupperingshjelperen (omdøpt til `erSatsEllerTilleggEndring`), ny gren i `skalRettFraBehandlingsresultatTilIverksetting`
- `BehandlingSteg.kt`: `SATSENDRING_EØS` får en dedikert `when`-gren — skiller seg fra SATSENDRING/MÅNEDLIG_VALUTAJUSTERING (ingen brev) og FINNMARKSTILLEGG/SVALBARDTILLEGG (ingen brev ved uendret utbetaling) ved at brev alltid sendes
- `VilkårsvurderingForNyBehandlingService.kt`: vilkårsvurdering kopieres uendret fra forrige behandling
- `PersongrunnlagService.kt`: henter enkel personinfo (ikke full PDL-kjøring)
- `VilkårsvurderingValidering.kt`: blandet regelverk gir warn, ikke kast
- `TilkjentYtelseValideringService.kt`: hopper over 100 %-validering
- `pom.xml`: bump `familie-eksterne-kontrakter` stonadsstatistikk for å inkludere `SATSENDRING_EØS` i `BehandlingÅrsakV2`

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.