### PR TITLE
Sett søknadstidspunkt også for søker ved søknad om utvidet barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -261,7 +261,7 @@ class EndretUtbetalingAndelService(
         if (lagretSøknadstidspunktPerIdent.isEmpty() && behandlingSøknadMottattDato == null) return
 
         if (registrereSøknadstidspunktToggleErPå) {
-            val andelerSomSkalRyddes = finnAndelerSomSkalRyddes(behandling, barnSomErSøktFor = lagretSøknadstidspunktPerIdent.keys)
+            val andelerSomSkalRyddes = finnAndelerSomSkalRyddes(behandling, personerSomErSøktFor = lagretSøknadstidspunktPerIdent.keys)
             fjernEndretUtbetalingAndelerOgOppdaterTilkjentYtelse(behandling, andelerSomSkalRyddes)
         } else {
             fjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen(behandling)
@@ -309,7 +309,7 @@ class EndretUtbetalingAndelService(
 
     private fun finnAndelerSomSkalRyddes(
         behandling: Behandling,
-        barnSomErSøktFor: Set<String>,
+        personerSomErSøktFor: Set<String>,
     ): List<Long> =
         endretUtbetalingAndelRepository
             .findByBehandlingId(behandling.id)
@@ -317,7 +317,7 @@ class EndretUtbetalingAndelService(
                 it.manglerObligatoriskFelt() ||
                     (
                         it.årsak in setOf(ETTERBETALING_3ÅR, ETTERBETALING_3MND) &&
-                            it.personer.any { person -> person.aktør.aktivFødselsnummer() in barnSomErSøktFor }
+                            it.personer.any { person -> person.aktør.aktivFødselsnummer() in personerSomErSøktFor }
                     )
             }.map { it.id }
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonService.kt
@@ -23,18 +23,20 @@ class RegistrertSøknadstidspunktPåPersonService(
     fun hentForBehandling(behandlingId: Long): List<RegistrertSøknadstidspunktPåPerson> = registrertSøknadstidspunktRepository.findByBehandlingId(behandlingId)
 
     @Transactional
-    fun settSøknadstidspunktForBarn(behandling: Behandling) {
+    fun settSøknadstidspunktForPersonerFremstiltKravFor(behandling: Behandling) {
         if (!featureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON)) return
         if (behandling.opprettetÅrsak != BehandlingÅrsak.SØKNAD) return
 
         val søknadMottattDato = behandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id)?.toLocalDate() ?: return
-        val barnFremstiltKravFor = søknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = null).toSet()
+        val personerFremstiltKravFor = søknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = null).toSet()
         val aktørerMedRegistrertSøknadstidspunkt = registrertSøknadstidspunktRepository.findByBehandlingId(behandling.id).map { it.aktør }.toSet()
 
+        // Søker er blant personene det er fremstilt krav for når det er søkt om utvidet barnetrygd
         val nyeRegistrerteSøknadstidspunkt =
             persongrunnlagService
-                .hentBarna(behandling)
-                .filter { it.aktør in barnFremstiltKravFor && it.aktør !in aktørerMedRegistrertSøknadstidspunkt }
+                .hentAktivThrows(behandling.id)
+                .personer
+                .filter { it.aktør in personerFremstiltKravFor && it.aktør !in aktørerMedRegistrertSøknadstidspunkt }
                 .map {
                     RegistrertSøknadstidspunktPåPerson(
                         behandlingId = behandling.id,

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingSteg.kt
@@ -113,7 +113,7 @@ class VilkårsvurderingSteg(
 
         beregningService.genererTilkjentYtelseFraVilkårsvurdering(behandling, personopplysningGrunnlag)
 
-        registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
+        registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
 
         endretUtbetalingAndelService.genererEndretUtbetalingAndelerMedÅrsakEtterbetaling3ÅrEller3Mnd(behandling)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -26,6 +26,7 @@ import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoServ
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ba.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.kjerne.endretutbetaling.domene.tilEndretUtbetalingAndelDto
@@ -532,6 +533,61 @@ class EndretUtbetalingAndelServiceTest {
                 EndretUtbetalingAndel(
                     behandlingId = behandling.id,
                     personer = mutableSetOf(barnMedRegistrertTidspunkt),
+                    prosent = BigDecimal.ZERO,
+                    fom = fomAndelTilkjentYtelse,
+                    tom = søknadstidspunkt.minusMonths(4).toYearMonth(),
+                    årsak = Årsak.ETTERBETALING_3MND,
+                    søknadstidspunkt = søknadstidspunkt,
+                    begrunnelse = "Fylt ut automatisk fra søknadstidspunkt.",
+                    erAutomatiskGenerert = true,
+                )
+            verify(exactly = 1) { mockEndretUtbetalingAndelRepository.saveAllAndFlush(listOf(forventetEndretUtbetalingAndel)) }
+        }
+
+        @Test
+        fun `Skal generere endret utbetaling andel for søker med utvidet barnetrygd når søker har registrert søknadstidspunkt`() {
+            // Arrange
+            val søker = lagPerson(type = PersonType.SØKER)
+            val barn = lagPerson(type = PersonType.BARN)
+
+            val fomAndelTilkjentYtelse = YearMonth.of(2020, 1)
+            val tomAndelTilkjentYtelse = YearMonth.of(2025, 12)
+            val søknadstidspunkt = LocalDate.of(2025, 4, 15)
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søker, barn)
+
+            every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) } returns null
+            every { mockRegistrertSøknadstidspunktPåPersonService.hentForBehandling(any()) } returns
+                listOf(
+                    RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = søker.aktør, søknadstidspunkt = søknadstidspunkt),
+                    RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barn.aktør, søknadstidspunkt = søknadstidspunkt),
+                )
+            every { mockEndretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
+            every { mockEndretUtbetalingAndelRepository.saveAllAndFlush<EndretUtbetalingAndel>(any()) } returnsArgument 0
+            every { mockEndretUtbetalingAndelRepository.deleteAllById(any()) } just Runs
+            every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(any()) } returns personopplysningGrunnlag
+            every { mockBeregningService.oppdaterBehandlingMedBeregning(any(), any()) } returns mockk()
+            every { mockPersongrunnlagService.hentPersonerPåBehandling(any(), any()) } returns listOf(søker, barn)
+            every { mockBeregningService.hentAndelerTilkjentYtelseForBehandling(any()) } returns
+                listOf(
+                    lagAndelTilkjentYtelse(
+                        behandling = behandling,
+                        person = søker,
+                        ytelseType = YtelseType.UTVIDET_BARNETRYGD,
+                        fom = fomAndelTilkjentYtelse,
+                        tom = tomAndelTilkjentYtelse,
+                        beløp = 2000,
+                    ),
+                )
+            every { mockBeregningService.hentAndelerFraForrigeIverksattebehandling(any()) } returns emptyList()
+
+            // Act
+            endretUtbetalingAndelService.genererEndretUtbetalingAndelerMedÅrsakEtterbetaling3ÅrEller3Mnd(behandling = behandling)
+
+            // Assert
+            val forventetEndretUtbetalingAndel =
+                EndretUtbetalingAndel(
+                    behandlingId = behandling.id,
+                    personer = mutableSetOf(søker),
                     prosent = BigDecimal.ZERO,
                     fom = fomAndelTilkjentYtelse,
                     tom = søknadstidspunkt.minusMonths(4).toYearMonth(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
+import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -157,7 +158,7 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
     }
 
     @Nested
-    inner class SettSøknadstidspunktForBarnTest {
+    inner class SettSøknadstidspunktForPersonerFremstiltKravForTest {
         @Test
         fun `skal sette søknad mottatt-dato for barn som mangler, men ikke overskrive eksisterende`() {
             // Arrange
@@ -177,12 +178,12 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
                         søknadstidspunkt = LocalDate.of(2020, 1, 1),
                     ),
                 )
-            every { mockPersongrunnlagService.hentBarna(behandling) } returns listOf(barnMedEksisterende, barnUtenEksisterende)
+            every { mockPersongrunnlagService.hentAktivThrows(behandling.id) } returns lagTestPersonopplysningGrunnlag(behandling.id, barnMedEksisterende, barnUtenEksisterende)
             val lagretSlot = slot<List<RegistrertSøknadstidspunktPåPerson>>()
             every { mockRegistrertSøknadstidspunktPåPersonRepository.saveAll(capture(lagretSlot)) } answers { firstArg() }
 
             // Act
-            registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
+            registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
 
             // Assert – kun barnet uten eksisterende rad får default satt
             assertThat(lagretSlot.captured).containsExactly(
@@ -200,7 +201,7 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
             val behandling = lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE)
 
             // Act
-            registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
+            registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
 
             // Assert
             verify(exactly = 0) { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) }
@@ -217,12 +218,12 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
             every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id) } returns søknadMottattDato.atStartOfDay()
             every { mockSøknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = null) } returns listOf(barn.aktør)
             every { mockRegistrertSøknadstidspunktPåPersonRepository.findByBehandlingId(behandling.id) } returns emptyList()
-            every { mockPersongrunnlagService.hentBarna(behandling) } returns listOf(barn)
+            every { mockPersongrunnlagService.hentAktivThrows(behandling.id) } returns lagTestPersonopplysningGrunnlag(behandling.id, barn)
             val lagretSlot = slot<List<RegistrertSøknadstidspunktPåPerson>>()
             every { mockRegistrertSøknadstidspunktPåPersonRepository.saveAll(capture(lagretSlot)) } answers { firstArg() }
 
             // Act
-            registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
+            registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
 
             // Assert
             assertThat(lagretSlot.captured).containsExactly(
@@ -241,16 +242,41 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
             every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id) } returns søknadMottattDato.atStartOfDay()
             every { mockSøknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = null) } returns listOf(barnSøktFor.aktør)
             every { mockRegistrertSøknadstidspunktPåPersonRepository.findByBehandlingId(behandling.id) } returns emptyList()
-            every { mockPersongrunnlagService.hentBarna(behandling) } returns listOf(barnSøktFor, barnIkkeSøktFor)
+            every { mockPersongrunnlagService.hentAktivThrows(behandling.id) } returns lagTestPersonopplysningGrunnlag(behandling.id, barnSøktFor, barnIkkeSøktFor)
             val lagretSlot = slot<List<RegistrertSøknadstidspunktPåPerson>>()
             every { mockRegistrertSøknadstidspunktPåPersonRepository.saveAll(capture(lagretSlot)) } answers { firstArg() }
 
             // Act
-            registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
+            registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
 
             // Assert – barnet det ikke er framstilt krav for får ikke default satt
             assertThat(lagretSlot.captured).containsExactly(
                 RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barnSøktFor.aktør, søknadstidspunkt = søknadMottattDato),
+            )
+        }
+
+        @Test
+        fun `skal sette søknadstidspunkt for søker når det er fremstilt krav om utvidet barnetrygd`() {
+            // Arrange
+            val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
+            val søker = lagPerson(type = PersonType.SØKER)
+            val barn = lagPerson(type = PersonType.BARN)
+            val søknadMottattDato = LocalDate.of(2025, 4, 15)
+
+            every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id) } returns søknadMottattDato.atStartOfDay()
+            every { mockSøknadGrunnlagService.finnPersonerFremstiltKravFor(behandling = behandling, forrigeBehandling = null) } returns listOf(barn.aktør, søker.aktør)
+            every { mockRegistrertSøknadstidspunktPåPersonRepository.findByBehandlingId(behandling.id) } returns emptyList()
+            every { mockPersongrunnlagService.hentAktivThrows(behandling.id) } returns lagTestPersonopplysningGrunnlag(behandling.id, søker, barn)
+            val lagretSlot = slot<List<RegistrertSøknadstidspunktPåPerson>>()
+            every { mockRegistrertSøknadstidspunktPåPersonRepository.saveAll(capture(lagretSlot)) } answers { firstArg() }
+
+            // Act
+            registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
+
+            // Assert – søker får også søknadtidspunkt satt slik at endret utbetaling kan genereres for utvidet-andeler
+            assertThat(lagretSlot.captured).containsExactlyInAnyOrder(
+                RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = søker.aktør, søknadstidspunkt = søknadMottattDato),
+                RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barn.aktør, søknadstidspunkt = søknadMottattDato),
             )
         }
 
@@ -261,7 +287,7 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
             every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id) } returns null
 
             // Act
-            registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
+            registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
 
             // Assert
             verify(exactly = 0) { mockRegistrertSøknadstidspunktPåPersonRepository.saveAll(any<List<RegistrertSøknadstidspunktPåPerson>>()) }
@@ -274,7 +300,7 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
             every { mockFeatureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) } returns false
 
             // Act
-            registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
+            registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling)
 
             // Assert
             verify(exactly = 0) { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingStegTest.kt
@@ -131,7 +131,7 @@ class VilkårsvurderingStegTest {
         every { tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(BehandlingId(behandling.id)) } just Runs
         justRun { automatiskOppdaterValutakursService.oppdaterAndelerMedValutakurser(any()) }
         every { endretUtbetalingAndelService.genererEndretUtbetalingAndelerMedÅrsakEtterbetaling3ÅrEller3Mnd(any()) } just runs
-        every { registrertSøknadstidspunktService.settSøknadstidspunktForBarn(any()) } just runs
+        every { registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(any()) } just runs
     }
 
     @Test
@@ -164,7 +164,7 @@ class VilkårsvurderingStegTest {
 
         assertDoesNotThrow { vilkårsvurderingSteg.utførStegOgAngiNeste(behandling, null) }
 
-        verify(exactly = 1) { registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling) }
+        verify(exactly = 1) { registrertSøknadstidspunktService.settSøknadstidspunktForPersonerFremstiltKravFor(behandling) }
     }
 
     @Test


### PR DESCRIPTION
### 📮 Favro: Nav-30002

### 💰 Hva skal gjøres, og hvorfor?

Endret utbetaling andeler med årsak `ETTERBETALING_3MND`/`ETTERBETALING_3ÅR` ble kun generert automatisk for barn. Søker fikk aldri registrert et søknadstidspunkt, og det ble derfor ikke opprettet noe endret utbetaling for sker. 

Årsaken var at `settSøknadstidspunktForBarn` slo opp mot `persongrunnlagService.hentBarna` og filtrerte bort søker — selv om `finnPersonerFremstiltKravFor` allerede returnerer søker når underkategorien er `UTVIDET`.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.
