### PR TITLE
Legg til validering for SATSENDRING_EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ba.sak.common.secureLogger
 import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toYearMonth
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
@@ -37,12 +38,12 @@ import no.nav.familie.ba.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValide
 import no.nav.familie.ba.sak.kjerne.eøs.felles.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.KompetanseRepository
 import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
 import no.nav.familie.ba.sak.kjerne.steg.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -52,6 +53,8 @@ import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.outerJoin
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import no.nav.familie.tidslinje.verdier
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 
@@ -67,6 +70,7 @@ class BehandlingsresultatStegValideringService(
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val strengtFortroligService: StrengtFortroligService,
     private val clockProvider: ClockProvider,
+    private val satsendringEøsKjøringService: SatsendringEøsKjøringService,
 ) {
     fun validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling: Behandling) {
         if (behandling.status == BehandlingStatus.AVSLUTTET) return
@@ -247,6 +251,49 @@ class BehandlingsresultatStegValideringService(
             andelerDenneBehandlingen = andelerDenneBehandlingen,
             andelerForrigeBehandling = andelerForrigeBehandling,
         )
+    }
+
+    fun validerAtMinstEttUtenlandskPeriodebeløpErEndret(behandling: Behandling) {
+        val utbetalingsland = satsendringEøsKjøringService.hentSatsendringEøsKjøring(behandling.id).utbetalingsland
+        if (finnEndredeUtenlandskePeriodebeløp(behandling, utbetalingsland).isEmpty()) {
+            throw Feil("Forventet endring i minst ett utenlandsk periodebeløp for satsendring EØS i behandling ${behandling.id} i fagsak ${behandling.fagsak.id}.")
+        }
+    }
+
+    fun validerIngenEndringIAndelerFørSatsendringstidspunkt(tilkjentYtelse: TilkjentYtelse) {
+        val satsTidspunkt = satsendringEøsKjøringService.hentSatsendringEøsKjøring(tilkjentYtelse.behandling.id).satsTidspunkt
+        val andelerForrigeBehandling = beregningService.hentAndelerFraForrigeVedtatteBehandling(tilkjentYtelse.behandling)
+        BehandlingsresultatValideringUtils.validerIngenEndringFørMåned(
+            andelerDenneBehandlingen = tilkjentYtelse.andelerTilkjentYtelse,
+            andelerForrigeBehandling = andelerForrigeBehandling,
+            grensemåned = satsTidspunkt,
+        )
+    }
+
+    private fun finnEndredeUtenlandskePeriodebeløp(
+        behandling: Behandling,
+        utbetalingsland: String,
+    ): List<UtenlandskPeriodebeløp> {
+        val forrigeBehandling =
+            behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(behandling)
+                ?: throw Feil("Kan ikke kjøre EØS-satsendring uten en tidligere vedtatt behandling.")
+
+        val upbPerBarnInneværendeBehandling =
+            utenlandskPeriodebeløpRepository
+                .finnFraBehandlingId(behandling.id)
+                .filter { it.utbetalingsland == utbetalingsland }
+                .tilSeparateTidslinjerForBarna()
+
+        val upbPerBarnForrigeBehandling =
+            utenlandskPeriodebeløpRepository
+                .finnFraBehandlingId(forrigeBehandling.id)
+                .filter { it.utbetalingsland == utbetalingsland }
+                .tilSeparateTidslinjerForBarna()
+
+        return upbPerBarnInneværendeBehandling
+            .outerJoin(upbPerBarnForrigeBehandling) { nyUpb, gammelUpb ->
+                nyUpb.takeIf { compareValues(nyUpb?.kalkulertMånedligBeløp, gammelUpb?.kalkulertMånedligBeløp) != 0 }
+            }.flatMap { it.value.tilPerioderIkkeNull().verdier() }
     }
 
     fun validerSekundærlandKompetanse(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.common.sisteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.tilMånedÅr
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.AVSLÅTT
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.AVSLÅTT_OG_ENDRET
@@ -22,6 +21,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.FORTSA
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.FORTSATT_OPPHØRT
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.IKKE_VURDERT
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat.OPPHØRT
+import no.nav.familie.ba.sak.kjerne.behandlingsresultat.BehandlingsresultatValideringUtils.validerIngenEndringTilbakeITid
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.beregning.domene.tilTidslinjerPerAktørOgType
@@ -123,13 +123,30 @@ object BehandlingsresultatValideringUtils {
         andelerDenneBehandlingen: Collection<AndelTilkjentYtelse>,
         andelerForrigeBehandling: Collection<AndelTilkjentYtelse>,
         nåMåned: YearMonth,
-    ) {
-        val forrigeMåned = nåMåned.minusMonths(1)
-        val andelerIFortidenTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType().beskjærTilOgMed(forrigeMåned.sisteDagIInneværendeMåned())
-        val andelerIFortidenForrigeBehanldingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType().beskjærTilOgMed(forrigeMåned.sisteDagIInneværendeMåned())
+    ) = validerIngenEndringFørMåned(
+        andelerDenneBehandlingen = andelerDenneBehandlingen,
+        andelerForrigeBehandling = andelerForrigeBehandling,
+        grensemåned = nåMåned,
+    )
 
-        val endringerIAndelerTilbakeITidTidslinjer =
-            andelerIFortidenTidslinje.outerJoin(andelerIFortidenForrigeBehanldingTidslinje) { nyAndel, gammelAndel ->
+    /**
+     * Validerer at det ikke finnes endringer i kalkulert utbetalingsbeløp på andeler
+     * i måneder som er tidligere enn [grensemåned].
+     *
+     * Brukes av månedlig valutajustering (via [validerIngenEndringTilbakeITid]) og
+     * EØS-satsendring, der grensen er satsens fom-dato.
+     */
+    fun validerIngenEndringFørMåned(
+        andelerDenneBehandlingen: Collection<AndelTilkjentYtelse>,
+        andelerForrigeBehandling: Collection<AndelTilkjentYtelse>,
+        grensemåned: YearMonth,
+    ) {
+        val sisteMånedUtenEndring = grensemåned.minusMonths(1)
+        val andelerIFortidenTidslinje = andelerDenneBehandlingen.tilTidslinjerPerAktørOgType().beskjærTilOgMed(sisteMånedUtenEndring.sisteDagIInneværendeMåned())
+        val andelerIFortidenForrigeBehandlingTidslinje = andelerForrigeBehandling.tilTidslinjerPerAktørOgType().beskjærTilOgMed(sisteMånedUtenEndring.sisteDagIInneværendeMåned())
+
+        val endringerIAndelerTidslinje =
+            andelerIFortidenTidslinje.outerJoin(andelerIFortidenForrigeBehandlingTidslinje) { nyAndel, gammelAndel ->
                 if (nyAndel?.kalkulertUtbetalingsbeløp != gammelAndel?.kalkulertUtbetalingsbeløp) {
                     ErEndringIAndel(andelForrigeBehandling = gammelAndel, andelDenneBehandlingen = nyAndel)
                 } else {
@@ -137,7 +154,7 @@ object BehandlingsresultatValideringUtils {
                 }
             }
 
-        endringerIAndelerTilbakeITidTidslinjer.kastFeilOgLoggVedEndringerIAndeler()
+        endringerIAndelerTidslinje.kastFeilOgLoggVedEndringerIAndeler()
     }
 
     fun validerSatsErUendret(

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
@@ -73,6 +73,11 @@ class BehandlingsresultatSteg(
             behandlingsresultatstegValideringService.validerSatsErUendret(tilkjentYtelse)
         }
 
+        if (behandling.erSatsendringEøs()) {
+            behandlingsresultatstegValideringService.validerAtMinstEttUtenlandskPeriodebeløpErEndret(behandling)
+            behandlingsresultatstegValideringService.validerIngenEndringIAndelerFørSatsendringstidspunkt(tilkjentYtelse)
+        }
+
         if (behandling.erEndreMigreringsdato()) {
             behandlingsresultatstegValideringService
                 .validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -443,6 +443,7 @@ class CucumberMock(
             clockProvider = clockProvider,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
             strengtFortroligService = mockk(relaxed = true),
+            satsendringEøsKjøringService = mockk(relaxed = true),
         )
 
     val behandlingsresultatSteg =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
@@ -20,12 +20,15 @@ import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.datagenerator.lagValutakurs
 import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType.FØRSTEGANGSBEHANDLING
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType.REVURDERING
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.FINNMARKSTILLEGG
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SATSENDRING
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SATSENDRING_EØS
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SVALBARDTILLEGG
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak.SØKNAD
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
@@ -64,6 +67,7 @@ class BehandlingsresultatStegValideringServiceTest {
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService = mockk()
     private val strengtFortroligService = mockk<no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService>(relaxed = true)
     private val clockProvider = lagClockProviderMedFastTidspunkt(LocalDate.of(2025, 10, 10))
+    private val satsendringEøsKjøringService: SatsendringEøsKjøringService = mockk()
 
     private val behandlingsresultatStegValideringService =
         BehandlingsresultatStegValideringService(
@@ -77,6 +81,7 @@ class BehandlingsresultatStegValideringServiceTest {
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
             strengtFortroligService = strengtFortroligService,
             clockProvider = clockProvider,
+            satsendringEøsKjøringService = satsendringEøsKjøringService,
         )
 
     private val barn = lagPerson(type = PersonType.BARN)
@@ -1646,6 +1651,248 @@ class BehandlingsresultatStegValideringServiceTest {
             every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(nåværendeBehandling) } returns forrigeBehandling
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns skjermetBarnsHistoriskeAndeler
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns skjermetBarnsAndelerINåværendeBehandling
+        }
+    }
+
+    @Nested
+    inner class ValiderAtMinstEttUtenlandskPeriodebeløpErEndret {
+        private val barn = lagPerson(type = PersonType.BARN)
+        private val forrigeBehandling = lagBehandling(årsak = SØKNAD)
+        private val nåværendeBehandling = lagBehandling(årsak = SATSENDRING_EØS)
+        private val satsendringstidspunkt = YearMonth.of(2025, 5)
+        private val kjøring =
+            SatsendringEøsKjøring(
+                fagsakId = nåværendeBehandling.fagsak.id,
+                behandlingId = nåværendeBehandling.id,
+                utbetalingsland = "PL",
+                satsTidspunkt = satsendringstidspunkt,
+            )
+
+        @Test
+        fun `skal ikke kaste feil når minst ett UPB har endret beløp`() {
+            // Arrange
+            val forrigeUpb =
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = forrigeBehandling.id,
+                    fom = satsendringstidspunkt,
+                    beløp = BigDecimal("1000"),
+                    intervall = Intervall.MÅNEDLIG,
+                    valutakode = "PLN",
+                    utbetalingsland = "PL",
+                    barnAktører = setOf(barn.aktør),
+                )
+            val nyUpb =
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = nåværendeBehandling.id,
+                    fom = satsendringstidspunkt,
+                    beløp = BigDecimal("1200"),
+                    intervall = Intervall.MÅNEDLIG,
+                    valutakode = "PLN",
+                    utbetalingsland = "PL",
+                    barnAktører = setOf(barn.aktør),
+                )
+            every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(nåværendeBehandling.id) } returns kjøring
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(nåværendeBehandling) } returns forrigeBehandling
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(nåværendeBehandling.id) } returns listOf(nyUpb)
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(forrigeBehandling.id) } returns listOf(forrigeUpb)
+
+            // Act & Assert
+            assertDoesNotThrow {
+                behandlingsresultatStegValideringService.validerAtMinstEttUtenlandskPeriodebeløpErEndret(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal kaste feil når beløp er identisk med forrige behandling`() {
+            // Arrange
+            val forrigeUpb =
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = forrigeBehandling.id,
+                    fom = satsendringstidspunkt,
+                    beløp = BigDecimal("1000"),
+                    intervall = Intervall.MÅNEDLIG,
+                    valutakode = "PLN",
+                    utbetalingsland = "PL",
+                    barnAktører = setOf(barn.aktør),
+                )
+            val nyUpb =
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = nåværendeBehandling.id,
+                    fom = satsendringstidspunkt,
+                    beløp = BigDecimal("1000"),
+                    intervall = Intervall.MÅNEDLIG,
+                    valutakode = "PLN",
+                    utbetalingsland = "PL",
+                    barnAktører = setOf(barn.aktør),
+                )
+            every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(nåværendeBehandling.id) } returns kjøring
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(nåværendeBehandling) } returns forrigeBehandling
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(nåværendeBehandling.id) } returns listOf(nyUpb)
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(forrigeBehandling.id) } returns listOf(forrigeUpb)
+
+            // Act & Assert
+            assertThrows<Feil> {
+                behandlingsresultatStegValideringService.validerAtMinstEttUtenlandskPeriodebeløpErEndret(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal kaste feil når UPB-endring er for et annet land enn det kjøringen gjelder`() {
+            // Arrange
+            val forrigeUpb =
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = forrigeBehandling.id,
+                    fom = satsendringstidspunkt,
+                    beløp = BigDecimal("1000"),
+                    intervall = Intervall.MÅNEDLIG,
+                    valutakode = "SEK",
+                    utbetalingsland = "SE",
+                    barnAktører = setOf(barn.aktør),
+                )
+            val nyUpb =
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = nåværendeBehandling.id,
+                    fom = satsendringstidspunkt,
+                    beløp = BigDecimal("1200"),
+                    intervall = Intervall.MÅNEDLIG,
+                    valutakode = "SEK",
+                    utbetalingsland = "SE",
+                    barnAktører = setOf(barn.aktør),
+                )
+            every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(nåværendeBehandling.id) } returns kjøring
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(nåværendeBehandling) } returns forrigeBehandling
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(nåværendeBehandling.id) } returns listOf(nyUpb)
+            every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(forrigeBehandling.id) } returns listOf(forrigeUpb)
+
+            // Act & Assert
+            assertThrows<Feil> {
+                behandlingsresultatStegValideringService.validerAtMinstEttUtenlandskPeriodebeløpErEndret(nåværendeBehandling)
+            }
+        }
+
+        @Test
+        fun `skal kaste feil når det ikke finnes SatsendringEøsKjøring for behandlingen`() {
+            every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(nåværendeBehandling.id) } throws Feil("Fant ikke")
+
+            assertThrows<Feil> {
+                behandlingsresultatStegValideringService.validerAtMinstEttUtenlandskPeriodebeløpErEndret(nåværendeBehandling)
+            }
+        }
+    }
+
+    @Nested
+    inner class ValiderIngenEndringFørSatsendringstidspunkt {
+        private val barn = lagPerson(type = PersonType.BARN)
+        private val forrigeBehandling = lagBehandling(årsak = SØKNAD)
+        private val nåværendeBehandling = lagBehandling(årsak = SATSENDRING_EØS)
+        private val satsendringstidspunkt = YearMonth.of(2025, 5)
+        private val kjøring =
+            SatsendringEøsKjøring(
+                fagsakId = nåværendeBehandling.fagsak.id,
+                behandlingId = nåværendeBehandling.id,
+                utbetalingsland = "PL",
+                satsTidspunkt = satsendringstidspunkt,
+            )
+
+        @Test
+        fun `skal ikke kaste feil når andeler er uendret før satsendringstidspunktet`() {
+            // Arrange
+            val tilkjentYtelse =
+                lagTilkjentYtelse(
+                    behandling = nåværendeBehandling,
+                    lagAndelerTilkjentYtelse = { ty ->
+                        setOf(
+                            lagAndelTilkjentYtelse(
+                                fom = YearMonth.of(2025, 1),
+                                tom = satsendringstidspunkt.minusMonths(1),
+                                aktør = barn.aktør,
+                                kalkulertUtbetalingsbeløp = 500,
+                                tilkjentYtelse = ty,
+                            ),
+                            lagAndelTilkjentYtelse(
+                                fom = satsendringstidspunkt,
+                                tom = YearMonth.of(2025, 12),
+                                aktør = barn.aktør,
+                                kalkulertUtbetalingsbeløp = 400,
+                                tilkjentYtelse = ty,
+                            ),
+                        )
+                    },
+                )
+            val forrigeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 1),
+                        tom = satsendringstidspunkt.minusMonths(1),
+                        aktør = barn.aktør,
+                        kalkulertUtbetalingsbeløp = 500,
+                        behandling = forrigeBehandling,
+                    ),
+                    lagAndelTilkjentYtelse(
+                        fom = satsendringstidspunkt,
+                        tom = YearMonth.of(2025, 12),
+                        aktør = barn.aktør,
+                        kalkulertUtbetalingsbeløp = 500,
+                        behandling = forrigeBehandling,
+                    ),
+                )
+
+            every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(nåværendeBehandling.id) } returns kjøring
+            every { beregningService.hentAndelerFraForrigeVedtatteBehandling(nåværendeBehandling) } returns forrigeAndeler
+
+            // Act & Assert
+            assertDoesNotThrow {
+                behandlingsresultatStegValideringService.validerIngenEndringIAndelerFørSatsendringstidspunkt(tilkjentYtelse)
+            }
+        }
+
+        @Test
+        fun `skal kaste feil når kalkulert utbetalingsbeløp er endret i en måned før satsendringstidspunktet`() {
+            // Arrange
+            val tilkjentYtelse =
+                lagTilkjentYtelse(
+                    behandling = nåværendeBehandling,
+                    lagAndelerTilkjentYtelse = { ty ->
+                        setOf(
+                            lagAndelTilkjentYtelse(
+                                fom = YearMonth.of(2025, 1),
+                                tom = YearMonth.of(2025, 12),
+                                aktør = barn.aktør,
+                                kalkulertUtbetalingsbeløp = 400,
+                                tilkjentYtelse = ty,
+                            ),
+                        )
+                    },
+                )
+            val forrigeAndeler =
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2025, 12),
+                        aktør = barn.aktør,
+                        kalkulertUtbetalingsbeløp = 500,
+                        behandling = forrigeBehandling,
+                    ),
+                )
+
+            every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(nåværendeBehandling.id) } returns kjøring
+            every { beregningService.hentAndelerFraForrigeVedtatteBehandling(nåværendeBehandling) } returns forrigeAndeler
+
+            // Act & Assert
+            assertThrows<Feil> {
+                behandlingsresultatStegValideringService.validerIngenEndringIAndelerFørSatsendringstidspunkt(tilkjentYtelse)
+            }
+        }
+
+        @Test
+        fun `skal kaste feil når det ikke finnes SatsendringEøsKjøring for behandlingen`() {
+            val tilkjentYtelse = lagTilkjentYtelse(behandling = nåværendeBehandling)
+
+            every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(nåværendeBehandling.id) } throws Feil("Fant ikke")
+
+            assertThrows<Feil> {
+                behandlingsresultatStegValideringService.validerIngenEndringIAndelerFørSatsendringstidspunkt(tilkjentYtelse)
+            }
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.datagenerator.lagPersonResultat
+import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -16,6 +17,7 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -392,5 +394,124 @@ internal class BehandlingsresultatValideringUtilsTest {
 
         // Act & Assert
         assertDoesNotThrow { BehandlingsresultatValideringUtils.validerBehandlingsresultat(behandling) }
+    }
+
+    @Nested
+    inner class ValiderIngenEndringFørMåned {
+        private val aktør = randomAktør()
+        private val grensemåned = YearMonth.of(2025, 5)
+
+        @Test
+        fun `skal ikke kaste feil når andeler er uendret før grensemåneden`() {
+            // Arrange
+            val andel =
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 4),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1000,
+                )
+
+            // Act & Assert
+            assertDoesNotThrow {
+                BehandlingsresultatValideringUtils.validerIngenEndringFørMåned(
+                    andelerDenneBehandlingen = listOf(andel),
+                    andelerForrigeBehandling = listOf(andel.copy()),
+                    grensemåned = grensemåned,
+                )
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil når endring kun skjer fra og med grensemåneden`() {
+            // Arrange
+            val andelFør =
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 4),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1000,
+                )
+            val andelEtter =
+                lagAndelTilkjentYtelse(
+                    fom = grensemåned,
+                    tom = YearMonth.of(2025, 12),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1200,
+                )
+            val forrigeAndelEtter =
+                lagAndelTilkjentYtelse(
+                    fom = grensemåned,
+                    tom = YearMonth.of(2025, 12),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1000,
+                )
+
+            // Act & Assert
+            assertDoesNotThrow {
+                BehandlingsresultatValideringUtils.validerIngenEndringFørMåned(
+                    andelerDenneBehandlingen = listOf(andelFør, andelEtter),
+                    andelerForrigeBehandling = listOf(andelFør.copy(), forrigeAndelEtter),
+                    grensemåned = grensemåned,
+                )
+            }
+        }
+
+        @Test
+        fun `skal kaste feil når kalkulert utbetalingsbeløp er endret i en måned før grensemåneden`() {
+            // Arrange
+            val andelDenneBehandlingen =
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 4),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1200,
+                )
+            val andelForrigeBehandling =
+                lagAndelTilkjentYtelse(
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 4),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1000,
+                )
+
+            // Act & Assert
+            assertThrows<Feil> {
+                BehandlingsresultatValideringUtils.validerIngenEndringFørMåned(
+                    andelerDenneBehandlingen = listOf(andelDenneBehandlingen),
+                    andelerForrigeBehandling = listOf(andelForrigeBehandling),
+                    grensemåned = grensemåned,
+                )
+            }
+        }
+
+        @Test
+        fun `validerIngenEndringTilbakeITid delegerer korrekt til validerIngenEndringFørMåned`() {
+            // Arrange – endring i forrige måned skal gi feil
+            val nåMåned = grensemåned
+            val andelDenneBehandlingen =
+                lagAndelTilkjentYtelse(
+                    fom = nåMåned.minusMonths(2),
+                    tom = nåMåned.minusMonths(1),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1200,
+                )
+            val andelForrigeBehandling =
+                lagAndelTilkjentYtelse(
+                    fom = nåMåned.minusMonths(2),
+                    tom = nåMåned.minusMonths(1),
+                    aktør = aktør,
+                    kalkulertUtbetalingsbeløp = 1000,
+                )
+
+            // Act & Assert
+            assertThrows<Feil> {
+                BehandlingsresultatValideringUtils.validerIngenEndringTilbakeITid(
+                    andelerDenneBehandlingen = listOf(andelDenneBehandlingen),
+                    andelerForrigeBehandling = listOf(andelForrigeBehandling),
+                    nåMåned = nåMåned,
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29793

### 💰 Hva skal gjøres, og hvorfor?
**Validering i behandlingsresultatsteget:** Ved `SATSENDRING_EØS`-behandlinger valideres det at:
  - minst ett utenlandsk periodebeløp er endret for riktig land
  - ingen andeler er endret før satsendringstidspunktet
  
`validerIngenEndringTilbakeITid` er refaktorert til å delegere til en ny `validerIngenEndringFørMåned` som aksepterer en vilkårlig grensemåned, slik at logikken kan gjenbrukes for EØS-satsendring.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er det andre ting som bør valideres?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.