### PR TITLE
Fiks kopiering av EndretUtbetalingAndel til å referere riktig persongrunnlag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -26,6 +26,7 @@ import no.nav.familie.ba.sak.kjerne.registrertsøknadstidspunkt.RegistrertSøkna
 import no.nav.familie.ba.sak.kjerne.registrertsøknadstidspunkt.RegistrertSøknadstidspunktPåPersonService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ba.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -45,6 +46,8 @@ class EndretUtbetalingAndelService(
     private val registrertSøknadstidspunktService: RegistrertSøknadstidspunktPåPersonService,
     private val featureToggleService: FeatureToggleService,
 ) {
+    private val logger = LoggerFactory.getLogger(EndretUtbetalingAndelService::class.java)
+
     @Transactional
     fun oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
         behandling: Behandling,
@@ -190,15 +193,47 @@ class EndretUtbetalingAndelService(
         behandling: Behandling,
         forrigeBehandling: Behandling,
     ) {
-        endretUtbetalingAndelHentOgPersisterService.hentForBehandling(forrigeBehandling.id).forEach {
-            endretUtbetalingAndelRepository.save(
-                it.copy(
-                    id = 0,
-                    behandlingId = behandling.id,
-                    personer = it.personer.toMutableSet(),
-                ),
+        val personopplysningGrunnlag = persongrunnlagService.hentAktivThrows(behandlingId = behandling.id)
+        val nyPersonPerAktør = personopplysningGrunnlag.personer.associateBy { it.aktør }
+
+        endretUtbetalingAndelHentOgPersisterService.hentForBehandling(forrigeBehandling.id).forEach { forrigeEndretUtbetalingAndel ->
+            kopierEndretUtbetalingAndel(forrigeEndretUtbetalingAndel, behandling, forrigeBehandling, nyPersonPerAktør)
+        }
+    }
+
+    private fun kopierEndretUtbetalingAndel(
+        forrigeEndretUtbetalingAndel: EndretUtbetalingAndel,
+        behandling: Behandling,
+        forrigeBehandling: Behandling,
+        nyPersonPerAktør: Map<Aktør, Person>,
+    ) {
+        val nyePersoner = forrigeEndretUtbetalingAndel.personer.mapNotNull { nyPersonPerAktør[it.aktør] }
+        val droppedeAktørIder = forrigeEndretUtbetalingAndel.personer.map { it.aktør }.filterNot { it in nyPersonPerAktør }
+
+        if (droppedeAktørIder.isNotEmpty()) {
+            logger.warn(
+                "Dropper person(er) med aktørId ${droppedeAktørIder.joinToString(", ") { it.aktørId }} fra EndretUtbetalingAndel " +
+                    "${forrigeEndretUtbetalingAndel.id} ved kopiering fra behandling ${forrigeBehandling.id} " +
+                    "til behandling ${behandling.id}: finnes ikke i det nye persongrunnlaget",
             )
         }
+
+        if (nyePersoner.isEmpty()) {
+            logger.warn(
+                "Dropper EndretUtbetalingAndel ${forrigeEndretUtbetalingAndel.id} ved " +
+                    "kopiering fra behandling ${forrigeBehandling.id} til behandling " +
+                    "${behandling.id}: ingen av personene finnes i det nye persongrunnlaget",
+            )
+            return
+        }
+
+        endretUtbetalingAndelRepository.save(
+            forrigeEndretUtbetalingAndel.copy(
+                id = 0,
+                behandlingId = behandling.id,
+                personer = nyePersoner.toMutableSet(),
+            ),
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/grunnlagForNyBehandling/VilkårsvurderingForNyBehandlingService.kt
@@ -349,8 +349,8 @@ class VilkårsvurderingForNyBehandlingService(
                 aktørerMedUtvidetAndelerIForrigeBehandling = finnAktørerMedUtvidetBarnetrygdIForrigeBehandling(forrigeBehandlingSomErVedtatt),
             )
         endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
-            behandling,
-            forrigeBehandlingSomErVedtatt,
+            behandling = behandling,
+            forrigeBehandling = forrigeBehandlingSomErVedtatt,
         )
         return vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -773,7 +773,7 @@ class EndretUtbetalingAndelServiceTest {
     @Nested
     inner class KopierEndretUtbetalingAndelFraForrigeBehandling {
         @Test
-        fun `Skal repunkte personer til den nye behandlingens eget persongrunnlag, ikke forrige behandling sine Person-rader`() {
+        fun `Skal bruke Personer fra inneværende behandlingen ved kopiering`() {
             // Arrange
             val forrigeBehandling = lagBehandling()
             val behandling = lagBehandling()
@@ -806,7 +806,7 @@ class EndretUtbetalingAndelServiceTest {
         }
 
         @Test
-        fun `Skal filtrere bort personer som ikke finnes i det nye persongrunnlaget`() {
+        fun `Skal filtrere bort personer som ikke finnes i inneværende behandling`() {
             // Arrange
             val forrigeBehandling = lagBehandling()
             val behandling = lagBehandling()
@@ -845,7 +845,7 @@ class EndretUtbetalingAndelServiceTest {
         }
 
         @Test
-        fun `Skal ikke kopiere EndretUtbetalingAndel hvis ingen av personene finnes i det nye persongrunnlaget`() {
+        fun `Skal filtrere bort EndretUtbetalingAndel hvis ingen av personene finnes i inneværende behandling`() {
             // Arrange
             val forrigeBehandling = lagBehandling()
             val behandling = lagBehandling()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ba.sak.datagenerator.lagAktør
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagEndretUtbetalingAndel
@@ -766,6 +767,108 @@ class EndretUtbetalingAndelServiceTest {
                 // Assert
                 assertThat(endretUtbetalingAndelIDer.captured).containsExactly(endretUtbetalingAndel.id)
             }
+        }
+    }
+
+    @Nested
+    inner class KopierEndretUtbetalingAndelFraForrigeBehandling {
+        @Test
+        fun `Skal repunkte personer til den nye behandlingens eget persongrunnlag, ikke forrige behandling sine Person-rader`() {
+            // Arrange
+            val forrigeBehandling = lagBehandling()
+            val behandling = lagBehandling()
+            val aktør = lagAktør()
+
+            val gammelPerson = lagPerson(id = 1L, type = PersonType.BARN, aktør = aktør)
+            val nyPerson = lagPerson(id = 2L, type = PersonType.BARN, aktør = aktør)
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, nyPerson)
+
+            val forrigeEndretUtbetalingAndel =
+                lagEndretUtbetalingAndel(id = 100L, behandlingId = forrigeBehandling.id, personer = setOf(gammelPerson))
+            val lagretEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
+
+            every { mockPersongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
+            every { mockEndretUtbetalingAndelHentOgPersisterService.hentForBehandling(forrigeBehandling.id) } returns
+                listOf(forrigeEndretUtbetalingAndel)
+            every { mockEndretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) } returnsArgument 0
+
+            // Act
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling = behandling,
+                forrigeBehandling = forrigeBehandling,
+            )
+
+            // Assert
+            val lagret = lagretEndretUtbetalingAndelSlot.captured
+            assertThat(lagret.behandlingId).isEqualTo(behandling.id)
+            assertThat(lagret.personer).extracting("id").containsExactly(2L)
+            assertThat(lagret.personer).extracting("id").doesNotContain(1L)
+        }
+
+        @Test
+        fun `Skal filtrere bort personer som ikke finnes i det nye persongrunnlaget`() {
+            // Arrange
+            val forrigeBehandling = lagBehandling()
+            val behandling = lagBehandling()
+
+            val aktørSomBlirMed = lagAktør()
+            val aktørSomFallerUt = lagAktør()
+
+            val gammelPersonSomBlirMed = lagPerson(id = 1L, type = PersonType.BARN, aktør = aktørSomBlirMed)
+            val gammelPersonSomFallerUt = lagPerson(id = 2L, type = PersonType.BARN, aktør = aktørSomFallerUt)
+            val nyPersonSomBlirMed = lagPerson(id = 3L, type = PersonType.BARN, aktør = aktørSomBlirMed)
+            // Merk: nytt grunnlag inneholder ikke aktørSomFallerUt, f.eks. fordi barnet har falt ut av saken.
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, nyPersonSomBlirMed)
+
+            val forrigeEndretUtbetalingAndel =
+                lagEndretUtbetalingAndel(
+                    id = 100L,
+                    behandlingId = forrigeBehandling.id,
+                    personer = setOf(gammelPersonSomBlirMed, gammelPersonSomFallerUt),
+                )
+            val lagretEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
+
+            every { mockPersongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
+            every { mockEndretUtbetalingAndelHentOgPersisterService.hentForBehandling(forrigeBehandling.id) } returns
+                listOf(forrigeEndretUtbetalingAndel)
+            every { mockEndretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) } returnsArgument 0
+
+            // Act
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling = behandling,
+                forrigeBehandling = forrigeBehandling,
+            )
+
+            // Assert
+            val lagret = lagretEndretUtbetalingAndelSlot.captured
+            assertThat(lagret.personer).extracting("id").containsExactly(3L)
+        }
+
+        @Test
+        fun `Skal ikke kopiere EndretUtbetalingAndel hvis ingen av personene finnes i det nye persongrunnlaget`() {
+            // Arrange
+            val forrigeBehandling = lagBehandling()
+            val behandling = lagBehandling()
+
+            val gammelPerson = lagPerson(id = 1L, type = PersonType.BARN)
+            // Nytt grunnlag inneholder en helt annen aktør enn den som var med i forrige EndretUtbetalingAndel.
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, lagPerson(id = 2L, type = PersonType.BARN))
+
+            val forrigeEndretUtbetalingAndel =
+                lagEndretUtbetalingAndel(id = 100L, behandlingId = forrigeBehandling.id, personer = setOf(gammelPerson))
+
+            every { mockPersongrunnlagService.hentAktivThrows(behandling.id) } returns personopplysningGrunnlag
+            every { mockEndretUtbetalingAndelHentOgPersisterService.hentForBehandling(forrigeBehandling.id) } returns
+                listOf(forrigeEndretUtbetalingAndel)
+
+            // Act
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling = behandling,
+                forrigeBehandling = forrigeBehandling,
+            )
+
+            // Assert
+            verify(exactly = 0) { mockEndretUtbetalingAndelRepository.save(any()) }
         }
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29959

### 💰 Hva skal gjøres, og hvorfor?
`kopierEndretUtbetalingAndelFraForrigeBehandling` kopierte tidligere `EndretUtbetalingAndel.personer` direkte fra forrige behandling, slik at den nye behandlingen fikk data som pekte på `Person`-rader eid av forrige behandling sitt persongrunnlag i stedet for sitt eget. Dette brøt antakelsen om at en behandling kun refererer sitt eget persongrunnlag, og gjorde det vanskeligere å rydde opp i inaktive persongrunnlag uten å risikere å slette data som fortsatt var i bruk.

Personer hentes nå fra den nye behandlingens eget persongrunnlag. Dersom en aktør ikke lenger finnes i det nye grunnlaget (f.eks. barn falt ut av saken), droppes personen fra andelen med en logget advarsel. Dersom ingen av personene finnes igjen, droppes hele EndretUtbetalingAndel-kopien.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Vi har verifisert mot produksjonsdata at ingen eksisterende, ikke-henlagte behandlinger i dag har en aktør som mangler i sitt eget aktive persongrunnlag - dvs. at fiksen ikke endrer oppførsel for noen eksisterende saker, kun fremtidige kopieringer.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.
