### PR TITLE
forbidden 403 skal ikke retries

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/RetryTemplate.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/RetryTemplate.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ba.sak.integrasjoner
 
 import org.springframework.core.retry.RetryPolicy
 import org.springframework.core.retry.RetryTemplate
+import org.springframework.web.client.HttpClientErrorException
 import java.io.IOException
 import java.time.Duration
 
@@ -12,6 +13,7 @@ fun retryVedException(delayInMs: Long) =
         RetryPolicy
             .builder()
             .includes(Exception::class.java)
+            .excludes(HttpClientErrorException.Forbidden::class.java)
             .maxRetries(3)
             .delay(Duration.ofMillis(delayInMs))
             .build(),

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -50,8 +50,10 @@ import no.nav.familie.log.mdc.MDCConstants
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
+import org.springframework.core.NestedExceptionUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDate
 import no.nav.familie.kontrakter.felles.journalpost.Bruker as JournalpostBruker
 
@@ -92,7 +94,7 @@ class DokumentService(
 
         val pdf =
             if (skalHenteVedtaksbrevFraJoark) {
-                hentVedtaksbrevFraJoark(vedtak)
+                hentVedtaksbrevFraJoarkOgHåndterManglendeTilgang(vedtak)
                     ?: throw FunksjonellFeil(
                         melding = "Fant ikke vedtaksbrev for behandling med id ${vedtak.behandling.id} i Joark.",
                         frontendFeilmelding = "Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.",
@@ -116,6 +118,20 @@ class DokumentService(
             )
         }
     }
+
+    private fun hentVedtaksbrevFraJoarkOgHåndterManglendeTilgang(vedtak: Vedtak): ByteArray? =
+        try {
+            hentVedtaksbrevFraJoark(vedtak)
+        } catch (throwable: Throwable) {
+            if (NestedExceptionUtils.getMostSpecificCause(throwable) is HttpClientErrorException.Forbidden) {
+                throw FunksjonellFeil(
+                    melding = "Mangler tilgang til å hente vedtaksbrev for behandling med id ${vedtak.behandling.id} fra Joark.",
+                    frontendFeilmelding = "Du har ikke tilgang til å hente vedtaksbrevet.",
+                    throwable = throwable,
+                )
+            }
+            throw throwable
+        }
 
     private fun hentVedtaksbrevFraJoark(vedtak: Vedtak): ByteArray? {
         val behandling = vedtak.behandling

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/RetryTemplateTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/RetryTemplateTest.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.ba.sak.integrasjoner
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.core.retry.RetryException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
+
+class RetryTemplateTest {
+    @Test
+    fun `skal ikke retrye ved 403 Forbidden`() {
+        // Arrange
+        val forbidden =
+            HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN,
+                "Forbidden",
+                HttpHeaders(),
+                ByteArray(0),
+                null,
+            )
+        val kall = mockk<() -> String>()
+        every { kall.invoke() } throws forbidden
+
+        // Act & Assert
+        assertThatThrownBy {
+            retryVedException(delayInMs = 1).execute { kall() }
+        }.isInstanceOf(RetryException::class.java)
+            .hasCauseInstanceOf(HttpClientErrorException.Forbidden::class.java)
+
+        // Ingen retry ved 403 - kun det opprinnelige forsoeket
+        verify(exactly = 1) { kall.invoke() }
+    }
+
+    @Test
+    fun `skal retrye ved andre exceptions og til slutt kaste feilen`() {
+        // Arrange
+        val kall = mockk<() -> String>()
+        every { kall.invoke() } throws RuntimeException("feil")
+
+        // Act & Assert
+        assertThatThrownBy {
+            retryVedException(delayInMs = 1).execute { kall() }
+        }.isInstanceOf(RetryException::class.java)
+            .hasCauseInstanceOf(RuntimeException::class.java)
+
+        // 1 opprinnelig forsoek + 3 retries
+        verify(exactly = 4) { kall.invoke() }
+    }
+
+    @Test
+    fun `skal returnere resultat uten retry naar kallet lykkes`() {
+        // Arrange
+        val kall = mockk<() -> String>()
+        every { kall.invoke() } returns "ok"
+
+        // Act
+        val resultat = retryVedException(delayInMs = 1).execute { kall() }
+
+        // Assert
+        assertThat(resultat).isEqualTo("ok")
+        verify(exactly = 1) { kall.invoke() }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -75,6 +75,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDate
 
 internal class DokumentServiceTest {
@@ -612,6 +615,54 @@ internal class DokumentServiceTest {
 
             assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
         }
+
+        @Test
+        fun `Skal kaste funksjonell feil når saksbehandler mangler tilgang til vedtaksbrev i Joark`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } throws lagForbidden()
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    dokumentService.hentBrevForVedtak(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Du har ikke tilgang til å hente vedtaksbrevet.")
+        }
+
+        @Test
+        fun `Skal kaste funksjonell feil når manglende tilgang er pakket inn av retry`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } throws
+                RuntimeException("Kall mot integrasjoner feilet", lagForbidden())
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    dokumentService.hentBrevForVedtak(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Du har ikke tilgang til å hente vedtaksbrevet.")
+        }
+
+        private fun lagForbidden(): HttpClientErrorException.Forbidden =
+            HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN,
+                "Forbidden",
+                HttpHeaders.EMPTY,
+                ByteArray(0),
+                null,
+            ) as HttpClientErrorException.Forbidden
 
         private fun lagUtgåendeJournalpost(
             journalpostId: String,


### PR DESCRIPTION
### 📮 Favro: Nav-29981 

### 💰 Hva skal gjøres, og hvorfor?
Ved visning av vedtaksbrev som ender opp med 403 (ingen tilgang) fra familie-integrasjoner, retryet ba-sak kallet (3 forsøk med 5 sekunders backoff). Dette låste ba-sak opp i ~15 sekunder før feilen til slutt ble kastet. Et 403 løser seg ikke ved retry, så vi bør feile med én gang.

- `retryVedException` (`RetryTemplate.kt`): ekskluderer nå `HttpClientErrorException.Forbidden` fra retry-policyen, slik at 403 ikke retryes. Gjelder alle klienter som bruker denne helperen (bl.a. `IntegrasjonKlient`, som brukes i visning av vedtaksbrev via `hentJournalposterForBruker`).
- Tester: ny `RetryTemplateTest` som verifiserer at 403 ikke retryes, at andre exceptions fortsatt retryes, og at vellykkede kall returnerer uten retry.