### PR TITLE
Koble opp brev for EØS-satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevService.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ba.sak.kjerne.brev.domene.maler.AutovedtakEndring
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.AutovedtakFinnmarkstillegg
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.AutovedtakNyfødtBarnFraFør
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.AutovedtakNyfødtFørsteBarn
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.AutovedtakSatsendringEøs
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.AutovedtakSvalbardtillegg
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Avslag
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brev
@@ -282,6 +283,12 @@ class BrevService(
 
             Brevmal.AUTOVEDTAK_SVALBARDTILLEGG -> {
                 AutovedtakSvalbardtillegg(
+                    vedtakFellesfelter = vedtakFellesfelter,
+                )
+            }
+
+            Brevmal.AUTOVEDTAK_SATSENDRING_EØS -> {
+                AutovedtakSatsendringEøs(
                     vedtakFellesfelter = vedtakFellesfelter,
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevUtil.kt
@@ -75,6 +75,10 @@ fun hentAutomatiskVedtaksbrevtype(
             Brevmal.AUTOVEDTAK_ENDRING
         }
 
+        BehandlingÅrsak.SATSENDRING_EØS -> {
+            Brevmal.AUTOVEDTAK_SATSENDRING_EØS
+        }
+
         else -> {
             throw Feil("Det er ikke laget funksjonalitet for automatisk behandling for $behandlingÅrsak")
         }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequest.kt
@@ -614,6 +614,7 @@ fun ManueltBrevRequest.tilBrev(
         Brevmal.AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
         Brevmal.AUTOVEDTAK_FINNMARKSTILLEGG,
         Brevmal.AUTOVEDTAK_SVALBARDTILLEGG,
+        Brevmal.AUTOVEDTAK_SATSENDRING_EØS,
         Brevmal.TILBAKEKREVINGSVEDTAK_MOTREGNING,
         -> {
             throw Feil("Kan ikke mappe fra manuel brevrequest til ${this.brevmal}.")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/AutovedtakSatsendringEøs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/AutovedtakSatsendringEøs.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.ba.sak.kjerne.brev.domene.maler
+
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriode
+import no.nav.familie.ba.sak.kjerne.brev.domene.maler.utbetalingEøs.UtbetalingMndEøs
+
+data class AutovedtakSatsendringEøs(
+    override val mal: Brevmal = Brevmal.AUTOVEDTAK_SATSENDRING_EØS,
+    override val data: AutovedtakSatsendringEøsData,
+) : Vedtaksbrev {
+    constructor(vedtakFellesfelter: VedtakFellesfelter) :
+        this(
+            data =
+                AutovedtakSatsendringEøsData(
+                    delmalData =
+                        AutovedtakSatsendringEøsData.Delmaler(
+                            hjemmeltekst = vedtakFellesfelter.hjemmeltekst,
+                            autoUnderskrift = AutoUnderskrift(enhet = vedtakFellesfelter.enhet),
+                        ),
+                    flettefelter =
+                        FlettefelterForDokumentImpl(
+                            navn = vedtakFellesfelter.søkerNavn,
+                            fodselsnummer = vedtakFellesfelter.søkerFødselsnummer,
+                        ),
+                    perioder = vedtakFellesfelter.perioder,
+                ),
+        )
+}
+
+data class AutovedtakSatsendringEøsData(
+    override val delmalData: Delmaler,
+    override val flettefelter: FlettefelterForDokumentImpl,
+    override val perioder: List<BrevPeriode>,
+    override val utbetalingerPerMndEøs: Map<String, UtbetalingMndEøs>? = null,
+) : VedtaksbrevStandardData {
+    data class Delmaler(
+        val hjemmeltekst: Hjemmeltekst,
+        val autoUnderskrift: AutoUnderskrift,
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/maler/Brev.kt
@@ -171,6 +171,7 @@ enum class Brevmal(
     AUTOVEDTAK_NYFØDT_BARN_FRA_FØR(true, "autovedtakNyfodtBarnFraFor", "Autovedtak nyfødt - barn fra før"),
     AUTOVEDTAK_FINNMARKSTILLEGG(true, "autovedtakFinnmarkstillegg", "Vedtak finnmarkstillegg innvilget"),
     AUTOVEDTAK_SVALBARDTILLEGG(true, "autovedtakSvalbardtillegg", "Vedtak svalbardtillegg innvilget"),
+    AUTOVEDTAK_SATSENDRING_EØS(true, "satsendringEos", "Vedtak EØS-satsendring"),
     ;
 
     fun skalGenerereForside(): Boolean =
@@ -233,6 +234,7 @@ enum class Brevmal(
             AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
             AUTOVEDTAK_FINNMARKSTILLEGG,
             AUTOVEDTAK_SVALBARDTILLEGG,
+            AUTOVEDTAK_SATSENDRING_EØS,
             -> throw Feil("$this støtter ikke generering av forside")
         }
 
@@ -328,6 +330,7 @@ enum class Brevmal(
             AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
             AUTOVEDTAK_FINNMARKSTILLEGG,
             AUTOVEDTAK_SVALBARDTILLEGG,
+            AUTOVEDTAK_SATSENDRING_EØS,
             -> throw Feil("Ingen dokumenttype for $this")
         }
 
@@ -377,6 +380,7 @@ enum class Brevmal(
                 AUTOVEDTAK_NYFØDT_BARN_FRA_FØR,
                 AUTOVEDTAK_FINNMARKSTILLEGG,
                 AUTOVEDTAK_SVALBARDTILLEGG,
+                AUTOVEDTAK_SATSENDRING_EØS,
                 -> Distribusjonstype.VEDTAK
 
                 HENLEGGE_TRUKKET_SØKNAD,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalServiceTest.kt
@@ -194,4 +194,17 @@ internal class BrevmalServiceTest {
 
         assertThat(brevmalService.hentVedtaksbrevmal(behandling), Is(Brevmal.AUTOVEDTAK_ENDRING))
     }
+
+    @Test
+    fun `hentVedtaksbrevmal skal returnere AUTOVEDTAK_SATSENDRING_EØS for automatisk behandling med årsak SATSENDRING_EØS`() {
+        val behandling =
+            lagBehandling(
+                årsak = BehandlingÅrsak.SATSENDRING_EØS,
+                skalBehandlesAutomatisk = true,
+                behandlingType = BehandlingType.REVURDERING,
+                resultat = Behandlingsresultat.ENDRET_UTBETALING,
+            )
+
+        assertThat(brevmalService.hentVedtaksbrevmal(behandling), Is(Brevmal.AUTOVEDTAK_SATSENDRING_EØS))
+    }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29802

### 💰 Hva skal gjøres, og hvorfor?
Brevet for EØS-satsendring er opprettet i Sanity (apiNavn `satsendringEos`), men var ikke koblet opp i ba-sak. Behandlingsflyten for `SATSENDRING_EØS` går allerede gjennom `JOURNALFØR_VEDTAKSBREV` og `DISTRIBUER_VEDTAKSBREV`, men `hentAutomatiskVedtaksbrevtype` hadde ingen mapping for årsaken og kastet `Feil` i `else`-grenen – så brevsteget ville feilet.

Denne PR-en kobler opp brevet:
- Ny brevmal `AUTOVEDTAK_SATSENDRING_EØS` med `apiNavn = "satsendringEos"` (`Brev.kt`), lagt inn i de uttømmende `when`-blokkene (`skalGenerereForside`, `tilFamilieKontrakterDokumentType`, `distribusjonstype → VEDTAK`).
- Ny malklasse `AutovedtakSatsendringEøs` (følger samme mønster som `AutovedtakSvalbardtillegg`).
- Bygger brevdata i `BrevService.hentVedtaksbrevData`.
- Mapper `BehandlingÅrsak.SATSENDRING_EØS → Brevmal.AUTOVEDTAK_SATSENDRING_EØS` i `hentAutomatiskVedtaksbrevtype` (`BrevUtil.kt`).
- Lagt til i «kan ikke mappe fra manuell brevrequest»-lista (`ManueltBrevRequest.kt`), siden dette kun er et autovedtaksbrev.
