### PR TITLE
Legg til validering på at alle barn med andeler er med

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringService.kt
@@ -40,9 +40,9 @@ import no.nav.familie.ba.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
+import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.steg.BehandlingsresultatSteg
 import no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService
-import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNull
 import no.nav.familie.ba.sak.kjerne.tidslinje.komposisjon.kombinerUtenNullMed
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
@@ -66,6 +66,7 @@ class BehandlingsresultatStegValideringService(
     private val valutakursRepository: ValutakursRepository,
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val strengtFortroligService: StrengtFortroligService,
+    private val persongrunnlagService: PersongrunnlagService,
     private val clockProvider: ClockProvider,
 ) {
     fun validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(behandling: Behandling) {
@@ -350,6 +351,41 @@ class BehandlingsresultatStegValideringService(
             if (andelDenneBehandling != null && andelForrigeBehandling == null) {
                 throw FunksjonellFeil("Det finnes nye andeler i behandling. Kan ikke innvilge nye andeler i 'Falsk identitet'-behandling.")
             }
+        }
+    }
+
+    fun validerAtAlleBarnMedEksisterendeAndelerFraForrigeIverksatteBehandlingErMed(behandling: Behandling) {
+        val forrigeIverksatteBehandling = behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(behandling) ?: return
+
+        val aktørerMedAndelerIForrigeIverksatteBehandling =
+            andelTilkjentYtelseRepository
+                .finnAndelerTilkjentYtelseForBehandling(forrigeIverksatteBehandling.id)
+                .map { it.aktør }
+                .toSet()
+
+        val aktørerIDenneBehandlingen =
+            persongrunnlagService
+                .hentSøkerOgBarnPåBehandlingThrows(behandling.id)
+                .map { it.aktør }
+                .toSet()
+
+        val barnMedAndelerSomManglerIBehandlingenFraForrigeBehandling =
+            aktørerMedAndelerIForrigeIverksatteBehandling - aktørerIDenneBehandlingen
+
+        if (barnMedAndelerSomManglerIBehandlingenFraForrigeBehandling.isNotEmpty()) {
+            secureLogger.warn(
+                "Behandling ${behandling.id} mangler ${barnMedAndelerSomManglerIBehandlingenFraForrigeBehandling.size} barn med barnetrygd " +
+                    "fra forrige iverksatte behandling ${forrigeIverksatteBehandling.id}: " +
+                    "${barnMedAndelerSomManglerIBehandlingenFraForrigeBehandling.map { it.aktivFødselsnummer() }}.",
+            )
+            throw FunksjonellFeil(
+                melding =
+                    "Behandlingen mangler barn som har barnetrygd i forrige iverksatte behandling. " +
+                        "Antall barn som mangler: ${barnMedAndelerSomManglerIBehandlingenFraForrigeBehandling.size}.",
+                frontendFeilmelding =
+                    "Det finnes barn med løpende barnetrygd som ikke er med i behandlingen. " +
+                        "Du må legge til alle brukers barn i behandlingen.",
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatSteg.kt
@@ -66,6 +66,7 @@ class BehandlingsresultatSteg(
             behandlingsresultatstegValideringService.validerKompetanse(behandling.id)
             behandlingsresultatstegValideringService.validerSekundærlandKompetanse(behandling.id)
             behandlingsresultatstegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(behandling)
+            behandlingsresultatstegValideringService.validerAtAlleBarnMedEksisterendeAndelerFraForrigeIverksatteBehandlingErMed(behandling)
         }
 
         if (behandling.erMånedligValutajustering()) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -443,6 +443,7 @@ class CucumberMock(
             clockProvider = clockProvider,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
             strengtFortroligService = mockk(relaxed = true),
+            persongrunnlagService = persongrunnlagService,
         )
 
     val behandlingsresultatSteg =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
@@ -20,9 +20,9 @@ import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.datagenerator.lagValutakurs
 import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.datagenerator.tilPersonEnkel
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
-import no.nav.familie.ba.sak.datagenerator.tilPersonEnkel
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType.FØRSTEGANGSBEHANDLING

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatStegValideringServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.datagenerator.lagValutakurs
 import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.datagenerator.tilPersonEnkel
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType.FØRSTEGANGSBEHANDLING
@@ -42,6 +43,7 @@ import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Vurderingsform
 import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
+import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårService
 import no.nav.familie.prosessering.error.RekjørSenereException
 import org.assertj.core.api.Assertions.assertThat
@@ -63,6 +65,7 @@ class BehandlingsresultatStegValideringServiceTest {
     private val valutakursRepository: ValutakursRepository = mockk()
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService = mockk()
     private val strengtFortroligService = mockk<no.nav.familie.ba.sak.kjerne.strengtfortrolig.StrengtFortroligService>(relaxed = true)
+    private val persongrunnlagService = mockk<no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService>()
     private val clockProvider = lagClockProviderMedFastTidspunkt(LocalDate.of(2025, 10, 10))
 
     private val behandlingsresultatStegValideringService =
@@ -76,6 +79,7 @@ class BehandlingsresultatStegValideringServiceTest {
             valutakursRepository = valutakursRepository,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
             strengtFortroligService = strengtFortroligService,
+            persongrunnlagService = persongrunnlagService,
             clockProvider = clockProvider,
         )
 
@@ -1646,6 +1650,61 @@ class BehandlingsresultatStegValideringServiceTest {
             every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErVedtatt(nåværendeBehandling) } returns forrigeBehandling
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns skjermetBarnsHistoriskeAndeler
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns skjermetBarnsAndelerINåværendeBehandling
+        }
+    }
+
+    @Nested
+    inner class ValiderAtAlleBarnMedEksisterendeAndelerFraForrigeIverksatteBehandlingErMed {
+        private val søker = lagPerson(type = PersonType.SØKER)
+        private val barn1 = lagPerson(type = PersonType.BARN)
+        private val barn2 = lagPerson(type = PersonType.BARN)
+        private val forrigeBehandling = lagBehandling()
+        private val nåværendeBehandling = lagBehandling()
+
+        private fun andelForBarn(
+            aktør: Aktør,
+            tom: YearMonth,
+            beløp: Int = 1000,
+        ) = lagAndelTilkjentYtelse(fom = YearMonth.of(2024, 1), tom = tom, aktør = aktør, beløp = beløp)
+
+        @Test
+        fun `kaster FunksjonellFeil når et barn med andeler i forrige behandling mangler`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(nåværendeBehandling) } returns forrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns
+                listOf(
+                    andelForBarn(barn1.aktør, tom = YearMonth.of(2030, 1)),
+                    andelForBarn(barn2.aktør, tom = YearMonth.of(2030, 1)),
+                )
+            every { persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(nåværendeBehandling.id) } returns
+                listOf(søker.tilPersonEnkel(), barn1.tilPersonEnkel())
+
+            // Act
+            val feil =
+                assertThrows<FunksjonellFeil> {
+                    behandlingsresultatStegValideringService.validerAtAlleBarnMedEksisterendeAndelerFraForrigeIverksatteBehandlingErMed(nåværendeBehandling)
+                }
+
+            // Assert
+            assertThat(feil.frontendFeilmelding).contains("Du må legge til alle brukers barn i behandlingen")
+        }
+
+        @Test
+        fun `kaster ikke feil når alle barn med andeler i forrige behandling er med`() {
+            // Arrange
+            every { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(nåværendeBehandling) } returns forrigeBehandling
+            every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns
+                listOf(
+                    andelForBarn(barn1.aktør, tom = YearMonth.of(2030, 1)),
+                    andelForBarn(barn2.aktør, tom = YearMonth.of(2030, 1)),
+                )
+            every { persongrunnlagService.hentSøkerOgBarnPåBehandlingThrows(nåværendeBehandling.id) } returns
+                listOf(søker.tilPersonEnkel(), barn1.tilPersonEnkel(), barn2.tilPersonEnkel())
+
+            // Act & Assert
+            assertDoesNotThrow {
+                behandlingsresultatStegValideringService.validerAtAlleBarnMedEksisterendeAndelerFraForrigeIverksatteBehandlingErMed(nåværendeBehandling)
+            }
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/BehandlingsresultatStegTest.kt
@@ -112,6 +112,7 @@ class BehandlingsresultatStegTest {
             justRun { behandlingsresultatstegValideringService.validerSatsErUendret(any()) }
             justRun { behandlingsresultatstegValideringService.validerIngenEndringIUtbetalingEtterMigreringsdatoenTilForrigeIverksatteBehandling(any()) }
             justRun { behandlingsresultatstegValideringService.validerIngenEndringIUtbetalingIPerioderMedSkjermedeBarn(any()) }
+            justRun { behandlingsresultatstegValideringService.validerAtAlleBarnMedEksisterendeAndelerFraForrigeIverksatteBehandlingErMed(any()) }
         }
 
         @ParameterizedTest
@@ -141,6 +142,20 @@ class BehandlingsresultatStegTest {
             // Assert
             verify(exactly = 1) {
                 behandlingsresultatstegValideringService.validerAtUtenlandskPeriodebeløpOgValutakursErUtfylt(behandling)
+            }
+        }
+
+        @Test
+        fun `skal validere at alle barn med andeler fra forrige iverksatte behandling er med`() {
+            // Arrange
+            val behandling = lagBehandling()
+
+            // Act
+            behandlingsresultatSteg.preValiderSteg(behandling)
+
+            // Assert
+            verify(exactly = 1) {
+                behandlingsresultatstegValideringService.validerAtAlleBarnMedEksisterendeAndelerFraForrigeIverksatteBehandlingErMed(behandling)
             }
         }
 


### PR DESCRIPTION

### 📮 Favro: Nav-29818

### 💰 Hva skal gjøres, og hvorfor?
En revurdering kan i dag stanse barnetrygden til et barn ved en feil - 
F.eks hvis det opprettes en revurdering der hele barnetrygden stanses, men så har det vært en innvilget fødselshendelse i mellomtiden som har gått gjennom. Da vil viderebehandling av revurderingen stanse barnetrygden til det nyfødte barnet (siden barnet ikke finnes i personopplysninggrunnlaget). Saksbehandler får ikke noe beskjed om dette med mindre de er oppmerksom når de kommer seg til simuleringssteget.

Denne PR-en legger inn en validering som stopper behandlingen og ber saksbehandler legge inn alle brukers
barn. Vi bruker sist iverksatte behandling som fasit på hva slags aktører som bør ha vært med, avhengig om de har hatt andeler fra før av.