### PR TITLE
NAV-29767: Støtt "SED er sendt til" på svartidsbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -102,15 +102,18 @@ data class ManueltBrevRequest(
 
     fun enhetNavn(): String = this.enhet?.enhetNavn ?: throw Feil("Finner ikke enhetsnavn på manuell brevrequest")
 
-    fun mottakerlandSED(): List<String> {
+    fun mottakerlandSED(): List<String> =
+        mottakerlandSedEllerNull()
+            ?: throw Feil("Finner ikke noen mottakerland for SED på manuell brevrequest")
+
+    fun mottakerlandSedEllerNull(): List<String>? {
         if (this.mottakerlandSed.contains("NO")) {
             throw FunksjonellFeil(
                 frontendFeilmelding = "Norge kan ikke velges som mottakerland.",
-                melding = "Ugyldig mottakerland for brevtype 'varsel om årlig revurdering EØS'",
+                melding = "Ugyldig mottakerland for SED på manuell brevrequest",
             )
         }
         return this.mottakerlandSed.takeIf { it.isNotEmpty() }
-            ?: throw Feil("Finner ikke noen mottakerland for SED på manuell brevrequest")
     }
 }
 
@@ -415,6 +418,11 @@ fun ManueltBrevRequest.tilBrev(
                 enhet = this.enhetNavn(),
                 mal = Brevmal.SVARTIDSBREV,
                 erEøsBehandling = erEøsBehandling(behandlingKategori),
+                mottakerlandSed =
+                    this
+                        .mottakerlandSedEllerNull()
+                        ?.map { tilLandNavn(hentLandkoder(), it) }
+                        ?.slåSammen(),
                 saksbehandlerNavn = saksbehandlerNavn,
             )
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Svartidsbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Svartidsbrev.kt
@@ -13,6 +13,7 @@ data class Svartidsbrev(
         enhet: String,
         mal: Brevmal,
         erEøsBehandling: Boolean,
+        mottakerlandSed: String? = null,
         organisasjonsnummer: String? = null,
         gjelder: String? = null,
         saksbehandlerNavn: String,
@@ -35,6 +36,8 @@ data class Svartidsbrev(
                                 saksbehandlerNavn = saksbehandlerNavn,
                             ),
                         kontonummer = erEøsBehandling,
+                        // Settes kun når SED er sendt til andre EØS-land, slik at delmalen utelates ellers.
+                        sedErSendtTil = mottakerlandSed?.let { SedErSendtTilDelmal(it) },
                     ),
             ),
     )
@@ -67,5 +70,14 @@ data class SvartidsbrevData(
     data class DelmalData(
         val signatur: SignaturDelmal,
         val kontonummer: Boolean,
+        val sedErSendtTil: SedErSendtTilDelmal? = null,
+    )
+}
+
+data class SedErSendtTilDelmal(
+    val mottakerlandSed: Flettefelt,
+) {
+    constructor(mottakerlandSed: String) : this(
+        mottakerlandSed = flettefelt(mottakerlandSed),
     )
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Svartidsbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Svartidsbrev.kt
@@ -37,7 +37,7 @@ data class Svartidsbrev(
                             ),
                         kontonummer = erEøsBehandling,
                         // Settes kun når SED er sendt til andre EØS-land, slik at delmalen utelates ellers.
-                        sedErSendtTil = mottakerlandSed?.let { SedErSendtTilDelmal(it) },
+                        sedErSendtTil = if (erEøsBehandling) mottakerlandSed?.let { SedErSendtTilDelmal(it) } else null,
                     ),
             ),
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.ba.sak.kjerne.brev.domene
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.ForlengetSvartidsbrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.InformasjonsbrevInnhenteOpplysningerKlageData
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Svartidsbrev
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.UtbetalingEtterKAVedtakData
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.VarselbrevÅrlegKontrollEøs
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
@@ -327,6 +329,62 @@ class ManueltBrevRequestTest {
             val brevRequest =
                 baseRequest.copy(
                     brevmal = Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS,
+                    mottakerlandSed = listOf("SE", "NO"),
+                )
+
+            assertThrows<FunksjonellFeil> {
+                brevRequest.tilBrev("12345678910", "mottakerNavn", "saksbehandlerNavn") {
+                    mapOf(Pair("SE", "Sverige"), Pair("NO", "Norge"))
+                }
+            }
+        }
+
+        @Test
+        fun `Svartidsbrev request med mottakerland skal gi svartidsbrev med SED-flettefelt`() {
+            val brev =
+                baseRequest
+                    .copy(
+                        brevmal = Brevmal.SVARTIDSBREV,
+                        behandlingKategori = BehandlingKategori.EØS,
+                        mottakerlandSed = listOf("SE", "DK"),
+                    ).tilBrev("12345678910", "mottakerNavn", "saksbehandlerNavn") {
+                        mapOf(Pair("SE", "Sverige"), Pair("DK", "Danmark"))
+                    }
+
+            assertThat(brev::class).isEqualTo(Svartidsbrev::class)
+            brev as Svartidsbrev
+
+            assertThat(brev.mal).isEqualTo(Brevmal.SVARTIDSBREV)
+            assertThat(
+                brev.data.delmalData.sedErSendtTil!!
+                    .mottakerlandSed!!
+                    .single(),
+            ).isEqualTo("Sverige og Danmark")
+        }
+
+        @Test
+        fun `Svartidsbrev request uten mottakerland skal gi svartidsbrev uten SED-flettefelt`() {
+            val brev =
+                baseRequest
+                    .copy(
+                        brevmal = Brevmal.SVARTIDSBREV,
+                        behandlingKategori = BehandlingKategori.NASJONAL,
+                        mottakerlandSed = emptyList(),
+                    ).tilBrev("12345678910", "mottakerNavn", "saksbehandlerNavn") { emptyMap() }
+
+            assertThat(brev::class).isEqualTo(Svartidsbrev::class)
+            brev as Svartidsbrev
+
+            assertThat(brev.mal).isEqualTo(Brevmal.SVARTIDSBREV)
+            assertThat(brev.data.delmalData.sedErSendtTil).isNull()
+        }
+
+        @Test
+        fun `Svartidsbrev request skal ikke tillate Norge som mottakerland for SED`() {
+            val brevRequest =
+                baseRequest.copy(
+                    brevmal = Brevmal.SVARTIDSBREV,
+                    behandlingKategori = BehandlingKategori.EØS,
                     mottakerlandSed = listOf("SE", "NO"),
                 )
 


### PR DESCRIPTION
### 📮 Favro:
Nav-29767 – Legge inn "SED er sendt til" i brevmeny på svartidsbrev til søknad EØS

### 💰 Hva skal gjøres, og hvorfor?
Ved EØS-saker ønsker vi å orientere søker allerede i søknadsprosessen om at vi innhenter opplysninger fra et annet EØS-land. "SED er sendt til" var tidligere kun mulig på varsel om årlig revurdering EØS – nå støttes det også på svartidsbrev.

- **Brevmal (`Svartidsbrev`):** ny valgfri `sedErSendtTil`-delmal som bærer flettefeltet `mottakerlandSed`. Delmalen settes kun når saksbehandler har valgt land, og utelates ellers.
- **Mapping (`ManueltBrevRequest`):** trekker ut `mottakerlandSedEllerNull()` (kaster ikke ved tom liste, men avviser fortsatt Norge), og mapper valgte land til delmalen i `SVARTIDSBREV`-grenen. `SVARTIDSBREV_INSTITUSJON` er bevisst ikke inkludert.
- **Tester:** enhetstester for svartidsbrev med land, uten land og med Norge (skal avvises).

Bilder:
<img width="347" height="394" alt="Screenshot 2026-06-28 at 17 57 55" src="https://github.com/user-attachments/assets/bdaabbd7-478e-4692-ac55-5c65623dfab2" />
<img width="764" height="279" alt="Screenshot 2026-06-28 at 17 58 01" src="https://github.com/user-attachments/assets/5a1d670d-7d2f-4960-b2c8-4d6fe280a063" />


