### PR TITLE
NAV-30005: Slett featuretoggle for endret utbetaling og søknadstidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/config/featureToggle/FeatureToggle.kt
@@ -59,9 +59,6 @@ enum class FeatureToggle(
     // NAV-29193
     KAN_GENERERE_BARNAS_VILKÅR("familie-ba-sak.kan-generere-barnas-vilkar"),
 
-    // NAV-25661
-    KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON("familie-ba-sak.kan-registrere-soknadstidspunkt"),
-
     // NAV-29800
     KAN_KJØRE_SATSENDRING_EØS("familie-ba-sak.kan-kjore-satsendring-eos"),
 

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -2,12 +2,8 @@ package no.nav.familie.ba.sak.kjerne.endretutbetaling
 
 import no.nav.familie.ba.sak.common.Feil
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.EndretUtbetalingAndelDto
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -42,9 +38,7 @@ class EndretUtbetalingAndelService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val endretUtbetalingAndelOppdatertAbonnementer: List<EndretUtbetalingAndelerOppdatertAbonnent> = emptyList(),
     private val endretUtbetalingAndelHentOgPersisterService: EndretUtbetalingAndelHentOgPersisterService,
-    private val behandlingSøknadsinfoService: BehandlingSøknadsinfoService,
     private val registrertSøknadstidspunktService: RegistrertSøknadstidspunktPåPersonService,
-    private val featureToggleService: FeatureToggleService,
 ) {
     private val logger = LoggerFactory.getLogger(EndretUtbetalingAndelService::class.java)
 
@@ -56,7 +50,7 @@ class EndretUtbetalingAndelService(
     ) {
         val endretUtbetalingAndel = endretUtbetalingAndelRepository.getReferenceById(endretUtbetalingAndelId)
 
-        if (featureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) && endretUtbetalingAndel.erAutomatiskGenerert == true) {
+        if (endretUtbetalingAndel.erAutomatiskGenerert == true) {
             throw FunksjonellFeil("Automatisk genererte endrede utbetalingsperioder kan ikke endres, kun fjernes.")
         }
 
@@ -147,17 +141,6 @@ class EndretUtbetalingAndelService(
     }
 
     @Transactional
-    fun fjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen(behandling: Behandling) {
-        val endretUtbetalingAndelerSomSkalSlettes =
-            endretUtbetalingAndelRepository
-                .findByBehandlingId(behandling.id)
-                .filter { it.manglerObligatoriskFelt() || it.årsak in setOf(ETTERBETALING_3ÅR, ETTERBETALING_3MND) }
-                .map { it.id }
-
-        fjernEndretUtbetalingAndelerOgOppdaterTilkjentYtelse(behandling, endretUtbetalingAndelerSomSkalSlettes)
-    }
-
-    @Transactional
     fun slettEndretUtbetalingAndelerForPersonerIkkeIPersonopplysningGrunnlag(behandling: Behandling) {
         val personopplysningGrunnlag =
             personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = behandling.id)
@@ -238,34 +221,15 @@ class EndretUtbetalingAndelService(
 
     @Transactional
     fun genererEndretUtbetalingAndelerMedÅrsakEtterbetaling3ÅrEller3Mnd(behandling: Behandling) {
-        val registrereSøknadstidspunktToggleErPå = featureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON)
-
-        if (!registrereSøknadstidspunktToggleErPå && behandling.kategori == BehandlingKategori.EØS) return
-
         val lagretSøknadstidspunktPerIdent =
-            if (registrereSøknadstidspunktToggleErPå) {
-                registrertSøknadstidspunktService
-                    .hentForBehandling(behandling.id)
-                    .associate { it.aktør.aktivFødselsnummer() to it.søknadstidspunkt }
-            } else {
-                emptyMap()
-            }
+            registrertSøknadstidspunktService
+                .hentForBehandling(behandling.id)
+                .associate { it.aktør.aktivFødselsnummer() to it.søknadstidspunkt }
 
-        val behandlingSøknadMottattDato =
-            if (registrereSøknadstidspunktToggleErPå) {
-                null
-            } else {
-                behandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id)?.toLocalDate()
-            }
+        if (lagretSøknadstidspunktPerIdent.isEmpty()) return
 
-        if (lagretSøknadstidspunktPerIdent.isEmpty() && behandlingSøknadMottattDato == null) return
-
-        if (registrereSøknadstidspunktToggleErPå) {
-            val andelerSomSkalRyddes = finnAndelerSomSkalRyddes(behandling, barnSomErSøktFor = lagretSøknadstidspunktPerIdent.keys)
-            fjernEndretUtbetalingAndelerOgOppdaterTilkjentYtelse(behandling, andelerSomSkalRyddes)
-        } else {
-            fjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen(behandling)
-        }
+        val andelerSomSkalRyddes = finnAndelerSomSkalRyddes(behandling, barnSomErSøktFor = lagretSøknadstidspunktPerIdent.keys)
+        fjernEndretUtbetalingAndelerOgOppdaterTilkjentYtelse(behandling, andelerSomSkalRyddes)
 
         val nåværendeAndeler = beregningService.hentAndelerTilkjentYtelseForBehandling(behandling.id)
         val forrigeAndeler = beregningService.hentAndelerFraForrigeIverksattebehandling(behandling)
@@ -277,7 +241,6 @@ class EndretUtbetalingAndelService(
             grupperPersonerPåSøknadstidspunkt(
                 personerPåBehandling = personerPåBehandling,
                 lagretSøknadstidspunktPerIdent = lagretSøknadstidspunktPerIdent,
-                behandlingSøknadMottattDato = behandlingSøknadMottattDato,
             )
 
         val genererteAndeler =
@@ -290,7 +253,7 @@ class EndretUtbetalingAndelService(
                     forrigeAndeler = forrigeAndeler.filter { it.aktør in aktuelleAktører },
                     nåværendeEndretUtbetalingAndeler = nåværendeEndretUtbetalingAndeler,
                     personerPåBehandling = personerMedDato,
-                    erAutomatiskGenerert = registrereSøknadstidspunktToggleErPå,
+                    erAutomatiskGenerert = true,
                 )
             }
 
@@ -324,13 +287,10 @@ class EndretUtbetalingAndelService(
     private fun grupperPersonerPåSøknadstidspunkt(
         personerPåBehandling: List<Person>,
         lagretSøknadstidspunktPerIdent: Map<String, LocalDate>,
-        behandlingSøknadMottattDato: LocalDate?,
     ): Map<LocalDate, List<Person>> =
         personerPåBehandling
             .mapNotNull { person ->
-                val søknadstidspunkt =
-                    lagretSøknadstidspunktPerIdent[person.aktør.aktivFødselsnummer()] ?: behandlingSøknadMottattDato
-                søknadstidspunkt?.let { person to it }
+                lagretSøknadstidspunktPerIdent[person.aktør.aktivFødselsnummer()]?.let { person to it }
             }.groupBy({ it.second }, { it.first })
 
     private fun oppdaterBehandlingMedBeregningOgVarsleAbonnenter(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonController.kt
@@ -4,8 +4,6 @@ import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.validerBehandlingKanRedigeres
 import no.nav.familie.ba.sak.config.AuditLoggerEvent
 import no.nav.familie.ba.sak.config.BehandlerRolle
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.ekstern.restDomene.EndreSøknadstidspunktRequestDto
 import no.nav.familie.ba.sak.ekstern.restDomene.RegistrertSøknadstidspunktPåPersonDto
 import no.nav.familie.ba.sak.ekstern.restDomene.UtvidetBehandlingDto
@@ -36,13 +34,11 @@ class RegistrertSøknadstidspunktPåPersonController(
     private val registrertSøknadstidspunktService: RegistrertSøknadstidspunktPåPersonService,
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
     private val utvidetBehandlingService: UtvidetBehandlingService,
-    private val featureToggleService: FeatureToggleService,
 ) {
     @GetMapping("/behandling/{behandlingId}")
     fun hentRegistrertSøknadstidspunktPåPersoner(
         @PathVariable behandlingId: Long,
     ): ResponseEntity<Ressurs<List<RegistrertSøknadstidspunktPåPersonDto>>> {
-        validerAtRegistreringAvSøknadstidspunktErAktivert()
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.ACCESS)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.VEILEDER,
@@ -64,7 +60,6 @@ class RegistrertSøknadstidspunktPåPersonController(
         @PathVariable behandlingId: Long,
         @RequestBody request: EndreSøknadstidspunktRequestDto,
     ): ResponseEntity<Ressurs<UtvidetBehandlingDto>> {
-        validerAtRegistreringAvSøknadstidspunktErAktivert()
         tilgangService.validerTilgangTilBehandling(behandlingId = behandlingId, event = AuditLoggerEvent.UPDATE)
         tilgangService.verifiserHarTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
@@ -81,12 +76,6 @@ class RegistrertSøknadstidspunktPåPersonController(
         )
 
         return ResponseEntity.ok(Ressurs.success(utvidetBehandlingService.lagUtvidetBehandlingDto(behandlingId)))
-    }
-
-    private fun validerAtRegistreringAvSøknadstidspunktErAktivert() {
-        if (!featureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON)) {
-            throw FunksjonellFeil("Registrering av søknadstidspunkt er ikke aktivert.")
-        }
     }
 
     private fun validerAtBehandlingErSøknadsbehandling(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonService.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ba.sak.kjerne.registrertsøknadstidspunkt
 
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -18,13 +16,11 @@ class RegistrertSøknadstidspunktPåPersonService(
     private val persongrunnlagService: PersongrunnlagService,
     private val behandlingSøknadsinfoService: BehandlingSøknadsinfoService,
     private val søknadGrunnlagService: SøknadGrunnlagService,
-    private val featureToggleService: FeatureToggleService,
 ) {
     fun hentForBehandling(behandlingId: Long): List<RegistrertSøknadstidspunktPåPerson> = registrertSøknadstidspunktRepository.findByBehandlingId(behandlingId)
 
     @Transactional
     fun settSøknadstidspunktForBarn(behandling: Behandling) {
-        if (!featureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON)) return
         if (behandling.opprettetÅrsak != BehandlingÅrsak.SØKNAD) return
 
         val søknadMottattDato = behandlingSøknadsinfoService.hentSøknadMottattDato(behandling.id)?.toLocalDate() ?: return

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/cucumber/mock/CucumberMock.kt
@@ -572,9 +572,7 @@ class CucumberMock(
             vilkårsvurderingService = vilkårsvurderingService,
             endretUtbetalingAndelOppdatertAbonnementer = emptyList(),
             endretUtbetalingAndelHentOgPersisterService = endretUtbetalingAndelHentOgPersisterService,
-            behandlingSøknadsinfoService = behandlingSøknadsinfoService,
             registrertSøknadstidspunktService = mockk(relaxed = true),
-            featureToggleService = featureToggleService,
         )
 
     val preutfyllBosattIRiketService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -9,8 +9,6 @@ import io.mockk.verify
 import no.nav.familie.ba.sak.common.FunksjonellFeil
 import no.nav.familie.ba.sak.common.førsteDagIInneværendeMåned
 import no.nav.familie.ba.sak.common.toYearMonth
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagAktør
 import no.nav.familie.ba.sak.datagenerator.lagAndelTilkjentYtelse
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
@@ -22,7 +20,6 @@ import no.nav.familie.ba.sak.datagenerator.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ba.sak.ekstern.restDomene.EndretUtbetalingAndelDto
 import no.nav.familie.ba.sak.kjerne.autovedtak.fødselshendelse.Resultat
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
 import no.nav.familie.ba.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ba.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -60,9 +57,7 @@ class EndretUtbetalingAndelServiceTest {
     private val mockVilkårsvurderingService = mockk<VilkårsvurderingService>()
     private val mockEndretUtbetalingAndelHentOgPersisterService = mockk<EndretUtbetalingAndelHentOgPersisterService>()
     private val mockBeregningService = mockk<BeregningService>()
-    private val mockBehandlingSøknadsinfoService = mockk<BehandlingSøknadsinfoService>()
     private val mockRegistrertSøknadstidspunktPåPersonService = mockk<RegistrertSøknadstidspunktPåPersonService>()
-    private val mockFeatureToggleService = mockk<FeatureToggleService>()
 
     private lateinit var endretUtbetalingAndelService: EndretUtbetalingAndelService
 
@@ -77,11 +72,8 @@ class EndretUtbetalingAndelServiceTest {
                 andelTilkjentYtelseRepository = mockAndelTilkjentYtelseRepository,
                 vilkårsvurderingService = mockVilkårsvurderingService,
                 endretUtbetalingAndelHentOgPersisterService = mockEndretUtbetalingAndelHentOgPersisterService,
-                behandlingSøknadsinfoService = mockBehandlingSøknadsinfoService,
                 registrertSøknadstidspunktService = mockRegistrertSøknadstidspunktPåPersonService,
-                featureToggleService = mockFeatureToggleService,
             )
-        every { mockFeatureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) } returns true
     }
 
     @Test
@@ -301,27 +293,6 @@ class EndretUtbetalingAndelServiceTest {
         verify(exactly = 0) { mockPersongrunnlagService.hentPersonerPåBehandling(any(), any()) }
     }
 
-    @Test
-    fun `Skal ikke blokkere oppdatering av automatisk generert andel når toggle er av`() {
-        // Arrange
-        val behandling = lagBehandling()
-        every { mockFeatureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) } returns false
-        every { mockEndretUtbetalingAndelRepository.getReferenceById(any()) } returns
-            EndretUtbetalingAndel(behandlingId = behandling.id, erAutomatiskGenerert = true)
-
-        // Act & assert
-        val feil =
-            assertThrows<FunksjonellFeil> {
-                endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
-                    behandling = behandling,
-                    endretUtbetalingAndelId = 1L,
-                    endretUtbetalingAndelDto = lagEndretUtbetalingAndelDtoForOppdatering(personIdenter = null),
-                )
-            }
-
-        assertThat(feil.message).isEqualTo("Endret utbetalingsperiode må gjelde minst én person")
-    }
-
     private fun lagEndretUtbetalingAndelDtoForOppdatering(personIdenter: List<String>? = listOf("12345678910")) =
         EndretUtbetalingAndelDto(
             id = 1L,
@@ -341,68 +312,7 @@ class EndretUtbetalingAndelServiceTest {
         private val behandling = lagBehandling()
 
         @Test
-        fun `Skal generere endret utbetaling andeler basert på behandlingens søknad mottatt-dato når toggle er av`() {
-            // Arrange
-            val søker = lagPerson(type = PersonType.SØKER)
-            val barn = lagPerson(type = PersonType.BARN)
-
-            val fomAndelTilkjentYtelse = YearMonth.of(2020, 1)
-            val tomAndelTilkjentYtelse = YearMonth.of(2025, 12)
-            val søknadMottattDato = LocalDateTime.of(2025, 4, 15, 0, 0)
-            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søker, barn)
-
-            every { mockFeatureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) } returns false
-            every { mockEndretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
-            every { mockEndretUtbetalingAndelRepository.saveAllAndFlush<EndretUtbetalingAndel>(any()) } returnsArgument 0
-            every { mockEndretUtbetalingAndelRepository.deleteAllById(any()) } just Runs
-            every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(any()) } returns personopplysningGrunnlag
-            every { mockBeregningService.oppdaterBehandlingMedBeregning(any(), any()) } returns mockk()
-            every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) } returns søknadMottattDato
-            every { mockPersongrunnlagService.hentPersonerPåBehandling(any(), any()) } returns listOf(søker, barn)
-            every { mockBeregningService.hentAndelerTilkjentYtelseForBehandling(any()) } returns
-                listOf(
-                    lagAndelTilkjentYtelse(
-                        behandling = behandling,
-                        person = barn,
-                        fom = fomAndelTilkjentYtelse,
-                        tom = tomAndelTilkjentYtelse,
-                        beløp = 2000,
-                    ),
-                )
-            every { mockBeregningService.hentAndelerFraForrigeIverksattebehandling(any()) } returns
-                listOf(
-                    lagAndelTilkjentYtelse(
-                        behandling = behandling,
-                        person = barn,
-                        fom = fomAndelTilkjentYtelse,
-                        tom = tomAndelTilkjentYtelse,
-                        beløp = 1000,
-                    ),
-                )
-
-            // Act
-            endretUtbetalingAndelService.genererEndretUtbetalingAndelerMedÅrsakEtterbetaling3ÅrEller3Mnd(behandling = behandling)
-
-            // Assert
-            val forventetEndretUtbetalingAndel =
-                EndretUtbetalingAndel(
-                    behandlingId = behandling.id,
-                    personer = mutableSetOf(barn),
-                    prosent = BigDecimal.ZERO,
-                    fom = fomAndelTilkjentYtelse,
-                    tom = søknadMottattDato.minusMonths(4).toLocalDate().toYearMonth(),
-                    årsak = Årsak.ETTERBETALING_3MND,
-                    søknadstidspunkt = søknadMottattDato.toLocalDate(),
-                    begrunnelse = "Fylt ut automatisk fra søknadstidspunkt.",
-                    erAutomatiskGenerert = false,
-                )
-            verify(exactly = 1) { mockEndretUtbetalingAndelRepository.deleteAllById(emptyList()) }
-            verify(exactly = 1) { mockEndretUtbetalingAndelRepository.saveAllAndFlush(listOf(forventetEndretUtbetalingAndel)) }
-            verify(exactly = 2) { mockBeregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag) }
-        }
-
-        @Test
-        fun `Skal ikke generere endret utbetaling andeler når ingen lagret søknadstidspunkt finnes og toggle er på`() {
+        fun `Skal ikke generere endret utbetaling andeler når ingen lagret søknadstidspunkt finnes`() {
             // Arrange
             every { mockRegistrertSøknadstidspunktPåPersonService.hentForBehandling(any()) } returns emptyList()
 
@@ -413,20 +323,6 @@ class EndretUtbetalingAndelServiceTest {
             verify(exactly = 0) { mockEndretUtbetalingAndelRepository.deleteAllById(any()) }
             verify(exactly = 0) { mockEndretUtbetalingAndelRepository.saveAllAndFlush<EndretUtbetalingAndel>(any()) }
             verify(exactly = 0) { mockBeregningService.oppdaterBehandlingMedBeregning(any(), any()) }
-        }
-
-        @Test
-        fun `Skal ikke generere for EØS og ikke lese registrert søknadstidspunkt når toggle er av`() {
-            // Arrange
-            val eøsBehandling = behandling.copy(kategori = BehandlingKategori.EØS)
-            every { mockFeatureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) } returns false
-
-            // Act
-            endretUtbetalingAndelService.genererEndretUtbetalingAndelerMedÅrsakEtterbetaling3ÅrEller3Mnd(behandling = eøsBehandling)
-
-            // Assert
-            verify(exactly = 0) { mockRegistrertSøknadstidspunktPåPersonService.hentForBehandling(any()) }
-            verify(exactly = 0) { mockEndretUtbetalingAndelRepository.saveAllAndFlush<EndretUtbetalingAndel>(any()) }
         }
 
         @Test
@@ -441,7 +337,6 @@ class EndretUtbetalingAndelServiceTest {
             val søknadstidspunkt = LocalDate.of(2025, 4, 15)
             val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(behandling.id, søker, barn)
 
-            every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) } returns null
             every { mockRegistrertSøknadstidspunktPåPersonService.hentForBehandling(any()) } returns
                 listOf(RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barn.aktør, søknadstidspunkt = søknadstidspunkt))
             every { mockEndretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
@@ -503,7 +398,6 @@ class EndretUtbetalingAndelServiceTest {
             val personopplysningGrunnlag =
                 lagTestPersonopplysningGrunnlag(behandling.id, søker, barnMedRegistrertTidspunkt, barnUtenRegistrertTidspunkt)
 
-            every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) } returns LocalDateTime.of(2025, 4, 15, 0, 0)
             every { mockRegistrertSøknadstidspunktPåPersonService.hentForBehandling(any()) } returns
                 listOf(RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barnMedRegistrertTidspunkt.aktør, søknadstidspunkt = søknadstidspunkt))
             every { mockEndretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
@@ -562,7 +456,6 @@ class EndretUtbetalingAndelServiceTest {
                     årsak = Årsak.ETTERBETALING_3MND,
                 )
 
-            every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) } returns null
             every { mockRegistrertSøknadstidspunktPåPersonService.hentForBehandling(any()) } returns
                 listOf(RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barnFramstiltKravFor.aktør, søknadstidspunkt = søknadstidspunkt))
             every { mockEndretUtbetalingAndelRepository.findByBehandlingId(any()) } returns listOf(kopiertAndelForIkkeFramstilt)
@@ -617,7 +510,6 @@ class EndretUtbetalingAndelServiceTest {
                         RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barnMedAndel.aktør, søknadstidspunkt = søknadstidspunkt),
                         RegistrertSøknadstidspunktPåPerson(behandlingId = behandling.id, aktør = barnUtenAndel.aktør, søknadstidspunkt = søknadstidspunkt),
                     )
-                every { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) } returns null
 
                 every { mockEndretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
                 every { mockEndretUtbetalingAndelRepository.saveAllAndFlush<EndretUtbetalingAndel>(any()) } returnsArgument 0
@@ -723,49 +615,6 @@ class EndretUtbetalingAndelServiceTest {
                 // Assert
                 verify(exactly = 0) { mockEndretUtbetalingAndelRepository.delete(any()) }
                 verify(exactly = 0) { mockEndretUtbetalingAndelRepository.save(any()) }
-            }
-        }
-
-        @Nested
-        inner class FjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen {
-            @Test
-            fun `Skal slette eksisterende endretUtbetalingAndeler hvis den er ugyldig`() {
-                // Arrange
-                val behandling = lagBehandling()
-                val endretUtbetalingAndel = EndretUtbetalingAndel(behandlingId = behandling.id) // Mangler påkrevde felter
-                val endretUtbetalingAndelIDer = slot<List<Long>>()
-
-                every { mockEndretUtbetalingAndelRepository.findByBehandlingId(behandling.id) } returns listOf(endretUtbetalingAndel)
-                every { mockEndretUtbetalingAndelRepository.deleteAllById(capture(endretUtbetalingAndelIDer)) } just Runs
-                every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) } returns mockk()
-                every { mockBeregningService.oppdaterBehandlingMedBeregning(behandling, any()) } returns mockk()
-
-                // Act
-                endretUtbetalingAndelService.fjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen(behandling)
-
-                // Assert
-                assertThat(endretUtbetalingAndelIDer.captured).containsExactly(endretUtbetalingAndel.id)
-            }
-
-            @ParameterizedTest
-            @EnumSource(Årsak::class, names = ["ETTERBETALING_3ÅR", "ETTERBETALING_3MND"])
-            fun `Skal slette eksisterende endretUtbetalingAndeler hvis årsak er etterbetaling`(årsak: Årsak) {
-                // Arrange
-                val behandling = lagBehandling()
-                val person = lagPerson()
-                val endretUtbetalingAndel = lagEndretUtbetalingAndel(behandlingId = behandling.id, årsak = årsak, personer = setOf(person))
-                val endretUtbetalingAndelIDer = slot<List<Long>>()
-
-                every { mockEndretUtbetalingAndelRepository.findByBehandlingId(behandling.id) } returns listOf(endretUtbetalingAndel)
-                every { mockEndretUtbetalingAndelRepository.deleteAllById(capture(endretUtbetalingAndelIDer)) } just Runs
-                every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) } returns mockk()
-                every { mockBeregningService.oppdaterBehandlingMedBeregning(behandling, any()) } returns mockk()
-
-                // Act
-                endretUtbetalingAndelService.fjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen(behandling)
-
-                // Assert
-                assertThat(endretUtbetalingAndelIDer.captured).containsExactly(endretUtbetalingAndel.id)
             }
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/registrertsøknadstidspunkt/RegistrertSøknadstidspunktPåPersonServiceTest.kt
@@ -7,8 +7,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ba.sak.common.FunksjonellFeil
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ba.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ba.sak.datagenerator.lagBehandling
 import no.nav.familie.ba.sak.datagenerator.lagPerson
 import no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingKategori
@@ -18,7 +16,6 @@ import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersonType
 import no.nav.familie.ba.sak.kjerne.grunnlag.personopplysninger.PersongrunnlagService
 import no.nav.familie.ba.sak.kjerne.grunnlag.søknad.SøknadGrunnlagService
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -29,7 +26,6 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
     private val mockPersongrunnlagService = mockk<PersongrunnlagService>()
     private val mockBehandlingSøknadsinfoService = mockk<BehandlingSøknadsinfoService>()
     private val mockSøknadGrunnlagService = mockk<SøknadGrunnlagService>()
-    private val mockFeatureToggleService = mockk<FeatureToggleService>()
 
     private val registrertSøknadstidspunktService =
         RegistrertSøknadstidspunktPåPersonService(
@@ -37,13 +33,7 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
             persongrunnlagService = mockPersongrunnlagService,
             behandlingSøknadsinfoService = mockBehandlingSøknadsinfoService,
             søknadGrunnlagService = mockSøknadGrunnlagService,
-            featureToggleService = mockFeatureToggleService,
         )
-
-    @BeforeEach
-    fun setup() {
-        every { mockFeatureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) } returns true
-    }
 
     @Nested
     inner class LagreSøknadstidspunkterPåPersonerTest {
@@ -264,20 +254,6 @@ class RegistrertSøknadstidspunktPåPersonServiceTest {
             registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
 
             // Assert
-            verify(exactly = 0) { mockRegistrertSøknadstidspunktPåPersonRepository.saveAll(any<List<RegistrertSøknadstidspunktPåPerson>>()) }
-        }
-
-        @Test
-        fun `skal ikke gjøre noe når feature toggle er av`() {
-            // Arrange
-            val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
-            every { mockFeatureToggleService.isEnabled(FeatureToggle.KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON) } returns false
-
-            // Act
-            registrertSøknadstidspunktService.settSøknadstidspunktForBarn(behandling)
-
-            // Assert
-            verify(exactly = 0) { mockBehandlingSøknadsinfoService.hentSøknadMottattDato(any()) }
             verify(exactly = 0) { mockRegistrertSøknadstidspunktPåPersonRepository.saveAll(any<List<RegistrertSøknadstidspunktPåPerson>>()) }
         }
     }


### PR DESCRIPTION
### 📮 Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-30005

### 💰 Hva skal gjøres, og hvorfor?

Sletter featuretoggelen `KAN_REGISTRERE_SØKNADSTIDSPUNKT_PÅ_PERSON` (`familie-ba-sak.kan-registrere-soknadstidspunkt`). Toggelen har vært på i prod, så oppførselen den ga beholdes som standard, og den gamle grenen slettes som død kode.

Oppførsel som nå er permanent:

| Sted | Før (toggle av) | Nå |
| --- | --- | --- |
| `RegistrertSøknadstidspunktPåPersonService` | returnerte med en gang | setter alltid søknadstidspunkt per barn |
| `RegistrertSøknadstidspunktPåPersonController` | kastet `FunksjonellFeil` | endepunktene er alltid åpne |
| `EndretUtbetalingAndelService` (oppdatering) | automatisk genererte andeler kunne endres | kan aldri endres, kun fjernes |
| `EndretUtbetalingAndelService` (generering) | hoppet over EØS, brukte behandlingens søknad mottatt-dato | kjører også for EØS, bruker alltid lagret søknadstidspunkt per person |
| `erAutomatiskGenerert` | `false` | `true` |

I tillegg er koden som kun eksisterte for den gamle grenen ryddet bort:

- `fjernEndretUtbetalingAndelerMedÅrsak3MndEller3ÅrGenerertIDenneBehandlingen`
- `behandlingSøknadsinfoService`-avhengigheten i `EndretUtbetalingAndelService`
- `behandlingSøknadMottattDato`-fallbacken i `grupperPersonerPåSøknadstidspunkt`

Netto −245/+10 linjer.

Tilhørende frontend-PR: navikt/familie-ba-sak-frontend#4702