### PR TITLE
NAV-29801: Legg til spørring og endepunkt for å trigge EØS-satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsController.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs
+
+import no.nav.familie.ba.sak.config.BehandlerRolle
+import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Ressurs
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.YearMonth
+
+@RestController
+@RequestMapping("/api/satsendring-eos")
+class SatsendringEøsController(
+    private val startSatsendringEøs: StartSatsendringEøs,
+    private val tilgangService: TilgangService,
+) {
+    @PostMapping(path = ["/kjor"])
+    fun opprettSatsendringEøsForRelevanteFagsaker(
+        @RequestBody request: SatsendringEøsRequest,
+    ): ResponseEntity<Ressurs<String>> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            BehandlerRolle.FORVALTER,
+            "Trigge EØS-satsendring for alle relevante fagsaker",
+        )
+        val fagsakIder =
+            startSatsendringEøs.opprettSatsendringEøsTaskerForRelevanteFagsaker(
+                utbetalingsland = request.utbetalingsland,
+                satsTidspunkt = request.satsTidspunkt,
+            )
+        return ResponseEntity.ok(Ressurs.success("Trigget EØS-satsendring for ${fagsakIder.size} fagsaker"))
+    }
+
+    @PostMapping(path = ["/kjor/{fagsakId}"])
+    fun opprettSatsendringEøsForFagsak(
+        @PathVariable fagsakId: Long,
+        @RequestBody request: SatsendringEøsRequest,
+    ): ResponseEntity<Ressurs<String>> {
+        tilgangService.verifiserHarTilgangTilHandling(
+            BehandlerRolle.FORVALTER,
+            "Trigge EØS-satsendring for én fagsak",
+        )
+        startSatsendringEøs.opprettSatsendringEøsTaskForFagsak(
+            fagsakId = fagsakId,
+            utbetalingsland = request.utbetalingsland,
+            satsTidspunkt = request.satsTidspunkt,
+        )
+        return ResponseEntity.ok(Ressurs.success("Trigget EØS-satsendring for fagsak $fagsakId"))
+    }
+}
+
+data class SatsendringEøsRequest(
+    val utbetalingsland: String,
+    val satsTidspunkt: YearMonth,
+)

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/StartSatsendringEøs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/StartSatsendringEøs.kt
@@ -44,7 +44,6 @@ class StartSatsendringEøs(
         utbetalingsland: String,
         satsTidspunkt: YearMonth,
     ) {
-        EøsSatserRegister.hentSatsForLandIMåned(utbetalingsland, satsTidspunkt)
         opprettTaskService.opprettSatsendringEøsTask(
             fagsakId = fagsakId,
             utbetalingsland = utbetalingsland,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/StartSatsendringEøs.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/StartSatsendringEøs.kt
@@ -1,0 +1,58 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs
+
+import no.nav.familie.ba.sak.common.toLocalDate
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister
+import no.nav.familie.ba.sak.task.OpprettTaskService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+
+@Service
+class StartSatsendringEøs(
+    private val behandlingRepository: BehandlingRepository,
+    private val opprettTaskService: OpprettTaskService,
+) {
+    fun opprettSatsendringEøsTaskerForRelevanteFagsaker(
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+    ): List<Long> {
+        val nySats = EøsSatserRegister.hentSatsForLandIMåned(utbetalingsland, satsTidspunkt)
+        val fagsakIder =
+            behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats(
+                utbetalingsland = utbetalingsland,
+                satsFom = nySats.fom.toLocalDate(),
+                satsTom = nySats.tom?.toLocalDate(),
+            )
+
+        logger.info("Oppretter EØS-satsendringstasker for ${fagsakIder.size} fagsaker for utbetalingsland $utbetalingsland og satstidspunkt $satsTidspunkt")
+
+        fagsakIder.forEach { fagsakId ->
+            opprettTaskService.opprettSatsendringEøsTask(
+                fagsakId = fagsakId,
+                utbetalingsland = utbetalingsland,
+                satsTidspunkt = satsTidspunkt,
+            )
+        }
+
+        return fagsakIder
+    }
+
+    fun opprettSatsendringEøsTaskForFagsak(
+        fagsakId: Long,
+        utbetalingsland: String,
+        satsTidspunkt: YearMonth,
+    ) {
+        EøsSatserRegister.hentSatsForLandIMåned(utbetalingsland, satsTidspunkt)
+        opprettTaskService.opprettSatsendringEøsTask(
+            fagsakId = fagsakId,
+            utbetalingsland = utbetalingsland,
+            satsTidspunkt = satsTidspunkt,
+        )
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(StartSatsendringEøs::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -141,6 +141,32 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnAlleFagsakerMedLøpendeValutakursIMåned(måned: LocalDate): List<Long>
 
     @Query(
+        value = """WITH siste_vedtatte_behandling_per_fagsak AS (
+                    SELECT DISTINCT ON (b.fk_fagsak_id) b.id, b.fk_fagsak_id, b.kategori
+                    FROM behandling b
+                        INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
+                    WHERE f.status = 'LØPENDE'
+                      AND f.arkivert = false
+                      AND b.status = 'AVSLUTTET'
+                      AND b.resultat NOT LIKE '%HENLAGT%'
+                    ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC
+                )
+                SELECT DISTINCT b.fk_fagsak_id
+                FROM siste_vedtatte_behandling_per_fagsak b
+                    INNER JOIN utenlandsk_periodebeloep upb ON upb.fk_behandling_id = b.id
+                WHERE b.kategori = 'EØS'
+                  AND upb.utbetalingsland = :utbetalingsland
+                  AND (upb.tom IS NULL OR upb.tom >= :satsFom)
+                  AND (CAST(:satsTom AS DATE) IS NULL OR upb.fom <= CAST(:satsTom AS DATE))""",
+        nativeQuery = true,
+    )
+    fun finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats(
+        utbetalingsland: String,
+        satsFom: LocalDate,
+        satsTom: LocalDate?,
+    ): List<Long>
+
+    @Query(
         """select b from Behandling b
                            inner join TilkjentYtelse ty on b.id = ty.behandling.id
                         where b.fagsak.id = :fagsakId AND ty.utbetalingsoppdrag IS NOT NULL""",

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/StartSatsendringEøsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/StartSatsendringEøsTest.kt
@@ -1,0 +1,93 @@
+package no.nav.familie.ba.sak.kjerne.autovedtak.satsendringeøs
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ba.sak.kjerne.eøs.differanseberegning.domene.Intervall
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSats
+import no.nav.familie.ba.sak.kjerne.eøs.sats.EøsSatserRegister
+import no.nav.familie.ba.sak.task.OpprettTaskService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.YearMonth
+
+class StartSatsendringEøsTest {
+    private val behandlingRepository = mockk<BehandlingRepository>()
+    private val opprettTaskService = mockk<OpprettTaskService>(relaxed = true)
+
+    private val startSatsendringEøs =
+        StartSatsendringEøs(
+            behandlingRepository = behandlingRepository,
+            opprettTaskService = opprettTaskService,
+        )
+
+    private val land = "PL"
+    private val satsTidspunkt = YearMonth.of(2025, 3)
+    private val satsFom = YearMonth.of(2025, 1)
+
+    private val sats =
+        EøsSats(
+            land = land,
+            valuta = "PLN",
+            beløp = BigDecimal("1000"),
+            fom = satsFom,
+            intervall = Intervall.MÅNEDLIG,
+        )
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(EøsSatserRegister)
+        every { EøsSatserRegister.hentSatsForLandIMåned(land, satsTidspunkt) } returns sats
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(EøsSatserRegister)
+    }
+
+    @Test
+    fun `skal opprette EØS-satsendringstask for hver relevante fagsak basert på satsens fom`() {
+        // Arrange
+        every {
+            behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats(land, satsFom.atDay(1), null)
+        } returns listOf(1L, 2L)
+
+        // Act
+        val fagsakIder = startSatsendringEøs.opprettSatsendringEøsTaskerForRelevanteFagsaker(land, satsTidspunkt)
+
+        // Assert
+        assertThat(fagsakIder).containsExactly(1L, 2L)
+        verify(exactly = 1) { opprettTaskService.opprettSatsendringEøsTask(1L, land, satsTidspunkt) }
+        verify(exactly = 1) { opprettTaskService.opprettSatsendringEøsTask(2L, land, satsTidspunkt) }
+    }
+
+    @Test
+    fun `skal ikke opprette tasker når ingen fagsaker er relevante`() {
+        // Arrange
+        every {
+            behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats(land, satsFom.atDay(1), null)
+        } returns emptyList()
+
+        // Act
+        val fagsakIder = startSatsendringEøs.opprettSatsendringEøsTaskerForRelevanteFagsaker(land, satsTidspunkt)
+
+        // Assert
+        assertThat(fagsakIder).isEmpty()
+        verify(exactly = 0) { opprettTaskService.opprettSatsendringEøsTask(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal opprette EØS-satsendringstask for én fagsak`() {
+        // Act
+        startSatsendringEøs.opprettSatsendringEøsTaskForFagsak(42L, land, satsTidspunkt)
+
+        // Assert
+        verify(exactly = 1) { opprettTaskService.opprettSatsendringEøsTask(42L, land, satsTidspunkt) }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.sak.datagenerator.lagBehandlingUtenId
 import no.nav.familie.ba.sak.datagenerator.lagFagsakUtenId
 import no.nav.familie.ba.sak.datagenerator.lagInitiellTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagTilkjentYtelse
+import no.nav.familie.ba.sak.datagenerator.lagUtenlandskPeriodebeløp
 import no.nav.familie.ba.sak.datagenerator.randomAktør
 import no.nav.familie.ba.sak.datagenerator.tilfeldigPerson
 import no.nav.familie.ba.sak.integrasjoner.økonomi.utbetalingsoppdrag.lagMinimalUtbetalingsoppdragString
@@ -14,6 +15,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.IVERKSETT
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingStatus.UTREDES
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ba.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Valutakurs
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ba.sak.kjerne.eøs.valutakurs.Vurderingsform
@@ -42,6 +44,7 @@ class BehandlingRepositoryTest(
     @Autowired private val tilkjentRepository: TilkjentYtelseRepository,
     @Autowired private val valutakursRepository: ValutakursRepository,
     @Autowired private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    @Autowired private val utenlandskPeriodebeløpRepository: UtenlandskPeriodebeløpRepository,
 ) : AbstractSpringIntegrationTest() {
     @Nested
     inner class FinnSisteIverksatteBehandling {
@@ -585,5 +588,243 @@ class BehandlingRepositoryTest(
         }
 
         return fagsak
+    }
+
+    @Nested
+    inner class FinnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats {
+        @Test
+        fun `skal finne løpende EØS-fagsak med utenlandsk periodebeløp som overlapper satsperioden`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "PL",
+                    periodebeløpFom = YearMonth.of(2025, 1),
+                    periodebeløpTom = YearMonth.of(2025, 12),
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).contains(fagsak.id)
+        }
+
+        @Test
+        fun `skal finne fagsak når utenlandsk periodebeløp er løpende uten tom`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "PL",
+                    periodebeløpFom = YearMonth.of(2025, 1),
+                    periodebeløpTom = null,
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).contains(fagsak.id)
+        }
+
+        @Test
+        fun `skal finne fagsak når utenlandsk periodebeløp starter etter satsens fom og satsen er løpende`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 1, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "PL",
+                    periodebeløpFom = YearMonth.of(2025, 6),
+                    periodebeløpTom = null,
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).contains(fagsak.id)
+        }
+
+        @Test
+        fun `skal ikke finne fagsak med annet utbetalingsland`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "SE",
+                    periodebeløpFom = YearMonth.of(2025, 1),
+                    periodebeløpTom = YearMonth.of(2025, 12),
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).doesNotContain(fagsak.id)
+        }
+
+        @Test
+        fun `skal ikke finne fagsak når behandlingen ikke er EØS`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "PL",
+                    periodebeløpFom = YearMonth.of(2025, 1),
+                    periodebeløpTom = YearMonth.of(2025, 12),
+                    kategori = BehandlingKategori.NASJONAL,
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).doesNotContain(fagsak.id)
+        }
+
+        @Test
+        fun `skal ikke finne fagsak når utenlandsk periodebeløp opphørte før satsperioden`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "PL",
+                    periodebeløpFom = YearMonth.of(2025, 1),
+                    periodebeløpTom = YearMonth.of(2025, 2),
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).doesNotContain(fagsak.id)
+        }
+
+        @Test
+        fun `skal ikke finne fagsak når utenlandsk periodebeløp starter etter en avgrenset satsperiode`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 1, 1)
+            val satsTom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "PL",
+                    periodebeløpFom = YearMonth.of(2025, 6),
+                    periodebeløpTom = null,
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, satsTom)
+
+            // Assert
+            assertThat(result).doesNotContain(fagsak.id)
+        }
+
+        @Test
+        fun `skal ikke finne arkivert eller ikke-løpende fagsak`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak =
+                opprettEøsFagsakMedUtenlandskPeriodebeløp(
+                    aktør = aktør,
+                    utbetalingsland = "PL",
+                    periodebeløpFom = YearMonth.of(2025, 1),
+                    periodebeløpTom = YearMonth.of(2025, 12),
+                    fagsakStatus = FagsakStatus.AVSLUTTET,
+                )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).doesNotContain(fagsak.id)
+        }
+
+        @Test
+        fun `skal bare se på siste vedtatte behandling per fagsak`() {
+            // Arrange
+            val satsFom = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+            val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, status = FagsakStatus.LØPENDE, arkivert = false))
+
+            val gammelBehandling =
+                behandlingRepository.save(
+                    lagBehandlingUtenId(
+                        fagsak = fagsak,
+                        behandlingKategori = BehandlingKategori.EØS,
+                        status = AVSLUTTET,
+                        aktivertTid = LocalDateTime.now().minusDays(10),
+                        aktiv = false,
+                    ),
+                )
+            utenlandskPeriodebeløpRepository.save(
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = gammelBehandling.id,
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 12),
+                    utbetalingsland = "PL",
+                ),
+            )
+
+            behandlingRepository.save(
+                lagBehandlingUtenId(
+                    fagsak = fagsak,
+                    behandlingKategori = BehandlingKategori.EØS,
+                    status = AVSLUTTET,
+                    aktivertTid = LocalDateTime.now().minusDays(1),
+                ),
+            )
+
+            // Act
+            val result = behandlingRepository.finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats("PL", satsFom, null)
+
+            // Assert
+            assertThat(result).doesNotContain(fagsak.id)
+        }
+
+        private fun opprettEøsFagsakMedUtenlandskPeriodebeløp(
+            aktør: Aktør,
+            utbetalingsland: String,
+            periodebeløpFom: YearMonth?,
+            periodebeløpTom: YearMonth?,
+            kategori: BehandlingKategori = BehandlingKategori.EØS,
+            fagsakStatus: FagsakStatus = FagsakStatus.LØPENDE,
+            arkivert: Boolean = false,
+        ): Fagsak {
+            val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, status = fagsakStatus, arkivert = arkivert))
+            val behandling =
+                behandlingRepository.save(
+                    lagBehandlingUtenId(
+                        fagsak = fagsak,
+                        behandlingKategori = kategori,
+                        status = AVSLUTTET,
+                        aktivertTid = LocalDateTime.now().minusDays(1),
+                    ),
+                )
+            utenlandskPeriodebeløpRepository.save(
+                lagUtenlandskPeriodebeløp(
+                    behandlingId = behandling.id,
+                    fom = periodebeløpFom,
+                    tom = periodebeløpTom,
+                    utbetalingsland = utbetalingsland,
+                ),
+            )
+            return fagsak
+        }
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29801

### 💰 Hva skal gjøres, og hvorfor?
Legger til spørring og endepunkt for å trigge EØS-satsendring manuelt.

- Ny spørring `finnLøpendeEøsFagsakerMedUtenlandskPeriodebeløpSomOverlapperSats` som finner løpende EØS-fagsaker der siste vedtatte behandling har et utenlandsk periodebeløp for gitt utbetalingsland som overlapper perioden den nye satsen gjelder for. Bruker samme relevans-semantikk som `AutovedtakSatsendringEøsService` (via `EøsSats.overlapper`), i stedet for å basere seg på hva som er løpende akkurat nå – som fungerer dårlig hvis satsendringen kjøres en tid etter at satsen trådte i kraft.

- `StartSatsendringEøs` regner ut ny sats og oppretter idempotente `SatsendringEøsTask`-er.

- `SatsendringEøsController` med to FORVALTER-sikrede endepunkter:
  - `POST /api/satsendring-eos/kjor` – oppretter tasks for alle relevante fagsaker for gitt utbetalingsland og satstidspunkt.
  - `POST /api/satsendring-eos/kjor/{fagsakId}` – oppretter task for én fagsak.

All validering og idempotens ligger allerede i task-behandlingen, så det er trygt å opprette og kjøre tasks flere ganger.