### PR TITLE
EøsSatsendringService: oppdater UtenlandskPeriodebeløp med siste EØS-sats

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
@@ -1,11 +1,12 @@
 package no.nav.familie.ba.sak.kjerne.eøs.sats
 
+import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import java.math.BigDecimal
 import java.time.YearMonth
 
 /**
- * Representerer en EØS-sats fra et bestemt land i landets valuta og utbetalingsintervall.
+ * Representerer en sats fra et bestemt EØS-land i landets valuta og utbetalingsintervall.
  *
  * Beløpet angir det utenlandske periodebeløpet som utbetales fra [land],
  * i valutaen [valuta] og med hyppigheten [intervall].
@@ -22,4 +23,6 @@ data class EøsSats(
     val intervall: Intervall = Intervall.MÅNEDLIG,
 ) {
     fun erGyldigForMåned(måned: YearMonth): Boolean = måned >= fom && (tom == null || måned <= tom)
+
+    override fun toString() = "${javaClass.simpleName}(land='$land', valuta='$valuta', beløp=$beløp, fom=${fom.tilKortString()}, tom=${tom?.tilKortString()}, intervall=$intervall)"
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsService.kt
@@ -23,9 +23,9 @@ object EøsSatsService {
     /**
      * @return gjeldende sats for et land i en gitt måned eller null dersom ingen sats er registrert for landet i den aktuelle måneden.
      */
-    fun finnGjeldendeSatsForLand(
+    fun finnSatsForLandIMåned(
         land: String,
-        måned: YearMonth = YearMonth.now(),
+        måned: YearMonth,
     ): EøsSats? =
         satser
             .find { it.land == land }
@@ -33,10 +33,13 @@ object EøsSatsService {
             ?.find { it.erGyldigForMåned(måned) }
 
     /**
-     * @return den nyeste satsen for et land.
-     * @throws [Feil] dersom ingen sats er registrert for landet.
+     * @return gjeldende sats for et land i en gitt måned
+     * @throws [Feil] hvis ingen sats er registrert for landet i den aktuelle måneden.
      */
-    fun hentSisteSatsForLand(land: String): EøsSats =
-        satser.find { it.land == land }?.satser?.maxByOrNull { it.fom }
-            ?: throw Feil("Ingen EØS-sats registrert for land: $land")
+    fun hentSatsForLandIMåned(
+        land: String,
+        måned: YearMonth,
+    ): EøsSats =
+        finnSatsForLandIMåned(land, måned)
+            ?: throw Feil("Ingen EØS-sats registrert for land $land i måned $måned.")
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatser.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatser.kt
@@ -1,25 +1,14 @@
 package no.nav.familie.ba.sak.kjerne.eøs.sats
 
 /**
- * Abstrakt klasse som representerer alle registrerte EØS-satser for ett bestemt land.
+ * Sealed klasse som representerer alle registrerte satser for ett bestemt EØS-land.
  *
- * Hvert land som har EØS-satser i systemet oppretter et eget `object` som arver fra denne klassen,
+ * Hvert land som har satser i systemet oppretter et eget `object` som arver fra denne klassen,
  * og legger inn sine satser i [satser]-listen.
  *
- * Eksempel på bruk:
- * ```kotlin
- * object EøsSatserPolen : EøsSatser() {
- *     override val land = "PL"
- *     override val satser = listOf(
- *         EøsSats(land = "PL", valuta = "PLN", intervall = Intervall.MÅNEDLIG,
- *                 beløp = BigDecimal("800"), fom = YearMonth.of(2025, 1)),
- *     )
- * }
- * ```
- *
- * Nye land registreres i [EøsSatsService.satser].
+ * @sample EøsSatserPolen
  */
-abstract class EøsSatser {
+sealed class EøsSatser {
     abstract val land: String
     abstract val satser: List<EøsSats>
 
@@ -29,7 +18,7 @@ abstract class EøsSatser {
 }
 
 /**
- * EØS-satser for Polen (PL) i polske zloty (PLN).
+ * Satser for Polen (PL).
  */
 object EøsSatserPolen : EøsSatser() {
     override val land = "PL"

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegister.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegister.kt
@@ -1,24 +1,22 @@
 package no.nav.familie.ba.sak.kjerne.eøs.sats
 
 import no.nav.familie.ba.sak.common.Feil
-import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.satser
 import java.time.YearMonth
 
 /**
- * Hardkodet register over EØS-satser per land, analogt med [no.nav.familie.ba.sak.kjerne.beregning.SatsService].
+ * Hardkodet register over satser per EØS-land.
  *
- * Nye land legges til i [satser] som egne [EøsSatser]-objekter.
- * Satser innen hvert land vedlikeholdes i den tilhørende filen (f.eks. [EøsSatserPolen]).
+ * Satser for hvert land legges til i [hei](./EøsSatser.kt) vedlikeholdes i den tilhørende filen (f.eks. [EøsSatserPolen]).
+ *
  */
-object EøsSatsService {
+object EøsSatserRegister {
     /**
      * Register over alle land med EØS-satser.
-     * Nye land registreres her når de legges til i systemet.
      */
     internal val satser: List<EøsSatser> =
-        listOf(
-            EøsSatserPolen,
-        )
+        EøsSatser::class
+            .sealedSubclasses
+            .map { it.objectInstance ?: error("${it.simpleName} må være object") }
 
     /**
      * @return gjeldende sats for et land i en gitt måned eller null dersom ingen sats er registrert for landet i den aktuelle måneden.

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
@@ -1,0 +1,134 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.common.AutovedtakSkalIkkeGjennomføresFeil
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.konverterBeløpTilMånedlig
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.hentSatsForLandIMåned
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.filtrerErUtfylt
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SatsendringEøsService(
+    private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService,
+    private val satsendringEøsKjøringService: SatsendringEøsKjøringService,
+) {
+    /**
+     * Oppdaterer alle [UtenlandskPeriodebeløp] på [behandlingId] der
+     * [utbetalingsland][UtenlandskPeriodebeløp.utbetalingsland] matcher utbetalingslandet
+     * registrert i den tilhørende [SatsendringEøsKjøringService]-kjøringen.
+     *
+     * @throws [Feil] hvis ingen kjøring er registrert for [behandlingId], eller hvis ny sats
+     *   eller forrige sats ikke finnes for utbetalingslandet.
+     * @throws [AutovedtakSkalIkkeGjennomføresFeil] hvis ingen [UtenlandskPeriodebeløp] ble
+     *   oppdatert — f.eks. fordi alle perioder allerede har ny sats eller ikke overlapper den.
+     */
+    @Transactional
+    fun oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId: BehandlingId) {
+        val kjøring = satsendringEøsKjøringService.hentSatsendringEøsKjøring(behandlingId.id)
+        val nySats = hentSatsForLandIMåned(kjøring.utbetalingsland, kjøring.satsTidspunkt)
+        val forrigeSats = hentSatsForLandIMåned(kjøring.utbetalingsland, nySats.fom.minusMonths(1))
+
+        val antallOppdaterteUtenlandskPeriodebeløp =
+            utenlandskPeriodebeløpService
+                .hentUtenlandskePeriodebeløp(behandlingId)
+                .filtrerErUtfylt()
+                .filter { it.utbetalingsland == nySats.land }
+                .filter { oppdaterMedNySats(it, forrigeSats, nySats) }
+                .size
+
+        if (antallOppdaterteUtenlandskPeriodebeløp == 0) {
+            throw AutovedtakSkalIkkeGjennomføresFeil(
+                "Ingen UtenlandskPeriodebeløp trenger oppdatering for behandling ${behandlingId.id}.",
+            )
+        }
+    }
+
+    /**
+     * Forsøker å oppdatere [utenlandskPeriodebeløp] fra [forrigeSats] til [nySats].
+     *
+     * Returnerer `true` hvis [utenlandskPeriodebeløp] ble oppdatert, `false` hvis perioden
+     * ikke overlapper [nySats] eller beløpet allerede er lik [nySats].
+     *
+     * @throws [AutovedtakMåBehandlesManueltFeil] via
+     *   [validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk] hvis periodebeløpet ikke kan
+     *   oppdateres automatisk.
+     */
+    private fun oppdaterMedNySats(
+        utenlandskPeriodebeløp: UtfyltUtenlandskPeriodebeløp,
+        forrigeSats: EøsSats,
+        nySats: EøsSats,
+    ): Boolean {
+        if (!utenlandskPeriodebeløp.overlapper(nySats)) return false
+        if (nySats.beløp.compareTo(utenlandskPeriodebeløp.beløp) == 0) return false
+
+        validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(utenlandskPeriodebeløp, forrigeSats, nySats)
+
+        val nyttUtenlandskPeriodebeløp =
+            UtenlandskPeriodebeløp(
+                fom = maxOf(nySats.fom, utenlandskPeriodebeløp.fom),
+                tom = utenlandskPeriodebeløp.tom,
+                barnAktører = utenlandskPeriodebeløp.barnAktører,
+                beløp = nySats.beløp,
+                valutakode = nySats.valuta,
+                intervall = nySats.intervall,
+                utbetalingsland = utenlandskPeriodebeløp.utbetalingsland,
+                kalkulertMånedligBeløp = nySats.intervall.konverterBeløpTilMånedlig(nySats.beløp),
+            )
+
+        utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(BehandlingId(utenlandskPeriodebeløp.behandlingId), nyttUtenlandskPeriodebeløp)
+
+        return true
+    }
+
+    /**
+     * Validerer at [utenlandskPeriodebeløp] kan oppdateres automatisk til [nySats].
+     *
+     * @throws [AutovedtakMåBehandlesManueltFeil] hvis ett av følgende krav ikke er oppfylt:
+     * - Beløp i [utenlandskPeriodebeløp] er lik beløp i [forrigeSats] (uendret siden forrige satsendring)
+     * - Valuta i [utenlandskPeriodebeløp] er lik valuta i [nySats]
+     * - Intervall i [utenlandskPeriodebeløp] er lik intervall i [nySats]
+     */
+    private fun validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
+        utenlandskPeriodebeløp: UtfyltUtenlandskPeriodebeløp,
+        forrigeSats: EøsSats,
+        nySats: EøsSats,
+    ) {
+        val behandlingId = utenlandskPeriodebeløp.behandlingId
+        val utbetalingsland = utenlandskPeriodebeløp.utbetalingsland
+        val valutakode = utenlandskPeriodebeløp.valutakode
+        val beløp = utenlandskPeriodebeløp.beløp
+        val intervall = utenlandskPeriodebeløp.intervall
+
+        if (forrigeSats.beløp.compareTo(beløp) != 0) {
+            throw AutovedtakMåBehandlesManueltFeil(
+                "UtenlandskPeriodebeløp for behandling $behandlingId og land $utbetalingsland " +
+                    "har beløp $beløp $valutakode, mens forrige EØS-sats har beløp ${forrigeSats.beløp} ${forrigeSats.valuta}.",
+            )
+        }
+
+        if (nySats.valuta != valutakode) {
+            throw AutovedtakMåBehandlesManueltFeil(
+                "UtenlandskPeriodebeløp for behandling $behandlingId og land $utbetalingsland " +
+                    "har valuta $valutakode, mens ny EØS-sats har valuta ${nySats.valuta}.",
+            )
+        }
+
+        if (nySats.intervall != intervall) {
+            throw AutovedtakMåBehandlesManueltFeil(
+                "UtenlandskPeriodebeløp for behandling $behandlingId og land $utbetalingsland " +
+                    "har intervall $intervall, mens ny EØS-sats har intervall ${nySats.intervall}.",
+            )
+        }
+    }
+}
+
+private fun UtfyltUtenlandskPeriodebeløp.overlapper(eøsSats: EøsSats): Boolean =
+    (this.tom == null || eøsSats.fom <= this.tom) &&
+        (eøsSats.tom == null || this.fom <= eøsSats.tom)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
@@ -6,11 +6,12 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.konverterBeløpTilMånedlig
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
-import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.hentSatsForLandIMåned
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister.hentSatsForLandIMåned
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.filtrerErUtfylt
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -65,8 +66,14 @@ class SatsendringEøsService(
         forrigeSats: EøsSats,
         nySats: EøsSats,
     ): Boolean {
-        if (!utenlandskPeriodebeløp.overlapper(nySats)) return false
-        if (nySats.beløp.compareTo(utenlandskPeriodebeløp.beløp) == 0) return false
+        if (!utenlandskPeriodebeløp.overlapper(nySats)) {
+            logger.info("UtenlandskPeriodebeløp ${utenlandskPeriodebeløp.id} overlapper ikke ny sats $nySats.")
+            return false
+        }
+        if (nySats.beløp.compareTo(utenlandskPeriodebeløp.beløp) == 0) {
+            logger.info("UtenlandskPeriodebeløp ${utenlandskPeriodebeløp.id} er allerede oppdatert med ny sats $nySats.")
+            return false
+        }
 
         validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(utenlandskPeriodebeløp, forrigeSats, nySats)
 
@@ -127,8 +134,12 @@ class SatsendringEøsService(
             )
         }
     }
-}
 
-private fun UtfyltUtenlandskPeriodebeløp.overlapper(eøsSats: EøsSats): Boolean =
-    (this.tom == null || eøsSats.fom <= this.tom) &&
-        (eøsSats.tom == null || this.fom <= eøsSats.tom)
+    private fun UtfyltUtenlandskPeriodebeløp.overlapper(eøsSats: EøsSats): Boolean =
+        (this.tom == null || eøsSats.fom <= this.tom) &&
+            (eøsSats.tom == null || this.fom <= eøsSats.tom)
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ba.sak.kjerne.eøs.endringsabonnement.TilpassKompetanserTilRegelverkService
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.sats.SatsendringEøsService
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.AutomatiskOppdaterValutakursService
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
@@ -49,6 +50,7 @@ class VilkårsvurderingSteg(
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
     private val registrertSøknadstidspunktService: RegistrertSøknadstidspunktPåPersonService,
     private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService,
+    private val satsendringEøsService: SatsendringEøsService,
 ) : BehandlingSteg<List<String>?> {
     override fun preValiderSteg(
         behandling: Behandling,
@@ -133,6 +135,10 @@ class VilkårsvurderingSteg(
 
         if (behandling.erMånedligValutajustering()) {
             månedligValutajusteringService.oppdaterValutakurserFraOgMedInneværendeMåned(BehandlingId(behandling.id))
+        }
+
+        if (behandling.erSatsendringEøs()) {
+            satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(BehandlingId(behandling.id))
         }
 
         automatiskOppdaterValutakursService.oppdaterAndelerMedValutakurser(BehandlingId(behandling.id))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -712,6 +712,7 @@ class CucumberMock(
             endretUtbetalingAndelService = endretUtbetalingAndelService,
             registrertSøknadstidspunktService = mockk(relaxed = true),
             utenlandskPeriodebeløpService = utenlandskPeriodebeløpService,
+            satsendringEøsService = mockk(relaxed = true),
         )
 
     val stegService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsServiceTest.kt
@@ -4,13 +4,10 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.unmockkObject
-import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
-import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.finnGjeldendeSatsForLand
-import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.hentSisteSatsForLand
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.finnSatsForLandIMåned
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -92,16 +89,16 @@ class EøsSatsServiceTest {
     }
 
     @Nested
-    inner class FinnGjeldendeSatsForLand {
+    inner class FinnSatsForLandIMåned {
         @Test
         fun `Returnerer korrekt sats for måned inni gyldig periode`() {
-            assertThat(finnGjeldendeSatsForLand("PL", YearMonth.of(2024, 6))).isEqualTo(polskSats2024)
+            assertThat(finnSatsForLandIMåned("PL", YearMonth.of(2024, 6))).isEqualTo(polskSats2024)
         }
 
         @Test
         fun `Returnerer løpende sats for måned etter siste fom`() {
             // Act
-            val resultat = finnGjeldendeSatsForLand("PL", YearMonth.of(2025, 6))
+            val resultat = finnSatsForLandIMåned("PL", YearMonth.of(2025, 6))
 
             // Assert
             assertThat(resultat).isEqualTo(polskSats2025)
@@ -110,7 +107,7 @@ class EøsSatsServiceTest {
 
         @Test
         fun `Returnerer null for måned før noen satser`() {
-            assertThat(finnGjeldendeSatsForLand("PL", YearMonth.of(2023, 12))).isNull()
+            assertThat(finnSatsForLandIMåned("PL", YearMonth.of(2023, 12))).isNull()
         }
 
         @Test
@@ -119,43 +116,12 @@ class EøsSatsServiceTest {
             every { EøsSatserPolen.satser } returns emptyList()
 
             // Act & Assert
-            assertThat(finnGjeldendeSatsForLand("PL")).isNull()
+            assertThat(finnSatsForLandIMåned("PL", YearMonth.now())).isNull()
         }
     }
 
     @Nested
-    inner class HentSisteSatsForLand {
-        @Test
-        fun `Returnerer satsen med høyest fom for landet`() {
-            // Act
-            val resultat = hentSisteSatsForLand("PL")
-
-            // Assert
-            assertThat(resultat.beløp).isEqualTo(BigDecimal("900"))
-            assertThat(resultat.fom).isEqualTo(YearMonth.of(2025, 1))
-        }
-
-        @Test
-        fun `Returnerer eneste sats dersom kun én er registrert for landet`() {
-            // Arrange
-            every { EøsSatserPolen.satser } returns listOf(polskSats2024)
-
-            // Act & Assert
-            assertThat(hentSisteSatsForLand("PL")).isEqualTo(polskSats2024)
-        }
-
-        @Test
-        fun `Kaster Feil dersom ingen sats er registrert for landet`() {
-            // Arrange
-            every { EøsSatserPolen.satser } returns emptyList()
-
-            // Act & Assert
-            assertThatThrownBy { hentSisteSatsForLand("PL") }.isInstanceOf(Feil::class.java)
-        }
-    }
-
-    @Nested
-    inner class ProduksjonsSatserErKonsistente {
+    inner class ProduksjonsatserErKonsistente {
         @BeforeEach
         fun setup() {
             unmockkObject(EøsSatsService)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegisterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegisterTest.kt
@@ -6,7 +6,7 @@ import io.mockk.unmockkAll
 import io.mockk.unmockkObject
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
-import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatsService.finnSatsForLandIMåned
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister.finnSatsForLandIMåned
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.YearMonth
 
-class EøsSatsServiceTest {
-    private val polskSats2024 =
+class EøsSatserRegisterTest {
+    private val forrigeSats =
         EøsSats(
             land = "PL",
             valuta = "PLN",
@@ -26,23 +26,23 @@ class EøsSatsServiceTest {
             tom = YearMonth.of(2024, 12),
         )
 
-    private val polskSats2025 =
+    private val nySats =
         EøsSats(
             land = "PL",
             valuta = "PLN",
             intervall = Intervall.MÅNEDLIG,
             beløp = BigDecimal("900"),
             fom = YearMonth.of(2025, 1),
-            tom = null, // løpende
+            tom = null,
         )
 
     @BeforeEach
     fun setup() {
         mockkObject(EøsSatserPolen)
-        every { EøsSatserPolen.satser } returns listOf(polskSats2024, polskSats2025)
+        every { EøsSatserPolen.satser } returns listOf(forrigeSats, nySats)
 
-        mockkObject(EøsSatsService)
-        every { EøsSatsService.satser } returns listOf(EøsSatserPolen)
+        mockkObject(EøsSatserRegister)
+        every { EøsSatserRegister.satser } returns listOf(EøsSatserPolen)
     }
 
     @AfterEach
@@ -54,37 +54,37 @@ class EøsSatsServiceTest {
     inner class EøsSatsErGyldigForMåned {
         @Test
         fun `Sats med fom og tom - gyldig for måned inni perioden`() {
-            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2024, 6))).isTrue()
+            assertThat(forrigeSats.erGyldigForMåned(YearMonth.of(2024, 6))).isTrue()
         }
 
         @Test
         fun `Sats med fom og tom - gyldig for første måned`() {
-            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2024, 1))).isTrue()
+            assertThat(forrigeSats.erGyldigForMåned(YearMonth.of(2024, 1))).isTrue()
         }
 
         @Test
         fun `Sats med fom og tom - gyldig for siste måned`() {
-            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2024, 12))).isTrue()
+            assertThat(forrigeSats.erGyldigForMåned(YearMonth.of(2024, 12))).isTrue()
         }
 
         @Test
         fun `Sats med fom og tom - ikke gyldig for måned etter tom`() {
-            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2025, 1))).isFalse()
+            assertThat(forrigeSats.erGyldigForMåned(YearMonth.of(2025, 1))).isFalse()
         }
 
         @Test
         fun `Sats med fom og tom - ikke gyldig for måned før fom`() {
-            assertThat(polskSats2024.erGyldigForMåned(YearMonth.of(2023, 12))).isFalse()
+            assertThat(forrigeSats.erGyldigForMåned(YearMonth.of(2023, 12))).isFalse()
         }
 
         @Test
         fun `Løpende sats (tom = null) - gyldig for måned etter fom`() {
-            assertThat(polskSats2025.erGyldigForMåned(YearMonth.of(2026, 6))).isTrue()
+            assertThat(nySats.erGyldigForMåned(YearMonth.of(2026, 6))).isTrue()
         }
 
         @Test
         fun `Løpende sats (tom = null) - ikke gyldig for måned før fom`() {
-            assertThat(polskSats2025.erGyldigForMåned(YearMonth.of(2024, 12))).isFalse()
+            assertThat(nySats.erGyldigForMåned(YearMonth.of(2024, 12))).isFalse()
         }
     }
 
@@ -92,7 +92,7 @@ class EøsSatsServiceTest {
     inner class FinnSatsForLandIMåned {
         @Test
         fun `Returnerer korrekt sats for måned inni gyldig periode`() {
-            assertThat(finnSatsForLandIMåned("PL", YearMonth.of(2024, 6))).isEqualTo(polskSats2024)
+            assertThat(finnSatsForLandIMåned("PL", YearMonth.of(2024, 6))).isEqualTo(forrigeSats)
         }
 
         @Test
@@ -101,7 +101,7 @@ class EøsSatsServiceTest {
             val resultat = finnSatsForLandIMåned("PL", YearMonth.of(2025, 6))
 
             // Assert
-            assertThat(resultat).isEqualTo(polskSats2025)
+            assertThat(resultat).isEqualTo(nySats)
             assertThat(resultat?.tom).isNull()
         }
 
@@ -124,13 +124,13 @@ class EøsSatsServiceTest {
     inner class ProduksjonsatserErKonsistente {
         @BeforeEach
         fun setup() {
-            unmockkObject(EøsSatsService)
+            unmockkObject(EøsSatserRegister)
             unmockkObject(EøsSatserPolen)
         }
 
         @Test
         fun `Ingen land har overlappende gyldighetsperioder`() {
-            EøsSatsService.satser.forEach { (land, satser) ->
+            EøsSatserRegister.satser.forEach { (land, satser) ->
                 satser.sortedBy { it.fom }.zipWithNext { nåværende, neste ->
                     assertThat(nåværende.tom != null && nåværende.tom < neste.fom)
                         .withFailMessage(
@@ -143,7 +143,7 @@ class EøsSatsServiceTest {
 
         @Test
         fun `Alle satser har positivt beløp`() {
-            EøsSatsService.satser.forEach { (land, satser) ->
+            EøsSatserRegister.satser.forEach { (land, satser) ->
                 satser.forEach { sats ->
                     assertThat(sats.beløp)
                         .withFailMessage("Sats for $land har ikke-positivt beløp: ${sats.beløp}")
@@ -154,7 +154,7 @@ class EøsSatsServiceTest {
 
         @Test
         fun `Alle satser har tom etter eller lik fom`() {
-            EøsSatsService.satser.forEach { (land, satser) ->
+            EøsSatserRegister.satser.forEach { (land, satser) ->
                 satser.forEach { sats ->
                     assertThat(sats.tom == null || sats.tom >= sats.fom)
                         .withFailMessage("Sats for $land har tom ${sats.tom?.tilKortString()} før fom ${sats.fom.tilKortString()}")
@@ -165,7 +165,7 @@ class EøsSatsServiceTest {
 
         @Test
         fun `EøsSats-land matcher land-objektets land-felt`() {
-            EøsSatsService.satser.forEach { (land, satser) ->
+            EøsSatserRegister.satser.forEach { (land, satser) ->
                 satser.forEach { sats ->
                     assertThat(sats.land)
                         .withFailMessage("Sats med land '${sats.land}' ligger i listen med satser for '$land'")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
@@ -1,0 +1,299 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.common.AutovedtakSkalIkkeGjennomføresFeil
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.YearMonth
+
+class SatsendringEøsServiceTest {
+    private val utenlandskPeriodebeløpService = mockk<UtenlandskPeriodebeløpService>()
+    private val satsendringEøsKjøringService = mockk<SatsendringEøsKjøringService>()
+    private val satsendringEøsService = SatsendringEøsService(utenlandskPeriodebeløpService, satsendringEøsKjøringService)
+    private val behandlingId = BehandlingId(42L)
+    private val barnAktører = setOf(randomAktør())
+
+    private val forrigeSats =
+        EøsSats(
+            land = "PL",
+            valuta = "PLN",
+            intervall = Intervall.MÅNEDLIG,
+            beløp = BigDecimal("800"),
+            fom = YearMonth.of(2024, 1),
+            tom = YearMonth.of(2024, 12),
+        )
+
+    private val nySats =
+        EøsSats(
+            land = "PL",
+            valuta = "PLN",
+            intervall = Intervall.MÅNEDLIG,
+            beløp = BigDecimal("900"),
+            fom = YearMonth.of(2025, 1),
+            tom = null,
+        )
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(EøsSatserPolen)
+        every { EøsSatserPolen.satser } returns listOf(forrigeSats, nySats)
+
+        mockkObject(EøsSatsService)
+        every { EøsSatsService.satser } returns listOf(EøsSatserPolen)
+
+        every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(behandlingId.id) } returns
+            SatsendringEøsKjøring(fagsakId = 1L, utbetalingsland = "PL", satsTidspunkt = YearMonth.of(2025, 1))
+
+        every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns listOf(lagUPB())
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Nested
+    inner class OppdaterUtenlandskPeriodebeløpMedSisteSats {
+        @Test
+        fun `UPB oppdateres til ny sats`() {
+            // Arrange
+            val lagretSkjema = slot<UtenlandskPeriodebeløp>()
+            justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), capture(lagretSkjema)) }
+
+            // Act
+            satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId)
+
+            // Assert
+            verify(exactly = 1) { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
+            assertThat(lagretSkjema.captured.beløp).isEqualByComparingTo(nySats.beløp)
+            assertThat(lagretSkjema.captured.fom).isEqualTo(nySats.fom)
+            assertThat(lagretSkjema.captured.tom).isNull()
+            assertThat(lagretSkjema.captured.valutakode).isEqualTo("PLN")
+            assertThat(lagretSkjema.captured.intervall).isEqualTo(Intervall.MÅNEDLIG)
+            assertThat(lagretSkjema.captured.utbetalingsland).isEqualTo("PL")
+            assertThat(lagretSkjema.captured.kalkulertMånedligBeløp).isEqualByComparingTo(nySats.beløp)
+        }
+
+        @Test
+        fun `sats-fom midt i UPB-periode gir ny fom lik sats-fom`() {
+            // Arrange
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                listOf(lagUPB(fom = YearMonth.of(2024, 6)))
+
+            val lagretSkjema = slot<UtenlandskPeriodebeløp>()
+            justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), capture(lagretSkjema)) }
+
+            // Act
+            satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId)
+
+            // Assert
+            assertThat(lagretSkjema.captured.fom).isEqualTo(nySats.fom)
+        }
+
+        @Test
+        fun `UPB-fom etter sats-fom gir ny fom lik UPB-fom`() {
+            // Arrange
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                listOf(lagUPB(fom = YearMonth.of(2025, 6)))
+
+            val lagretSkjema = slot<UtenlandskPeriodebeløp>()
+            justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), capture(lagretSkjema)) }
+
+            // Act
+            satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId)
+
+            // Assert
+            assertThat(lagretSkjema.captured.fom).isEqualTo(YearMonth.of(2025, 6))
+        }
+
+        @Test
+        fun `Kun UPB for gjeldende utbetalingsland oppdateres`() {
+            // Arrange
+            val upbForLandUtenSats = lagUPB(utbetalingsland = "DE", barnAktører = setOf(randomAktør()))
+            val upbForLandMedSats = lagUPB()
+
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                listOf(upbForLandUtenSats, upbForLandMedSats)
+
+            justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
+
+            // Act
+            satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId)
+
+            // Assert
+            verify(exactly = 1) { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
+        }
+
+        @Test
+        fun `Flere UPB for samme land oppdateres`() {
+            // Arrange
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                listOf(lagUPB(), lagUPB(fom = YearMonth.of(2024, 1), barnAktører = setOf(randomAktør())))
+            justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
+
+            // Act
+            satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId)
+
+            // Assert
+            verify(exactly = 2) { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
+        }
+
+        @Nested
+        inner class KasterFeil {
+            @Test
+            fun `Ingen sats registrert for landet`() {
+                // Arrange
+                every { EøsSatserPolen.satser } returns emptyList()
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(Feil::class.java)
+                    .hasMessageContaining("Ingen EØS-sats registrert for land PL i måned 2025-01")
+            }
+
+            @Test
+            fun `Ingen forrige sats registrert for landet`() {
+                // Arrange
+                every { EøsSatserPolen.satser } returns listOf(nySats)
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(Feil::class.java)
+                    .hasMessageContaining("Ingen EØS-sats registrert for land PL i måned 2024-12")
+            }
+        }
+
+        @Nested
+        inner class KasterAutovedtakSkalIkkeGjennomføresFeil {
+            @Test
+            fun `UPB som ikke er utfylt filtreres bort`() {
+                // Arrange
+                every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                    listOf(lagUPB(fom = null, beløp = null, utbetalingsland = null))
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(AutovedtakSkalIkkeGjennomføresFeil::class.java)
+                    .hasMessageContaining("Ingen UtenlandskPeriodebeløp trenger oppdatering")
+            }
+
+            @Test
+            fun `UPB som allerede har ny sats oppdateres ikke`() {
+                // Arrange
+                every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                    listOf(lagUPB(fom = YearMonth.of(2025, 1), beløp = nySats.beløp))
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(AutovedtakSkalIkkeGjennomføresFeil::class.java)
+                    .hasMessageContaining("Ingen UtenlandskPeriodebeløp trenger oppdatering")
+
+                verify(exactly = 0) { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
+            }
+
+            @Test
+            fun `UPB som ikke overlapper sats oppdateres ikke`() {
+                // Arrange
+                every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                    listOf(lagUPB(tom = YearMonth.of(2024, 6)))
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(AutovedtakSkalIkkeGjennomføresFeil::class.java)
+                    .hasMessageContaining("Ingen UtenlandskPeriodebeløp trenger oppdatering")
+            }
+
+            @Test
+            fun `Tom liste med UPB`() {
+                // Arrange
+                every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns emptyList()
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(AutovedtakSkalIkkeGjennomføresFeil::class.java)
+                    .hasMessageContaining("Ingen UtenlandskPeriodebeløp trenger oppdatering")
+            }
+        }
+
+        @Nested
+        inner class KasterAutovedtakMåBehandlesManueltFeil {
+            @Test
+            fun `Beløp-mismatch mot sats`() {
+                // Arrange
+                every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                    listOf(lagUPB(beløp = BigDecimal("500")))
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+                    .hasMessageContaining("UtenlandskPeriodebeløp for behandling ${behandlingId.id} og land PL har beløp 500 PLN")
+            }
+
+            @Test
+            fun `Valutakode-mismatch mot sats`() {
+                // Arrange
+                every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                    listOf(lagUPB(valutakode = "EUR"))
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+                    .hasMessageContaining("UtenlandskPeriodebeløp for behandling ${behandlingId.id} og land PL har valuta EUR")
+            }
+
+            @Test
+            fun `Intervall-mismatch mot sats`() {
+                // Arrange
+                every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
+                    listOf(lagUPB(intervall = Intervall.ÅRLIG))
+
+                // Act & Assert
+                assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
+                    .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+                    .hasMessageContaining("UtenlandskPeriodebeløp for behandling ${behandlingId.id} og land PL har intervall ÅRLIG")
+            }
+        }
+    }
+
+    private fun lagUPB(
+        fom: YearMonth? = YearMonth.of(2023, 1),
+        tom: YearMonth? = null,
+        beløp: BigDecimal? = forrigeSats.beløp,
+        valutakode: String = "PLN",
+        intervall: Intervall = Intervall.MÅNEDLIG,
+        utbetalingsland: String? = "PL",
+        barnAktører: Set<Aktør> = this.barnAktører,
+    ) = UtenlandskPeriodebeløp(
+        fom = fom,
+        tom = tom,
+        barnAktører = barnAktører,
+        beløp = beløp,
+        valutakode = valutakode,
+        intervall = intervall,
+        utbetalingsland = utbetalingsland,
+        kalkulertMånedligBeløp = beløp,
+    ).also {
+        it.behandlingId = behandlingId.id
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
@@ -59,13 +59,13 @@ class SatsendringEøsServiceTest {
         mockkObject(EøsSatserPolen)
         every { EøsSatserPolen.satser } returns listOf(forrigeSats, nySats)
 
-        mockkObject(EøsSatsService)
-        every { EøsSatsService.satser } returns listOf(EøsSatserPolen)
+        mockkObject(EøsSatserRegister)
+        every { EøsSatserRegister.satser } returns listOf(EøsSatserPolen)
 
         every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(behandlingId.id) } returns
             SatsendringEøsKjøring(fagsakId = 1L, utbetalingsland = "PL", satsTidspunkt = YearMonth.of(2025, 1))
 
-        every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns listOf(lagUPB())
+        every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns listOf(lagUtenlandskPeriodebeløp())
     }
 
     @AfterEach
@@ -76,7 +76,7 @@ class SatsendringEøsServiceTest {
     @Nested
     inner class OppdaterUtenlandskPeriodebeløpMedSisteSats {
         @Test
-        fun `UPB oppdateres til ny sats`() {
+        fun `Utenlandsk periodebeløp oppdateres til ny sats`() {
             // Arrange
             val lagretSkjema = slot<UtenlandskPeriodebeløp>()
             justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), capture(lagretSkjema)) }
@@ -96,10 +96,10 @@ class SatsendringEøsServiceTest {
         }
 
         @Test
-        fun `sats-fom midt i UPB-periode gir ny fom lik sats-fom`() {
+        fun `sats-fom midt i utenlandsk periodebeløp-periode gir ny fom lik sats-fom`() {
             // Arrange
             every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                listOf(lagUPB(fom = YearMonth.of(2024, 6)))
+                listOf(lagUtenlandskPeriodebeløp(fom = YearMonth.of(2024, 6)))
 
             val lagretSkjema = slot<UtenlandskPeriodebeløp>()
             justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), capture(lagretSkjema)) }
@@ -112,10 +112,10 @@ class SatsendringEøsServiceTest {
         }
 
         @Test
-        fun `UPB-fom etter sats-fom gir ny fom lik UPB-fom`() {
+        fun `Utenlandsk periodebeløp-fom etter sats-fom gir ny fom lik utenlandsk periodebeløp-fom`() {
             // Arrange
             every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                listOf(lagUPB(fom = YearMonth.of(2025, 6)))
+                listOf(lagUtenlandskPeriodebeløp(fom = YearMonth.of(2025, 6)))
 
             val lagretSkjema = slot<UtenlandskPeriodebeløp>()
             justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), capture(lagretSkjema)) }
@@ -128,13 +128,13 @@ class SatsendringEøsServiceTest {
         }
 
         @Test
-        fun `Kun UPB for gjeldende utbetalingsland oppdateres`() {
+        fun `Kun utenlandsk periodebeløp for gjeldende utbetalingsland oppdateres`() {
             // Arrange
-            val upbForLandUtenSats = lagUPB(utbetalingsland = "DE", barnAktører = setOf(randomAktør()))
-            val upbForLandMedSats = lagUPB()
+            val utenlandskPeriodebeløpForLandUtenSats = lagUtenlandskPeriodebeløp(utbetalingsland = "DE", barnAktører = setOf(randomAktør()))
+            val utenlandskPeriodebeløpForLandMedSats = lagUtenlandskPeriodebeløp()
 
             every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                listOf(upbForLandUtenSats, upbForLandMedSats)
+                listOf(utenlandskPeriodebeløpForLandUtenSats, utenlandskPeriodebeløpForLandMedSats)
 
             justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
 
@@ -146,10 +146,10 @@ class SatsendringEøsServiceTest {
         }
 
         @Test
-        fun `Flere UPB for samme land oppdateres`() {
+        fun `Flere utenlandsk periodebeløp for samme land oppdateres`() {
             // Arrange
             every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                listOf(lagUPB(), lagUPB(fom = YearMonth.of(2024, 1), barnAktører = setOf(randomAktør())))
+                listOf(lagUtenlandskPeriodebeløp(), lagUtenlandskPeriodebeløp(fom = YearMonth.of(2024, 1), barnAktører = setOf(randomAktør())))
             justRun { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) }
 
             // Act
@@ -187,10 +187,10 @@ class SatsendringEøsServiceTest {
         @Nested
         inner class KasterAutovedtakSkalIkkeGjennomføresFeil {
             @Test
-            fun `UPB som ikke er utfylt filtreres bort`() {
+            fun `Utenlandsk periodebeløp som ikke er utfylt filtreres bort`() {
                 // Arrange
                 every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                    listOf(lagUPB(fom = null, beløp = null, utbetalingsland = null))
+                    listOf(lagUtenlandskPeriodebeløp(fom = null, beløp = null, utbetalingsland = null))
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
@@ -199,10 +199,10 @@ class SatsendringEøsServiceTest {
             }
 
             @Test
-            fun `UPB som allerede har ny sats oppdateres ikke`() {
+            fun `Utenlandsk periodebeløp som allerede har ny sats oppdateres ikke`() {
                 // Arrange
                 every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                    listOf(lagUPB(fom = YearMonth.of(2025, 1), beløp = nySats.beløp))
+                    listOf(lagUtenlandskPeriodebeløp(fom = YearMonth.of(2025, 1), beløp = nySats.beløp))
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
@@ -213,10 +213,10 @@ class SatsendringEøsServiceTest {
             }
 
             @Test
-            fun `UPB som ikke overlapper sats oppdateres ikke`() {
+            fun `Utenlandsk periodebeløp som ikke overlapper sats oppdateres ikke`() {
                 // Arrange
                 every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                    listOf(lagUPB(tom = YearMonth.of(2024, 6)))
+                    listOf(lagUtenlandskPeriodebeløp(tom = YearMonth.of(2024, 6)))
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
@@ -225,7 +225,7 @@ class SatsendringEøsServiceTest {
             }
 
             @Test
-            fun `Tom liste med UPB`() {
+            fun `Tom liste med utenlandsk periodebeløp`() {
                 // Arrange
                 every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns emptyList()
 
@@ -242,7 +242,7 @@ class SatsendringEøsServiceTest {
             fun `Beløp-mismatch mot sats`() {
                 // Arrange
                 every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                    listOf(lagUPB(beløp = BigDecimal("500")))
+                    listOf(lagUtenlandskPeriodebeløp(beløp = BigDecimal("500")))
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
@@ -254,7 +254,7 @@ class SatsendringEøsServiceTest {
             fun `Valutakode-mismatch mot sats`() {
                 // Arrange
                 every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                    listOf(lagUPB(valutakode = "EUR"))
+                    listOf(lagUtenlandskPeriodebeløp(valutakode = "EUR"))
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
@@ -266,7 +266,7 @@ class SatsendringEøsServiceTest {
             fun `Intervall-mismatch mot sats`() {
                 // Arrange
                 every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId) } returns
-                    listOf(lagUPB(intervall = Intervall.ÅRLIG))
+                    listOf(lagUtenlandskPeriodebeløp(intervall = Intervall.ÅRLIG))
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
@@ -276,7 +276,7 @@ class SatsendringEøsServiceTest {
         }
     }
 
-    private fun lagUPB(
+    private fun lagUtenlandskPeriodebeløp(
         fom: YearMonth? = YearMonth.of(2023, 1),
         tom: YearMonth? = null,
         beløp: BigDecimal? = forrigeSats.beløp,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
@@ -103,6 +103,7 @@ class VilkårsvurderingStegTest {
             endretUtbetalingAndelService = endretUtbetalingAndelService,
             registrertSøknadstidspunktService = registrertSøknadstidspunktService,
             utenlandskPeriodebeløpService = utenlandskPeriodebeløpService,
+            satsendringEøsService = mockk(relaxed = true),
         )
 
     val behandling =
@@ -646,6 +647,7 @@ class VilkårsvurderingStegTest {
                     endretUtbetalingAndelService = endretUtbetalingAndelService,
                     registrertSøknadstidspunktService = registrertSøknadstidspunktService,
                     utenlandskPeriodebeløpService = realUtenlandskPeriodebeløpService,
+                    satsendringEøsService = mockk(relaxed = true),
                 )
 
             // Act/Assert


### PR DESCRIPTION
### 📮 Favro: NAV-29741

### 💰 Hva skal gjøres, og hvorfor?

Implementerer `EøsSatsendringService` som oppdaterer `UtenlandskPeriodebeløp` med siste
registrerte EØS-sats for et gitt utbetalingsland, som en del av automatisk satsendring (SATSENDRING_EØS).

**EøsSatsService** – `finnGjeldendeSatsForLand` omdøpt til `finnSatsForLandIMåned`.

**EøsSatsendringService (ny)** – henter utbetalingsland og satstidspunkt fra `satsendringEøsKjøringRepository`, filtrerer UPB per `utbetalingsland` og oppdaterer beløp/fom
til ny sats. Kaster `AutovedtakMåBehandlesManueltFeil` ved avvik i beløp/valuta/intervall,
`AutovedtakSkalIkkeGjennomføresFeil` hvis ingen UPB trengte oppdatering, og `Feil` ved
manglende satskonfig.

**VilkårsvurderingSteg** – branch for `erSatsendringEøs()` som kaller oppdatering av UPB.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.