### PR TITLE
NAV-29965: Oppdatert spørring for utvelgelse av fagsaker til månedlig valutajustering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -119,19 +119,18 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     fun finnSisteVedtatteBehandlingForLøpendeEøsFagsaker(page: Pageable): Page<FagsakIdBehandlingIdOgKategori>
 
     @Query(
-        value = """WITH siste_iverksatte_behandling_per_fagsak AS (
+        value = """WITH siste_vedtatte_behandling_per_fagsak AS (
                     SELECT DISTINCT ON (b.fk_fagsak_id) b.id, b.fk_fagsak_id
                     FROM behandling b
                         INNER JOIN fagsak f ON f.id = b.fk_fagsak_id
-                        INNER JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
                     WHERE f.status = 'LØPENDE'
                       AND f.arkivert = false
                       AND b.status = 'AVSLUTTET'
-                      AND ty.utbetalingsoppdrag IS NOT NULL
+                      AND b.resultat NOT LIKE '%HENLAGT%'
                     ORDER BY b.fk_fagsak_id, b.aktivert_tid DESC
                 )
                 SELECT DISTINCT b.fk_fagsak_id
-                FROM siste_iverksatte_behandling_per_fagsak b
+                FROM siste_vedtatte_behandling_per_fagsak b
                     INNER JOIN valutakurs v ON v.fk_behandling_id = b.id
                     INNER JOIN tilkjent_ytelse ty ON ty.fk_behandling_id = b.id
                 WHERE ty.stonad_tom >= :måned

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -461,6 +461,29 @@ class BehandlingRepositoryTest(
         }
 
         @Test
+        fun `skal inkludere fagsaker uten utbetalingsoppdrag når det finnes løpende valutakurs`() {
+            // Arrange
+            val måned = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+
+            val fagsak =
+                opprettFagsakMedBehandlingValutakursOgAndeler(
+                    aktør = aktør,
+                    medUtbetalingsoppdrag = false,
+                    andelFom = YearMonth.of(2025, 1),
+                    andelTom = YearMonth.of(2025, 12),
+                    valutakursFom = YearMonth.of(2025, 1),
+                    valutakursTom = YearMonth.of(2025, 12),
+                )
+
+            // Act
+            val result = behandlingRepository.finnAlleFagsakerMedLøpendeValutakursIMåned(måned)
+
+            // Assert
+            assertThat(result).contains(fagsak.id)
+        }
+
+        @Test
         fun `skal bruke nest siste vedtatte behandling hvis siste er henlagt`() {
             // Arrange
             val måned = LocalDate.of(2025, 3, 1)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -381,29 +381,6 @@ class BehandlingRepositoryTest(
         }
 
         @Test
-        fun `skal filtrere bort behandlinger uten utbetalingsoppdrag`() {
-            // Arrange
-            val måned = LocalDate.of(2025, 3, 1)
-            val aktør = aktørIdRepository.save(randomAktør())
-
-            val fagsak =
-                opprettFagsakMedBehandlingValutakursOgAndeler(
-                    aktør = aktør,
-                    medUtbetalingsoppdrag = false,
-                    andelFom = YearMonth.of(2025, 1),
-                    andelTom = YearMonth.of(2025, 12),
-                    valutakursFom = YearMonth.of(2025, 1),
-                    valutakursTom = YearMonth.of(2025, 12),
-                )
-
-            // Act
-            val result = behandlingRepository.finnAlleFagsakerMedLøpendeValutakursIMåned(måned)
-
-            // Assert
-            assertThat(result).doesNotContain(fagsak.id)
-        }
-
-        @Test
         fun `skal filtrere bort fagsaker der tilkjent ytelse er utløpt før gitt måned`() {
             // Arrange
             val måned = LocalDate.of(2025, 6, 1)
@@ -458,6 +435,95 @@ class BehandlingRepositoryTest(
 
             // Assert
             assertThat(result).contains(fagsak1.id, fagsak2.id)
+        }
+
+        @Test
+        fun `skal ekskludere fagsaker der eneste vedtatte behandling er henlagt`() {
+            // Arrange
+            val måned = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+
+            val fagsak =
+                opprettFagsakMedBehandlingValutakursOgAndeler(
+                    aktør = aktør,
+                    resultat = Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
+                    andelFom = YearMonth.of(2025, 1),
+                    andelTom = YearMonth.of(2025, 12),
+                    valutakursFom = YearMonth.of(2025, 1),
+                    valutakursTom = YearMonth.of(2025, 12),
+                )
+
+            // Act
+            val result = behandlingRepository.finnAlleFagsakerMedLøpendeValutakursIMåned(måned)
+
+            // Assert
+            assertThat(result).doesNotContain(fagsak.id)
+        }
+
+        @Test
+        fun `skal bruke nest siste vedtatte behandling hvis siste er henlagt`() {
+            // Arrange
+            val måned = LocalDate.of(2025, 3, 1)
+            val aktør = aktørIdRepository.save(randomAktør())
+
+            val fagsak = fagsakRepository.save(lagFagsakUtenId(aktør = aktør, status = FagsakStatus.LØPENDE, arkivert = false))
+
+            val eldreBehandling =
+                behandlingRepository.save(
+                    lagBehandlingUtenId(
+                        fagsak = fagsak,
+                        status = AVSLUTTET,
+                        aktivertTid = LocalDateTime.now().minusDays(2),
+                        aktiv = false,
+                    ),
+                )
+
+            val eldreTilkjentYtelse =
+                tilkjentRepository.save(
+                    lagTilkjentYtelse(
+                        behandling = eldreBehandling,
+                        stønadFom = YearMonth.of(2025, 1),
+                        stønadTom = YearMonth.of(2025, 12),
+                        utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = eldreBehandling.id),
+                    ),
+                )
+
+            andelTilkjentYtelseRepository.save(
+                lagAndelTilkjentYtelse(
+                    aktør = aktør,
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 12),
+                    behandling = eldreBehandling,
+                    tilkjentYtelse = eldreTilkjentYtelse,
+                ),
+            )
+
+            valutakursRepository.save(
+                Valutakurs(
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 12),
+                    barnAktører = setOf(aktør),
+                    valutakursdato = LocalDate.of(2025, 1, 15),
+                    valutakode = "EUR",
+                    kurs = BigDecimal("10.5"),
+                    vurderingsform = Vurderingsform.AUTOMATISK,
+                ).apply { behandlingId = eldreBehandling.id },
+            )
+
+            behandlingRepository.save(
+                lagBehandlingUtenId(
+                    fagsak = fagsak,
+                    status = AVSLUTTET,
+                    resultat = Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
+                    aktivertTid = LocalDateTime.now().minusDays(1),
+                ),
+            )
+
+            // Act
+            val result = behandlingRepository.finnAlleFagsakerMedLøpendeValutakursIMåned(måned)
+
+            // Assert
+            assertThat(result).contains(fagsak.id)
         }
     }
 
@@ -522,6 +588,7 @@ class BehandlingRepositoryTest(
         fagsakStatus: FagsakStatus = FagsakStatus.LØPENDE,
         arkivert: Boolean = false,
         behandlingStatus: BehandlingStatus = AVSLUTTET,
+        resultat: Behandlingsresultat = Behandlingsresultat.INNVILGET,
         aktivertTid: LocalDateTime = LocalDateTime.now().minusDays(1),
         medUtbetalingsoppdrag: Boolean = true,
         andelFom: YearMonth? = null,
@@ -538,6 +605,7 @@ class BehandlingRepositoryTest(
                 lagBehandlingUtenId(
                     fagsak = fagsak,
                     status = behandlingStatus,
+                    resultat = resultat,
                     aktivertTid = aktivertTid,
                 ),
             )


### PR DESCRIPTION
### 📮 Favro: [NAV-29965](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29965) 

### 💰 Hva skal gjøres, og hvorfor?
I Januar 2026 ble det innført logikk i spørringen `finnAlleFagsakerMedLøpendeValutakursIMåned` som kun plukket ut fagsaker med iverksatte behandlinger. Problemet med det er at vi i en del EØS-saker aldri har iverksatt noe som helst, da det andre landet utbetaler en høyere sum enn det Norge gjør. Konsekvensen ble at månedlige valutajustering ikke lenger ble kjørt i disse sakene.

Justerer her logikken til å se på siste vedtatte behandling fremfor siste iverksatte. Ellers er logikken lik som tidligere.

 > NB: Ved neste månedlige valutajustering vil fagsaker som har manglet månedlig valutajustering få et "hull" i valutakursene. Man vil altså ikke få valutakurs per mnd i de månedene vi ikke har kjørt valutajustering. Fra og med neste månedlige valutajustering vil vi igjen få for hver måned fremover i tid.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.
