### PR TITLE
NAV-29193: Nullstiller utdypende vilkårsvurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultat.kt
@@ -105,6 +105,7 @@ data class VilkårResultat(
         periodeFom = null
         periodeTom = null
         begrunnelse = ""
+        utdypendeVilkårsvurderinger = emptyList()
         resultat = Resultat.IKKE_VURDERT
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/VilkårResultatTest.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene
+
+import no.nav.familie.ba.sak.datagenerator.lagVilkårResultat
+import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class VilkårResultatTest {
+    @Nested
+    inner class Nullstill {
+        @Test
+        fun `skal nullstille vilkår resultat`() {
+            // Arrange
+            val dagensDato = LocalDate.now()
+
+            val vilkårResultat =
+                lagVilkårResultat(
+                    periodeFom = dagensDato,
+                    periodeTom = dagensDato.plusDays(1),
+                    begrunnelse = "begrunnelse",
+                    utdypendeVilkårsvurderinger =
+                        listOf(
+                            UtdypendeVilkårsvurdering.DELT_BOSTED,
+                        ),
+                    resultat = Resultat.OPPFYLT,
+                )
+
+            // Act
+            vilkårResultat.nullstill()
+
+            // Assert
+            assertThat(vilkårResultat.periodeFom).isNull()
+            assertThat(vilkårResultat.periodeTom).isNull()
+            assertThat(vilkårResultat.begrunnelse).isEmpty()
+            assertThat(vilkårResultat.utdypendeVilkårsvurderinger).isEmpty()
+            assertThat(vilkårResultat.resultat).isEqualTo(Resultat.IKKE_VURDERT)
+        }
+    }
+}


### PR DESCRIPTION
### 📮 Favro:
NAV-29193

### 💰 Hva skal gjøres, og hvorfor?
Nullstiller utdypende vilkårsvurdering

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.