### PR TITLE
Kast funksjonell feil når 403 oppstår ved henting av vedtaksbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentService.kt
@@ -50,8 +50,10 @@ import no.nav.familie.log.mdc.MDCConstants
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
+import org.springframework.core.NestedExceptionUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDate
 import no.nav.familie.kontrakter.felles.journalpost.Bruker as JournalpostBruker
 
@@ -92,7 +94,7 @@ class DokumentService(
 
         val pdf =
             if (skalHenteVedtaksbrevFraJoark) {
-                hentVedtaksbrevFraJoark(vedtak)
+                hentVedtaksbrevFraJoarkOgHåndterManglendeTilgang(vedtak)
                     ?: throw FunksjonellFeil(
                         melding = "Fant ikke vedtaksbrev for behandling med id ${vedtak.behandling.id} i Joark.",
                         frontendFeilmelding = "Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.",
@@ -116,6 +118,20 @@ class DokumentService(
             )
         }
     }
+
+    private fun hentVedtaksbrevFraJoarkOgHåndterManglendeTilgang(vedtak: Vedtak): ByteArray? =
+        try {
+            hentVedtaksbrevFraJoark(vedtak)
+        } catch (throwable: Throwable) {
+            if (NestedExceptionUtils.getMostSpecificCause(throwable) is HttpClientErrorException.Forbidden) {
+                throw FunksjonellFeil(
+                    melding = "Mangler tilgang til å hente vedtaksbrev for behandling med id ${vedtak.behandling.id} fra Joark.",
+                    frontendFeilmelding = "Du har ikke tilgang til å hente vedtaksbrevet.",
+                    throwable = throwable,
+                )
+            }
+            throw throwable
+        }
 
     private fun hentVedtaksbrevFraJoark(vedtak: Vedtak): ByteArray? {
         val behandling = vedtak.behandling

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceTest.kt
@@ -75,6 +75,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDate
 
 internal class DokumentServiceTest {
@@ -612,6 +615,54 @@ internal class DokumentServiceTest {
 
             assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
         }
+
+        @Test
+        fun `Skal kaste funksjonell feil når saksbehandler mangler tilgang til vedtaksbrev i Joark`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } throws lagForbidden()
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    dokumentService.hentBrevForVedtak(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Du har ikke tilgang til å hente vedtaksbrevet.")
+        }
+
+        @Test
+        fun `Skal kaste funksjonell feil når manglende tilgang er pakket inn av retry`() {
+            // Arrange
+            every { SikkerhetContext.hentHøyesteRolletilgangForInnloggetBruker() } returns BehandlerRolle.BESLUTTER
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val vedtak = lagVedtak(behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } throws
+                RuntimeException("Kall mot integrasjoner feilet", lagForbidden())
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    dokumentService.hentBrevForVedtak(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Du har ikke tilgang til å hente vedtaksbrevet.")
+        }
+
+        private fun lagForbidden(): HttpClientErrorException.Forbidden =
+            HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN,
+                "Forbidden",
+                HttpHeaders.EMPTY,
+                ByteArray(0),
+                null,
+            ) as HttpClientErrorException.Forbidden
 
         private fun lagUtgåendeJournalpost(
             journalpostId: String,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Bygger videre på retry-fiksen (base-branchen). Selv uten retry ender et 403-svar fra familie-integrasjoner
ved henting av vedtaksbrev opp som en generisk 500-feil, fordi 403-en pakkes inn
(`IntegrasjonException → RetryException → Forbidden`) før den når controlleren og aldri treffer
`@ExceptionHandler(Forbidden)`. Denne PR-en fanger manglende tilgang og gir saksbehandler en forståelig
melding.

- **Fang 403 og kast funksjonell feil** (`kjerne/brev/DokumentService.kt`): ved henting av vedtaksbrev fra
  Joark fanges manglende tilgang og oversettes til en `FunksjonellFeil` med frontend-melding
  «Du har ikke tilgang til å hente vedtaksbrevet.» i stedet for en generisk 500. Deteksjonen bruker
  `NestedExceptionUtils.getMostSpecificCause`, samme mønster som `ApiExceptionHandler`.
- **Tester** (`DokumentServiceTest.kt`): verifiserer at både direkte og retry-innpakket 403 gir
  `FunksjonellFeil`.
