### PR TITLE
Håndter nettverksfeil separat og reduser Sentry-støy

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandler.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ba.sak.config
 
+import io.micrometer.core.instrument.Metrics
+import jakarta.servlet.http.HttpServletRequest
 import no.nav.familie.ba.sak.common.EksternTjenesteFeil
 import no.nav.familie.ba.sak.common.EksternTjenesteFeilException
 import no.nav.familie.ba.sak.common.Feil
@@ -30,13 +32,40 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import java.io.EOFException
+import java.io.IOException
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.net.SocketException
+import java.nio.channels.ClosedChannelException
 import java.time.format.DateTimeParseException
 
 @ControllerAdvice
 class ApiExceptionHandler {
     private val logger = LoggerFactory.getLogger(ApiExceptionHandler::class.java)
+
+    private val nettverksfeilTeller =
+        NettverksfeilType.entries.associateWith {
+            Metrics.counter("nettverksfeil.klientavbrudd", "type", it.metrikknavn)
+        }
+
+    @ExceptionHandler(IOException::class, ClosedChannelException::class, EOFException::class)
+    fun handleNettverksfeil(
+        e: Exception,
+        request: HttpServletRequest,
+    ): ResponseEntity<Ressurs<Nothing>> {
+        val cause = NestedExceptionUtils.getMostSpecificCause(e)
+        val type = NettverksfeilType.fraException(cause)
+
+        nettverksfeilTeller[type]?.increment()
+        logger.info(
+            "Nettverksfeil av type=${type.metrikknavn} url=${request.method} ${request.requestURI} melding=${cause.message}",
+        )
+
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(
+            Ressurs.failure(frontendFeilmelding = "Tilkoblingen ble brutt"),
+        )
+    }
 
     @ExceptionHandler(RolleTilgangskontrollFeil::class)
     fun handleRolleTilgangskontrollFeil(rolleTilgangskontrollFeil: RolleTilgangskontrollFeil): ResponseEntity<Ressurs<Nothing>> = rolleTilgangResponse(rolleTilgangskontrollFeil)
@@ -185,4 +214,26 @@ class ApiExceptionHandler {
                         .joinToString(" ,"),
                 ),
             )
+}
+
+enum class NettverksfeilType(
+    val metrikknavn: String,
+) {
+    BROKEN_PIPE("broken_pipe"),
+    CLOSED_CHANNEL("closed_channel"),
+    CONNECTION_RESET("connection_reset"),
+    EOF("eof"),
+    UKJENT("ukjent"),
+    ;
+
+    companion object {
+        fun fraException(e: Throwable): NettverksfeilType =
+            when {
+                e is ClosedChannelException -> CLOSED_CHANNEL
+                e is EOFException -> EOF
+                e is IOException && e.message?.lowercase()?.contains("broken pipe") == true -> BROKEN_PIPE
+                e is SocketException && e.message?.lowercase()?.contains("connection reset") == true -> CONNECTION_RESET
+                else -> UKJENT
+            }
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandlerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/ApiExceptionHandlerTest.kt
@@ -1,0 +1,95 @@
+package no.nav.familie.ba.sak.config
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.HttpStatus
+import java.io.EOFException
+import java.io.IOException
+import java.net.SocketException
+import java.nio.channels.ClosedChannelException
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApiExceptionHandlerTest {
+    private val handler = ApiExceptionHandler()
+    private val request = mockk<HttpServletRequest>()
+
+    @BeforeEach
+    fun setUp() {
+        every { request.requestURI } returns "/api/behandling/123"
+        every { request.method } returns "GET"
+    }
+
+    @Test
+    fun `handleNettverksfeil returnerer 503 ved IOException broken pipe`() {
+        // Arrange
+        val feil = IOException("Broken pipe")
+
+        // Act
+        val respons = handler.handleNettverksfeil(feil, request)
+
+        // Assert
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        assertThat(respons.body?.frontendFeilmelding).isEqualTo("Tilkoblingen ble brutt")
+    }
+
+    @Test
+    fun `handleNettverksfeil returnerer 503 ved ClosedChannelException`() {
+        // Arrange
+        val feil = ClosedChannelException()
+
+        // Act
+        val respons = handler.handleNettverksfeil(feil, request)
+
+        // Assert
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+    }
+
+    @Test
+    fun `handleNettverksfeil returnerer 503 ved EOFException`() {
+        // Arrange
+        val feil = EOFException("Unexpected end of stream")
+
+        // Act
+        val respons = handler.handleNettverksfeil(feil, request)
+
+        // Assert
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+    }
+
+    @Test
+    fun `NettverksfeilType klassifiserer broken pipe korrekt`() {
+        assertThat(NettverksfeilType.fraException(IOException("Broken pipe"))).isEqualTo(NettverksfeilType.BROKEN_PIPE)
+        assertThat(NettverksfeilType.fraException(IOException("broken pipe"))).isEqualTo(NettverksfeilType.BROKEN_PIPE)
+    }
+
+    @Test
+    fun `NettverksfeilType klassifiserer ClosedChannelException korrekt`() {
+        assertThat(NettverksfeilType.fraException(ClosedChannelException())).isEqualTo(NettverksfeilType.CLOSED_CHANNEL)
+    }
+
+    @Test
+    fun `NettverksfeilType klassifiserer EOFException korrekt`() {
+        assertThat(NettverksfeilType.fraException(EOFException())).isEqualTo(NettverksfeilType.EOF)
+    }
+
+    @Test
+    fun `NettverksfeilType klassifiserer ukjent IOException som ukjent`() {
+        assertThat(NettverksfeilType.fraException(IOException("Connection reset"))).isEqualTo(NettverksfeilType.UKJENT)
+    }
+
+    @Test
+    fun `NettverksfeilType klassifiserer SocketException connection reset korrekt`() {
+        assertThat(NettverksfeilType.fraException(SocketException("Connection reset"))).isEqualTo(NettverksfeilType.CONNECTION_RESET)
+        assertThat(NettverksfeilType.fraException(SocketException("connection reset by peer"))).isEqualTo(NettverksfeilType.CONNECTION_RESET)
+    }
+
+    @Test
+    fun `NettverksfeilType klassifiserer ukjent SocketException som ukjent`() {
+        assertThat(NettverksfeilType.fraException(SocketException("Network unreachable"))).isEqualTo(NettverksfeilType.UKJENT)
+    }
+}


### PR DESCRIPTION
### 📮 Favro: NAV-29757

### 💰 Hva skal gjøres, og hvorfor?
Nettverksfeil som `Broken pipe`, `ClosedChannelException`, `EOFException` og
`Connection reset` havnet tidligere i default-handleren, som logget dem som
alvorlige feil og sendte dem til Sentry. Dette skapte støy og skjulte reelle
applikasjonsfeil.

Disse feilene er typisk klientavbrudd eller infrastruktur-hiccups — ikke feil
i applikasjonen vår.

- Ny `handleNettverksfeil` i `ApiExceptionHandler` fanger `IOException`,
  `ClosedChannelException` og `EOFException`
- Logger på INFO-nivå (ikke ERROR) og returnerer 503 til klienten
- Ingen Sentry-capture for disse feiltypene
- Ny `NettverksfeilType`-enum klassifiserer feil etter type og melding:
  `BROKEN_PIPE`, `CLOSED_CHANNEL`, `CONNECTION_RESET`, `EOF`, `UKJENT`

Mulige grafana alerts
```
increase(nettverksfeil_klientavbrudd_total{app="familie-ba-sak", type="broken_pipe"}[1h]) > 10
```

Mulige loki alerts
```
count_over_time(
  {app="familie-ba-sak", cluster="prod-gcp"}
  |= "Nettverksfeil av type"
  | logfmt
  | type = "broken_pipe"
  [1h]
) > 10
```

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
