### PR TITLE
Legg til autovedtak for satsendring EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/common/Feil.kt
@@ -13,8 +13,8 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
 class AutovedtakSkalIkkeGjennomføresFeil(
-    message: String,
-) : RuntimeException(message)
+    val beskrivelse: String,
+) : RuntimeException(beskrivelse)
 
 class AutovedtakMåBehandlesManueltFeil(
     val beskrivelse: String,

--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -61,4 +61,7 @@ enum class FeatureToggle(
 
     // NAV-25661
     KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON("familie-ba-sak.kan-registrere-soknadstidspunkt"),
+
+    // NAV-29800
+    KAN_KJØRE_SATSENDRING_EØS("familie-ba-sak.kan-kjore-satsendring-eos"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakService.kt
@@ -29,7 +29,7 @@ class AutovedtakService(
     /**
      * Oppretter en ny, automatisk behandling med gitt type og årsak, og kjører den til behandlingsresultat.
      *
-     * [førVilkårsvurdering] kalles med den nyopprettede behandlingen etter at den har fått en id,
+     * [kjørFørVilkårsvurdering] kalles med den nyopprettede behandlingen etter at den har fått en id,
      * men før vilkårsvurderingssteget kjøres. Nyttig for kallere som trenger å koble noe til
      * `behandlingId` før vilkårsvurderingssteget og behandlingsresultatsteget kjører.
      */
@@ -37,7 +37,7 @@ class AutovedtakService(
         behandlingType: BehandlingType,
         behandlingÅrsak: BehandlingÅrsak,
         fagsakId: Long,
-        førVilkårsvurdering: (Behandling) -> Unit = {},
+        kjørFørVilkårsvurdering: (Behandling) -> Unit = {},
     ): Behandling {
         val nyBehandling =
             stegService.håndterNyBehandling(
@@ -49,7 +49,7 @@ class AutovedtakService(
                 ),
             )
 
-        førVilkårsvurdering(nyBehandling)
+        kjørFørVilkårsvurdering(nyBehandling)
 
         val behandlingEtterBehandlingsresultat = stegService.håndterVilkårsvurdering(nyBehandling)
         return behandlingEtterBehandlingsresultat

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakService.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.fagsak.Beslutning
 import no.nav.familie.ba.sak.kjerne.logg.LoggService
-import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.kjerne.steg.StegService
 import no.nav.familie.ba.sak.kjerne.steg.StegType
 import no.nav.familie.ba.sak.kjerne.steg.TilbakestillBehandlingTilBehandlingsresultatService
@@ -27,10 +26,18 @@ class AutovedtakService(
     private val totrinnskontrollService: TotrinnskontrollService,
     private val tilbakestillBehandlingTilBehandlingsresultatService: TilbakestillBehandlingTilBehandlingsresultatService,
 ) {
+    /**
+     * Oppretter en ny, automatisk behandling med gitt type og årsak, og kjører den til behandlingsresultat.
+     *
+     * [førVilkårsvurdering] kalles med den nyopprettede behandlingen etter at den har fått en id,
+     * men før vilkårsvurderingssteget kjøres. Nyttig for kallere som trenger å koble noe til
+     * `behandlingId` før vilkårsvurderingssteget og behandlingsresultatsteget kjører.
+     */
     fun opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
         behandlingType: BehandlingType,
         behandlingÅrsak: BehandlingÅrsak,
         fagsakId: Long,
+        førVilkårsvurdering: (Behandling) -> Unit = {},
     ): Behandling {
         val nyBehandling =
             stegService.håndterNyBehandling(
@@ -41,6 +48,8 @@ class AutovedtakService(
                     fagsakId = fagsakId,
                 ),
             )
+
+        førVilkårsvurdering(nyBehandling)
 
         val behandlingEtterBehandlingsresultat = stegService.håndterVilkårsvurdering(nyBehandling)
         return behandlingEtterBehandlingsresultat

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutovedtakStegService.kt
@@ -4,11 +4,13 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.secureLogger
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.AutovedtakFødselshendelseService
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.AutovedtakSatsendringEøsService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.AutovedtakSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.AutovedtakSvalbardtilleggService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
@@ -29,6 +31,7 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.YearMonth
 import java.time.temporal.ChronoUnit
 
 interface AutovedtakBehandlingService<Behandlingsdata : AutomatiskBehandlingData> {
@@ -45,6 +48,7 @@ enum class Autovedtaktype(
     OMREGNING_BREV("Omregning"),
     FINNMARKSTILLEGG("Finnmarkstillegg"),
     SVALBARDTILLEGG("Svalbardtillegg"),
+    SATSENDRING_EØS("Satsendring EØS"),
 }
 
 sealed interface AutomatiskBehandlingData {
@@ -84,6 +88,14 @@ data class SvalbardtilleggData(
     override val type = Autovedtaktype.SVALBARDTILLEGG
 }
 
+data class SatsendringEøsData(
+    val fagsakId: Long,
+    val utbetalingsland: String,
+    val satsTidspunkt: YearMonth,
+) : AutomatiskBehandlingData {
+    override val type = Autovedtaktype.SATSENDRING_EØS
+}
+
 @Service
 class AutovedtakStegService(
     private val fagsakService: FagsakService,
@@ -94,6 +106,7 @@ class AutovedtakStegService(
     private val autovedtakSmåbarnstilleggService: AutovedtakSmåbarnstilleggService,
     private val autovedtakFinnmarkstilleggService: AutovedtakFinnmarkstilleggService,
     private val autovedtakSvalbardtilleggService: AutovedtakSvalbardtilleggService,
+    private val autovedtakSatsendringEøsService: AutovedtakSatsendringEøsService,
     private val snikeIKøenService: SnikeIKøenService,
     private val featureToggleService: FeatureToggleService,
 ) {
@@ -164,6 +177,24 @@ class AutovedtakStegService(
             førstegangKjørt = førstegangKjørt,
         )
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun kjørBehandlingSatsendringEøs(
+        mottakersAktør: Aktør,
+        fagsakId: Long,
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+        førstegangKjørt: LocalDateTime = LocalDateTime.now(),
+    ): String {
+        if (!featureToggleService.isEnabled(FeatureToggle.KAN_KJØRE_SATSENDRING_EØS)) {
+            throw Feil("Toggle KAN_KJØRE_SATSENDRING_EØS er skrudd av")
+        }
+        return kjørBehandling(
+            mottakersAktør = mottakersAktør,
+            automatiskBehandlingData = SatsendringEøsData(fagsakId, utbetalingsland, satsTidspunkt),
+            førstegangKjørt = førstegangKjørt,
+        )
+    }
+
     private fun kjørBehandling(
         automatiskBehandlingData: AutomatiskBehandlingData,
         mottakersAktør: Aktør,
@@ -179,6 +210,7 @@ class AutovedtakStegService(
                 is SmåbarnstilleggData -> autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(automatiskBehandlingData)
                 is FinnmarkstilleggData -> autovedtakFinnmarkstilleggService.skalAutovedtakBehandles(automatiskBehandlingData)
                 is SvalbardtilleggData -> autovedtakSvalbardtilleggService.skalAutovedtakBehandles(automatiskBehandlingData)
+                is SatsendringEøsData -> autovedtakSatsendringEøsService.skalAutovedtakBehandles(automatiskBehandlingData)
             }
 
         if (!skalAutovedtakBehandles) {
@@ -212,6 +244,7 @@ class AutovedtakStegService(
                 is SmåbarnstilleggData -> autovedtakSmåbarnstilleggService.kjørBehandling(automatiskBehandlingData)
                 is FinnmarkstilleggData -> autovedtakFinnmarkstilleggService.kjørBehandling(automatiskBehandlingData)
                 is SvalbardtilleggData -> autovedtakSvalbardtilleggService.kjørBehandling(automatiskBehandlingData)
+                is SatsendringEøsData -> autovedtakSatsendringEøsService.kjørBehandling(automatiskBehandlingData)
             }
 
         secureLoggAutovedtakBehandling(
@@ -232,6 +265,8 @@ class AutovedtakStegService(
             is FinnmarkstilleggData -> behandlingsdata.fagsakId
 
             is SvalbardtilleggData -> behandlingsdata.fagsakId
+
+            is SatsendringEøsData -> behandlingsdata.fagsakId
 
             is FødselshendelseData,
             is SmåbarnstilleggData,
@@ -266,7 +301,7 @@ class AutovedtakStegService(
                         årsak = autovedtaktype.tilMaskinellVentÅrsak(),
                     )
                     return false
-                } else if (autovedtaktype == Autovedtaktype.FINNMARKSTILLEGG) {
+                } else if (skalRekjøresSenere(autovedtaktype)) {
                     throw RekjørSenereException(
                         årsak = "Åpen behandling med status ${åpenBehandling.status} ble endret for under fire timer siden. Prøver igjen klokken 06.00 neste virkedag",
                         triggerTid = nesteVirkedag(LocalDate.now()).atTime(6, 0),
@@ -306,6 +341,14 @@ class AutovedtakStegService(
         return true
     }
 
+    private fun skalRekjøresSenere(autovedtakType: Autovedtaktype): Boolean =
+        autovedtakType in
+            setOf(
+                Autovedtaktype.FINNMARKSTILLEGG,
+                Autovedtaktype.SVALBARDTILLEGG,
+                Autovedtaktype.SATSENDRING_EØS,
+            )
+
     private fun begrunnelseForÅpenBehandling(automatiskBehandlingData: AutomatiskBehandlingData) =
         when {
             automatiskBehandlingData is OmregningBrevData &&
@@ -335,4 +378,5 @@ private fun Autovedtaktype.tilMaskinellVentÅrsak() =
         Autovedtaktype.SMÅBARNSTILLEGG -> SettPåMaskinellVentÅrsak.SMÅBARNSTILLEGG
         Autovedtaktype.FINNMARKSTILLEGG -> SettPåMaskinellVentÅrsak.FINNMARKSTILLEGG
         Autovedtaktype.SVALBARDTILLEGG -> SettPåMaskinellVentÅrsak.SVALBARDTILLEGG
+        Autovedtaktype.SATSENDRING_EØS -> SettPåMaskinellVentÅrsak.SATSENDRING_EØS
     }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsService.kt
@@ -1,0 +1,144 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs
+
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakBehandlingService
+import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
+import no.nav.familie.ba.sak.kjerne.autovedtak.SatsendringEøsData
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsSvar.SATSENDRING_EØS_ER_ALLEREDE_UTFØRT
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsSvar.SATSENDRING_EØS_INGEN_RELEVANTE_UTENLANDSK_PERIODEBELØP
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsSvar.SATSENDRING_EØS_KJØRT_OK
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister
+import no.nav.familie.ba.sak.kjerne.eøs.sats.SatsendringEøsValidering.validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk
+import no.nav.familie.ba.sak.kjerne.eøs.sats.filtrerErRelevantForSats
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.steg.StegType
+import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
+import no.nav.familie.ba.sak.task.JournalførVedtaksbrevTask
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AutovedtakSatsendringEøsService(
+    private val behandlingHentOgPersisterService: BehandlingHentOgPersisterService,
+    private val satsendringEøsKjøringService: SatsendringEøsKjøringService,
+    private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService,
+    private val autovedtakService: AutovedtakService,
+    private val taskRepository: TaskRepositoryWrapper,
+) : AutovedtakBehandlingService<SatsendringEøsData> {
+    override fun skalAutovedtakBehandles(behandlingsdata: SatsendringEøsData): Boolean {
+        val sisteVedtatteBehandling =
+            behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandlingsdata.fagsakId)
+                ?: return false
+
+        return sisteVedtatteBehandling.kategori == BehandlingKategori.EØS &&
+            sisteVedtatteBehandling.fagsak.status == FagsakStatus.LØPENDE
+    }
+
+    /**
+     * Gjennomfører og committer revurderingsbehandling med årsak SATSENDRING_EØS.
+     *
+     * Kaster [AutovedtakMåBehandlesManueltFeil] dersom det er avvik i valuta,
+     * intervall eller beløp og saksbehandler må opprette en manuell revurdering.
+     */
+    @Transactional
+    override fun kjørBehandling(behandlingsdata: SatsendringEøsData): String {
+        val fagsakId = behandlingsdata.fagsakId
+        val utbetalingsland = behandlingsdata.utbetalingsland
+        val satsTidspunkt = behandlingsdata.satsTidspunkt
+
+        val sisteVedtatteBehandling =
+            behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsakId)
+                ?: throw Feil("Fant ikke siste vedtatte behandling for fagsak=$fagsakId")
+
+        val nySats = EøsSatserRegister.hentSatsForLandIMåned(utbetalingsland, satsTidspunkt)
+        val relevanteUtenlandskPeriodebeløp =
+            utenlandskPeriodebeløpService
+                .hentUtenlandskePeriodebeløp(BehandlingId(sisteVedtatteBehandling.id))
+                .filtrerErRelevantForSats(nySats)
+
+        if (relevanteUtenlandskPeriodebeløp.isEmpty()) {
+            logger.info("${SATSENDRING_EØS_INGEN_RELEVANTE_UTENLANDSK_PERIODEBELØP.melding} for fagsak $fagsakId")
+            return SATSENDRING_EØS_INGEN_RELEVANTE_UTENLANDSK_PERIODEBELØP.melding
+        }
+
+        if (relevanteUtenlandskPeriodebeløp.all { it.beløp == nySats.beløp }) {
+            logger.info("${SATSENDRING_EØS_ER_ALLEREDE_UTFØRT.melding} for fagsak $fagsakId")
+            return SATSENDRING_EØS_ER_ALLEREDE_UTFØRT.melding
+        }
+
+        val forrigeSats = EøsSatserRegister.hentSatsForLandIMåned(utbetalingsland, nySats.fom.minusMonths(1))
+
+        relevanteUtenlandskPeriodebeløp.forEach { utenlandskPeriodebeløp ->
+            validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
+                utenlandskPeriodebeløp = utenlandskPeriodebeløp,
+                forrigeSats = forrigeSats,
+                nySats = nySats,
+            )
+        }
+
+        val behandlingEtterBehandlingsresultat =
+            autovedtakService.opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
+                behandlingType = BehandlingType.REVURDERING,
+                behandlingÅrsak = BehandlingÅrsak.SATSENDRING_EØS,
+                fagsakId = fagsakId,
+                førVilkårsvurdering = { behandling ->
+                    satsendringEøsKjøringService.settBehandlingId(fagsakId, utbetalingsland, satsTidspunkt, behandling.id)
+                },
+            )
+
+        val opprettetVedtak =
+            autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(
+                behandlingEtterBehandlingsresultat,
+            )
+
+        val task =
+            when (behandlingEtterBehandlingsresultat.steg) {
+                StegType.IVERKSETT_MOT_OPPDRAG -> {
+                    IverksettMotOppdragTask.opprettTask(
+                        behandling = behandlingEtterBehandlingsresultat,
+                        vedtak = opprettetVedtak,
+                        saksbehandlerId = SikkerhetContext.hentSaksbehandler(),
+                    )
+                }
+
+                StegType.JOURNALFØR_VEDTAKSBREV -> {
+                    JournalførVedtaksbrevTask.opprettTaskJournalførVedtaksbrev(
+                        personIdent = behandlingEtterBehandlingsresultat.fagsak.aktør.aktivFødselsnummer(),
+                        behandlingId = behandlingEtterBehandlingsresultat.id,
+                        vedtakId = opprettetVedtak.id,
+                    )
+                }
+
+                else -> {
+                    throw Feil("Ugyldig neste steg ${behandlingEtterBehandlingsresultat.steg} ved satsendring EØS for fagsak=$fagsakId")
+                }
+            }
+
+        taskRepository.save(task)
+
+        return SATSENDRING_EØS_KJØRT_OK.melding
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AutovedtakSatsendringEøsService::class.java)
+    }
+}
+
+enum class SatsendringEøsSvar(
+    val melding: String,
+) {
+    SATSENDRING_EØS_KJØRT_OK("Satsendring EØS kjørt OK"),
+    SATSENDRING_EØS_ER_ALLEREDE_UTFØRT("Satsendring EØS allerede utført"),
+    SATSENDRING_EØS_INGEN_RELEVANTE_UTENLANDSK_PERIODEBELØP("Ingen relevante utenlandsk periodebeløp for satsendring EØS"),
+    SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT("Satsendring EØS må behandles manuelt fordi utenlandsk periodebeløp har avvik i beløp, valuta eller intervall"),
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsService.kt
@@ -91,7 +91,7 @@ class AutovedtakSatsendringEøsService(
                 behandlingType = BehandlingType.REVURDERING,
                 behandlingÅrsak = BehandlingÅrsak.SATSENDRING_EØS,
                 fagsakId = fagsakId,
-                førVilkårsvurdering = { behandling ->
+                kjørFørVilkårsvurdering = { behandling ->
                     satsendringEøsKjøringService.settBehandlingId(fagsakId, utbetalingsland, satsTidspunkt, behandling.id)
                 },
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsKjøringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsKjøringService.kt
@@ -4,6 +4,8 @@ import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøringRepository
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.time.YearMonth
 
 @Service
 class SatsendringEøsKjøringService(
@@ -12,4 +14,44 @@ class SatsendringEøsKjøringService(
     fun hentSatsendringEøsKjøring(behandlingId: Long): SatsendringEøsKjøring =
         satsendringEøsKjøringRepository.findByBehandlingId(behandlingId)
             ?: throw Feil("Ingen SatsendringEøsKjøring funnet for behandling $behandlingId.")
+
+    fun hentSatsendringEøsKjøring(
+        fagsakId: Long,
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+    ): SatsendringEøsKjøring =
+        satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+            ?: throw Feil("Ingen SatsendringEøsKjøring funnet for fagsak $fagsakId, utbetalingsland $utbetalingsland og tidspunkt $satsTidspunkt.")
+
+    fun settBehandlingId(
+        fagsakId: Long,
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+        behandlingId: Long,
+    ) {
+        val kjøring = hentSatsendringEøsKjøring(fagsakId, utbetalingsland, satsTidspunkt)
+        kjøring.behandlingId = behandlingId
+        satsendringEøsKjøringRepository.save(kjøring)
+    }
+
+    fun settFerdigTidspunkt(
+        fagsakId: Long,
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+    ) {
+        val kjøring = hentSatsendringEøsKjøring(fagsakId, utbetalingsland, satsTidspunkt)
+        kjøring.ferdigTidspunkt = LocalDateTime.now()
+        satsendringEøsKjøringRepository.save(kjøring)
+    }
+
+    fun settFeiltype(
+        fagsakId: Long,
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+        feiltype: String,
+    ) {
+        val kjøring = hentSatsendringEøsKjøring(fagsakId, utbetalingsland, satsTidspunkt)
+        kjøring.feiltype = feiltype
+        satsendringEøsKjøringRepository.save(kjøring)
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/SnikeIKøenService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/SnikeIKøenService.kt
@@ -150,6 +150,7 @@ enum class SettPåMaskinellVentÅrsak(
     val årsak: String,
 ) {
     SATSENDRING("Satsendring"),
+    SATSENDRING_EØS("Satsendring EØS"),
     OMREGNING_6_ELLER_18_ÅR("Omregning 6 eller 18 år"),
     SMÅBARNSTILLEGG("Småbarnstillegg"),
     FØDSELSHENDELSE("Fødselshendelse"),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
@@ -2,6 +2,9 @@ package no.nav.familie.ba.sak.kjerne.eøs.sats
 
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.filtrerErUtfylt
 import java.math.BigDecimal
 import java.time.YearMonth
 
@@ -26,3 +29,13 @@ data class EøsSats(
 
     override fun toString() = "${javaClass.simpleName}(land='$land', valuta='$valuta', beløp=$beløp, fom=${fom.tilKortString()}, tom=${tom?.tilKortString()}, intervall=$intervall)"
 }
+
+fun UtfyltUtenlandskPeriodebeløp.overlapper(eøsSats: EøsSats): Boolean =
+    (this.tom == null || eøsSats.fom <= this.tom) &&
+        (eøsSats.tom == null || this.fom <= eøsSats.tom)
+
+/**
+ * Filtrerer ut [UtenlandskPeriodebeløp] som er relevante for [eøsSats] — dvs. er utfylt,
+ * gjelder samme utbetalingsland som [eøsSats], og overlapper perioden [eøsSats] gjelder for.
+ */
+fun Collection<UtenlandskPeriodebeløp>.filtrerErRelevantForSats(eøsSats: EøsSats): List<UtfyltUtenlandskPeriodebeløp> = this.filtrerErUtfylt().filter { it.utbetalingsland == eøsSats.land && it.overlapper(eøsSats) }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSats.kt
@@ -38,4 +38,4 @@ fun UtfyltUtenlandskPeriodebeløp.overlapper(eøsSats: EøsSats): Boolean =
  * Filtrerer ut [UtenlandskPeriodebeløp] som er relevante for [eøsSats] — dvs. er utfylt,
  * gjelder samme utbetalingsland som [eøsSats], og overlapper perioden [eøsSats] gjelder for.
  */
-fun Collection<UtenlandskPeriodebeløp>.filtrerErRelevantForSats(eøsSats: EøsSats): List<UtfyltUtenlandskPeriodebeløp> = this.filtrerErUtfylt().filter { it.utbetalingsland == eøsSats.land && it.overlapper(eøsSats) }
+fun Collection<UtenlandskPeriodebeløp>.filtrerErRelevantForSats(eøsSats: EøsSats) = filtrerErUtfylt().filter { it.utbetalingsland == eøsSats.land && it.overlapper(eøsSats) }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegister.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegister.kt
@@ -4,19 +4,21 @@ import no.nav.familie.ba.sak.common.Feil
 import java.time.YearMonth
 
 /**
- * Hardkodet register over satser per EØS-land.
+ * Register over satser per EØS-land.
  *
- * Satser for hvert land legges til i [hei](./EøsSatser.kt) vedlikeholdes i den tilhørende filen (f.eks. [EøsSatserPolen]).
+ * Satser for hvert land legges til i [EøsSatser.kt](./EøsSatser.kt) (f.eks. [EøsSatserPolen]).
  *
  */
 object EøsSatserRegister {
     /**
      * Register over alle land med EØS-satser.
      */
-    internal val satser: List<EøsSatser> =
-        EøsSatser::class
-            .sealedSubclasses
-            .map { it.objectInstance ?: error("${it.simpleName} må være object") }
+    internal val satser: List<EøsSats>
+        get() =
+            EøsSatser::class
+                .sealedSubclasses
+                .map { it.objectInstance ?: error("${it.simpleName} må være object") }
+                .flatMap { it.satser }
 
     /**
      * @return gjeldende sats for et land i en gitt måned eller null dersom ingen sats er registrert for landet i den aktuelle måneden.
@@ -24,11 +26,7 @@ object EøsSatserRegister {
     fun finnSatsForLandIMåned(
         land: String,
         måned: YearMonth,
-    ): EøsSats? =
-        satser
-            .find { it.land == land }
-            ?.satser
-            ?.find { it.erGyldigForMåned(måned) }
+    ): EøsSats? = satser.find { it.land == land && it.erGyldigForMåned(måned) }
 
     /**
      * @return gjeldende sats for et land i en gitt måned

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKj
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.konverterBeløpTilMånedlig
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
 import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister.hentSatsForLandIMåned
+import no.nav.familie.ba.sak.kjerne.eøs.sats.SatsendringEøsValidering.validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
@@ -86,47 +87,6 @@ class SatsendringEøsService(
         utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(BehandlingId(utenlandskPeriodebeløp.behandlingId), nyttUtenlandskPeriodebeløp)
 
         return true
-    }
-
-    /**
-     * Validerer at [utenlandskPeriodebeløp] kan oppdateres automatisk til [nySats].
-     *
-     * @throws [AutovedtakMåBehandlesManueltFeil] hvis ett av følgende krav ikke er oppfylt:
-     * - Beløp i [utenlandskPeriodebeløp] er lik beløp i [forrigeSats] (uendret siden forrige satsendring)
-     * - Valuta i [utenlandskPeriodebeløp] er lik valuta i [nySats]
-     * - Intervall i [utenlandskPeriodebeløp] er lik intervall i [nySats]
-     */
-    private fun validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
-        utenlandskPeriodebeløp: UtfyltUtenlandskPeriodebeløp,
-        forrigeSats: EøsSats,
-        nySats: EøsSats,
-    ) {
-        val behandlingId = utenlandskPeriodebeløp.behandlingId
-        val utbetalingsland = utenlandskPeriodebeløp.utbetalingsland
-        val valutakode = utenlandskPeriodebeløp.valutakode
-        val beløp = utenlandskPeriodebeløp.beløp
-        val intervall = utenlandskPeriodebeløp.intervall
-
-        if (forrigeSats.beløp.compareTo(beløp) != 0) {
-            throw AutovedtakMåBehandlesManueltFeil(
-                "UtenlandskPeriodebeløp for behandling $behandlingId og land $utbetalingsland " +
-                    "har beløp $beløp $valutakode, mens forrige EØS-sats har beløp ${forrigeSats.beløp} ${forrigeSats.valuta}.",
-            )
-        }
-
-        if (nySats.valuta != valutakode) {
-            throw AutovedtakMåBehandlesManueltFeil(
-                "UtenlandskPeriodebeløp for behandling $behandlingId og land $utbetalingsland " +
-                    "har valuta $valutakode, mens ny EØS-sats har valuta ${nySats.valuta}.",
-            )
-        }
-
-        if (nySats.intervall != intervall) {
-            throw AutovedtakMåBehandlesManueltFeil(
-                "UtenlandskPeriodebeløp for behandling $behandlingId og land $utbetalingsland " +
-                    "har intervall $intervall, mens ny EØS-sats har intervall ${nySats.intervall}.",
-            )
-        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsService.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister.hentSatsForLand
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
 import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
-import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.filtrerErUtfylt
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -39,8 +38,7 @@ class SatsendringEøsService(
         val antallOppdaterteUtenlandskPeriodebeløp =
             utenlandskPeriodebeløpService
                 .hentUtenlandskePeriodebeløp(behandlingId)
-                .filtrerErUtfylt()
-                .filter { it.utbetalingsland == nySats.land }
+                .filtrerErRelevantForSats(nySats)
                 .filter { oppdaterMedNySats(it, forrigeSats, nySats) }
                 .size
 
@@ -54,8 +52,8 @@ class SatsendringEøsService(
     /**
      * Forsøker å oppdatere [utenlandskPeriodebeløp] fra [forrigeSats] til [nySats].
      *
-     * Returnerer `true` hvis [utenlandskPeriodebeløp] ble oppdatert, `false` hvis perioden
-     * ikke overlapper [nySats] eller beløpet allerede er lik [nySats].
+     * Returnerer `true` hvis [utenlandskPeriodebeløp] ble oppdatert, `false` hvis
+     * beløpet allerede er lik [nySats].
      *
      * @throws [AutovedtakMåBehandlesManueltFeil] via
      *   [validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk] hvis periodebeløpet ikke kan
@@ -66,10 +64,6 @@ class SatsendringEøsService(
         forrigeSats: EøsSats,
         nySats: EøsSats,
     ): Boolean {
-        if (!utenlandskPeriodebeløp.overlapper(nySats)) {
-            logger.info("UtenlandskPeriodebeløp ${utenlandskPeriodebeløp.id} overlapper ikke ny sats $nySats.")
-            return false
-        }
         if (nySats.beløp.compareTo(utenlandskPeriodebeløp.beløp) == 0) {
             logger.info("UtenlandskPeriodebeløp ${utenlandskPeriodebeløp.id} er allerede oppdatert med ny sats $nySats.")
             return false
@@ -134,10 +128,6 @@ class SatsendringEøsService(
             )
         }
     }
-
-    private fun UtfyltUtenlandskPeriodebeløp.overlapper(eøsSats: EøsSats): Boolean =
-        (this.tom == null || eøsSats.fom <= this.tom) &&
-            (eøsSats.tom == null || this.fom <= eøsSats.tom)
 
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsValidering.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
+
+object SatsendringEøsValidering {
+    /**
+     * Validerer at [utenlandskPeriodebeløp] kan oppdateres automatisk til [nySats].
+     *
+     * @throws [no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil] hvis ett av følgende krav ikke er oppfylt:
+     * - Beløp i [utenlandskPeriodebeløp] er lik beløp i [forrigeSats] (uendret siden forrige satsendring)
+     * - Valuta i [utenlandskPeriodebeløp] er lik valuta i [nySats]
+     * - Intervall i [utenlandskPeriodebeløp] er lik intervall i [nySats]
+     */
+    fun validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
+        utenlandskPeriodebeløp: UtfyltUtenlandskPeriodebeløp,
+        forrigeSats: EøsSats,
+        nySats: EøsSats,
+    ) {
+        val harAvvikIBeløp = forrigeSats.beløp.compareTo(utenlandskPeriodebeløp.beløp) != 0
+        val harAvvikIValuta = nySats.valuta != utenlandskPeriodebeløp.valutakode
+        val harAvvikIIntervall = nySats.intervall != utenlandskPeriodebeløp.intervall
+
+        if (harAvvikIBeløp || harAvvikIValuta || harAvvikIIntervall) {
+            throw AutovedtakMåBehandlesManueltFeil(SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/OpprettTaskService.kt
@@ -7,8 +7,9 @@ import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggTask
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.Satskjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøringRepository
 import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.AutovedtakSvalbardtilleggTask
-import no.nav.familie.ba.sak.kjerne.behandling.HenleggÅrsak
 import no.nav.familie.ba.sak.kjerne.personident.Aktør
 import no.nav.familie.ba.sak.task.dto.AutobrevOpphørSmåbarnstilleggDTO
 import no.nav.familie.ba.sak.task.dto.AutobrevPgaAlderDTO
@@ -33,6 +34,7 @@ import java.util.Properties
 class OpprettTaskService(
     private val taskRepository: TaskRepositoryWrapper,
     private val satskjøringRepository: SatskjøringRepository,
+    private val satsendringEøsKjøringRepository: SatsendringEøsKjøringRepository,
     private val envService: EnvService,
 ) {
     fun opprettOppgaveTask(
@@ -165,6 +167,31 @@ class OpprettTaskService(
                     properties =
                         Properties().apply {
                             this["fagsakId"] = fagsakId.toString()
+                        },
+                ),
+            )
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun opprettSatsendringEøsTask(
+        fagsakId: Long,
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+    ) {
+        if (satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt) == null) {
+            satsendringEøsKjøringRepository.save(SatsendringEøsKjøring(fagsakId = fagsakId, utbetalingsland = utbetalingsland, satsTidspunkt = satsTidspunkt))
+        }
+        overstyrTaskMedNyCallId(IdUtils.generateId()) {
+            taskRepository.save(
+                Task(
+                    type = SatsendringEøsTask.TASK_STEP_TYPE,
+                    payload = jsonMapper.writeValueAsString(SatsendringEøsTaskDto(fagsakId, utbetalingsland, satsTidspunkt)),
+                    properties =
+                        Properties().apply {
+                            this["fagsakId"] = fagsakId.toString()
+                            this["utbetalingsland"] = utbetalingsland
+                            this["satsTidspunkt"] = satsTidspunkt.toString()
                         },
                 ),
             )

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SatsendringEøsTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SatsendringEøsTask.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ba.sak.task
+
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.common.AutovedtakSkalIkkeGjennomføresFeil
+import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = SatsendringEøsTask.TASK_STEP_TYPE,
+    beskrivelse = "Utfør satsendring EØS",
+    maxAntallFeil = 3,
+)
+class SatsendringEøsTask(
+    private val autovedtakStegService: AutovedtakStegService,
+    private val fagsakService: FagsakService,
+    private val satsendringEøsKjøringService: SatsendringEøsKjøringService,
+) : AsyncTaskStep {
+    @WithSpan
+    override fun doTask(task: Task) {
+        val dto = jsonMapper.readValue(task.payload, SatsendringEøsTaskDto::class.java)
+        val aktør = fagsakService.hentAktør(dto.fagsakId)
+
+        val resultat =
+            try {
+                autovedtakStegService.kjørBehandlingSatsendringEøs(
+                    mottakersAktør = aktør,
+                    fagsakId = dto.fagsakId,
+                    utbetalingsland = dto.utbetalingsland,
+                    satsTidspunkt = dto.satsTidspunkt,
+                    førstegangKjørt = task.opprettetTid,
+                )
+            } catch (feil: AutovedtakSkalIkkeGjennomføresFeil) {
+                feil.beskrivelse
+            } catch (feil: AutovedtakMåBehandlesManueltFeil) {
+                satsendringEøsKjøringService.settFeiltype(dto.fagsakId, dto.utbetalingsland, dto.satsTidspunkt, feil.beskrivelse)
+                feil.beskrivelse
+            }
+
+        satsendringEøsKjøringService.settFerdigTidspunkt(dto.fagsakId, dto.utbetalingsland, dto.satsTidspunkt)
+
+        task.metadata["resultat"] = resultat
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "satsendringEøs"
+    }
+}
+
+data class SatsendringEøsTaskDto(
+    val fagsakId: Long,
+    val utbetalingsland: String,
+    val satsTidspunkt: YearMonth,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -694,6 +694,7 @@ class CucumberMock(
             taskRepository = taskRepository,
             satskjøringRepository = mockk(),
             envService = mockk(),
+            satsendringEøsKjøringRepository = mockk(),
         )
 
     val vilkårsvurderingSteg =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/MockAutovedtakSmåbarnstilleggService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/MockAutovedtakSmåbarnstilleggService.kt
@@ -42,6 +42,7 @@ fun mockAutovedtakSmåbarnstilleggService(
         autovedtakSmåbarnstilleggService = cucumberMock.autovedtakSmåbarnstilleggService,
         autovedtakFinnmarkstilleggService = mockk(),
         autovedtakSvalbardtilleggService = mockk(),
+        autovedtakSatsendringEøsService = mockk(),
         snikeIKøenService = mockk(),
         featureToggleService = mockk(),
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
@@ -3,6 +3,9 @@ package no.nav.familie.ba.sak.kjerne.autovedtak
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ba.sak.common.Feil
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.defaultFagsak
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.randomAktør
@@ -10,16 +13,22 @@ import no.nav.familie.ba.sak.integrasjoner.oppgave.OppgaveService
 import no.nav.familie.ba.sak.kjerne.autovedtak.finnmarkstillegg.AutovedtakFinnmarkstilleggService
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.AutovedtakFødselshendelseService
 import no.nav.familie.ba.sak.kjerne.autovedtak.omregning.AutovedtakBrevService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.AutovedtakSatsendringEøsService
 import no.nav.familie.ba.sak.kjerne.autovedtak.småbarnstillegg.AutovedtakSmåbarnstilleggService
 import no.nav.familie.ba.sak.kjerne.autovedtak.svalbardtillegg.AutovedtakSvalbardtilleggService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.SettPåMaskinellVentÅrsak
 import no.nav.familie.ba.sak.kjerne.behandling.SnikeIKøenService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.prosessering.error.RekjørSenereException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
+import java.time.YearMonth
 
 class AutobrevStegServiceTest {
     private val fagsakService = mockk<FagsakService>()
@@ -30,7 +39,9 @@ class AutobrevStegServiceTest {
     private val autovedtakSmåbarnstilleggService = mockk<AutovedtakSmåbarnstilleggService>()
     private val autovedtakFinnmarkstilleggService = mockk<AutovedtakFinnmarkstilleggService>()
     private val autovedtakSvalbardtilleggService = mockk<AutovedtakSvalbardtilleggService>()
+    private val autovedtakSatsendringEøsService = mockk<AutovedtakSatsendringEøsService>()
     private val snikeIKøenService = mockk<SnikeIKøenService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     val autovedtakStegService =
         AutovedtakStegService(
@@ -43,83 +54,201 @@ class AutobrevStegServiceTest {
             snikeIKøenService = snikeIKøenService,
             autovedtakFinnmarkstilleggService = autovedtakFinnmarkstilleggService,
             autovedtakSvalbardtilleggService = autovedtakSvalbardtilleggService,
-            autovedtakSatsendringEøsService = mockk(),
-            featureToggleService = mockk(),
+            autovedtakSatsendringEøsService = autovedtakSatsendringEøsService,
+            featureToggleService = featureToggleService,
         )
 
-    @Test
-    fun `Skal stoppe autovedtak og opprette oppgave ved åpen behandling som utredes og ikke kan snikes forbi`() {
-        val aktør = randomAktør()
-        val fagsak = defaultFagsak(aktør)
-        val behandling =
-            lagBehandling(fagsak = fagsak).also {
-                it.status = BehandlingStatus.UTREDES
-            }
+    @Nested
+    inner class KjørBehandlingSmåbarnstillegg {
+        @Test
+        fun `Skal stoppe autovedtak og opprette oppgave ved åpen behandling som utredes og ikke kan snikes forbi`() {
+            val aktør = randomAktør()
+            val fagsak = defaultFagsak(aktør)
+            val behandling =
+                lagBehandling(fagsak = fagsak).also {
+                    it.status = BehandlingStatus.UTREDES
+                }
 
-        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
-        every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
-        every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
-        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
-        every { snikeIKøenService.kanSnikeForbi(any()) } returns false
+            every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
+            every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
+            every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
+            every { snikeIKøenService.kanSnikeForbi(any()) } returns false
 
-        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
-            mottakersAktør = aktør,
-            aktør = aktør,
-        )
-
-        verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
-    }
-
-    @Test
-    fun `Skal stoppe autovedtak og opprette oppgave etter 7 dager ved åpen behandling med status Fatter vedtak`() {
-        val aktør = randomAktør()
-        val fagsak = defaultFagsak(aktør)
-        val behandling =
-            lagBehandling(fagsak = fagsak).also {
-                it.status = BehandlingStatus.FATTER_VEDTAK
-            }
-
-        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
-        every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
-        every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
-        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
-
-        assertThrows<RekjørSenereException> {
             autovedtakStegService.kjørBehandlingSmåbarnstillegg(
                 mottakersAktør = aktør,
                 aktør = aktør,
-                førstegangKjørt = LocalDateTime.now().minusDays(6),
             )
+
+            verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
         }
 
-        autovedtakStegService.kjørBehandlingSmåbarnstillegg(
-            mottakersAktør = aktør,
-            aktør = aktør,
-            førstegangKjørt = LocalDateTime.now().minusDays(7),
-        )
+        @Test
+        fun `Skal stoppe autovedtak og opprette oppgave etter 7 dager ved åpen behandling med status Fatter vedtak`() {
+            val aktør = randomAktør()
+            val fagsak = defaultFagsak(aktør)
+            val behandling =
+                lagBehandling(fagsak = fagsak).also {
+                    it.status = BehandlingStatus.FATTER_VEDTAK
+                }
 
-        verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
-    }
+            every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
+            every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
+            every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
 
-    @Test
-    fun `Skal stoppe autovedtak ved å kaste feil ved åpen behandling som iverksettes`() {
-        val aktør = randomAktør()
-        val fagsak = defaultFagsak(aktør)
-        val behandling =
-            lagBehandling(fagsak = fagsak).also {
-                it.status = BehandlingStatus.IVERKSETTER_VEDTAK
+            assertThrows<RekjørSenereException> {
+                autovedtakStegService.kjørBehandlingSmåbarnstillegg(
+                    mottakersAktør = aktør,
+                    aktør = aktør,
+                    førstegangKjørt = LocalDateTime.now().minusDays(6),
+                )
             }
 
-        every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
-        every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
-        every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
-        every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
-
-        assertThrows<RekjørSenereException> {
             autovedtakStegService.kjørBehandlingSmåbarnstillegg(
                 mottakersAktør = aktør,
                 aktør = aktør,
+                førstegangKjørt = LocalDateTime.now().minusDays(7),
             )
+
+            verify(exactly = 1) { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `Skal stoppe autovedtak ved å kaste feil ved åpen behandling som iverksettes`() {
+            val aktør = randomAktør()
+            val fagsak = defaultFagsak(aktør)
+            val behandling =
+                lagBehandling(fagsak = fagsak).also {
+                    it.status = BehandlingStatus.IVERKSETTER_VEDTAK
+                }
+
+            every { autovedtakSmåbarnstilleggService.skalAutovedtakBehandles(SmåbarnstilleggData(aktør)) } returns true
+            every { fagsakService.hentNormalFagsak(aktør) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
+            every { oppgaveService.opprettOppgaveForManuellBehandling(any(), any(), any(), any()) } returns ""
+
+            assertThrows<RekjørSenereException> {
+                autovedtakStegService.kjørBehandlingSmåbarnstillegg(
+                    mottakersAktør = aktør,
+                    aktør = aktør,
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class KjørBehandlingSatsendringEøs {
+        @Test
+        fun `skal kaste feil når toggle KAN_KJØRE_SATSENDRING_EØS er skrudd av`() {
+            // Arrange
+            val aktør = randomAktør()
+            every { featureToggleService.isEnabled(FeatureToggle.KAN_KJØRE_SATSENDRING_EØS) } returns false
+
+            // Act & Assert
+            assertThatThrownBy {
+                autovedtakStegService.kjørBehandlingSatsendringEøs(
+                    mottakersAktør = aktør,
+                    fagsakId = 1L,
+                    utbetalingsland = "PL",
+                    satsTidspunkt = YearMonth.of(2026, 1),
+                )
+            }.isInstanceOf(Feil::class.java)
+
+            verify(exactly = 0) { autovedtakSatsendringEøsService.skalAutovedtakBehandles(any()) }
+        }
+
+        @Test
+        fun `skal rute til AutovedtakSatsendringEøsService når toggle er på`() {
+            // Arrange
+            val aktør = randomAktør()
+            val fagsak = defaultFagsak(aktør)
+            val satsTidspunkt = YearMonth.of(2026, 1)
+            val data = SatsendringEøsData(fagsakId = fagsak.id, utbetalingsland = "PL", satsTidspunkt = satsTidspunkt)
+
+            every { featureToggleService.isEnabled(FeatureToggle.KAN_KJØRE_SATSENDRING_EØS) } returns true
+            every { autovedtakSatsendringEøsService.skalAutovedtakBehandles(data) } returns true
+            every { fagsakService.hentPåFagsakId(fagsak.id) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns null
+            every { autovedtakSatsendringEøsService.kjørBehandling(data) } returns "Satsendring EØS kjørt OK"
+
+            // Act
+            val resultat =
+                autovedtakStegService.kjørBehandlingSatsendringEøs(
+                    mottakersAktør = aktør,
+                    fagsakId = fagsak.id,
+                    utbetalingsland = "PL",
+                    satsTidspunkt = satsTidspunkt,
+                )
+
+            // Assert
+            assertThat(resultat).isEqualTo("Satsendring EØS kjørt OK")
+            verify(exactly = 1) { autovedtakSatsendringEøsService.kjørBehandling(data) }
+        }
+
+        @Test
+        fun `skal kaste RekjørSenereException ved åpen behandling som ikke kan snikes forbi`() {
+            // Arrange
+            val aktør = randomAktør()
+            val fagsak = defaultFagsak(aktør)
+            val satsTidspunkt = YearMonth.of(2026, 1)
+            val data = SatsendringEøsData(fagsakId = fagsak.id, utbetalingsland = "PL", satsTidspunkt = satsTidspunkt)
+            val behandling =
+                lagBehandling(fagsak = fagsak).also {
+                    it.status = BehandlingStatus.UTREDES
+                }
+
+            every { featureToggleService.isEnabled(FeatureToggle.KAN_KJØRE_SATSENDRING_EØS) } returns true
+            every { autovedtakSatsendringEøsService.skalAutovedtakBehandles(data) } returns true
+            every { fagsakService.hentPåFagsakId(fagsak.id) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
+            every { snikeIKøenService.kanSnikeForbi(any()) } returns false
+
+            // Act & Assert
+            assertThatThrownBy {
+                autovedtakStegService.kjørBehandlingSatsendringEøs(
+                    mottakersAktør = aktør,
+                    fagsakId = fagsak.id,
+                    utbetalingsland = "PL",
+                    satsTidspunkt = satsTidspunkt,
+                )
+            }.isInstanceOf(RekjørSenereException::class.java)
+
+            verify(exactly = 0) { autovedtakSatsendringEøsService.kjørBehandling(any()) }
+        }
+
+        @Test
+        fun `skal sette behandling på maskinell vent med årsak SATSENDRING_EØS når den kan snikes forbi`() {
+            // Arrange
+            val aktør = randomAktør()
+            val fagsak = defaultFagsak(aktør)
+            val satsTidspunkt = YearMonth.of(2026, 1)
+            val data = SatsendringEøsData(fagsakId = fagsak.id, utbetalingsland = "PL", satsTidspunkt = satsTidspunkt)
+            val behandling =
+                lagBehandling(fagsak = fagsak).also {
+                    it.status = BehandlingStatus.UTREDES
+                }
+
+            every { featureToggleService.isEnabled(FeatureToggle.KAN_KJØRE_SATSENDRING_EØS) } returns true
+            every { autovedtakSatsendringEøsService.skalAutovedtakBehandles(data) } returns true
+            every { fagsakService.hentPåFagsakId(fagsak.id) } returns fagsak
+            every { behandlingHentOgPersisterService.finnAktivOgÅpenForFagsak(fagsakId = fagsak.id) } returns behandling
+            every { snikeIKøenService.kanSnikeForbi(any()) } returns true
+            every { snikeIKøenService.settAktivBehandlingPåMaskinellVent(any(), any()) } returns mockk()
+            every { autovedtakSatsendringEøsService.kjørBehandling(data) } returns "Satsendring EØS kjørt OK"
+
+            // Act
+            autovedtakStegService.kjørBehandlingSatsendringEøs(
+                mottakersAktør = aktør,
+                fagsakId = fagsak.id,
+                utbetalingsland = "PL",
+                satsTidspunkt = satsTidspunkt,
+            )
+
+            // Assert
+            verify(exactly = 1) {
+                snikeIKøenService.settAktivBehandlingPåMaskinellVent(behandling.id, SettPåMaskinellVentÅrsak.SATSENDRING_EØS)
+            }
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/AutobrevStegServiceTest.kt
@@ -43,6 +43,7 @@ class AutobrevStegServiceTest {
             snikeIKøenService = snikeIKøenService,
             autovedtakFinnmarkstilleggService = autovedtakFinnmarkstilleggService,
             autovedtakSvalbardtilleggService = autovedtakSvalbardtilleggService,
+            autovedtakSatsendringEøsService = mockk(),
             featureToggleService = mockk(),
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -45,7 +45,7 @@ internal class StartSatsendringTest {
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(any(), any()) } returns null
         val taskSlot = slot<Task>()
         every { taskRepository.save(capture(taskSlot)) } answers { taskSlot.captured }
-        val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository, mockk())
+        val opprettTaskService = OpprettTaskService(taskRepository, satskjøringRepository, mockk(), mockk())
 
         every { satsendringService.erFagsakOppdatertMedSisteSatser(any()) } returns true
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsServiceTest.kt
@@ -1,0 +1,245 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.datagenerator.lagAktør
+import no.nav.familie.ba.sak.datagenerator.lagBehandling
+import no.nav.familie.ba.sak.datagenerator.lagFagsak
+import no.nav.familie.ba.sak.datagenerator.lagVedtak
+import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakService
+import no.nav.familie.ba.sak.kjerne.autovedtak.SatsendringEøsData
+import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSats
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakStatus
+import no.nav.familie.ba.sak.kjerne.steg.StegType
+import no.nav.familie.ba.sak.task.IverksettMotOppdragTask
+import no.nav.familie.ba.sak.task.JournalførVedtaksbrevTask
+import no.nav.familie.prosessering.domene.Task
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.YearMonth
+
+class AutovedtakSatsendringEøsServiceTest {
+    private val behandlingHentOgPersisterService = mockk<BehandlingHentOgPersisterService>()
+    private val satsendringEøsKjøringService = mockk<SatsendringEøsKjøringService>(relaxed = true)
+    private val utenlandskPeriodebeløpService = mockk<UtenlandskPeriodebeløpService>()
+    private val autovedtakService = mockk<AutovedtakService>()
+    private val taskRepository = mockk<TaskRepositoryWrapper>()
+
+    private val service =
+        AutovedtakSatsendringEøsService(
+            behandlingHentOgPersisterService = behandlingHentOgPersisterService,
+            satsendringEøsKjøringService = satsendringEøsKjøringService,
+            utenlandskPeriodebeløpService = utenlandskPeriodebeløpService,
+            autovedtakService = autovedtakService,
+            taskRepository = taskRepository,
+        )
+
+    private val land = "SE"
+    private val satsTidspunkt = YearMonth.of(2026, 1)
+    private val forrigeSatsTidspunkt = satsTidspunkt.minusMonths(1)
+    private val fagsak = lagFagsak(status = FagsakStatus.LØPENDE)
+    private val behandling = lagBehandling(fagsak = fagsak, behandlingKategori = BehandlingKategori.EØS)
+    private val satsendringEøsData = SatsendringEøsData(fagsakId = fagsak.id, utbetalingsland = land, satsTidspunkt = satsTidspunkt)
+
+    private val forrigeSats =
+        EøsSats(
+            land = land,
+            valuta = "SEK",
+            beløp = BigDecimal("1000"),
+            fom = forrigeSatsTidspunkt,
+            tom = satsTidspunkt.minusMonths(1),
+            intervall = Intervall.MÅNEDLIG,
+        )
+
+    private val gjeldendeSats =
+        EøsSats(
+            land = land,
+            valuta = "SEK",
+            beløp = BigDecimal("1200"),
+            fom = satsTidspunkt,
+            intervall = Intervall.MÅNEDLIG,
+        )
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(EøsSatserRegister)
+        every { EøsSatserRegister.satser } returns listOf(forrigeSats, gjeldendeSats)
+        every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(fagsak.id) } returns behandling
+        every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(any()) } returns emptyList()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(EøsSatserRegister)
+    }
+
+    @Nested
+    inner class AutovedtakSkalIkkeGjennomføres {
+        @Test
+        fun `returnerer allerede utført når alle utenlandsk periodebeløp har korrekt beløp`() {
+            // Arrange
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(BehandlingId(behandling.id)) } returns
+                listOf(lagUtenlandskPeriodebeløp(beløp = gjeldendeSats.beløp))
+
+            // Act
+            val resultat = service.kjørBehandling(satsendringEøsData)
+
+            // Assert
+            assertThat(resultat).isEqualTo(SatsendringEøsSvar.SATSENDRING_EØS_ER_ALLEREDE_UTFØRT.melding)
+        }
+
+        @Test
+        fun `returnerer ingen relevante utenlandsk periodebeløp når utenlandsk periodebeløp-listen er tom`() {
+            // Act
+            val resultat = service.kjørBehandling(satsendringEøsData)
+
+            // Assert
+            assertThat(resultat).isEqualTo(SatsendringEøsSvar.SATSENDRING_EØS_INGEN_RELEVANTE_UTENLANDSK_PERIODEBELØP.melding)
+        }
+
+        @Test
+        fun `kaster feil når utenlandsk periodebeløp har annen valutakode enn gjeldende sats`() {
+            // Arrange
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(BehandlingId(behandling.id)) } returns
+                listOf(lagUtenlandskPeriodebeløp(valutakode = "DKK", beløp = forrigeSats.beløp))
+
+            // Act & Assert
+            assertThatThrownBy { service.kjørBehandling(satsendringEøsData) }
+                .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+                .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
+        }
+
+        @Test
+        fun `kaster feil når utenlandsk periodebeløp har annet intervall enn gjeldende sats`() {
+            // Arrange
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(BehandlingId(behandling.id)) } returns
+                listOf(lagUtenlandskPeriodebeløp(intervall = Intervall.KVARTALSVIS, beløp = forrigeSats.beløp))
+
+            // Act & Assert
+            assertThatThrownBy { service.kjørBehandling(satsendringEøsData) }
+                .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+                .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
+        }
+
+        @Test
+        fun `kaster feil når utenlandsk periodebeløp har avvikende beløp fra forrige sats`() {
+            // Arrange
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(BehandlingId(behandling.id)) } returns
+                listOf(lagUtenlandskPeriodebeløp(beløp = BigDecimal("999")))
+
+            // Act & Assert
+            assertThatThrownBy { service.kjørBehandling(satsendringEøsData) }
+                .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+                .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
+        }
+    }
+
+    @Nested
+    inner class AutovedtakSkalGjennomføres {
+        @BeforeEach
+        fun setup() {
+            val utenlandskPeriodebeløp = lagUtenlandskPeriodebeløp(beløp = forrigeSats.beløp)
+            every { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(any()) } returns listOf(utenlandskPeriodebeløp)
+            every { autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(any()) } returns lagVedtak()
+            every { taskRepository.save(any()) } returns mockk()
+        }
+
+        @Test
+        fun `oppretter IverksettMotOppdragTask når steg er IVERKSETT_MOT_OPPDRAG`() {
+            // Arrange
+            val behandlingEtterResultat = lagBehandling(fagsak = fagsak, førsteSteg = StegType.IVERKSETT_MOT_OPPDRAG)
+            val taskSlot = slot<Task>()
+            every {
+                autovedtakService.opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(any(), any(), any(), any())
+            } returns behandlingEtterResultat
+            every { taskRepository.save(capture(taskSlot)) } returns mockk()
+
+            // Act
+            val resultat = service.kjørBehandling(satsendringEøsData)
+
+            // Assert
+            assertThat(resultat).isEqualTo(SatsendringEøsSvar.SATSENDRING_EØS_KJØRT_OK.melding)
+            assertThat(taskSlot.captured.type).isEqualTo(IverksettMotOppdragTask.TASK_STEP_TYPE)
+        }
+
+        @Test
+        fun `oppretter JournalførVedtaksbrevTask når steg er JOURNALFØR_VEDTAKSBREV`() {
+            // Arrange
+            val behandlingEtterResultat = lagBehandling(fagsak = fagsak, førsteSteg = StegType.JOURNALFØR_VEDTAKSBREV)
+            val taskSlot = slot<Task>()
+            every {
+                autovedtakService.opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(any(), any(), any(), any())
+            } returns behandlingEtterResultat
+            every { taskRepository.save(capture(taskSlot)) } returns mockk()
+
+            // Act
+            val resultat = service.kjørBehandling(satsendringEøsData)
+
+            // Assert
+            assertThat(resultat).isEqualTo(SatsendringEøsSvar.SATSENDRING_EØS_KJØRT_OK.melding)
+            assertThat(taskSlot.captured.type).isEqualTo(JournalførVedtaksbrevTask.TASK_STEP_TYPE)
+        }
+
+        @Test
+        fun `kaller settBehandlingId med behandlingen som opprettes, via førVilkårsvurdering-callback`() {
+            // Arrange
+            val behandlingEtterResultat = lagBehandling(fagsak = fagsak, førsteSteg = StegType.IVERKSETT_MOT_OPPDRAG)
+            val førVilkårsvurderingSlot = slot<(Behandling) -> Unit>()
+            every {
+                autovedtakService.opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
+                    behandlingType = any(),
+                    behandlingÅrsak = any(),
+                    fagsakId = any(),
+                    førVilkårsvurdering = capture(førVilkårsvurderingSlot),
+                )
+            } answers {
+                førVilkårsvurderingSlot.captured.invoke(behandlingEtterResultat)
+                behandlingEtterResultat
+            }
+
+            // Act
+            service.kjørBehandling(satsendringEøsData)
+
+            // Assert
+            verify(exactly = 1) {
+                satsendringEøsKjøringService.settBehandlingId(fagsak.id, land, satsTidspunkt, behandlingEtterResultat.id)
+            }
+        }
+    }
+
+    private fun lagUtenlandskPeriodebeløp(
+        valutakode: String = gjeldendeSats.valuta,
+        intervall: Intervall = gjeldendeSats.intervall,
+        beløp: BigDecimal = BigDecimal("1000"),
+    ): UtenlandskPeriodebeløp =
+        UtenlandskPeriodebeløp(
+            fom = YearMonth.of(2025, 1),
+            tom = null,
+            barnAktører = setOf(lagAktør(randomFnr())),
+            beløp = beløp,
+            valutakode = valutakode,
+            intervall = intervall,
+            utbetalingsland = land,
+            kalkulertMånedligBeløp = beløp,
+        ).also { it.behandlingId = behandling.id }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/AutovedtakSatsendringEøsServiceTest.kt
@@ -210,7 +210,7 @@ class AutovedtakSatsendringEøsServiceTest {
                     behandlingType = any(),
                     behandlingÅrsak = any(),
                     fagsakId = any(),
-                    førVilkårsvurdering = capture(førVilkårsvurderingSlot),
+                    kjørFørVilkårsvurdering = capture(førVilkårsvurderingSlot),
                 )
             } answers {
                 førVilkårsvurderingSlot.captured.invoke(behandlingEtterResultat)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsKjøringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsKjøringServiceTest.kt
@@ -2,20 +2,27 @@ package no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøringRepository
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
 
 class SatsendringEøsKjøringServiceTest {
     private val satsendringEøsKjøringRepository: SatsendringEøsKjøringRepository = mockk()
     private val satsendringEøsKjøringService = SatsendringEøsKjøringService(satsendringEøsKjøringRepository)
 
+    private val fagsakId = 10L
+    private val utbetalingsland = "SE"
+    private val satsTidspunkt = YearMonth.of(2025, 9)
+
     @Test
-    fun `hentSatsendringEøsKjøring returnerer kjøring når den finnes`() {
+    fun `hentSatsendringEøsKjøring med behandlingId returnerer kjøring når den finnes`() {
+        // Arrange
         val kjøring =
             SatsendringEøsKjøring(
                 id = 1L,
@@ -26,20 +33,100 @@ class SatsendringEøsKjøringServiceTest {
             )
         every { satsendringEøsKjøringRepository.findByBehandlingId(42L) } returns kjøring
 
+        // Act
         val resultat = satsendringEøsKjøringService.hentSatsendringEøsKjøring(42L)
 
+        // Assert
         assertThat(resultat).isEqualTo(kjøring)
     }
 
     @Test
     fun `hentSatsendringEøsKjøring kaster Feil når ingen kjøring finnes for behandlingId`() {
+        // Arrange
         every { satsendringEøsKjøringRepository.findByBehandlingId(99L) } returns null
 
-        val feil =
-            assertThrows<Feil> {
-                satsendringEøsKjøringService.hentSatsendringEøsKjøring(99L)
-            }
+        // Act & Assert
+        assertThatThrownBy { satsendringEøsKjøringService.hentSatsendringEøsKjøring(99L) }
+            .isInstanceOf(Feil::class.java)
+            .hasMessageContaining("99")
+    }
 
-        assertThat(feil.message).contains("99")
+    @Test
+    fun `hentSatsendringEøsKjøring med fagsakId, land og tidspunkt returnerer kjøring når den finnes`() {
+        // Arrange
+        val kjøring = SatsendringEøsKjøring(fagsakId = fagsakId, utbetalingsland = utbetalingsland, satsTidspunkt = satsTidspunkt)
+        every {
+            satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+        } returns kjøring
+
+        // Act
+        val resultat = satsendringEøsKjøringService.hentSatsendringEøsKjøring(fagsakId, utbetalingsland, satsTidspunkt)
+
+        // Assert
+        assertThat(resultat).isEqualTo(kjøring)
+    }
+
+    @Test
+    fun `hentSatsendringEøsKjøring med fagsakId, land og tidspunkt kaster Feil når ingen kjøring finnes`() {
+        // Arrange
+        every {
+            satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+        } returns null
+
+        // Act & Assert
+        assertThatThrownBy { satsendringEøsKjøringService.hentSatsendringEøsKjøring(fagsakId, utbetalingsland, satsTidspunkt) }
+            .isInstanceOf(Feil::class.java)
+    }
+
+    @Test
+    fun `settBehandlingId setter behandlingId på kjøringen og lagrer den`() {
+        // Arrange
+        val kjøring = SatsendringEøsKjøring(fagsakId = fagsakId, utbetalingsland = utbetalingsland, satsTidspunkt = satsTidspunkt)
+        every {
+            satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+        } returns kjøring
+        val kjøringSlot = slot<SatsendringEøsKjøring>()
+        every { satsendringEøsKjøringRepository.save(capture(kjøringSlot)) } answers { firstArg() }
+
+        // Act
+        satsendringEøsKjøringService.settBehandlingId(fagsakId, utbetalingsland, satsTidspunkt, 123L)
+
+        // Assert
+        assertThat(kjøringSlot.captured.behandlingId).isEqualTo(123L)
+    }
+
+    @Test
+    fun `settFerdigTidspunkt setter ferdigTidspunkt på kjøringen og lagrer den`() {
+        // Arrange
+        val kjøring = SatsendringEøsKjøring(fagsakId = fagsakId, utbetalingsland = utbetalingsland, satsTidspunkt = satsTidspunkt)
+        every {
+            satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+        } returns kjøring
+        val kjøringSlot = slot<SatsendringEøsKjøring>()
+        every { satsendringEøsKjøringRepository.save(capture(kjøringSlot)) } answers { firstArg() }
+
+        // Act
+        satsendringEøsKjøringService.settFerdigTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+
+        // Assert
+        assertThat(kjøringSlot.captured.ferdigTidspunkt).isNotNull()
+    }
+
+    @Test
+    fun `settFeiltype setter feiltype på kjøringen og lagrer den`() {
+        // Arrange
+        val kjøring = SatsendringEøsKjøring(fagsakId = fagsakId, utbetalingsland = utbetalingsland, satsTidspunkt = satsTidspunkt)
+        every {
+            satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+        } returns kjøring
+        val kjøringSlot = slot<SatsendringEøsKjøring>()
+        every { satsendringEøsKjøringRepository.save(capture(kjøringSlot)) } answers { firstArg() }
+
+        // Act
+        satsendringEøsKjøringService.settFeiltype(fagsakId, utbetalingsland, satsTidspunkt, "Må behandles manuelt")
+
+        // Assert
+        assertThat(kjøringSlot.captured.feiltype).isEqualTo("Må behandles manuelt")
+        verify(exactly = 1) { satsendringEøsKjøringRepository.save(any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatsTest.kt
@@ -1,0 +1,147 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import no.nav.familie.ba.sak.datagenerator.lagAktør
+import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløp
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.filtrerErUtfylt
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.YearMonth
+
+class EøsSatsTest {
+    private val eøsSats =
+        EøsSats(
+            land = "PL",
+            valuta = "PLN",
+            beløp = BigDecimal("1200"),
+            fom = YearMonth.of(2026, 1),
+            tom = YearMonth.of(2026, 6),
+            intervall = Intervall.MÅNEDLIG,
+        )
+
+    @Nested
+    inner class Overlapper {
+        @Test
+        fun `returnerer true når utenladsk periodebeløp har åpen sluttdato`() {
+            // Arrange
+            val utenladskPeriodebeløp =
+                lagUtenlandskPeriodebeløp(tom = null)
+                    .tilUtfyltUtenlandskPeriodebeløp()
+
+            // Act & Assert
+            assertThat(utenladskPeriodebeløp.overlapper(eøsSats)).isTrue()
+        }
+
+        @Test
+        fun `returnerer true når periodene akkurat tangerer hverandre`() {
+            // Arrange
+            val utenladskPeriodebeløp =
+                lagUtenlandskPeriodebeløp(fom = YearMonth.of(2025, 1), tom = eøsSats.fom)
+                    .tilUtfyltUtenlandskPeriodebeløp()
+
+            // Act & Assert
+            assertThat(utenladskPeriodebeløp.overlapper(eøsSats)).isTrue()
+        }
+
+        @Test
+        fun `returnerer false når utenladsk periodebeløp avsluttes før satsens fom`() {
+            // Arrange
+            val utenladskPeriodebeløp =
+                lagUtenlandskPeriodebeløp(fom = YearMonth.of(2024, 1), tom = eøsSats.fom.minusMonths(1))
+                    .tilUtfyltUtenlandskPeriodebeløp()
+
+            // Act & Assert
+            assertThat(utenladskPeriodebeløp.overlapper(eøsSats)).isFalse()
+        }
+
+        @Test
+        fun `returnerer false når utenladsk periodebeløp starter etter satsens tom`() {
+            // Arrange
+            val utenladskPeriodebeløp =
+                lagUtenlandskPeriodebeløp(fom = eøsSats.tom!!.plusMonths(1), tom = null)
+                    .tilUtfyltUtenlandskPeriodebeløp()
+
+            // Act & Assert
+            assertThat(utenladskPeriodebeløp.overlapper(eøsSats)).isFalse()
+        }
+    }
+
+    @Nested
+    inner class FiltrerErRelevantForSats {
+        @Test
+        fun `filtrerer bort utenladsk periodebeløp som ikke er utfylt`() {
+            // Arrange
+            val ikkeUtfyltUtenlandskPeriodebeløp = lagUtenlandskPeriodebeløp(beløp = null)
+
+            // Act
+            val relevante =
+                listOf(ikkeUtfyltUtenlandskPeriodebeløp)
+                    .filtrerErRelevantForSats(eøsSats)
+
+            // Assert
+            assertThat(relevante).isEmpty()
+        }
+
+        @Test
+        fun `filtrerer bort utenladsk periodebeløp for annet land`() {
+            // Arrange
+            val utenlandskPeriodebeløpMedAnnetLand = lagUtenlandskPeriodebeløp(utbetalingsland = "SE")
+
+            // Act
+            val relevante =
+                listOf(utenlandskPeriodebeløpMedAnnetLand)
+                    .filtrerErRelevantForSats(eøsSats)
+
+            // Assert
+            assertThat(relevante).isEmpty()
+        }
+
+        @Test
+        fun `filtrerer bort utenladsk periodebeløp som ikke overlapper satsen`() {
+            // Arrange
+            val utenlandskPeriodebeløpSomIkkeOverlapper =
+                lagUtenlandskPeriodebeløp(fom = YearMonth.of(2024, 1), tom = YearMonth.of(2024, 12))
+
+            // Act
+            val relevante =
+                listOf(utenlandskPeriodebeløpSomIkkeOverlapper)
+                    .filtrerErRelevantForSats(eøsSats)
+
+            // Assert
+            assertThat(relevante).isEmpty()
+        }
+
+        @Test
+        fun `beholder utenladsk periodebeløp som er utfylt, samme land og overlapper`() {
+            // Arrange
+            val utenlandskPeriodebeløp = lagUtenlandskPeriodebeløp()
+
+            // Act
+            val relevante = listOf(utenlandskPeriodebeløp).filtrerErRelevantForSats(eøsSats)
+
+            // Assert
+            assertThat(relevante).hasSize(1)
+        }
+    }
+
+    private fun lagUtenlandskPeriodebeløp(
+        fom: YearMonth? = YearMonth.of(2025, 1),
+        tom: YearMonth? = null,
+        utbetalingsland: String? = "PL",
+        beløp: BigDecimal? = BigDecimal("1000"),
+    ) = UtenlandskPeriodebeløp(
+        fom = fom,
+        tom = tom,
+        barnAktører = setOf(lagAktør(randomFnr())),
+        beløp = beløp,
+        valutakode = "PLN",
+        intervall = Intervall.MÅNEDLIG,
+        utbetalingsland = utbetalingsland,
+        kalkulertMånedligBeløp = beløp,
+    )
+
+    private fun UtenlandskPeriodebeløp.tilUtfyltUtenlandskPeriodebeløp() = listOf(this).filtrerErUtfylt().first()
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegisterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/EøsSatserRegisterTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ba.sak.kjerne.eøs.sats
 
 import io.mockk.every
 import io.mockk.mockkObject
-import io.mockk.unmockkAll
 import io.mockk.unmockkObject
 import no.nav.familie.ba.sak.common.tilKortString
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
@@ -38,16 +37,13 @@ class EøsSatserRegisterTest {
 
     @BeforeEach
     fun setup() {
-        mockkObject(EøsSatserPolen)
-        every { EøsSatserPolen.satser } returns listOf(forrigeSats, nySats)
-
         mockkObject(EøsSatserRegister)
-        every { EøsSatserRegister.satser } returns listOf(EøsSatserPolen)
+        every { EøsSatserRegister.satser } returns listOf(forrigeSats, nySats)
     }
 
     @AfterEach
     fun teardown() {
-        unmockkAll()
+        unmockkObject(EøsSatserRegister)
     }
 
     @Nested
@@ -97,12 +93,7 @@ class EøsSatserRegisterTest {
 
         @Test
         fun `Returnerer løpende sats for måned etter siste fom`() {
-            // Act
-            val resultat = finnSatsForLandIMåned("PL", YearMonth.of(2025, 6))
-
-            // Assert
-            assertThat(resultat).isEqualTo(nySats)
-            assertThat(resultat?.tom).isNull()
+            assertThat(finnSatsForLandIMåned("PL", YearMonth.of(2025, 6))).isEqualTo(nySats)
         }
 
         @Test
@@ -113,7 +104,7 @@ class EøsSatserRegisterTest {
         @Test
         fun `Returnerer null når registeret er tomt`() {
             // Arrange
-            every { EøsSatserPolen.satser } returns emptyList()
+            every { EøsSatserRegister.satser } returns emptyList()
 
             // Act & Assert
             assertThat(finnSatsForLandIMåned("PL", YearMonth.now())).isNull()
@@ -125,12 +116,11 @@ class EøsSatserRegisterTest {
         @BeforeEach
         fun setup() {
             unmockkObject(EøsSatserRegister)
-            unmockkObject(EøsSatserPolen)
         }
 
         @Test
         fun `Ingen land har overlappende gyldighetsperioder`() {
-            EøsSatserRegister.satser.forEach { (land, satser) ->
+            EøsSatserRegister.satser.groupBy { it.land }.forEach { (land, satser) ->
                 satser.sortedBy { it.fom }.zipWithNext { nåværende, neste ->
                     assertThat(nåværende.tom != null && nåværende.tom < neste.fom)
                         .withFailMessage(
@@ -143,29 +133,25 @@ class EøsSatserRegisterTest {
 
         @Test
         fun `Alle satser har positivt beløp`() {
-            EøsSatserRegister.satser.forEach { (land, satser) ->
-                satser.forEach { sats ->
-                    assertThat(sats.beløp)
-                        .withFailMessage("Sats for $land har ikke-positivt beløp: ${sats.beløp}")
-                        .isGreaterThan(BigDecimal.ZERO)
-                }
+            EøsSatserRegister.satser.forEach { sats ->
+                assertThat(sats.beløp)
+                    .withFailMessage("Sats for ${sats.land} har ikke-positivt beløp: ${sats.beløp}")
+                    .isGreaterThan(BigDecimal.ZERO)
             }
         }
 
         @Test
         fun `Alle satser har tom etter eller lik fom`() {
-            EøsSatserRegister.satser.forEach { (land, satser) ->
-                satser.forEach { sats ->
-                    assertThat(sats.tom == null || sats.tom >= sats.fom)
-                        .withFailMessage("Sats for $land har tom ${sats.tom?.tilKortString()} før fom ${sats.fom.tilKortString()}")
-                        .isTrue()
-                }
+            EøsSatserRegister.satser.forEach { sats ->
+                assertThat(sats.tom == null || sats.tom >= sats.fom)
+                    .withFailMessage("Sats for ${sats.land} har tom ${sats.tom?.tilKortString()} før fom ${sats.fom.tilKortString()}")
+                    .isTrue()
             }
         }
 
         @Test
         fun `EøsSats-land matcher land-objektets land-felt`() {
-            EøsSatserRegister.satser.forEach { (land, satser) ->
+            EøsSatserRegister.satser.groupBy { it.land }.forEach { (land, satser) ->
                 satser.forEach { sats ->
                     assertThat(sats.land)
                         .withFailMessage("Sats med land '${sats.land}' ligger i listen med satser for '$land'")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ba.sak.common.AutovedtakSkalIkkeGjennomføresFeil
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsSvar
 import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
 import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ba.sak.kjerne.eøs.felles.BehandlingId
@@ -244,7 +245,7 @@ class SatsendringEøsServiceTest {
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
                     .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
-                    .hasMessageContaining("UtenlandskPeriodebeløp for behandling ${behandlingId.id} og land PL har beløp 500 PLN")
+                    .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
             }
 
             @Test
@@ -256,7 +257,7 @@ class SatsendringEøsServiceTest {
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
                     .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
-                    .hasMessageContaining("UtenlandskPeriodebeløp for behandling ${behandlingId.id} og land PL har valuta EUR")
+                    .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
             }
 
             @Test
@@ -268,7 +269,7 @@ class SatsendringEøsServiceTest {
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
                     .isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
-                    .hasMessageContaining("UtenlandskPeriodebeløp for behandling ${behandlingId.id} og land PL har intervall ÅRLIG")
+                    .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
             }
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsServiceTest.kt
@@ -56,11 +56,8 @@ class SatsendringEøsServiceTest {
 
     @BeforeEach
     fun setup() {
-        mockkObject(EøsSatserPolen)
-        every { EøsSatserPolen.satser } returns listOf(forrigeSats, nySats)
-
         mockkObject(EøsSatserRegister)
-        every { EøsSatserRegister.satser } returns listOf(EøsSatserPolen)
+        every { EøsSatserRegister.satser } returns listOf(forrigeSats, nySats)
 
         every { satsendringEøsKjøringService.hentSatsendringEøsKjøring(behandlingId.id) } returns
             SatsendringEøsKjøring(fagsakId = 1L, utbetalingsland = "PL", satsTidspunkt = YearMonth.of(2025, 1))
@@ -164,7 +161,7 @@ class SatsendringEøsServiceTest {
             @Test
             fun `Ingen sats registrert for landet`() {
                 // Arrange
-                every { EøsSatserPolen.satser } returns emptyList()
+                every { EøsSatserRegister.satser } returns emptyList()
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }
@@ -175,7 +172,7 @@ class SatsendringEøsServiceTest {
             @Test
             fun `Ingen forrige sats registrert for landet`() {
                 // Arrange
-                every { EøsSatserPolen.satser } returns listOf(nySats)
+                every { EøsSatserRegister.satser } returns listOf(nySats)
 
                 // Act & Assert
                 assertThatThrownBy { satsendringEøsService.oppdaterUtenlandskPeriodebeløpMedSisteSats(behandlingId) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/sats/SatsendringEøsValideringTest.kt
@@ -1,0 +1,114 @@
+package no.nav.familie.ba.sak.kjerne.eøs.sats
+
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.datagenerator.lagAktør
+import no.nav.familie.ba.sak.datagenerator.randomFnr
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsSvar
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtfyltUtenlandskPeriodebeløp
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.YearMonth
+
+class SatsendringEøsValideringTest {
+    private val land = "PL"
+    private val forrigeSats =
+        EøsSats(
+            land = land,
+            valuta = "PLN",
+            beløp = BigDecimal("1000"),
+            fom = YearMonth.of(2025, 1),
+            tom = YearMonth.of(2025, 12),
+            intervall = Intervall.MÅNEDLIG,
+        )
+    private val nySats =
+        EøsSats(
+            land = land,
+            valuta = "PLN",
+            beløp = BigDecimal("1200"),
+            fom = YearMonth.of(2026, 1),
+            intervall = Intervall.MÅNEDLIG,
+        )
+
+    private fun lagUtfyltUtenlandskPeriodebeløp(
+        beløp: BigDecimal = forrigeSats.beløp,
+        valutakode: String = nySats.valuta,
+        intervall: Intervall = nySats.intervall,
+    ) = UtfyltUtenlandskPeriodebeløp(
+        id = 1L,
+        behandlingId = 42L,
+        fom = YearMonth.of(2025, 1),
+        tom = null,
+        barnAktører = setOf(lagAktør(randomFnr())),
+        beløp = beløp,
+        valutakode = valutakode,
+        intervall = intervall,
+        utbetalingsland = land,
+        kalkulertMånedligBeløp = beløp,
+    )
+
+    @Test
+    fun `kaster ikke feil når utenlandsk periodebeløp samsvarer med forrige og ny sats`() {
+        // Arrange
+        val utenlandskPeriodebeløp = lagUtfyltUtenlandskPeriodebeløp()
+
+        // Act & Assert
+        assertThatCode {
+            SatsendringEøsValidering.validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
+                utenlandskPeriodebeløp = utenlandskPeriodebeløp,
+                forrigeSats = forrigeSats,
+                nySats = nySats,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `kaster feil ved avvik i beløp mot forrige sats`() {
+        // Arrange
+        val utenlandskPeriodebeløp = lagUtfyltUtenlandskPeriodebeløp(beløp = BigDecimal("500"))
+
+        // Act & Assert
+        assertThatThrownBy {
+            SatsendringEøsValidering.validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
+                utenlandskPeriodebeløp = utenlandskPeriodebeløp,
+                forrigeSats = forrigeSats,
+                nySats = nySats,
+            )
+        }.isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+            .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
+    }
+
+    @Test
+    fun `kaster feil ved avvik i valuta mot ny sats`() {
+        // Arrange
+        val utenlandskPeriodebeløp = lagUtfyltUtenlandskPeriodebeløp(valutakode = "EUR")
+
+        // Act & Assert
+        assertThatThrownBy {
+            SatsendringEøsValidering.validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
+                utenlandskPeriodebeløp = utenlandskPeriodebeløp,
+                forrigeSats = forrigeSats,
+                nySats = nySats,
+            )
+        }.isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+            .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
+    }
+
+    @Test
+    fun `kaster feil ved avvik i intervall mot ny sats`() {
+        // Arrange
+        val utenlandskPeriodebeløp = lagUtfyltUtenlandskPeriodebeløp(intervall = Intervall.ÅRLIG)
+
+        // Act & Assert
+        assertThatThrownBy {
+            SatsendringEøsValidering.validerAtUtenlandskPeriodebeløpKanOppdateresAutomatisk(
+                utenlandskPeriodebeløp = utenlandskPeriodebeløp,
+                forrigeSats = forrigeSats,
+                nySats = nySats,
+            )
+        }.isInstanceOf(AutovedtakMåBehandlesManueltFeil::class.java)
+            .hasMessage(SatsendringEøsSvar.SATSENDRING_EØS_MÅ_BEHANDLES_MANUELT.melding)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
@@ -26,7 +26,7 @@ class GrensesnittavstemMotOppdragTest {
     fun setUp() {
         val avstemmingServiceMock = mockk<AvstemmingService>()
         taskRepositoryMock = mockk()
-        grensesnittavstemMotOppdrag = GrensesnittavstemMotOppdrag(avstemmingServiceMock, OpprettTaskService(taskRepositoryMock, mockk(), mockk()))
+        grensesnittavstemMotOppdrag = GrensesnittavstemMotOppdrag(avstemmingServiceMock, OpprettTaskService(taskRepositoryMock, mockk(), mockk(), mockk()))
     }
 
     @ParameterizedTest

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/OpprettTaskServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/OpprettTaskServiceTest.kt
@@ -1,0 +1,94 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.EnvService
+import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendring.domene.SatskjøringRepository
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøringRepository
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.prosessering.domene.Task
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class OpprettTaskServiceTest {
+    private val taskRepository = mockk<TaskRepositoryWrapper>()
+    private val satskjøringRepository = mockk<SatskjøringRepository>()
+    private val satsendringEøsKjøringRepository = mockk<SatsendringEøsKjøringRepository>()
+    private val envService = mockk<EnvService>()
+
+    private val opprettTaskService =
+        OpprettTaskService(
+            taskRepository = taskRepository,
+            satskjøringRepository = satskjøringRepository,
+            satsendringEøsKjøringRepository = satsendringEøsKjøringRepository,
+            envService = envService,
+        )
+
+    @Nested
+    inner class OpprettSatsendringEøsTask {
+        private val fagsakId = 1L
+        private val utbetalingsland = "PL"
+        private val satsTidspunkt = YearMonth.of(2026, 1)
+
+        @BeforeEach
+        fun setUp() {
+            every {
+                satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+            } returns null
+            every { satsendringEøsKjøringRepository.save(any()) } answers { firstArg() }
+            every { taskRepository.save(any()) } answers { firstArg() }
+        }
+
+        @Test
+        fun `opprettSatsendringEøsTask oppretter SatsendringEøsKjøring når ingen finnes fra før`() {
+            // Act
+            opprettTaskService.opprettSatsendringEøsTask(fagsakId, utbetalingsland, satsTidspunkt)
+
+            // Assert
+            val kjøringSlot = slot<SatsendringEøsKjøring>()
+            verify(exactly = 1) { satsendringEøsKjøringRepository.save(capture(kjøringSlot)) }
+            assertThat(kjøringSlot.captured.fagsakId).isEqualTo(fagsakId)
+            assertThat(kjøringSlot.captured.utbetalingsland).isEqualTo(utbetalingsland)
+            assertThat(kjøringSlot.captured.satsTidspunkt).isEqualTo(satsTidspunkt)
+        }
+
+        @Test
+        fun `opprettSatsendringEøsTask oppretter ikke ny SatsendringEøsKjøring når en allerede finnes`() {
+            // Arrange
+            every {
+                satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(fagsakId, utbetalingsland, satsTidspunkt)
+            } returns
+                SatsendringEøsKjøring(fagsakId = fagsakId, utbetalingsland = utbetalingsland, satsTidspunkt = satsTidspunkt)
+
+            // Act
+            opprettTaskService.opprettSatsendringEøsTask(fagsakId, utbetalingsland, satsTidspunkt)
+
+            // Assert
+            verify(exactly = 0) { satsendringEøsKjøringRepository.save(any()) }
+        }
+
+        @Test
+        fun `opprettSatsendringEøsTask oppretter task med riktig type, payload og properties`() {
+            // Arrange
+            val taskSlot = slot<Task>()
+
+            // Act
+            opprettTaskService.opprettSatsendringEøsTask(fagsakId, utbetalingsland, satsTidspunkt)
+
+            // Assert
+            verify(exactly = 1) { taskRepository.save(capture(taskSlot)) }
+            assertThat(taskSlot.captured.type).isEqualTo(SatsendringEøsTask.TASK_STEP_TYPE)
+            assertThat(taskSlot.captured.payload).isEqualTo(jsonMapper.writeValueAsString(SatsendringEøsTaskDto(fagsakId, utbetalingsland, satsTidspunkt)))
+            assertThat(taskSlot.captured.metadata["fagsakId"]).isEqualTo(fagsakId.toString())
+            assertThat(taskSlot.captured.metadata["utbetalingsland"]).isEqualTo(utbetalingsland)
+            assertThat(taskSlot.captured.metadata["satsTidspunkt"]).isEqualTo(satsTidspunkt.toString())
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SatsendringEøsTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SatsendringEøsTaskTest.kt
@@ -1,0 +1,147 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ba.sak.common.AutovedtakMåBehandlesManueltFeil
+import no.nav.familie.ba.sak.common.AutovedtakSkalIkkeGjennomføresFeil
+import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.kjerne.autovedtak.AutovedtakStegService
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.SatsendringEøsKjøringService
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.prosessering.domene.Task
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+internal class SatsendringEøsTaskTest {
+    private val autovedtakStegService = mockk<AutovedtakStegService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val satsendringEøsKjøringService = mockk<SatsendringEøsKjøringService>()
+
+    private val satsendringEøsTask =
+        SatsendringEøsTask(
+            autovedtakStegService = autovedtakStegService,
+            fagsakService = fagsakService,
+            satsendringEøsKjøringService = satsendringEøsKjøringService,
+        )
+
+    private val fagsakId = 12345L
+    private val utbetalingsland = "PL"
+    private val satsTidspunkt = YearMonth.of(2026, 1)
+    private val aktør = randomAktør()
+
+    private fun lagTask() =
+        Task(
+            type = SatsendringEøsTask.TASK_STEP_TYPE,
+            payload = jsonMapper.writeValueAsString(SatsendringEøsTaskDto(fagsakId, utbetalingsland, satsTidspunkt)),
+        )
+
+    @Test
+    fun `doTask skal kjøre behandling og sette ferdigTidspunkt og resultat ved suksess`() {
+        // Arrange
+        val task = lagTask()
+
+        every { fagsakService.hentAktør(fagsakId) } returns aktør
+        every {
+            autovedtakStegService.kjørBehandlingSatsendringEøs(
+                mottakersAktør = aktør,
+                fagsakId = fagsakId,
+                utbetalingsland = utbetalingsland,
+                satsTidspunkt = satsTidspunkt,
+                førstegangKjørt = any(),
+            )
+        } returns "Satsendring EØS kjørt OK"
+        justRun { satsendringEøsKjøringService.settFerdigTidspunkt(fagsakId, utbetalingsland, satsTidspunkt) }
+
+        // Act
+        satsendringEøsTask.doTask(task)
+
+        // Assert
+        assertThat(task.metadata["resultat"]).isEqualTo("Satsendring EØS kjørt OK")
+        verify(exactly = 1) { satsendringEøsKjøringService.settFerdigTidspunkt(fagsakId, utbetalingsland, satsTidspunkt) }
+        verify(exactly = 0) { satsendringEøsKjøringService.settFeiltype(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `doTask skal håndtere AutovedtakSkalIkkeGjennomføresFeil uten å sette feiltype`() {
+        // Arrange
+        val task = lagTask()
+
+        every { fagsakService.hentAktør(fagsakId) } returns aktør
+        every {
+            autovedtakStegService.kjørBehandlingSatsendringEøs(
+                mottakersAktør = aktør,
+                fagsakId = fagsakId,
+                utbetalingsland = utbetalingsland,
+                satsTidspunkt = satsTidspunkt,
+                førstegangKjørt = any(),
+            )
+        } throws AutovedtakSkalIkkeGjennomføresFeil("Ingen endring")
+        justRun { satsendringEøsKjøringService.settFerdigTidspunkt(fagsakId, utbetalingsland, satsTidspunkt) }
+
+        // Act
+        assertThatCode { satsendringEøsTask.doTask(task) }.doesNotThrowAnyException()
+
+        // Assert
+        assertThat(task.metadata["resultat"]).isEqualTo("Ingen endring")
+        verify(exactly = 1) { satsendringEøsKjøringService.settFerdigTidspunkt(fagsakId, utbetalingsland, satsTidspunkt) }
+        verify(exactly = 0) { satsendringEøsKjøringService.settFeiltype(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `doTask skal sette feiltype og ferdigTidspunkt ved AutovedtakMåBehandlesManueltFeil`() {
+        // Arrange
+        val task = lagTask()
+
+        every { fagsakService.hentAktør(fagsakId) } returns aktør
+        every {
+            autovedtakStegService.kjørBehandlingSatsendringEøs(
+                mottakersAktør = aktør,
+                fagsakId = fagsakId,
+                utbetalingsland = utbetalingsland,
+                satsTidspunkt = satsTidspunkt,
+                førstegangKjørt = any(),
+            )
+        } throws AutovedtakMåBehandlesManueltFeil("Må behandles manuelt")
+        justRun { satsendringEøsKjøringService.settFeiltype(fagsakId, utbetalingsland, satsTidspunkt, "Må behandles manuelt") }
+        justRun { satsendringEøsKjøringService.settFerdigTidspunkt(fagsakId, utbetalingsland, satsTidspunkt) }
+
+        // Act
+        assertThatCode { satsendringEøsTask.doTask(task) }.doesNotThrowAnyException()
+
+        // Assert
+        assertThat(task.metadata["resultat"]).isEqualTo("Må behandles manuelt")
+        verify(exactly = 1) {
+            satsendringEøsKjøringService.settFeiltype(fagsakId, utbetalingsland, satsTidspunkt, "Må behandles manuelt")
+        }
+        verify(exactly = 1) { satsendringEøsKjøringService.settFerdigTidspunkt(fagsakId, utbetalingsland, satsTidspunkt) }
+    }
+
+    @Test
+    fun `doTask skal propagere uventede exceptions og ikke sette ferdigTidspunkt`() {
+        // Arrange
+        val task = lagTask()
+
+        every { fagsakService.hentAktør(fagsakId) } returns aktør
+        every {
+            autovedtakStegService.kjørBehandlingSatsendringEøs(
+                mottakersAktør = aktør,
+                fagsakId = fagsakId,
+                utbetalingsland = utbetalingsland,
+                satsTidspunkt = satsTidspunkt,
+                førstegangKjørt = any(),
+            )
+        } throws RuntimeException("Uventet feil")
+
+        // Act & Assert
+        assertThatThrownBy { satsendringEøsTask.doTask(task) }.isInstanceOf(RuntimeException::class.java)
+
+        verify(exactly = 0) { satsendringEøsKjøringService.settFerdigTidspunkt(any(), any(), any()) }
+        verify(exactly = 0) { satsendringEøsKjøringService.settFeiltype(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
### 📮 Favro: NAV-29800

### 💰 Hva skal gjøres, og hvorfor?
Legger til en ny autovedtak-løype for satsendring på EØS-saker. Ved endring av EØS-satser skal berørte fagsaker automatisk kunne rekjøres og få oppdatert vedtak, uten manuell saksbehandling.

Endringene inkluderer:
- Ny `Autovedtaktype.SATSENDRING_EØS` med tilhørende `AutovedtakSatsendringEøsService` og validering
- Ny `SatsendringEøsTask` og `SatsendringEøsKjøringService`/-repository for å spore og trigge kjøringer per fagsak/utbetalingsland/satstidspunkt
- Ny feature toggle `KAN_KJØRE_SATSENDRING_EØS` som styrer om løypen er aktiv
- Autovedtak for satsendring EØS rekjøres senere ved åpen behandling (samme mønster som finnmarkstillegg/svalbardtillegg)
- Flatmapping av satser i `EøsSatserRegister` og sammenslåing av filtreringsfunksjon for `UtenlandskPeriodebeløp`
- Tilgjengeliggjør feilmelding i `AutovedtakSkalIkkeGjennomføresFeil`

Begrunnelser for vedtaket legges til i en senere PR.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.
