### PR TITLE
Nav 29936 slett gamle vedtaksbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -64,4 +64,7 @@ enum class FeatureToggle(
 
     // NAV-29800
     KAN_KJØRE_SATSENDRING_EØS("familie-ba-sak.kan-kjore-satsendring-eos"),
+
+    // NAV-29936
+    SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB("familie-ba-sak.skal-slette-gamle-vedtaksbrev-fra-db"),
 }

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakRepository.kt
@@ -25,11 +25,14 @@ interface VedtakRepository : JpaRepository<Vedtak, Long> {
         pageable: Pageable,
     ): List<Long>
 
-    // Bulk-UPDATE (JPQL) går utenom JPA-livssyklusen: den bumper ikke @Version, oppdaterer ikke
-    // endret_av/endret_tid (@PreUpdate) og trigger ikke RollestyringMotDatabase-listeneren. Det er
-    // ønsket her – dette er en systemjobb uten innlogget saksbehandler, og vi nuller kun ut en pdf.
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Vedtak v SET v.stønadBrevPdF = null WHERE v.id IN :vedtakIder")
+    @Modifying(clearAutomatically = true)
+    @Query(
+        """
+        UPDATE Vedtak v
+        SET v.stønadBrevPdF = null
+        WHERE v.id IN :vedtakIder
+        """,
+    )
     fun slettStønadBrevPdfForVedtak(vedtakIder: List<Long>): Int
 
     @Query("SELECT v FROM Vedtak v WHERE v.behandling.id = :behandlingId AND v.aktiv = true")

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakRepository.kt
@@ -1,12 +1,36 @@
 package no.nav.familie.ba.sak.kjerne.vedtak
 
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
 interface VedtakRepository : JpaRepository<Vedtak, Long> {
     @Query(value = "SELECT v FROM Vedtak v WHERE v.behandling.id = :behandlingId")
     fun finnVedtakForBehandling(behandlingId: Long): List<Vedtak>
+
+    @Query(
+        """
+        SELECT v.id FROM Vedtak v
+        WHERE v.stønadBrevPdF IS NOT NULL
+        AND v.behandling.status = :status
+        AND v.vedtaksdato < :vedtaksdatoFør
+        """,
+    )
+    fun finnVedtakIderMedStønadBrevPdf(
+        status: BehandlingStatus,
+        vedtaksdatoFør: LocalDateTime,
+        pageable: Pageable,
+    ): List<Long>
+
+    // Bulk-UPDATE (JPQL) går utenom JPA-livssyklusen: den bumper ikke @Version, oppdaterer ikke
+    // endret_av/endret_tid (@PreUpdate) og trigger ikke RollestyringMotDatabase-listeneren. Det er
+    // ønsket her – dette er en systemjobb uten innlogget saksbehandler, og vi nuller kun ut en pdf.
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE Vedtak v SET v.stønadBrevPdF = null WHERE v.id IN :vedtakIder")
+    fun slettStønadBrevPdfForVedtak(vedtakIder: List<Long>): Int
 
     @Query("SELECT v FROM Vedtak v WHERE v.behandling.id = :behandlingId AND v.aktiv = true")
     fun findByBehandlingAndAktivOptional(behandlingId: Long): Vedtak?

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevScheduler.kt
@@ -1,0 +1,60 @@
+package no.nav.familie.ba.sak.task
+
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
+import no.nav.familie.leader.LeaderClient
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * Sletter (nuller ut) gamle vedtaksbrev-pdf-er som ligger lagret i databasen på avsluttede
+ * behandlinger. Brevene hentes nå fra Joark for avsluttede behandlinger, så vi trenger ikke
+ * å lagre dem i vår egen database lenger. Se NAV-29936 / NAV-29382.
+ */
+@Component
+class SlettGamleVedtaksbrevScheduler(
+    private val vedtakRepository: VedtakRepository,
+    private val featureToggleService: FeatureToggleService,
+) {
+    @Scheduled(cron = "0 0 6 1 */3 *")
+    @Transactional
+    fun slettGamleVedtaksbrev() {
+        if (LeaderClient.isLeader() != true) return
+        if (!featureToggleService.isEnabled(FeatureToggle.SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB)) return
+
+        val vedtaksdatoFør = LocalDateTime.now().minusMonths(ANTALL_MÅNEDER_FØR_SLETTING)
+
+        // Hele jobben kjører i én transaksjon. Batchingen begrenser størrelsen på IN-lista i UPDATE-en
+        // (og dermed antall parametere), ikke transaksjonsstørrelsen. Volumet er lavt siden jobben kun
+        // kjører kvartalsvis, så vi holder det bevisst enkelt fremfor én transaksjon per batch.
+        var totaltSlettet = 0
+        for (batch in 0 until MAKS_ANTALL_BATCHER_PER_KJØRING) {
+            val vedtakIder =
+                vedtakRepository.finnVedtakIderMedStønadBrevPdf(
+                    status = BehandlingStatus.AVSLUTTET,
+                    vedtaksdatoFør = vedtaksdatoFør,
+                    pageable = PageRequest.of(0, BATCH_STØRRELSE),
+                )
+            if (vedtakIder.isEmpty()) break
+
+            totaltSlettet += vedtakRepository.slettStønadBrevPdfForVedtak(vedtakIder)
+        }
+
+        if (totaltSlettet > 0) {
+            logger.info("Slettet $totaltSlettet gamle vedtaksbrev fra databasen")
+        }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(SlettGamleVedtaksbrevScheduler::class.java)
+        private const val ANTALL_MÅNEDER_FØR_SLETTING = 3L
+        private const val BATCH_STØRRELSE = 500
+        private const val MAKS_ANTALL_BATCHER_PER_KJØRING = 20
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevScheduler.kt
@@ -13,16 +13,15 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 /**
- * Sletter (nuller ut) gamle vedtaksbrev-pdf-er som ligger lagret i databasen på avsluttede
- * behandlinger. Brevene hentes nå fra Joark for avsluttede behandlinger, så vi trenger ikke
- * å lagre dem i vår egen database lenger. Se NAV-29936 / NAV-29382.
+ * Sletter gamle vedtaksbrev-pdf-er som ligger lagret i databasen på avsluttede
+ * behandlinger.
  */
 @Component
 class SlettGamleVedtaksbrevScheduler(
     private val vedtakRepository: VedtakRepository,
     private val featureToggleService: FeatureToggleService,
 ) {
-    @Scheduled(cron = "0 0 6 1 */3 *")
+    @Scheduled(cron = "0 0 6 * * *")
     @Transactional
     fun slettGamleVedtaksbrev() {
         if (LeaderClient.isLeader() != true) return
@@ -30,9 +29,6 @@ class SlettGamleVedtaksbrevScheduler(
 
         val vedtaksdatoFør = LocalDateTime.now().minusMonths(ANTALL_MÅNEDER_FØR_SLETTING)
 
-        // Hele jobben kjører i én transaksjon. Batchingen begrenser størrelsen på IN-lista i UPDATE-en
-        // (og dermed antall parametere), ikke transaksjonsstørrelsen. Volumet er lavt siden jobben kun
-        // kjører kvartalsvis, så vi holder det bevisst enkelt fremfor én transaksjon per batch.
         var totaltSlettet = 0
         for (batch in 0 until MAKS_ANTALL_BATCHER_PER_KJØRING) {
             val vedtakIder =
@@ -55,6 +51,6 @@ class SlettGamleVedtaksbrevScheduler(
         private val logger = LoggerFactory.getLogger(SlettGamleVedtaksbrevScheduler::class.java)
         private const val ANTALL_MÅNEDER_FØR_SLETTING = 3L
         private const val BATCH_STØRRELSE = 500
-        private const val MAKS_ANTALL_BATCHER_PER_KJØRING = 20
+        private const val MAKS_ANTALL_BATCHER_PER_KJØRING = 60
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerTest.kt
@@ -1,0 +1,128 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
+import no.nav.familie.leader.LeaderClient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+
+class SlettGamleVedtaksbrevSchedulerTest {
+    private val vedtakRepository = mockk<VedtakRepository>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val scheduler = SlettGamleVedtaksbrevScheduler(vedtakRepository, featureToggleService)
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(LeaderClient::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(LeaderClient::class)
+    }
+
+    @Test
+    fun `skal ikke slette noe når podden ikke er leader`() {
+        // Arrange
+        every { LeaderClient.isLeader() } returns false
+
+        // Act
+        scheduler.slettGamleVedtaksbrev()
+
+        // Assert
+        verify(exactly = 0) { featureToggleService.isEnabled(any<FeatureToggle>()) }
+        verify(exactly = 0) { vedtakRepository.finnVedtakIderMedStønadBrevPdf(any(), any(), any()) }
+        verify(exactly = 0) { vedtakRepository.slettStønadBrevPdfForVedtak(any()) }
+    }
+
+    @Test
+    fun `skal ikke slette noe når feature toggle er avslått`() {
+        // Arrange
+        every { LeaderClient.isLeader() } returns true
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB) } returns false
+
+        // Act
+        scheduler.slettGamleVedtaksbrev()
+
+        // Assert
+        verify(exactly = 0) { vedtakRepository.finnVedtakIderMedStønadBrevPdf(any(), any(), any()) }
+        verify(exactly = 0) { vedtakRepository.slettStønadBrevPdfForVedtak(any()) }
+    }
+
+    @Test
+    fun `skal slette vedtaksbrev på avsluttede behandlinger i batcher til det ikke er flere igjen`() {
+        // Arrange
+        every { LeaderClient.isLeader() } returns true
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB) } returns true
+
+        val førsteBatch = (1L..500L).toList()
+        val andreBatch = (501L..800L).toList()
+        every {
+            vedtakRepository.finnVedtakIderMedStønadBrevPdf(any(), any(), any())
+        } returnsMany listOf(førsteBatch, andreBatch, emptyList())
+        every { vedtakRepository.slettStønadBrevPdfForVedtak(any()) } answers { firstArg<List<Long>>().size }
+
+        // Act
+        scheduler.slettGamleVedtaksbrev()
+
+        // Assert
+        verify(exactly = 1) { vedtakRepository.slettStønadBrevPdfForVedtak(førsteBatch) }
+        verify(exactly = 1) { vedtakRepository.slettStønadBrevPdfForVedtak(andreBatch) }
+        // Tredje kall til finn returnerer tom liste -> løkka stopper og sletter ikke mer
+        verify(exactly = 3) { vedtakRepository.finnVedtakIderMedStønadBrevPdf(any(), any(), any()) }
+        verify(exactly = 2) { vedtakRepository.slettStønadBrevPdfForVedtak(any()) }
+    }
+
+    @Test
+    fun `skal bruke vedtaksdato tre måneder tilbake i tid som grense`() {
+        // Arrange
+        every { LeaderClient.isLeader() } returns true
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB) } returns true
+        every { vedtakRepository.finnVedtakIderMedStønadBrevPdf(any(), any(), any()) } returns emptyList()
+
+        val førKjøring = LocalDateTime.now().minusMonths(3)
+
+        // Act
+        scheduler.slettGamleVedtaksbrev()
+
+        val etterKjøring = LocalDateTime.now().minusMonths(3)
+
+        // Assert
+        verify {
+            vedtakRepository.finnVedtakIderMedStønadBrevPdf(
+                status = BehandlingStatus.AVSLUTTET,
+                vedtaksdatoFør =
+                    match {
+                        !it.isBefore(førKjøring) && !it.isAfter(etterKjøring)
+                    },
+                pageable = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `skal ikke slette mer enn maks antall batcher per kjøring`() {
+        // Arrange
+        every { LeaderClient.isLeader() } returns true
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB) } returns true
+        // Returnerer alltid en full batch -> ville løpt uendelig uten maksgrense
+        every { vedtakRepository.finnVedtakIderMedStønadBrevPdf(any(), any(), any()) } returns (1L..500L).toList()
+        every { vedtakRepository.slettStønadBrevPdfForVedtak(any()) } returns 500
+
+        // Act
+        scheduler.slettGamleVedtaksbrev()
+
+        // Assert
+        verify(exactly = 20) { vedtakRepository.slettStønadBrevPdfForVedtak(any()) }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerTest.kt
@@ -13,7 +13,6 @@ import no.nav.familie.leader.LeaderClient
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.Pageable
 import java.time.LocalDateTime
 
 class SlettGamleVedtaksbrevSchedulerTest {
@@ -123,6 +122,6 @@ class SlettGamleVedtaksbrevSchedulerTest {
         scheduler.slettGamleVedtaksbrev()
 
         // Assert
-        verify(exactly = 20) { vedtakRepository.slettStønadBrevPdfForVedtak(any()) }
+        verify(exactly = 60) { vedtakRepository.slettStønadBrevPdfForVedtak(any()) }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
@@ -5,7 +5,12 @@ import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
 import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
 import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
+import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøringRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -13,6 +18,8 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakRepositoryTest.kt
@@ -5,12 +5,7 @@ import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
 import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
 import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
-import no.nav.familie.ba.sak.datagenerator.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.datagenerator.randomAktør
-import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøring
-import no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs.domene.SatsendringEøsKjøringRepository
-import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType
@@ -18,8 +13,6 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
-import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
-import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerIntegrationTest.kt
@@ -1,0 +1,114 @@
+package no.nav.familie.ba.sak.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import no.nav.familie.ba.sak.config.AbstractSpringIntegrationTest
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
+import no.nav.familie.ba.sak.datagenerator.randomAktør
+import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ba.sak.kjerne.fagsak.Fagsak
+import no.nav.familie.ba.sak.kjerne.fagsak.FagsakRepository
+import no.nav.familie.ba.sak.kjerne.personident.AktørIdRepository
+import no.nav.familie.ba.sak.kjerne.vedtak.Vedtak
+import no.nav.familie.ba.sak.kjerne.vedtak.VedtakRepository
+import no.nav.familie.leader.LeaderClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Transactional
+class SlettGamleVedtaksbrevSchedulerIntegrationTest(
+    @Autowired private val aktørIdRepository: AktørIdRepository,
+    @Autowired private val fagsakRepository: FagsakRepository,
+    @Autowired private val behandlingRepository: BehandlingRepository,
+    @Autowired private val vedtakRepository: VedtakRepository,
+) : AbstractSpringIntegrationTest() {
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val scheduler = SlettGamleVedtaksbrevScheduler(vedtakRepository, featureToggleService)
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(LeaderClient::class)
+        every { LeaderClient.isLeader() } returns true
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB) } returns true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(LeaderClient::class)
+    }
+
+    @Test
+    fun `skal kun slette vedtaksbrev på gamle avsluttede behandlinger`() {
+        // Arrange
+        val gammelVedtaksdato = LocalDateTime.now().minusMonths(6)
+        val nyVedtaksdato = LocalDateTime.now().minusDays(1)
+
+        val skalSlettes =
+            lagreVedtakMedStønadBrev(
+                status = BehandlingStatus.AVSLUTTET,
+                vedtaksdato = gammelVedtaksdato,
+            )
+        val avsluttetMenForNylig =
+            lagreVedtakMedStønadBrev(
+                status = BehandlingStatus.AVSLUTTET,
+                vedtaksdato = nyVedtaksdato,
+            )
+        val ikkeAvsluttet =
+            lagreVedtakMedStønadBrev(
+                status = BehandlingStatus.UTREDES,
+                vedtaksdato = gammelVedtaksdato,
+            )
+
+        // Act
+        scheduler.slettGamleVedtaksbrev()
+
+        // Assert
+        assertThat(vedtakRepository.findById(skalSlettes.id).get().stønadBrevPdF).isNull()
+        assertThat(vedtakRepository.findById(avsluttetMenForNylig.id).get().stønadBrevPdF).isNotNull()
+        assertThat(vedtakRepository.findById(ikkeAvsluttet.id).get().stønadBrevPdF).isNotNull()
+    }
+
+    @Test
+    fun `skal ikke slette noe når feature toggle er avslått`() {
+        // Arrange
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SLETTE_GAMLE_VEDTAKSBREV_FRA_DB) } returns false
+        val vedtak =
+            lagreVedtakMedStønadBrev(
+                status = BehandlingStatus.AVSLUTTET,
+                vedtaksdato = LocalDateTime.now().minusMonths(6),
+            )
+
+        // Act
+        scheduler.slettGamleVedtaksbrev()
+
+        // Assert
+        assertThat(vedtakRepository.findById(vedtak.id).get().stønadBrevPdF).isNotNull()
+    }
+
+    private fun lagreVedtakMedStønadBrev(
+        status: BehandlingStatus,
+        vedtaksdato: LocalDateTime,
+    ): Vedtak {
+        val søker = aktørIdRepository.save(randomAktør())
+        val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
+        val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak, status = status))
+        return vedtakRepository.save(
+            Vedtak(
+                behandling = behandling,
+                vedtaksdato = vedtaksdato,
+                stønadBrevPdF = "et vedtaksbrev".toByteArray(),
+            ),
+        )
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/SlettGamleVedtaksbrevSchedulerIntegrationTest.kt
@@ -74,7 +74,8 @@ class SlettGamleVedtaksbrevSchedulerIntegrationTest(
         scheduler.slettGamleVedtaksbrev()
 
         // Assert
-        assertThat(vedtakRepository.findById(skalSlettes.id).get().stønadBrevPdF).isNull()
+        val slettetVedtak = vedtakRepository.findById(skalSlettes.id).get()
+        assertThat(slettetVedtak.stønadBrevPdF).isNull()
         assertThat(vedtakRepository.findById(avsluttetMenForNylig.id).get().stønadBrevPdF).isNotNull()
         assertThat(vedtakRepository.findById(ikkeAvsluttet.id).get().stønadBrevPdF).isNotNull()
     }


### PR DESCRIPTION
### 📮 Favro: Nav-29936 
### 💰 Hva skal gjøres, og hvorfor?
Vedtaksbrev for avsluttede behandlinger hentes nå fra Joark (NAV-29382), så vi trenger ikke lenger å lagre selve pdf-en i vår egen database. Denne PR-en rydder bort gamle brev-pdf-er for å redusere lagringsbehovet.

- Ny scheduled jobb `SlettGamleVedtaksbrevScheduler` som daglig (kl. 06) nuller ut `stonad_brev_pdf` på avsluttede behandlinger med vedtaksdato eldre enn 3 måneder. Jobben er leader-styrt og bak feature toggle.
- Nye spørringer i `VedtakRepository`: `finnVedtakIderMedStønadBrevPdf` (henter id-er i batcher) og `slettStønadBrevPdfForVedtak` (bulk-UPDATE som nuller ut pdf-en).
- Ny feature toggle `familie-ks-sak.skal-slette-gamle-vedtaksbrev-fra-db`.
- Enhetstester og integrasjonstester for scheduleren.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
- Batchingen (500 per batch, maks 60 batcher per kjøring) begrenser størrelsen på IN-lista i UPDATE-en, ikke transaksjonsstørrelsen – hele kjøringen går i én transaksjon. Volumet er lavt siden jobben kjører daglig, så vi holder det bevisst enkelt.
- Bulk-UPDATE-en bruker `@Modifying(clearAutomatically = true)` slik at kallere som allerede har lastet Vedtak-entiteter i samme transaksjon ikke leser utdaterte verdier fra førstenivåcachen.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.