### PR TITLE
Mapp 9-sifret ident til ORGNR ved journalføring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/JournalføringDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/JournalføringDto.kt
@@ -56,6 +56,7 @@ data class JournalføringDto(
         val avsenderMottakerIdType =
             when {
                 journalpost.kanal == "EESSI" -> journalpost.avsenderMottaker?.type
+                this.avsender.id.length == 9 && this.avsender.id.all { it.isDigit() } -> AvsenderMottakerIdType.ORGNR
                 this.avsender.id != "" -> AvsenderMottakerIdType.FNR
                 else -> null
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/JournalføringDto.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/JournalføringDto.kt
@@ -56,15 +56,20 @@ data class JournalføringDto(
         val avsenderMottakerIdType =
             when {
                 journalpost.kanal == "EESSI" -> journalpost.avsenderMottaker?.type
-                this.avsender.id.length == 9 && this.avsender.id.all { it.isDigit() } -> AvsenderMottakerIdType.ORGNR
+
+                this.avsender.id
+                    .trim()
+                    .length == 9 && this.avsender.id.all { it.isDigit() } -> AvsenderMottakerIdType.ORGNR
+
                 this.avsender.id != "" -> AvsenderMottakerIdType.FNR
+
                 else -> null
             }
 
         return OppdaterJournalpostRequest(
             avsenderMottaker =
                 AvsenderMottaker(
-                    id = this.avsender.id,
+                    id = this.avsender.id.trim(),
                     idType = avsenderMottakerIdType,
                     navn = this.avsender.navn,
                 ),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringDtoTest.kt
@@ -57,6 +57,28 @@ class JournalføringDtoTest {
         }
 
         @Test
+        fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til ORGNR dersom ident er 9 siffer`() {
+            // Arrange
+            val sak =
+                Sak(
+                    arkivsaksnummer = "arkivsaksnummer",
+                    arkivsaksystem = "arkivsaksystem",
+                    fagsakId = "1",
+                    sakstype = "sakstype",
+                    fagsaksystem = "BA",
+                )
+
+            val journalføringDto = lagMockJournalføringDto(NavnOgIdent("Organisasjon AS", "123456789"))
+            val journalpost = lagTestJournalpost("123456789", "1", null, "NAV_NO")
+
+            // Act
+            val oppdaterJournalpostRequest = journalføringDto.oppdaterMedDokumentOgSak(sak, journalpost)
+
+            // Assert
+            assertThat(oppdaterJournalpostRequest.avsenderMottaker?.idType).isEqualTo(AvsenderMottakerIdType.ORGNR)
+        }
+
+        @Test
         fun `Skal sette AvsenderMottakerIdType i AvsenderMottaker til null dersom ident er blank`() {
             // Arrange
             val sak =


### PR DESCRIPTION
### 📮 Favro: NAV-29830

### 💰 Hva skal gjøres, og hvorfor?

Journalføringsendepunktet (`journalførV2`) antok at avsenderident alltid var fødselsnummer. Organisasjonsnummer (9 numeriske tegn) ble feilaktig sendt som `FNR` til Dokarkiv.

Nå sjekker vi om ident er 9 siffer — da settes `AvsenderMottakerIdType.ORGNR` i stedet for `FNR`.

Fikser masse sentry-alarmer av typen HttpClientErrorException$BadRequest

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

Sjekken er kun lengde + numerisk. Ingen Enhetsregisteret-validering. Er det godt nok, eller bør vi sjekke mot et mønster (f.eks. at første siffer er 8 eller 9)?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.