### PR TITLE
fix: Håndtering av 401 Unauthorized når f.eks. klienter kaster det

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.common.RessursUtils.frontendFeil
 import no.nav.familie.ba.sak.common.RessursUtils.funksjonellFeil
 import no.nav.familie.ba.sak.common.RessursUtils.illegalState
 import no.nav.familie.ba.sak.common.RessursUtils.rolleTilgangResponse
+import no.nav.familie.ba.sak.common.RessursUtils.unauthorized
 import no.nav.familie.ba.sak.common.RolleTilgangskontrollFeil
 import no.nav.familie.ba.sak.common.lesRessurs
 import no.nav.familie.ba.sak.common.secureLogger
@@ -88,6 +89,12 @@ class ApiExceptionHandler {
                 ?: "Ikke tilgang"
 
         return forbidden(melding)
+    }
+
+    @ExceptionHandler(HttpClientErrorException.Unauthorized::class)
+    fun handleUnauhtorized(): ResponseEntity<Ressurs<Nothing>> {
+        logger.info("Fikk 401 Unauthorized")
+        return unauthorized("Unauthorized")
     }
 
     @ExceptionHandler(IntegrasjonException::class)


### PR DESCRIPTION
### 📮 Favro: [NAV-29757](https://favro.com/organization/98c34fb974ce445eac854de0/?card=NAV-29757)

### 💰 Hva skal gjøres, og hvorfor?
Sentry catcher Unauthorized mot f.eks. /hent-klagebehandlinger som ikke hadde trengt å komme i Sentry. Lagt til egen exceptionhåndtering for denne og returnerer mer riktig statusmelding
https://sentry.gc.nav.no/organizations/nav/issues/644989/?alert_rule_id=146&alert_type=issue&environment=prod&notification_uuid=e270f230-5186-4660-8c53-69fda33d51f5&project=112&referrer=slack

