### PR TITLE
NAV-29382: Hent vedtaksbrev fra Joark for avsluttede behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -64,4 +64,7 @@ enum class FeatureToggle(
 
     // NAV-29800
     KAN_KJØRE_SATSENDRING_EØS("familie-ba-sak.kan-kjore-satsendring-eos"),
+
+    // NAV-29382
+    HENT_VEDTAKSBREV_FRA_JOARK("familie-ba-sak.hent-vedtaksbrev-fra-joark"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -14,7 +14,6 @@ import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.ValiderBrevmottakerService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
@@ -42,6 +41,7 @@ import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
+import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
@@ -87,7 +87,7 @@ class DokumentService(
             )
         val skalHenteVedtaksbrevFraJoark =
             featureToggleService.isEnabled(FeatureToggle.HENT_VEDTAKSBREV_FRA_JOARK) &&
-                vedtak.behandling.status == BehandlingStatus.AVSLUTTET &&
+                vedtak.behandling.erVedtatt() &&
                 vedtak.behandling.erBehandlingMedVedtaksbrevutsending()
 
         val pdf =
@@ -138,15 +138,30 @@ class DokumentService(
                 .filter { it.journalstatus == Journalstatus.FERDIGSTILT || it.journalstatus == Journalstatus.EKSPEDERT }
                 .filter { it.hoveddokumentErVedtaksbrev() }
 
-        val journalpost = journalposterForVedtaksbrev.firstOrNull() ?: return null
-        val dokumentInfoId = journalpost.dokumenter?.firstOrNull()?.dokumentInfoId ?: return null
+        if (journalposterForVedtaksbrev.isEmpty()) {
+            logger.warn("Fant ingen journalpost med vedtaksbrev i Joark for behandling ${behandling.id}")
+            return null
+        }
 
-        return integrasjonKlient.hentDokument(dokumentInfoId = dokumentInfoId, journalpostId = journalpost.journalpostId)
+        if (journalposterForVedtaksbrev.size > 1) {
+            logger.info(
+                "Fant flere journalposter med vedtaksbrev i Joark for behandling ${behandling.id}: " +
+                    "${journalposterForVedtaksbrev.map { it.journalpostId }}. Brevet er likt for alle mottakere, bruker den første.",
+            )
+        }
+
+        val journalpost = journalposterForVedtaksbrev.first()
+        val hoveddokument = checkNotNull(journalpost.hentHoveddokument())
+
+        return integrasjonKlient.hentDokument(dokumentInfoId = hoveddokument.dokumentInfoId, journalpostId = journalpost.journalpostId)
     }
 
+    // Hoveddokumentet er det eneste dokumentet i journalposten med brevkode, vedlegg journalføres uten
+    private fun Journalpost.hentHoveddokument(): DokumentInfo? = dokumenter?.firstOrNull { it.brevkode != null }
+
     private fun Journalpost.hoveddokumentErVedtaksbrev(): Boolean {
-        val tittel = dokumenter?.firstOrNull()?.tittel?.lowercase() ?: return false
-        return tittel.contains("vedtak")
+        val brevkode = hentHoveddokument()?.brevkode ?: return false
+        return brevkode in BREVKODER_FOR_VEDTAKSBREV
     }
 
     @Transactional
@@ -357,6 +372,9 @@ class DokumentService(
     }
 
     companion object {
+        // Brevkodene vedtaksbrev journalføres med i familie-integrasjoner (BAA1 = innvilgelse/avslag, opphor = opphør)
+        private val BREVKODER_FOR_VEDTAKSBREV = setOf("BAA1", "opphor")
+
         fun genererEksternReferanseIdForJournalpost(
             fagsakId: Long,
             behandlingId: Long?,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.ValiderBrevmottakerService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.settpåvent.SettPåVentService
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManuellBrevmottaker
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
@@ -36,9 +37,15 @@ import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.leggTilBlankAnnenVurdering
 import no.nav.familie.ba.sak.sikkerhet.SaksbehandlerContext
 import no.nav.familie.ba.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ba.sak.task.JournalførManueltBrevTask
+import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
+import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
+import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
+import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.log.mdc.MDCConstants
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -46,6 +53,7 @@ import org.slf4j.MDC
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import no.nav.familie.kontrakter.felles.journalpost.Bruker as JournalpostBruker
 
 @Service
 class DokumentService(
@@ -77,20 +85,70 @@ class DokumentService(
                 BehandlerRolle.SAKSBEHANDLER,
                 BehandlerRolle.BESLUTTER,
             )
-        if (høyesteRolletilgangForInnloggetBruker in funksjonelleRoller && vedtak.stønadBrevPdF == null) {
+        val skalHenteVedtaksbrevFraJoark =
+            featureToggleService.isEnabled(FeatureToggle.HENT_VEDTAKSBREV_FRA_JOARK) &&
+                vedtak.behandling.status == BehandlingStatus.AVSLUTTET &&
+                vedtak.behandling.erBehandlingMedVedtaksbrevutsending()
+
+        if (skalHenteVedtaksbrevFraJoark) {
+            val pdf =
+                hentVedtaksbrevFraJoark(vedtak)
+                    ?: throw FunksjonellFeil(
+                        melding = "Fant ikke vedtaksbrev for behandling med id ${vedtak.behandling.id} i Joark.",
+                        frontendFeilmelding = "Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.",
+                    )
+            return Ressurs.success(pdf)
+        }
+
+        val pdf = vedtak.stønadBrevPdF
+
+        if (høyesteRolletilgangForInnloggetBruker in funksjonelleRoller && pdf == null) {
             throw FunksjonellFeil(
                 melding =
                     "Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}. Innlogget bruker har rolle: $høyesteRolletilgangForInnloggetBruker",
                 frontendFeilmelding = "Det finnes ikke noe vedtaksbrev.",
             )
         } else {
-            val pdf =
-                vedtak.stønadBrevPdF ?: throw Feil(
+            return Ressurs.success(
+                pdf ?: throw Feil(
                     "Klarte ikke finne vedtaksbrev for vedtak med id ${vedtak.id}. " +
                         "Innlogget bruker har rolle: $høyesteRolletilgangForInnloggetBruker",
-                )
-            return Ressurs.success(pdf)
+                ),
+            )
         }
+    }
+
+    private fun hentVedtaksbrevFraJoark(vedtak: Vedtak): ByteArray? {
+        val behandling = vedtak.behandling
+        // Må matche formatet i genererEksternReferanseIdForJournalpost
+        val eksternReferanseIdPrefiks = "${behandling.fagsak.id}_${behandling.id}_"
+
+        val journalposterForVedtaksbrev =
+            integrasjonKlient
+                .hentJournalposterForBruker(
+                    JournalposterForBrukerRequest(
+                        brukerId =
+                            JournalpostBruker(
+                                id = behandling.fagsak.aktør.aktivFødselsnummer(),
+                                type = BrukerIdType.FNR,
+                            ),
+                        antall = 1000,
+                        tema = listOf(Tema.BAR),
+                        journalposttype = listOf(Journalposttype.U),
+                    ),
+                ).filter { it.eksternReferanseId?.startsWith(eksternReferanseIdPrefiks) == true }
+                .filter { it.journalstatus == Journalstatus.FERDIGSTILT || it.journalstatus == Journalstatus.EKSPEDERT }
+                .filter { it.hoveddokumentErVedtaksbrev() }
+
+        val journalpost = journalposterForVedtaksbrev.firstOrNull() ?: return null
+        val dokumentInfoId = journalpost.dokumenter?.firstOrNull()?.dokumentInfoId ?: return null
+
+        return integrasjonKlient.hentDokument(dokumentInfoId = dokumentInfoId, journalpostId = journalpost.journalpostId)
+    }
+
+    private fun Journalpost.hoveddokumentErVedtaksbrev(): Boolean {
+        val tittel = dokumenter?.firstOrNull()?.tittel?.lowercase() ?: return false
+        return tittel.contains("vedtak")
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -90,17 +90,16 @@ class DokumentService(
                 vedtak.behandling.status == BehandlingStatus.AVSLUTTET &&
                 vedtak.behandling.erBehandlingMedVedtaksbrevutsending()
 
-        if (skalHenteVedtaksbrevFraJoark) {
-            val pdf =
+        val pdf =
+            if (skalHenteVedtaksbrevFraJoark) {
                 hentVedtaksbrevFraJoark(vedtak)
                     ?: throw FunksjonellFeil(
                         melding = "Fant ikke vedtaksbrev for behandling med id ${vedtak.behandling.id} i Joark.",
                         frontendFeilmelding = "Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.",
                     )
-            return Ressurs.success(pdf)
-        }
-
-        val pdf = vedtak.stønadBrevPdF
+            } else {
+                vedtak.stønadBrevPdF
+            }
 
         if (høyesteRolletilgangForInnloggetBruker in funksjonelleRoller && pdf == null) {
             throw FunksjonellFeil(
@@ -120,7 +119,6 @@ class DokumentService(
 
     private fun hentVedtaksbrevFraJoark(vedtak: Vedtak): ByteArray? {
         val behandling = vedtak.behandling
-        // Må matche formatet i genererEksternReferanseIdForJournalpost
         val eksternReferanseIdPrefiks = "${behandling.fagsak.id}_${behandling.id}_"
 
         val journalposterForVedtaksbrev =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -37,6 +37,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
@@ -467,7 +468,7 @@ internal class DokumentServiceTest {
         }
 
         @Test
-        fun `Skal ikke bruke journalpost der hoveddokumentet mangler tittel`() {
+        fun `Skal ikke bruke journalpost der hoveddokumentet ikke er et vedtaksbrev selv om tittelen inneholder vedtak`() {
             // Arrange
             every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
             every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
@@ -480,8 +481,8 @@ internal class DokumentServiceTest {
                         journalpostId = "1",
                         eksternReferanseId = "${vedtak.behandling.fagsak.id}_${vedtak.behandling.id}_callId",
                         dokumentInfoId = "10",
-                        tittel = null,
-                        brevkode = "BAA1",
+                        tittel = "Vedtak om tilbakekreving ved motregning",
+                        brevkode = "Vedtak om tilbakekreving ved motregning",
                     ),
                 )
 
@@ -492,6 +493,88 @@ internal class DokumentServiceTest {
                 }.frontendFeilmelding
 
             assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
+        }
+
+        @Test
+        fun `Skal bruke første journalpost når vedtaksbrevet er journalført for flere mottakere`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
+            val fagsakId = vedtak.behandling.fagsak.id
+            val behandlingId = vedtak.behandling.id
+            val pdfFraJoark = byteArrayOf(1, 2, 3)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId1",
+                        dokumentInfoId = "10",
+                    ),
+                    lagUtgåendeJournalpost(
+                        journalpostId = "2",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_verge_callId1",
+                        dokumentInfoId = "20",
+                    ),
+                )
+            every { integrasjonKlient.hentDokument(dokumentInfoId = "10", journalpostId = "1") } returns pdfFraJoark
+
+            // Act
+            val vedtaksbrevPdf = dokumentService.hentBrevForVedtak(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf.data).isEqualTo(pdfFraJoark)
+        }
+
+        @Test
+        fun `Skal hente vedtaksbrev med brevkode for opphør fra Joark`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
+            val pdfFraJoark = byteArrayOf(1, 2, 3)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${vedtak.behandling.fagsak.id}_${vedtak.behandling.id}_callId",
+                        dokumentInfoId = "10",
+                        tittel = "Vedtak om opphørt barnetrygd",
+                        brevkode = "opphor",
+                    ),
+                )
+            every { integrasjonKlient.hentDokument(dokumentInfoId = "10", journalpostId = "1") } returns pdfFraJoark
+
+            // Act
+            val vedtaksbrevPdf = dokumentService.hentBrevForVedtak(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf.data).isEqualTo(pdfFraJoark)
+        }
+
+        @Test
+        fun `Skal hente vedtaksbrev fra databasen når toggle er på og behandlingen er henlagt`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val pdfFraDatabasen = byteArrayOf(9)
+            val vedtak =
+                lagVedtak(
+                    behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET),
+                    stønadBrevPdF = pdfFraDatabasen,
+                )
+
+            // Act
+            val vedtaksbrevPdf = dokumentService.hentBrevForVedtak(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf.data).isEqualTo(pdfFraDatabasen)
+            verify(exactly = 0) { integrasjonKlient.hentJournalposterForBruker(any()) }
         }
 
         @Test
@@ -536,13 +619,17 @@ internal class DokumentServiceTest {
             dokumentInfoId: String,
             journalstatus: Journalstatus = Journalstatus.FERDIGSTILT,
             tittel: String? = "Vedtak om barnetrygd",
-            brevkode: String? = null,
+            brevkode: String? = "BAA1",
         ) = Journalpost(
             journalpostId = journalpostId,
             journalposttype = Journalposttype.U,
             journalstatus = journalstatus,
             eksternReferanseId = eksternReferanseId,
-            dokumenter = listOf(DokumentInfo(dokumentInfoId = dokumentInfoId, tittel = tittel, brevkode = brevkode)),
+            dokumenter =
+                listOf(
+                    DokumentInfo(dokumentInfoId = dokumentInfoId, tittel = tittel, brevkode = brevkode),
+                    DokumentInfo(dokumentInfoId = "vedlegg-$dokumentInfoId", tittel = "Stønadsmottakerens rettigheter og plikter", brevkode = null),
+                ),
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.config.BehandlerRolle
 import no.nav.familie.ba.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle.HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle.HENT_VEDTAKSBREV_FRA_JOARK
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.defaultFagsak
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -34,6 +35,9 @@ import no.nav.familie.ba.sak.kjerne.arbeidsfordeling.BarnetrygdEnhet.STORD
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.BehandlingHentOgPersisterService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.brev.domene.ManueltBrevRequest
 import no.nav.familie.ba.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ba.sak.kjerne.brev.mottaker.BrevmottakerRepository
@@ -55,6 +59,10 @@ import no.nav.familie.ba.sak.task.dto.JournalførManueltBrevDTO
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
+import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
+import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
+import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
 import no.nav.familie.prosessering.domene.Task
@@ -417,6 +425,180 @@ internal class DokumentServiceTest {
             // Assert
             assertThat(vedtaksbrevPdf.data).isEqualTo(byteArray)
         }
+
+        @Test
+        fun `Skal hente vedtaksbrev fra Joark når toggle er på og behandlingen er avsluttet`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
+            val fagsakId = vedtak.behandling.fagsak.id
+            val behandlingId = vedtak.behandling.id
+            val pdfFraJoark = byteArrayOf(1, 2, 3)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId1",
+                        dokumentInfoId = "10",
+                        tittel = "Innhente opplysninger",
+                        brevkode = "innhente-opplysninger",
+                    ),
+                    lagUtgåendeJournalpost(
+                        journalpostId = "4",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId3",
+                        dokumentInfoId = "40",
+                    ),
+                    lagUtgåendeJournalpost(
+                        journalpostId = "5",
+                        eksternReferanseId = "${fagsakId}_${behandlingId + 1}_callId4",
+                        dokumentInfoId = "50",
+                    ),
+                )
+            every { integrasjonKlient.hentDokument(dokumentInfoId = "40", journalpostId = "4") } returns pdfFraJoark
+
+            // Act
+            val vedtaksbrevPdf = dokumentService.hentBrevForVedtak(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf.data).isEqualTo(pdfFraJoark)
+        }
+
+        @Test
+        fun `Skal ikke bruke journalpost der hoveddokumentet mangler tittel`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${vedtak.behandling.fagsak.id}_${vedtak.behandling.id}_callId",
+                        dokumentInfoId = "10",
+                        tittel = null,
+                        brevkode = "BAA1",
+                    ),
+                )
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    dokumentService.hentBrevForVedtak(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
+        }
+
+        @Test
+        fun `Skal hente vedtaksbrev fra databasen når behandlingen ikke sender vedtaksbrev`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val pdfFraDatabasen = byteArrayOf(9)
+            val vedtak =
+                lagVedtak(
+                    behandling =
+                        lagBehandling(
+                            behandlingType = BehandlingType.TEKNISK_ENDRING,
+                            årsak = BehandlingÅrsak.TEKNISK_ENDRING,
+                            status = BehandlingStatus.AVSLUTTET,
+                        ),
+                    stønadBrevPdF = pdfFraDatabasen,
+                )
+
+            // Act
+            val vedtaksbrevPdf = dokumentService.hentBrevForVedtak(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf.data).isEqualTo(pdfFraDatabasen)
+            verify(exactly = 0) { integrasjonKlient.hentJournalposterForBruker(any()) }
+        }
+
+        @Test
+        fun `Skal hente vedtaksbrev fra databasen når toggle er på og behandlingen ikke er avsluttet`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val pdfFraDatabasen = byteArrayOf(9)
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.UTREDES), stønadBrevPdF = pdfFraDatabasen)
+
+            // Act
+            val vedtaksbrevPdf = dokumentService.hentBrevForVedtak(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf.data).isEqualTo(pdfFraDatabasen)
+            verify(exactly = 0) { integrasjonKlient.hentJournalposterForBruker(any()) }
+        }
+
+        @Test
+        fun `Skal kaste funksjonell feil når toggle er på og vedtaksbrevet ikke finnes i Joark`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns emptyList()
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    dokumentService.hentBrevForVedtak(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
+        }
+
+        @Test
+        fun `Skal kaste funksjonell feil når journalposten for vedtaksbrevet er feilregistrert`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.VEILEDER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
+            val fagsakId = vedtak.behandling.fagsak.id
+            val behandlingId = vedtak.behandling.id
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId",
+                        dokumentInfoId = "10",
+                        journalstatus = Journalstatus.FEILREGISTRERT,
+                    ),
+                )
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    dokumentService.hentBrevForVedtak(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
+        }
+
+        private fun lagUtgåendeJournalpost(
+            journalpostId: String,
+            eksternReferanseId: String,
+            dokumentInfoId: String,
+            journalstatus: Journalstatus = Journalstatus.FERDIGSTILT,
+            tittel: String? = "Vedtak om barnetrygd",
+            brevkode: String? = null,
+        ) = Journalpost(
+            journalpostId = journalpostId,
+            journalposttype = Journalposttype.U,
+            journalstatus = journalstatus,
+            eksternReferanseId = eksternReferanseId,
+            dokumenter = listOf(DokumentInfo(dokumentInfoId = dokumentInfoId, tittel = tittel, brevkode = brevkode)),
+        )
     }
 
     @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -495,32 +495,6 @@ internal class DokumentServiceTest {
         }
 
         @Test
-        fun `Skal hente vedtaksbrev fra databasen når behandlingen ikke sender vedtaksbrev`() {
-            // Arrange
-            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
-            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
-
-            val pdfFraDatabasen = byteArrayOf(9)
-            val vedtak =
-                lagVedtak(
-                    behandling =
-                        lagBehandling(
-                            behandlingType = BehandlingType.TEKNISK_ENDRING,
-                            årsak = BehandlingÅrsak.TEKNISK_ENDRING,
-                            status = BehandlingStatus.AVSLUTTET,
-                        ),
-                    stønadBrevPdF = pdfFraDatabasen,
-                )
-
-            // Act
-            val vedtaksbrevPdf = dokumentService.hentBrevForVedtak(vedtak)
-
-            // Assert
-            assertThat(vedtaksbrevPdf.data).isEqualTo(pdfFraDatabasen)
-            verify(exactly = 0) { integrasjonKlient.hentJournalposterForBruker(any()) }
-        }
-
-        @Test
         fun `Skal hente vedtaksbrev fra databasen når toggle er på og behandlingen ikke er avsluttet`() {
             // Arrange
             every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
@@ -546,35 +520,6 @@ internal class DokumentServiceTest {
             val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
 
             every { integrasjonKlient.hentJournalposterForBruker(any()) } returns emptyList()
-
-            // Act && Assert
-            val feilmelding =
-                assertThrows<FunksjonellFeil> {
-                    dokumentService.hentBrevForVedtak(vedtak)
-                }.frontendFeilmelding
-
-            assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
-        }
-
-        @Test
-        fun `Skal kaste funksjonell feil når journalposten for vedtaksbrevet er feilregistrert`() {
-            // Arrange
-            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.VEILEDER
-            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
-
-            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
-            val fagsakId = vedtak.behandling.fagsak.id
-            val behandlingId = vedtak.behandling.id
-
-            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
-                listOf(
-                    lagUtgåendeJournalpost(
-                        journalpostId = "1",
-                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId",
-                        dokumentInfoId = "10",
-                        journalstatus = Journalstatus.FEILREGISTRERT,
-                    ),
-                )
 
             // Act && Assert
             val feilmelding =


### PR DESCRIPTION
### 📮 Favro:
Nav-29382 – Undersøk om vi kan slette gamle vedtaksbrev i familie-ba-sak og familie-ks-sak etter at brevene er sendt ut.

### 💰 Hva skal gjøres, og hvorfor?
Vedtaksbrev lagres i dag for evig i databasen (`vedtak.stonad_brev_pdf`), selv om de også arkiveres i Joark. For å kunne rydde opp i de lagrede brevene må visning av vedtaksbrev for avsluttede behandlinger hente brevet fra Joark i stedet for fra databasen.

Bak ny feature toggle `familie-ba-sak.hent-vedtaksbrev-fra-joark`:
- `GET /api/dokument/vedtaksbrev/{vedtakId}` henter brevet fra Joark når behandlingen er avsluttet og har vedtaksbrevutsending. Journalposten finnes via saf (`hentJournalposterForBruker`) ved å matche `eksternReferanseId`-prefikset `{fagsakId}_{behandlingId}_`, filtrert på ferdigstilte/ekspederte utgående journalposter der hoveddokumentets tittel inneholder "vedtak". Selve PDF-en hentes via det tilgangsstyrte hentdokument-endepunktet i familie-integrasjoner.
- Finnes ikke brevet i Joark, kastes en funksjonell feil som ber saksbehandler finne brevet i dokumentoversikten (vises som warning i frontend, se tilhørende PR i familie-ba-sak-frontend).
- Behandlinger som ikke er avsluttet, behandlinger uten vedtaksbrevutsending og toggle av gir uendret oppførsel (leser fra databasen som før).

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
- `eksternReferanseId`-formatet har vært stabilt siden januar 2022. Vedtaksbrev journalført før det vil gi funksjonell feil, og saksbehandler må finne brevet via dokumentoversikten.
