### PR TITLE
Håndter NoResourceFoundException som 404

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.time.format.DateTimeParseException
@@ -38,6 +39,17 @@ class ApiExceptionHandler {
 
     @ExceptionHandler(RolleTilgangskontrollFeil::class)
     fun handleRolleTilgangskontrollFeil(rolleTilgangskontrollFeil: RolleTilgangskontrollFeil): ResponseEntity<Ressurs<Nothing>> = rolleTilgangResponse(rolleTilgangskontrollFeil)
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResourceFoundException(exception: NoResourceFoundException): ResponseEntity<Ressurs<Nothing>> {
+        logger.info("Fant ikke ressurs for request=${exception.resourcePath}", exception.resourcePath)
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            Ressurs.failure(
+                frontendFeilmelding = "Fant ikke ressurs for request=${exception.resourcePath}",
+            ),
+        )
+    }
 
     @ExceptionHandler(Exception::class)
     fun handleException(exception: Exception): ResponseEntity<Ressurs<Nothing>> {


### PR DESCRIPTION
### 📮 Favro: NAV-29757 

### 💰 Hva skal gjøres, og hvorfor?
Det er lagt til eksplisitt håndtering av `NoResourceFoundException` i `ApiExceptionHandler`.

Tidligere ble kall mot manglende statiske ressurser, som `/swagger-ui/`, håndtert av generell exception-håndtering. Det ga unødvendige warnings i loggene og behandlet en forventet 404 som en intern feil. Disse feilene ble ignorert i Sentry

Endringen gjør at disse kallene nå:
- returnerer `404 Not Found`
- logges på `INFO`
- ikke behandles som intern feil
